### PR TITLE
DeadStoreElimination: don't require values stored back to memory if the control flow ends in an unreachable

### DIFF
--- a/include/swift/SIL/MemoryLifetime.h
+++ b/include/swift/SIL/MemoryLifetime.h
@@ -22,6 +22,16 @@
 
 namespace swift {
 
+void printBitsAsArray(llvm::raw_ostream &OS, const SmallBitVector &bits);
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                                     const SmallBitVector &bits) {
+  printBitsAsArray(OS, bits);
+  return OS;
+}
+
+void dumpBits(const SmallBitVector &bits);
+
 /// The MemoryLocations utility provides functions to analyze memory locations.
 ///
 /// Memory locations are limited to addresses which are guaranteed to

--- a/lib/SIL/MemoryLifetime.cpp
+++ b/lib/SIL/MemoryLifetime.cpp
@@ -28,16 +28,8 @@ llvm::cl::opt<bool> DontAbortOnMemoryLifetimeErrors(
     llvm::cl::desc("Don't abort compliation if the memory lifetime checker "
                    "detects an error."));
 
-namespace swift {
-namespace {
-
-//===----------------------------------------------------------------------===//
-//                            Utility functions
-//===----------------------------------------------------------------------===//
-
 /// Debug dump a location bit vector.
-llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                              const SmallBitVector &bits) {
+void swift::printBitsAsArray(llvm::raw_ostream &OS, const SmallBitVector &bits) {
   const char *separator = "";
   OS << '[';
   for (int idx = bits.find_first(); idx >= 0; idx = bits.find_next(idx)) {
@@ -45,8 +37,18 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
     separator = ",";
   }
   OS << ']';
-  return OS;
 }
+
+void swift::dumpBits(const SmallBitVector &bits) {
+  llvm::dbgs() << bits << '\n';
+}
+
+namespace swift {
+namespace {
+
+//===----------------------------------------------------------------------===//
+//                            Utility functions
+//===----------------------------------------------------------------------===//
 
 /// Enlarge the bitset if needed to set the bit with \p idx.
 static void setBitAndResize(SmallBitVector &bits, unsigned idx) {
@@ -238,10 +240,6 @@ void MemoryLocations::dump() const {
                  << ": " << loc.representativeValue;
     idx++;
   }
-}
-
-void MemoryLocations::dumpBits(const Bits &bits) {
-  llvm::errs() << bits << '\n';
 }
 
 void MemoryLocations::clear() {

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -60,6 +60,7 @@
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/MemoryLifetime.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -269,6 +270,8 @@ public:
     init(LocationNum, Optimistic);
   }
 
+  void dump();
+
   /// Initialize the bitvectors for the current basic block.
   void init(unsigned LocationNum, bool Optimistic);
 
@@ -448,6 +451,8 @@ public:
              llvm::SpecificBumpPtrAllocator<BlockState> &BPA) 
     : Mod(M), F(F), PM(PM), AA(AA), TE(TE), EAFI(EAFI), BPA(BPA) {}
 
+  void dump();
+
   /// Entry point for dead store elimination.
   bool run();
 
@@ -481,6 +486,12 @@ public:
 
 } // end anonymous namespace
 
+void BlockState::dump() {
+  llvm::dbgs() << "  block " << BB->getDebugID() << ": in=" << BBWriteSetIn
+               << ", out=" << BBWriteSetOut << ", mid=" << BBWriteSetMid
+               << ", gen=" << BBGenSet << ", kill=" << BBKillSet << '\n';
+}
+
 void BlockState::init(unsigned LocationNum, bool Optimistic) {
   // For function that requires just 1 iteration of the data flow to converge
   // we set the initial state of BBWriteSetIn to 0.
@@ -511,6 +522,21 @@ void BlockState::init(unsigned LocationNum, bool Optimistic) {
 
   // DeallocateLocation initially empty.
   BBDeallocateLocation.resize(LocationNum, false);
+}
+
+#if __has_attribute(used)
+__attribute((used))
+#endif
+void DSEContext::dump() {
+  llvm::dbgs() << "Locations:\n";
+  unsigned idx = 0;
+  for (const LSLocation &loc : LocationVault) {
+    llvm::dbgs() << "  #" << idx << ": " << loc.getBase();
+    ++idx;
+  }
+  for (SILBasicBlock &BB : *F) {
+    getBlockState(&BB)->dump();
+  }
 }
 
 unsigned DSEContext::getLocationBit(const LSLocation &Loc) {

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -717,6 +717,10 @@ void DSEContext::mergeSuccessorLiveIns(SILBasicBlock *BB) {
   // dead for block with no successor.
   BlockState *C = getBlockState(BB);
   if (BB->succ_empty()) {
+    if (isa<UnreachableInst>(BB->getTerminator())) {
+      C->BBWriteSetOut.set();
+      return;
+    }
     C->BBWriteSetOut |= C->BBDeallocateLocation;
     return;
   }

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -291,6 +291,29 @@ bb3:
   return %9999 : $()
 }
 
+// CHECK-LABEL: sil @handle_unreachable : $@convention(thin) (@inout Builtin.Int32) -> () {
+// CHECK: bb0
+// CHECK-NEXT: integer_literal
+// CHECK-NEXT: cond_br
+// CHECK: return
+sil @handle_unreachable : $@convention(thin) (@inout Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.Int32):
+  %1 = integer_literal $Builtin.Int32, 0
+  store %1 to %0 : $*Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  unreachable
+
+bb2:
+  br bb3
+
+bb3:
+  store %1 to %0 : $*Builtin.Int32
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 // CHECK-LABEL: sil @post_dominating_dead_store_partial : $@convention(thin) (@inout Builtin.Int32) -> () {
 // CHECK: bb0(
 // CHECK-NOT: {{ store}}


### PR DESCRIPTION
This makes dead store elimination less conservative, e.g. if error checks are in the control flow.
