### PR TITLE
Fix property wrapper profiling bug

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -249,6 +249,11 @@ struct SILDeclRef {
   bool isStoredPropertyInitializer() const {
     return kind == Kind::StoredPropertyInitializer;
   }
+  /// True if the SILDeclRef references the initializer for the backing storage
+  /// of a property wrapper.
+  bool isPropertyWrapperBackingInitializer() const {
+    return kind == Kind::PropertyWrapperBackingInitializer;
+  }
 
   /// True if the SILDeclRef references the ivar initializer or deinitializer of
   /// a class.

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -135,6 +135,7 @@ static bool canCreateProfilerForAST(ASTNode N, SILDeclRef forDecl) {
       return true;
   } else if (auto *E = N.get<Expr *>()) {
     if (forDecl.isStoredPropertyInitializer() ||
+        forDecl.isPropertyWrapperBackingInitializer() ||
         forDecl.getAbstractClosureExpr())
       return true;
   }
@@ -151,8 +152,10 @@ SILProfiler *SILProfiler::create(SILModule &M, ForDefinition_t forDefinition,
   if (!doesASTRequireProfiling(M, N) && Opts.UseProfile.empty())
     return nullptr;
 
-  if (!canCreateProfilerForAST(N, forDecl))
+  if (!canCreateProfilerForAST(N, forDecl)) {
+    N.dump(llvm::errs());
     llvm_unreachable("Invalid AST node for profiling");
+  }
 
   auto *Buf = M.allocate<SILProfiler>(1);
   auto *SP =

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1145,10 +1145,11 @@ emitPropertyWrapperBackingInitializer(VarDecl *var) {
     preEmitFunction(constant, var, f, var);
     PrettyStackTraceSILFunction X(
         "silgen emitPropertyWrapperBackingInitializer", f);
-    f->createProfiler(var, constant, ForDefinition);
-    auto varDC = var->getInnermostDeclContext();
     auto wrapperInfo = var->getPropertyWrapperBackingPropertyInfo();
     assert(wrapperInfo.initializeFromOriginal);
+    f->createProfiler(wrapperInfo.initializeFromOriginal, constant,
+                      ForDefinition);
+    auto varDC = var->getInnermostDeclContext();
     SILGenFunction SGF(*this, *f, varDC);
     SGF.emitGeneratorFunction(constant, wrapperInfo.initializeFromOriginal);
     postEmitFunction(constant, f);

--- a/test/Profiler/coverage_var_init.swift
+++ b/test/Profiler/coverage_var_init.swift
@@ -1,6 +1,10 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_var_init %s | %FileCheck %s
 
 final class VarInit {
+  // CHECK: sil_coverage_map {{.*}} "$s17coverage_var_init7VarInitC018initializedWrapperE0SivpfP"
+  // CHECK-NEXT: [[@LINE+1]]:4 -> [[@LINE+1]]:38 : 0
+  @Wrapper var initializedWrapperInit = 2
+
   // CHECK: sil_coverage_map {{.*}} "$s17coverage_var_init7VarInitC04lazydE033_49373CB2DFB47C8DC62FA963604688DFLLSSvgSSyXEfU_"
   // CHECK-NEXT: [[@LINE+1]]:42 -> [[@LINE+3]]:4 : 0
   private lazy var lazyVarInit: String = {
@@ -23,7 +27,13 @@ final class VarInit {
     print(lazyVarInit)
     print(basicVarInit)
     print(simpleVar)
+    print(initializedWrapperInit)
   }
+}
+
+@propertyWrapper struct Wrapper {
+  init(wrappedValue: Int) {}
+  var wrappedValue: Int { 1 }
 }
 
 VarInit().coverageFunction()


### PR DESCRIPTION
This PR adds a test for coverage information in a property wrapper backing initializer and corrects a bug in that handling. Fixes rdar://problem/56137860.