### PR TITLE
[ClangImporter] Fix edge cases where custom name matches native name

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1354,7 +1354,7 @@ bool ClangImporter::importHeader(StringRef header, ModuleDecl *adapter,
 
   // If we've made it to here, this is some header other than the bridging
   // header, which means we can no longer rely on one file's modification time
-  // to invalid code completion caches. :-(
+  // to invalidate code completion caches. :-(
   Impl.setSinglePCHImport(None);
 
   if (!cachedContents.empty() && cachedContents.back() == '\0')

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3702,8 +3702,16 @@ EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
       (nominal->getAttrs().hasAttribute<ObjCAttr>() ||
        (!nominal->getParentSourceFile() && nominal->isObjC()))) {
     // Map the name. If we can't represent the Swift name in Clang.
-    // FIXME: We should be using the Objective-C name here!
-    auto clangName = exportName(nominal->getName());
+    Identifier name = nominal->getName();
+    if (auto objcAttr = nominal->getAttrs().getAttribute<ObjCAttr>()) {
+      if (auto objcName = objcAttr->getName()) {
+        if (objcName->getNumArgs() == 0) {
+          // This is an error if not 0, but it should be caught later.
+          name = objcName->getSimpleName();
+        }
+      }
+    }
+    auto clangName = exportName(name);
     if (!clangName)
       return EffectiveClangContext();
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1781,9 +1781,11 @@ ImportedName NameImporter::importName(const clang::NamedDecl *decl,
                                       ImportNameVersion version,
                                       clang::DeclarationName givenName) {
   CacheKeyType key(decl, version);
-  if (importNameCache.count(key) && !givenName) {
-    ++ImportNameNumCacheHits;
-    return importNameCache[key];
+  if (!givenName) {
+    if (auto cachedRes = importNameCache[key]) {
+      ++ImportNameNumCacheHits;
+      return cachedRes;
+    }
   }
   ++ImportNameNumCacheMisses;
   auto res = importNameImpl(decl, version, givenName);

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1393,7 +1393,7 @@ IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
     // Classes can be @objc.
 
     // Protocols and enums can also be @objc, but this is covered by the
-    // isObjC() check a the beginning.;
+    // isObjC() check at the beginning.
     isObjC = shouldMarkAsObjC(VD, /*allowImplicit=*/false);
   } else if (auto enumDecl = dyn_cast<EnumDecl>(VD)) {
     // Enums can be @objc so long as they have a raw type that is representable

--- a/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
@@ -68,6 +68,62 @@ SWIFT_PROTOCOL("SwiftProto")
 id<SwiftProtoWithCustomName> _Nonnull
 convertToProto(SwiftClassWithCustomName *_Nonnull obj);
 
+SWIFT_CLASS("ObjCClass")
+__attribute__((objc_root_class))
+@interface ObjCClass
+@end
+
+SWIFT_CLASS("ImplicitlyObjCClass")
+@interface ImplicitlyObjCClass : ObjCClass
+@end
+void consumeImplicitlyObjCClass(ImplicitlyObjCClass *_Nonnull obj);
+
+SWIFT_CLASS("ExplicitlyObjCClass")
+__attribute__((objc_root_class))
+@interface ExplicitlyObjCClass
+@end
+void consumeExplicitlyObjCClass(ExplicitlyObjCClass *_Nonnull obj);
+
+SWIFT_CLASS_NAMED("HasSameCustomNameClass")
+__attribute__((objc_root_class))
+@interface HasSameCustomNameClass
+@end
+void consumeHasSameCustomNameClass(HasSameCustomNameClass *_Nonnull obj);
+
+SWIFT_CLASS_NAMED("SwiftNativeTypeHasDifferentCustomNameClass")
+__attribute__((objc_root_class))
+@interface NativeTypeHasDifferentCustomNameClass
+@end
+SWIFT_CLASS_NAMED("NativeTypeHasDifferentCustomNameClass")
+__attribute__((objc_root_class))
+@interface ObjCNativeTypeHasDifferentCustomNameClass
+@end
+void consumeNativeTypeHasDifferentCustomNameClass(NativeTypeHasDifferentCustomNameClass *_Nonnull obj);
+void consumeObjCNativeTypeHasDifferentCustomNameClass(ObjCNativeTypeHasDifferentCustomNameClass *_Nonnull obj);
+
+SWIFT_CLASS_NAMED("SwiftNativeTypeIsNonObjCClass")
+__attribute__((objc_root_class))
+@interface NativeTypeIsNonObjCClass
+@end
+void consumeNativeTypeIsNonObjCClass(NativeTypeIsNonObjCClass *_Nonnull obj);
+
+@class ForwardImplicitlyObjCClass;
+void consumeForwardImplicitlyObjCClass(ForwardImplicitlyObjCClass *_Nonnull obj);
+
+@class ForwardExplicitlyObjCClass;
+void consumeForwardExplicitlyObjCClass(ForwardExplicitlyObjCClass *_Nonnull obj);
+
+@class ForwardHasSameCustomNameClass;
+void consumeForwardHasSameCustomNameClass(ForwardHasSameCustomNameClass *_Nonnull obj);
+
+@class ForwardNativeTypeHasDifferentCustomNameClass;
+@class ObjCForwardNativeTypeHasDifferentCustomNameClass;
+void consumeForwardNativeTypeHasDifferentCustomNameClass(ForwardNativeTypeHasDifferentCustomNameClass *_Nonnull obj);
+void consumeObjCForwardNativeTypeHasDifferentCustomNameClass(ObjCForwardNativeTypeHasDifferentCustomNameClass *_Nonnull obj);
+
+@class ForwardNativeTypeIsNonObjCClass;
+void consumeForwardNativeTypeIsNonObjCClass(ForwardNativeTypeIsNonObjCClass *_Nonnull obj);
+
 SWIFT_CLASS("BOGUS")
 @interface BogusClass
 @end

--- a/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.swift
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.swift
@@ -31,3 +31,70 @@ public class CustomNameClass : CustomName {
   @objc func protoMethod()
   @objc var protoProperty: Int { get }
 }
+
+@objc
+public class ObjCClass {
+  public init() {}
+}
+
+public class ImplicitlyObjCClass : ObjCClass {
+    public override init() { super.init() }
+}
+
+@objc
+public class ExplicitlyObjCClass {
+    public init() {}
+}
+
+@objc(HasSameCustomNameClass)
+public class HasSameCustomNameClass {
+    public init() {}
+}
+
+@objc(ObjCNativeTypeHasDifferentCustomNameClass)
+public class NativeTypeHasDifferentCustomNameClass {
+    public init() {}
+}
+@objc(NativeTypeHasDifferentCustomNameClass)
+public class SwiftNativeTypeHasDifferentCustomNameClass {
+    public init() {}
+}
+
+public class NativeTypeIsNonObjCClass {
+    public init() {}
+}
+@objc(NativeTypeIsNonObjCClass)
+public class SwiftNativeTypeIsNonObjCClass {
+    public init() {}
+}
+
+public class ForwardImplicitlyObjCClass : ObjCClass {
+    public override init() { super.init() }
+}
+
+@objc
+public class ForwardExplicitlyObjCClass {
+    public init() {}
+}
+
+@objc(ForwardHasSameCustomNameClass)
+public class ForwardHasSameCustomNameClass {
+    public init() {}
+}
+
+@objc(ObjCForwardNativeTypeHasDifferentCustomNameClass)
+public class ForwardNativeTypeHasDifferentCustomNameClass {
+    public init() {}
+}
+@objc(ForwardNativeTypeHasDifferentCustomNameClass)
+public class SwiftForwardNativeTypeHasDifferentCustomNameClass {
+    public init() {}
+}
+
+public class ForwardNativeTypeIsNonObjCClass {
+    public init() {}
+}
+@objc(ForwardNativeTypeIsNonObjCClass)
+public class SwiftForwardNativeTypeIsNonObjCClass {
+    public init() {}
+}

--- a/test/ClangImporter/MixedSource/import-mixed-framework.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework.swift
@@ -32,3 +32,31 @@ func testAnyObject(_ obj: AnyObject) {
   obj.protoMethod()
   _ = obj.protoProperty
 }
+
+consumeImplicitlyObjCClass(ImplicitlyObjCClass())
+
+consumeExplicitlyObjCClass(ExplicitlyObjCClass())
+
+consumeHasSameCustomNameClass(HasSameCustomNameClass())
+
+consumeNativeTypeHasDifferentCustomNameClass(SwiftNativeTypeHasDifferentCustomNameClass())
+consumeObjCNativeTypeHasDifferentCustomNameClass(NativeTypeHasDifferentCustomNameClass())
+consumeNativeTypeHasDifferentCustomNameClass(NativeTypeHasDifferentCustomNameClass()) // expected-error {{cannot convert value of type 'NativeTypeHasDifferentCustomNameClass' to expected argument type 'SwiftNativeTypeHasDifferentCustomNameClass'}}
+consumeObjCNativeTypeHasDifferentCustomNameClass(SwiftNativeTypeHasDifferentCustomNameClass()) // expected-error {{cannot convert value of type 'SwiftNativeTypeHasDifferentCustomNameClass' to expected argument type 'NativeTypeHasDifferentCustomNameClass'}}
+
+consumeNativeTypeIsNonObjCClass(SwiftNativeTypeIsNonObjCClass())
+consumeNativeTypeIsNonObjCClass(NativeTypeIsNonObjCClass()) // expected-error {{cannot convert value of type 'NativeTypeIsNonObjCClass' to expected argument type 'SwiftNativeTypeIsNonObjCClass'}}
+
+consumeForwardImplicitlyObjCClass(ForwardImplicitlyObjCClass())
+
+consumeForwardExplicitlyObjCClass(ForwardExplicitlyObjCClass())
+
+consumeForwardHasSameCustomNameClass(ForwardHasSameCustomNameClass())
+
+consumeForwardNativeTypeHasDifferentCustomNameClass(SwiftForwardNativeTypeHasDifferentCustomNameClass())
+consumeObjCForwardNativeTypeHasDifferentCustomNameClass(ForwardNativeTypeHasDifferentCustomNameClass())
+consumeForwardNativeTypeHasDifferentCustomNameClass(ForwardNativeTypeHasDifferentCustomNameClass()) // expected-error {{cannot convert value of type 'ForwardNativeTypeHasDifferentCustomNameClass' to expected argument type 'SwiftForwardNativeTypeHasDifferentCustomNameClass'}}
+consumeObjCForwardNativeTypeHasDifferentCustomNameClass(SwiftForwardNativeTypeHasDifferentCustomNameClass()) // expected-error {{cannot convert value of type 'SwiftForwardNativeTypeHasDifferentCustomNameClass' to expected argument type 'ForwardNativeTypeHasDifferentCustomNameClass'}}
+
+consumeForwardNativeTypeIsNonObjCClass(SwiftForwardNativeTypeIsNonObjCClass())
+consumeForwardNativeTypeIsNonObjCClass(ForwardNativeTypeIsNonObjCClass()) // expected-error {{cannot convert value of type 'ForwardNativeTypeIsNonObjCClass' to expected argument type 'SwiftForwardNativeTypeIsNonObjCClass'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
The code does naive lookup of Swift types using the type name, but sometimes the Swift type we're looking for only has that name in its @objc attribute. This change makes the compiler exclude certain Swift declarations from matching even if the Swift name is the same (namely, not being available in Obj-C or having a mismatched `@objc` name) and continue to find the correct declaration without using lookup by name.

I'm not quite sure how some cases worked before this, so some modifications may be necessary.

The main change is in the first commit. The other commits are some other changes I had sitting around. I don't have any tests for the Obj-C name commit (for the FIXME) and am not quite sure if it helps (tests still pass if I revert those changes), so I can drop that commit.

On a personal note, this also removes the need for a workaround I’ve had in my codebase at work to get Swift to associate a forward declaration to its Swift declaration (which involves creating a Clang module of the same name containing the generated Obj-C interface of the problematic class). 🎉

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4827](https://bugs.swift.org/browse/SR-4827).