### PR TITLE
[NFC] Distinguish references to names from declarations of those names by type

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -188,7 +188,10 @@ public:
   ASTPrinter &operator<<(unsigned long long N);
   ASTPrinter &operator<<(UUID UU);
 
+  ASTPrinter &operator<<(Identifier name);
+  ASTPrinter &operator<<(DeclBaseName name);
   ASTPrinter &operator<<(DeclName name);
+  ASTPrinter &operator<<(DeclNameRef name);
 
   // Special case for 'char', but not arbitrary things that convert to 'char'.
   template <typename T>

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -412,7 +412,7 @@ public:
 
   /// Entry point into ASTScopeImpl-land for lookups
   static llvm::SmallVector<const ASTScopeImpl *, 0>
-  unqualifiedLookup(SourceFile *, DeclName, SourceLoc,
+  unqualifiedLookup(SourceFile *, DeclNameRef, SourceLoc,
                     const DeclContext *startingContext, DeclConsumer);
 
   static Optional<bool>
@@ -422,7 +422,7 @@ public:
 #pragma mark - - lookup- starting point
 private:
   static const ASTScopeImpl *findStartingScopeForLookup(SourceFile *,
-                                                        const DeclName name,
+                                                        const DeclNameRef name,
                                                         const SourceLoc where,
                                                         const DeclContext *ctx);
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -68,7 +68,7 @@ public:
 
   struct Convention {
     StringRef Name = {};
-    DeclName WitnessMethodProtocol = {};
+    DeclNameRef WitnessMethodProtocol = {};
     StringRef ClangType = {};
     // Carry the source location for diagnostics.
     SourceLoc ClangTypeLoc = {};
@@ -78,7 +78,7 @@ public:
     /// Don't use this function if you are creating a C convention as you
     /// probably need a ClangType field as well.
     static Convention makeSwiftConvention(StringRef name) {
-      return {name, DeclName(), "", {}};
+      return {name, DeclNameRef(), "", {}};
     }
   };
 
@@ -1057,15 +1057,16 @@ class DynamicReplacementAttr final
   friend TrailingObjects;
   friend class DynamicallyReplacedDeclRequest;
 
-  DeclName ReplacedFunctionName;
+  DeclNameRef ReplacedFunctionName;
   LazyMemberLoader *Resolver = nullptr;
   uint64_t ResolverContextData;
 
   /// Create an @_dynamicReplacement(for:) attribute written in the source.
   DynamicReplacementAttr(SourceLoc atLoc, SourceRange baseRange,
-                         DeclName replacedFunctionName, SourceRange parenRange);
+                         DeclNameRef replacedFunctionName,
+                         SourceRange parenRange);
 
-  DynamicReplacementAttr(DeclName name, AbstractFunctionDecl *f)
+  DynamicReplacementAttr(DeclNameRef name, AbstractFunctionDecl *f)
       : DeclAttribute(DAK_DynamicReplacement, SourceLoc(), SourceRange(),
                       /*Implicit=*/false),
         ReplacedFunctionName(name),
@@ -1073,7 +1074,7 @@ class DynamicReplacementAttr final
     Bits.DynamicReplacementAttr.HasTrailingLocationInfo = false;
   }
 
-  DynamicReplacementAttr(DeclName name,
+  DynamicReplacementAttr(DeclNameRef name,
                          LazyMemberLoader *Resolver = nullptr,
                          uint64_t Data = 0)
       : DeclAttribute(DAK_DynamicReplacement, SourceLoc(), SourceRange(),
@@ -1100,18 +1101,18 @@ class DynamicReplacementAttr final
 public:
   static DynamicReplacementAttr *
   create(ASTContext &Context, SourceLoc AtLoc, SourceLoc DynReplLoc,
-         SourceLoc LParenLoc, DeclName replacedFunction, SourceLoc RParenLoc);
+         SourceLoc LParenLoc, DeclNameRef replacedFunction, SourceLoc RParenLoc);
 
   static DynamicReplacementAttr *create(ASTContext &ctx,
-                                        DeclName replacedFunction,
+                                        DeclNameRef replacedFunction,
                                         AbstractFunctionDecl *replacedFuncDecl);
 
   static DynamicReplacementAttr *create(ASTContext &ctx,
-                                        DeclName replacedFunction,
+                                        DeclNameRef replacedFunction,
                                         LazyMemberLoader *Resolver,
                                         uint64_t Data);
 
-  DeclName getReplacedFunctionName() const {
+  DeclNameRef getReplacedFunctionName() const {
     return ReplacedFunctionName;
   }
 
@@ -1630,8 +1631,8 @@ public:
 };
 
 /// A declaration name with location.
-struct DeclNameWithLoc {
-  DeclName Name;
+struct DeclNameRefWithLoc {
+  DeclNameRef Name;
   DeclNameLoc Loc;
 };
 
@@ -1652,9 +1653,9 @@ class DifferentiableAttr final
   /// The number of parsed parameters specified in 'wrt:'.
   unsigned NumParsedParameters = 0;
   /// The JVP function.
-  Optional<DeclNameWithLoc> JVP;
+  Optional<DeclNameRefWithLoc> JVP;
   /// The VJP function.
-  Optional<DeclNameWithLoc> VJP;
+  Optional<DeclNameRefWithLoc> VJP;
   /// The JVP function (optional), resolved by the type checker if JVP name is
   /// specified.
   FuncDecl *JVPFunction = nullptr;
@@ -1674,15 +1675,15 @@ class DifferentiableAttr final
   explicit DifferentiableAttr(bool implicit, SourceLoc atLoc,
                               SourceRange baseRange, bool linear,
                               ArrayRef<ParsedAutoDiffParameter> parameters,
-                              Optional<DeclNameWithLoc> jvp,
-                              Optional<DeclNameWithLoc> vjp,
+                              Optional<DeclNameRefWithLoc> jvp,
+                              Optional<DeclNameRefWithLoc> vjp,
                               TrailingWhereClause *clause);
 
   explicit DifferentiableAttr(Decl *original, bool implicit, SourceLoc atLoc,
                               SourceRange baseRange, bool linear,
                               IndexSubset *parameterIndices,
-                              Optional<DeclNameWithLoc> jvp,
-                              Optional<DeclNameWithLoc> vjp,
+                              Optional<DeclNameRefWithLoc> jvp,
+                              Optional<DeclNameRefWithLoc> vjp,
                               GenericSignature derivativeGenericSignature);
 
 public:
@@ -1690,27 +1691,27 @@ public:
                                     SourceLoc atLoc, SourceRange baseRange,
                                     bool linear,
                                     ArrayRef<ParsedAutoDiffParameter> params,
-                                    Optional<DeclNameWithLoc> jvp,
-                                    Optional<DeclNameWithLoc> vjp,
+                                    Optional<DeclNameRefWithLoc> jvp,
+                                    Optional<DeclNameRefWithLoc> vjp,
                                     TrailingWhereClause *clause);
 
   static DifferentiableAttr *create(AbstractFunctionDecl *original,
                                     bool implicit, SourceLoc atLoc,
                                     SourceRange baseRange, bool linear,
                                     IndexSubset *parameterIndices,
-                                    Optional<DeclNameWithLoc> jvp,
-                                    Optional<DeclNameWithLoc> vjp,
+                                    Optional<DeclNameRefWithLoc> jvp,
+                                    Optional<DeclNameRefWithLoc> vjp,
                                     GenericSignature derivativeGenSig);
 
   /// Get the optional 'jvp:' function name and location.
   /// Use this instead of `getJVPFunction` to check whether the attribute has a
   /// registered JVP.
-  Optional<DeclNameWithLoc> getJVP() const { return JVP; }
+  Optional<DeclNameRefWithLoc> getJVP() const { return JVP; }
 
   /// Get the optional 'vjp:' function name and location.
   /// Use this instead of `getVJPFunction` to check whether the attribute has a
   /// registered VJP.
-  Optional<DeclNameWithLoc> getVJP() const { return VJP; }
+  Optional<DeclNameRefWithLoc> getVJP() const { return VJP; }
 
   IndexSubset *getParameterIndices() const {
     return ParameterIndices;
@@ -1775,7 +1776,7 @@ class DerivativeAttr final
   friend TrailingObjects;
 
   /// The original function name.
-  DeclNameWithLoc OriginalFunctionName;
+  DeclNameRefWithLoc OriginalFunctionName;
   /// The original function declaration, resolved by the type checker.
   AbstractFunctionDecl *OriginalFunction = nullptr;
   /// The number of parsed parameters specified in 'wrt:'.
@@ -1786,23 +1787,24 @@ class DerivativeAttr final
   Optional<AutoDiffDerivativeFunctionKind> Kind = None;
 
   explicit DerivativeAttr(bool implicit, SourceLoc atLoc, SourceRange baseRange,
-                          DeclNameWithLoc original,
+                          DeclNameRefWithLoc original,
                           ArrayRef<ParsedAutoDiffParameter> params);
 
   explicit DerivativeAttr(bool implicit, SourceLoc atLoc, SourceRange baseRange,
-                          DeclNameWithLoc original, IndexSubset *indices);
+                          DeclNameRefWithLoc original, IndexSubset *indices);
 
 public:
   static DerivativeAttr *create(ASTContext &context, bool implicit,
                                 SourceLoc atLoc, SourceRange baseRange,
-                                DeclNameWithLoc original,
+                                DeclNameRefWithLoc original,
                                 ArrayRef<ParsedAutoDiffParameter> params);
 
   static DerivativeAttr *create(ASTContext &context, bool implicit,
                                 SourceLoc atLoc, SourceRange baseRange,
-                                DeclNameWithLoc original, IndexSubset *indices);
+                                DeclNameRefWithLoc original,
+                                IndexSubset *indices);
 
-  DeclNameWithLoc getOriginalFunctionName() const {
+  DeclNameRefWithLoc getOriginalFunctionName() const {
     return OriginalFunctionName;
   }
   AbstractFunctionDecl *getOriginalFunction() const {

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -68,7 +68,7 @@ public:
 
   struct Convention {
     StringRef Name = {};
-    StringRef WitnessMethodProtocol = {};
+    DeclName WitnessMethodProtocol = {};
     StringRef ClangType = {};
     // Carry the source location for diagnostics.
     SourceLoc ClangTypeLoc = {};
@@ -78,7 +78,7 @@ public:
     /// Don't use this function if you are creating a C convention as you
     /// probably need a ClangType field as well.
     static Convention makeSwiftConvention(StringRef name) {
-      return {name, "", "", {}};
+      return {name, DeclName(), "", {}};
     }
   };
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2462,7 +2462,7 @@ public:
   /// Generates a DeclNameRef referring to this declaration with as much
   /// specificity as possible.
   DeclNameRef createNameRef() const {
-    return DeclNameRef_(getFullName());
+    return DeclNameRef(getFullName());
   }
 
   /// Retrieve the name to use for this declaration when interoperating

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6997,6 +6997,13 @@ public:
   SourceLoc getNameLoc() const { return NameLoc; }
   Identifier getName() const { return name; }
 
+  /// Get the list of identifiers after the colon in the operator declaration.
+  ///
+  /// This list includes the names of designated types. For infix operators, the
+  /// first item in the list is a precedence group instead.
+  ///
+  /// \todo These two purposes really ought to be in separate properties and the
+  /// designated type list should be of TypeReprs instead of Identifiers.
   ArrayRef<Identifier> getIdentifiers() const {
     return Identifiers;
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2459,6 +2459,12 @@ public:
   /// names.
   DeclBaseName getBaseName() const { return Name.getBaseName(); }
 
+  /// Generates a DeclNameRef referring to this declaration with as much
+  /// specificity as possible.
+  DeclNameRef createNameRef() const {
+    return DeclNameRef_(getFullName());
+  }
+
   /// Retrieve the name to use for this declaration when interoperating
   /// with the Objective-C runtime.
   ///

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -505,7 +505,7 @@ public:
   /// lookup.
   ///
   /// \returns true if anything was found.
-  bool lookupQualified(Type type, DeclName member, NLOptions options,
+  bool lookupQualified(Type type, DeclNameRef member, NLOptions options,
                        SmallVectorImpl<ValueDecl *> &decls) const;
 
   /// Look for the set of declarations with the given name within the
@@ -522,12 +522,13 @@ public:
   /// lookup.
   ///
   /// \returns true if anything was found.
-  bool lookupQualified(ArrayRef<NominalTypeDecl *> types, DeclName member,
+  bool lookupQualified(ArrayRef<NominalTypeDecl *> types, DeclNameRef member,
                        NLOptions options,
                        SmallVectorImpl<ValueDecl *> &decls) const;
 
   /// Perform qualified lookup for the given member in the given module.
-  bool lookupQualified(ModuleDecl *module, DeclName member, NLOptions options,
+  bool lookupQualified(ModuleDecl *module, DeclNameRef member,
+                       NLOptions options,
                        SmallVectorImpl<ValueDecl *> &decls) const;
 
   /// Look up all Objective-C methods with the given selector visible

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -105,7 +105,7 @@ namespace swift {
       int IntegerVal;
       unsigned UnsignedVal;
       StringRef StringVal;
-      DeclName IdentifierVal;
+      DeclNameRef IdentifierVal;
       ObjCSelector ObjCSelectorVal;
       ValueDecl *TheValueDecl;
       Type TypeVal;
@@ -133,14 +133,20 @@ namespace swift {
       : Kind(DiagnosticArgumentKind::Unsigned), UnsignedVal(I) {
     }
 
+    DiagnosticArgument(DeclNameRef R)
+        : Kind(DiagnosticArgumentKind::Identifier), IdentifierVal(R) {}
+
     DiagnosticArgument(DeclName D)
-        : Kind(DiagnosticArgumentKind::Identifier), IdentifierVal(D) {}
+        : Kind(DiagnosticArgumentKind::Identifier),
+          IdentifierVal(DeclNameRef_(D)) {}
 
     DiagnosticArgument(DeclBaseName D)
-        : Kind(DiagnosticArgumentKind::Identifier), IdentifierVal(D) {}
+        : Kind(DiagnosticArgumentKind::Identifier),
+          IdentifierVal(DeclNameRef_(D)) {}
 
     DiagnosticArgument(Identifier I)
-      : Kind(DiagnosticArgumentKind::Identifier), IdentifierVal(I) {
+      : Kind(DiagnosticArgumentKind::Identifier),
+        IdentifierVal(DeclNameRef_(I)) {
     }
 
     DiagnosticArgument(ObjCSelector S)
@@ -225,7 +231,7 @@ namespace swift {
       return UnsignedVal;
     }
 
-    DeclName getAsIdentifier() const {
+    DeclNameRef getAsIdentifier() const {
       assert(Kind == DiagnosticArgumentKind::Identifier);
       return IdentifierVal;
     }

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -138,15 +138,15 @@ namespace swift {
 
     DiagnosticArgument(DeclName D)
         : Kind(DiagnosticArgumentKind::Identifier),
-          IdentifierVal(DeclNameRef_(D)) {}
+          IdentifierVal(DeclNameRef(D)) {}
 
     DiagnosticArgument(DeclBaseName D)
         : Kind(DiagnosticArgumentKind::Identifier),
-          IdentifierVal(DeclNameRef_(D)) {}
+          IdentifierVal(DeclNameRef(D)) {}
 
     DiagnosticArgument(Identifier I)
       : Kind(DiagnosticArgumentKind::Identifier),
-        IdentifierVal(DeclNameRef_(I)) {
+        IdentifierVal(DeclNameRef(I)) {
     }
 
     DiagnosticArgument(ObjCSelector S)

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -163,7 +163,7 @@ NOTE(kind_declname_declared_here,none,
 WARNING(warn_property_wrapper_module_scope,none,
         "ignoring associated type %0 in favor of module-scoped property "
         "wrapper %0; please qualify the reference with %1",
-        (DeclName, Identifier))
+        (DeclNameRef, Identifier))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -207,7 +207,7 @@ ERROR(lex_conflict_marker_in_file,none,
 //------------------------------------------------------------------------------
 
 NOTE(note_in_decl_extension,none,
-     "in %select{declaration|extension}0 of %1", (bool, Identifier))
+     "in %select{declaration|extension}0 of %1", (bool, DeclName))
 ERROR(line_directive_style_deprecated,none,
         "#line directive was renamed to #sourceLocation",
         ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -207,7 +207,7 @@ ERROR(lex_conflict_marker_in_file,none,
 //------------------------------------------------------------------------------
 
 NOTE(note_in_decl_extension,none,
-     "in %select{declaration|extension}0 of %1", (bool, DeclName))
+     "in %select{declaration|extension}0 of %1", (bool, DeclNameRef))
 ERROR(line_directive_style_deprecated,none,
         "#line directive was renamed to #sourceLocation",
         ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3576,7 +3576,7 @@ ERROR(cannot_convert_single_tuple_into_multiple_arguments,none,
 
 ERROR(enum_element_pattern_assoc_values_mismatch,none,
       "pattern with associated values does not match enum case %0",
-      (Identifier))
+      (DeclName))
 NOTE(enum_element_pattern_assoc_values_remove,none,
      "remove associated values to make the pattern match", ())
 ERROR(tuple_pattern_length_mismatch,none,
@@ -3584,14 +3584,14 @@ ERROR(tuple_pattern_length_mismatch,none,
 ERROR(tuple_pattern_label_mismatch,none,
       "tuple pattern element label %0 must be %1", (Identifier, Identifier))
 ERROR(enum_element_pattern_member_not_found,none,
-      "enum case '%0' not found in type %1", (StringRef, Type))
+      "enum case %0 not found in type %1", (DeclName, Type))
 ERROR(optional_element_pattern_not_valid_type,none,
       "'?' pattern cannot match values of type %0", (Type))
 ERROR(condition_optional_element_pattern_not_valid_type,none,
       "initializer for conditional binding must have Optional type, not %0",
       (Type))
 ERROR(enum_element_pattern_not_member_of_enum,none,
-      "enum case '%0' is not a member of type %1", (StringRef, Type))
+      "enum case %0 is not a member of type %1", (DeclName, Type))
 ERROR(ambiguous_enum_pattern_type,none,
       "generic enum type %0 is ambiguous without explicit generic parameters "
       "when matching value of type %1", (Type, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4210,24 +4210,24 @@ ERROR(dynamic_and_library_evolution_not_supported,none,
 //------------------------------------------------------------------------------
 
 ERROR(dynamic_replacement_accessor_type_mismatch, none,
-      "replaced accessor %0's type does not match", (DeclName))
+      "replaced accessor %0's type does not match", (DeclNameRef))
 ERROR(dynamic_replacement_accessor_not_dynamic, none,
-      "replaced accessor for %0 is not marked dynamic", (DeclName))
+      "replaced accessor for %0 is not marked dynamic", (DeclNameRef))
 ERROR(dynamic_replacement_accessor_not_explicit, none,
       "replaced accessor %select{get|set|_read|_modify|willSet|didSet|unsafeAddress|addressWithOwner|addressWithNativeOwner|unsafeMutableAddress|mutableAddressWithOwner|}0 for %1 is not explicitly defined",
-      (unsigned, DeclName))
+      (unsigned, DeclNameRef))
 ERROR(dynamic_replacement_function_not_dynamic, none,
       "replaced function %0 is not marked dynamic", (DeclName))
 ERROR(dynamic_replacement_function_not_found, none,
-     "replaced function %0 could not be found", (DeclName))
+     "replaced function %0 could not be found", (DeclNameRef))
 ERROR(dynamic_replacement_accessor_not_found, none,
-      "replaced accessor for %0 could not be found", (DeclName))
+      "replaced accessor for %0 could not be found", (DeclNameRef))
 ERROR(dynamic_replacement_accessor_ambiguous, none,
-      "replaced accessor for %0 occurs in multiple places", (DeclName))
+      "replaced accessor for %0 occurs in multiple places", (DeclNameRef))
 NOTE(dynamic_replacement_accessor_ambiguous_candidate, none,
       "candidate accessor found in module %0", (DeclName))
 ERROR(dynamic_replacement_function_of_type_not_found, none,
-      "replaced function %0 of type %1 could not be found", (DeclName, Type))
+      "replaced function %0 of type %1 could not be found", (DeclNameRef, Type))
 NOTE(dynamic_replacement_found_function_of_type, none,
       "found function %0 of type %1", (DeclName, Type))
 ERROR(dynamic_replacement_not_in_extension, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -781,21 +781,21 @@ NOTE(invalid_redecl_prev,none,
      "%0 previously declared here", (DeclName))
 
 ERROR(ambiguous_type_base,none,
-      "%0 is ambiguous for type lookup in this context", (Identifier))
+      "%0 is ambiguous for type lookup in this context", (DeclName))
 ERROR(invalid_member_type,none,
-      "%0 is not a member type of %1", (Identifier, Type))
+      "%0 is not a member type of %1", (DeclName, Type))
 ERROR(invalid_member_type_suggest,none,
       "%0 does not have a member type named %1; did you mean %2?",
-      (Type, Identifier, Identifier))
+      (Type, DeclName, DeclName))
 ERROR(invalid_member_reference,none,
       "%0 %1 is not a member type of %2",
-      (DescriptiveDeclKind, Identifier, Type))
+      (DescriptiveDeclKind, DeclName, Type))
 ERROR(ambiguous_member_type,none,
-      "ambiguous type name %0 in %1", (Identifier, Type))
+      "ambiguous type name %0 in %1", (DeclName, Type))
 ERROR(no_module_type,none,
-      "no type named %0 in module %1", (Identifier, Identifier))
+      "no type named %0 in module %1", (DeclName, Identifier))
 ERROR(ambiguous_module_type,none,
-      "ambiguous type name %0 in module %1", (Identifier, Identifier))
+      "ambiguous type name %0 in module %1", (DeclName, Identifier))
 ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
       (DeclName, unsigned))
@@ -828,9 +828,9 @@ NOTE(confusable_character,none,
       "did you mean to use '%2'?",
       (bool, StringRef, StringRef))
 ERROR(use_undeclared_type,none,
-      "use of undeclared type %0", (Identifier))
+      "use of undeclared type %0", (DeclName))
 ERROR(use_undeclared_type_did_you_mean,none,
-      "use of undeclared type %0; did you mean to use '%1'?", (Identifier, StringRef))
+      "use of undeclared type %0; did you mean to use '%1'?", (DeclName, StringRef))
 NOTE(note_typo_candidate_implicit_member,none,
      "did you mean the implicitly-synthesized %1 '%0'?", (StringRef, StringRef))
 NOTE(note_remapped_type,none,
@@ -2178,10 +2178,10 @@ WARNING(append_interpolation_access_control,none,
 // Protocols and existentials
 ERROR(assoc_type_outside_of_protocol,none,
       "associated type %0 can only be used with a concrete type or "
-      "generic parameter base", (Identifier))
+      "generic parameter base", (DeclName))
 ERROR(typealias_outside_of_protocol,none,
       "type alias %0 can only be used with a concrete type or "
-      "generic parameter base", (Identifier))
+      "generic parameter base", (DeclName))
 
 ERROR(objc_protocol_inherits_non_objc_protocol,none,
       "@objc protocol %0 cannot refine non-@objc protocol %1", (Type, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -57,7 +57,7 @@ NOTE(opaque_return_type_declared_here,none,
 //------------------------------------------------------------------------------
 
 ERROR(ambiguous_member_overload_set,none,
-      "ambiguous reference to member %0", (DeclName))
+      "ambiguous reference to member %0", (DeclNameRef))
 ERROR(ambiguous_reference_to_decl,none,
       "ambiguous reference to %0 %1", (DescriptiveDeclKind, DeclName))
 ERROR(no_overloads_match_exactly_in_call,none,
@@ -81,25 +81,25 @@ ERROR(could_not_find_value_subscript,none,
       (Type))
 
 ERROR(could_not_find_tuple_member,none,
-      "value of tuple type %0 has no member %1", (Type, DeclName))
+      "value of tuple type %0 has no member %1", (Type, DeclNameRef))
 
 ERROR(could_not_find_value_member,none,
-      "value of type %0 has no member %1", (Type, DeclName))
+      "value of type %0 has no member %1", (Type, DeclNameRef))
 ERROR(could_not_find_value_member_corrected,none,
       "value of type %0 has no member %1; did you mean %2?",
-      (Type, DeclName, DeclName))
+      (Type, DeclNameRef, DeclName))
 ERROR(could_not_find_value_dynamic_member_corrected,none,
       "value of type %0 has no dynamic member %2 using key path from root type %1; did you mean %3?",
-      (Type, Type, DeclName, DeclName))
+      (Type, Type, DeclNameRef, DeclName))
 ERROR(could_not_find_value_dynamic_member,none,
       "value of type %0 has no dynamic member %2 using key path from root type %1",
-      (Type, Type, DeclName))
+      (Type, Type, DeclNameRef))
 
 ERROR(could_not_find_type_member,none,
-      "type %0 has no member %1", (Type, DeclName))
+      "type %0 has no member %1", (Type, DeclNameRef))
 ERROR(could_not_find_type_member_corrected,none,
       "type %0 has no member %1; did you mean %2?",
-      (Type, DeclName, DeclName))
+      (Type, DeclNameRef, DeclName))
 
 ERROR(could_not_find_subscript_member_did_you_mean,none,
       "value of type %0 has no property or method named 'subscript'; "
@@ -107,7 +107,8 @@ ERROR(could_not_find_subscript_member_did_you_mean,none,
       (Type))
 
 ERROR(could_not_find_enum_case,none,
-      "enum type %0 has no case %1; did you mean %2", (Type, DeclName, DeclName))
+      "enum type %0 has no case %1; did you mean %2",
+      (Type, DeclNameRef, DeclName))
 
 NOTE(did_you_mean_raw_type,none,
      "did you mean to specify a raw type on the enum declaration?", ())
@@ -128,35 +129,35 @@ ERROR(unexpected_arguments_in_enum_case,none,
       "enum case %0 has no associated values", (DeclName))
 
 ERROR(could_not_use_value_member,none,
-      "member %1 cannot be used on value of type %0", (Type, DeclName))
+      "member %1 cannot be used on value of type %0", (Type, DeclNameRef))
 ERROR(could_not_use_type_member,none,
-      "member %1 cannot be used on type %0", (Type, DeclName))
+      "member %1 cannot be used on type %0", (Type, DeclNameRef))
 
 ERROR(could_not_use_type_member_on_instance,none,
       "static member %1 cannot be used on instance of type %0",
-      (Type, DeclName))
+      (Type, DeclNameRef))
 ERROR(could_not_use_enum_element_on_instance,none,
       "enum case %0 cannot be used as an instance member",
-      (DeclName))
+      (DeclNameRef))
 ERROR(could_not_use_type_member_on_protocol_metatype,none,
       "static member %1 cannot be used on protocol metatype %0",
-      (Type, DeclName))
+      (Type, DeclNameRef))
 ERROR(could_not_use_instance_member_on_type,none,
       "instance member %1"
       "%select{| of type %2}3 cannot be used on"
       "%select{| instance of nested}3 type %0",
-      (Type, DeclName, Type, bool))
+      (Type, DeclNameRef, Type, bool))
 ERROR(could_not_use_member_on_existential,none,
       "member %1 cannot be used on value of protocol type %0; use a generic"
       " constraint instead",
-      (Type, DeclName))
+      (Type, DeclNameRef))
 FIXIT(replace_with_type,"%0",(Type))
 FIXIT(insert_type_qualification,"%0.",(Type))
 
 ERROR(candidate_inaccessible,none,
       "%0 is inaccessible due to "
       "'%select{private|fileprivate|internal|%error|%error}1' protection level",
-      (DeclName, AccessLevel))
+      (DeclBaseName, AccessLevel))
 
 NOTE(note_candidate_inaccessible,none,
      "%0 is inaccessible due to "
@@ -577,7 +578,7 @@ WARNING(expr_keypath_swift3_objc_inference,none,
         (DeclName, Identifier))
 ERROR(expr_keypath_type_of_property,none,
       "cannot refer to type member %0 within instance of type %1",
-      (DeclName, Type))
+      (DeclNameRef, Type))
 ERROR(expr_keypath_generic_type,none,
       "key path cannot refer to generic type %0", (DeclName))
 ERROR(expr_keypath_not_property,none,
@@ -781,24 +782,24 @@ NOTE(invalid_redecl_prev,none,
      "%0 previously declared here", (DeclName))
 
 ERROR(ambiguous_type_base,none,
-      "%0 is ambiguous for type lookup in this context", (DeclName))
+      "%0 is ambiguous for type lookup in this context", (DeclNameRef))
 ERROR(invalid_member_type,none,
-      "%0 is not a member type of %1", (DeclName, Type))
+      "%0 is not a member type of %1", (DeclNameRef, Type))
 ERROR(invalid_member_type_suggest,none,
       "%0 does not have a member type named %1; did you mean %2?",
-      (Type, DeclName, DeclName))
+      (Type, DeclNameRef, DeclName))
 ERROR(invalid_member_reference,none,
       "%0 %1 is not a member type of %2",
       (DescriptiveDeclKind, DeclName, Type))
 ERROR(ambiguous_member_type,none,
-      "ambiguous type name %0 in %1", (DeclName, Type))
+      "ambiguous type name %0 in %1", (DeclNameRef, Type))
 ERROR(no_module_type,none,
-      "no type named %0 in module %1", (DeclName, Identifier))
+      "no type named %0 in module %1", (DeclNameRef, Identifier))
 ERROR(ambiguous_module_type,none,
-      "ambiguous type name %0 in module %1", (DeclName, Identifier))
+      "ambiguous type name %0 in module %1", (DeclNameRef, Identifier))
 ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
-      (DeclName, unsigned))
+      (DeclNameRef, unsigned))
 ERROR(unsupported_recursion_in_associated_type_reference,none,
       "unsupported recursion for reference to %select{associated type|type alias}0 %1 of type %2",
       (bool, DeclName, Type))
@@ -819,18 +820,18 @@ ERROR(unspaced_unary_operator,none,
       ())
 
 ERROR(use_unresolved_identifier,none,
-      "use of unresolved %select{identifier|operator}1 %0", (DeclName, bool))
+      "use of unresolved %select{identifier|operator}1 %0", (DeclNameRef, bool))
 ERROR(use_unresolved_identifier_corrected,none,
       "use of unresolved %select{identifier|operator}1 %0; did you mean '%2'?",
-      (DeclName, bool, StringRef))
+      (DeclNameRef, bool, StringRef))
 NOTE(confusable_character,none,
       "%select{identifier|operator}0 '%1' contains possibly confused characters; "
       "did you mean to use '%2'?",
       (bool, StringRef, StringRef))
 ERROR(use_undeclared_type,none,
-      "use of undeclared type %0", (DeclName))
+      "use of undeclared type %0", (DeclNameRef))
 ERROR(use_undeclared_type_did_you_mean,none,
-      "use of undeclared type %0; did you mean to use '%1'?", (DeclName, StringRef))
+      "use of undeclared type %0; did you mean to use '%1'?", (DeclNameRef, StringRef))
 NOTE(note_typo_candidate_implicit_member,none,
      "did you mean the implicitly-synthesized %1 '%0'?", (StringRef, StringRef))
 NOTE(note_remapped_type,none,
@@ -847,7 +848,7 @@ NOTE(object_literal_resolve_import,none,
      (StringRef, StringRef, StringRef))
 
 ERROR(use_local_before_declaration,none,
-      "use of local variable %0 before its declaration", (DeclName))
+      "use of local variable %0 before its declaration", (DeclNameRef))
 ERROR(unsupported_existential_type,none,
       "protocol %0 can only be used as a generic constraint because it has "
       "Self or associated type requirements", (Identifier))
@@ -1068,10 +1069,10 @@ NOTE(unwrap_with_guard,none,
      "if the optional value contains 'nil'", ())
 ERROR(optional_base_not_unwrapped,none,
       "value of optional type %0 must be unwrapped to refer to member %1 of "
-      "wrapped base type %2", (Type, DeclName, Type))
+      "wrapped base type %2", (Type, DeclNameRef, Type))
 NOTE(optional_base_chain,none,
      "chain the optional using '?' to access member %0 only for non-'nil' "
-     "base values", (DeclName))
+     "base values", (DeclNameRef))
 ERROR(missing_unwrap_optional_try,none,
       "value of optional type %0 not unwrapped; did you mean to use 'try!' "
       "or chain with '?'?",
@@ -1138,21 +1139,21 @@ NOTE(candidate_expected_different_labels,none,
 
 ERROR(member_shadows_global_function,none,
       "use of %0 refers to %1 %2 rather than %3 %4 in %5 %6",
-      (DeclName, DescriptiveDeclKind, DeclName, DescriptiveDeclKind, DeclName,
-       DescriptiveDeclKind, DeclName))
+      (DeclNameRef, DescriptiveDeclKind, DeclName, DescriptiveDeclKind,
+       DeclName, DescriptiveDeclKind, DeclName))
 ERROR(member_shadows_global_function_near_match,none,
       "use of %0 nearly matches %3 %4 in %5 %6 rather than %1 %2",
-      (DeclName, DescriptiveDeclKind, DeclName, DescriptiveDeclKind, DeclName,
-      DescriptiveDeclKind, DeclName))
+      (DeclNameRef, DescriptiveDeclKind, DeclName, DescriptiveDeclKind,
+       DeclName, DescriptiveDeclKind, DeclName))
 
 ERROR(instance_member_use_on_type,none,
       "instance member %1 cannot be used on type %0; "
-      "did you mean to use a value of this type instead?", (Type, DeclName))
+      "did you mean to use a value of this type instead?", (Type, DeclNameRef))
 ERROR(instance_member_in_initializer,none,
       "cannot use instance member %0 within property initializer; "
-      "property initializers run before 'self' is available", (DeclName))
+      "property initializers run before 'self' is available", (DeclNameRef))
 ERROR(instance_member_in_default_parameter,none,
-      "cannot use instance member %0 as a default parameter", (DeclName))
+      "cannot use instance member %0 as a default parameter", (DeclNameRef))
 
 ERROR(missing_argument_named,none,
       "missing argument for parameter %0 in call", (Identifier))
@@ -2178,10 +2179,10 @@ WARNING(append_interpolation_access_control,none,
 // Protocols and existentials
 ERROR(assoc_type_outside_of_protocol,none,
       "associated type %0 can only be used with a concrete type or "
-      "generic parameter base", (DeclName))
+      "generic parameter base", (DeclNameRef))
 ERROR(typealias_outside_of_protocol,none,
       "type alias %0 can only be used with a concrete type or "
-      "generic parameter base", (DeclName))
+      "generic parameter base", (DeclNameRef))
 
 ERROR(objc_protocol_inherits_non_objc_protocol,none,
       "@objc protocol %0 cannot refine non-@objc protocol %1", (Type, Type))
@@ -2903,7 +2904,7 @@ ERROR(no_MaxBuiltinFloatType_found,none,
    "standard library error: _MaxBuiltinFloatType is not properly defined", ())
 
 ERROR(no_member_of_module,none,
-      "module %0 has no member named %1", (Identifier, DeclName))
+      "module %0 has no member named %1", (Identifier, DeclNameRef))
 
 ERROR(super_with_no_base_class,none,
       "'super' members cannot be referenced in a root class", ())
@@ -3049,9 +3050,9 @@ ERROR(collection_literal_empty,none,
 
 ERROR(unresolved_member_no_inference,none,
       "reference to member %0 cannot be resolved without a contextual type",
-      (DeclName))
+      (DeclNameRef))
 ERROR(cannot_infer_base_of_unresolved_member,none,
-      "cannot infer contextual base in reference to member %0", (DeclName))
+      "cannot infer contextual base in reference to member %0", (DeclNameRef))
 ERROR(unresolved_collection_literal,none,
       "cannot infer type for empty collection literal without a "
       "contextual type", ())
@@ -3138,9 +3139,9 @@ WARNING(use_of_void_pointer,none,
 
 // Ambiguities
 ERROR(ambiguous_decl_ref,none,
-      "ambiguous use of %0", (DeclName))
+      "ambiguous use of %0", (DeclNameRef))
 ERROR(ambiguous_operator_ref,none,
-      "ambiguous use of operator %0", (DeclName))
+      "ambiguous use of operator %0", (DeclNameRef))
 NOTE(ambiguous_because_of_trailing_closure,none,
      "%select{use an explicit argument label instead of a trailing closure|"
      "avoid using a trailing closure}0 to call %1",
@@ -3213,7 +3214,7 @@ NOTE(fix_unqualified_access_top_level_multi,none,
 WARNING(warn_deprecated_conditional_conformance_outer_access,none,
         "use of %0 as reference to %1 in %2 %3 will change in future versions of Swift to reference %4 in %5 %6 "
         "which comes via a conditional conformance",
-        (DeclName, DescriptiveDeclKind, DescriptiveDeclKind, DeclName,
+        (DeclNameRef, DescriptiveDeclKind, DescriptiveDeclKind, DeclName,
         DescriptiveDeclKind, DescriptiveDeclKind, DeclName))
 NOTE(fix_deprecated_conditional_conformance_outer_access,none,
      "use '%0' to continue to reference the %1",
@@ -3425,7 +3426,7 @@ NOTE(masked_mutable_property,none,
 
 ERROR(assignment_let_property_delegating_init,none,
       "'let' property %0 may not be initialized directly; use "
-      "\"self.init(...)\" or \"self = ...\" instead", (DeclName))
+      "\"self.init(...)\" or \"self = ...\" instead", (DeclNameRef))
 
 ERROR(label_shadowed, none,
       "label %0 cannot be reused on an inner statement", (Identifier))
@@ -3576,7 +3577,7 @@ ERROR(cannot_convert_single_tuple_into_multiple_arguments,none,
 
 ERROR(enum_element_pattern_assoc_values_mismatch,none,
       "pattern with associated values does not match enum case %0",
-      (DeclName))
+      (DeclNameRef))
 NOTE(enum_element_pattern_assoc_values_remove,none,
      "remove associated values to make the pattern match", ())
 ERROR(tuple_pattern_length_mismatch,none,
@@ -3584,14 +3585,14 @@ ERROR(tuple_pattern_length_mismatch,none,
 ERROR(tuple_pattern_label_mismatch,none,
       "tuple pattern element label %0 must be %1", (Identifier, Identifier))
 ERROR(enum_element_pattern_member_not_found,none,
-      "enum case %0 not found in type %1", (DeclName, Type))
+      "enum case %0 not found in type %1", (DeclNameRef, Type))
 ERROR(optional_element_pattern_not_valid_type,none,
       "'?' pattern cannot match values of type %0", (Type))
 ERROR(condition_optional_element_pattern_not_valid_type,none,
       "initializer for conditional binding must have Optional type, not %0",
       (Type))
 ERROR(enum_element_pattern_not_member_of_enum,none,
-      "enum case %0 is not a member of type %1", (DeclName, Type))
+      "enum case %0 is not a member of type %1", (DeclNameRef, Type))
 ERROR(ambiguous_enum_pattern_type,none,
       "generic enum type %0 is ambiguous without explicit generic parameters "
       "when matching value of type %1", (Type, Type))
@@ -4210,12 +4211,12 @@ ERROR(dynamic_and_library_evolution_not_supported,none,
 //------------------------------------------------------------------------------
 
 ERROR(dynamic_replacement_accessor_type_mismatch, none,
-      "replaced accessor %0's type does not match", (DeclNameRef))
+      "replaced accessor %0's type does not match", (DeclName))
 ERROR(dynamic_replacement_accessor_not_dynamic, none,
-      "replaced accessor for %0 is not marked dynamic", (DeclNameRef))
+      "replaced accessor for %0 is not marked dynamic", (DeclName))
 ERROR(dynamic_replacement_accessor_not_explicit, none,
       "replaced accessor %select{get|set|_read|_modify|willSet|didSet|unsafeAddress|addressWithOwner|addressWithNativeOwner|unsafeMutableAddress|mutableAddressWithOwner|}0 for %1 is not explicitly defined",
-      (unsigned, DeclNameRef))
+      (unsigned, DeclName))
 ERROR(dynamic_replacement_function_not_dynamic, none,
       "replaced function %0 is not marked dynamic", (DeclName))
 ERROR(dynamic_replacement_function_not_found, none,
@@ -4231,7 +4232,8 @@ ERROR(dynamic_replacement_function_of_type_not_found, none,
 NOTE(dynamic_replacement_found_function_of_type, none,
       "found function %0 of type %1", (DeclName, Type))
 ERROR(dynamic_replacement_not_in_extension, none,
-      "dynamicReplacement(for:) of %0 is not defined in an extension or at the file level", (DeclName))
+      "dynamicReplacement(for:) of %0 is not defined in an extension or at the "
+      "file level", (DeclName))
 ERROR(dynamic_replacement_must_not_be_dynamic, none,
       "dynamicReplacement(for:) of %0 must not be dynamic itself", (DeclName))
 ERROR(dynamic_replacement_replaced_not_objc_dynamic, none,
@@ -4239,9 +4241,9 @@ ERROR(dynamic_replacement_replaced_not_objc_dynamic, none,
 ERROR(dynamic_replacement_replacement_not_objc_dynamic, none,
       "%0 is marked @objc dynamic", (DeclName))
 ERROR(dynamic_replacement_replaced_constructor_is_convenience, none,
-      "replaced constructor %0 is marked as convenience", (DeclName))
+      "replaced constructor %0 is marked as convenience", (DeclNameRef))
 ERROR(dynamic_replacement_replaced_constructor_is_not_convenience, none,
-      "replaced constructor %0 is not marked as convenience", (DeclName))
+      "replaced constructor %0 is not marked as convenience", (DeclNameRef))
 
 //------------------------------------------------------------------------------
 // MARK: @available
@@ -4675,7 +4677,7 @@ WARNING(property_wrapper_init_initialValue,none,
         "to 'init(wrappedValue:)'; use of 'init(initialValue:)' is deprecated",
         ())
 ERROR(property_wrapper_projection_value_missing,none,
-      "could not find projection value property %0", (Identifier))
+      "could not find projection value property %0", (DeclNameRef))
 ERROR(property_wrapper_missing_arg_init, none, "missing argument for parameter "
       "%0 in property wrapper initializer; add 'wrappedValue' and %0 "
       "arguments in '@%1(...)'", (Identifier, StringRef))

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1340,19 +1340,19 @@ public:
 
   
   /// Create a TypeExpr for a TypeDecl at the specified location.
-  static TypeExpr *createForDecl(SourceLoc Loc, TypeDecl *D,
+  static TypeExpr *createForDecl(DeclNameLoc Loc, TypeDecl *D,
                                  DeclContext *DC,
                                  bool isImplicit);
 
   /// Create a TypeExpr for a member TypeDecl of the given parent TypeDecl.
-  static TypeExpr *createForMemberDecl(SourceLoc ParentNameLoc,
+  static TypeExpr *createForMemberDecl(DeclNameLoc ParentNameLoc,
                                        TypeDecl *Parent,
-                                       SourceLoc NameLoc,
+                                       DeclNameLoc NameLoc,
                                        TypeDecl *Decl);
 
   /// Create a TypeExpr for a member TypeDecl of the given parent IdentTypeRepr.
   static TypeExpr *createForMemberDecl(IdentTypeRepr *ParentTR,
-                                       SourceLoc NameLoc,
+                                       DeclNameLoc NameLoc,
                                        TypeDecl *Decl);
 
   /// Create a TypeExpr from an IdentTypeRepr with the given arguments applied

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1503,7 +1503,7 @@ public:
   static UnresolvedDeclRefExpr *createImplicit(
       ASTContext &C, DeclName name,
       DeclRefKind refKind = DeclRefKind::Ordinary) {
-    return new (C) UnresolvedDeclRefExpr(DeclNameRef_(name), refKind,
+    return new (C) UnresolvedDeclRefExpr(DeclNameRef(name), refKind,
                                          DeclNameLoc());
   }
 
@@ -2430,7 +2430,7 @@ public:
   static UnresolvedDotExpr *createImplicit(
       ASTContext &C, Expr *base, DeclName name) {
     return new (C) UnresolvedDotExpr(base, SourceLoc(),
-                                     DeclNameRef_(name), DeclNameLoc(),
+                                     DeclNameRef(name), DeclNameLoc(),
                                      /*implicit=*/true);
   }
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1499,7 +1499,26 @@ public:
       static_cast<unsigned>(Loc.isCompound() ? FunctionRefKind::Compound
                                              : FunctionRefKind::Unapplied);
   }
-  
+
+  static UnresolvedDeclRefExpr *createImplicit(
+      ASTContext &C, DeclName name,
+      DeclRefKind refKind = DeclRefKind::Ordinary) {
+    return new (C) UnresolvedDeclRefExpr(name, refKind,
+                                         DeclNameLoc());
+  }
+
+  static UnresolvedDeclRefExpr *createImplicit(
+      ASTContext &C, DeclBaseName baseName, ArrayRef<Identifier> argLabels) {
+    return UnresolvedDeclRefExpr::createImplicit(C,
+        DeclName(C, baseName, argLabels));
+  }
+
+  static UnresolvedDeclRefExpr *createImplicit(
+      ASTContext &C, DeclBaseName baseName, ParameterList *paramList) {
+    return UnresolvedDeclRefExpr::createImplicit(C,
+        DeclName(C, baseName, paramList));
+  }
+
   bool hasName() const { return static_cast<bool>(Name); }
   DeclName getName() const { return Name; }
 
@@ -2407,7 +2426,28 @@ public:
       static_cast<unsigned>(NameLoc.isCompound() ? FunctionRefKind::Compound
                                                  : FunctionRefKind::Unapplied);
   }
-  
+
+  static UnresolvedDotExpr *createImplicit(
+      ASTContext &C, Expr *base, DeclName name) {
+    return new (C) UnresolvedDotExpr(base, SourceLoc(),
+                                     name, DeclNameLoc(),
+                                     /*implicit=*/true);
+  }
+
+  static UnresolvedDotExpr *createImplicit(
+      ASTContext &C, Expr *base,
+      DeclBaseName baseName, ArrayRef<Identifier> argLabels) {
+    return UnresolvedDotExpr::createImplicit(C, base,
+                                             DeclName(C, baseName, argLabels));
+  }
+
+  static UnresolvedDotExpr *createImplicit(
+      ASTContext &C, Expr *base,
+      DeclBaseName baseName, ParameterList *paramList) {
+    return UnresolvedDotExpr::createImplicit(C, base,
+                                             DeclName(C, baseName, paramList));
+  }
+
   SourceLoc getLoc() const {
     if (NameLoc.isValid())
       return NameLoc.getBaseNameLoc();

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -59,7 +59,7 @@ class Identifier {
   
 public:
   enum : size_t {
-    NumLowBitsAvailable = 2,
+    NumLowBitsAvailable = 3,
     RequiredAlignment = 1 << NumLowBitsAvailable,
     SpareBitMask = ((intptr_t)1 << NumLowBitsAvailable) - 1
   };
@@ -72,7 +72,7 @@ private:
   }
 
   /// A type with the alignment expected of a valid \c Identifier::Pointer .
-  struct alignas(uint32_t) Aligner {};
+  struct alignas(uint64_t) Aligner {};
 
   static_assert(alignof(Aligner) >= RequiredAlignment,
                 "Identifier table will provide enough spare bits");

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -638,25 +638,14 @@ public:
   void *getOpaqueValue() const { return FullName.getOpaqueValue(); }
   static DeclNameRef getFromOpaqueValue(void *p);
 
-  // *** TRANSITIONAL CODE STARTS HERE ***
-
-  // We want all DeclNameRef constructions to be explicit, but they need to be
-  // threaded through large portions of the compiler, so that would be
-  // difficult. Instead, we will make uses of DeclNameRef(...) implicit but
-  // deprecated, and use DeclNameRef_(...) as a stand-in for intentional calls
-  // to the constructors. The deprecations and DeclNameRef_ function will go
-  // away before we merge any of this into master.
-
-  [[deprecated]] DeclNameRef(DeclName FullName)
+  explicit DeclNameRef(DeclName FullName)
     : FullName(FullName) { }
 
-  [[deprecated]] DeclNameRef(DeclBaseName BaseName)
+  explicit DeclNameRef(DeclBaseName BaseName)
     : FullName(BaseName) { }
 
-  [[deprecated]] DeclNameRef(Identifier BaseName)
+  explicit DeclNameRef(Identifier BaseName)
     : FullName(BaseName) { }
-
-  // *** TRANSITIONAL CODE ENDS HERE ***
 
   /// The name of the declaration being referenced.
   DeclName getFullName() const {
@@ -775,38 +764,26 @@ public:
                             "only for use within the debugger");
 };
 
-// *** TRANSITIONAL CODE STARTS HERE ***
-
-template<typename T>
-static DeclNameRef DeclNameRef_(T name) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  return DeclNameRef(name);
-#pragma clang diagnostic pop
-}
-
-// *** TRANSITIONAL CODE ENDS HERE ***
-
 inline DeclNameRef DeclNameRef::getFromOpaqueValue(void *p) {
-  return DeclNameRef_(DeclName::getFromOpaqueValue(p));
+  return DeclNameRef(DeclName::getFromOpaqueValue(p));
 }
 
 inline DeclNameRef DeclNameRef::withoutArgumentLabels() const {
-  return DeclNameRef_(getBaseName());
+  return DeclNameRef(getBaseName());
 }
 
 inline DeclNameRef DeclNameRef::withArgumentLabels(
     ASTContext &C, ArrayRef<Identifier> argumentNames) const {
-  return DeclNameRef_(DeclName(C, getBaseName(), argumentNames));
+  return DeclNameRef(DeclName(C, getBaseName(), argumentNames));
 }
 
 
 inline DeclNameRef DeclNameRef::createSubscript() {
-  return DeclNameRef_(DeclBaseName::createSubscript());
+  return DeclNameRef(DeclBaseName::createSubscript());
 }
 
 inline DeclNameRef DeclNameRef::createConstructor() {
-  return DeclNameRef_(DeclBaseName::createConstructor());
+  return DeclNameRef(DeclBaseName::createConstructor());
 }
 
 void simple_display(llvm::raw_ostream &out, DeclNameRef name);
@@ -972,10 +949,10 @@ namespace llvm {
   // DeclNameRefs hash just like DeclNames.
   template<> struct DenseMapInfo<swift::DeclNameRef> {
     static swift::DeclNameRef getEmptyKey() {
-      return DeclNameRef_(DenseMapInfo<swift::DeclName>::getEmptyKey());
+      return swift::DeclNameRef(DenseMapInfo<swift::DeclName>::getEmptyKey());
     }
     static swift::DeclNameRef getTombstoneKey() {
-      return DeclNameRef_(DenseMapInfo<swift::DeclName>::getTombstoneKey());
+      return swift::DeclNameRef(DenseMapInfo<swift::DeclName>::getTombstoneKey());
     }
     static unsigned getHashValue(swift::DeclNameRef Val) {
       return DenseMapInfo<swift::DeclName>::getHashValue(Val.getFullName());

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -397,11 +397,11 @@ public:
 class NamedDeclConsumer : public VisibleDeclConsumer {
   virtual void anchor() override;
 public:
-  DeclName name;
+  DeclNameRef name;
   SmallVectorImpl<LookupResultEntry> &results;
   bool isTypeLookup;
 
-  NamedDeclConsumer(DeclName name,
+  NamedDeclConsumer(DeclNameRef name,
                     SmallVectorImpl<LookupResultEntry> &results,
                     bool isTypeLookup)
     : name(name), results(results), isTypeLookup(isTypeLookup) {}
@@ -412,7 +412,7 @@ public:
     // to avoid circular validation.
     if (isTypeLookup && !isa<TypeDecl>(VD))
       return;
-    if (VD->getFullName().matchesRef(name))
+    if (VD->getFullName().matchesRef(name.getFullName()))
       results.push_back(LookupResultEntry(VD));
   }
 };
@@ -666,7 +666,7 @@ public:
 
   /// \return the scopes traversed
   static llvm::SmallVector<const ast_scope::ASTScopeImpl *, 0>
-  unqualifiedLookup(SourceFile *, DeclName, SourceLoc,
+  unqualifiedLookup(SourceFile *, DeclNameRef, SourceLoc,
                     const DeclContext *startingContext,
                     namelookup::AbstractASTScopeDeclConsumer &);
 

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -27,6 +27,7 @@ namespace swift {
 class ClassDecl;
 class DeclContext;
 class DeclName;
+class DeclNameRef;
 class DestructorDecl;
 class GenericContext;
 class GenericParamList;
@@ -316,24 +317,15 @@ class UnqualifiedLookupDescriptor {
   using LookupOptions = OptionSet<UnqualifiedLookupFlags>;
 
 public:
-  DeclName Name;
+  DeclNameRef Name;
   DeclContext *DC;
   SourceLoc Loc;
   LookupOptions Options;
 
-  /// Transitional entry point.
-  [[deprecated]] UnqualifiedLookupDescriptor(DeclName name, DeclContext *dc,
-                              SourceLoc loc = SourceLoc(),
-                              LookupOptions options = {})
-      : Name(name), DC(dc), Loc(loc), Options(options) {}
-
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   UnqualifiedLookupDescriptor(DeclNameRef name, DeclContext *dc,
                               SourceLoc loc = SourceLoc(),
                               LookupOptions options = {})
-      : UnqualifiedLookupDescriptor(name.getFullName(), dc, loc, options) { }
-  #pragma clang diagnostic pop
+      : Name(name), DC(dc), Loc(loc), Options(options) { }
 
   friend llvm::hash_code hash_value(const UnqualifiedLookupDescriptor &desc) {
     return llvm::hash_combine(desc.Name, desc.DC, desc.Loc,

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -321,10 +321,19 @@ public:
   SourceLoc Loc;
   LookupOptions Options;
 
-  UnqualifiedLookupDescriptor(DeclName name, DeclContext *dc,
+  /// Transitional entry point.
+  [[deprecated]] UnqualifiedLookupDescriptor(DeclName name, DeclContext *dc,
                               SourceLoc loc = SourceLoc(),
                               LookupOptions options = {})
       : Name(name), DC(dc), Loc(loc), Options(options) {}
+
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  UnqualifiedLookupDescriptor(DeclNameRef name, DeclContext *dc,
+                              SourceLoc loc = SourceLoc(),
+                              LookupOptions options = {})
+      : UnqualifiedLookupDescriptor(name.getFullName(), dc, loc, options) { }
+  #pragma clang diagnostic pop
 
   friend llvm::hash_code hash_value(const UnqualifiedLookupDescriptor &desc) {
     return llvm::hash_combine(desc.Name, desc.DC, desc.Loc,
@@ -389,8 +398,8 @@ private:
 /// Perform \c AnyObject lookup for a given member.
 class AnyObjectLookupRequest
     : public SimpleRequest<AnyObjectLookupRequest,
-                           QualifiedLookupResult(const DeclContext *, DeclName,
-                                                 NLOptions),
+                           QualifiedLookupResult(const DeclContext *,
+                                                 DeclNameRef, NLOptions),
                            CacheKind::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -400,7 +409,7 @@ private:
 
   llvm::Expected<QualifiedLookupResult> evaluate(Evaluator &evaluator,
                                                  const DeclContext *dc,
-                                                 DeclName name,
+                                                 DeclNameRef name,
                                                  NLOptions options) const;
 };
 

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -505,13 +505,13 @@ class EnumElementPattern : public Pattern {
   TypeLoc ParentType;
   SourceLoc DotLoc;
   DeclNameLoc NameLoc;
-  DeclName Name;
+  DeclNameRef Name;
   PointerUnion<EnumElementDecl *, Expr*> ElementDeclOrUnresolvedOriginalExpr;
   Pattern /*nullable*/ *SubPattern;
   
 public:
   EnumElementPattern(TypeLoc ParentType, SourceLoc DotLoc, DeclNameLoc NameLoc,
-                     DeclName Name, EnumElementDecl *Element,
+                     DeclNameRef Name, EnumElementDecl *Element,
                      Pattern *SubPattern, Optional<bool> Implicit = None)
     : Pattern(PatternKind::EnumElement),
       ParentType(ParentType), DotLoc(DotLoc), NameLoc(NameLoc), Name(Name),
@@ -525,7 +525,7 @@ public:
   /// contextual type.
   EnumElementPattern(SourceLoc DotLoc,
                      DeclNameLoc NameLoc,
-                     DeclName Name,
+                     DeclNameRef Name,
                      Pattern *SubPattern,
                      Expr *UnresolvedOriginalExpr)
     : Pattern(PatternKind::EnumElement),
@@ -551,7 +551,7 @@ public:
   
   void setSubPattern(Pattern *p) { SubPattern = p; }
   
-  DeclName getName() const { return Name; }
+  DeclNameRef getName() const { return Name; }
   
   EnumElementDecl *getElementDecl() const {
     return ElementDeclOrUnresolvedOriginalExpr.dyn_cast<EnumElementDecl*>();

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -504,14 +504,14 @@ public:
 class EnumElementPattern : public Pattern {
   TypeLoc ParentType;
   SourceLoc DotLoc;
-  SourceLoc NameLoc;
-  Identifier Name;
+  DeclNameLoc NameLoc;
+  DeclName Name;
   PointerUnion<EnumElementDecl *, Expr*> ElementDeclOrUnresolvedOriginalExpr;
   Pattern /*nullable*/ *SubPattern;
   
 public:
-  EnumElementPattern(TypeLoc ParentType, SourceLoc DotLoc, SourceLoc NameLoc,
-                     Identifier Name, EnumElementDecl *Element,
+  EnumElementPattern(TypeLoc ParentType, SourceLoc DotLoc, DeclNameLoc NameLoc,
+                     DeclName Name, EnumElementDecl *Element,
                      Pattern *SubPattern, Optional<bool> Implicit = None)
     : Pattern(PatternKind::EnumElement),
       ParentType(ParentType), DotLoc(DotLoc), NameLoc(NameLoc), Name(Name),
@@ -524,8 +524,8 @@ public:
   /// Create an unresolved EnumElementPattern for a `.foo` pattern relying on
   /// contextual type.
   EnumElementPattern(SourceLoc DotLoc,
-                     SourceLoc NameLoc,
-                     Identifier Name,
+                     DeclNameLoc NameLoc,
+                     DeclName Name,
                      Pattern *SubPattern,
                      Expr *UnresolvedOriginalExpr)
     : Pattern(PatternKind::EnumElement),
@@ -551,7 +551,7 @@ public:
   
   void setSubPattern(Pattern *p) { SubPattern = p; }
   
-  Identifier getName() const { return Name; }
+  DeclName getName() const { return Name; }
   
   EnumElementDecl *getElementDecl() const {
     return ElementDeclOrUnresolvedOriginalExpr.dyn_cast<EnumElementDecl*>();
@@ -567,18 +567,18 @@ public:
     return ElementDeclOrUnresolvedOriginalExpr.is<Expr*>();
   }
   
-  SourceLoc getNameLoc() const { return NameLoc; }
-  SourceLoc getLoc() const { return NameLoc; }
+  DeclNameLoc getNameLoc() const { return NameLoc; }
+  SourceLoc getLoc() const { return NameLoc.getBaseNameLoc(); }
   SourceLoc getStartLoc() const {
     return ParentType.hasLocation() ? ParentType.getSourceRange().Start :
            DotLoc.isValid()         ? DotLoc
-                                    : NameLoc;
+                                    : NameLoc.getBaseNameLoc();
   }
   SourceLoc getEndLoc() const {
     if (SubPattern && SubPattern->getSourceRange().isValid()) {
       return SubPattern->getSourceRange().End;
     }
-    return NameLoc;
+    return NameLoc.getEndLoc();
   }
   SourceRange getSourceRange() const { return {getStartLoc(), getEndLoc()}; }
   

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -263,23 +263,23 @@ class ComponentIdentTypeRepr : public IdentTypeRepr {
   ///
   /// The initial parsed representation is always an identifier, and
   /// name binding will resolve this to a specific declaration.
-  llvm::PointerUnion<DeclName, TypeDecl *> IdOrDecl;
+  llvm::PointerUnion<DeclNameRef, TypeDecl *> IdOrDecl;
 
   /// The declaration context from which the bound declaration was
   /// found. only valid if IdOrDecl is a TypeDecl.
   DeclContext *DC;
 
 protected:
-  ComponentIdentTypeRepr(TypeReprKind K, DeclNameLoc Loc, DeclName Id)
+  ComponentIdentTypeRepr(TypeReprKind K, DeclNameLoc Loc, DeclNameRef Id)
     : IdentTypeRepr(K), Loc(Loc), IdOrDecl(Id), DC(nullptr) {}
 
 public:
   DeclNameLoc getNameLoc() const { return Loc; }
-  DeclName getNameRef() const;
+  DeclNameRef getNameRef() const;
 
   /// Replace the identifier with a new identifier, e.g., due to typo
   /// correction.
-  void overwriteNameRef(DeclName newId) { IdOrDecl = newId; }
+  void overwriteNameRef(DeclNameRef newId) { IdOrDecl = newId; }
 
   /// Return true if this has been name-bound already.
   bool isBound() const { return IdOrDecl.is<TypeDecl *>(); }
@@ -312,7 +312,7 @@ protected:
 /// A simple identifier type like "Int".
 class SimpleIdentTypeRepr : public ComponentIdentTypeRepr {
 public:
-  SimpleIdentTypeRepr(DeclNameLoc Loc, DeclName Id)
+  SimpleIdentTypeRepr(DeclNameLoc Loc, DeclNameRef Id)
     : ComponentIdentTypeRepr(TypeReprKind::SimpleIdent, Loc, Id) {}
 
   // SmallVector::emplace_back will never need to call this because
@@ -342,7 +342,7 @@ class GenericIdentTypeRepr final : public ComponentIdentTypeRepr,
   friend TrailingObjects;
   SourceRange AngleBrackets;
 
-  GenericIdentTypeRepr(DeclNameLoc Loc, DeclName Id,
+  GenericIdentTypeRepr(DeclNameLoc Loc, DeclNameRef Id,
                        ArrayRef<TypeRepr*> GenericArgs,
                        SourceRange AngleBrackets)
     : ComponentIdentTypeRepr(TypeReprKind::GenericIdent, Loc, Id),
@@ -360,7 +360,7 @@ class GenericIdentTypeRepr final : public ComponentIdentTypeRepr,
 public:
   static GenericIdentTypeRepr *create(const ASTContext &C,
                                       DeclNameLoc Loc,
-                                      DeclName Id,
+                                      DeclNameRef Id,
                                       ArrayRef<TypeRepr*> GenericArgs,
                                       SourceRange AngleBrackets);
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -747,7 +747,7 @@ public:
     getScopeInfo().addToScope(D, *this, diagnoseRedefinitions);
   }
 
-  ValueDecl *lookupInScope(DeclName Name) {
+  ValueDecl *lookupInScope(DeclNameRef Name) {
     if (Context.LangOpts.DisableParserLookup)
           return nullptr;
 
@@ -990,7 +990,8 @@ public:
   /// Parse the arguments inside the @differentiable attribute.
   bool parseDifferentiableAttributeArguments(
       bool &linear, SmallVectorImpl<ParsedAutoDiffParameter> &params,
-      Optional<DeclNameWithLoc> &jvpSpec, Optional<DeclNameWithLoc> &vjpSpec,
+      Optional<DeclNameRefWithLoc> &jvpSpec,
+      Optional<DeclNameRefWithLoc> &vjpSpec,
       TrailingWhereClause *&whereClause);
 
   /// Parse a differentiation parameters clause.
@@ -1421,10 +1422,10 @@ public:
   /// \param loc Will be populated with the location of the name.
   /// \param diag The diagnostic to emit if this is not a name.
   /// \param allowOperators Whether to allow operator basenames too.
-  DeclBaseName parseUnqualifiedDeclBaseName(bool afterDot, DeclNameLoc &loc,
-                                            const Diagnostic &diag,
-                                            bool allowOperators=false,
-                                            bool allowDeinitAndSubscript=false);
+  DeclNameRef parseUnqualifiedDeclBaseName(bool afterDot, DeclNameLoc &loc,
+                                           const Diagnostic &diag,
+                                           bool allowOperators=false,
+                                           bool allowDeinitAndSubscript=false);
 
   /// Parse an unqualified-decl-name.
   ///
@@ -1438,11 +1439,11 @@ public:
   /// \param diag The diagnostic to emit if this is not a name.
   /// \param allowOperators Whether to allow operator basenames too.
   /// \param allowZeroArgCompoundNames Whether to allow empty argument lists.
-  DeclName parseUnqualifiedDeclName(bool afterDot, DeclNameLoc &loc,
-                                    const Diagnostic &diag,
-                                    bool allowOperators=false,
-                                    bool allowZeroArgCompoundNames=false,
-                                    bool allowDeinitAndSubscript=false);
+  DeclNameRef parseUnqualifiedDeclName(bool afterDot, DeclNameLoc &loc,
+                                       const Diagnostic &diag,
+                                       bool allowOperators=false,
+                                       bool allowZeroArgCompoundNames=false,
+                                       bool allowDeinitAndSubscript=false);
 
   Expr *parseExprIdentifier();
   Expr *parseExprEditorPlaceholder(Token PlaceholderTok,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1411,11 +1411,26 @@ public:
   /// \param loc The location of the label (empty if it doesn't exist)
   void parseOptionalArgumentLabel(Identifier &name, SourceLoc &loc);
 
-  /// Parse an unqualified-decl-name.
+  /// Parse an unqualified-decl-base-name.
   ///
   ///   unqualified-decl-name:
   ///     identifier
-  ///     identifier '(' ((identifier | '_') ':') + ')'
+  ///
+  /// \param afterDot Whether this identifier is coming after a period, which
+  /// enables '.init' and '.default' like expressions.
+  /// \param loc Will be populated with the location of the name.
+  /// \param diag The diagnostic to emit if this is not a name.
+  /// \param allowOperators Whether to allow operator basenames too.
+  DeclBaseName parseUnqualifiedDeclBaseName(bool afterDot, DeclNameLoc &loc,
+                                            const Diagnostic &diag,
+                                            bool allowOperators=false,
+                                            bool allowDeinitAndSubscript=false);
+
+  /// Parse an unqualified-decl-name.
+  ///
+  ///   unqualified-decl-name:
+  ///     unqualified-decl-base-name
+  ///     unqualified-decl-base-name '(' ((identifier | '_') ':') + ')'
   ///
   /// \param afterDot Whether this identifier is coming after a period, which
   /// enables '.init' and '.default' like expressions.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1661,6 +1661,9 @@ struct ParsedDeclName {
 
   /// Form a declaration name from this parsed declaration name.
   DeclName formDeclName(ASTContext &ctx) const;
+
+  /// Form a declaration name from this parsed declaration name.
+  DeclNameRef formDeclNameRef(ASTContext &ctx) const;
 };
 
 /// Parse a stringified Swift declaration name,
@@ -1673,6 +1676,13 @@ DeclName formDeclName(ASTContext &ctx,
                       ArrayRef<StringRef> argumentLabels,
                       bool isFunctionName,
                       bool isInitializer);
+
+/// Form a Swift declaration name referemce from its constituent parts.
+DeclNameRef formDeclNameRef(ASTContext &ctx,
+                            StringRef baseName,
+                            ArrayRef<StringRef> argumentLabels,
+                            bool isFunctionName,
+                            bool isInitializer);
 
 /// Parse a stringified Swift declaration name, e.g. "init(frame:)".
 DeclName parseDeclName(ASTContext &ctx, StringRef name);

--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -47,7 +47,7 @@ private:
   unsigned ResolvableDepth = 0;
 
 public:
-  ValueDecl *lookupValueName(DeclName Name);
+  ValueDecl *lookupValueName(DeclNameRef Name);
 
   Scope *getCurrentScope() const { return CurScope; }
 
@@ -159,7 +159,7 @@ public:
   }
 };
 
-inline ValueDecl *ScopeInfo::lookupValueName(DeclName Name) {
+inline ValueDecl *ScopeInfo::lookupValueName(DeclNameRef Name) {
   // FIXME: this check can go away when SIL parser parses everything in
   // a toplevel scope.
   if (!CurScope)
@@ -169,7 +169,8 @@ inline ValueDecl *ScopeInfo::lookupValueName(DeclName Name) {
   // If we found nothing, or we found a decl at the top-level, return nothing.
   // We ignore results at the top-level because we may have overloading that
   // will be resolved properly by name binding.
-  std::pair<unsigned, ValueDecl *> Res = HT.lookup(CurScope->HTScope, Name);
+  std::pair<unsigned, ValueDecl *> Res = HT.lookup(CurScope->HTScope,
+                                                   Name.getFullName());
   if (Res.first < ResolvableDepth)
     return 0;
   return Res.second;

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -82,6 +82,11 @@ namespace swift {
     ArrayRef<ValueDecl*> getMemberDecls(InterestedMemberKind Kind);
   };
 
+  /// Look up a member with the given name in the given type.
+  ///
+  /// Unlike other member lookup functions, \c swift::resolveValueMember()
+  /// should be used when you want to look up declarations with the same name as
+  /// one you already have.
   ResolvedMemberResult resolveValueMember(DeclContext &DC, Type BaseTy,
                                          DeclName Name);
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -167,7 +167,8 @@ namespace swift {
   
   /// Once parsing and name-binding are complete this optionally walks the ASTs
   /// to add calls to externally provided functions that simulate
-  /// "program counter"-like debugging events.
+  /// "program counter"-like debugging events. See the comment at the top of
+  /// lib/Sema/PCMacro.cpp for a description of the calls inserted.
   void performPCMacro(SourceFile &SF);
 
   /// Creates a type checker instance on the given AST context, if it

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -833,7 +833,8 @@ DECLTYPE *ASTContext::get##NAME##Decl() const { \
       /* Note: lookupQualified() will search both the Swift overlay \
        * and the Clang module it imports. */ \
       SmallVector<ValueDecl *, 1> decls; \
-      M->lookupQualified(M, getIdentifier(#NAME), NL_OnlyTypes, decls); \
+      M->lookupQualified(M, DeclNameRef_(getIdentifier(#NAME)), NL_OnlyTypes, \
+                         decls); \
       if (decls.size() == 1 && isa<DECLTYPE>(decls[0])) { \
         auto decl = cast<DECLTYPE>(decls[0]); \
         if (isa<ProtocolDecl>(decl) || decl->getGenericParams() == nullptr) { \

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -833,7 +833,7 @@ DECLTYPE *ASTContext::get##NAME##Decl() const { \
       /* Note: lookupQualified() will search both the Swift overlay \
        * and the Clang module it imports. */ \
       SmallVector<ValueDecl *, 1> decls; \
-      M->lookupQualified(M, DeclNameRef_(getIdentifier(#NAME)), NL_OnlyTypes, \
+      M->lookupQualified(M, DeclNameRef(getIdentifier(#NAME)), NL_OnlyTypes, \
                          decls); \
       if (decls.size() == 1 && isa<DECLTYPE>(decls[0])) { \
         auto decl = cast<DECLTYPE>(decls[0]); \

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2884,7 +2884,7 @@ public:
       OS << '\n';
       printCommon("component");
       PrintWithColorRAII(OS, IdentifierColor)
-        << " id='" << comp->getIdentifier() << '\'';
+        << " id='" << comp->getNameRef() << '\'';
       OS << " bind=";
       if (comp->isBound())
         comp->getBoundDecl()->dumpRef(OS);
@@ -3599,7 +3599,7 @@ namespace {
       if (auto assocType = T->getAssocType()) {
         printField("assoc_type", assocType->printRef());
       } else {
-        printField("name", T->getName().str());
+        printField("name", T->getName());
       }
       printRec("base", T->getBase());
       PrintWithColorRAII(OS, ParenthesisColor) << ')';

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -334,10 +334,26 @@ ASTPrinter &ASTPrinter::operator<<(UUID UU) {
   return *this;
 }
 
+ASTPrinter &ASTPrinter::operator<<(Identifier name) {
+  return *this << DeclName(name);
+}
+
+ASTPrinter &ASTPrinter::operator<<(DeclBaseName name) {
+  return *this << DeclName(name);
+}
+
 ASTPrinter &ASTPrinter::operator<<(DeclName name) {
   llvm::SmallString<32> str;
   llvm::raw_svector_ostream os(str);
   name.print(os);
+  printTextImpl(os.str());
+  return *this;
+}
+
+ASTPrinter &ASTPrinter::operator<<(DeclNameRef ref) {
+  llvm::SmallString<32> str;
+  llvm::raw_svector_ostream os(str);
+  ref.print(os);
   printTextImpl(os.str());
   return *this;
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2834,7 +2834,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
       // TypeRepr is not getting 'typechecked'. See
       // \c resolveTopLevelIdentTypeComponent function in TypeCheckType.cpp.
       if (auto *simId = dyn_cast_or_null<SimpleIdentTypeRepr>(ResultTyLoc.getTypeRepr())) {
-        if (simId->getIdentifier() == Ctx.Id_Self)
+        if (simId->getNameRef().isSimpleName(Ctx.Id_Self))
           ResultTyLoc = TypeLoc::withoutLoc(ResultTy);
       }
       Printer << " -> ";

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -39,7 +39,7 @@ using namespace ast_scope;
 #pragma mark ASTScope
 
 llvm::SmallVector<const ASTScopeImpl *, 0> ASTScope::unqualifiedLookup(
-    SourceFile *SF, DeclName name, SourceLoc loc,
+    SourceFile *SF, DeclNameRef name, SourceLoc loc,
     const DeclContext *startingContext,
     namelookup::AbstractASTScopeDeclConsumer &consumer) {
   if (auto *s = SF->getASTContext().Stats)

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -39,7 +39,7 @@ using namespace ast_scope;
 static bool isLocWithinAnInactiveClause(const SourceLoc loc, SourceFile *SF);
 
 llvm::SmallVector<const ASTScopeImpl *, 0> ASTScopeImpl::unqualifiedLookup(
-    SourceFile *sourceFile, const DeclName name, const SourceLoc loc,
+    SourceFile *sourceFile, const DeclNameRef name, const SourceLoc loc,
     const DeclContext *const startingContext, DeclConsumer consumer) {
   SmallVector<const ASTScopeImpl *, 0> history;
   const auto *start =
@@ -50,7 +50,7 @@ llvm::SmallVector<const ASTScopeImpl *, 0> ASTScopeImpl::unqualifiedLookup(
 }
 
 const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
-    SourceFile *sourceFile, const DeclName name, const SourceLoc loc,
+    SourceFile *sourceFile, const DeclNameRef name, const SourceLoc loc,
     const DeclContext *const startingContext) {
   // At present, use legacy code in unqualifiedLookup.cpp to handle module-level
   // lookups

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -88,7 +88,7 @@ void TypeAttributes::getConventionArguments(SmallVectorImpl<char> &buf) const {
   llvm::raw_svector_ostream stream(buf);
   auto &convention = ConventionArguments.getValue();
   stream << convention.Name;
-  if (!convention.WitnessMethodProtocol.empty()) {
+  if (convention.WitnessMethodProtocol) {
     stream << ": " << convention.WitnessMethodProtocol;
     return;
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1741,12 +1741,12 @@ static bool isDefaultInitializable(const TypeRepr *typeRepr, ASTContext &ctx) {
   // Also support the desugared 'Optional<T>' spelling.
   if (!ctx.isSwiftVersionAtLeast(5)) {
     if (auto *identRepr = dyn_cast<SimpleIdentTypeRepr>(typeRepr)) {
-      if (identRepr->getIdentifier() == ctx.Id_Void)
+      if (identRepr->getNameRef().getBaseIdentifier() == ctx.Id_Void)
         return true;
     }
 
     if (auto *identRepr = dyn_cast<GenericIdentTypeRepr>(typeRepr)) {
-      if (identRepr->getIdentifier() == ctx.Id_Optional &&
+      if (identRepr->getNameRef().getBaseIdentifier() == ctx.Id_Optional &&
           identRepr->getNumGenericArgs() == 1)
         return true;
     }

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -414,7 +414,7 @@ const ValueDecl *findDefaultProvidedDeclWithDocComment(const ValueDecl *VD) {
 
   SmallVector<ValueDecl *, 2> members;
   protocol->lookupQualified(const_cast<ProtocolDecl *>(protocol),
-                            DeclNameRef_(VD->getFullName()),
+                            DeclNameRef(VD->getFullName()),
                             NLOptions::NL_ProtocolMembers,
                             members);
 

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -414,7 +414,8 @@ const ValueDecl *findDefaultProvidedDeclWithDocComment(const ValueDecl *VD) {
 
   SmallVector<ValueDecl *, 2> members;
   protocol->lookupQualified(const_cast<ProtocolDecl *>(protocol),
-                            VD->getFullName(), NLOptions::NL_ProtocolMembers,
+                            DeclNameRef_(VD->getFullName()),
+                            NLOptions::NL_ProtocolMembers,
                             members);
 
   for (auto *member : members) {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1533,7 +1533,7 @@ DynamicSubscriptExpr::create(ASTContext &ctx, Expr *base, SourceLoc lSquareLoc,
 
 UnresolvedMemberExpr::UnresolvedMemberExpr(SourceLoc dotLoc,
                                            DeclNameLoc nameLoc,
-                                           DeclName name, Expr *argument,
+                                           DeclNameRef name, Expr *argument,
                                            ArrayRef<Identifier> argLabels,
                                            ArrayRef<SourceLoc> argLabelLocs,
                                            bool hasTrailingClosure,
@@ -1550,7 +1550,7 @@ UnresolvedMemberExpr::UnresolvedMemberExpr(SourceLoc dotLoc,
 UnresolvedMemberExpr *UnresolvedMemberExpr::create(ASTContext &ctx,
                                                    SourceLoc dotLoc,
                                                    DeclNameLoc nameLoc,
-                                                   DeclName name,
+                                                   DeclNameRef name,
                                                    bool implicit) {
   size_t size = totalSizeToAlloc({ }, { }, /*hasTrailingClosure=*/false);
 
@@ -1563,7 +1563,7 @@ UnresolvedMemberExpr *UnresolvedMemberExpr::create(ASTContext &ctx,
 
 UnresolvedMemberExpr *
 UnresolvedMemberExpr::create(ASTContext &ctx, SourceLoc dotLoc,
-                             DeclNameLoc nameLoc, DeclName name,
+                             DeclNameLoc nameLoc, DeclNameRef name,
                              SourceLoc lParenLoc,
                              ArrayRef<Expr *> args,
                              ArrayRef<Identifier> argLabels,
@@ -1887,7 +1887,7 @@ TypeExpr *TypeExpr::createForDecl(DeclNameLoc Loc, TypeDecl *Decl,
                                   bool isImplicit) {
   ASTContext &C = Decl->getASTContext();
   assert(Loc.isValid() || isImplicit);
-  auto *Repr = new (C) SimpleIdentTypeRepr(Loc, Decl->getName());
+  auto *Repr = new (C) SimpleIdentTypeRepr(Loc, Decl->createNameRef());
   Repr->setValue(Decl, DC);
   auto result = new (C) TypeExpr(TypeLoc(Repr, Type()));
   if (isImplicit)
@@ -1908,13 +1908,13 @@ TypeExpr *TypeExpr::createForMemberDecl(DeclNameLoc ParentNameLoc,
 
   // The first component is the parent type.
   auto *ParentComp = new (C) SimpleIdentTypeRepr(ParentNameLoc,
-                                                 Parent->getName());
+                                                 Parent->createNameRef());
   ParentComp->setValue(Parent, nullptr);
   Components.push_back(ParentComp);
 
   // The second component is the member we just found.
   auto *NewComp = new (C) SimpleIdentTypeRepr(NameLoc,
-                                              Decl->getName());
+                                              Decl->createNameRef());
   NewComp->setValue(Decl, nullptr);
   Components.push_back(NewComp);
 
@@ -1935,7 +1935,7 @@ TypeExpr *TypeExpr::createForMemberDecl(IdentTypeRepr *ParentTR,
   assert(!Components.empty());
 
   // Add a new component for the member we just found.
-  auto *NewComp = new (C) SimpleIdentTypeRepr(NameLoc, Decl->getName());
+  auto *NewComp = new (C) SimpleIdentTypeRepr(NameLoc, Decl->createNameRef());
   NewComp->setValue(Decl, nullptr);
   Components.push_back(NewComp);
 
@@ -2172,7 +2172,7 @@ void InterpolatedStringLiteralExpr::forEachSegment(ASTContext &Ctx,
           name = fn->getFullName();
         } else if (auto unresolvedDot =
                       dyn_cast<UnresolvedDotExpr>(call->getFn())) {
-          name = unresolvedDot->getName();
+          name = unresolvedDot->getName().getFullName();
         }
 
         bool isInterpolation = (name.getBaseName() ==

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1882,7 +1882,7 @@ Type TypeExpr::getInstanceType(
 }
 
 
-TypeExpr *TypeExpr::createForDecl(SourceLoc Loc, TypeDecl *Decl,
+TypeExpr *TypeExpr::createForDecl(DeclNameLoc Loc, TypeDecl *Decl,
                                   DeclContext *DC,
                                   bool isImplicit) {
   ASTContext &C = Decl->getASTContext();
@@ -1895,9 +1895,9 @@ TypeExpr *TypeExpr::createForDecl(SourceLoc Loc, TypeDecl *Decl,
   return result;
 }
 
-TypeExpr *TypeExpr::createForMemberDecl(SourceLoc ParentNameLoc,
+TypeExpr *TypeExpr::createForMemberDecl(DeclNameLoc ParentNameLoc,
                                         TypeDecl *Parent,
-                                        SourceLoc NameLoc,
+                                        DeclNameLoc NameLoc,
                                         TypeDecl *Decl) {
   ASTContext &C = Decl->getASTContext();
   assert(ParentNameLoc.isValid());
@@ -1923,7 +1923,7 @@ TypeExpr *TypeExpr::createForMemberDecl(SourceLoc ParentNameLoc,
 }
 
 TypeExpr *TypeExpr::createForMemberDecl(IdentTypeRepr *ParentTR,
-                                        SourceLoc NameLoc,
+                                        DeclNameLoc NameLoc,
                                         TypeDecl *Decl) {
   ASTContext &C = Decl->getASTContext();
 
@@ -1983,7 +1983,7 @@ TypeExpr *TypeExpr::createForSpecializedDecl(IdentTypeRepr *ParentTR,
     }
 
     auto *genericComp = GenericIdentTypeRepr::create(C,
-      last->getIdLoc(), last->getIdentifier(),
+      last->getNameLoc(), last->getNameRef(),
       Args, AngleLocs);
     genericComp->setValue(last->getBoundDecl(), last->getDeclContext());
     components.push_back(genericComp);

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1886,7 +1886,7 @@ TypeDecl *EquivalenceClass::lookupNestedType(
     if (decl) {
       SmallVector<ValueDecl *, 2> foundMembers;
       decl->getParentModule()->lookupQualified(
-          decl, name,
+          decl, DeclNameRef_(name),
           NL_QualifiedDefault | NL_OnlyTypes | NL_ProtocolMembers,
           foundMembers);
       for (auto member : foundMembers) {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1886,7 +1886,7 @@ TypeDecl *EquivalenceClass::lookupNestedType(
     if (decl) {
       SmallVector<ValueDecl *, 2> foundMembers;
       decl->getParentModule()->lookupQualified(
-          decl, DeclNameRef_(name),
+          decl, DeclNameRef(name),
           NL_QualifiedDefault | NL_OnlyTypes | NL_ProtocolMembers,
           foundMembers);
       for (auto member : foundMembers) {

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -51,6 +51,15 @@ void swift::simple_display(llvm::raw_ostream &out, DeclName name) {
   out << "'" << name << "'";
 }
 
+raw_ostream &llvm::operator<<(raw_ostream &OS, DeclNameRef I) {
+  OS << I.getFullName();
+  return OS;
+}
+
+void swift::simple_display(llvm::raw_ostream &out, DeclNameRef name) {
+  out << "'" << name << "'";
+}
+
 raw_ostream &llvm::operator<<(raw_ostream &OS, swift::ObjCSelector S) {
   unsigned n = S.getNumArgs();
   if (n == 0) {
@@ -187,6 +196,24 @@ llvm::raw_ostream &DeclName::print(llvm::raw_ostream &os,
 
 llvm::raw_ostream &DeclName::printPretty(llvm::raw_ostream &os) const {
   return print(os, /*skipEmptyArgumentNames=*/!isSpecial());
+}
+
+void DeclNameRef::dump() const {
+  llvm::errs() << *this << "\n";
+}
+
+StringRef DeclNameRef::getString(llvm::SmallVectorImpl<char> &scratch,
+                             bool skipEmptyArgumentNames) const {
+  return FullName.getString(scratch, skipEmptyArgumentNames);
+}
+
+llvm::raw_ostream &DeclNameRef::print(llvm::raw_ostream &os,
+                                  bool skipEmptyArgumentNames) const {
+  return FullName.print(os, skipEmptyArgumentNames);
+}
+
+llvm::raw_ostream &DeclNameRef::printPretty(llvm::raw_ostream &os) const {
+  return FullName.printPretty(os);
 }
 
 ObjCSelector::ObjCSelector(ASTContext &ctx, unsigned numArgs,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2331,7 +2331,7 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
 
             ComponentIdentTypeRepr *components[2] = {
               new (ctx) SimpleIdentTypeRepr(identTypeRepr->getNameLoc(),
-                                            moduleName),
+                                            DeclNameRef_(moduleName)),
               identTypeRepr
             };
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2331,7 +2331,7 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
 
             ComponentIdentTypeRepr *components[2] = {
               new (ctx) SimpleIdentTypeRepr(identTypeRepr->getNameLoc(),
-                                            DeclNameRef_(moduleName)),
+                                            DeclNameRef(moduleName)),
               identTypeRepr
             };
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -83,7 +83,7 @@ DeclNameRef ComponentIdentTypeRepr::getNameRef() const {
   if (IdOrDecl.is<DeclNameRef>())
     return IdOrDecl.get<DeclNameRef>();
 
-  return DeclNameRef_(IdOrDecl.get<TypeDecl *>()->getFullName());
+  return IdOrDecl.get<TypeDecl *>()->createNameRef();
 }
 
 static void printTypeRepr(const TypeRepr *TyR, ASTPrinter &Printer,

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -79,11 +79,11 @@ void *TypeRepr::operator new(size_t Bytes, const ASTContext &C,
   return C.Allocate(Bytes, Alignment);
 }
 
-DeclName ComponentIdentTypeRepr::getNameRef() const {
-  if (IdOrDecl.is<DeclName>())
-    return IdOrDecl.get<DeclName>();
+DeclNameRef ComponentIdentTypeRepr::getNameRef() const {
+  if (IdOrDecl.is<DeclNameRef>())
+    return IdOrDecl.get<DeclNameRef>();
 
-  return IdOrDecl.get<TypeDecl *>()->getFullName();
+  return DeclNameRef_(IdOrDecl.get<TypeDecl *>()->getFullName());
 }
 
 static void printTypeRepr(const TypeRepr *TyR, ASTPrinter &Printer,
@@ -450,7 +450,7 @@ TupleTypeRepr *TupleTypeRepr::createEmpty(const ASTContext &C,
 
 GenericIdentTypeRepr *GenericIdentTypeRepr::create(const ASTContext &C,
                                                    DeclNameLoc Loc,
-                                                   DeclName Id,
+                                                   DeclNameRef Id,
                                                 ArrayRef<TypeRepr*> GenericArgs,
                                                    SourceRange AngleBrackets) {
   auto size = totalSizeToAlloc<TypeRepr*>(GenericArgs.size());

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -79,11 +79,11 @@ void *TypeRepr::operator new(size_t Bytes, const ASTContext &C,
   return C.Allocate(Bytes, Alignment);
 }
 
-Identifier ComponentIdentTypeRepr::getIdentifier() const {
-  if (IdOrDecl.is<Identifier>())
-    return IdOrDecl.get<Identifier>();
+DeclName ComponentIdentTypeRepr::getNameRef() const {
+  if (IdOrDecl.is<DeclName>())
+    return IdOrDecl.get<DeclName>();
 
-  return IdOrDecl.get<TypeDecl *>()->getName();
+  return IdOrDecl.get<TypeDecl *>()->getFullName();
 }
 
 static void printTypeRepr(const TypeRepr *TyR, ASTPrinter &Printer,
@@ -138,7 +138,7 @@ TypeRepr *CloneVisitor::visitAttributedTypeRepr(AttributedTypeRepr *T) {
 }
 
 TypeRepr *CloneVisitor::visitSimpleIdentTypeRepr(SimpleIdentTypeRepr *T) {
-  return new (Ctx) SimpleIdentTypeRepr(T->getIdLoc(), T->getIdentifier());
+  return new (Ctx) SimpleIdentTypeRepr(T->getNameLoc(), T->getNameRef());
 }
 
 TypeRepr *CloneVisitor::visitGenericIdentTypeRepr(GenericIdentTypeRepr *T) {
@@ -148,7 +148,7 @@ TypeRepr *CloneVisitor::visitGenericIdentTypeRepr(GenericIdentTypeRepr *T) {
   for (auto &arg : T->getGenericArgs()) {
     genericArgs.push_back(visit(arg));
   }
-  return GenericIdentTypeRepr::create(Ctx, T->getIdLoc(), T->getIdentifier(),
+  return GenericIdentTypeRepr::create(Ctx, T->getNameLoc(), T->getNameRef(),
                                         genericArgs, T->getAngleBrackets());
 }
 
@@ -347,11 +347,11 @@ void ComponentIdentTypeRepr::printImpl(ASTPrinter &Printer,
                                        const PrintOptions &Opts) const {
   if (auto *TD = dyn_cast_or_null<TypeDecl>(getBoundDecl())) {
     if (auto MD = dyn_cast<ModuleDecl>(TD))
-      Printer.printModuleRef(MD, getIdentifier());
+      Printer.printModuleRef(MD, getNameRef().getBaseIdentifier());
     else
-      Printer.printTypeRef(Type(), TD, getIdentifier());
+      Printer.printTypeRef(Type(), TD, getNameRef().getBaseIdentifier());
   } else {
-    Printer.printName(getIdentifier());
+    Printer.printName(getNameRef().getBaseIdentifier());
   }
 
   if (auto GenIdT = dyn_cast<GenericIdentTypeRepr>(this))
@@ -449,8 +449,8 @@ TupleTypeRepr *TupleTypeRepr::createEmpty(const ASTContext &C,
 }
 
 GenericIdentTypeRepr *GenericIdentTypeRepr::create(const ASTContext &C,
-                                                   SourceLoc Loc,
-                                                   Identifier Id,
+                                                   DeclNameLoc Loc,
+                                                   DeclName Id,
                                                 ArrayRef<TypeRepr*> GenericArgs,
                                                    SourceRange AngleBrackets) {
   auto size = totalSizeToAlloc<TypeRepr*>(GenericArgs.size());

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5017,7 +5017,7 @@ namespace {
 
         if (lookupContext) {
           SmallVector<ValueDecl *, 2> lookup;
-          dc->lookupQualified(lookupContext, DeclNameRef_(name),
+          dc->lookupQualified(lookupContext, DeclNameRef(name),
                               NL_QualifiedDefault | NL_KnownNoDependency,
                               lookup);
           bool foundMethod = false;
@@ -6396,7 +6396,7 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
     return;
   // Dig out the Objective-C superclass.
   SmallVector<ValueDecl *, 4> results;
-  superDecl->lookupQualified(superDecl, DeclNameRef_(decl->getFullName()),
+  superDecl->lookupQualified(superDecl, DeclNameRef(decl->getFullName()),
                              NL_QualifiedDefault | NL_KnownNoDependency,
                              results);
   for (auto member : results) {
@@ -6469,7 +6469,7 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
   // operation.
   SmallVector<ValueDecl *, 2> lookup;
   subscript->getModuleContext()->lookupQualified(
-      superDecl, DeclNameRef_(subscript->getFullName()),
+      superDecl, DeclNameRef(subscript->getFullName()),
       NL_QualifiedDefault | NL_KnownNoDependency, lookup);
 
   for (auto result : lookup) {
@@ -7752,7 +7752,7 @@ static void finishTypeWitnesses(
                           NL_OnlyTypes |
                           NL_ProtocolMembers);
 
-    dc->lookupQualified(nominal, DeclNameRef_(assocType->getFullName()), options,
+    dc->lookupQualified(nominal, DeclNameRef(assocType->getFullName()), options,
                         lookupResults);
     for (auto member : lookupResults) {
       auto typeDecl = cast<TypeDecl>(member);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7752,7 +7752,7 @@ static void finishTypeWitnesses(
                           NL_OnlyTypes |
                           NL_ProtocolMembers);
 
-    dc->lookupQualified(nominal, assocType->getFullName(), options,
+    dc->lookupQualified(nominal, DeclNameRef_(assocType->getFullName()), options,
                         lookupResults);
     for (auto member : lookupResults) {
       auto typeDecl = cast<TypeDecl>(member);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5017,7 +5017,7 @@ namespace {
 
         if (lookupContext) {
           SmallVector<ValueDecl *, 2> lookup;
-          dc->lookupQualified(lookupContext, name,
+          dc->lookupQualified(lookupContext, DeclNameRef_(name),
                               NL_QualifiedDefault | NL_KnownNoDependency,
                               lookup);
           bool foundMethod = false;
@@ -6396,7 +6396,7 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
     return;
   // Dig out the Objective-C superclass.
   SmallVector<ValueDecl *, 4> results;
-  superDecl->lookupQualified(superDecl, decl->getFullName(),
+  superDecl->lookupQualified(superDecl, DeclNameRef_(decl->getFullName()),
                              NL_QualifiedDefault | NL_KnownNoDependency,
                              results);
   for (auto member : results) {
@@ -6469,7 +6469,7 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
   // operation.
   SmallVector<ValueDecl *, 2> lookup;
   subscript->getModuleContext()->lookupQualified(
-      superDecl, subscript->getFullName(),
+      superDecl, DeclNameRef_(subscript->getFullName()),
       NL_QualifiedDefault | NL_KnownNoDependency, lookup);
 
   for (auto result : lookup) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1325,8 +1325,8 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
     if (auto *ITR = dyn_cast<IdentTypeRepr>(ParsedTypeLoc.getTypeRepr())) {
       SmallVector<ImportDecl::AccessPathElement, 4> AccessPath;
       for (auto Component : ITR->getComponentRange())
-        AccessPath.push_back({ Component->getIdentifier(),
-                               Component->getIdLoc() });
+        AccessPath.push_back({ Component->getNameRef().getBaseIdentifier(),
+                               Component->getLoc() });
       if (auto Module = Context.getLoadedModule(AccessPath))
         ParsedTypeLoc.setType(ModuleType::get(Module));
         return true;

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -393,7 +393,7 @@ static bool collectPossibleCalleesForApply(
   } else if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(fnExpr)) {
     if (auto *DRE = dyn_cast<DeclRefExpr>(DSCE->getFn())) {
     collectPossibleCalleesByQualifiedLookup(
-        DC, DSCE->getArg(), DeclNameRef_(DRE->getDecl()->getFullName()),
+        DC, DSCE->getArg(), DeclNameRef(DRE->getDecl()->getFullName()),
                                             candidates);
     }
   }

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -278,12 +278,13 @@ public:
 
 /// Collect function (or subscript) members with the given \p name on \p baseTy.
 static void collectPossibleCalleesByQualifiedLookup(
-    DeclContext &DC, Type baseTy, DeclBaseName name,
+    DeclContext &DC, Type baseTy, DeclNameRef name,
     SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
   bool isOnMetaType = baseTy->is<AnyMetatypeType>();
 
   SmallVector<ValueDecl *, 2> decls;
-  if (!DC.lookupQualified(baseTy->getMetatypeInstanceType(), name,
+  if (!DC.lookupQualified(baseTy->getMetatypeInstanceType(),
+                          name.withoutArgumentLabels(),
                           NL_QualifiedDefault | NL_ProtocolMembers,
                           decls))
     return;
@@ -341,7 +342,7 @@ static void collectPossibleCalleesByQualifiedLookup(
 /// Collect function (or subscript) members with the given \p name on
 /// \p baseExpr expression.
 static void collectPossibleCalleesByQualifiedLookup(
-    DeclContext &DC, Expr *baseExpr, DeclBaseName name,
+    DeclContext &DC, Expr *baseExpr, DeclNameRef name,
     SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
   ConcreteDeclRef ref = nullptr;
   auto baseTyOpt = getTypeOfCompletionContextExpr(
@@ -388,11 +389,12 @@ static bool collectPossibleCalleesForApply(
     }
   } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(fnExpr)) {
     collectPossibleCalleesByQualifiedLookup(
-        DC, UDE->getBase(), UDE->getName().getBaseName(), candidates);
+        DC, UDE->getBase(), UDE->getName(), candidates);
   } else if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(fnExpr)) {
     if (auto *DRE = dyn_cast<DeclRefExpr>(DSCE->getFn())) {
     collectPossibleCalleesByQualifiedLookup(
-        DC, DSCE->getArg(), DRE->getDecl()->getBaseName(), candidates);
+        DC, DSCE->getArg(), DeclNameRef_(DRE->getDecl()->getFullName()),
+                                            candidates);
     }
   }
 
@@ -409,7 +411,7 @@ static bool collectPossibleCalleesForApply(
       auto baseTy = AMT->getInstanceType();
       if (baseTy->mayHaveMembers())
         collectPossibleCalleesByQualifiedLookup(
-            DC, AMT, DeclBaseName::createConstructor(), candidates);
+            DC, AMT, DeclNameRef::createConstructor(), candidates);
     }
   }
 
@@ -430,7 +432,7 @@ static bool collectPossibleCalleesForSubscript(
     }
   } else {
     collectPossibleCalleesByQualifiedLookup(DC, subscriptExpr->getBase(),
-                                            DeclBaseName::createSubscript(),
+                                            DeclNameRef::createSubscript(),
                                             candidates);
   }
   return !candidates.empty();
@@ -442,7 +444,6 @@ static bool collectPossibleCalleesForUnresolvedMember(
     DeclContext &DC, UnresolvedMemberExpr *unresolvedMemberExpr,
     SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
   auto currModule = DC.getParentModule();
-  auto baseName = unresolvedMemberExpr->getName().getBaseName();
 
   // Get the context of the expression itself.
   ExprContextInfo contextInfo(&DC, unresolvedMemberExpr);
@@ -451,7 +452,8 @@ static bool collectPossibleCalleesForUnresolvedMember(
       continue;
     SmallVector<FunctionTypeAndDecl, 2> members;
     collectPossibleCalleesByQualifiedLookup(DC, MetatypeType::get(expectedTy),
-                                            baseName, members);
+                                            unresolvedMemberExpr->getName(),
+                                            members);
     for (auto member : members) {
       if (isReferenceableByImplicitMemberExpr(currModule, &DC, expectedTy,
                                               member.second))

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -74,7 +74,7 @@ private:
   bool passReference(ValueDecl *D, Type Ty, SourceLoc Loc, SourceRange Range,
                      ReferenceMetaData Data);
   bool passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data);
-  bool passReference(ModuleEntity Mod, std::pair<DeclName, SourceLoc> IdLoc);
+  bool passReference(ModuleEntity Mod, std::pair<DeclNameRef, SourceLoc> IdLoc);
 
   bool passSubscriptReference(ValueDecl *D, SourceLoc Loc,
                               ReferenceMetaData Data, bool IsOpenBracket);
@@ -668,7 +668,7 @@ passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc, SourceRange Range,
 }
 
 bool SemaAnnotator::passReference(ModuleEntity Mod,
-                                  std::pair<DeclName, SourceLoc> IdLoc) {
+                                  std::pair<DeclNameRef, SourceLoc> IdLoc) {
   if (IdLoc.second.isInvalid())
     return true;
   unsigned NameLen = IdLoc.first.getBaseIdentifier().getLength();

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -74,7 +74,7 @@ private:
   bool passReference(ValueDecl *D, Type Ty, SourceLoc Loc, SourceRange Range,
                      ReferenceMetaData Data);
   bool passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data);
-  bool passReference(ModuleEntity Mod, std::pair<Identifier, SourceLoc> IdLoc);
+  bool passReference(ModuleEntity Mod, std::pair<DeclName, SourceLoc> IdLoc);
 
   bool passSubscriptReference(ValueDecl *D, SourceLoc Loc,
                               ReferenceMetaData Data, bool IsOpenBracket);
@@ -490,10 +490,10 @@ bool SemaAnnotator::walkToTypeReprPre(TypeRepr *T) {
   if (auto IdT = dyn_cast<ComponentIdentTypeRepr>(T)) {
     if (ValueDecl *VD = IdT->getBoundDecl()) {
       if (auto *ModD = dyn_cast<ModuleDecl>(VD))
-        return passReference(ModD, std::make_pair(IdT->getIdentifier(),
-                                                  IdT->getIdLoc()));
+        return passReference(ModD, std::make_pair(IdT->getNameRef(),
+                                                  IdT->getLoc()));
 
-      return passReference(VD, Type(), DeclNameLoc(IdT->getIdLoc()),
+      return passReference(VD, Type(), IdT->getNameLoc(),
                            ReferenceMetaData(SemaReferenceKind::TypeRef, None));
     }
   }
@@ -668,10 +668,10 @@ passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc, SourceRange Range,
 }
 
 bool SemaAnnotator::passReference(ModuleEntity Mod,
-                                  std::pair<Identifier, SourceLoc> IdLoc) {
+                                  std::pair<DeclName, SourceLoc> IdLoc) {
   if (IdLoc.second.isInvalid())
     return true;
-  unsigned NameLen = IdLoc.first.getLength();
+  unsigned NameLen = IdLoc.first.getBaseIdentifier().getLength();
   CharSourceRange Range{ IdLoc.second, NameLen };
   bool Continue = SEWalker.visitModuleReference(Mod, Range);
   if (!Continue)

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -74,7 +74,7 @@ private:
   bool passReference(ValueDecl *D, Type Ty, SourceLoc Loc, SourceRange Range,
                      ReferenceMetaData Data);
   bool passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data);
-  bool passReference(ModuleEntity Mod, std::pair<DeclNameRef, SourceLoc> IdLoc);
+  bool passReference(ModuleEntity Mod, std::pair<Identifier, SourceLoc> IdLoc);
 
   bool passSubscriptReference(ValueDecl *D, SourceLoc Loc,
                               ReferenceMetaData Data, bool IsOpenBracket);
@@ -489,9 +489,10 @@ bool SemaAnnotator::walkToTypeReprPre(TypeRepr *T) {
 
   if (auto IdT = dyn_cast<ComponentIdentTypeRepr>(T)) {
     if (ValueDecl *VD = IdT->getBoundDecl()) {
-      if (auto *ModD = dyn_cast<ModuleDecl>(VD))
-        return passReference(ModD, std::make_pair(IdT->getNameRef(),
-                                                  IdT->getLoc()));
+      if (auto *ModD = dyn_cast<ModuleDecl>(VD)) {
+        auto ident = IdT->getNameRef().getBaseIdentifier();
+        return passReference(ModD, std::make_pair(ident, IdT->getLoc()));
+      }
 
       return passReference(VD, Type(), IdT->getNameLoc(),
                            ReferenceMetaData(SemaReferenceKind::TypeRef, None));
@@ -668,10 +669,10 @@ passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc, SourceRange Range,
 }
 
 bool SemaAnnotator::passReference(ModuleEntity Mod,
-                                  std::pair<DeclNameRef, SourceLoc> IdLoc) {
+                                  std::pair<Identifier, SourceLoc> IdLoc) {
   if (IdLoc.second.isInvalid())
     return true;
-  unsigned NameLen = IdLoc.first.getBaseIdentifier().getLength();
+  unsigned NameLen = IdLoc.first.getLength();
   CharSourceRange Range{ IdLoc.second, NameLen };
   bool Continue = SEWalker.visitModuleReference(Mod, Range);
   if (!Continue)

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1108,11 +1108,11 @@ bool ModelASTWalker::walkToTypeReprPre(TypeRepr *T) {
       return false;
 
   } else if (auto IdT = dyn_cast<ComponentIdentTypeRepr>(T)) {
-    if (!passTokenNodesUntil(IdT->getIdLoc(),
+    if (!passTokenNodesUntil(IdT->getStartLoc(),
                              ExcludeNodeAtLocation).shouldContinue)
       return false;
     if (TokenNodes.empty() ||
-        TokenNodes.front().Range.getStart() != IdT->getIdLoc())
+        TokenNodes.front().Range.getStart() != IdT->getStartLoc())
       return false;
     if (!passNode({SyntaxNodeKind::TypeId, TokenNodes.front().Range}))
       return false;

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -1092,7 +1092,7 @@ public:
           ASTContext &ctx = CI.getASTContext();
           SourceFile &SF =
               MostRecentModule->getMainSourceFile(SourceFileKind::REPL);
-          auto name = DeclNameRef_(ctx.getIdentifier(Tok.getText()));
+          DeclNameRef name(ctx.getIdentifier(Tok.getText()));
           auto descriptor = UnqualifiedLookupDescriptor(name, &SF);
           auto lookup = evaluateOrDefault(
               ctx.evaluator, UnqualifiedLookupRequest{descriptor}, {});

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -1092,7 +1092,7 @@ public:
           ASTContext &ctx = CI.getASTContext();
           SourceFile &SF =
               MostRecentModule->getMainSourceFile(SourceFileKind::REPL);
-          DeclName name = ctx.getIdentifier(Tok.getText());
+          auto name = DeclNameRef_(ctx.getIdentifier(Tok.getText()));
           auto descriptor = UnqualifiedLookupDescriptor(name, &SF);
           auto lookup = evaluateOrDefault(
               ctx.evaluator, UnqualifiedLookupRequest{descriptor}, {});

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -1092,7 +1092,7 @@ public:
           ASTContext &ctx = CI.getASTContext();
           SourceFile &SF =
               MostRecentModule->getMainSourceFile(SourceFileKind::REPL);
-          auto name = ctx.getIdentifier(Tok.getText());
+          DeclName name = ctx.getIdentifier(Tok.getText());
           auto descriptor = UnqualifiedLookupDescriptor(name, &SF);
           auto lookup = evaluateOrDefault(
               ctx.evaluator, UnqualifiedLookupRequest{descriptor}, {});

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -919,7 +919,7 @@ bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet 
 
   if (auto *T = dyn_cast_or_null<IdentTypeRepr>(Ty.getTypeRepr())) {
     auto Comps = T->getComponentRange();
-    SourceLoc IdLoc = Comps.back()->getIdLoc();
+    SourceLoc IdLoc = Comps.back()->getLoc();
     NominalTypeDecl *NTD = nullptr;
     bool isImplicit = false;
     if (auto *VD = Comps.back()->getBoundDecl()) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2567,15 +2567,12 @@ bool Parser::parseConventionAttributeInternal(
                  diag::convention_attribute_witness_method_expected_colon);
       return true;
     }
-    if (Tok.isNot(tok::identifier)) {
-      if (!justChecking)
-        diagnose(Tok,
-                 diag::convention_attribute_witness_method_expected_protocol);
-      return true;
-    }
 
-    convention.WitnessMethodProtocol = Tok.getText();
-    consumeToken(tok::identifier);
+    DeclNameLoc unusedWitnessMethodProtocolLoc;
+    convention.WitnessMethodProtocol = parseUnqualifiedDeclBaseName(
+        /*afterDot=*/false, unusedWitnessMethodProtocolLoc,
+       diag::convention_attribute_witness_method_expected_protocol
+    );
   }
   
   // Parse the ')'.  We can't use parseMatchingToken if we're in
@@ -3660,7 +3657,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
         if (auto repr = extension->getExtendedTypeRepr()) {
           if (auto idRepr = dyn_cast<IdentTypeRepr>(repr)) {
             diagnose(extension->getLoc(), diag::note_in_decl_extension, true,
-                     idRepr->getComponentRange().front()->getIdentifier());
+                     idRepr->getComponentRange().front()->getNameRef());
           }
         }
       }
@@ -4044,7 +4041,7 @@ ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
 
       // Add 'AnyObject' to the inherited list.
       Inherited.push_back(
-        new (Context) SimpleIdentTypeRepr(classLoc,
+        new (Context) SimpleIdentTypeRepr(DeclNameLoc(classLoc),
                                           Context.getIdentifier("AnyObject")));
       continue;
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -753,7 +753,7 @@ Parser::parseImplementsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
   SourceLoc lParenLoc = consumeToken();
 
   DeclNameLoc MemberNameLoc;
-  DeclName MemberName;
+  DeclNameRef MemberName;
   ParserResult<TypeRepr> ProtocolType;
   {
     SyntaxParsingContext ContentContext(
@@ -794,9 +794,12 @@ Parser::parseImplementsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
     return Status;
   }
 
+  // FIXME(ModQual): Reject module qualification on MemberName.
+
   return ParserResult<ImplementsAttr>(
     ImplementsAttr::create(Context, AtLoc, SourceRange(Loc, rParenLoc),
-                           ProtocolType.get(), MemberName, MemberNameLoc));
+                           ProtocolType.get(), MemberName.getFullName(),
+                           MemberNameLoc));
 }
 
 /// Parse a `@differentiable` attribute, returning true on error.
@@ -817,8 +820,8 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
   SourceLoc lParenLoc = loc, rParenLoc = loc;
   bool linear = false;
   SmallVector<ParsedAutoDiffParameter, 8> params;
-  Optional<DeclNameWithLoc> jvpSpec;
-  Optional<DeclNameWithLoc> vjpSpec;
+  Optional<DeclNameRefWithLoc> jvpSpec;
+  Optional<DeclNameRefWithLoc> vjpSpec;
   TrailingWhereClause *whereClause = nullptr;
 
   // Parse '('.
@@ -946,7 +949,8 @@ bool Parser::parseDifferentiationParametersClause(
 
 bool Parser::parseDifferentiableAttributeArguments(
     bool &linear, SmallVectorImpl<ParsedAutoDiffParameter> &params,
-    Optional<DeclNameWithLoc> &jvpSpec, Optional<DeclNameWithLoc> &vjpSpec,
+    Optional<DeclNameRefWithLoc> &jvpSpec,
+    Optional<DeclNameRefWithLoc> &vjpSpec,
     TrailingWhereClause *&whereClause) {
   StringRef AttrName = "differentiable";
 
@@ -1006,7 +1010,7 @@ bool Parser::parseDifferentiableAttributeArguments(
 
   // Function that parses a label and a function specifier, e.g. 'vjp: foo(_:)'.
   // Return true on error.
-  auto parseFuncSpec = [&](StringRef label, DeclNameWithLoc &result,
+  auto parseFuncSpec = [&](StringRef label, DeclNameRefWithLoc &result,
                            bool &terminateParsingArgs) -> bool {
     // Parse label.
     if (parseSpecificIdentifier(label,
@@ -1035,7 +1039,7 @@ bool Parser::parseDifferentiableAttributeArguments(
   if (isIdentifier(Tok, "jvp")) {
     SyntaxParsingContext JvpContext(
         SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
-    jvpSpec = DeclNameWithLoc();
+    jvpSpec = DeclNameRefWithLoc();
     if (parseFuncSpec("jvp", *jvpSpec, terminateParsingArgs))
       return errorAndSkipUntilConsumeRightParen(*this, AttrName);
     if (terminateParsingArgs)
@@ -1048,7 +1052,7 @@ bool Parser::parseDifferentiableAttributeArguments(
   if (isIdentifier(Tok, "vjp")) {
     SyntaxParsingContext VjpContext(
         SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
-    vjpSpec = DeclNameWithLoc();
+    vjpSpec = DeclNameRefWithLoc();
     if (parseFuncSpec("vjp", *vjpSpec, terminateParsingArgs))
       return errorAndSkipUntilConsumeRightParen(*this, AttrName);
     if (terminateParsingArgs)
@@ -1087,7 +1091,7 @@ ParserResult<DerivativeAttr> Parser::parseDerivativeAttribute(SourceLoc atLoc,
                                                               SourceLoc loc) {
   StringRef AttrName = "derivative";
   SourceLoc lParenLoc = loc, rParenLoc = loc;
-  DeclNameWithLoc original;
+  DeclNameRefWithLoc original;
   SmallVector<ParsedAutoDiffParameter, 8> params;
 
   // Parse trailing comma, if it exists, and check for errors.
@@ -2033,7 +2037,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     }
 
     SourceLoc LParenLoc = consumeToken(tok::l_paren);
-    DeclName replacedFunction;
+    DeclNameRef replacedFunction;
     {
       SyntaxParsingContext ContentContext(
           SyntaxContext, SyntaxKind::NamedAttributeStringArgument);
@@ -3652,7 +3656,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
     if (CurDeclContext) {
       if (auto nominal = dyn_cast<NominalTypeDecl>(CurDeclContext)) {
         diagnose(nominal->getLoc(), diag::note_in_decl_extension, false,
-                 nominal->getName());
+                 nominal->createNameRef());
       } else if (auto extension = dyn_cast<ExtensionDecl>(CurDeclContext)) {
         if (auto repr = extension->getExtendedTypeRepr()) {
           if (auto idRepr = dyn_cast<IdentTypeRepr>(repr)) {
@@ -4041,8 +4045,8 @@ ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
 
       // Add 'AnyObject' to the inherited list.
       Inherited.push_back(
-        new (Context) SimpleIdentTypeRepr(DeclNameLoc(classLoc),
-                                          Context.getIdentifier("AnyObject")));
+        new (Context) SimpleIdentTypeRepr(DeclNameLoc(classLoc), DeclNameRef_(
+                                          Context.getIdentifier("AnyObject"))));
       continue;
     }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4045,7 +4045,7 @@ ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
 
       // Add 'AnyObject' to the inherited list.
       Inherited.push_back(
-        new (Context) SimpleIdentTypeRepr(DeclNameLoc(classLoc), DeclNameRef_(
+        new (Context) SimpleIdentTypeRepr(DeclNameLoc(classLoc), DeclNameRef(
                                           Context.getIdentifier("AnyObject"))));
       continue;
     }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2278,8 +2278,7 @@ Expr *Parser::parseExprIdentifier() {
     // global or local declarations here.
     assert(!TD->getDeclContext()->isTypeContext() ||
            isa<GenericTypeParamDecl>(TD));
-    E = TypeExpr::createForDecl(loc.getBaseNameLoc(), TD, /*DC*/nullptr,
-                                /*implicit*/false);
+    E = TypeExpr::createForDecl(loc, TD, /*DC*/nullptr, /*implicit*/false);
   } else {
     E = new (Context) DeclRefExpr(D, loc, /*Implicit=*/false);
   }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -462,7 +462,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
     } else {
       bool isVoid = false;
       if (const auto Void = dyn_cast<SimpleIdentTypeRepr>(tyR)) {
-        if (Void->getIdentifier().str() == "Void") {
+        if (Void->getNameRef().isSimpleName(Context.Id_Void)) {
           isVoid = true;
         }
       }
@@ -529,7 +529,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
         if (auto ident = dyn_cast<ComponentIdentTypeRepr>(T)) {
           if (auto decl = ident->getBoundDecl()) {
             if (auto genericParam = dyn_cast<GenericTypeParamDecl>(decl))
-              ident->overwriteIdentifier(genericParam->getName());
+              ident->overwriteNameRef(genericParam->getName());
           }
         }
         return true;
@@ -666,17 +666,12 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifier() {
   SmallVector<ComponentIdentTypeRepr *, 4> ComponentsR;
   SourceLoc EndLoc;
   while (true) {
-    SourceLoc Loc;
-    Identifier Name;
-    if (Tok.is(tok::kw_Self)) {
-      Loc = consumeIdentifier(&Name);
-    } else {
-      // FIXME: specialize diagnostic for 'Type': type cannot start with
-      // 'metatype'
-      // FIXME: offer a fixit: 'self' -> 'Self'
-      if (parseIdentifier(Name, Loc, diag::expected_identifier_in_dotted_type))
-        Status.setIsParseError();
-    }
+    DeclNameLoc Loc;
+    DeclName Name = parseUnqualifiedDeclBaseName(
+        /*afterDot=*/false, Loc,
+        diag::expected_identifier_in_dotted_type);
+    if (!Name)
+      Status.setIsParseError();
 
     if (Loc.isValid()) {
       SourceLoc LAngle, RAngle;
@@ -686,7 +681,7 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifier() {
         if (genericArgsStatus.isError())
           return genericArgsStatus;
       }
-      EndLoc = Loc;
+      EndLoc = Loc.getEndLoc();
 
       ComponentIdentTypeRepr *CompT;
       if (!GenericArgs.empty())
@@ -724,7 +719,7 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifier() {
   if (!ComponentsR.empty()) {
     // Lookup element #0 through our current scope chains in case it is some
     // thing local (this returns null if nothing is found).
-    if (auto Entry = lookupInScope(ComponentsR[0]->getIdentifier()))
+    if (auto Entry = lookupInScope(ComponentsR[0]->getNameRef()))
       if (auto *TD = dyn_cast<TypeDecl>(Entry))
         ComponentsR[0]->setValue(TD, nullptr);
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -529,7 +529,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
         if (auto ident = dyn_cast<ComponentIdentTypeRepr>(T)) {
           if (auto decl = ident->getBoundDecl()) {
             if (auto genericParam = dyn_cast<GenericTypeParamDecl>(decl))
-              ident->overwriteNameRef(genericParam->getName());
+              ident->overwriteNameRef(genericParam->createNameRef());
           }
         }
         return true;
@@ -667,7 +667,7 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifier() {
   SourceLoc EndLoc;
   while (true) {
     DeclNameLoc Loc;
-    DeclName Name = parseUnqualifiedDeclBaseName(
+    DeclNameRef Name = parseUnqualifiedDeclBaseName(
         /*afterDot=*/false, Loc,
         diag::expected_identifier_in_dotted_type);
     if (!Name)

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1371,7 +1371,6 @@ DeclName swift::formDeclName(ASTContext &ctx,
 
 DeclNameRef swift::formDeclNameRef(ASTContext &ctx,
                                    StringRef baseName,
-
                                    ArrayRef<StringRef> argumentLabels,
                                    bool isFunctionName,
                                    bool isInitializer) {
@@ -1387,7 +1386,7 @@ DeclNameRef swift::formDeclNameRef(ASTContext &ctx,
                              : ctx.getIdentifier(baseName));
 
   // For non-functions, just use the base name.
-  if (!isFunctionName) return DeclNameRef_(baseNameId);
+  if (!isFunctionName) return DeclNameRef(baseNameId);
 
   // For functions, we need to form a complete name.
 
@@ -1403,7 +1402,7 @@ DeclNameRef swift::formDeclNameRef(ASTContext &ctx,
   }
 
   // Build the result.
-  return DeclNameRef_(DeclName(ctx, baseNameId, argumentLabelIds));
+  return DeclNameRef({ ctx, baseNameId, argumentLabelIds });
 }
 
 DeclName swift::parseDeclName(ASTContext &ctx, StringRef name) {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -902,7 +902,7 @@ namespace {
     bool walkToTypeReprPre(TypeRepr *Ty) override {
       auto *T = dyn_cast_or_null<IdentTypeRepr>(Ty);
       auto Comp = T->getComponentRange().front();
-      if (auto Entry = P.lookupInScope(Comp->getIdentifier()))
+      if (auto Entry = P.lookupInScope(Comp->getNameRef()))
         if (auto *TD = dyn_cast<TypeDecl>(Entry)) {
           Comp->setValue(TD, nullptr);
           return false;
@@ -1703,7 +1703,7 @@ static void bindProtocolSelfInTypeRepr(TypeLoc &TL, ProtocolDecl *proto) {
       virtual bool walkToTypeReprPre(TypeRepr *T) override {
         if (auto ident = dyn_cast<IdentTypeRepr>(T)) {
           auto firstComponent = ident->getComponentRange().front();
-          if (firstComponent->getIdentifier() == selfId)
+          if (firstComponent->getNameRef().isSimpleName(selfId))
             firstComponent->setValue(selfParam, proto);
         }
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1187,7 +1187,7 @@ lookupTopDecl(Parser &P, DeclBaseName Name, bool typeLookup) {
     options |= UnqualifiedLookupFlags::TypeLookup;
 
   auto &ctx = P.SF.getASTContext();
-  auto descriptor = UnqualifiedLookupDescriptor(DeclNameRef_(Name), &P.SF);
+  auto descriptor = UnqualifiedLookupDescriptor(DeclNameRef(Name), &P.SF);
   auto lookup = evaluateOrDefault(ctx.evaluator,
                                   UnqualifiedLookupRequest{descriptor}, {});
   assert(lookup.size() == 1);

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1187,7 +1187,7 @@ lookupTopDecl(Parser &P, DeclBaseName Name, bool typeLookup) {
     options |= UnqualifiedLookupFlags::TypeLookup;
 
   auto &ctx = P.SF.getASTContext();
-  auto descriptor = UnqualifiedLookupDescriptor(DeclName(Name), &P.SF);
+  auto descriptor = UnqualifiedLookupDescriptor(DeclNameRef_(Name), &P.SF);
   auto lookup = evaluateOrDefault(ctx.evaluator,
                                   UnqualifiedLookupRequest{descriptor}, {});
   assert(lookup.size() == 1);

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1187,7 +1187,7 @@ lookupTopDecl(Parser &P, DeclBaseName Name, bool typeLookup) {
     options |= UnqualifiedLookupFlags::TypeLookup;
 
   auto &ctx = P.SF.getASTContext();
-  auto descriptor = UnqualifiedLookupDescriptor(Name, &P.SF);
+  auto descriptor = UnqualifiedLookupDescriptor(DeclName(Name), &P.SF);
   auto lookup = evaluateOrDefault(ctx.evaluator,
                                   UnqualifiedLookupRequest{descriptor}, {});
   assert(lookup.size() == 1);

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -895,7 +895,7 @@ private:
                                  const ParsedDeclName renamedParsedDeclName) {
     auto declContext = D->getDeclContext();
     ASTContext &astContext = D->getASTContext();
-    auto renamedDeclName = renamedParsedDeclName.formDeclName(astContext);
+    auto renamedDeclName = renamedParsedDeclName.formDeclNameRef(astContext);
 
     if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D)) {
       if (!renamedParsedDeclName.ContextName.empty()) {
@@ -903,7 +903,7 @@ private:
       }
       SmallVector<ValueDecl *, 1> decls;
       declContext->lookupQualified(declContext->getParentModule(),
-                                   renamedDeclName.getBaseIdentifier(),
+                                   renamedDeclName.withoutArgumentLabels(),
                                    NL_OnlyTypes,
                                    decls);
       if (decls.size() == 1)

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -203,7 +203,7 @@ static CanType getKnownType(Optional<CanType> &cacheSlot, ASTContext &C,
       // lookupValue would only give us types actually declared in the overlays
       // themselves.
       SmallVector<ValueDecl *, 2> decls;
-      mod->lookupQualified(mod, DeclNameRef_(C.getIdentifier(typeName)),
+      mod->lookupQualified(mod, DeclNameRef(C.getIdentifier(typeName)),
                            NL_QualifiedDefault | NL_KnownNonCascadingDependency,
                            decls);
       if (decls.size() != 1)

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -203,7 +203,7 @@ static CanType getKnownType(Optional<CanType> &cacheSlot, ASTContext &C,
       // lookupValue would only give us types actually declared in the overlays
       // themselves.
       SmallVector<ValueDecl *, 2> decls;
-      mod->lookupQualified(mod, C.getIdentifier(typeName),
+      mod->lookupQualified(mod, DeclNameRef_(C.getIdentifier(typeName)),
                            NL_QualifiedDefault | NL_KnownNonCascadingDependency,
                            decls);
       if (decls.size() != 1)

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -550,7 +550,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     assert(UIKit && "couldn't find UIKit objc module?!");
     SmallVector<ValueDecl *, 1> results;
     UIKit->lookupQualified(UIKit,
-                           ctx.getIdentifier("UIApplicationMain"),
+                           DeclNameRef_(ctx.getIdentifier("UIApplicationMain")),
                            NL_QualifiedDefault,
                            results);
     assert(results.size() == 1

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -550,7 +550,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     assert(UIKit && "couldn't find UIKit objc module?!");
     SmallVector<ValueDecl *, 1> results;
     UIKit->lookupQualified(UIKit,
-                           DeclNameRef_(ctx.getIdentifier("UIApplicationMain")),
+                           DeclNameRef(ctx.getIdentifier("UIApplicationMain")),
                            NL_QualifiedDefault,
                            results);
     assert(results.size() == 1

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -80,7 +80,8 @@ private:
 
     typeExpr->setImplicit();
     auto memberRef = new (ctx) UnresolvedDotExpr(
-        typeExpr, loc, fnName, DeclNameLoc(loc), /*implicit=*/true);
+        typeExpr, loc, DeclNameRef_(fnName), DeclNameLoc(loc),
+        /*implicit=*/true);
     SourceLoc openLoc = args.empty() ? loc : args.front()->getStartLoc();
     SourceLoc closeLoc = args.empty() ? loc : args.back()->getEndLoc();
     Expr *result = CallExpr::create(ctx, memberRef, openLoc, args,
@@ -450,7 +451,7 @@ public:
     auto optionalTypeExpr =
       TypeExpr::createImplicitHack(loc, optionalType, ctx);
     auto someRef = new (ctx) UnresolvedDotExpr(
-        optionalTypeExpr, loc, ctx.getIdentifier("some"),
+        optionalTypeExpr, loc, DeclNameRef_(ctx.getIdentifier("some")),
         DeclNameLoc(loc), /*implicit=*/true);
     return CallExpr::createImplicit(ctx, someRef, arg, { });
   }
@@ -462,7 +463,7 @@ public:
     auto optionalTypeExpr =
       TypeExpr::createImplicitHack(endLoc, optionalType, ctx);
     return new (ctx) UnresolvedDotExpr(
-        optionalTypeExpr, endLoc, ctx.getIdentifier("none"),
+        optionalTypeExpr, endLoc, DeclNameRef_(ctx.getIdentifier("none")),
         DeclNameLoc(endLoc), /*implicit=*/true);
   }
 

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -80,7 +80,7 @@ private:
 
     typeExpr->setImplicit();
     auto memberRef = new (ctx) UnresolvedDotExpr(
-        typeExpr, loc, DeclNameRef_(fnName), DeclNameLoc(loc),
+        typeExpr, loc, DeclNameRef(fnName), DeclNameLoc(loc),
         /*implicit=*/true);
     SourceLoc openLoc = args.empty() ? loc : args.front()->getStartLoc();
     SourceLoc closeLoc = args.empty() ? loc : args.back()->getEndLoc();
@@ -451,7 +451,7 @@ public:
     auto optionalTypeExpr =
       TypeExpr::createImplicitHack(loc, optionalType, ctx);
     auto someRef = new (ctx) UnresolvedDotExpr(
-        optionalTypeExpr, loc, DeclNameRef_(ctx.getIdentifier("some")),
+        optionalTypeExpr, loc, DeclNameRef(ctx.getIdentifier("some")),
         DeclNameLoc(loc), /*implicit=*/true);
     return CallExpr::createImplicit(ctx, someRef, arg, { });
   }
@@ -463,7 +463,7 @@ public:
     auto optionalTypeExpr =
       TypeExpr::createImplicitHack(endLoc, optionalType, ctx);
     return new (ctx) UnresolvedDotExpr(
-        optionalTypeExpr, endLoc, DeclNameRef_(ctx.getIdentifier("none")),
+        optionalTypeExpr, endLoc, DeclNameRef(ctx.getIdentifier("none")),
         DeclNameLoc(endLoc), /*implicit=*/true);
   }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2440,7 +2440,7 @@ namespace {
                                    ->getNominalOrBoundGenericNominal();
           auto results = TypeChecker::lookupMember(
               baseTyNominalDecl->getModuleContext(), baseTyUnwrapped,
-              DeclNameRef_(memberName), defaultMemberLookupOptions);
+              DeclNameRef(memberName), defaultMemberLookupOptions);
 
           // Filter out any functions, instance members, enum cases with
           // associated values or variables whose type does not match the

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2440,7 +2440,7 @@ namespace {
                                    ->getNominalOrBoundGenericNominal();
           auto results = TypeChecker::lookupMember(
               baseTyNominalDecl->getModuleContext(), baseTyUnwrapped,
-              memberName, defaultMemberLookupOptions);
+              DeclNameRef_(memberName), defaultMemberLookupOptions);
 
           // Filter out any functions, instance members, enum cases with
           // associated values or variables whose type does not match the

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -239,12 +239,13 @@ private:
   /// unviable ones.
   void diagnoseUnviableLookupResults(MemberLookupResult &lookupResults,
                                      Expr *expr, Type baseObjTy, Expr *baseExpr,
-                                     DeclName memberName, DeclNameLoc nameLoc,
-                                     SourceLoc loc);
+                                     DeclNameRef memberName,
+                                     DeclNameLoc nameLoc, SourceLoc loc);
 
   bool diagnoseMemberFailures(
-      Expr *E, Expr *baseEpxr, ConstraintKind lookupKind, DeclName memberName,
-      FunctionRefKind funcRefKind, ConstraintLocator *locator,
+      Expr *E, Expr *baseEpxr, ConstraintKind lookupKind,
+      DeclNameRef memberName, FunctionRefKind funcRefKind,
+      ConstraintLocator *locator,
       Optional<std::function<bool(ArrayRef<OverloadChoice>)>> callback = None,
       bool includeInaccessibleMembers = true);
 
@@ -274,7 +275,7 @@ private:
 /// unviable ones.
 void FailureDiagnosis::diagnoseUnviableLookupResults(
     MemberLookupResult &result, Expr *E, Type baseObjTy, Expr *baseExpr,
-    DeclName memberName, DeclNameLoc nameLoc, SourceLoc loc) {
+    DeclNameRef memberName, DeclNameLoc nameLoc, SourceLoc loc) {
   SourceRange baseRange = baseExpr ? baseExpr->getSourceRange() : SourceRange();
 
   // If we found no results at all, mention that fact.
@@ -1626,7 +1627,7 @@ bool FailureDiagnosis::diagnoseSubscriptErrors(SubscriptExpr *SE,
       CS.getConstraintLocator(SE, ConstraintLocator::SubscriptMember);
 
   return diagnoseMemberFailures(SE, baseExpr, ConstraintKind::ValueMember,
-                                DeclBaseName::createSubscript(),
+                                DeclNameRef::createSubscript(),
                                 FunctionRefKind::DoubleApply, locator,
                                 callback);
 }
@@ -2671,7 +2672,7 @@ bool FailureDiagnosis::visitUnresolvedMemberExpr(UnresolvedMemberExpr *E) {
 }
 
 bool FailureDiagnosis::diagnoseMemberFailures(
-    Expr *E, Expr *baseExpr, ConstraintKind lookupKind, DeclName memberName,
+    Expr *E, Expr *baseExpr, ConstraintKind lookupKind, DeclNameRef memberName,
     FunctionRefKind funcRefKind, ConstraintLocator *locator,
     Optional<std::function<bool(ArrayRef<OverloadChoice>)>> callback,
     bool includeInaccessibleMembers) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1259,7 +1259,7 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
           emitDiagnostic(loc, diag::assignment_let_property_delegating_init,
                       member->getName());
           if (auto *ref = getResolvedMemberRef(member)) {
-            emitDiagnostic(ref, diag::decl_declared_here, member->getName());
+            emitDiagnostic(ref, diag::decl_declared_here, ref->getFullName());
           }
           return true;
         }
@@ -3042,7 +3042,7 @@ bool SubscriptMisuseFailure::diagnoseAsNote() {
 /// meaning their lower case counterparts are identical.
 ///   - DeclName is valid when such a correct case is found; invalid otherwise.
 DeclName MissingMemberFailure::findCorrectEnumCaseName(
-    Type Ty, TypoCorrectionResults &corrections, DeclName memberName) {
+    Type Ty, TypoCorrectionResults &corrections, DeclNameRef memberName) {
   if (memberName.isSpecial() || !memberName.isSimpleName())
     return DeclName();
   if (!Ty->getEnumOrBoundGenericEnum())
@@ -3146,10 +3146,9 @@ bool MissingMemberFailure::diagnoseAsError() {
                getName().getBaseName() == DeclBaseName::createConstructor()) {
       auto &cs = getConstraintSystem();
 
-      auto memberName = getName().getBaseName();
       auto result = cs.performMemberLookup(
-          ConstraintKind::ValueMember, memberName, metatypeTy,
-          FunctionRefKind::DoubleApply, getLocator(),
+          ConstraintKind::ValueMember, getName().withoutArgumentLabels(),
+          metatypeTy, FunctionRefKind::DoubleApply, getLocator(),
           /*includeInaccessibleMembers=*/true);
 
       // If there are no `init` members at all produce a tailored
@@ -3470,10 +3469,10 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
         // static members doesn't make a whole lot of sense
         if (auto TAD = dyn_cast<TypeAliasDecl>(Member)) {
           Diag.emplace(emitDiagnostic(loc, diag::typealias_outside_of_protocol,
-                                      TAD->getName()));
+                                      Name));
         } else if (auto ATD = dyn_cast<AssociatedTypeDecl>(Member)) {
           Diag.emplace(emitDiagnostic(loc, diag::assoc_type_outside_of_protocol,
-                                      ATD->getName()));
+                                      Name));
         } else if (isa<ConstructorDecl>(Member)) {
           Diag.emplace(emitDiagnostic(loc, diag::construct_protocol_by_name,
                                       instanceTy));

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1486,7 +1486,7 @@ bool AssignmentFailure::diagnoseAsError() {
       if (auto typeContext = DC->getInnermostTypeContext()) {
         SmallVector<ValueDecl *, 2> results;
         DC->lookupQualified(typeContext->getSelfNominalTypeDecl(),
-                            VD->getFullName(), NL_QualifiedDefault, results);
+                            VD->createNameRef(), NL_QualifiedDefault, results);
 
         auto foundProperty = llvm::find_if(results, [&](ValueDecl *decl) {
           // We're looking for a settable property that is the same type as the

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -461,13 +461,13 @@ private:
 /// Diagnose failures related to attempting member access on optional base
 /// type without optional chaining or force-unwrapping it first.
 class MemberAccessOnOptionalBaseFailure final : public FailureDiagnostic {
-  DeclName Member;
+  DeclNameRef Member;
   bool ResultTypeIsOptional;
 
 public:
   MemberAccessOnOptionalBaseFailure(ConstraintSystem &cs,
                                     ConstraintLocator *locator,
-                                    DeclName memberName, bool resultOptional)
+                                    DeclNameRef memberName, bool resultOptional)
       : FailureDiagnostic(cs, locator), Member(memberName),
         ResultTypeIsOptional(resultOptional) {}
 
@@ -977,17 +977,17 @@ public:
 
 class InvalidMemberRefFailure : public FailureDiagnostic {
   Type BaseType;
-  DeclName Name;
+  DeclNameRef Name;
 
 public:
   InvalidMemberRefFailure(ConstraintSystem &cs, Type baseType,
-                          DeclName memberName, ConstraintLocator *locator)
+                          DeclNameRef memberName, ConstraintLocator *locator)
       : FailureDiagnostic(cs, locator), BaseType(baseType->getRValueType()),
         Name(memberName) {}
 
 protected:
   Type getBaseType() const { return BaseType; }
-  DeclName getName() const { return Name; }
+  DeclNameRef getName() const { return Name; }
 };
 
 /// Diagnose situations when member referenced by name is missing
@@ -1002,7 +1002,7 @@ protected:
 class MissingMemberFailure final : public InvalidMemberRefFailure {
 public:
   MissingMemberFailure(ConstraintSystem &cs, Type baseType,
-                       DeclName memberName, ConstraintLocator *locator)
+                       DeclNameRef memberName, ConstraintLocator *locator)
       : InvalidMemberRefFailure(cs, baseType, memberName, locator) {}
 
   bool diagnoseAsError() override;
@@ -1016,7 +1016,7 @@ private:
 
   static DeclName findCorrectEnumCaseName(Type Ty,
                                           TypoCorrectionResults &corrections,
-                                          DeclName memberName);
+                                          DeclNameRef memberName);
 };
 
 /// Diagnose cases where a member only accessible on generic constraints
@@ -1035,7 +1035,7 @@ private:
 class InvalidMemberRefOnExistential final : public InvalidMemberRefFailure {
 public:
   InvalidMemberRefOnExistential(ConstraintSystem &cs, Type baseType,
-                                DeclName memberName, ConstraintLocator *locator)
+                                DeclNameRef memberName, ConstraintLocator *locator)
       : InvalidMemberRefFailure(cs, baseType, memberName, locator) {}
 
   bool diagnoseAsError() override;
@@ -1060,12 +1060,12 @@ public:
 class AllowTypeOrInstanceMemberFailure final : public FailureDiagnostic {
   Type BaseType;
   ValueDecl *Member;
-  DeclName Name;
+  DeclNameRef Name;
 
 public:
   AllowTypeOrInstanceMemberFailure(ConstraintSystem &cs,
                                    Type baseType, ValueDecl *member,
-                                   DeclName name, ConstraintLocator *locator)
+                                   DeclNameRef name, ConstraintLocator *locator)
       : FailureDiagnostic(cs, locator),
         BaseType(baseType->getRValueType()), Member(member), Name(name) {
     assert(member);
@@ -1884,10 +1884,11 @@ private:
 };
 
 class MissingContextualBaseInMemberRefFailure final : public FailureDiagnostic {
-  DeclName MemberName;
+  DeclNameRef MemberName;
 
 public:
-  MissingContextualBaseInMemberRefFailure(ConstraintSystem &cs, DeclName member,
+  MissingContextualBaseInMemberRefFailure(ConstraintSystem &cs,
+                                          DeclNameRef member,
                                           ConstraintLocator *locator)
       : FailureDiagnostic(cs, locator), MemberName(member) {}
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -88,14 +88,14 @@ bool UnwrapOptionalBase::diagnose(bool asNote) const {
 }
 
 UnwrapOptionalBase *UnwrapOptionalBase::create(ConstraintSystem &cs,
-                                               DeclName member,
+                                               DeclNameRef member,
                                                ConstraintLocator *locator) {
   return new (cs.getAllocator())
       UnwrapOptionalBase(cs, FixKind::UnwrapOptionalBase, member, locator);
 }
 
 UnwrapOptionalBase *UnwrapOptionalBase::createWithOptionalResult(
-    ConstraintSystem &cs, DeclName member, ConstraintLocator *locator) {
+    ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator) {
   return new (cs.getAllocator()) UnwrapOptionalBase(
       cs, FixKind::UnwrapOptionalBaseWithOptionalResult, member, locator);
 }
@@ -428,14 +428,14 @@ bool DefineMemberBasedOnUse::diagnose(bool asNote) const {
 
 DefineMemberBasedOnUse *
 DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
-                               DeclName member, ConstraintLocator *locator) {
+                               DeclNameRef member, ConstraintLocator *locator) {
   return new (cs.getAllocator())
       DefineMemberBasedOnUse(cs, baseType, member, locator);
 }
 
 AllowMemberRefOnExistential *
 AllowMemberRefOnExistential::create(ConstraintSystem &cs, Type baseType,
-                                    ValueDecl *member, DeclName memberName,
+                                    ValueDecl *member, DeclNameRef memberName,
                                     ConstraintLocator *locator) {
   return new (cs.getAllocator())
       AllowMemberRefOnExistential(cs, baseType, memberName, member, locator);
@@ -457,7 +457,7 @@ bool AllowTypeOrInstanceMember::diagnose(bool asNote) const {
 
 AllowTypeOrInstanceMember *
 AllowTypeOrInstanceMember::create(ConstraintSystem &cs, Type baseType,
-                                  ValueDecl *member, DeclName usedName,
+                                  ValueDecl *member, DeclNameRef usedName,
                                   ConstraintLocator *locator) {
   return new (cs.getAllocator())
       AllowTypeOrInstanceMember(cs, baseType, member, usedName, locator);
@@ -618,7 +618,7 @@ bool AllowInaccessibleMember::diagnose(bool asNote) const {
 
 AllowInaccessibleMember *
 AllowInaccessibleMember::create(ConstraintSystem &cs, Type baseType,
-                                ValueDecl *member, DeclName name,
+                                ValueDecl *member, DeclNameRef name,
                                 ConstraintLocator *locator) {
   return new (cs.getAllocator())
       AllowInaccessibleMember(cs, baseType, member, name, locator);
@@ -793,7 +793,7 @@ bool AllowMutatingMemberOnRValueBase::diagnose(bool asNote) const {
 
 AllowMutatingMemberOnRValueBase *
 AllowMutatingMemberOnRValueBase::create(ConstraintSystem &cs, Type baseType,
-                                        ValueDecl *member, DeclName name,
+                                        ValueDecl *member, DeclNameRef name,
                                         ConstraintLocator *locator) {
   return new (cs.getAllocator())
       AllowMutatingMemberOnRValueBase(cs, baseType, member, name, locator);
@@ -1102,7 +1102,7 @@ bool SpecifyBaseTypeForContextualMember::diagnose(bool asNote) const {
 }
 
 SpecifyBaseTypeForContextualMember *SpecifyBaseTypeForContextualMember::create(
-    ConstraintSystem &cs, DeclName member, ConstraintLocator *locator) {
+    ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator) {
   return new (cs.getAllocator())
       SpecifyBaseTypeForContextualMember(cs, member, locator);
 }

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -284,9 +284,9 @@ protected:
 
 /// Unwrap an optional base when we have a member access.
 class UnwrapOptionalBase final : public ConstraintFix {
-  DeclName MemberName;
+  DeclNameRef MemberName;
 
-  UnwrapOptionalBase(ConstraintSystem &cs, FixKind kind, DeclName member,
+  UnwrapOptionalBase(ConstraintSystem &cs, FixKind kind, DeclNameRef member,
                      ConstraintLocator *locator)
       : ConstraintFix(cs, kind, locator), MemberName(member) {
     assert(kind == FixKind::UnwrapOptionalBase ||
@@ -300,11 +300,11 @@ public:
 
   bool diagnose(bool asNote = false) const override;
 
-  static UnwrapOptionalBase *create(ConstraintSystem &cs, DeclName member,
+  static UnwrapOptionalBase *create(ConstraintSystem &cs, DeclNameRef member,
                                     ConstraintLocator *locator);
 
   static UnwrapOptionalBase *
-  createWithOptionalResult(ConstraintSystem &cs, DeclName member,
+  createWithOptionalResult(ConstraintSystem &cs, DeclNameRef member,
                            ConstraintLocator *locator);
 };
 
@@ -801,9 +801,9 @@ public:
 
 class DefineMemberBasedOnUse final : public ConstraintFix {
   Type BaseType;
-  DeclName Name;
+  DeclNameRef Name;
 
-  DefineMemberBasedOnUse(ConstraintSystem &cs, Type baseType, DeclName member,
+  DefineMemberBasedOnUse(ConstraintSystem &cs, Type baseType, DeclNameRef member,
                          ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::DefineMemberBasedOnUse, locator),
         BaseType(baseType), Name(member) {}
@@ -819,18 +819,18 @@ public:
   bool diagnose(bool asNote = false) const override;
 
   static DefineMemberBasedOnUse *create(ConstraintSystem &cs, Type baseType,
-                                        DeclName member,
+                                        DeclNameRef member,
                                         ConstraintLocator *locator);
 };
 
 class AllowInvalidMemberRef : public ConstraintFix {
   Type BaseType;
   ValueDecl *Member;
-  DeclName Name;
+  DeclNameRef Name;
 
 protected:
   AllowInvalidMemberRef(ConstraintSystem &cs, FixKind kind, Type baseType,
-                        ValueDecl *member, DeclName name,
+                        ValueDecl *member, DeclNameRef name,
                         ConstraintLocator *locator)
       : ConstraintFix(cs, kind, locator), BaseType(baseType), Member(member),
         Name(name) {}
@@ -840,12 +840,12 @@ public:
 
   ValueDecl *getMember() const { return Member; }
 
-  DeclName getMemberName() const { return Name; }
+  DeclNameRef getMemberName() const { return Name; }
 };
 
 class AllowMemberRefOnExistential final : public AllowInvalidMemberRef {
   AllowMemberRefOnExistential(ConstraintSystem &cs, Type baseType,
-                              DeclName memberName, ValueDecl *member,
+                              DeclNameRef memberName, ValueDecl *member,
                               ConstraintLocator *locator)
       : AllowInvalidMemberRef(cs, FixKind::AllowMemberRefOnExistential,
                               baseType, member, memberName, locator) {}
@@ -862,13 +862,13 @@ public:
 
   static AllowMemberRefOnExistential *create(ConstraintSystem &cs,
                                              Type baseType, ValueDecl *member,
-                                             DeclName memberName,
+                                             DeclNameRef memberName,
                                              ConstraintLocator *locator);
 };
 
 class AllowTypeOrInstanceMember final : public AllowInvalidMemberRef {
   AllowTypeOrInstanceMember(ConstraintSystem &cs, Type baseType,
-                            ValueDecl *member, DeclName name,
+                            ValueDecl *member, DeclNameRef name,
                             ConstraintLocator *locator)
       : AllowInvalidMemberRef(cs, FixKind::AllowTypeOrInstanceMember, baseType,
                               member, name, locator) {
@@ -883,7 +883,7 @@ public:
   bool diagnose(bool asNote = false) const override;
 
   static AllowTypeOrInstanceMember *create(ConstraintSystem &cs, Type baseType,
-                                           ValueDecl *member, DeclName usedName,
+                                           ValueDecl *member, DeclNameRef usedName,
                                            ConstraintLocator *locator);
 };
 
@@ -989,7 +989,7 @@ public:
 
 class AllowMutatingMemberOnRValueBase final : public AllowInvalidMemberRef {
   AllowMutatingMemberOnRValueBase(ConstraintSystem &cs, Type baseType,
-                                  ValueDecl *member, DeclName name,
+                                  ValueDecl *member, DeclNameRef name,
                                   ConstraintLocator *locator)
       : AllowInvalidMemberRef(cs, FixKind::AllowMutatingMemberOnRValueBase,
                               baseType, member, name, locator) {}
@@ -1002,8 +1002,8 @@ public:
   bool diagnose(bool asNote = false) const override;
 
   static AllowMutatingMemberOnRValueBase *
-  create(ConstraintSystem &cs, Type baseType, ValueDecl *member, DeclName name,
-         ConstraintLocator *locator);
+  create(ConstraintSystem &cs, Type baseType, ValueDecl *member,
+         DeclNameRef name, ConstraintLocator *locator);
 };
 
 class AllowClosureParamDestructuring final : public ConstraintFix {
@@ -1145,7 +1145,7 @@ public:
 
 class AllowInaccessibleMember final : public AllowInvalidMemberRef {
   AllowInaccessibleMember(ConstraintSystem &cs, Type baseType,
-                          ValueDecl *member, DeclName name,
+                          ValueDecl *member, DeclNameRef name,
                           ConstraintLocator *locator)
       : AllowInvalidMemberRef(cs, FixKind::AllowInaccessibleMember, baseType,
                               member, name, locator) {}
@@ -1158,7 +1158,7 @@ public:
   bool diagnose(bool asNote = false) const override;
 
   static AllowInaccessibleMember *create(ConstraintSystem &cs, Type baseType,
-                                         ValueDecl *member, DeclName name,
+                                         ValueDecl *member, DeclNameRef name,
                                          ConstraintLocator *locator);
 };
 
@@ -1557,9 +1557,9 @@ public:
 };
 
 class SpecifyBaseTypeForContextualMember final : public ConstraintFix {
-  DeclName MemberName;
+  DeclNameRef MemberName;
 
-  SpecifyBaseTypeForContextualMember(ConstraintSystem &cs, DeclName member,
+  SpecifyBaseTypeForContextualMember(ConstraintSystem &cs, DeclNameRef member,
                                      ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::SpecifyBaseTypeForContextualMember, locator),
         MemberName(member) {}
@@ -1574,7 +1574,7 @@ public:
   bool diagnose(bool asNote = false) const;
 
   static SpecifyBaseTypeForContextualMember *
-  create(ConstraintSystem &cs, DeclName member, ConstraintLocator *locator);
+  create(ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2043,7 +2043,7 @@ namespace {
 
     Type visitTupleElementExpr(TupleElementExpr *expr) {
       ASTContext &context = CS.getASTContext();
-      auto name = DeclNameRef_(
+      DeclNameRef name(
           context.getIdentifier(llvm::utostr(expr->getFieldNumber())));
       return addMemberRefConstraints(expr, expr->getBase(), name,
                                      FunctionRefKind::Unapplied,
@@ -3874,7 +3874,7 @@ swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
 
   // Look up all members of BaseTy with the given Name.
   MemberLookupResult LookupResult = CS.performMemberLookup(
-    ConstraintKind::ValueMember, DeclNameRef_(Name), BaseTy,
+    ConstraintKind::ValueMember, DeclNameRef(Name), BaseTy,
     FunctionRefKind::SingleApply, nullptr, false);
 
   // Keep track of all the unviable members.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -932,7 +932,7 @@ namespace {
 
     /// Add constraints for a reference to a named member of the given
     /// base type, and return the type of such a reference.
-    Type addMemberRefConstraints(Expr *expr, Expr *base, DeclName name,
+    Type addMemberRefConstraints(Expr *expr, Expr *base, DeclNameRef name,
                                  FunctionRefKind functionRefKind,
                                  ArrayRef<ValueDecl *> outerAlternatives) {
       // The base must have a member of the given name, such that accessing
@@ -1077,7 +1077,7 @@ namespace {
         CS.addBindOverloadConstraint(memberTy, choice, memberLocator,
                                      CurDC);
       } else {
-        CS.addValueMemberConstraint(baseTy, DeclBaseName::createSubscript(),
+        CS.addValueMemberConstraint(baseTy, DeclNameRef::createSubscript(),
                                     memberTy, CurDC,
                                     FunctionRefKind::DoubleApply,
                                     /*outerAlternatives=*/{},
@@ -2043,8 +2043,8 @@ namespace {
 
     Type visitTupleElementExpr(TupleElementExpr *expr) {
       ASTContext &context = CS.getASTContext();
-      Identifier name
-        = context.getIdentifier(llvm::utostr(expr->getFieldNumber()));
+      auto name = DeclNameRef_(
+          context.getIdentifier(llvm::utostr(expr->getFieldNumber())));
       return addMemberRefConstraints(expr, expr->getBase(), name,
                                      FunctionRefKind::Unapplied,
                                      /*outerAlternatives=*/{});
@@ -3053,8 +3053,8 @@ namespace {
                                                 TVO_CanBindToNoEscape);
           componentTypeVars.push_back(memberTy);
           auto lookupName = kind == KeyPathExpr::Component::Kind::UnresolvedProperty
-            ? component.getUnresolvedDeclName()
-            : component.getDeclRef().getDecl()->getFullName();
+            ? DeclNameRef(component.getUnresolvedDeclName()) // FIXME: type change needed
+            : component.getDeclRef().getDecl()->createNameRef();
           
           auto refKind = lookupName.isSimpleName()
             ? FunctionRefKind::Unapplied
@@ -3874,8 +3874,8 @@ swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
 
   // Look up all members of BaseTy with the given Name.
   MemberLookupResult LookupResult = CS.performMemberLookup(
-    ConstraintKind::ValueMember, Name, BaseTy, FunctionRefKind::SingleApply,
-    nullptr, false);
+    ConstraintKind::ValueMember, DeclNameRef_(Name), BaseTy,
+    FunctionRefKind::SingleApply, nullptr, false);
 
   // Keep track of all the unviable members.
   for (auto Can : LookupResult.UnviableCandidates)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4660,7 +4660,7 @@ ConstraintSystem::simplifyConstructionConstraint(
   // variable T. T2 is the result type provided via the construction
   // constraint itself.
   addValueMemberConstraint(MetatypeType::get(valueType, getASTContext()),
-                           DeclBaseName::createConstructor(),
+                           DeclNameRef::createConstructor(),
                            memberType,
                            useDC, functionRefKind,
                            /*outerAlternatives=*/{},
@@ -5372,7 +5372,7 @@ static bool isSelfRecursiveKeyPathDynamicMemberLookup(
 /// try to identify and classify inaccessible members that may be being
 /// referenced.
 MemberLookupResult ConstraintSystem::
-performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
+performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
                     Type baseTy, FunctionRefKind functionRefKind,
                     ConstraintLocator *memberLocator,
                     bool includeInaccessibleMembers) {
@@ -5446,8 +5446,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     // anything else, because the cost of the general search is so
     // high.
     if (auto info = getArgumentInfo(memberLocator)) {
-      memberName = DeclName(ctx, memberName.getBaseName(),
-                            info->Labels);
+      memberName.getFullName() = DeclName(ctx, memberName.getBaseName(),
+                                          info->Labels);
     }
   }
 
@@ -5767,7 +5767,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       memberName.getBaseName() == DeclBaseName::createConstructor() &&
       !isImplicitInit) {
     auto &compatLookup = lookupMember(instanceTy,
-                                      ctx.getIdentifier("init"));
+                                      DeclNameRef_(ctx.getIdentifier("init")));
     for (auto result : compatLookup)
       addChoice(getOverloadChoice(result.getValueDecl(),
                                   /*isBridged=*/false,
@@ -5840,8 +5840,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       auto subscriptName =
           DeclName(ctx, DeclBaseName::createSubscript(), ctx.Id_dynamicMember);
       auto subscripts = performMemberLookup(
-          constraintKind, subscriptName, baseTy, functionRefKind, memberLocator,
-          includeInaccessibleMembers);
+          constraintKind, DeclNameRef_(subscriptName), baseTy, functionRefKind,
+          memberLocator, includeInaccessibleMembers);
 
       // Reflect the candidates found as `DynamicMemberLookup` results.
       auto name = memberName.getBaseIdentifier();
@@ -6052,7 +6052,7 @@ static ConstraintFix *validateInitializerRef(ConstraintSystem &cs,
 
 static ConstraintFix *
 fixMemberRef(ConstraintSystem &cs, Type baseTy,
-             DeclName memberName, const OverloadChoice &choice,
+             DeclNameRef memberName, const OverloadChoice &choice,
              ConstraintLocator *locator,
              Optional<MemberLookupResult::UnviableReason> reason = None) {
   // Not all of the choices handled here are going
@@ -6120,7 +6120,7 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
 }
 
 ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
-    ConstraintKind kind, Type baseTy, DeclName member, Type memberTy,
+    ConstraintKind kind, Type baseTy, DeclNameRef member, Type memberTy,
     DeclContext *useDC, FunctionRefKind functionRefKind,
     ArrayRef<OverloadChoice> outerAlternatives, TypeMatchOptions flags,
     ConstraintLocatorBuilder locatorB) {
@@ -6339,7 +6339,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
     }
 
     auto solveWithNewBaseOrName = [&](Type baseType,
-                                      DeclName memberName) -> SolutionKind {
+                                      DeclNameRef memberName) -> SolutionKind {
       return simplifyMemberConstraint(kind, baseType, memberName, memberTy,
                                       useDC, functionRefKind, outerAlternatives,
                                       flags | TMF_ApplyingFix, locatorB);
@@ -6382,7 +6382,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
     // Instead of using subscript operator spelled out `subscript` directly.
     if (member.getBaseName() == getTokenText(tok::kw_subscript)) {
       auto result =
-          solveWithNewBaseOrName(baseTy, DeclBaseName::createSubscript());
+          solveWithNewBaseOrName(baseTy, DeclNameRef::createSubscript());
       // Looks like it was indeed meant to be a subscript operator.
       if (result == SolutionKind::Solved)
         return recordFix(UseSubscriptOperator::create(*this, locator))
@@ -7474,7 +7474,8 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     // Static member constraint requires `FunctionRefKind::DoubleApply`.
     // TODO: Use a custom locator element to identify this member constraint
     // instead of just pointing to the function expr.
-    addValueMemberConstraint(origLValueType2, DeclName(ctx.Id_callAsFunction),
+    addValueMemberConstraint(origLValueType2,
+                             DeclNameRef_(ctx.Id_callAsFunction),
                              memberTy, DC, FunctionRefKind::SingleApply,
                              /*outerAlternatives*/ {}, locator);
     // Add new applicable function constraint based on the member type
@@ -7608,7 +7609,7 @@ lookupDynamicCallableMethods(Type type, ConstraintSystem &CS,
   auto decl = type->getAnyNominal();
   auto methodName = DeclName(ctx, ctx.Id_dynamicallyCall, { argumentName });
   auto matches = CS.performMemberLookup(ConstraintKind::ValueMember,
-                                        methodName, type,
+                                        DeclNameRef_(methodName), type,
                                         FunctionRefKind::SingleApply,
                                         CS.getConstraintLocator(locator),
                                         /*includeInaccessibleMembers*/ false);
@@ -7845,9 +7846,9 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
     // TODO(diagnostics): This is not going to be necessary once
     // `@dynamicCallable` uses existing `member` machinery.
 
-    auto memberName = DeclName(
-        ctx, ctx.Id_dynamicallyCall,
-        {useKwargsMethod ? ctx.Id_withKeywordArguments : ctx.Id_withArguments});
+    auto argLabel = useKwargsMethod ? ctx.Id_withKeywordArguments
+                                    : ctx.Id_withArguments;
+    DeclNameRef memberName({ ctx, ctx.Id_dynamicallyCall, {argLabel} });
 
     auto *fix = DefineMemberBasedOnUse::create(
         *this, desugar2, memberName,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5767,7 +5767,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       memberName.getBaseName() == DeclBaseName::createConstructor() &&
       !isImplicitInit) {
     auto &compatLookup = lookupMember(instanceTy,
-                                      DeclNameRef_(ctx.getIdentifier("init")));
+                                      DeclNameRef(ctx.getIdentifier("init")));
     for (auto result : compatLookup)
       addChoice(getOverloadChoice(result.getValueDecl(),
                                   /*isBridged=*/false,
@@ -5837,11 +5837,11 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
       auto &ctx = getASTContext();
 
       // Recursively look up `subscript(dynamicMember:)` methods in this type.
-      auto subscriptName =
-          DeclName(ctx, DeclBaseName::createSubscript(), ctx.Id_dynamicMember);
+      DeclNameRef subscriptName(
+          { ctx, DeclBaseName::createSubscript(), { ctx.Id_dynamicMember } });
       auto subscripts = performMemberLookup(
-          constraintKind, DeclNameRef_(subscriptName), baseTy, functionRefKind,
-          memberLocator, includeInaccessibleMembers);
+          constraintKind, subscriptName, baseTy, functionRefKind, memberLocator,
+          includeInaccessibleMembers);
 
       // Reflect the candidates found as `DynamicMemberLookup` results.
       auto name = memberName.getBaseIdentifier();
@@ -7475,7 +7475,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     // TODO: Use a custom locator element to identify this member constraint
     // instead of just pointing to the function expr.
     addValueMemberConstraint(origLValueType2,
-                             DeclNameRef_(ctx.Id_callAsFunction),
+                             DeclNameRef(ctx.Id_callAsFunction),
                              memberTy, DC, FunctionRefKind::SingleApply,
                              /*outerAlternatives*/ {}, locator);
     // Add new applicable function constraint based on the member type
@@ -7607,12 +7607,11 @@ lookupDynamicCallableMethods(Type type, ConstraintSystem &CS,
                              Identifier argumentName, bool hasKeywordArgs) {
   auto &ctx = CS.getASTContext();
   auto decl = type->getAnyNominal();
-  auto methodName = DeclName(ctx, ctx.Id_dynamicallyCall, { argumentName });
-  auto matches = CS.performMemberLookup(ConstraintKind::ValueMember,
-                                        DeclNameRef_(methodName), type,
-                                        FunctionRefKind::SingleApply,
-                                        CS.getConstraintLocator(locator),
-                                        /*includeInaccessibleMembers*/ false);
+  DeclNameRef methodName({ ctx, ctx.Id_dynamicallyCall, { argumentName } });
+  auto matches = CS.performMemberLookup(
+      ConstraintKind::ValueMember, methodName, type,
+      FunctionRefKind::SingleApply, CS.getConstraintLocator(locator),
+      /*includeInaccessibleMembers*/ false);
   // Filter valid candidates.
   auto candidates = matches.ViableCandidates;
   auto filter = [&](OverloadChoice choice) {

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -150,7 +150,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
 }
 
 Constraint::Constraint(ConstraintKind kind, Type first, Type second,
-                       DeclName member, DeclContext *useDC,
+                       DeclNameRef member, DeclContext *useDC,
                        FunctionRefKind functionRefKind,
                        ConstraintLocator *locator,
                        ArrayRef<TypeVariableType *> typeVars)
@@ -610,7 +610,7 @@ Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind,
 
 Constraint *Constraint::createMemberOrOuterDisjunction(
     ConstraintSystem &cs, ConstraintKind kind, Type first, Type second,
-    DeclName member, DeclContext *useDC, FunctionRefKind functionRefKind,
+    DeclNameRef member, DeclContext *useDC, FunctionRefKind functionRefKind,
     ArrayRef<OverloadChoice> outerAlternatives, ConstraintLocator *locator) {
   auto memberConstraint = createMember(cs, kind, first, second, member,
                              useDC, functionRefKind, locator);
@@ -629,8 +629,8 @@ Constraint *Constraint::createMemberOrOuterDisjunction(
 }
 
 Constraint *Constraint::createMember(ConstraintSystem &cs, ConstraintKind kind, 
-                                     Type first, Type second, DeclName member,
-                                     DeclContext *useDC,
+                                     Type first, Type second,
+                                     DeclNameRef member, DeclContext *useDC,
                                      FunctionRefKind functionRefKind,
                                      ConstraintLocator *locator) {
   // Collect type variables.

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -317,7 +317,7 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 
       /// If non-null, the name of a member of the first type is that
       /// being related to the second type.
-      DeclName Member;
+      DeclNameRef Member;
 
       /// The DC in which the use appears.
       DeclContext *UseDC;
@@ -360,7 +360,7 @@ class Constraint final : public llvm::ilist_node<Constraint>,
              ArrayRef<TypeVariableType *> typeVars);
 
   /// Construct a new member constraint.
-  Constraint(ConstraintKind kind, Type first, Type second, DeclName member,
+  Constraint(ConstraintKind kind, Type first, Type second, DeclNameRef member,
              DeclContext *useDC, FunctionRefKind functionRefKind,
              ConstraintLocator *locator,
              ArrayRef<TypeVariableType *> typeVars);
@@ -400,12 +400,12 @@ public:
   /// alternatives.
   static Constraint *createMemberOrOuterDisjunction(
       ConstraintSystem &cs, ConstraintKind kind, Type first, Type second,
-      DeclName member, DeclContext *useDC, FunctionRefKind functionRefKind,
+      DeclNameRef member, DeclContext *useDC, FunctionRefKind functionRefKind,
       ArrayRef<OverloadChoice> outerAlternatives, ConstraintLocator *locator);
 
   /// Create a new member constraint.
   static Constraint *createMember(ConstraintSystem &cs, ConstraintKind kind,
-                                  Type first, Type second, DeclName member,
+                                  Type first, Type second, DeclNameRef member,
                                   DeclContext *useDC,
                                   FunctionRefKind functionRefKind,
                                   ConstraintLocator *locator);
@@ -586,7 +586,7 @@ public:
   ProtocolDecl *getProtocol() const;
 
   /// Retrieve the name of the member for a member constraint.
-  DeclName getMember() const {
+  DeclNameRef getMember() const {
     assert(Kind == ConstraintKind::ValueMember ||
            Kind == ConstraintKind::UnresolvedValueMember);
     return Member.Member;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2051,7 +2051,7 @@ std::pair<Type, bool> ConstraintSystem::adjustTypeOfOverloadReference(
     DeclNameRef memberName = isSubscriptRef
                            ? DeclNameRef::createSubscript()
                            // FIXME: Should propagate name-as-written through.
-                           : DeclNameRef_(choice.getName());
+                           : DeclNameRef(choice.getName());
 
     auto *memberRef = Constraint::createMember(
         *this, ConstraintKind::ValueMember, LValueType::get(rootTy), memberTy,
@@ -2962,7 +2962,7 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
     auto &overload = diff.overloads[*bestOverload];
     // FIXME: We would prefer to emit the name as written, but that information
     // is not sufficiently centralized in the AST.
-    auto name = DeclNameRef_(getOverloadChoiceName(overload.choices));
+    DeclNameRef name(getOverloadChoiceName(overload.choices));
     auto anchor = simplifyLocatorToAnchor(overload.locator);
 
     // Emit the ambiguity diagnostic.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1177,7 +1177,7 @@ private:
   size_t MaxMemory = 0;
 
   /// Cached member lookups.
-  llvm::DenseMap<std::pair<Type, DeclName>, Optional<LookupResult>>
+  llvm::DenseMap<std::pair<Type, DeclNameRef>, Optional<LookupResult>>
     MemberLookups;
 
   /// Cached sets of "alternative" literal types.
@@ -1907,7 +1907,7 @@ public:
   /// and no new names are introduced after name binding.
   ///
   /// \returns A reference to the member-lookup result.
-  LookupResult &lookupMember(Type base, DeclName name);
+  LookupResult &lookupMember(Type base, DeclNameRef name);
 
   /// Retrieve the set of "alternative" literal types that we'll explore
   /// for a given literal protocol kind.
@@ -2306,7 +2306,7 @@ public:
   }
 
   /// Add a value member constraint to the constraint system.
-  void addValueMemberConstraint(Type baseTy, DeclName name, Type memberTy,
+  void addValueMemberConstraint(Type baseTy, DeclNameRef name, Type memberTy,
                                 DeclContext *useDC,
                                 FunctionRefKind functionRefKind,
                                 ArrayRef<OverloadChoice> outerAlternatives,
@@ -2336,7 +2336,7 @@ public:
 
   /// Add a value member constraint for an UnresolvedMemberRef
   /// to the constraint system.
-  void addUnresolvedValueMemberConstraint(Type baseTy, DeclName name,
+  void addUnresolvedValueMemberConstraint(Type baseTy, DeclNameRef name,
                                           Type memberTy, DeclContext *useDC,
                                           FunctionRefKind functionRefKind,
                                           ConstraintLocatorBuilder locator) {
@@ -3181,7 +3181,7 @@ public:
   /// try to identify and classify inaccessible members that may be being
   /// referenced.
   MemberLookupResult performMemberLookup(ConstraintKind constraintKind,
-                                         DeclName memberName, Type baseTy,
+                                         DeclNameRef memberName, Type baseTy,
                                          FunctionRefKind functionRefKind,
                                          ConstraintLocator *memberLocator,
                                          bool includeInaccessibleMembers);
@@ -3258,7 +3258,7 @@ private:
 
   /// Attempt to simplify the given member constraint.
   SolutionKind simplifyMemberConstraint(
-      ConstraintKind kind, Type baseType, DeclName member, Type memberType,
+      ConstraintKind kind, Type baseType, DeclNameRef member, Type memberType,
       DeclContext *useDC, FunctionRefKind functionRefKind,
       ArrayRef<OverloadChoice> outerAlternatives, TypeMatchOptions flags,
       ConstraintLocatorBuilder locator);

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -67,14 +67,14 @@ class DebuggerTestingTransform : public ASTWalker {
   ASTContext &Ctx;
   DiscriminatorFinder &DF;
   std::vector<DeclContext *> LocalDeclContextStack;
-  const DeclName StringForPrintObjectName;
-  const DeclName DebuggerTestingCheckExpectName;
+  const DeclNameRef StringForPrintObjectName;
+  const DeclNameRef DebuggerTestingCheckExpectName;
 
 public:
   DebuggerTestingTransform(ASTContext &Ctx, DiscriminatorFinder &DF)
       : Ctx(Ctx), DF(DF),
-        StringForPrintObjectName((Ctx.getIdentifier("_stringForPrintObject"))),
-        DebuggerTestingCheckExpectName((Ctx.getIdentifier("_debuggerTestingCheckExpect"))) {}
+        StringForPrintObjectName(DeclNameRef_(Ctx.getIdentifier("_stringForPrintObject"))),
+        DebuggerTestingCheckExpectName(DeclNameRef_(Ctx.getIdentifier("_debuggerTestingCheckExpect"))) {}
 
   bool walkToDeclPre(Decl *D) override {
     pushLocalDeclContext(D);

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -73,8 +73,9 @@ class DebuggerTestingTransform : public ASTWalker {
 public:
   DebuggerTestingTransform(ASTContext &Ctx, DiscriminatorFinder &DF)
       : Ctx(Ctx), DF(DF),
-        StringForPrintObjectName(DeclNameRef_(Ctx.getIdentifier("_stringForPrintObject"))),
-        DebuggerTestingCheckExpectName(DeclNameRef_(Ctx.getIdentifier("_debuggerTestingCheckExpect"))) {}
+        StringForPrintObjectName(Ctx.getIdentifier("_stringForPrintObject")),
+        DebuggerTestingCheckExpectName(
+            Ctx.getIdentifier("_debuggerTestingCheckExpect")) {}
 
   bool walkToDeclPre(Decl *D) override {
     pushLocalDeclContext(D);

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -67,10 +67,14 @@ class DebuggerTestingTransform : public ASTWalker {
   ASTContext &Ctx;
   DiscriminatorFinder &DF;
   std::vector<DeclContext *> LocalDeclContextStack;
+  const DeclName StringForPrintObjectName;
+  const DeclName DebuggerTestingCheckExpectName;
 
 public:
   DebuggerTestingTransform(ASTContext &Ctx, DiscriminatorFinder &DF)
-      : Ctx(Ctx), DF(DF) {}
+      : Ctx(Ctx), DF(DF),
+        StringForPrintObjectName((Ctx.getIdentifier("_stringForPrintObject"))),
+        DebuggerTestingCheckExpectName((Ctx.getIdentifier("_debuggerTestingCheckExpect"))) {}
 
   bool walkToDeclPre(Decl *D) override {
     pushLocalDeclContext(D);
@@ -200,7 +204,7 @@ private:
 
     // Create _stringForPrintObject($Varname).
     auto *PODeclRef = new (Ctx)
-        UnresolvedDeclRefExpr(Ctx.getIdentifier("_stringForPrintObject"),
+        UnresolvedDeclRefExpr(StringForPrintObjectName,
                               DeclRefKind::Ordinary, DeclNameLoc());
     Expr *POArgs[] = {DstRef};
     Identifier POLabels[] = {Identifier()};
@@ -211,7 +215,7 @@ private:
     Identifier CheckExpectLabels[] = {Identifier(), Identifier()};
     Expr *CheckExpectArgs[] = {Varname, POCall};
     UnresolvedDeclRefExpr *CheckExpectDRE = new (Ctx)
-        UnresolvedDeclRefExpr(Ctx.getIdentifier("_debuggerTestingCheckExpect"),
+        UnresolvedDeclRefExpr(DebuggerTestingCheckExpectName,
                               DeclRefKind::Ordinary, DeclNameLoc());
     auto *CheckExpectExpr = CallExpr::createImplicit(
         Ctx, CheckExpectDRE, CheckExpectArgs, CheckExpectLabels);

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -415,14 +415,10 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
   keyedByDecl->setSpecifier(ParamSpecifier::Default);
   keyedByDecl->setInterfaceType(returnType);
 
-  // container(keyedBy:) method name
-  auto *paramList = ParameterList::createWithoutLoc(keyedByDecl);
-  DeclName callName(C, C.Id_container, paramList);
-
   // base.container(keyedBy:) expr
-  auto *unboundCall = new (C) UnresolvedDotExpr(base, SourceLoc(), callName,
-                                                DeclNameLoc(),
-                                                /*Implicit=*/true);
+  auto *paramList = ParameterList::createWithoutLoc(keyedByDecl);
+  auto *unboundCall = UnresolvedDotExpr::createImplicit(C, base, C.Id_container,
+                                                        paramList);
 
   // CodingKeys.self expr
   auto *codingKeysExpr = TypeExpr::createForDecl(SourceLoc(),
@@ -583,12 +579,10 @@ deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *) {
 
     // encode(_:forKey:)/encodeIfPresent(_:forKey:)
     auto methodName = useIfPresentVariant ? C.Id_encodeIfPresent : C.Id_encode;
-
     SmallVector<Identifier, 2> argNames{Identifier(), C.Id_forKey};
-    DeclName name(C, methodName, argNames);
-    auto *encodeCall = new (C) UnresolvedDotExpr(containerExpr, SourceLoc(),
-                                                 name, DeclNameLoc(),
-                                                 /*Implicit=*/true);
+
+    auto *encodeCall = UnresolvedDotExpr::createImplicit(C, containerExpr,
+                                                         methodName, argNames);
 
     // container.encode(self.x, forKey: CodingKeys.x)
     Expr *args[2] = {varExpr, keyExpr};
@@ -608,9 +602,7 @@ deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *) {
     // Need to generate `try super.encode(to: container.superEncoder())`
 
     // superEncoder()
-    auto *method = new (C) UnresolvedDeclRefExpr(DeclName(C.Id_superEncoder),
-                                                 DeclRefKind::Ordinary,
-                                                 DeclNameLoc());
+    auto *method = UnresolvedDeclRefExpr::createImplicit(C, C.Id_superEncoder);
 
     // container.superEncoder()
     auto *superEncoderRef = new (C) DotSyntaxCallExpr(containerExpr,
@@ -814,10 +806,8 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
 
       // decode(_:forKey:)/decodeIfPresent(_:forKey:)
       SmallVector<Identifier, 2> argNames{Identifier(), C.Id_forKey};
-      DeclName name(C, methodName, argNames);
-      auto *decodeCall = new (C) UnresolvedDotExpr(containerExpr, SourceLoc(),
-                                                   name, DeclNameLoc(),
-                                                   /*Implicit=*/true);
+      auto *decodeCall = UnresolvedDotExpr::createImplicit(
+          C, containerExpr, methodName, argNames);
 
       // container.decode(Type.self, forKey: CodingKeys.x)
       Expr *args[2] = {targetExpr, keyExpr};
@@ -830,10 +820,8 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
                                       /*Implicit=*/true);
 
       auto *selfRef = DerivedConformance::createSelfDeclRef(initDecl);
-      auto *varExpr = new (C) UnresolvedDotExpr(selfRef, SourceLoc(),
-                                                DeclName(varDecl->getName()),
-                                                DeclNameLoc(),
-                                                /*implicit=*/true);
+      auto *varExpr = UnresolvedDotExpr::createImplicit(C, selfRef,
+                                                        varDecl->getFullName());
       auto *assignExpr = new (C) AssignExpr(varExpr, SourceLoc(), tryExpr,
                                             /*Implicit=*/true);
       statements.push_back(assignExpr);
@@ -849,9 +837,8 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
 
         // container.superDecoder
         auto *superDecoderRef =
-          new (C) UnresolvedDotExpr(containerExpr, SourceLoc(),
-                                    DeclName(C.Id_superDecoder),
-                                    DeclNameLoc(), /*Implicit=*/true);
+          UnresolvedDotExpr::createImplicit(C, containerExpr,
+                                            C.Id_superDecoder);
 
         // container.superDecoder()
         auto *superDecoderCall =
@@ -863,10 +850,8 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
                                               SourceLoc(), /*Implicit=*/true);
 
         // super.init(from:)
-        auto initName = DeclName(C, DeclBaseName::createConstructor(), C.Id_from);
-        auto *initCall = new (C) UnresolvedDotExpr(superRef, SourceLoc(),
-                                                   initName, DeclNameLoc(),
-                                                   /*Implicit=*/true);
+        auto *initCall = UnresolvedDotExpr::createImplicit(
+            C, superRef, DeclBaseName::createConstructor(), {C.Id_from});
 
         // super.decode(from: container.superDecoder())
         Expr *args[1] = {superDecoderCall};
@@ -899,9 +884,8 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
                                               SourceLoc(), /*Implicit=*/true);
 
         // super.init()
-        auto *superInitRef = new (C) UnresolvedDotExpr(superRef, SourceLoc(),
-                                                       initName, DeclNameLoc(),
-                                                       /*Implicit=*/true);
+        auto *superInitRef = UnresolvedDotExpr::createImplicit(C, superRef,
+                                                               initName);
         // super.init() call
         Expr *callExpr = CallExpr::createImplicit(C, superInitRef,
                                                   ArrayRef<Expr *>(),

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -999,7 +999,8 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
       }
 
       auto result =
-          TypeChecker::lookupMember(superclassDecl, superType, memberName);
+          TypeChecker::lookupMember(superclassDecl, superType,
+                                    DeclNameRef_(memberName));
 
       if (result.empty()) {
         // No super initializer for us to call.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1000,7 +1000,7 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
 
       auto result =
           TypeChecker::lookupMember(superclassDecl, superType,
-                                    DeclNameRef_(memberName));
+                                    DeclNameRef(memberName));
 
       if (result.empty()) {
         // No super initializer for us to call.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -421,7 +421,7 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
                                                         paramList);
 
   // CodingKeys.self expr
-  auto *codingKeysExpr = TypeExpr::createForDecl(SourceLoc(),
+  auto *codingKeysExpr = TypeExpr::createForDecl(DeclNameLoc(),
                                                  param,
                                                  param->getDeclContext(),
                                                  /*Implicit=*/true);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -214,7 +214,7 @@ deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl, void *) {
     for (auto *elt : elements) {
       auto *pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
                                              SourceLoc(), DeclNameLoc(),
-                                             DeclName(), elt, nullptr);
+                                             DeclNameRef(), elt, nullptr);
       pat->setImplicit();
 
       auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -213,8 +213,8 @@ deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl, void *) {
     SmallVector<ASTNode, 4> cases;
     for (auto *elt : elements) {
       auto *pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
-                                             SourceLoc(), SourceLoc(),
-                                             Identifier(), elt, nullptr);
+                                             SourceLoc(), DeclNameLoc(),
+                                             DeclName(), elt, nullptr);
       pat->setImplicit();
 
       auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -50,9 +50,8 @@ deriveRawValueReturn(AbstractFunctionDecl *funcDecl, void *) {
   auto &C = parentDC->getASTContext();
 
   auto *selfRef = DerivedConformance::createSelfDeclRef(funcDecl);
-  auto *memberRef = new (C) UnresolvedDotExpr(selfRef, SourceLoc(),
-                                              C.Id_rawValue, DeclNameLoc(),
-                                              /*Implicit=*/true);
+  auto *memberRef =
+      UnresolvedDotExpr::createImplicit(C, selfRef, C.Id_rawValue);
 
   auto *returnStmt = new (C) ReturnStmt(SourceLoc(), memberRef);
   auto *body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
@@ -84,13 +83,10 @@ deriveRawValueInit(AbstractFunctionDecl *initDecl, void *) {
   rawValueDecl->setImplicit();
   auto *paramList = ParameterList::createWithoutLoc(rawValueDecl);
 
-  // init(rawValue:) constructor name
-  DeclName ctorName(C, DeclBaseName::createConstructor(), paramList);
-
   // self.init(rawValue:) expr
   auto *selfRef = DerivedConformance::createSelfDeclRef(initDecl);
-  auto *initExpr = new (C) UnresolvedDotExpr(selfRef, SourceLoc(), ctorName,
-                                             DeclNameLoc(), /*Implicit=*/true);
+  auto *initExpr = UnresolvedDotExpr::createImplicit(
+      C, selfRef, DeclBaseName::createConstructor(), paramList);
 
   // Bind the value param in self.init(rawValue: {string,int}Value).
   Expr *args[1] = {valueParamExpr};

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -308,8 +308,8 @@ static DeclRefExpr *convertEnumToIndex(SmallVectorImpl<ASTNode> &stmts,
   for (auto elt : enumDecl->getAllElements()) {
     // generate: case .<Case>:
     auto pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
-                                          SourceLoc(), SourceLoc(),
-                                          Identifier(), elt, nullptr);
+                                          SourceLoc(), DeclNameLoc(),
+                                          DeclName(), elt, nullptr);
     pat->setImplicit();
     pat->setType(enumType);
 
@@ -511,8 +511,8 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
     auto lhsSubpattern = enumElementPayloadSubpattern(elt, 'l', eqDecl,
                                                       lhsPayloadVars);
     auto lhsElemPat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
-                                                 SourceLoc(), SourceLoc(),
-                                                 Identifier(), elt,
+                                                 SourceLoc(), DeclNameLoc(),
+                                                 DeclName(), elt,
                                                  lhsSubpattern);
     lhsElemPat->setImplicit();
 
@@ -521,8 +521,8 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
     auto rhsSubpattern = enumElementPayloadSubpattern(elt, 'r', eqDecl,
                                                       rhsPayloadVars);
     auto rhsElemPat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
-                                                 SourceLoc(), SourceLoc(),
-                                                 Identifier(), elt,
+                                                 SourceLoc(), DeclNameLoc(),
+                                                 DeclName(), elt,
                                                  rhsSubpattern);
     rhsElemPat->setImplicit();
 
@@ -1033,8 +1033,9 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
     auto payloadPattern = enumElementPayloadSubpattern(elt, 'a', hashIntoDecl,
                                                        payloadVars);
     auto pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
-                                          SourceLoc(), SourceLoc(),
-                                          elt->getName(), elt, payloadPattern);
+                                          SourceLoc(), DeclNameLoc(),
+                                          elt->getName(), elt,
+                                          payloadPattern);
     pat->setImplicit();
 
     auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -309,7 +309,7 @@ static DeclRefExpr *convertEnumToIndex(SmallVectorImpl<ASTNode> &stmts,
     // generate: case .<Case>:
     auto pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
                                           SourceLoc(), DeclNameLoc(),
-                                          DeclName(), elt, nullptr);
+                                          DeclNameRef(), elt, nullptr);
     pat->setImplicit();
     pat->setType(enumType);
 
@@ -369,7 +369,7 @@ static GuardStmt *returnIfNotEqualGuard(ASTContext &C,
   // Next, generate the condition being checked.
   // lhs == rhs
   auto cmpFuncExpr = new (C) UnresolvedDeclRefExpr(
-    DeclName(C.getIdentifier("==")), DeclRefKind::BinaryOperator,
+    DeclNameRef_(C.Id_EqualsOperator), DeclRefKind::BinaryOperator,
     DeclNameLoc());
   auto cmpArgsTuple = TupleExpr::create(C, SourceLoc(),
                                         { lhsExpr, rhsExpr },
@@ -512,7 +512,7 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
                                                       lhsPayloadVars);
     auto lhsElemPat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
                                                  SourceLoc(), DeclNameLoc(),
-                                                 DeclName(), elt,
+                                                 DeclNameRef(), elt,
                                                  lhsSubpattern);
     lhsElemPat->setImplicit();
 
@@ -522,7 +522,7 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
                                                       rhsPayloadVars);
     auto rhsElemPat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
                                                  SourceLoc(), DeclNameLoc(),
-                                                 DeclName(), elt,
+                                                 DeclNameRef(), elt,
                                                  rhsSubpattern);
     rhsElemPat->setImplicit();
 
@@ -1034,7 +1034,7 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
                                                        payloadVars);
     auto pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
                                           SourceLoc(), DeclNameLoc(),
-                                          elt->getName(), elt,
+                                          DeclNameRef_(elt->getName()), elt,
                                           payloadPattern);
     pat->setImplicit();
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -833,11 +833,9 @@ static CallExpr *createHasherCombineCall(ASTContext &C,
                                          Expr *hashable) {
   Expr *hasherExpr = new (C) DeclRefExpr(ConcreteDeclRef(hasher),
                                          DeclNameLoc(), /*implicit*/ true);
-  DeclName name(C, C.Id_combine, {Identifier()});
   // hasher.combine(_:)
-  auto *combineCall = new (C) UnresolvedDotExpr(hasherExpr, SourceLoc(),
-                                                name, DeclNameLoc(),
-                                                /*implicit*/ true);
+  auto *combineCall = UnresolvedDotExpr::createImplicit(
+      C, hasherExpr, C.Id_combine, {Identifier()});
   
   // hasher.combine(hashable)
   return CallExpr::createImplicit(C, combineCall, {hashable}, {Identifier()});
@@ -912,9 +910,8 @@ deriveBodyHashable_compat_hashInto(AbstractFunctionDecl *hashIntoDecl, void *) {
   auto selfDecl = hashIntoDecl->getImplicitSelfDecl();
   auto selfRef = new (C) DeclRefExpr(selfDecl, DeclNameLoc(),
                                      /*implicit*/ true);
-  auto hashValueExpr = new (C) UnresolvedDotExpr(selfRef, SourceLoc(),
-                                                 C.Id_hashValue, DeclNameLoc(),
-                                                 /*implicit*/ true);
+  auto hashValueExpr = UnresolvedDotExpr::createImplicit(C, selfRef,
+                                                         C.Id_hashValue);
   auto hasherParam = hashIntoDecl->getParameters()->get(0);
   auto hasherExpr = createHasherCombineCall(C, hasherParam, hashValueExpr);
 
@@ -938,9 +935,8 @@ deriveBodyHashable_enum_rawValue_hashInto(
 
   // generate: self.rawValue
   auto *selfRef = DerivedConformance::createSelfDeclRef(hashIntoDecl);
-  auto *rawValueRef = new (C) UnresolvedDotExpr(selfRef, SourceLoc(),
-                                                C.Id_rawValue, DeclNameLoc(),
-                                                /*Implicit=*/true);
+  auto *rawValueRef = UnresolvedDotExpr::createImplicit(C, selfRef,
+                                                        C.Id_rawValue);
 
   // generate: hasher.combine(discriminator)
   auto hasherParam = hashIntoDecl->getParameters()->get(0);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -369,7 +369,7 @@ static GuardStmt *returnIfNotEqualGuard(ASTContext &C,
   // Next, generate the condition being checked.
   // lhs == rhs
   auto cmpFuncExpr = new (C) UnresolvedDeclRefExpr(
-    DeclNameRef_(C.Id_EqualsOperator), DeclRefKind::BinaryOperator,
+    DeclNameRef(C.Id_EqualsOperator), DeclRefKind::BinaryOperator,
     DeclNameLoc());
   auto cmpArgsTuple = TupleExpr::create(C, SourceLoc(),
                                         { lhsExpr, rhsExpr },
@@ -1034,7 +1034,7 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
                                                        payloadVars);
     auto pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
                                           SourceLoc(), DeclNameLoc(),
-                                          DeclNameRef_(elt->getName()), elt,
+                                          DeclNameRef(elt->getName()), elt,
                                           payloadPattern);
     pat->setImplicit();
 

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -42,7 +42,7 @@ deriveBodyBridgedNSError_enum_nsErrorDomain(AbstractFunctionDecl *domainDecl,
   auto self = domainDecl->getImplicitSelfDecl();
 
   auto selfRef = new (C) DeclRefExpr(self, DeclNameLoc(), /*implicit*/ true);
-  auto stringType = TypeExpr::createForDecl(SourceLoc(), C.getStringDecl(),
+  auto stringType = TypeExpr::createForDecl(DeclNameLoc(), C.getStringDecl(),
                                             domainDecl, /*implicit*/ true);
   auto initReflectingCall =
     CallExpr::createImplicit(C, stringType,

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -91,10 +91,8 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
     // a bitcast.
 
     // return unsafeBitCast(self, to: RawType.self)
-    DeclName name(C, C.getIdentifier("unsafeBitCast"), {Identifier(), C.Id_to});
-    auto functionRef = new (C) UnresolvedDeclRefExpr(name,
-                                                     DeclRefKind::Ordinary,
-                                                     DeclNameLoc());
+    auto functionRef = UnresolvedDeclRefExpr::createImplicit(
+        C, C.getIdentifier("unsafeBitCast"), {Identifier(), C.Id_to});
     auto selfRef = DerivedConformance::createSelfDeclRef(toRawDecl);
     auto bareTypeExpr = TypeExpr::createImplicit(rawTy, C);
     auto typeExpr = new (C) DotSelfExpr(bareTypeExpr, SourceLoc(), SourceLoc());
@@ -374,9 +372,8 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
   Expr *switchArg = rawRef;
   if (isStringEnum) {
     // Call _findStringSwitchCase with an array of strings as argument.
-    auto *Fun = new (C) UnresolvedDeclRefExpr(
-                  C.getIdentifier("_findStringSwitchCase"),
-                  DeclRefKind::Ordinary, DeclNameLoc());
+    auto *Fun = UnresolvedDeclRefExpr::createImplicit(
+        C, C.getIdentifier("_findStringSwitchCase"));
     auto *strArray = ArrayExpr::create(C, SourceLoc(), stringExprs, {},
                                        SourceLoc());;
     Identifier tableId = C.getIdentifier("cases");

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -109,8 +109,8 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
   SmallVector<ASTNode, 4> cases;
   for (auto elt : enumDecl->getAllElements()) {
     auto pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
-                                          SourceLoc(), SourceLoc(),
-                                          Identifier(), elt, nullptr);
+                                          SourceLoc(), DeclNameLoc(),
+                                          DeclName(), elt, nullptr);
     pat->setImplicit();
 
     auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -110,7 +110,7 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
   for (auto elt : enumDecl->getAllElements()) {
     auto pat = new (C) EnumElementPattern(TypeLoc::withoutLoc(enumType),
                                           SourceLoc(), DeclNameLoc(),
-                                          DeclName(), elt, nullptr);
+                                          DeclNameRef(), elt, nullptr);
     pat->setImplicit();
 
     auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -90,7 +90,8 @@ InstrumenterBase::InstrumenterBase(ASTContext &C, DeclContext *DC)
   TypeCheckDC->getParentModule()->lookupValue(
       moduleIdentifier, NLKind::UnqualifiedLookup, results);
 
-  ModuleIdentifier = (results.size() == 1) ? moduleIdentifier : Identifier();
+  if (results.size() == 1)
+    ModuleIdentifier = results.front()->getFullName();
 
   // Setup File identifier
   StringRef filePath = TypeCheckDC->getParentSourceFile()->getFilename();
@@ -106,7 +107,8 @@ InstrumenterBase::InstrumenterBase(ASTContext &C, DeclContext *DC)
   TypeCheckDC->getParentModule()->lookupValue(
       fileIdentifier, NLKind::UnqualifiedLookup, results);
 
-  FileIdentifier = (results.size() == 1) ? fileIdentifier : Identifier();
+  if (results.size() == 1)
+    FileIdentifier = results.front()->getFullName();
 }
 
 void InstrumenterBase::anchor() {}
@@ -128,3 +130,13 @@ bool InstrumenterBase::doTypeCheckImpl(ASTContext &Ctx, DeclContext *DC,
 
   return false;
 }
+
+Expr *InstrumenterBase::buildIDArgumentExpr(Optional<DeclName> name,
+                                            SourceRange SR) {
+  if (!name)
+    return IntegerLiteralExpr::createFromUnsigned(Context, 0);
+
+  return new (Context) UnresolvedDeclRefExpr(*name, DeclRefKind::Ordinary,
+                                             DeclNameLoc(SR.End));
+}
+

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -91,7 +91,7 @@ InstrumenterBase::InstrumenterBase(ASTContext &C, DeclContext *DC)
       moduleIdentifier, NLKind::UnqualifiedLookup, results);
 
   if (results.size() == 1)
-    ModuleIdentifier = results.front()->getFullName();
+    ModuleIdentifier = results.front()->createNameRef();
 
   // Setup File identifier
   StringRef filePath = TypeCheckDC->getParentSourceFile()->getFilename();
@@ -108,7 +108,7 @@ InstrumenterBase::InstrumenterBase(ASTContext &C, DeclContext *DC)
       fileIdentifier, NLKind::UnqualifiedLookup, results);
 
   if (results.size() == 1)
-    FileIdentifier = results.front()->getFullName();
+    FileIdentifier = results.front()->createNameRef();
 }
 
 void InstrumenterBase::anchor() {}
@@ -131,7 +131,7 @@ bool InstrumenterBase::doTypeCheckImpl(ASTContext &Ctx, DeclContext *DC,
   return false;
 }
 
-Expr *InstrumenterBase::buildIDArgumentExpr(Optional<DeclName> name,
+Expr *InstrumenterBase::buildIDArgumentExpr(Optional<DeclNameRef> name,
                                             SourceRange SR) {
   if (!name)
     return IntegerLiteralExpr::createFromUnsigned(Context, 0);

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -42,14 +42,18 @@ class InstrumenterBase {
 protected:
   ASTContext &Context;
   DeclContext *TypeCheckDC;
-  Identifier ModuleIdentifier;
-  Identifier FileIdentifier;
+  Optional<DeclName> ModuleIdentifier;
+  Optional<DeclName> FileIdentifier;
 
   InstrumenterBase(ASTContext &C, DeclContext *DC);
   virtual ~InstrumenterBase() = default;
   virtual void anchor();
   virtual BraceStmt *transformBraceStmt(BraceStmt *BS,
                                         bool TopLevel = false) = 0;
+
+  /// Create an expression which retrieves a valid ModuleIdentifier or
+  /// FileIdentifier, if available.
+  Expr *buildIDArgumentExpr(Optional<DeclName> name, SourceRange SR);
 
   class ClosureFinder : public ASTWalker {
   private:

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -42,8 +42,8 @@ class InstrumenterBase {
 protected:
   ASTContext &Context;
   DeclContext *TypeCheckDC;
-  Optional<DeclName> ModuleIdentifier;
-  Optional<DeclName> FileIdentifier;
+  Optional<DeclNameRef> ModuleIdentifier;
+  Optional<DeclNameRef> FileIdentifier;
 
   InstrumenterBase(ASTContext &C, DeclContext *DC);
   virtual ~InstrumenterBase() = default;
@@ -53,7 +53,7 @@ protected:
 
   /// Create an expression which retrieves a valid ModuleIdentifier or
   /// FileIdentifier, if available.
-  Expr *buildIDArgumentExpr(Optional<DeclName> name, SourceRange SR);
+  Expr *buildIDArgumentExpr(Optional<DeclNameRef> name, SourceRange SR);
 
   class ClosureFinder : public ASTWalker {
   private:

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -993,8 +993,8 @@ static void lookupVisibleDynamicMemberLookupDecls(
   auto &ctx = dc->getASTContext();
 
   // Lookup the `subscript(dynamicMember:)` methods in this type.
-  auto subscriptName =
-      DeclName(ctx, DeclBaseName::createSubscript(), ctx.Id_dynamicMember);
+  auto subscriptName = DeclNameRef_(
+      DeclName(ctx, DeclBaseName::createSubscript(), ctx.Id_dynamicMember));
 
   SmallVector<ValueDecl *, 2> subscripts;
   dc->lookupQualified(baseType, subscriptName, NL_QualifiedDefault,

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -993,8 +993,8 @@ static void lookupVisibleDynamicMemberLookupDecls(
   auto &ctx = dc->getASTContext();
 
   // Lookup the `subscript(dynamicMember:)` methods in this type.
-  auto subscriptName = DeclNameRef_(
-      DeclName(ctx, DeclBaseName::createSubscript(), ctx.Id_dynamicMember));
+  DeclNameRef subscriptName(
+      { ctx, DeclBaseName::createSubscript(), { ctx.Id_dynamicMember} });
 
   SmallVector<ValueDecl *, 2> subscripts;
   dc->lookupQualified(baseType, subscriptName, NL_QualifiedDefault,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -533,7 +533,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       DeclContext *topLevelContext = DC->getModuleScopeContext();
       auto descriptor = UnqualifiedLookupDescriptor(
-          DeclNameRef_(VD->getBaseName()), topLevelContext, SourceLoc(),
+          DeclNameRef(VD->getBaseName()), topLevelContext, SourceLoc(),
           UnqualifiedLookupFlags::KnownPrivate);
       auto lookup = evaluateOrDefault(Ctx.evaluator,
                                       UnqualifiedLookupRequest{descriptor}, {});
@@ -3177,7 +3177,7 @@ class ObjCSelectorWalker : public ASTWalker {
     auto nominal = method->getDeclContext()->getSelfNominalTypeDecl();
     auto result = TypeChecker::lookupMember(
         const_cast<DeclContext *>(DC), nominal->getDeclaredInterfaceType(),
-        DeclNameRef_(lookupName),
+        DeclNameRef(lookupName),
         (defaultMemberLookupOptions | NameLookupFlags::KnownPrivate));
 
     // If we didn't find multiple methods, there is no ambiguity.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3177,7 +3177,7 @@ class ObjCSelectorWalker : public ASTWalker {
     auto nominal = method->getDeclContext()->getSelfNominalTypeDecl();
     auto result = TypeChecker::lookupMember(
         const_cast<DeclContext *>(DC), nominal->getDeclaredInterfaceType(),
-        lookupName,
+        DeclNameRef_(lookupName),
         (defaultMemberLookupOptions | NameLookupFlags::KnownPrivate));
 
     // If we didn't find multiple methods, there is no ambiguity.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -533,7 +533,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       DeclContext *topLevelContext = DC->getModuleScopeContext();
       auto descriptor = UnqualifiedLookupDescriptor(
-          VD->getBaseName(), topLevelContext, SourceLoc(),
+          DeclName(VD->getBaseName()), topLevelContext, SourceLoc(),
           UnqualifiedLookupFlags::KnownPrivate);
       auto lookup = evaluateOrDefault(Ctx.evaluator,
                                       UnqualifiedLookupRequest{descriptor}, {});

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -533,7 +533,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       DeclContext *topLevelContext = DC->getModuleScopeContext();
       auto descriptor = UnqualifiedLookupDescriptor(
-          DeclName(VD->getBaseName()), topLevelContext, SourceLoc(),
+          DeclNameRef_(VD->getBaseName()), topLevelContext, SourceLoc(),
           UnqualifiedLookupFlags::KnownPrivate);
       auto lookup = evaluateOrDefault(Ctx.evaluator,
                                       UnqualifiedLookupRequest{descriptor}, {});

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -40,14 +40,14 @@ namespace {
 class Instrumenter : InstrumenterBase {
 private:
   unsigned &TmpNameIndex;
-  DeclName LogBeforeName;
-  DeclName LogAfterName;
+  DeclNameRef LogBeforeName;
+  DeclNameRef LogAfterName;
 
 public:
   Instrumenter(ASTContext &C, DeclContext *DC, unsigned &TmpNameIndex)
       : InstrumenterBase(C, DC), TmpNameIndex(TmpNameIndex),
-        LogBeforeName((C.getIdentifier("__builtin_pc_before"))),
-        LogAfterName((C.getIdentifier("__builtin_pc_after"))) {}
+        LogBeforeName(DeclNameRef_(C.getIdentifier("__builtin_pc_before"))),
+        LogAfterName(DeclNameRef_(C.getIdentifier("__builtin_pc_after"))) {}
 
   Stmt *transformStmt(Stmt *S) {
     switch (S->getKind()) {
@@ -592,7 +592,7 @@ public:
     return *AddedGet;
   }
 
-  Added<Stmt *> buildLoggerCallWithArgs(DeclName LoggerName,
+  Added<Stmt *> buildLoggerCallWithArgs(DeclNameRef LoggerName,
                                         SourceRange SR) {
     if (!SR.isValid()) {
       return nullptr;

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -46,8 +46,8 @@ private:
 public:
   Instrumenter(ASTContext &C, DeclContext *DC, unsigned &TmpNameIndex)
       : InstrumenterBase(C, DC), TmpNameIndex(TmpNameIndex),
-        LogBeforeName(DeclNameRef_(C.getIdentifier("__builtin_pc_before"))),
-        LogAfterName(DeclNameRef_(C.getIdentifier("__builtin_pc_after"))) {}
+        LogBeforeName(C.getIdentifier("__builtin_pc_before")),
+        LogAfterName(C.getIdentifier("__builtin_pc_after")) {}
 
   Stmt *transformStmt(Stmt *S) {
     switch (S->getKind()) {

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -126,13 +126,13 @@ public:
                unsigned &TmpNameIndex)
       : InstrumenterBase(C, DC), RNG(RNG), TmpNameIndex(TmpNameIndex),
         HighPerformance(HP),
-        DebugPrintName(DeclNameRef_(C.getIdentifier("__builtin_debugPrint"))),
-        PrintName(DeclNameRef_(C.getIdentifier("__builtin_print"))),
-        PostPrintName(DeclNameRef_(C.getIdentifier("__builtin_postPrint"))),
-        LogWithIDName(DeclNameRef_(C.getIdentifier("__builtin_log_with_id"))),
-        LogScopeExitName(DeclNameRef_(C.getIdentifier("__builtin_log_scope_exit"))),
-        LogScopeEntryName(DeclNameRef_(C.getIdentifier("__builtin_log_scope_entry"))),
-        SendDataName(DeclNameRef_(C.getIdentifier("__builtin_send_data"))) { }
+        DebugPrintName(C.getIdentifier("__builtin_debugPrint")),
+        PrintName(C.getIdentifier("__builtin_print")),
+        PostPrintName(C.getIdentifier("__builtin_postPrint")),
+        LogWithIDName(C.getIdentifier("__builtin_log_with_id")),
+        LogScopeExitName(C.getIdentifier("__builtin_log_scope_exit")),
+        LogScopeEntryName(C.getIdentifier("__builtin_log_scope_entry")),
+        SendDataName(C.getIdentifier("__builtin_send_data")) { }
 
   Stmt *transformStmt(Stmt *S) {
     switch (S->getKind()) {

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -42,13 +42,13 @@ private:
   unsigned &TmpNameIndex;
   bool HighPerformance;
 
-  DeclName DebugPrintName;
-  DeclName PrintName;
-  DeclName PostPrintName;
-  DeclName LogWithIDName;
-  DeclName LogScopeExitName;
-  DeclName LogScopeEntryName;
-  DeclName SendDataName;
+  DeclNameRef DebugPrintName;
+  DeclNameRef PrintName;
+  DeclNameRef PostPrintName;
+  DeclNameRef LogWithIDName;
+  DeclNameRef LogScopeExitName;
+  DeclNameRef LogScopeEntryName;
+  DeclNameRef SendDataName;
 
   struct BracePair {
   public:
@@ -126,13 +126,13 @@ public:
                unsigned &TmpNameIndex)
       : InstrumenterBase(C, DC), RNG(RNG), TmpNameIndex(TmpNameIndex),
         HighPerformance(HP),
-        DebugPrintName((C.getIdentifier("__builtin_debugPrint"))),
-        PrintName((C.getIdentifier("__builtin_print"))),
-        PostPrintName((C.getIdentifier("__builtin_postPrint"))),
-        LogWithIDName((C.getIdentifier("__builtin_log_with_id"))),
-        LogScopeExitName((C.getIdentifier("__builtin_log_scope_exit"))),
-        LogScopeEntryName((C.getIdentifier("__builtin_log_scope_entry"))),
-        SendDataName((C.getIdentifier("__builtin_send_data"))) { }
+        DebugPrintName(DeclNameRef_(C.getIdentifier("__builtin_debugPrint"))),
+        PrintName(DeclNameRef_(C.getIdentifier("__builtin_print"))),
+        PostPrintName(DeclNameRef_(C.getIdentifier("__builtin_postPrint"))),
+        LogWithIDName(DeclNameRef_(C.getIdentifier("__builtin_log_with_id"))),
+        LogScopeExitName(DeclNameRef_(C.getIdentifier("__builtin_log_scope_exit"))),
+        LogScopeEntryName(DeclNameRef_(C.getIdentifier("__builtin_log_scope_entry"))),
+        SendDataName(DeclNameRef_(C.getIdentifier("__builtin_send_data"))) { }
 
   Stmt *transformStmt(Stmt *S) {
     switch (S->getKind()) {
@@ -714,7 +714,7 @@ public:
   Added<Stmt *> logPrint(bool isDebugPrint, ApplyExpr *AE,
                          PatternBindingDecl *&ArgPattern,
                          VarDecl *&ArgVariable) {
-    DeclName LoggerName = isDebugPrint ? DebugPrintName : PrintName;
+    DeclNameRef LoggerName = isDebugPrint ? DebugPrintName : PrintName;
 
     UnresolvedDeclRefExpr *LoggerRef = new (Context) UnresolvedDeclRefExpr(
         LoggerName, DeclRefKind::Ordinary,
@@ -801,7 +801,7 @@ public:
     return buildLoggerCallWithArgs(LoggerName, MutableArrayRef<Expr *>(), SR);
   }
 
-  Added<Stmt *> buildLoggerCallWithArgs(DeclName LoggerName,
+  Added<Stmt *> buildLoggerCallWithArgs(DeclNameRef LoggerName,
                                         MutableArrayRef<Expr *> Args,
                                         SourceRange SR) {
     // If something doesn't have a valid source range it can not be playground

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1127,8 +1127,7 @@ static bool hasValidDynamicCallableMethod(NominalTypeDecl *decl,
                                           bool hasKeywordArgs) {
   auto &ctx = decl->getASTContext();
   auto declType = decl->getDeclaredType();
-  auto methodName = DeclNameRef_(DeclName(ctx, ctx.Id_dynamicallyCall,
-                                          { argumentName }));
+  DeclNameRef methodName({ ctx, ctx.Id_dynamicallyCall, { argumentName } });
   auto candidates = TypeChecker::lookupMember(decl, declType, methodName);
   if (candidates.empty()) return false;
 
@@ -1252,8 +1251,8 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   };
 
   // Look up `subscript(dynamicMember:)` candidates.
-  auto subscriptName = DeclNameRef_(
-      DeclName(ctx, DeclBaseName::createSubscript(), ctx.Id_dynamicMember));
+  DeclNameRef subscriptName(
+      { ctx, DeclBaseName::createSubscript(), { ctx.Id_dynamicMember } });
   auto candidates = TypeChecker::lookupMember(decl, type, subscriptName);
 
   if (!candidates.empty()) {
@@ -2387,7 +2386,7 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     // Check that the ProtocolType has the specified member.
     LookupResult R =
         TypeChecker::lookupMember(PD->getDeclContext(), PT,
-                                  DeclNameRef_(attr->getMemberName()));
+                                  DeclNameRef(attr->getMemberName()));
     if (!R) {
       diagnose(attr->getLocation(),
                diag::implements_attr_protocol_lacks_member,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2076,7 +2076,7 @@ void AttributeChecker::visitDiscardableResultAttr(DiscardableResultAttr *attr) {
 }
 
 /// Lookup the replaced decl in the replacments scope.
-static void lookupReplacedDecl(DeclName replacedDeclName,
+static void lookupReplacedDecl(DeclNameRef replacedDeclName,
                                const DynamicReplacementAttr *attr,
                                const ValueDecl *replacement,
                                SmallVectorImpl<ValueDecl *> &results) {
@@ -2130,7 +2130,7 @@ static Type getDynamicComparisonType(ValueDecl *value) {
   return interfaceType->removeArgumentLabels(numArgumentLabels);
 }
 
-static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
+static FuncDecl *findReplacedAccessor(DeclNameRef replacedVarName,
                                       AccessorDecl *replacement,
                                       DynamicReplacementAttr *attr,
                                       ASTContext &ctx) {
@@ -2219,7 +2219,7 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
 }
 
 static AbstractFunctionDecl *
-findReplacedFunction(DeclName replacedFunctionName,
+findReplacedFunction(DeclNameRef replacedFunctionName,
                      const AbstractFunctionDecl *replacement,
                      DynamicReplacementAttr *attr, DiagnosticEngine *Diags) {
 
@@ -2246,7 +2246,7 @@ findReplacedFunction(DeclName replacedFunctionName,
         if (Diags) {
           Diags->diagnose(attr->getLocation(),
                           diag::dynamic_replacement_function_not_dynamic,
-                          replacedFunctionName);
+                          result->getFullName());
           attr->setInvalid();
         }
         return nullptr;
@@ -2261,17 +2261,17 @@ findReplacedFunction(DeclName replacedFunctionName,
   if (results.empty()) {
     Diags->diagnose(attr->getLocation(),
                     diag::dynamic_replacement_function_not_found,
-                    attr->getReplacedFunctionName());
+                    replacedFunctionName);
   } else {
     Diags->diagnose(attr->getLocation(),
                     diag::dynamic_replacement_function_of_type_not_found,
-                    attr->getReplacedFunctionName(),
+                    replacedFunctionName,
                     replacement->getInterfaceType()->getCanonicalType());
 
     for (auto *result : results) {
       Diags->diagnose(SourceLoc(),
                       diag::dynamic_replacement_found_function_of_type,
-                      attr->getReplacedFunctionName(),
+                      result->getFullName(),
                       result->getInterfaceType()->getCanonicalType());
     }
   }
@@ -2280,7 +2280,7 @@ findReplacedFunction(DeclName replacedFunctionName,
 }
 
 static AbstractStorageDecl *
-findReplacedStorageDecl(DeclName replacedFunctionName,
+findReplacedStorageDecl(DeclNameRef replacedFunctionName,
                         const AbstractStorageDecl *replacement,
                         const DynamicReplacementAttr *attr) {
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -655,7 +655,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
                                        D->getInterfaceType());
     }
 
-    return TypeExpr::createForDecl(Loc, D,
+    return TypeExpr::createForDecl(UDRE->getNameLoc(), D,
                                    Lookup[0].getDeclContext(),
                                    UDRE->isImplicit());
   }
@@ -747,12 +747,13 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
   if (AllMemberRefs) {
     Expr *BaseExpr;
     if (auto PD = dyn_cast<ProtocolDecl>(Base)) {
-      BaseExpr = TypeExpr::createForDecl(Loc,
+      BaseExpr = TypeExpr::createForDecl(UDRE->getNameLoc(),
                                          PD->getGenericParams()->getParams().front(),
                                          /*DC*/nullptr,
                                          /*isImplicit=*/true);
     } else if (auto NTD = dyn_cast<NominalTypeDecl>(Base)) {
-      BaseExpr = TypeExpr::createForDecl(Loc, NTD, BaseDC, /*isImplicit=*/true);
+      BaseExpr = TypeExpr::createForDecl(UDRE->getNameLoc(), NTD, BaseDC,
+                                         /*isImplicit=*/true);
     } else {
       BaseExpr = new (Context) DeclRefExpr(Base, UDRE->getNameLoc(),
                                            /*Implicit=*/true);
@@ -1416,9 +1417,8 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
       // If there is no nested type with this name, we have a lookup of
       // a non-type member, so leave the expression as-is.
       if (Result.size() == 1) {
-        return TypeExpr::createForMemberDecl(DRE->getNameLoc().getBaseNameLoc(),
-                                             TD, NameLoc,
-                                             Result.front().Member);
+        return TypeExpr::createForMemberDecl(
+            DRE->getNameLoc(), TD, UDE->getNameLoc(), Result.front().Member);
       }
     }
 
@@ -1472,7 +1472,7 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
       // If there is no nested type with this name, we have a lookup of
       // a non-type member, so leave the expression as-is.
       if (Result.size() == 1) {
-        return TypeExpr::createForMemberDecl(ITR, NameLoc,
+        return TypeExpr::createForMemberDecl(ITR, UDE->getNameLoc(),
                                              Result.front().Member);
       }
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1349,7 +1349,8 @@ PrecedenceGroupDecl *TypeChecker::lookupPrecedenceGroup(DeclContext *dc,
 static NominalTypeDecl *resolveSingleNominalTypeDecl(
     DeclContext *DC, SourceLoc loc, Identifier ident, ASTContext &Ctx,
     TypeResolutionFlags flags = TypeResolutionFlags(0)) {
-  auto *TyR = new (Ctx) SimpleIdentTypeRepr(DeclNameLoc(loc), ident);
+  auto *TyR = new (Ctx) SimpleIdentTypeRepr(DeclNameLoc(loc),
+                                            DeclNameRef_(ident));
   TypeLoc typeLoc = TypeLoc(TyR);
 
   TypeResolutionOptions options = TypeResolverContext::TypeAliasDecl;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1350,7 +1350,7 @@ static NominalTypeDecl *resolveSingleNominalTypeDecl(
     DeclContext *DC, SourceLoc loc, Identifier ident, ASTContext &Ctx,
     TypeResolutionFlags flags = TypeResolutionFlags(0)) {
   auto *TyR = new (Ctx) SimpleIdentTypeRepr(DeclNameLoc(loc),
-                                            DeclNameRef_(ident));
+                                            DeclNameRef(ident));
   TypeLoc typeLoc = TypeLoc(TyR);
 
   TypeResolutionOptions options = TypeResolverContext::TypeAliasDecl;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1349,7 +1349,7 @@ PrecedenceGroupDecl *TypeChecker::lookupPrecedenceGroup(DeclContext *dc,
 static NominalTypeDecl *resolveSingleNominalTypeDecl(
     DeclContext *DC, SourceLoc loc, Identifier ident, ASTContext &Ctx,
     TypeResolutionFlags flags = TypeResolutionFlags(0)) {
-  auto *TyR = new (Ctx) SimpleIdentTypeRepr(loc, ident);
+  auto *TyR = new (Ctx) SimpleIdentTypeRepr(DeclNameLoc(loc), ident);
   TypeLoc typeLoc = TypeLoc(TyR);
 
   TypeResolutionOptions options = TypeResolverContext::TypeAliasDecl;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -745,7 +745,7 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
     for (auto *ctx : superContexts) {
       ctx->synthesizeSemanticMembersIfNeeded(membersName);
     }
-    dc->lookupQualified(superContexts, membersName,
+    dc->lookupQualified(superContexts, DeclNameRef_(membersName),
                         NL_QualifiedDefault, members);
   }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -745,7 +745,7 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
     for (auto *ctx : superContexts) {
       ctx->synthesizeSemanticMembersIfNeeded(membersName);
     }
-    dc->lookupQualified(superContexts, DeclNameRef_(membersName),
+    dc->lookupQualified(superContexts, DeclNameRef(membersName),
                         NL_QualifiedDefault, members);
   }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -964,7 +964,8 @@ static void diagnoseClassWithoutInitializers(ClassDecl *classDecl) {
       // We're going to diagnose on the concrete init(from:) decl if it exists
       // and isn't implicit; otherwise, on the subclass itself.
       ValueDecl *diagDest = classDecl;
-      auto initFrom = DeclName(C, DeclBaseName::createConstructor(), C.Id_from);
+      auto initFrom = DeclNameRef_(
+          DeclName(C, DeclBaseName::createConstructor(), C.Id_from));
       auto result =
           TypeChecker::lookupMember(superclassDecl, superclassType, initFrom,
                                     NameLookupFlags::ProtocolMembers |

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -964,8 +964,8 @@ static void diagnoseClassWithoutInitializers(ClassDecl *classDecl) {
       // We're going to diagnose on the concrete init(from:) decl if it exists
       // and isn't implicit; otherwise, on the subclass itself.
       ValueDecl *diagDest = classDecl;
-      auto initFrom = DeclNameRef_(
-          DeclName(C, DeclBaseName::createConstructor(), C.Id_from));
+      DeclNameRef initFrom(
+          { C, DeclBaseName::createConstructor(), { C.Id_from } });
       auto result =
           TypeChecker::lookupMember(superclassDecl, superclassType, initFrom,
                                     NameLookupFlags::ProtocolMembers |

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -623,9 +623,9 @@ static Type lookupDefaultLiteralType(const DeclContext *dc,
   auto lookupOptions = defaultUnqualifiedLookupOptions;
   if (isa<AbstractFunctionDecl>(dc))
     lookupOptions |= NameLookupFlags::KnownPrivate;
+  auto nameRef = DeclNameRef_(ctx.getIdentifier(name));
   auto lookup = TypeChecker::lookupUnqualified(dc->getModuleScopeContext(),
-                                               ctx.getIdentifier(name),
-                                               SourceLoc(),
+                                               nameRef, SourceLoc(),
                                                lookupOptions);
   TypeDecl *TD = lookup.getSingleTypeResult();
   if (!TD)

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -623,7 +623,7 @@ static Type lookupDefaultLiteralType(const DeclContext *dc,
   auto lookupOptions = defaultUnqualifiedLookupOptions;
   if (isa<AbstractFunctionDecl>(dc))
     lookupOptions |= NameLookupFlags::KnownPrivate;
-  auto nameRef = DeclNameRef_(ctx.getIdentifier(name));
+  DeclNameRef nameRef(ctx.getIdentifier(name));
   auto lookup = TypeChecker::lookupUnqualified(dc->getModuleScopeContext(),
                                                nameRef, SourceLoc(),
                                                lookupOptions);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -254,7 +254,7 @@ static void installPropertyWrapperMembersIfNeeded(NominalTypeDecl *target,
   }
 }
 
-LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclName name,
+LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclNameRef name,
                                             SourceLoc loc,
                                             NameLookupOptions options) {
   auto ulOptions = convertToUnqualifiedLookupOptions(options);
@@ -262,7 +262,7 @@ LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclName name,
   // Make sure we've resolved implicit members, if we need them.
   if (auto *current = dc->getInnermostTypeContext()) {
     installPropertyWrapperMembersIfNeeded(current->getSelfNominalTypeDecl(),
-                                          name);
+                                          name.getFullName());
   }
 
   auto &ctx = dc->getASTContext();
@@ -294,7 +294,7 @@ LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclName name,
 }
 
 LookupResult
-TypeChecker::lookupUnqualifiedType(DeclContext *dc, DeclName name,
+TypeChecker::lookupUnqualifiedType(DeclContext *dc, DeclNameRef name,
                                    SourceLoc loc,
                                    NameLookupOptions options) {
   auto &ctx = dc->getASTContext();
@@ -327,7 +327,7 @@ TypeChecker::lookupUnqualifiedType(DeclContext *dc, DeclName name,
 }
 
 LookupResult TypeChecker::lookupMember(DeclContext *dc,
-                                       Type type, DeclName name,
+                                       Type type, DeclNameRef name,
                                        NameLookupOptions options) {
   assert(type->mayHaveMembers());
 
@@ -350,8 +350,8 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
 
   // Make sure we've resolved implicit members, if we need them.
   if (auto *current = type->getAnyNominal()) {
-    current->synthesizeSemanticMembersIfNeeded(name);
-    installPropertyWrapperMembersIfNeeded(current, name);
+    current->synthesizeSemanticMembersIfNeeded(name.getFullName());
+    installPropertyWrapperMembersIfNeeded(current, name.getFullName());
   }
 
   LookupResultBuilder builder(result, dc, options);
@@ -413,7 +413,7 @@ bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
 }
 
 LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
-                                               Type type, Identifier name,
+                                               Type type, DeclNameRef name,
                                                NameLookupOptions options) {
   LookupTypeResult result;
 
@@ -430,8 +430,8 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
   // Make sure we've resolved implicit members, if we need them.
   if (auto *current = type->getAnyNominal()) {
-    current->synthesizeSemanticMembersIfNeeded(name);
-    installPropertyWrapperMembersIfNeeded(current, name);
+    current->synthesizeSemanticMembersIfNeeded(name.getFullName());
+    installPropertyWrapperMembersIfNeeded(current, name.getFullName());
   }
 
   if (!dc->lookupQualified(type, name, subOptions, decls))
@@ -555,7 +555,7 @@ LookupResult TypeChecker::lookupConstructors(DeclContext *dc, Type type,
   return lookupMember(dc, type, DeclNameRef::createConstructor(), options);
 }
 
-unsigned TypeChecker::getCallEditDistance(DeclName writtenName,
+unsigned TypeChecker::getCallEditDistance(DeclNameRef writtenName,
                                           DeclName correctedName,
                                           unsigned maxEditDistance) {
   // TODO: consider arguments.
@@ -591,7 +591,7 @@ unsigned TypeChecker::getCallEditDistance(DeclName writtenName,
   return distance;
 }
 
-static bool isPlausibleTypo(DeclRefKind refKind, DeclName typedName,
+static bool isPlausibleTypo(DeclRefKind refKind, DeclNameRef typedName,
                             ValueDecl *candidate) {
   // Ignore anonymous declarations.
   if (!candidate->hasName())

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -552,7 +552,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
 LookupResult TypeChecker::lookupConstructors(DeclContext *dc, Type type,
                                              NameLookupOptions options) {
-  return lookupMember(dc, type, DeclBaseName::createConstructor(), options);
+  return lookupMember(dc, type, DeclNameRef::createConstructor(), options);
 }
 
 unsigned TypeChecker::getCallEditDistance(DeclName writtenName,

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -174,7 +174,7 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
     // Get the declared type.
     if (auto *td = dyn_cast<TypeDecl>(dre->getDecl())) {
       components.push_back(
-        new (C) SimpleIdentTypeRepr(dre->getLoc(), td->getName()));
+        new (C) SimpleIdentTypeRepr(dre->getNameLoc(), td->getName()));
       components.back()->setValue(td, nullptr);
       return true;
     }
@@ -185,8 +185,8 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
     assert(components.empty() && "decl ref should be root element of expr");
     // Track the AST location of the component.
     components.push_back(
-      new (C) SimpleIdentTypeRepr(udre->getLoc(),
-                                  udre->getName().getBaseIdentifier()));
+      new (C) SimpleIdentTypeRepr(udre->getNameLoc(),
+                                  udre->getName()));
     return true;
   }
   
@@ -198,8 +198,8 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
 
     // Track the AST location of the new component.
     components.push_back(
-      new (C) SimpleIdentTypeRepr(ude->getLoc(),
-                                  ude->getName().getBaseIdentifier()));
+      new (C) SimpleIdentTypeRepr(ude->getNameLoc(),
+                                  ude->getName()));
     return true;
   }
   
@@ -215,8 +215,8 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
       argTypeReprs.push_back(arg.getTypeRepr());
     auto origComponent = components.back();
     components.back() =
-      GenericIdentTypeRepr::create(C, origComponent->getIdLoc(),
-                                   origComponent->getIdentifier(), argTypeReprs,
+      GenericIdentTypeRepr::create(C, origComponent->getNameLoc(),
+                                   origComponent->getNameRef(), argTypeReprs,
                                    SourceRange(use->getLAngleLoc(),
                                                use->getRAngleLoc()));
 
@@ -547,8 +547,7 @@ public:
     if (components.empty()) {
       // Only one component. Try looking up an enum element in context.
       referencedElement
-        = lookupUnqualifiedEnumMemberElement(DC,
-                                             tailComponent->getIdentifier(),
+        = lookupUnqualifiedEnumMemberElement(DC, tailComponent->getNameRef(),
                                              tailComponent->getLoc());
       if (!referencedElement)
         return nullptr;
@@ -572,7 +571,7 @@ public:
 
       referencedElement
         = lookupEnumMemberElement(DC, enumTy,
-                                  tailComponent->getIdentifier(),
+                                  tailComponent->getNameRef(),
                                   tailComponent->getLoc());
       if (!referencedElement)
         return nullptr;
@@ -586,8 +585,8 @@ public:
 
     auto *subPattern = getSubExprPattern(ce->getArg());
     return new (Context) EnumElementPattern(
-        loc, SourceLoc(), DeclNameLoc(tailComponent->getIdLoc()),
-        tailComponent->getIdentifier(), referencedElement,
+        loc, SourceLoc(), tailComponent->getNameLoc(),
+        tailComponent->getNameRef(), referencedElement,
         subPattern);
   }
 };

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -113,10 +113,10 @@ filterForEnumElement(DeclContext *DC, SourceLoc UseLoc,
 
 /// Find an unqualified enum element.
 static EnumElementDecl *
-lookupUnqualifiedEnumMemberElement(DeclContext *DC, DeclName name,
+lookupUnqualifiedEnumMemberElement(DeclContext *DC, DeclNameRef name,
                                    SourceLoc UseLoc) {
   // FIXME: We should probably pay attention to argument labels someday.
-  name = name.getBaseName();
+  name = name.withoutArgumentLabels();
 
   auto lookupOptions = defaultUnqualifiedLookupOptions;
   lookupOptions |= NameLookupFlags::KnownPrivate;
@@ -129,12 +129,12 @@ lookupUnqualifiedEnumMemberElement(DeclContext *DC, DeclName name,
 /// Find an enum element in an enum type.
 static EnumElementDecl *
 lookupEnumMemberElement(DeclContext *DC, Type ty,
-                        DeclName name, SourceLoc UseLoc) {
+                        DeclNameRef name, SourceLoc UseLoc) {
   if (!ty->mayHaveMembers())
     return nullptr;
 
   // FIXME: We should probably pay attention to argument labels someday.
-  name = name.getBaseName();
+  name = name.withoutArgumentLabels();
 
   // Look up the case inside the enum.
   // FIXME: We should be able to tell if this is a private lookup.
@@ -174,7 +174,7 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
     // Get the declared type.
     if (auto *td = dyn_cast<TypeDecl>(dre->getDecl())) {
       components.push_back(
-        new (C) SimpleIdentTypeRepr(dre->getNameLoc(), td->getName()));
+        new (C) SimpleIdentTypeRepr(dre->getNameLoc(), td->createNameRef()));
       components.back()->setValue(td, nullptr);
       return true;
     }
@@ -1134,7 +1134,7 @@ recur:
         P = new (Context) EnumElementPattern(TypeLoc::withoutLoc(type),
                                              NLE->getLoc(),
                                              DeclNameLoc(NLE->getLoc()),
-                                             NoneEnumElement->getFullName(),
+                                             NoneEnumElement->createNameRef(),
                                              NoneEnumElement, nullptr, false);
         return TypeChecker::coercePatternToType(P, resolution, type, options);
       }
@@ -1169,7 +1169,7 @@ recur:
         sub = new (Context) EnumElementPattern(TypeLoc(),
                                                IP->getStartLoc(),
                                                DeclNameLoc(IP->getEndLoc()),
-                                               some->getFullName(),
+                                               some->createNameRef(),
                                                nullptr, sub,
                                                /*Implicit=*/true);
       }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -43,7 +43,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
   SmallVector<VarDecl *, 2> vars;
   {
     SmallVector<ValueDecl *, 2> decls;
-    nominal->lookupQualified(nominal, DeclNameRef_(name), NL_QualifiedDefault,
+    nominal->lookupQualified(nominal, DeclNameRef(name), NL_QualifiedDefault,
                              decls);
     for (const auto &foundDecl : decls) {
       auto foundVar = dyn_cast<VarDecl>(foundDecl);
@@ -118,8 +118,7 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
     break;
   }
 
-  nominal->lookupQualified(nominal,
-                           DeclNameRef_(DeclBaseName::createConstructor()),
+  nominal->lookupQualified(nominal, DeclNameRef::createConstructor(),
                            NL_QualifiedDefault, decls);
   for (const auto &decl : decls) {
     auto init = dyn_cast<ConstructorDecl>(decl);

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -43,7 +43,8 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
   SmallVector<VarDecl *, 2> vars;
   {
     SmallVector<ValueDecl *, 2> decls;
-    nominal->lookupQualified(nominal, name, NL_QualifiedDefault, decls);
+    nominal->lookupQualified(nominal, DeclNameRef_(name), NL_QualifiedDefault,
+                             decls);
     for (const auto &foundDecl : decls) {
       auto foundVar = dyn_cast<VarDecl>(foundDecl);
       if (!foundVar || foundVar->isStatic() ||
@@ -117,7 +118,8 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
     break;
   }
 
-  nominal->lookupQualified(nominal, DeclBaseName::createConstructor(),
+  nominal->lookupQualified(nominal,
+                           DeclNameRef_(DeclBaseName::createConstructor()),
                            NL_QualifiedDefault, decls);
   for (const auto &decl : decls) {
     auto init = dyn_cast<ConstructorDecl>(decl);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4800,8 +4800,7 @@ diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
     static bool hasValidMethod(NominalTypeDecl *typeDecl,
                                SmallVectorImpl<InvalidMethod> &invalid) {
       auto type = typeDecl->getDeclaredType();
-      auto baseName =
-          DeclNameRef_(typeDecl->getASTContext().Id_appendInterpolation);
+      DeclNameRef baseName(typeDecl->getASTContext().Id_appendInterpolation);
       auto lookupOptions = defaultMemberTypeLookupOptions;
       lookupOptions -= NameLookupFlags::PerformConformanceCheck;
 
@@ -5569,7 +5568,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     if (assocType->getProtocol() != proto) {
       SmallVector<ValueDecl *, 2> found;
       proto->getModuleContext()->lookupQualified(
-                           proto, DeclNameRef_(assocType->getFullName()),
+                           proto, DeclNameRef(assocType->getFullName()),
                            NL_QualifiedDefault|NL_ProtocolMembers|NL_OnlyTypes,
                            found);
       if (found.size() == 1 && isa<AssociatedTypeDecl>(found[0]))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5565,7 +5565,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     if (assocType->getProtocol() != proto) {
       SmallVector<ValueDecl *, 2> found;
       proto->getModuleContext()->lookupQualified(
-                           proto, assocType->getFullName(),
+                           proto, DeclNameRef_(assocType->getFullName()),
                            NL_QualifiedDefault|NL_ProtocolMembers|NL_OnlyTypes,
                            found);
       if (found.size() == 1 && isa<AssociatedTypeDecl>(found[0]))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -898,8 +898,8 @@ WitnessChecker::lookupValueWitnessesViaImplementsAttr(
   auto lookupOptions = defaultMemberTypeLookupOptions;
   lookupOptions -= NameLookupFlags::PerformConformanceCheck;
   lookupOptions |= NameLookupFlags::IncludeAttributeImplements;
-  auto candidates =
-      TypeChecker::lookupMember(DC, Adoptee, req->getFullName(), lookupOptions);
+  auto candidates = TypeChecker::lookupMember(DC, Adoptee, req->createNameRef(),
+                                              lookupOptions);
   for (auto candidate : candidates) {
     if (witnessHasImplementsAttrForExactRequirement(candidate.getValueDecl(), req)) {
       witnesses.push_back(candidate.getValueDecl());
@@ -918,14 +918,17 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
   // for this requirement.
   lookupValueWitnessesViaImplementsAttr(req, witnesses);
 
+  auto reqName = req->createNameRef();
+  auto reqBaseName = reqName.withoutArgumentLabels();
+
   if (req->isOperator()) {
     // Operator lookup is always global.
     auto lookupOptions = defaultUnqualifiedLookupOptions;
     if (!DC->isCascadingContextForLookup(false))
       lookupOptions |= NameLookupFlags::KnownPrivate;
     auto lookup = TypeChecker::lookupUnqualified(DC->getModuleScopeContext(),
-                                                 req->getBaseName(),
-                                                 SourceLoc(), lookupOptions);
+                                                 reqBaseName, SourceLoc(),
+                                                 lookupOptions);
     for (auto candidate : lookup) {
       auto decl = candidate.getValueDecl();
       if (swift::isMemberOperator(cast<FuncDecl>(decl), Adoptee)) {
@@ -937,13 +940,13 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
     auto lookupOptions = defaultMemberTypeLookupOptions;
     lookupOptions -= NameLookupFlags::PerformConformanceCheck;
 
-    auto candidates = TypeChecker::lookupMember(DC, Adoptee, req->getFullName(),
+    auto candidates = TypeChecker::lookupMember(DC, Adoptee, reqName,
                                                 lookupOptions);
 
     // If we didn't find anything with the appropriate name, look
     // again using only the base name.
     if (candidates.empty() && ignoringNames) {
-      candidates = TypeChecker::lookupMember(DC, Adoptee, req->getBaseName(),
+      candidates = TypeChecker::lookupMember(DC, Adoptee, reqBaseName,
                                              lookupOptions);
       *ignoringNames = true;
     }
@@ -997,7 +1000,7 @@ bool WitnessChecker::findBestWitness(
       auto lookupOptions = defaultUnqualifiedLookupOptions;
       lookupOptions |= NameLookupFlags::KnownPrivate;
       auto lookup = TypeChecker::lookupUnqualified(
-          overlay, requirement->getBaseName(), SourceLoc(), lookupOptions);
+          overlay, requirement->createNameRef(), SourceLoc(), lookupOptions);
       for (auto candidate : lookup)
         witnesses.push_back(candidate.getValueDecl());
       break;
@@ -3534,7 +3537,8 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
 
   // Look for a member type with the same name as the associated type.
   auto candidates = TypeChecker::lookupMemberType(
-      DC, Adoptee, assocType->getName(), NameLookupFlags::ProtocolMembers);
+      DC, Adoptee, assocType->createNameRef(),
+      NameLookupFlags::ProtocolMembers);
 
   // If there aren't any candidates, we're done.
   if (!candidates) {
@@ -4797,7 +4801,7 @@ diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
                                SmallVectorImpl<InvalidMethod> &invalid) {
       auto type = typeDecl->getDeclaredType();
       auto baseName =
-          DeclName(typeDecl->getASTContext().Id_appendInterpolation);
+          DeclNameRef_(typeDecl->getASTContext().Id_appendInterpolation);
       auto lookupOptions = defaultMemberTypeLookupOptions;
       lookupOptions -= NameLookupFlags::PerformConformanceCheck;
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -563,7 +563,7 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
                    const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
                    AssociatedTypeDecl *assocType) {
   // Form the default name _Default_Foo.
-  Identifier defaultName;
+  DeclNameRef defaultName;
   {
     SmallString<32> defaultNameStr;
     {
@@ -572,7 +572,7 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
       out << assocType->getName().str();
     }
 
-    defaultName = getASTContext().getIdentifier(defaultNameStr);
+    defaultName = DeclNameRef_(getASTContext().getIdentifier(defaultNameStr));
   }
 
   // Look for types with the given default name that have appropriate

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -572,7 +572,7 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
       out << assocType->getName().str();
     }
 
-    defaultName = DeclNameRef_(getASTContext().getIdentifier(defaultNameStr));
+    defaultName = DeclNameRef(getASTContext().getIdentifier(defaultNameStr));
   }
 
   // Look for types with the given default name that have appropriate

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -75,7 +75,7 @@ struct REPLContext {
 
     auto *stdlib = TypeChecker::getStdlibModule(&SF);
     {
-      Identifier Id(Context.getIdentifier("_replPrintLiteralString"));
+      auto Id = DeclNameRef_(Context.getIdentifier("_replPrintLiteralString"));
       auto lookup = TypeChecker::lookupUnqualified(stdlib, Id, SourceLoc());
       if (!lookup)
         return true;
@@ -83,7 +83,7 @@ struct REPLContext {
         PrintDecls.push_back(result.getValueDecl());
     }
     {
-      Identifier Id(Context.getIdentifier("_replDebugPrintln"));
+      auto Id = DeclNameRef_(Context.getIdentifier("_replDebugPrintln"));
       auto lookup = TypeChecker::lookupUnqualified(stdlib, Id, SourceLoc());
       if (!lookup)
         return true;
@@ -451,7 +451,8 @@ Identifier REPLChecker::getNextResponseVariableName(DeclContext *DC) {
     names << "r" << NextResponseVariableIndex++;
 
     ident = Context.getIdentifier(names.str());
-    nameUsed = (bool)TypeChecker::lookupUnqualified(DC, ident, SourceLoc());
+    nameUsed = (bool)TypeChecker::lookupUnqualified(DC, DeclNameRef_(ident),
+                                                    SourceLoc());
   } while (nameUsed);
 
   return ident;

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -75,7 +75,7 @@ struct REPLContext {
 
     auto *stdlib = TypeChecker::getStdlibModule(&SF);
     {
-      auto Id = DeclNameRef_(Context.getIdentifier("_replPrintLiteralString"));
+      DeclNameRef Id(Context.getIdentifier("_replPrintLiteralString"));
       auto lookup = TypeChecker::lookupUnqualified(stdlib, Id, SourceLoc());
       if (!lookup)
         return true;
@@ -83,7 +83,7 @@ struct REPLContext {
         PrintDecls.push_back(result.getValueDecl());
     }
     {
-      auto Id = DeclNameRef_(Context.getIdentifier("_replDebugPrintln"));
+      DeclNameRef Id(Context.getIdentifier("_replDebugPrintln"));
       auto lookup = TypeChecker::lookupUnqualified(stdlib, Id, SourceLoc());
       if (!lookup)
         return true;
@@ -451,7 +451,7 @@ Identifier REPLChecker::getNextResponseVariableName(DeclContext *DC) {
     names << "r" << NextResponseVariableIndex++;
 
     ident = Context.getIdentifier(names.str());
-    nameUsed = (bool)TypeChecker::lookupUnqualified(DC, DeclNameRef_(ident),
+    nameUsed = (bool)TypeChecker::lookupUnqualified(DC, DeclNameRef(ident),
                                                     SourceLoc());
   } while (nameUsed);
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1905,10 +1905,8 @@ static Expr* constructCallToSuperInit(ConstructorDecl *ctor,
   ASTContext &Context = ctor->getASTContext();
   Expr *superRef = new (Context) SuperRefExpr(ctor->getImplicitSelfDecl(),
                                               SourceLoc(), /*Implicit=*/true);
-  Expr *r = new (Context) UnresolvedDotExpr(superRef, SourceLoc(),
-                                            DeclBaseName::createConstructor(),
-                                            DeclNameLoc(),
-                                            /*Implicit=*/true);
+  Expr *r = UnresolvedDotExpr::createImplicit(
+      Context, superRef, DeclBaseName::createConstructor());
   r = CallExpr::createImplicit(Context, r, { }, { });
 
   if (ctor->hasThrows())

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -925,7 +925,7 @@ public:
         } else {
           unsigned distance =
             TypeChecker::getCallEditDistance(
-                S->getTargetName(), (*I)->getLabelInfo().Name,
+                DeclNameRef_(S->getTargetName()), (*I)->getLabelInfo().Name,
                 TypeChecker::UnreasonableCallEditDistance);
           if (distance < TypeChecker::UnreasonableCallEditDistance)
             labelCorrections.insert(distance, std::move(*I));
@@ -990,7 +990,7 @@ public:
         } else {
           unsigned distance =
             TypeChecker::getCallEditDistance(
-                S->getTargetName(), (*I)->getLabelInfo().Name,
+                DeclNameRef_(S->getTargetName()), (*I)->getLabelInfo().Name,
                 TypeChecker::UnreasonableCallEditDistance);
           if (distance < TypeChecker::UnreasonableCallEditDistance)
             labelCorrections.insert(distance, std::move(*I));

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -925,7 +925,7 @@ public:
         } else {
           unsigned distance =
             TypeChecker::getCallEditDistance(
-                DeclNameRef_(S->getTargetName()), (*I)->getLabelInfo().Name,
+                DeclNameRef(S->getTargetName()), (*I)->getLabelInfo().Name,
                 TypeChecker::UnreasonableCallEditDistance);
           if (distance < TypeChecker::UnreasonableCallEditDistance)
             labelCorrections.insert(distance, std::move(*I));
@@ -990,7 +990,7 @@ public:
         } else {
           unsigned distance =
             TypeChecker::getCallEditDistance(
-                DeclNameRef_(S->getTargetName()), (*I)->getLabelInfo().Name,
+                DeclNameRef(S->getTargetName()), (*I)->getLabelInfo().Name,
                 TypeChecker::UnreasonableCallEditDistance);
           if (distance < TypeChecker::UnreasonableCallEditDistance)
             labelCorrections.insert(distance, std::move(*I));

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -800,18 +800,15 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
 
     // Key path referring to the property being accessed.
     Expr *propertyKeyPath = new (ctx) KeyPathDotExpr(SourceLoc());
-    propertyKeyPath = new (ctx) UnresolvedDotExpr(
-        propertyKeyPath, SourceLoc(),
-        enclosingSelfAccess->accessedProperty->getFullName(), DeclNameLoc(),
-        /*Implicit=*/true);
+    propertyKeyPath = UnresolvedDotExpr::createImplicit(ctx, propertyKeyPath,
+        enclosingSelfAccess->accessedProperty->getFullName());
     propertyKeyPath = new (ctx) KeyPathExpr(
         SourceLoc(), nullptr, propertyKeyPath);
 
     // Key path referring to the backing storage property.
     Expr *storageKeyPath = new (ctx) KeyPathDotExpr(SourceLoc());
-    storageKeyPath = new (ctx) UnresolvedDotExpr(
-        storageKeyPath, SourceLoc(), storage->getFullName(), DeclNameLoc(),
-        /*Implicit=*/true);
+    storageKeyPath = UnresolvedDotExpr::createImplicit(ctx, storageKeyPath,
+                                                       storage->getFullName());
     storageKeyPath = new (ctx) KeyPathExpr(
         SourceLoc(), nullptr, storageKeyPath);
     Expr *args[3] = {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2127,7 +2127,7 @@ static VarDecl *synthesizePropertyWrapperStorageWrapperProperty(
   // that to find the storage wrapper property.
   if (auto attr = var->getAttrs().getAttribute<ProjectedValuePropertyAttr>()){
     SmallVector<ValueDecl *, 2> declsFound;
-    auto projectionName = DeclNameRef_(attr->ProjectionPropertyName);
+    DeclNameRef projectionName(attr->ProjectionPropertyName);
     auto dc = var->getDeclContext();
     if (dc->isTypeContext()) {
       dc->lookupQualified(dc->getSelfNominalTypeDecl(), projectionName,

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2127,7 +2127,7 @@ static VarDecl *synthesizePropertyWrapperStorageWrapperProperty(
   // that to find the storage wrapper property.
   if (auto attr = var->getAttrs().getAttribute<ProjectedValuePropertyAttr>()){
     SmallVector<ValueDecl *, 2> declsFound;
-    auto projectionName = attr->ProjectionPropertyName;
+    auto projectionName = DeclNameRef_(attr->ProjectionPropertyName);
     auto dc = var->getDeclContext();
     if (dc->isTypeContext()) {
       dc->lookupQualified(dc->getSelfNominalTypeDecl(), projectionName,

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1451,7 +1451,9 @@ namespace {
         if (!SP) {
           // If there's no sub-pattern then there's no further recursive
           // structure here.  Yield the constructor space.
-          return Space::forConstructor(item->getType(), VP->getName(), None);
+          // FIXME: Compound names.
+          return Space::forConstructor(item->getType(),
+                                       VP->getName().getBaseIdentifier(), None);
         }
 
         SmallVector<Space, 4> conArgSpace;
@@ -1463,7 +1465,9 @@ namespace {
                          [&](TuplePatternElt pate) {
                            return projectPattern(pate.getPattern());
                          });
-          return Space::forConstructor(item->getType(), VP->getName(),
+          // FIXME: Compound names.
+          return Space::forConstructor(item->getType(),
+                                       VP->getName().getBaseIdentifier(),
                                        conArgSpace);
         }
         case PatternKind::Paren: {
@@ -1497,7 +1501,9 @@ namespace {
           } else {
             conArgSpace.push_back(projectPattern(SP));
           }
-          return Space::forConstructor(item->getType(), VP->getName(),
+          // FIXME: Compound names.
+          return Space::forConstructor(item->getType(),
+                                       VP->getName().getBaseIdentifier(),
                                        conArgSpace);
         }
         default:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1089,7 +1089,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
         auto type = resolution.mapTypeIntoContext(
           dc->getInnermostTypeContext()->getSelfInterfaceType());
 
-        comp->overwriteNameRef(DeclNameRef_(nominal->getName()));
+        comp->overwriteNameRef(DeclNameRef(nominal->getName()));
         comp->setValue(nominal, nominalDC->getParent());
         return type;
       }
@@ -1140,7 +1140,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
         .fixItReplace(R, RemappedTy);
 
       // Replace the computed type with the suggested type.
-      comp->overwriteNameRef(DeclNameRef_(ctx.getIdentifier(RemappedTy)));
+      comp->overwriteNameRef(DeclNameRef(ctx.getIdentifier(RemappedTy)));
 
       // HACK: 'NSUInteger' suggests both 'UInt' and 'Int'.
       if (TypeName == ctx.getSwiftName(KnownFoundationEntity::NSUInteger)) {
@@ -1647,7 +1647,7 @@ Type TypeChecker::resolveIdentifierType(
     if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
       auto moduleName = moduleTy->getModule()->getName();
       diags.diagnose(Components.back()->getNameLoc(),
-                     diag::use_undeclared_type, DeclNameRef_(moduleName));
+                     diag::use_undeclared_type, DeclNameRef(moduleName));
       diags.diagnose(Components.back()->getNameLoc(),
                      diag::note_module_as_type, moduleName);
     }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -209,7 +209,7 @@ Type TypeResolution::resolveDependentMemberType(
                     singleType->getBaseName().userFacingName());
 
     // Correct to the single type result.
-    ref->overwriteNameRef(singleType->getFullName());
+    ref->overwriteNameRef(singleType->createNameRef());
     ref->setValue(singleType, nullptr);
   }
 
@@ -1089,7 +1089,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
         auto type = resolution.mapTypeIntoContext(
           dc->getInnermostTypeContext()->getSelfInterfaceType());
 
-        comp->overwriteNameRef(nominal->getName());
+        comp->overwriteNameRef(DeclNameRef_(nominal->getName()));
         comp->setValue(nominal, nominalDC->getParent());
         return type;
       }
@@ -1140,7 +1140,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
         .fixItReplace(R, RemappedTy);
 
       // Replace the computed type with the suggested type.
-      comp->overwriteNameRef(ctx.getIdentifier(RemappedTy));
+      comp->overwriteNameRef(DeclNameRef_(ctx.getIdentifier(RemappedTy)));
 
       // HACK: 'NSUInteger' suggests both 'UInt' and 'Int'.
       if (TypeName == ctx.getSwiftName(KnownFoundationEntity::NSUInteger)) {
@@ -1394,7 +1394,7 @@ resolveTopLevelIdentTypeComponent(TypeResolution resolution,
 }
 
 static void diagnoseAmbiguousMemberType(Type baseTy, SourceRange baseRange,
-                                        DeclName name, DeclNameLoc nameLoc,
+                                        DeclNameRef name, DeclNameLoc nameLoc,
                                         LookupTypeResult &lookup) {
   ASTContext &ctx = baseTy->getASTContext();
   auto &diags = ctx.Diags;
@@ -1647,7 +1647,7 @@ Type TypeChecker::resolveIdentifierType(
     if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
       auto moduleName = moduleTy->getModule()->getName();
       diags.diagnose(Components.back()->getNameLoc(),
-                     diag::use_undeclared_type, moduleName);
+                     diag::use_undeclared_type, DeclNameRef_(moduleName));
       diags.diagnose(Components.back()->getNameLoc(),
                      diag::note_module_as_type, moduleName);
     }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -715,5 +715,5 @@ void swift::bindExtensions(SourceFile &SF) {
 
 LookupResult
 swift::lookupSemanticMember(DeclContext *DC, Type ty, DeclName name) {
-  return TypeChecker::lookupMember(DC, ty, name, None);
+  return TypeChecker::lookupMember(DC, ty, DeclNameRef(name), None);
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1238,7 +1238,7 @@ public:
   /// \param name The name of the entity to look for.
   /// \param loc The source location at which name lookup occurs.
   /// \param options Options that control name lookup.
-  static LookupResult lookupUnqualified(DeclContext *dc, DeclName name,
+  static LookupResult lookupUnqualified(DeclContext *dc, DeclNameRef name,
                                         SourceLoc loc,
                                         NameLookupOptions options
                                           = defaultUnqualifiedLookupOptions);
@@ -1251,7 +1251,7 @@ public:
   /// \param loc The source location at which name lookup occurs.
   /// \param options Options that control name lookup.
   LookupResult
-  static lookupUnqualifiedType(DeclContext *dc, DeclName name, SourceLoc loc,
+  static lookupUnqualifiedType(DeclContext *dc, DeclNameRef name, SourceLoc loc,
                                NameLookupOptions options
                                  = defaultUnqualifiedLookupOptions);
 
@@ -1263,7 +1263,7 @@ public:
   /// \param options Options that control name lookup.
   ///
   /// \returns The result of name lookup.
-  static LookupResult lookupMember(DeclContext *dc, Type type, DeclName name,
+  static LookupResult lookupMember(DeclContext *dc, Type type, DeclNameRef name,
                                    NameLookupOptions options
                                      = defaultMemberLookupOptions);
 
@@ -1279,7 +1279,7 @@ public:
   ///
   /// \returns The result of name lookup.
   static LookupTypeResult lookupMemberType(DeclContext *dc, Type type,
-                                           Identifier name,
+                                           DeclNameRef name,
                                            NameLookupOptions options
                                              = defaultMemberTypeLookupOptions);
 
@@ -1566,7 +1566,7 @@ public:
   static Optional<Identifier> omitNeedlessWords(VarDecl *var);
 
   /// Calculate edit distance between declaration names.
-  static unsigned getCallEditDistance(DeclName writtenName,
+  static unsigned getCallEditDistance(DeclNameRef writtenName,
                                       DeclName correctedName,
                                       unsigned maxEditDistance);
 

--- a/lib/Sema/TypoCorrection.h
+++ b/lib/Sema/TypoCorrection.h
@@ -34,11 +34,11 @@ class TypeChecker;
 /// correction even if the corrected name resolves to an overload set.
 class SyntacticTypoCorrection {
 public:
-  DeclName WrittenName;
+  DeclNameRef WrittenName;
   DeclNameLoc Loc;
   DeclName CorrectedName;
 
-  SyntacticTypoCorrection(DeclName writtenName, DeclNameLoc writtenLoc,
+  SyntacticTypoCorrection(DeclNameRef writtenName, DeclNameLoc writtenLoc,
                           DeclName correctedName)
     : WrittenName(writtenName), Loc(writtenLoc), CorrectedName(correctedName) {}
 
@@ -48,13 +48,13 @@ public:
 /// A collection of typo-correction candidates.
 class TypoCorrectionResults {
 public:
-  DeclName WrittenName;
+  DeclNameRef WrittenName;
   DeclNameLoc Loc;
   bool ClaimedCorrection = false;
 
   SmallVector<ValueDecl *, 4> Candidates;
 
-  TypoCorrectionResults(DeclName writtenName, DeclNameLoc loc)
+  TypoCorrectionResults(DeclNameRef writtenName, DeclNameLoc loc)
     : WrittenName(writtenName), Loc(loc) {}
 
   /// Try to claim a unique correction from this collection that's simple

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1273,7 +1273,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
       baseModule->lookupMember(values, baseModule, name,
                                getIdentifier(privateDiscriminator));
     } else {
-      baseModule->lookupQualified(baseModule, name,
+      baseModule->lookupQualified(baseModule, DeclNameRef_(name),
                                   NL_QualifiedDefault | NL_KnownNoDependency,
                                   values);
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4124,8 +4124,9 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         assert(numArgs != 0);
         assert(!isImplicit && "Need to update for implicit");
         Attr = DynamicReplacementAttr::create(
-            ctx, DeclName(ctx, baseName, ArrayRef<Identifier>(pieces)), &MF,
-            replacedFunID);
+            ctx,
+            DeclNameRef_(DeclName(ctx, baseName, ArrayRef<Identifier>(pieces))),
+            &MF, replacedFunID);
         break;
       }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1273,7 +1273,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
       baseModule->lookupMember(values, baseModule, name,
                                getIdentifier(privateDiscriminator));
     } else {
-      baseModule->lookupQualified(baseModule, DeclNameRef_(name),
+      baseModule->lookupQualified(baseModule, DeclNameRef(name),
                                   NL_QualifiedDefault | NL_KnownNoDependency,
                                   values);
     }
@@ -4124,9 +4124,7 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         assert(numArgs != 0);
         assert(!isImplicit && "Need to update for implicit");
         Attr = DynamicReplacementAttr::create(
-            ctx,
-            DeclNameRef_(DeclName(ctx, baseName, ArrayRef<Identifier>(pieces))),
-            &MF, replacedFunID);
+            ctx, DeclNameRef({ ctx, baseName, pieces }), &MF, replacedFunID);
         break;
       }
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2232,7 +2232,7 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
 
           SmallVector<ValueDecl *, 8> Decls;
           TopLevelModule->lookupQualified(
-              TopLevelModule, ScopeID,
+              TopLevelModule, DeclNameRef_(ScopeID),
               NL_QualifiedDefault | NL_KnownNoDependency, Decls);
           Optional<ImportKind> FoundKind = ImportDecl::findBestImportKind(Decls);
           assert(FoundKind.hasValue() &&

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2232,7 +2232,7 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
 
           SmallVector<ValueDecl *, 8> Decls;
           TopLevelModule->lookupQualified(
-              TopLevelModule, DeclNameRef_(ScopeID),
+              TopLevelModule, DeclNameRef(ScopeID),
               NL_QualifiedDefault | NL_KnownNoDependency, Decls);
           Optional<ImportKind> FoundKind = ImportDecl::findBestImportKind(Decls);
           assert(FoundKind.hasValue() &&

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -499,7 +499,7 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   // For now we use unqualified lookup to fetch other declarations with the same
   // base name.
   auto &ctx = VD->getASTContext();
-  auto descriptor = UnqualifiedLookupDescriptor(VD->getBaseName(),
+  auto descriptor = UnqualifiedLookupDescriptor(DeclNameRef_(VD->getBaseName()),
                                                 VD->getDeclContext());
   auto lookup = evaluateOrDefault(ctx.evaluator,
                                   UnqualifiedLookupRequest{descriptor}, {});

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -499,7 +499,7 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   // For now we use unqualified lookup to fetch other declarations with the same
   // base name.
   auto &ctx = VD->getASTContext();
-  auto descriptor = UnqualifiedLookupDescriptor(DeclNameRef_(VD->getBaseName()),
+  auto descriptor = UnqualifiedLookupDescriptor(DeclNameRef(VD->getBaseName()),
                                                 VD->getDeclContext());
   auto lookup = evaluateOrDefault(ctx.evaluator,
                                   UnqualifiedLookupRequest{descriptor}, {});

--- a/tools/swift-ast-script/ASTScriptEvaluator.cpp
+++ b/tools/swift-ast-script/ASTScriptEvaluator.cpp
@@ -115,8 +115,9 @@ bool ASTScript::execute() const {
     return true;
   }
 
-  auto descriptor = UnqualifiedLookupDescriptor(ctx.getIdentifier("View"),
-                                                swiftUI);
+  auto descriptor =
+      UnqualifiedLookupDescriptor(DeclNameRef_(ctx.getIdentifier("View")),
+                                  swiftUI);
   auto viewLookup = evaluateOrDefault(ctx.evaluator,
                                       UnqualifiedLookupRequest{descriptor}, {});
   auto viewProtocol =

--- a/tools/swift-ast-script/ASTScriptEvaluator.cpp
+++ b/tools/swift-ast-script/ASTScriptEvaluator.cpp
@@ -116,7 +116,7 @@ bool ASTScript::execute() const {
   }
 
   auto descriptor =
-      UnqualifiedLookupDescriptor(DeclNameRef_(ctx.getIdentifier("View")),
+      UnqualifiedLookupDescriptor(DeclNameRef(ctx.getIdentifier("View")),
                                   swiftUI);
   auto viewLookup = evaluateOrDefault(ctx.evaluator,
                                       UnqualifiedLookupRequest{descriptor}, {});

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2259,8 +2259,9 @@ static int doPrintDecls(const CompilerInvocation &InitInvok,
 
   for (const auto &name : DeclsToPrint) {
     ASTContext &ctx = CI.getASTContext();
-    auto descriptor = UnqualifiedLookupDescriptor(ctx.getIdentifier(name),
-                                                  CI.getPrimarySourceFile());
+    auto descriptor =
+        UnqualifiedLookupDescriptor(DeclNameRef_(ctx.getIdentifier(name)),
+                                    CI.getPrimarySourceFile());
     auto lookup = evaluateOrDefault(ctx.evaluator,
                                     UnqualifiedLookupRequest{descriptor}, {});
     for (auto result : lookup) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2260,7 +2260,7 @@ static int doPrintDecls(const CompilerInvocation &InitInvok,
   for (const auto &name : DeclsToPrint) {
     ASTContext &ctx = CI.getASTContext();
     auto descriptor =
-        UnqualifiedLookupDescriptor(DeclNameRef_(ctx.getIdentifier(name)),
+        UnqualifiedLookupDescriptor(DeclNameRef(ctx.getIdentifier(name)),
                                     CI.getPrimarySourceFile());
     auto lookup = evaluateOrDefault(ctx.evaluator,
                                     UnqualifiedLookupRequest{descriptor}, {});

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -42,42 +42,42 @@ TEST(SourceLoc, AssignExpr) {
   SourceLoc start = C.Ctx.SourceMgr.getLocForBufferStart(bufferID);
 
   auto destBase = new (C.Ctx) UnresolvedDeclRefExpr(
-      C.Ctx.getIdentifier("aa"),
+      DeclNameRef_(C.Ctx.getIdentifier("aa")),
       DeclRefKind::Ordinary,
       DeclNameLoc(start));
   auto dest = new (C.Ctx) UnresolvedDotExpr(
       destBase,
       start.getAdvancedLoc(2),
-      C.Ctx.getIdentifier("bb"),
+      DeclNameRef_(C.Ctx.getIdentifier("bb")),
       DeclNameLoc(start.getAdvancedLoc(3)),
       /*implicit*/false);
   auto destImplicit = new (C.Ctx) UnresolvedDotExpr(
       destBase,
       start.getAdvancedLoc(2),
-      C.Ctx.getIdentifier("bb"),
+      DeclNameRef_(C.Ctx.getIdentifier("bb")),
       DeclNameLoc(start.getAdvancedLoc(3)),
       /*implicit*/true);
 
   auto sourceBase = new (C.Ctx) UnresolvedDeclRefExpr(
-      C.Ctx.getIdentifier("cc"),
+      DeclNameRef_(C.Ctx.getIdentifier("cc")),
       DeclRefKind::Ordinary,
       DeclNameLoc(start.getAdvancedLoc(8)));
   auto source = new (C.Ctx) UnresolvedDotExpr(
       sourceBase,
       start.getAdvancedLoc(10),
-      C.Ctx.getIdentifier("dd"),
+      DeclNameRef_(C.Ctx.getIdentifier("dd")),
       DeclNameLoc(start.getAdvancedLoc(11)),
       /*implicit*/false);
   auto sourceImplicit = new (C.Ctx) UnresolvedDotExpr(
       sourceBase,
       start.getAdvancedLoc(10),
-      C.Ctx.getIdentifier("dd"),
+      DeclNameRef_(C.Ctx.getIdentifier("dd")),
       DeclNameLoc(start.getAdvancedLoc(11)),
       /*implicit*/true);
 
 
   auto invalid = new (C.Ctx) UnresolvedDeclRefExpr(
-      C.Ctx.getIdentifier("invalid"),
+      DeclNameRef_(C.Ctx.getIdentifier("invalid")),
       DeclRefKind::Ordinary,
       DeclNameLoc());
 
@@ -223,22 +223,22 @@ TEST(SourceLoc, TupleExpr) {
   SourceLoc start = C.Ctx.SourceMgr.getLocForBufferStart(bufferID);
   
   auto one = new (C.Ctx) UnresolvedDeclRefExpr(
-      C.Ctx.getIdentifier("one"),
+      DeclNameRef_(C.Ctx.getIdentifier("one")),
       DeclRefKind::Ordinary,
       DeclNameLoc(start));
   
   auto two = new (C.Ctx) UnresolvedDeclRefExpr(
-      C.Ctx.getIdentifier("two"),
+      DeclNameRef_(C.Ctx.getIdentifier("two")),
       DeclRefKind::Ordinary,
       DeclNameLoc());
   
   auto three = new (C.Ctx) UnresolvedDeclRefExpr(
-      C.Ctx.getIdentifier("three"),
+      DeclNameRef_(C.Ctx.getIdentifier("three")),
       DeclRefKind::Ordinary,
       DeclNameLoc());
   
   auto four = new (C.Ctx) UnresolvedDeclRefExpr(
-      C.Ctx.getIdentifier("four"),
+      DeclNameRef_(C.Ctx.getIdentifier("four")),
       DeclRefKind::Ordinary,
       DeclNameLoc(start.getAdvancedLoc(4)));
   

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -42,42 +42,42 @@ TEST(SourceLoc, AssignExpr) {
   SourceLoc start = C.Ctx.SourceMgr.getLocForBufferStart(bufferID);
 
   auto destBase = new (C.Ctx) UnresolvedDeclRefExpr(
-      DeclNameRef_(C.Ctx.getIdentifier("aa")),
+      DeclNameRef(C.Ctx.getIdentifier("aa")),
       DeclRefKind::Ordinary,
       DeclNameLoc(start));
   auto dest = new (C.Ctx) UnresolvedDotExpr(
       destBase,
       start.getAdvancedLoc(2),
-      DeclNameRef_(C.Ctx.getIdentifier("bb")),
+      DeclNameRef(C.Ctx.getIdentifier("bb")),
       DeclNameLoc(start.getAdvancedLoc(3)),
       /*implicit*/false);
   auto destImplicit = new (C.Ctx) UnresolvedDotExpr(
       destBase,
       start.getAdvancedLoc(2),
-      DeclNameRef_(C.Ctx.getIdentifier("bb")),
+      DeclNameRef(C.Ctx.getIdentifier("bb")),
       DeclNameLoc(start.getAdvancedLoc(3)),
       /*implicit*/true);
 
   auto sourceBase = new (C.Ctx) UnresolvedDeclRefExpr(
-      DeclNameRef_(C.Ctx.getIdentifier("cc")),
+      DeclNameRef(C.Ctx.getIdentifier("cc")),
       DeclRefKind::Ordinary,
       DeclNameLoc(start.getAdvancedLoc(8)));
   auto source = new (C.Ctx) UnresolvedDotExpr(
       sourceBase,
       start.getAdvancedLoc(10),
-      DeclNameRef_(C.Ctx.getIdentifier("dd")),
+      DeclNameRef(C.Ctx.getIdentifier("dd")),
       DeclNameLoc(start.getAdvancedLoc(11)),
       /*implicit*/false);
   auto sourceImplicit = new (C.Ctx) UnresolvedDotExpr(
       sourceBase,
       start.getAdvancedLoc(10),
-      DeclNameRef_(C.Ctx.getIdentifier("dd")),
+      DeclNameRef(C.Ctx.getIdentifier("dd")),
       DeclNameLoc(start.getAdvancedLoc(11)),
       /*implicit*/true);
 
 
   auto invalid = new (C.Ctx) UnresolvedDeclRefExpr(
-      DeclNameRef_(C.Ctx.getIdentifier("invalid")),
+      DeclNameRef(C.Ctx.getIdentifier("invalid")),
       DeclRefKind::Ordinary,
       DeclNameLoc());
 
@@ -223,22 +223,22 @@ TEST(SourceLoc, TupleExpr) {
   SourceLoc start = C.Ctx.SourceMgr.getLocForBufferStart(bufferID);
   
   auto one = new (C.Ctx) UnresolvedDeclRefExpr(
-      DeclNameRef_(C.Ctx.getIdentifier("one")),
+      DeclNameRef(C.Ctx.getIdentifier("one")),
       DeclRefKind::Ordinary,
       DeclNameLoc(start));
   
   auto two = new (C.Ctx) UnresolvedDeclRefExpr(
-      DeclNameRef_(C.Ctx.getIdentifier("two")),
+      DeclNameRef(C.Ctx.getIdentifier("two")),
       DeclRefKind::Ordinary,
       DeclNameLoc());
   
   auto three = new (C.Ctx) UnresolvedDeclRefExpr(
-      DeclNameRef_(C.Ctx.getIdentifier("three")),
+      DeclNameRef(C.Ctx.getIdentifier("three")),
       DeclRefKind::Ordinary,
       DeclNameLoc());
   
   auto four = new (C.Ctx) UnresolvedDeclRefExpr(
-      DeclNameRef_(C.Ctx.getIdentifier("four")),
+      DeclNameRef(C.Ctx.getIdentifier("four")),
       DeclRefKind::Ordinary,
       DeclNameLoc(start.getAdvancedLoc(4)));
   


### PR DESCRIPTION
This is a refactoring in support of the [module qualification feature](https://forums.swift.org/t/pitch-fully-qualified-name-syntax/28482/86) I've previously pitched on Evolution.

The eventual goal for that feature is to allow any place that *uses* a name for a declaration defined elsewhere to qualify it with a module name. That is, all of these should allow modules:

```swift
print(SomeModule::x)   // The `x` visible from SomeModule
({ () -> SomeModule::T in ... })(x)   // The `T` from SomeModule
T.SomeModule::init()   // The `T.init()` declared in SomeModule
```

But things like this should not:

```swift
func SomeModule::fn() { ... }   // defining a function in a different module???
let SomeModule::x = 1    // defining a constant in another module???
```

To support this distinction, this PR adds a `DeclNameRef` type to the compiler. This type currently just wraps `DeclName`, but in the future it will also be able to store a module name when the user module-qualifies a name. Declarations will continue to store a `DeclName` or `Identifier` for their own names, but name lookup entry points—and therefore many other AST nodes like `UnresolvedDeclRefExpr`s and `TypeRepr`s—will switch over to using `DeclNameRef`. Thus, this PR will establish the pathways through which module qualification information will flow without actually making any functional changes to the compiler. This will reduce the amount of merge conflicts during the feature's design and review.

~~While this PR is in progress, `DeclNameRef`'s constructors will be implicit but deprecated, and a `DeclNameRef_` function is used whenever we want to explicitly construct a `DeclNameRef`. Before I merge this commit, I will make the `DeclNameRef` constructors explicit, rename all `DeclNameRef_`s to `DeclNameRef`, and delete the `DeclNameRef` function.~~ 