### PR TITLE
[Diagnostics] Diagnose passing a non-@objc dynamic keypath to KVO observe

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4480,6 +4480,9 @@ WARNING(variable_never_mutated, none,
 WARNING(variable_never_read, none,
         "variable %0 was written to, but never read",
         (Identifier))
+WARNING(observe_keypath_property_not_objc_dynamic, none,
+        "passing reference to non-'@objc dynamic' property %0 to KVO method %1 "
+        "may lead to unexpected behavior or runtime trap", (DeclName, DeclName))
 
 //------------------------------------------------------------------------------
 // MARK: Debug diagnostics

--- a/test/expr/primary/keypath/keypath_observe_objc.swift
+++ b/test/expr/primary/keypath/keypath_observe_objc.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library  %s -verify
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import Foundation
+import ObjectiveC
+
+class Foo: NSObject {
+  var number1 = 1
+  dynamic var number2 = 2
+  @objc var number3 = 3
+  @objc dynamic var number4 = 4
+}
+
+class Bar: NSObject {
+  @objc dynamic let foo: Foo
+  var observer1: NSKeyValueObservation?
+  var observer2: NSKeyValueObservation?
+  var observer3: NSKeyValueObservation?
+  var observer4: NSKeyValueObservation?
+  
+  init(foo: Foo) {
+    self.foo = foo
+    super.init()
+    
+    observer1 = observe(\.foo.number1, options: [.new]) { _, change in
+      // expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number1' to KVO method 'observe(_:options:changeHandler:)' may lead to unexpected behavior or runtime trap}}
+      print("observer1")
+    }
+    
+    observer2 = observe(\.foo.number2, options: [.new]) { _, change in
+      // expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number2' to KVO method 'observe(_:options:changeHandler:)' may lead to unexpected behavior or runtime trap}}
+      print("observer2")
+    }
+    
+    observer3 = observe(\.foo.number3, options: [.new]) { _, change in
+      // expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number3' to KVO method 'observe(_:options:changeHandler:)' may lead to unexpected behavior or runtime trap}}
+      print("observer3")
+    }
+    
+    observer4 = observe(\.foo.number4, options: [.new]) { _, change in // Okay
+      print("observer4")
+    }
+  }
+}


### PR DESCRIPTION
Passing a KeyPath to a property which is not marked `@objc dynamic` to the KVO observe method can cause unexpected behavior or a runtime trap.

Resolves [SR-5115](https://bugs.swift.org/browse/SR-5115)
Resolves [SR-5159](https://bugs.swift.org/browse/SR-5159)
Resolves [SR-5177](https://bugs.swift.org/browse/SR-5177)
Resolves rdar://problem/32593787
Resolves rdar://problem/32775952