### PR TITLE
[DiagnosticsQoI] Strike VarDecls in Pattern Binding Initializers From Overloads

### DIFF
--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -616,12 +616,15 @@ struct PatternBindingWithTwoVars1 { var x = 3, y = x }
 // expected-error@-1 {{cannot use instance member 'x' within property initializer; property initializers run before 'self' is available}}
 
 struct PatternBindingWithTwoVars2 { var x = y, y = 3 }
-// expected-error@-1 {{type 'PatternBindingWithTwoVars2' has no member 'y'}}
+// expected-error@-1 {{property 'y' references itself}}
+// expected-error@-2 {{cannot use instance member 'y' within property initializer; property initializers run before 'self' is available}}
 
 // This one should be accepted, but for now PatternBindingDecl validation
 // circularity detection is not fine grained enough.
 struct PatternBindingWithTwoVars3 { var x = y, y = x }
-// expected-error@-1 {{type 'PatternBindingWithTwoVars3' has no member 'y'}}
+// expected-error@-1 {{cannot use instance member 'x' within property initializer; property initializers run before 'self' is available}}
+// expected-error@-2 {{cannot use instance member 'y' within property initializer; property initializers run before 'self' is available}}
+// expected-error@-3 {{property 'y' references itself}}
 
 // https://bugs.swift.org/browse/SR-9015
 func sr9015() {

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -571,23 +571,23 @@ enum SR_10084_E_8 {
 }
 
 enum SR_10084_E_9 {
-  case A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}}
-  static let A: SR_10084_E_9 = .A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}} // expected-error {{ambiguous use of 'A'}}
+  case A // expected-note {{'A' previously declared here}}
+  static let A: SR_10084_E_9 = .A // expected-error {{invalid redeclaration of 'A'}}
 }
 
 enum SR_10084_E_10 {
-  static let A: SR_10084_E_10 = .A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}} // expected-error {{ambiguous use of 'A'}}
-  case A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}}
+  static let A: SR_10084_E_10 = .A // expected-note {{'A' previously declared here}}
+  case A // expected-error {{invalid redeclaration of 'A'}}
 }
 
 enum SR_10084_E_11 {
-  case A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}}
-  static var A: SR_10084_E_11 = .A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}} // expected-error {{ambiguous use of 'A'}}
+  case A // expected-note {{'A' previously declared here}}
+  static var A: SR_10084_E_11 = .A // expected-error {{invalid redeclaration of 'A'}}
 }
 
 enum SR_10084_E_12 {
-  static var A: SR_10084_E_12 = .A // expected-note {{found this candidate}} // expected-note {{'A' previously declared here}} // expected-error {{ambiguous use of 'A'}}
-  case A // expected-note {{found this candidate}} // expected-error {{invalid redeclaration of 'A'}}
+  static var A: SR_10084_E_12 = .A // expected-note {{'A' previously declared here}}
+  case A // expected-error {{invalid redeclaration of 'A'}}
 }
 
 enum SR_10084_E_13 {
@@ -608,4 +608,12 @@ enum SR_10084_E_15 {
 enum SR_10084_E_16 {
   typealias Z = Int // expected-note {{'Z' previously declared here}}
   case Z // expected-error {{invalid redeclaration of 'Z'}}
+}
+
+// N.B. Validating the pattern binding initializer for `raw` used to cause
+// recursive validation of the VarDecl. Check that we don't regress now that
+// this isn't the case.
+public struct Cyclic {
+  static func pickMe(please: Bool) -> Int { return 42 }
+  public static let pickMe = Cyclic.pickMe(please: true)
 }


### PR DESCRIPTION
We would previously consider the VarDecls bound by a particular pattern
binding initializer context when performing overload resolution.  This
would lead to circular validation.  Validation was tacitly breaking the
cycle by returning an error type (but, crucially, not setting that
interface type).  Instead, pre-reject circular candidates.

This greatly improves the diagnostic we emit here in truly circular
cases since we can ride on `UR_InstanceMemberOnType` to yield

```
struct PatternBindingWithTwoVars2 { var x = y, y = x }
// cannot use instance member 'y' within property initializer; property initializers run before 'self' is available
```
