### PR TITLE
[AutoDiff] Add `@differentiable` attribute SILGen assertion.

### DIFF
--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -86,10 +86,7 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
     for (auto *A : Attrs.getAttributes<DifferentiableAttr>()) {
       // Get lowered argument indices.
       auto *paramIndices = A->getParameterIndices();
-      // NOTE: If `A->getParameterIndices()` is `nullptr`, continue. This is a
-      // necessary hack regarding deserialization.
-      if (!paramIndices)
-        continue;
+      assert(paramIndices && "Parameter indices should have been resolved");
       auto *loweredParamIndices = autodiff::getLoweredParameterIndices(
           paramIndices, decl->getInterfaceType()->castTo<AnyFunctionType>());
       SILAutoDiffIndices indices(/*source*/ 0, loweredParamIndices);


### PR DESCRIPTION
Previously, `@differentiable` attribute SILGen lowering was skipped if the
attribute did not have resolved parameter indices. This led to unexpected
and difficult-to-debug bugs like [TF-888](https://bugs.swift.org/browse/TF-888).

Re-add the assertion for robustness; I suspect this may be possible after
https://github.com/apple/swift/pull/27613.