### PR TITLE
Teach IRGen to Emit Invalid @objc Enums

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1127,10 +1127,12 @@ namespace {
   protected:
     int64_t getDiscriminatorIndex(EnumElementDecl *target) const override {
       // The elements are assigned discriminators ABI-compatible with their
-      // raw values from C.
-      assert(target->getRawValueExpr()
-             && "c-compatible enum elt has no raw value?!");
-      auto intExpr = cast<IntegerLiteralExpr>(target->getRawValueExpr());
+      // raw values from C. An invalid raw value is assigned the error index -1.
+      auto intExpr =
+          dyn_cast_or_null<IntegerLiteralExpr>(target->getRawValueExpr());
+      if (!intExpr) {
+        return -1;
+      }
       auto intType = getDiscriminatorType();
 
       APInt intValue =

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4187,20 +4187,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     auto nominal = cast<NominalTypeDecl>(D);
     Type declaredInterfaceTy = nominal->getDeclaredInterfaceType();
     nominal->setInterfaceType(MetatypeType::get(declaredInterfaceTy, Context));
-
-    if (auto *ED = dyn_cast<EnumDecl>(nominal)) {
-      // @objc enums use their raw values as the value representation, so we
-      // need to force the values to be checked even in non-primaries.
-      //
-      // FIXME: This check can be removed once IRGen can be made tolerant of
-      // semantic failures post-Sema.
-      if (ED->isObjC()) {
-        (void)evaluateOrDefault(
-            Context.evaluator,
-            EnumRawValuesRequest{ED, TypeResolutionStage::Interface}, true);
-      }
-    }
-
     break;
   }
 

--- a/test/decl/enum/objc_enum_multi_file.swift
+++ b/test/decl/enum/objc_enum_multi_file.swift
@@ -1,6 +1,7 @@
 // RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NO_RAW_TYPE 2>&1 | %FileCheck -check-prefix=NO_RAW_TYPE %s
 // RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D BAD_RAW_TYPE 2>&1 | %FileCheck -check-prefix=BAD_RAW_TYPE %s
 // RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NON_INT_RAW_TYPE 2>&1 | %FileCheck -check-prefix=NON_INT_RAW_TYPE %s
+// RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NON_INT_RAW_VALUE 2>&1 | %FileCheck -check-prefix=NON_INT_RAW_VALUE %s
 // RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NO_CASES 2>&1 | %FileCheck -check-prefix=NO_CASES %s
 // RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D DUPLICATE_CASES 2>&1 | %FileCheck -check-prefix=DUPLICATE_CASES %s
 // Note that the *other* file is the primary file in this test!
@@ -36,6 +37,13 @@
   // DUPLICATE_CASES: :[[@LINE-1]]:12: error: raw value for enum case is not unique
   // DUPLICATE_CASES: :[[@LINE-3]]:8: note: raw value previously used here
   // DUPLICATE_CASES: :[[@LINE-4]]:8: note: raw value implicitly auto-incremented from zero
+}
+
+#elseif NON_INT_RAW_VALUE
+@objc enum TheEnum : Int32 {
+  case A = 0
+  case B = "B"
+  // NON_INT_RAW_VALUE: :[[@LINE-1]]:12: error: cannot convert value of type 'String' to raw type 'Int32'
 }
 
 #else


### PR DESCRIPTION
In order to remove the enum raw value check request in validateDecl,
IRGen must now tolerate recieving an invalid raw value expression.
Switch the assert to instead check for this condition and emit an
invalid negative discriminator.