### PR TITLE
Remove -(enable|disable)-function-builder-one-way-constraints

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -202,9 +202,6 @@ namespace swift {
     /// before termination of the shrink phrase of the constraint solver.
     unsigned SolverShrinkUnsolvedThreshold = 10;
 
-    /// Enable one-way constraints in function builders.
-    bool FunctionBuilderOneWayConstraints = true;
-
     /// Disable the shrink phase of the expression type checker.
     bool SolverDisableShrink = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -414,14 +414,6 @@ def Rmodule_interface_rebuild : Flag<["-"], "Rmodule-interface-rebuild">,
 
 def solver_expression_time_threshold_EQ : Joined<["-"], "solver-expression-time-threshold=">;
 
-def enable_function_builder_one_way_constraints : Flag<["-"],
-  "enable-function-builder-one-way-constraints">,
-  HelpText<"Enable one-way constraints in the function builder transformation">;
-
-def disable_function_builder_one_way_constraints : Flag<["-"],
-  "disable-function-builder-one-way-constraints">,
-  HelpText<"Disable one-way constraints in the function builder transformation">;
-
 def solver_disable_shrink :
   Flag<["-"], "solver-disable-shrink">,
   HelpText<"Disable the shrink phase of expression type checking">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -443,10 +443,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.getLastArg(OPT_solver_disable_shrink))
     Opts.SolverDisableShrink = true;
-  Opts.FunctionBuilderOneWayConstraints =
-    Args.hasFlag(OPT_enable_function_builder_one_way_constraints,
-                 OPT_disable_function_builder_one_way_constraints,
-                 /*Default=*/true);
 
   if (const Arg *A = Args.getLastArg(OPT_value_recursion_threshold)) {
     unsigned threshold;

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -87,7 +87,7 @@ private:
                                     /*trailing closure*/ nullptr,
                                     /*implicit*/true);
 
-    if (ctx.LangOpts.FunctionBuilderOneWayConstraints && allowOneWay) {
+    if (allowOneWay) {
       // Form a one-way constraint to prevent backward propagation.
       result = new (ctx) OneWayExpr(result);
     }
@@ -169,7 +169,7 @@ public:
       }
 
       auto expr = node.get<Expr *>();
-      if (wantExpr && ctx.LangOpts.FunctionBuilderOneWayConstraints)
+      if (wantExpr)
         expr = new (ctx) OneWayExpr(expr);
 
       expressions.push_back(expr);
@@ -293,7 +293,7 @@ public:
                                     ctx.Id_buildIf, chainExpr,
                                     /*argLabels=*/{ },
                                     /*allowOneWay=*/true);
-    } else if (ctx.LangOpts.FunctionBuilderOneWayConstraints) {
+    } else {
       // Form a one-way constraint to prevent backward propagation.
       chainExpr = new (ctx) OneWayExpr(chainExpr);
     }

--- a/test/Constraints/function_builder_one_way.swift
+++ b/test/Constraints/function_builder_one_way.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-function-builder-one-way-constraints
-// RUN: %target-typecheck-verify-swift -debug-constraints -enable-function-builder-one-way-constraints > %t.log 2>&1
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -debug-constraints > %t.log 2>&1
 // RUN: %FileCheck %s < %t.log
 
 enum Either<T,U> {

--- a/test/IDE/complete_function_builder.swift
+++ b/test/IDE/complete_function_builder.swift
@@ -1,13 +1,6 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_TOP | %FileCheck %s -check-prefix=IN_CLOSURE_TOP
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_NONTOP | %FileCheck %s -check-prefix=IN_CLOSURE_TOP
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=IN_CLOSURE_COLOR_CONTEXT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=IN_CLOSURE_COLOR_CONTEXT_DOT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT_DOT
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_1 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_2 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_3 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_4 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_5 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_INVALID
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_COLOR_CONTEXT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT
 
 struct Tagged<Tag, Entity> {
   let tag: Tag
@@ -80,22 +73,11 @@ func testAcceptColorTagged(paramIntVal: Int, paramStringVal: String) {
   acceptColorTagged { color in
     paramIntVal.tag(#^IN_CLOSURE_COLOR_CONTEXT^#)
 // IN_CLOSURE_COLOR_CONTEXT: Begin completions
-// IN_CLOSURE_COLOR_CONTEXT-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#(tag): Color#}[')'][#Tagged<Color, Int>#]; name=tag: Color
-// IN_CLOSURE_COLOR_CONTEXT-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: color[#Color#]; name=color
+// IN_CLOSURE_COLOR_CONTEXT-DAG: Decl[LocalVar]/Local:               color; name=color
 // IN_CLOSURE_COLOR_CONTEXT-DAG: Decl[LocalVar]/Local:               taggedValue[#Tagged<Color, Int>#]; name=taggedValue
 // IN_CLOSURE_COLOR_CONTEXT-DAG: Decl[LocalVar]/Local:               paramIntVal[#Int#]; name=paramIntVal
 // IN_CLOSURE_COLOR_CONTEXT-DAG: Decl[LocalVar]/Local:               paramStringVal[#String#]; name=paramStringVal
-// IN_CLOSURE_COLOR_CONTEXT-DAG: Decl[Enum]/CurrModule/TypeRelation[Identical]: Color[#Color#]; name=Color
 // IN_CLOSURE_COLOR_CONTEXT: End completions
-  }
-
-  acceptColorTagged { color in
-    paramIntVal.tag(.#^IN_CLOSURE_COLOR_CONTEXT_DOT^#)
-// IN_CLOSURE_COLOR_CONTEXT_DOT: Begin completions, 3 items
-// IN_CLOSURE_COLOR_CONTEXT_DOT-DAG: Decl[EnumElement]/ExprSpecific:     red[#Color#]; name=red
-// IN_CLOSURE_COLOR_CONTEXT_DOT-DAG: Decl[EnumElement]/ExprSpecific:     green[#Color#]; name=green
-// IN_CLOSURE_COLOR_CONTEXT_DOT-DAG: Decl[EnumElement]/ExprSpecific:     blue[#Color#]; name=blue
-// IN_CLOSURE_COLOR_CONTEXT_DOT: End completions
   }
 }
 
@@ -111,38 +93,3 @@ struct EnumToVoidBuilder {
   static func buildBlock(_ :MyEnum, _: MyEnum, _: MyEnum) {}
 }
 func acceptBuilder(@EnumToVoidBuilder body: () -> Void) {}
-
-// CONTEXTUAL_TYPE_INVALID-NOT: Begin completions
-
-// CONTEXTUAL_TYPE_VALID: Begin completions, 4 items
-// CONTEXTUAL_TYPE_VALID-DAG: Decl[EnumElement]/ExprSpecific:     east[#MyEnum#]; name=east
-// CONTEXTUAL_TYPE_VALID-DAG: Decl[EnumElement]/ExprSpecific:     west[#MyEnum#]; name=west
-// CONTEXTUAL_TYPE_VALID-DAG: Decl[EnumElement]/ExprSpecific:     north[#MyEnum#]; name=north
-// CONTEXTUAL_TYPE_VALID-DAG: Decl[EnumElement]/ExprSpecific:     south[#MyEnum#]; name=south
-// CONTEXTUAL_TYPE_VALID: End completions 
-
-func testContextualType() {
-  acceptBuilder {
-    .#^CONTEXTUAL_TYPE_1^#
-  }
-  acceptBuilder {
-    .#^CONTEXTUAL_TYPE_2^#;
-    .north;
-  }
-  acceptBuilder {
-    .north;
-    .#^CONTEXTUAL_TYPE_3^#;
-  }
-  acceptBuilder {
-    .north;
-    .east;
-    .#^CONTEXTUAL_TYPE_4^#
-  }
-  acceptBuilder {
-    .north;
-    .east;
-    .south;
-// NOTE: Invalid because 'EnumToVoidBuilder' doesn't have 4 params overload.
-    .#^CONTEXTUAL_TYPE_5^#
-  }
-}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -311,13 +311,6 @@ EnableSourceImport("enable-source-import", llvm::cl::Hidden,
                    llvm::cl::cat(Category), llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
-DisableFunctionBuilderOneWayConstraints(
-    "disable-function-builder-one-way-constraints",
-    llvm::cl::desc("Disable one-way constraints in function builders"),
-    llvm::cl::cat(Category),
-    llvm::cl::init(false));
-
-static llvm::cl::opt<bool>
 SkipDeinit("skip-deinit",
            llvm::cl::desc("Whether to skip printing destructors"),
            llvm::cl::cat(Category),
@@ -3345,8 +3338,6 @@ int main(int argc, char *argv[]) {
     options::ImportObjCHeader;
   InitInvok.getLangOptions().EnableAccessControl =
     !options::DisableAccessControl;
-  InitInvok.getLangOptions().FunctionBuilderOneWayConstraints =
-    !options::DisableFunctionBuilderOneWayConstraints;
   InitInvok.getLangOptions().CodeCompleteInitsInPostfixExpr |=
       options::CodeCompleteInitsInPostfixExpr;
   InitInvok.getLangOptions().CodeCompleteCallPatternHeuristics |=


### PR DESCRIPTION
Remove the staging flags for unidirectional constraints in function
builders. We're not going back!
