### PR TITLE
Drastically Simplify VarDecl Validation

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4809,8 +4809,6 @@ public:
   /// this will use archetypes.
   Type getType() const;
 
-  void markInvalid();
-
   /// Retrieve the source range of the variable type, or an invalid range if the
   /// variable's type is not explicitly written in the source.
   ///

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -71,6 +71,7 @@ namespace swift {
   class GenericTypeParamDecl;
   class GenericTypeParamType;
   class ModuleDecl;
+  class NamedPattern;
   class EnumCaseDecl;
   class EnumElementDecl;
   class ParameterList;
@@ -4773,6 +4774,8 @@ enum class PropertyWrapperSynthesizedPropertyKind {
 
 /// VarDecl - 'var' and 'let' declarations.
 class VarDecl : public AbstractStorageDecl {
+  NamedPattern *NamingPattern = nullptr;
+
 public:
   enum class Introducer : uint8_t {
     Let = 0,
@@ -4785,8 +4788,6 @@ protected:
   VarDecl(DeclKind kind, bool isStatic, Introducer introducer,
           bool issCaptureList, SourceLoc nameLoc, Identifier name,
           DeclContext *dc, StorageIsMutable_t supportsMutation);
-
-  Type typeInContext;
 
 public:
   VarDecl(bool isStatic, Introducer introducer, bool isCaptureList,
@@ -4804,18 +4805,9 @@ public:
     return hasName() ? getBaseName().getIdentifier().str() : "_";
   }
 
-  bool hasType() const {
-    // We have a type if either the type has been computed already or if
-    // this is a deserialized declaration with an interface type.
-    return !typeInContext.isNull();
-  }
-
   /// Get the type of the variable within its context. If the context is generic,
   /// this will use archetypes.
   Type getType() const;
-
-  /// Set the type of the variable within its context.
-  void setType(Type t);
 
   void markInvalid();
 
@@ -4904,6 +4896,9 @@ public:
     assert(v && v != this);
     Parent = v;
   }
+
+  NamedPattern *getNamingPattern() const { return NamingPattern; }
+  void setNamingPattern(NamedPattern *Pat) { NamingPattern = Pat; }
 
   /// If this is a VarDecl that does not belong to a CaseLabelItem's pattern,
   /// return this. Otherwise, this VarDecl must belong to a CaseStmt's

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4786,8 +4786,6 @@ protected:
           bool issCaptureList, SourceLoc nameLoc, Identifier name,
           DeclContext *dc, StorageIsMutable_t supportsMutation);
 
-  TypeRepr *ParentRepr = nullptr;
-
   Type typeInContext;
 
 public:
@@ -4805,11 +4803,6 @@ public:
     assert(!getFullName().isSpecial() && "Cannot get string for special names");
     return hasName() ? getBaseName().getIdentifier().str() : "_";
   }
-
-  /// Retrieve the TypeRepr corresponding to the parsed type of the parent
-  /// pattern, if it exists.
-  TypeRepr *getTypeRepr() const { return ParentRepr; }
-  void setTypeRepr(TypeRepr *repr) { ParentRepr = repr; }
 
   bool hasType() const {
     // We have a type if either the type has been computed already or if
@@ -4863,6 +4856,14 @@ public:
   /// returns null.
   ///
   Pattern *getParentPattern() const;
+
+  /// Returns the parsed type of this variable declaration.  For parameters, this
+  /// is the parsed type the user explicitly wrote.  For variables, this is the
+  /// type the user wrote in the typed pattern that binds this variable.
+  ///
+  /// Note that there are many cases where the user may elide types.  This will
+  /// return null in those cases.
+  TypeRepr *getTypeReprOrParentPatternTypeRepr() const;
 
   /// Return the statement that owns the pattern associated with this VarDecl,
   /// if one exists.
@@ -5158,6 +5159,8 @@ class ParamDecl : public VarDecl {
   SourceLoc ArgumentNameLoc;
   SourceLoc SpecifierLoc;
 
+  TypeRepr *TyRepr = nullptr;
+
   struct StoredDefaultArgument {
     PointerUnion<Expr *, VarDecl *> DefaultArg;
     Initializer *InitContext = nullptr;
@@ -5202,6 +5205,10 @@ public:
   SourceLoc getParameterNameLoc() const { return ParameterNameLoc; }
 
   SourceLoc getSpecifierLoc() const { return SpecifierLoc; }
+
+  /// Retrieve the TypeRepr corresponding to the parsed type of the parameter, if it exists.
+  TypeRepr *getTypeRepr() const { return TyRepr; }
+  void setTypeRepr(TypeRepr *repr) { TyRepr = repr; }
 
   DefaultArgumentKind getDefaultArgumentKind() const {
     return static_cast<DefaultArgumentKind>(Bits.ParamDecl.defaultArgumentKind);

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1509,6 +1509,9 @@ ERROR(pattern_binds_no_variables,none,
       "%select{property|global variable}0 declaration does not bind any "
       "variables",
       (unsigned))
+ERROR(variable_bound_by_no_pattern,none,
+      "variable %0 is not bound by any pattern",
+      (DeclName))
 
 WARNING(optional_ambiguous_case_ref,none,
         "assuming you mean '%0.%2'; did you mean '%1.%2' instead?",

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -725,7 +725,7 @@ namespace {
 
       if (auto *var = dyn_cast<VarDecl>(VD)) {
         PrintWithColorRAII(OS, TypeColor) << " type='";
-        if (var->hasType())
+        if (auto varTy = var->hasInterfaceType())
           var->getType().print(PrintWithColorRAII(OS, TypeColor).getOS());
         else
           PrintWithColorRAII(OS, TypeColor) << "<null type>";
@@ -954,13 +954,11 @@ namespace {
         PrintWithColorRAII(OS, IdentifierColor)
           << " apiName=" << P->getArgumentName();
 
-      if (P->hasType()) {
+      if (P->hasInterfaceType()) {
         PrintWithColorRAII(OS, TypeColor) << " type='";
         P->getType().print(PrintWithColorRAII(OS, TypeColor).getOS());
         PrintWithColorRAII(OS, TypeColor) << "'";
-      }
 
-      if (P->hasInterfaceType()) {
         PrintWithColorRAII(OS, InterfaceTypeColor) << " interface type='";
         P->getInterfaceType().print(
             PrintWithColorRAII(OS, InterfaceTypeColor).getOS());

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2524,7 +2524,7 @@ void PrintAST::visitVarDecl(VarDecl *decl) {
   if (decl->hasInterfaceType()) {
     Printer << ": ";
     TypeLoc tyLoc;
-    if (auto *repr = decl->getTypeRepr())
+    if (auto *repr = decl->getTypeReprOrParentPatternTypeRepr())
       tyLoc = TypeLoc(repr, decl->getInterfaceType());
     else
       tyLoc = TypeLoc::withoutLoc(decl->getInterfaceType());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5010,10 +5010,6 @@ Type VarDecl::getType() const {
   return getDeclContext()->mapTypeIntoContext(getInterfaceType());
 }
 
-void VarDecl::markInvalid() {
-  setInterfaceType(ErrorType::get(getASTContext()));
-}
-
 /// Returns whether the var is settable in the specified context: this
 /// is either because it is a stored var, because it has a custom setter, or
 /// is a let member in an initializer.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2595,7 +2595,7 @@ OpaqueReturnTypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
         }
       }
     } else {
-      returnRepr = VD->getTypeRepr();
+      returnRepr = VD->getTypeReprOrParentPatternTypeRepr();
     }
   } else if (auto *FD = dyn_cast<FuncDecl>(this)) {
     returnRepr = FD->getBodyResultTypeLoc().getTypeRepr();
@@ -5282,6 +5282,16 @@ Pattern *VarDecl::getParentPattern() const {
 
   // Otherwise, this is a case we do not know or understand. Return nullptr to
   // signal we do not have any information.
+  return nullptr;
+}
+
+TypeRepr *VarDecl::getTypeReprOrParentPatternTypeRepr() const {
+  if (auto *param = dyn_cast<ParamDecl>(this))
+    return param->getTypeRepr();
+
+  if (auto *parentPattern = dyn_cast_or_null<TypedPattern>(getParentPattern()))
+      return parentPattern->getTypeLoc().getTypeRepr();
+
   return nullptr;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5007,24 +5007,11 @@ VarDecl::VarDecl(DeclKind kind, bool isStatic, VarDecl::Introducer introducer,
 }
 
 Type VarDecl::getType() const {
-  if (!typeInContext) {
-    const_cast<VarDecl *>(this)->typeInContext =
-      getDeclContext()->mapTypeIntoContext(
-        getInterfaceType());
-  }
-
-  return typeInContext;
-}
-
-void VarDecl::setType(Type t) {
-  assert(t.isNull() || !t->is<InOutType>());
-  typeInContext = t;
+  return getDeclContext()->mapTypeIntoContext(getInterfaceType());
 }
 
 void VarDecl::markInvalid() {
-  auto &Ctx = getASTContext();
-  setType(ErrorType::get(Ctx));
-  setInterfaceType(ErrorType::get(Ctx));
+  setInterfaceType(ErrorType::get(getASTContext()));
 }
 
 /// Returns whether the var is settable in the specified context: this
@@ -5269,9 +5256,6 @@ Pattern *VarDecl::getParentPattern() const {
           if (pat->containsVarDecl(this))
             return pat;
     }
-
-    //stmt->dump();
-    assert(0 && "Unknown parent pattern statement?");
   }
 
   // Otherwise, check if we have to walk our case stmt's var decl list to find
@@ -5290,7 +5274,7 @@ TypeRepr *VarDecl::getTypeReprOrParentPatternTypeRepr() const {
     return param->getTypeRepr();
 
   if (auto *parentPattern = dyn_cast_or_null<TypedPattern>(getParentPattern()))
-      return parentPattern->getTypeLoc().getTypeRepr();
+    return parentPattern->getTypeRepr();
 
   return nullptr;
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2110,7 +2110,6 @@ applyPropertyOwnership(VarDecl *prop,
   if (attrs & clang::ObjCPropertyDecl::OBJC_PR_weak) {
     prop->getAttrs().add(new (ctx)
                              ReferenceOwnershipAttr(ReferenceOwnership::Weak));
-    prop->setType(WeakStorageType::get(prop->getType(), ctx));
     prop->setInterfaceType(WeakStorageType::get(
         prop->getInterfaceType(), ctx));
     return;
@@ -2119,7 +2118,6 @@ applyPropertyOwnership(VarDecl *prop,
       (attrs & clang::ObjCPropertyDecl::OBJC_PR_unsafe_unretained)) {
     prop->getAttrs().add(
         new (ctx) ReferenceOwnershipAttr(ReferenceOwnership::Unmanaged));
-    prop->setType(UnmanagedStorageType::get(prop->getType(), ctx));
     prop->setInterfaceType(UnmanagedStorageType::get(
         prop->getInterfaceType(), ctx));
     return;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4455,7 +4455,6 @@ namespace {
           SourceLoc(),
           /*argument label*/ SourceLoc(), Identifier(),
           /*parameter name*/ SourceLoc(), ctx.getIdentifier("$0"), closure);
-      param->setType(baseTy);
       param->setInterfaceType(baseTy->mapTypeOutOfContext());
       param->setSpecifier(ParamSpecifier::Default);
 
@@ -4471,7 +4470,6 @@ namespace {
                               /*argument label*/ SourceLoc(), Identifier(),
                               /*parameter name*/ SourceLoc(),
                               ctx.getIdentifier("$kp$"), outerClosure);
-      outerParam->setType(keyPathTy);
       outerParam->setInterfaceType(keyPathTy->mapTypeOutOfContext());
       outerParam->setSpecifier(ParamSpecifier::Default);
 
@@ -4650,7 +4648,6 @@ namespace {
     Expr *visitTapExpr(TapExpr *E) {
       auto type = simplifyType(cs.getType(E));
 
-      E->getVar()->setType(type);
       E->getVar()->setInterfaceType(type->mapTypeOutOfContext());
 
       cs.setType(E, type);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -823,7 +823,7 @@ Type ConstraintSystem::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
           if (!var->isInvalid()) {
             TC.diagnose(var->getLoc(), diag::recursive_decl_reference,
                         var->getDescriptiveKind(), var->getName());
-            var->markInvalid();
+            var->setInterfaceType(ErrorType::get(getASTContext()));
           }
           return ErrorType::get(TC.Context);
         }

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -584,7 +584,7 @@ deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *) {
   auto codingKeysType = codingKeysEnum->getDeclaredType();
   auto *containerDecl = createKeyedContainer(C, funcDC,
                                              C.getKeyedEncodingContainerDecl(),
-                                             codingKeysType,
+                                             codingKeysEnum->getDeclaredInterfaceType(),
                                              VarDecl::Introducer::Var);
 
   auto *containerExpr = new (C) DeclRefExpr(ConcreteDeclRef(containerDecl),
@@ -806,7 +806,7 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
   auto codingKeysType = codingKeysEnum->getDeclaredType();
   auto *containerDecl = createKeyedContainer(C, funcDC,
                                              C.getKeyedDecodingContainerDecl(),
-                                             codingKeysType,
+                                             codingKeysEnum->getDeclaredInterfaceType(),
                                              VarDecl::Introducer::Let);
 
   auto *containerExpr = new (C) DeclRefExpr(ConcreteDeclRef(containerDecl),

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -186,7 +186,7 @@ static VarDecl *indexedVarDecl(char prefixChar, int index, Type type,
                                  /*IsCaptureList*/true, SourceLoc(),
                                  C.getIdentifier(indexStrRef),
                                  varContext);
-  varDecl->setType(type);
+  varDecl->setInterfaceType(type);
   varDecl->setHasNonPatternBindingInit(true);
   return varDecl;
 }
@@ -1225,7 +1225,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
     new (C) VarDecl(/*IsStatic*/false, VarDecl::Introducer::Var,
                     /*IsCaptureList*/false, SourceLoc(),
                     C.Id_hashValue, parentDC);
-  hashValueDecl->setType(intType);
+  hashValueDecl->setInterfaceType(intType);
 
   ParameterList *params = ParameterList::createEmpty(C);
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2077,7 +2077,7 @@ public:
     
     // If the variable was invalid, ignore it and notice that the code is
     // malformed.
-    if (VD->isInvalid() || !VD->hasType()) {
+    if (!VD->getInterfaceType() || VD->isInvalid()) {
       sawError = true;
       return false;
     }

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -482,7 +482,6 @@ public:
                               /*IsCaptureList*/false, SourceLoc(),
                               Context.getIdentifier(NameBuf),
                               TypeCheckDC);
-    VD->setType(MaybeLoadInitExpr->getType());
     VD->setInterfaceType(MaybeLoadInitExpr->getType()->mapTypeOutOfContext());
     VD->setImplicit();
 

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -745,7 +745,6 @@ public:
                               /*IsCaptureList*/false, SourceLoc(),
                               Context.getIdentifier(NameBuf),
                               TypeCheckDC);
-    VD->setType(MaybeLoadInitExpr->getType());
     VD->setInterfaceType(MaybeLoadInitExpr->getType()->mapTypeOutOfContext());
     VD->setImplicit();
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2824,7 +2824,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
           !var->getType()->hasError())
         return;
 
-      var->markInvalid();
+      var->setInterfaceType(ErrorType::get(Context));
     });
   }
 
@@ -3033,7 +3033,7 @@ bool TypeChecker::typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
         // compute a type for.
         if (var->hasInterfaceType() && !var->getType()->hasError())
           return;
-        var->markInvalid();
+        var->setInterfaceType(ErrorType::get(Context));
       });
     };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2136,8 +2136,10 @@ private:
     // Before producing fatal error here, let's check if there are any "error"
     // diagnostics already emitted or waiting to be emitted. Because they are
     // a better indication of the problem.
-    if (!(hadAnyErrors() || TC.Context.hasDelayedConformanceErrors()))
+    if (!(hadAnyErrors() || TC.Context.hasDelayedConformanceErrors())) {
       TC.diagnose(expr->getLoc(), diag::failed_to_produce_diagnostic);
+      llvm_unreachable("");
+    }
   }
 };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2136,10 +2136,8 @@ private:
     // Before producing fatal error here, let's check if there are any "error"
     // diagnostics already emitted or waiting to be emitted. Because they are
     // a better indication of the problem.
-    if (!(hadAnyErrors() || TC.Context.hasDelayedConformanceErrors())) {
+    if (!(hadAnyErrors() || TC.Context.hasDelayedConformanceErrors()))
       TC.diagnose(expr->getLoc(), diag::failed_to_produce_diagnostic);
-      llvm_unreachable("");
-    }
   }
 };
 
@@ -2821,7 +2819,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
     pattern->forEachVariable([&](VarDecl *var) {
       // Don't change the type of a variable that we've been able to
       // compute a type for.
-      if (var->hasType() &&
+      if (var->hasInterfaceType() &&
           !var->getType()->hasUnboundGenericType() &&
           !var->getType()->hasError())
         return;
@@ -3033,7 +3031,7 @@ bool TypeChecker::typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
       elt.getPattern()->forEachVariable([&](VarDecl *var) {
         // Don't change the type of a variable that we've been able to
         // compute a type for.
-        if (var->hasType() && !var->getType()->hasError())
+        if (var->hasInterfaceType() && !var->getType()->hasError())
           return;
         var->markInvalid();
       });
@@ -3090,7 +3088,6 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
                                          EP->getLoc(),
                                          Context.getIdentifier("$match"),
                                          DC);
-  matchVar->setType(rhsType);
   matchVar->setInterfaceType(rhsType->mapTypeOutOfContext());
 
   matchVar->setImplicit();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4243,6 +4243,14 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       // attempt to infer the interface type using the initializer expressions.
       if (!PBD->isBeingValidated()) {
         validatePatternBindingEntries(*this, PBD);
+      } else if (!VD->getNamingPattern()) {
+        // FIXME: This acts as a circularity breaker for overload resolution
+        // during pattern binding validation, which is allowed to lookup and
+        // find the very VarDecl attached to the binding it's trying to check.
+        // In order to tell it to back off, we surface an error type but don't
+        // set the interface type so a different caller can come along and
+        // do the right thing.
+        return;
       }
 
       if (PBD->isInvalid()) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -225,8 +225,7 @@ static void diagnoseFunctionParamNotRepresentable(
     AFD->diagnose(diag::objc_invalid_on_func_param_type,
                   ParamIndex + 1, getObjCDiagnosticAttrKind(Reason));
   }
-  if (P->hasType()) {
-    Type ParamTy = P->getType();
+  if (Type ParamTy = P->getType()) {
     SourceRange SR;
     if (auto typeRepr = P->getTypeRepr())
       SR = typeRepr->getSourceRange();

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1013,9 +1013,11 @@ recur:
 
     // Note that the pattern's type does not include the reference storage type.
     P->setType(type);
-    var->setInterfaceType(interfaceType);
     var->setType(var->getDeclContext()->mapTypeIntoContext(interfaceType));
-    var->setTypeRepr(tyLoc.getTypeRepr());
+    // If there's no parent pattern binding then take this opportunity to
+    // set the interface type as well.
+    if (var->getParentPatternBinding() == nullptr)
+      var->setInterfaceType(interfaceType);
 
     // FIXME: Should probably just remove the forbidden prefix stuff, it no
     // longer makes a lot of sense in a request-based world.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -806,7 +806,8 @@ bool TypeChecker::typeCheckPattern(Pattern *P, DeclContext *dc,
     P->setType(ErrorType::get(Context));
     if (auto named = dyn_cast<NamedPattern>(P)) {
       if (auto var = named->getDecl()) {
-        var->markInvalid();
+        var->setInterfaceType(ErrorType::get(Context));
+        var->setInvalid();
       }
     }
     return true;

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -233,7 +233,6 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
   auto *Arg = new (Context) ParamDecl(
       SourceLoc(), SourceLoc(), Identifier(), Loc,
       Context.getIdentifier("arg"), /*DC*/ newTopLevel);
-  Arg->setType(E->getType());
   Arg->setInterfaceType(E->getType());
   Arg->setSpecifier(ParamSpecifier::Default);
   auto params = ParameterList::createWithoutLoc(Arg);
@@ -314,7 +313,6 @@ void REPLChecker::processREPLTopLevelExpr(Expr *E) {
   VarDecl *vd = new (Context) VarDecl(/*IsStatic*/false, VarDecl::Introducer::Let,
                                       /*IsCaptureList*/false, E->getStartLoc(),
                                       name, &SF);
-  vd->setType(E->getType());
   vd->setInterfaceType(E->getType());
   SF.Decls.push_back(vd);
 
@@ -390,7 +388,6 @@ void REPLChecker::processREPLTopLevelPatternBinding(PatternBindingDecl *PBD) {
                                         VarDecl::Introducer::Let,
                                         /*IsCaptureList*/false,
                                         PBD->getStartLoc(), name, &SF);
-    vd->setType(pattern->getType());
     vd->setInterfaceType(pattern->getType());
     SF.Decls.push_back(vd);
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -792,7 +792,6 @@ public:
           /*IsStatic*/ false, VarDecl::Introducer::Var,
           /*IsCaptureList*/ false, S->getInLoc(),
           TC.Context.getIdentifier(name), DC);
-      iterator->setType(iteratorTy);
       iterator->setInterfaceType(iteratorTy->mapTypeOutOfContext());
       iterator->setImplicit();
       S->setIteratorVar(iterator);
@@ -1136,7 +1135,7 @@ public:
         }
         assert(isa<CaseStmt>(initialCaseVarDecl->getParentPatternStmt()));
 
-        if (vd->hasType() && initialCaseVarDecl->hasType() &&
+        if (vd->getInterfaceType() && initialCaseVarDecl->getType() &&
             !initialCaseVarDecl->isInvalid() &&
             !vd->getType()->isEqual(initialCaseVarDecl->getType())) {
           TC.diagnose(vd->getLoc(), diag::type_mismatch_multiple_pattern_list,
@@ -1322,8 +1321,6 @@ public:
           if (!prev->hasName() || expected->getName() != prev->getName()) {
             continue;
           }
-          if (prev->hasType())
-            expected->setType(prev->getType());
           if (prev->hasInterfaceType())
             expected->setInterfaceType(prev->getInterfaceType());
           break;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1064,7 +1064,10 @@ public:
 
       // If that failed, mark any variables binding pieces of the pattern
       // as invalid to silence follow-on errors.
-      pattern->forEachVariable([&](VarDecl *VD) { VD->markInvalid(); });
+      pattern->forEachVariable([&](VarDecl *VD) {
+        VD->setInterfaceType(ErrorType::get(TC.Context));
+        VD->setInvalid();
+      });
     }
     labelItem.setPattern(pattern);
 
@@ -1140,8 +1143,11 @@ public:
             !vd->getType()->isEqual(initialCaseVarDecl->getType())) {
           TC.diagnose(vd->getLoc(), diag::type_mismatch_multiple_pattern_list,
                       vd->getType(), initialCaseVarDecl->getType());
-          vd->markInvalid();
-          initialCaseVarDecl->markInvalid();
+          vd->setInterfaceType(ErrorType::get(TC.Context));
+          vd->setInvalid();
+
+          initialCaseVarDecl->setInterfaceType(ErrorType::get(TC.Context));
+          initialCaseVarDecl->setInvalid();
         }
 
         if (initialCaseVarDecl->isLet() == vd->isLet()) {
@@ -1161,8 +1167,11 @@ public:
         if (foundVP)
           diag.fixItReplace(foundVP->getLoc(),
                             initialCaseVarDecl->isLet() ? "let" : "var");
-        vd->markInvalid();
-        initialCaseVarDecl->markInvalid();
+        vd->setInterfaceType(ErrorType::get(TC.Context));
+        vd->setInvalid();
+
+        initialCaseVarDecl->setInterfaceType(ErrorType::get(TC.Context));
+        initialCaseVarDecl->setInvalid();
       }
     });
 
@@ -1229,8 +1238,11 @@ public:
           TC.diagnose(previous->getLoc(),
                       diag::type_mismatch_fallthrough_pattern_list,
                       previous->getType(), expected->getType());
-          previous->markInvalid();
-          expected->markInvalid();
+          previous->setInterfaceType(ErrorType::get(TC.Context));
+          previous->setInvalid();
+
+          expected->setInterfaceType(ErrorType::get(TC.Context));
+          expected->setInvalid();
         }
 
         // Ok, we found our match. Make the previous fallthrough statement var
@@ -1465,7 +1477,8 @@ bool TypeChecker::typeCheckCatchPattern(CatchStmt *S, DeclContext *DC) {
       // before we type-check the guard.  (This will probably kill
       // most of the type-checking, but maybe not.)
       pattern->forEachVariable([&](VarDecl *var) {
-        var->markInvalid();
+        var->setInterfaceType(ErrorType::get(Context));
+        var->setInvalid();
       });
     }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -39,7 +39,7 @@ void swift::setBoundVarsTypeError(Pattern *pattern, ASTContext &ctx) {
   pattern->forEachVariable([&](VarDecl *var) {
     // Don't change the type of a variable that we've been able to
     // compute a type for.
-    if (var->hasType() && !var->getType()->hasError())
+    if (var->hasInterfaceType() && !var->getType()->hasError())
       return;
 
     var->markInvalid();

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2421,7 +2421,7 @@ static void finishProtocolStorageImplInfo(AbstractStorageDecl *storage,
                                           StorageImplInfo &info) {
   if (auto *var = dyn_cast<VarDecl>(storage)) {
     SourceLoc typeLoc;
-    if (auto *repr = var->getTypeRepr())
+    if (auto *repr = var->getTypeReprOrParentPatternTypeRepr())
       typeLoc = repr->getLoc();
     
     if (info.hasStorage()) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -42,7 +42,8 @@ void swift::setBoundVarsTypeError(Pattern *pattern, ASTContext &ctx) {
     if (var->hasInterfaceType() && !var->getType()->hasError())
       return;
 
-    var->markInvalid();
+    var->setInterfaceType(ErrorType::get(var->getASTContext()));
+    var->setInvalid();
   });
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -86,7 +86,7 @@ struct A : P2 {
   func wonka() {}
 }
 let a = A()
-for j in i.wibble(a, a) { // expected-error {{type 'A' does not conform to protocol 'Sequence'}}
+for j in i.wibble(a, a) { // expected-error {{type 'A' does not conform to protocol 'Sequence'}}  expected-error{{variable 'j' is not bound by any pattern}}
 }
 
 // Generic as part of function/tuple types

--- a/test/Constraints/generic_protocol_witness.swift
+++ b/test/Constraints/generic_protocol_witness.swift
@@ -59,5 +59,5 @@ func usesAGenericMethod<U : NeedsAGenericMethod>(_ x: U) {
 struct L<T>: Sequence {} // expected-error {{type 'L<T>' does not conform to protocol 'Sequence'}}
 
 func z(_ x: L<Int>) {
-  for xx in x {}
+  for xx in x {} // expected-error {{variable 'xx' is not bound by any pattern}}
 }

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -316,7 +316,7 @@ struct S22490787 {
 func f22490787() {
   var path: S22490787 = S22490787()
 
-  for p in path {  // expected-error {{type 'S22490787' does not conform to protocol 'Sequence'}}
+  for p in path {  // expected-error {{type 'S22490787' does not conform to protocol 'Sequence'}} expected-error{{variable 'p' is not bound by any pattern}}
   }
 }
 

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -290,7 +290,7 @@ switch staticMembers {
 
   case .init(0): break
   case .init(_): break // expected-error{{'_' can only appear in a pattern}}
-  case .init(let x): break // expected-error{{cannot appear in an expression}}
+  case .init(let x): break // expected-error{{cannot appear in an expression}} expected-error{{variable 'x' is not bound by any pattern}}
   case .init(opt: 0): break // expected-error{{value of optional type 'StaticMembers?' must be unwrapped to a value of type 'StaticMembers'}}
   // expected-note@-1 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
   // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
@@ -302,12 +302,12 @@ switch staticMembers {
   case .method: break // expected-error{{cannot match}}
   case .method(0): break
   case .method(_): break // expected-error{{'_' can only appear in a pattern}}
-  case .method(let x): break // expected-error{{cannot appear in an expression}}
+  case .method(let x): break // expected-error{{cannot appear in an expression}} expected-error{{variable 'x' is not bound by any pattern}}
 
   case .method(withLabel:): break // expected-error{{cannot match}}
   case .method(withLabel: 0): break
   case .method(withLabel: _): break // expected-error{{'_' can only appear in a pattern}}
-  case .method(withLabel: let x): break // expected-error{{cannot appear in an expression}}
+  case .method(withLabel: let x): break // expected-error{{cannot appear in an expression}} expected-error{{variable 'x' is not bound by any pattern}}
 
   case .optMethod: break // expected-error{{cannot match}}
   case .optMethod(0): break

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -311,7 +311,7 @@ class DeducePropertyParams {
 // SR-69
 struct A {}
 func foo() {
-    for i in min(1,2) { // expected-error{{type 'Int' does not conform to protocol 'Sequence'}}
+    for i in min(1,2) { // expected-error{{type 'Int' does not conform to protocol 'Sequence'}} expected-error {{variable 'i' is not bound by any pattern}}
     }
     let j = min(Int(3), Float(2.5)) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
     let k = min(A(), A()) // expected-error{{global function 'min' requires that 'A' conform to 'Comparable'}}

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -616,15 +616,15 @@ struct PatternBindingWithTwoVars1 { var x = 3, y = x }
 // expected-error@-1 {{cannot use instance member 'x' within property initializer; property initializers run before 'self' is available}}
 
 struct PatternBindingWithTwoVars2 { var x = y, y = 3 }
-// expected-error@-1 {{type 'PatternBindingWithTwoVars2' has no member 'y'}}
+// expected-error@-1 {{variable 'y' is not bound by any pattern}}
 
 // This one should be accepted, but for now PatternBindingDecl validation
 // circularity detection is not fine grained enough.
 struct PatternBindingWithTwoVars3 { var x = y, y = x }
-// expected-error@-1 {{type 'PatternBindingWithTwoVars3' has no member 'y'}}
+// expected-error@-1 {{variable 'y' is not bound by any pattern}}
 
 // https://bugs.swift.org/browse/SR-9015
 func sr9015() {
-  let closure1 = { closure2() } // expected-error {{let 'closure1' references itself}}
+  let closure1 = { closure2() } // expected-error {{variable 'closure1' is not bound by any pattern}}
   let closure2 = { closure1() }
 }

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -616,15 +616,15 @@ struct PatternBindingWithTwoVars1 { var x = 3, y = x }
 // expected-error@-1 {{cannot use instance member 'x' within property initializer; property initializers run before 'self' is available}}
 
 struct PatternBindingWithTwoVars2 { var x = y, y = 3 }
-// expected-error@-1 {{variable 'y' is not bound by any pattern}}
+// expected-error@-1 {{type 'PatternBindingWithTwoVars2' has no member 'y'}}
 
 // This one should be accepted, but for now PatternBindingDecl validation
 // circularity detection is not fine grained enough.
 struct PatternBindingWithTwoVars3 { var x = y, y = x }
-// expected-error@-1 {{variable 'y' is not bound by any pattern}}
+// expected-error@-1 {{type 'PatternBindingWithTwoVars3' has no member 'y'}}
 
 // https://bugs.swift.org/browse/SR-9015
 func sr9015() {
-  let closure1 = { closure2() } // expected-error {{variable 'closure1' is not bound by any pattern}}
+  let closure1 = { closure2() } // expected-error {{let 'closure1' references itself}}
   let closure2 = { closure1() }
 }

--- a/test/Parse/EOF/unfinished-for-at-eof.swift
+++ b/test/Parse/EOF/unfinished-for-at-eof.swift
@@ -5,4 +5,5 @@ func fuzz() { for var H
 // expected-error@-2{{expected Sequence expression for for-each loop}}
 // expected-error@-3{{expected '{' to start the body of for-each loop}}
 // expected-note@-4 {{to match this opening '{'}}
+// expected-error@-5 {{variable 'H' is not bound by any pattern}}
 // expected-error@+1{{expected '}' at end of brace statement}}

--- a/test/Parse/enum_element_pattern_swift4.swift
+++ b/test/Parse/enum_element_pattern_swift4.swift
@@ -43,6 +43,7 @@ func testE(e: E) {
                    // expected-note@-1 {{remove associated values to make the pattern match}} {{12-14=}}
     case .D(let payload) = e // expected-error {{pattern with associated values does not match enum case 'D'}}
                              // expected-note@-1 {{remove associated values to make the pattern match}} {{12-25=}}
+                             // expected-error@-2 {{variable 'payload' is not bound by any pattern}}
   else { return }
 }
 

--- a/test/Parse/foreach.swift
+++ b/test/Parse/foreach.swift
@@ -36,5 +36,6 @@ func for_each(r: Range<Int>, iir: IntRange<Int>) { // expected-note {{'r' declar
             // expected-note @-2 {{join the identifiers together with camel-case}}
             // expected-error @-3 {{expected 'in' after for-each pattern}}
             // expected-error @-4 {{expected Sequence expression for for-each loop}}
+            // expected-error @-5 {{variable 'i' is not bound by any pattern}}
   for i in r sum = sum + i; // expected-error{{expected '{' to start the body of for-each loop}}
 }

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -118,8 +118,10 @@ enum Voluntary<T> : Equatable {
 var n : Voluntary<Int> = .Naught
 if case let .Naught(value) = n {} // expected-error{{pattern with associated values does not match enum case 'Naught'}}
                                   // expected-note@-1 {{remove associated values to make the pattern match}} {{20-27=}}
+                                  // expected-error@-2 {{variable 'value' is not bound by any pattern}}
 if case let .Naught(value1, value2, value3) = n {} // expected-error{{pattern with associated values does not match enum case 'Naught'}}
                                                    // expected-note@-1 {{remove associated values to make the pattern match}} {{20-44=}}
+                                                   // expected-error@-2 {{variable 'value1' is not bound by any pattern}}
 
 
 
@@ -282,10 +284,12 @@ case (1, 2, 3):
 case +++(_, var d, 3):
 // expected-error@-1{{'_' can only appear in a pattern or on the left side of an assignment}}
 // expected-error@-2{{'var' binding pattern cannot appear in an expression}}
+// expected-error@-3 {{variable 'd' is not bound by any pattern}}
   ()
 case (_, var e, 3) +++ (1, 2, 3):
 // expected-error@-1{{'_' can only appear in a pattern}}
 // expected-error@-2{{'var' binding pattern cannot appear in an expression}}
+// expected-error@-3 {{variable 'e' is not bound by any pattern}}
   ()
 case (let (_, _, _)) + 1:
 // expected-error@-1 2 {{'var' binding pattern cannot appear in an expression}}
@@ -301,6 +305,7 @@ class Derived : Base { }
 
 switch [Derived(), Derived(), Base()] {
 case let ds as [Derived]: // expected-error{{collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead}}
+  // expected-error@-1 {{variable 'ds' is not bound by any pattern}}
   ()
 case is [Derived]: // expected-error{{collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead}}
   ()

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -152,7 +152,7 @@ func missingControllingExprInFor() {
   for ; true { // expected-error {{C-style for statement has been removed in Swift 3}}
   }
 
-  for var i = 0; true { // expected-error {{C-style for statement has been removed in Swift 3}}
+  for var i = 0; true { // expected-error {{C-style for statement has been removed in Swift 3}} expected-error{{variable 'i' is not bound by any pattern}}
     i += 1
   }
 }
@@ -174,11 +174,13 @@ func missingControllingExprInForEach() {
   {
   }
 
+  // expected-error @+3 {{variable 'i' is not bound by any pattern}}
   // expected-error @+2 {{expected 'in' after for-each pattern}}
   // expected-error @+1 {{expected Sequence expression for for-each loop}}
   for i {
   }
 
+  // expected-error @+3 {{variable 'i' is not bound by any pattern}}
   // expected-error @+2 {{expected 'in' after for-each pattern}}
   // expected-error @+1 {{expected Sequence expression for for-each loop}}
   for var i {
@@ -199,6 +201,7 @@ func missingControllingExprInForEach() {
   for for in {
   }
 
+  // expected-error @+1 {{variable 'i' is not bound by any pattern}}
   for i in { // expected-error {{expected Sequence expression for for-each loop}}
   }
 

--- a/test/Parse/toplevel_library_invalid.swift
+++ b/test/Parse/toplevel_library_invalid.swift
@@ -10,6 +10,7 @@ x + x; // expected-error {{expressions are not allowed at the top level}} expect
 // expected-warning @-1 {{result of call to closure returning 'Int' is unused}}
 
 
+// expected-error @+4 {{variable 'i' is not bound by any pattern}}
 // expected-error @+3 {{expected 'in' after for-each pattern}}
 // expected-error @+2 {{expected Sequence expression for for-each loop}}
 // expected-error @+1 {{expected '{' to start the body of for-each loop}}

--- a/test/Sema/editor_placeholders.swift
+++ b/test/Sema/editor_placeholders.swift
@@ -27,4 +27,5 @@ f(<#T##Int#>) // expected-error{{editor placeholder in source file}}
 f(<#T##String#>) // expected-error{{editor placeholder in source file}} expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
 
 for x in <#T#> { // expected-error{{editor placeholder in source file}} expected-error{{type '()' does not conform to protocol 'Sequence'}}
+  // expected-error@-1{{variable 'x' is not bound by any pattern}}
 }

--- a/test/SourceKit/Sema/placeholders.swift.placeholders.response
+++ b/test/SourceKit/Sema/placeholders.swift.placeholders.response
@@ -16,6 +16,14 @@
   },
   {
     key.line: 4,
+    key.column: 7,
+    key.filepath: placeholders.swift,
+    key.severity: source.diagnostic.severity.error,
+    key.description: "variable '<#name#>' is not bound by any pattern",
+    key.diagnostic_stage: source.diagnostic.stage.swift.sema
+  },
+  {
+    key.line: 4,
     key.column: 19,
     key.filepath: placeholders.swift,
     key.severity: source.diagnostic.severity.error,

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -604,6 +604,7 @@ func keypath_with_incorrect_return_type(_ arr: Lens<Array<Int>>) {
     // expected-error@-2 {{operator function '..<' requires that 'Lens<Int>.Stride' conform to 'SignedInteger'}}
     // expected-error@-3 {{cannot convert value of type 'Int' to expected argument type 'Lens<Int>'}}
     // expected-error@-4 {{referencing operator function '..<' on 'Comparable' requires that 'Lens<Int>' conform to 'Comparable'}}
+    // expected-error@-5 {{variable 'idx' is not bound by any pattern}}
     let _ = arr[idx]
   }
 }

--- a/test/decl/init/nil.swift
+++ b/test/decl/init/nil.swift
@@ -10,8 +10,6 @@ var b: () -> Void = nil
 
 var c, d: Int = nil
 // expected-error@-1 {{type annotation missing in pattern}}
-// expected-error@-2 {{'nil' cannot initialize specified type 'Int'}}
-// expected-note@-3 {{add '?' to form the optional type 'Int?'}} {{14-14=?}}
 
 var (e, f): (Int, Int) = nil
 // expected-error@-1 {{'nil' cannot initialize specified type '(Int, Int)'}}

--- a/test/decl/protocol/conforms/circular_validation.swift
+++ b/test/decl/protocol/conforms/circular_validation.swift
@@ -10,6 +10,7 @@ protocol P {
 struct S : P { // expected-error {{type 'S' does not conform to protocol 'P'}}
   static var x = 0 // expected-note {{candidate operates on a type, not an instance as required}}
   var x = S.x // expected-note {{candidate references itself}}
+  // expected-error@-1 {{variable 'x' is not bound by any pattern}}
 }
 
 // FIXME: Lousy diagnostics on this case.

--- a/test/decl/protocol/conforms/circular_validation.swift
+++ b/test/decl/protocol/conforms/circular_validation.swift
@@ -10,7 +10,6 @@ protocol P {
 struct S : P { // expected-error {{type 'S' does not conform to protocol 'P'}}
   static var x = 0 // expected-note {{candidate operates on a type, not an instance as required}}
   var x = S.x // expected-note {{candidate references itself}}
-  // expected-error@-1 {{variable 'x' is not bound by any pattern}}
 }
 
 // FIXME: Lousy diagnostics on this case.

--- a/test/decl/var/overload_cycle.swift
+++ b/test/decl/var/overload_cycle.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+// Validating the pattern binding initializer for `raw` causes recursive
+// validation of the VarDecl. Overload resolution relies on getting back an
+// ErrorType from VarDecl validation to disqualify the recursive candidate.
+public struct Cyclic {
+  static func pickMe(please: Bool) -> Int { return 42 }
+  public static let pickMe = Cyclic.pickMe(please: true)
+}

--- a/test/decl/var/overload_cycle.swift
+++ b/test/decl/var/overload_cycle.swift
@@ -1,9 +1,0 @@
-// RUN: %target-typecheck-verify-swift
-
-// Validating the pattern binding initializer for `raw` causes recursive
-// validation of the VarDecl. Overload resolution relies on getting back an
-// ErrorType from VarDecl validation to disqualify the recursive candidate.
-public struct Cyclic {
-  static func pickMe(please: Bool) -> Int { return 42 }
-  public static let pickMe = Cyclic.pickMe(please: true)
-}

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -66,7 +66,7 @@ class SomeClass {}
 weak let V = SomeClass()  // expected-error {{'weak' must be a mutable variable, because it may change at runtime}}
 
 let a = b ; let b = a
-// expected-error@-1 {{let 'a' references itself}}
+// expected-error@-1 {{variable 'a' is not bound by any pattern}}
 
 // <rdar://problem/17501765> Swift should warn about immutable default initialized values
 let uselessValue : String?

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -66,7 +66,7 @@ class SomeClass {}
 weak let V = SomeClass()  // expected-error {{'weak' must be a mutable variable, because it may change at runtime}}
 
 let a = b ; let b = a
-// expected-error@-1 {{variable 'a' is not bound by any pattern}}
+// expected-error@-1 {{let 'a' references itself}}
 
 // <rdar://problem/17501765> Swift should warn about immutable default initialized values
 let uselessValue : String?

--- a/test/stmt/c_style_for.swift
+++ b/test/stmt/c_style_for.swift
@@ -2,27 +2,35 @@
 
 for var i = 0; i < 10; i++ {}
 // expected-error @-1 {{C-style for statement has been removed in Swift 3}}  {{none}}
+// expected-error @-2 {{variable 'i' is not bound by any pattern}}
 
 for var i = 0; i < 10; i += 1 {}
 // expected-error @-1 {{C-style for statement has been removed in Swift 3}}  {{none}}
+// expected-error @-2 {{variable 'i' is not bound by any pattern}}
 
 for var i = 0; i <= 10; i++ {}
 // expected-error @-1 {{C-style for statement has been removed in Swift 3}}  {{none}}
+// expected-error @-2 {{variable 'i' is not bound by any pattern}}
 
 for var i = 0; i <= 10; i += 1 {}
 // expected-error @-1 {{C-style for statement has been removed in Swift 3}}  {{none}}
+// expected-error @-2 {{variable 'i' is not bound by any pattern}}
 
 for var i = 10; i > 0; i-- {}
 // expected-error @-1 {{C-style for statement has been removed in Swift 3}}  {{none}}
+// expected-error @-2 {{variable 'i' is not bound by any pattern}}
 
 for var i = 10; i > 0; i -= 1 {}
 // expected-error @-1 {{C-style for statement has been removed in Swift 3}}  {{none}}
+// expected-error @-2 {{variable 'i' is not bound by any pattern}}
 
 for var i = 10; i >= 0; i-- {}
 // expected-error @-1 {{C-style for statement has been removed in Swift 3}}  {{none}}
+// expected-error @-2 {{variable 'i' is not bound by any pattern}}
 
 for var i = 10; i >= 0; i -= 1 {}
 // expected-error @-1 {{C-style for statement has been removed in Swift 3}}  {{none}}
+// expected-error @-2 {{variable 'i' is not bound by any pattern}}
 
 let start = Int8(4)
 let count = Int8(10)

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -6,6 +6,7 @@ struct BadContainer1 {
 
 func bad_containers_1(bc: BadContainer1) {
   for e in bc { } // expected-error{{type 'BadContainer1' does not conform to protocol 'Sequence'}}
+  // expected-error@-1{{variable 'e' is not bound by any pattern}}
 }
 
 struct BadContainer2 : Sequence { // expected-error{{type 'BadContainer2' does not conform to protocol 'Sequence'}}
@@ -14,6 +15,7 @@ struct BadContainer2 : Sequence { // expected-error{{type 'BadContainer2' does n
 
 func bad_containers_2(bc: BadContainer2) {
   for e in bc { }
+  // expected-error@-1{{variable 'e' is not bound by any pattern}}
 }
 
 struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does not conform to protocol 'Sequence'}}
@@ -22,6 +24,7 @@ struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does n
 
 func bad_containers_3(bc: BadContainer3) {
   for e in bc { }
+  // expected-error@-1{{variable 'e' is not bound by any pattern}}
 }
 
 struct BadIterator1 {}
@@ -33,6 +36,7 @@ struct BadContainer4 : Sequence { // expected-error{{type 'BadContainer4' does n
 
 func bad_containers_4(bc: BadContainer4) {
   for e in bc { }
+  // expected-error@-1{{variable 'e' is not bound by any pattern}}
 }
 
 // Pattern type-checking
@@ -126,6 +130,7 @@ func testForEachInference() {
 
   // Overloaded sequence not resolved contextually
   for v in getOvlSeq() { } // expected-error{{ambiguous use of 'getOvlSeq()'}}
+  // expected-error@-1{{variable 'v' is not bound by any pattern}}
 
   // Generic sequence resolved contextually
   for i: Int in getGenericSeq() { }
@@ -174,12 +179,14 @@ func testOptionalSequence() {
   for x in array {  // expected-error {{value of optional type '[Int]?' must be unwrapped}}
     // expected-note@-1{{coalesce}}
     // expected-note@-2{{force-unwrap}}
+    // expected-error@-3{{variable 'x' is not bound by any pattern}}
   }
 }
 
 // Crash with (invalid) for each over an existential
 func testExistentialSequence(s: Sequence) { // expected-error {{protocol 'Sequence' can only be used as a generic constraint because it has Self or associated type requirements}}
   for x in s { // expected-error {{value of protocol type 'Sequence' cannot conform to 'Sequence'; only struct/enum/class types can conform to protocols}}
+    // expected-error@-1{{variable 'x' is not bound by any pattern}}
     _ = x
   }
 }

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -30,7 +30,9 @@ guard let _ = nonOptionalStruct() else { fatalError() } // expected-error{{initi
 guard let _ = nonOptionalEnum() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
 
 if case let x? = nonOptionalStruct() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalStruct'}}
+// expected-error@-1{{variable 'x' is not bound by any pattern}}
 if case let x? = nonOptionalEnum() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalEnum'}}
+// expected-error@-1{{variable 'x' is not bound by any pattern}}
 
 class B {} // expected-note * {{did you mean 'B'?}}
 class D : B {}// expected-note * {{did you mean 'D'?}}
@@ -64,6 +66,7 @@ if var x = opt {} // expected-warning {{value 'x' was defined but never used; co
 let someInteger = 1
 if let y = someInteger {}  // expected-error {{initializer for conditional binding must have Optional type, not 'Int'}}
 if case let y? = someInteger {}  // expected-error {{'?' pattern cannot match values of type 'Int'}}
+// expected-error@-1{{variable 'y' is not bound by any pattern}}
 
 // Test multiple clauses on "if let".
 if let x = opt, let y = opt, x != y,


### PR DESCRIPTION
This is an amalgam of simplifications to the way VarDecls are checked
and assigned interface types.

First, remove TypeCheckPattern's ability to assign the interface and
contextual types for a given var decl.  Instead, replace it with the
notion of a "naming pattern".  This is the pattern that semantically
binds a given VarDecl into scope, and whose type will be used to compute
the interface type. Note that not all VarDecls have a naming pattern
because they may not be canonical.

Second, remove VarDecl's separate contextual type member, and force the
contextual type to be computed the way it always was: by mapping the
interface type into the parent decl context.

Third, introduce a catch-all diagnostic to properly handle the change in
the way that circularity checking occurs.  This is also motivated by
TypeCheckPattern not being principled about which parts of the AST it
chooses to invalidate, especially the parent pattern and naming patterns
for a given VarDecl.  Once VarDecls are invalidated along with their
parent patterns, a large amount of this diagnostic churn can disappear.
Unfortunately, if this isn't here, we will fail to catch a number of
obviously circular cases and fail to emit a diagnostic.