### PR TITLE
[AutoDiff] [ASTGen] Check for 'linear' when generating 'AttributedTypeRepr'.

### DIFF
--- a/lib/Parse/ASTGen.cpp
+++ b/lib/Parse/ASTGen.cpp
@@ -240,6 +240,13 @@ TypeRepr *ASTGen::generate(const AttributedTypeSyntax &Type,
         TypeAttrs.convention = Convention.str();
       }
 
+      // SWIFT_ENABLE_TENSORFLOW
+      if (AttrKind == TAK_differentiable && Attr.getArgument()) {
+        auto Argument = Attr.getArgument()->castTo<TokenSyntax>();
+        auto Linear = Context.getIdentifier(Argument.getIdentifierText());
+        TypeAttrs.linear = Linear.is("linear");
+      }
+
       if (AttrKind == TAK_opened) {
         auto AttrText = Attr.getArgument()->castTo<TokenSyntax>().getText();
         auto LiteralText = AttrText.slice(1, AttrText.size() - 1);

--- a/test/AutoDiff/differentiable_sil_function_type_parse.sil
+++ b/test/AutoDiff/differentiable_sil_function_type_parse.sil
@@ -34,3 +34,13 @@ bb0:
   %ret = tuple ()
   return %ret : $()
 }
+
+sil @takeAndReturnLinear : $@convention(thin) (@differentiable(linear) (Float) -> Float) -> @differentiable(linear) (Float) -> Float {
+bb0(%0 : $@differentiable(linear) (Float) -> Float):
+  return %0 : $@differentiable(linear) (Float) -> Float
+}
+
+// CHECK-LABEL: sil @takeAndReturnLinear : $@convention(thin) (@differentiable(linear) (Float) -> Float) -> @differentiable(linear) (Float) -> Float {
+// CHECK: bb0([[ARG:%.*]] : $@differentiable(linear) (Float) -> Float):
+// CHECK:   return [[ARG]] : $@differentiable(linear) (Float) -> Float
+// CHECK: }


### PR DESCRIPTION
ASTGen did not know how to handle `@differentiable(linear)`, which caused parsed `@differentiable(linear)` function types to lose the "linear" bit when they are an argument or a result in a SIL function's type signature. This patch teaches ASTGen to check for `linear` in `TypeAttributes` when generating AST.

Resolves [TF-901](https://bugs.swift.org/browse/TF-901).