### PR TITLE
[AutoDiff] [IRGen] Lower `@differentiable(linear)` function types.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -39,10 +39,22 @@ class SILFunctionType;
 typedef CanTypeWrapper<SILFunctionType> CanSILFunctionType;
 enum class SILLinkage : uint8_t;
 
-enum class DifferentiabilityKind: uint8_t {
+enum class DifferentiabilityKind : uint8_t {
   NonDifferentiable = 0b00,
   Normal = 0b01,
   Linear = 0b11
+};
+
+// TODO(TF-904): Replace `DifferentiableFunctionExtractInst::Extractee`.
+enum class NormalDifferentiableFunctionTypeComponent : uint8_t {
+  Original = 0,
+  JVP = 1,
+  VJP = 2
+};
+
+enum class LinearDifferentiableFunctionTypeComponent : uint8_t {
+  Original = 0,
+  Transpose = 1
 };
 
 class ParsedAutoDiffParameter {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4220,11 +4220,16 @@ public:
 
   CanSILFunctionType getWithoutDifferentiability();
 
-  /// Returns the type of a differentiation function that is associated with
-  /// a function of this type.
+  /// Returns the type of the derivative function.
   CanSILFunctionType getAutoDiffDerivativeFunctionType(
       IndexSubset *parameterIndices, unsigned resultIndex,
       AutoDiffDerivativeFunctionKind kind, Lowering::TypeConverter &TC,
+      LookupConformanceFn lookupConformance,
+      CanGenericSignature derivativeFunctionGenericSignature = nullptr);
+
+  /// Returns the type of the transpose function.
+  CanSILFunctionType getAutoDiffTransposeFunctionType(
+      IndexSubset *parameterIndices, Lowering::TypeConverter &TC,
       LookupConformanceFn lookupConformance,
       CanGenericSignature derivativeFunctionGenericSignature = nullptr);
 

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -37,7 +37,8 @@ using namespace irgen;
 // `@differentiable` (non-linear) function type info
 //----------------------------------------------------------------------------//
 namespace {
-class DifferentiableFuncFieldInfo final : public RecordField<DifferentiableFuncFieldInfo> {
+class DifferentiableFuncFieldInfo final
+    : public RecordField<DifferentiableFuncFieldInfo> {
 public:
   DifferentiableFuncFieldInfo(
       DifferentiableFunctionExtractee component, const TypeInfo &type,

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -480,8 +480,14 @@ Address irgen::projectBlockStorageCapture(IRGenFunction &IGF,
 
 const TypeInfo *TypeConverter::convertFunctionType(SILFunctionType *T) {
   // SWIFT_ENABLE_TENSORFLOW
-  if (T->isDifferentiable())
-    return convertDifferentiableFunctionType(T);
+  switch (T->getDifferentiabilityKind()) {
+  case DifferentiabilityKind::Normal:
+    return convertNormalDifferentiableFunctionType(T);
+  case DifferentiabilityKind::Linear:
+    return convertLinearDifferentiableFunctionType(T);
+  case DifferentiabilityKind::NonDifferentiable:
+    break;
+  }
 
   switch (T->getRepresentation()) {
   case SILFunctionType::Representation::Block:

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -138,7 +138,8 @@ private:
   const TypeInfo *convertStructType(TypeBase *key, CanType type, StructDecl *D);
   const TypeInfo *convertFunctionType(SILFunctionType *T);
   // SWIFT_ENABLE_TENSORFLOW
-  const TypeInfo *convertDifferentiableFunctionType(SILFunctionType *T);
+  const TypeInfo *convertNormalDifferentiableFunctionType(SILFunctionType *T);
+  const TypeInfo *convertLinearDifferentiableFunctionType(SILFunctionType *T);
   const TypeInfo *convertBlockStorageType(SILBlockStorageType *T);
   const TypeInfo *convertBoxType(SILBoxType *T);
   const TypeInfo *convertArchetypeType(ArchetypeType *T);

--- a/test/AutoDiff/differentiable_func_type.sil
+++ b/test/AutoDiff/differentiable_func_type.sil
@@ -19,7 +19,7 @@ bb0(%0 : $@differentiable(linear) (Float) -> Float):
 // CHECK-SIL:   return [[ARG]] : $@differentiable(linear) (Float) -> Float
 // CHECK-SIL: }
 
-// CHECK-LLVM-LABEL: define {{.*}} swiftcc { i8*, %swift.refcounted*, i8*, %swift.refcounted* } @takeAndReturnLinear(i8*, %swift.refcounted*, i8*, %swift.refcounted*) #0 {
+// CHECK-LLVM-LABEL: define{{.*}} swiftcc { i8*, %swift.refcounted*, i8*, %swift.refcounted* } @takeAndReturnLinear(i8*, %swift.refcounted*, i8*, %swift.refcounted*) #0 {
 // CHECK-LLVM: entry:
 // CHECK-LLVM:   %4 = insertvalue { i8*, %swift.refcounted*, i8*, %swift.refcounted* } undef, i8* %0, 0
 // CHECK-LLVM:   %5 = insertvalue { i8*, %swift.refcounted*, i8*, %swift.refcounted* } %4, %swift.refcounted* %1, 1
@@ -39,7 +39,7 @@ bb0(%0 : $@differentiable (Float) -> Float):
 // CHECK-SIL:   return [[ARG]] : $@differentiable (Float) -> Float
 // CHECK-SIL: }
 
-// CHECK-LLVM-LABEL: define {{.*}} swiftcc void @takeAndReturnDifferentiable(<{ %swift.function, %swift.function, %swift.function }>* noalias nocapture sret, <{ %swift.function, %swift.function, %swift.function }>* noalias nocapture dereferenceable(48)) #0 {
+// CHECK-LLVM-LABEL: define{{.*}} swiftcc void @takeAndReturnDifferentiable(<{ %swift.function, %swift.function, %swift.function }>* noalias nocapture sret, <{ %swift.function, %swift.function, %swift.function }>* noalias nocapture dereferenceable(48)) #0 {
 // CHECK-LLVM: entry:
 // CHECK-LLVM:   %.original = getelementptr inbounds <{ %swift.function, %swift.function, %swift.function }>, <{ %swift.function, %swift.function, %swift.function }>* %1, i32 0, i32 0
 // CHECK-LLVM:   %.original.fn = getelementptr inbounds %swift.function, %swift.function* %.original, i32 0, i32 0

--- a/test/AutoDiff/differentiable_func_type.sil
+++ b/test/AutoDiff/differentiable_func_type.sil
@@ -19,7 +19,7 @@ bb0(%0 : $@differentiable(linear) (Float) -> Float):
 // CHECK-SIL:   return [[ARG]] : $@differentiable(linear) (Float) -> Float
 // CHECK-SIL: }
 
-// CHECK-LLVM-LABEL: define swiftcc { i8*, %swift.refcounted*, i8*, %swift.refcounted* } @takeAndReturnLinear(i8*, %swift.refcounted*, i8*, %swift.refcounted*) #0 {
+// CHECK-LLVM-LABEL: define {{.*}} swiftcc { i8*, %swift.refcounted*, i8*, %swift.refcounted* } @takeAndReturnLinear(i8*, %swift.refcounted*, i8*, %swift.refcounted*) #0 {
 // CHECK-LLVM: entry:
 // CHECK-LLVM:   %4 = insertvalue { i8*, %swift.refcounted*, i8*, %swift.refcounted* } undef, i8* %0, 0
 // CHECK-LLVM:   %5 = insertvalue { i8*, %swift.refcounted*, i8*, %swift.refcounted* } %4, %swift.refcounted* %1, 1
@@ -39,7 +39,7 @@ bb0(%0 : $@differentiable (Float) -> Float):
 // CHECK-SIL:   return [[ARG]] : $@differentiable (Float) -> Float
 // CHECK-SIL: }
 
-// CHECK-LLVM-LABEL: define swiftcc void @takeAndReturnDifferentiable(<{ %swift.function, %swift.function, %swift.function }>* noalias nocapture sret, <{ %swift.function, %swift.function, %swift.function }>* noalias nocapture dereferenceable(48)) #0 {
+// CHECK-LLVM-LABEL: define {{.*}} swiftcc void @takeAndReturnDifferentiable(<{ %swift.function, %swift.function, %swift.function }>* noalias nocapture sret, <{ %swift.function, %swift.function, %swift.function }>* noalias nocapture dereferenceable(48)) #0 {
 // CHECK-LLVM: entry:
 // CHECK-LLVM:   %.original = getelementptr inbounds <{ %swift.function, %swift.function, %swift.function }>, <{ %swift.function, %swift.function, %swift.function }>* %1, i32 0, i32 0
 // CHECK-LLVM:   %.original.fn = getelementptr inbounds %swift.function, %swift.function* %.original, i32 0, i32 0

--- a/test/AutoDiff/differentiable_func_type.sil
+++ b/test/AutoDiff/differentiable_func_type.sil
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name differentiable_func_type
 // RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name differentiable_func_type
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name differentiable_func_type | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name differentiable_func_type | %FileCheck %s -check-prefix=CHECK-SIL
+
+// RUN: %target-swift-frontend %s -emit-ir -module-name differentiable_func_type | %FileCheck %s -check-prefix=CHECK-LLVM
 
 sil_stage raw
 
@@ -13,9 +15,18 @@ bb0(%0 : $@differentiable(linear) (Float) -> Float):
 }
 
 // CHECK-LABEL: sil @takeAndReturnLinear : $@convention(thin) (@differentiable(linear) (Float) -> Float) -> @differentiable(linear) (Float) -> Float {
-// CHECK: bb0([[ARG:%.*]] : $@differentiable(linear) (Float) -> Float):
-// CHECK:   return [[ARG]] : $@differentiable(linear) (Float) -> Float
-// CHECK: }
+// CHECK-SIL: bb0([[ARG:%.*]] : $@differentiable(linear) (Float) -> Float):
+// CHECK-SIL:   return [[ARG]] : $@differentiable(linear) (Float) -> Float
+// CHECK-SIL: }
+
+// CHECK-LLVM-LABEL: define swiftcc { i8*, %swift.refcounted*, i8*, %swift.refcounted* } @takeAndReturnLinear(i8*, %swift.refcounted*, i8*, %swift.refcounted*) #0 {
+// CHECK-LLVM: entry:
+// CHECK-LLVM:   %4 = insertvalue { i8*, %swift.refcounted*, i8*, %swift.refcounted* } undef, i8* %0, 0
+// CHECK-LLVM:   %5 = insertvalue { i8*, %swift.refcounted*, i8*, %swift.refcounted* } %4, %swift.refcounted* %1, 1
+// CHECK-LLVM:   %6 = insertvalue { i8*, %swift.refcounted*, i8*, %swift.refcounted* } %5, i8* %2, 2
+// CHECK-LLVM:   %7 = insertvalue { i8*, %swift.refcounted*, i8*, %swift.refcounted* } %6, %swift.refcounted* %3, 3
+// CHECK-LLVM:   ret { i8*, %swift.refcounted*, i8*, %swift.refcounted* } %7
+// CHECK-LLVM: }
 
 
 sil @takeAndReturnDifferentiable : $@convention(thin) (@differentiable (Float) -> Float) -> @differentiable (Float) -> Float {
@@ -24,6 +35,41 @@ bb0(%0 : $@differentiable (Float) -> Float):
 }
 
 // CHECK-LABEL: sil @takeAndReturnDifferentiable : $@convention(thin) (@differentiable (Float) -> Float) -> @differentiable (Float) -> Float {
-// CHECK: bb0([[ARG:%.*]] : $@differentiable (Float) -> Float):
-// CHECK:   return [[ARG]] : $@differentiable (Float) -> Float
-// CHECK: }
+// CHECK-SIL: bb0([[ARG:%.*]] : $@differentiable (Float) -> Float):
+// CHECK-SIL:   return [[ARG]] : $@differentiable (Float) -> Float
+// CHECK-SIL: }
+
+// CHECK-LLVM-LABEL: define swiftcc void @takeAndReturnDifferentiable(<{ %swift.function, %swift.function, %swift.function }>* noalias nocapture sret, <{ %swift.function, %swift.function, %swift.function }>* noalias nocapture dereferenceable(48)) #0 {
+// CHECK-LLVM: entry:
+// CHECK-LLVM:   %.original = getelementptr inbounds <{ %swift.function, %swift.function, %swift.function }>, <{ %swift.function, %swift.function, %swift.function }>* %1, i32 0, i32 0
+// CHECK-LLVM:   %.original.fn = getelementptr inbounds %swift.function, %swift.function* %.original, i32 0, i32 0
+// CHECK-LLVM:   %2 = load i8*, i8** %.original.fn, align 8
+// CHECK-LLVM:   %.original.data = getelementptr inbounds %swift.function, %swift.function* %.original, i32 0, i32 1
+// CHECK-LLVM:   %3 = load %swift.refcounted*, %swift.refcounted** %.original.data, align 8
+// CHECK-LLVM:   %.jvp = getelementptr inbounds <{ %swift.function, %swift.function, %swift.function }>, <{ %swift.function, %swift.function, %swift.function }>* %1, i32 0, i32 1
+// CHECK-LLVM:   %.jvp.fn = getelementptr inbounds %swift.function, %swift.function* %.jvp, i32 0, i32 0
+// CHECK-LLVM:   %4 = load i8*, i8** %.jvp.fn, align 8
+// CHECK-LLVM:   %.jvp.data = getelementptr inbounds %swift.function, %swift.function* %.jvp, i32 0, i32 1
+// CHECK-LLVM:   %5 = load %swift.refcounted*, %swift.refcounted** %.jvp.data, align 8
+// CHECK-LLVM:   %.vjp = getelementptr inbounds <{ %swift.function, %swift.function, %swift.function }>, <{ %swift.function, %swift.function, %swift.function }>* %1, i32 0, i32 2
+// CHECK-LLVM:   %.vjp.fn = getelementptr inbounds %swift.function, %swift.function* %.vjp, i32 0, i32 0
+// CHECK-LLVM:   %6 = load i8*, i8** %.vjp.fn, align 8
+// CHECK-LLVM:   %.vjp.data = getelementptr inbounds %swift.function, %swift.function* %.vjp, i32 0, i32 1
+// CHECK-LLVM:   %7 = load %swift.refcounted*, %swift.refcounted** %.vjp.data, align 8
+// CHECK-LLVM:   %.original1 = getelementptr inbounds <{ %swift.function, %swift.function, %swift.function }>, <{ %swift.function, %swift.function, %swift.function }>* %0, i32 0, i32 0
+// CHECK-LLVM:   %.original1.fn = getelementptr inbounds %swift.function, %swift.function* %.original1, i32 0, i32 0
+// CHECK-LLVM:   store i8* %2, i8** %.original1.fn, align 8
+// CHECK-LLVM:   %.original1.data = getelementptr inbounds %swift.function, %swift.function* %.original1, i32 0, i32 1
+// CHECK-LLVM:   store %swift.refcounted* %3, %swift.refcounted** %.original1.data, align 8
+// CHECK-LLVM:   %.jvp2 = getelementptr inbounds <{ %swift.function, %swift.function, %swift.function }>, <{ %swift.function, %swift.function, %swift.function }>* %0, i32 0, i32 1
+// CHECK-LLVM:   %.jvp2.fn = getelementptr inbounds %swift.function, %swift.function* %.jvp2, i32 0, i32 0
+// CHECK-LLVM:   store i8* %4, i8** %.jvp2.fn, align 8
+// CHECK-LLVM:   %.jvp2.data = getelementptr inbounds %swift.function, %swift.function* %.jvp2, i32 0, i32 1
+// CHECK-LLVM:   store %swift.refcounted* %5, %swift.refcounted** %.jvp2.data, align 8
+// CHECK-LLVM:   %.vjp3 = getelementptr inbounds <{ %swift.function, %swift.function, %swift.function }>, <{ %swift.function, %swift.function, %swift.function }>* %0, i32 0, i32 2
+// CHECK-LLVM:   %.vjp3.fn = getelementptr inbounds %swift.function, %swift.function* %.vjp3, i32 0, i32 0
+// CHECK-LLVM:   store i8* %6, i8** %.vjp3.fn, align 8
+// CHECK-LLVM:   %.vjp3.data = getelementptr inbounds %swift.function, %swift.function* %.vjp3, i32 0, i32 1
+// CHECK-LLVM:   store %swift.refcounted* %7, %swift.refcounted** %.vjp3.data, align 8
+// CHECK-LLVM:   ret void
+// CHECK-LLVM: }


### PR DESCRIPTION
This patch adds support for lowering `@differentiable(linear)` function types to LLVM IR.

* Add `SILFunctionType` transpose type calculation utility: `SILFunctionType:: getAutoDiffTransposeFunctionType`.
* Refactor `TypeClassifierBase` methods used for computing recursive properties of `@differentiable` function types and eliminated the need for repeatedly checking differentiability kind.
* Add `LinearDifferentiableSILFunctionTypeLowering`. Rename the original `DifferentiableSILFunctionTypeLowering` to `NormalDifferentiableSILFunctionTypeLowering` to make clear it's not for linear functions.
* Add `TypeConverter::convertLinearDifferentiableFunctionType`. Rename the original `TypeConverter::convertDifferentiableFunctionType` to `TypeConverter::convertNormalDifferentiableFunctionType` to make clear it's not for linear functions.

Resolves [TF-902](https://bugs.swift.org/browse/TF-902).