### PR TITLE
fix @differentiable(linear) type attr parsing

### DIFF
--- a/lib/Parse/ASTGen.cpp
+++ b/lib/Parse/ASTGen.cpp
@@ -451,6 +451,15 @@ TypeAttributes ASTGen::generateTypeAttributes(const AttributeListSyntax &syntax,
       if (indexTok.getText().getAsInteger(10, index))
         continue;
       attrs.setOpaqueReturnTypeOf(mangling.str(), index);
+      // SWIFT_ENABLE_TENSORFLOW
+    } else if (attr == TAK_differentiable) {
+      if (arg) {
+        auto argSyntax = arg->getAs<TokenSyntax>();
+        attrs.linear = argSyntax->getTokenKind() == tok::identifier &&
+                       argSyntax->getIdentifierText() == "linear";
+      } else {
+        attrs.linear = false;
+      }
     }
 
     attrs.setAttr(attr, atLoc);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2538,7 +2538,6 @@ ParsedSyntaxResult<ParsedAttributeSyntax> Parser::parseTypeAttributeSyntax() {
   // SWIFT_ENABLE_TENSORFLOW
   case TAK_differentiable:
     status |= [&]() -> ParserStatus {
-      bool linear = false;
       // Check if there is a 'linear' argument.
       // If next tokens are not `'(' identifier`, break early.
       if (!Tok.is(tok::l_paren) || !peekToken().is(tok::identifier))
@@ -2555,7 +2554,6 @@ ParsedSyntaxResult<ParsedAttributeSyntax> Parser::parseTypeAttributeSyntax() {
         if (Tok.is(tok::r_paren) && peekToken().is(tok::l_paren)) {
           // It is being used as an attribute argument, so cancel backtrack
           // as function is linear differentiable.
-          linear = true;
           backtrack.cancelBacktrack();
           builder.useLeftParen(std::move(lParen));
           builder.useArgument(std::move(linearIdentifier));

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2544,7 +2544,7 @@ ParsedSyntaxResult<ParsedAttributeSyntax> Parser::parseTypeAttributeSyntax() {
         return makeParserSuccess();
 
       Parser::BacktrackingScope backtrack(*this);
-      SourceLoc LParenLoc = Tok.getLoc();
+      SourceLoc lParenLoc = Tok.getLoc();
       auto lParen = consumeTokenSyntax(tok::l_paren);
 
       // Determine if we have '@differentiable(linear) (T) -> U'
@@ -2557,10 +2557,10 @@ ParsedSyntaxResult<ParsedAttributeSyntax> Parser::parseTypeAttributeSyntax() {
           backtrack.cancelBacktrack();
           builder.useLeftParen(std::move(lParen));
           builder.useArgument(std::move(linearIdentifier));
-          SourceLoc RParenLoc;
+          SourceLoc rParenLoc;
           auto rParen = parseMatchingTokenSyntax(
-              tok::r_paren, RParenLoc, diag::differentiable_attribute_expected_rparen,
-              LParenLoc);
+              tok::r_paren, rParenLoc, diag::differentiable_attribute_expected_rparen,
+              lParenLoc);
           if (!rParen)
             return makeParserError();
           builder.useRightParen(std::move(*rParen));

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -140,17 +140,6 @@ void ParsedRawSyntaxRecorder::verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> 
       ? elem.getRecordedRange()
       : elem.getDeferredRange(/*includeTrivia=*/true);
     if (range.isValid()) {
-      if (!(prevEndLoc.isInvalid() || range.getStart() == prevEndLoc)) {
-        // NOTE: Debugging utilities, delete before merging!
-        llvm::errs() << "ParsedRawSyntaxRecorder::verifyElementRanges ERROR!\n";
-        llvm::errs() << "ParsedRawSyntaxNode ELEMENT!\n";
-        elem.dump(llvm::errs());llvm::errs() << "\n";
-        llvm::errs() << "ALL ParsedRawSyntaxNode ELEMENTS:\n";
-        for (const auto &e: elements) {
-          e.dump();
-          llvm::errs() << "\n";
-        }
-      }
       assert((prevEndLoc.isInvalid() || range.getStart() == prevEndLoc)
              && "Non-contiguous child ranges?");
       prevEndLoc = range.getEnd();

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -140,6 +140,17 @@ void ParsedRawSyntaxRecorder::verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> 
       ? elem.getRecordedRange()
       : elem.getDeferredRange(/*includeTrivia=*/true);
     if (range.isValid()) {
+      if (!(prevEndLoc.isInvalid() || range.getStart() == prevEndLoc)) {
+        // NOTE: Debugging utilities, delete before merging!
+        llvm::errs() << "ParsedRawSyntaxRecorder::verifyElementRanges ERROR!\n";
+        llvm::errs() << "ParsedRawSyntaxNode ELEMENT!\n";
+        elem.dump(llvm::errs());llvm::errs() << "\n";
+        llvm::errs() << "ALL ParsedRawSyntaxNode ELEMENTS:\n";
+        for (const auto &e: elements) {
+          e.dump();
+          llvm::errs() << "\n";
+        }
+      }
       assert((prevEndLoc.isInvalid() || range.getStart() == prevEndLoc)
              && "Non-contiguous child ranges?");
       prevEndLoc = range.getEnd();


### PR DESCRIPTION
This is @dan-zheng's initial work on fixing the parsing plus additional required changes:
* Changed a few more `consumeToken`s to `consumeTokenSyntax`es.
* `builder.use*` must happen after we have decided not to backtrack, because it gets unhappy if you "use" some tokens that get backtracked.
* Update ASTGen.cpp to propagate `linear` in to the `TypeAttributes`.