### PR TITLE
[AutoDiff] Support '@differentiable(linear)' function conversion.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -445,6 +445,9 @@ ERROR(constexpr_imported_func_not_onone, none, "imported constant evaluable "
 // Automatic differentiation diagnostics
 ERROR(autodiff_internal_swift_not_imported,none,
       "AD internal error: the Swift module is not imported", ())
+ERROR(autodiff_conversion_to_linear_function_not_supported,none,
+      "conversion to '@differentiable(linear)' function type is not yet "
+      "supported", ())
 ERROR(autodiff_function_not_differentiable_error,none,
       "function is not differentiable", ())
 ERROR(autodiff_expression_not_differentiable_error,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1177,9 +1177,14 @@ ERROR(c_function_pointer_from_generic_function,none,
       "a C function pointer cannot be formed from a reference to a generic "
       "function", ())
 // SWIFT_ENABLE_TENSORFLOW
+// TODO(TF-908): Remove this diagnostic once linear-to-differentiable conversion
+// is supported.
+ERROR(unsupported_linear_to_differentiable_conversion,none,
+      "conversion from '@differentiable(linear)' to '@differentiable' is not "
+      "yet supported", ())
 ERROR(invalid_differentiable_function_conversion_expr,none,
-      "a '@differentiable' function can only be formed from a reference to a "
-      "'func' or a literal closure", ())
+      "a '@differentiable%select{|(linear)}0' function can only be formed from "
+      "a reference to a 'func' or a literal closure", (bool))
 NOTE(invalid_differentiable_function_conversion_parameter,none,
      "did you mean to take a '%0' closure?", (StringRef))
 ERROR(invalid_autoclosure_forwarding,none,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3034,6 +3034,16 @@ public:
   }
 };
 
+class LinearFunctionExpr : public ImplicitConversionExpr {
+public:
+  LinearFunctionExpr(Expr *subExpr, Type ty)
+      : ImplicitConversionExpr(ExprKind::LinearFunction, subExpr, ty) {}
+
+  static bool classof(const Expr *E) {
+    return E->getKind() == ExprKind::LinearFunction;
+  }
+};
+
 class DifferentiableFunctionExtractOriginalExpr
     : public ImplicitConversionExpr {
 public:
@@ -3043,6 +3053,28 @@ public:
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::DifferentiableFunctionExtractOriginal;
+  }
+};
+
+class LinearFunctionExtractOriginalExpr : public ImplicitConversionExpr {
+public:
+  LinearFunctionExtractOriginalExpr(Expr *subExpr, Type ty)
+      : ImplicitConversionExpr(ExprKind::LinearFunctionExtractOriginal,
+                               subExpr, ty) {}
+
+  static bool classof(const Expr *E) {
+    return E->getKind() == ExprKind::LinearFunctionExtractOriginal;
+  }
+};
+
+class LinearToDifferentiableFunctionExpr : public ImplicitConversionExpr {
+public:
+  LinearToDifferentiableFunctionExpr(Expr *subExpr, Type ty)
+      : ImplicitConversionExpr(
+            ExprKind::LinearToDifferentiableFunction, subExpr, ty) {}
+
+  static bool classof(const Expr *E) {
+    return E->getKind() == ExprKind::LinearToDifferentiableFunction;
   }
 };
 // SWIFT_ENABLE_TENSORFLOW END

--- a/include/swift/AST/ExprNodes.def
+++ b/include/swift/AST/ExprNodes.def
@@ -174,8 +174,11 @@ ABSTRACT_EXPR(ImplicitConversion, Expr)
   EXPR(UnderlyingToOpaque, ImplicitConversionExpr)
   // SWIFT_ENABLE_TENSORFLOW
   EXPR(DifferentiableFunction, ImplicitConversionExpr)
+  EXPR(LinearFunction, ImplicitConversionExpr)
   EXPR(DifferentiableFunctionExtractOriginal, ImplicitConversionExpr)
-  EXPR_RANGE(ImplicitConversion, Load, DifferentiableFunctionExtractOriginal)
+  EXPR(LinearFunctionExtractOriginal, ImplicitConversionExpr)
+  EXPR(LinearToDifferentiableFunction, ImplicitConversionExpr)
+  EXPR_RANGE(ImplicitConversion, Load, LinearToDifferentiableFunction)
   // SWIFT_ENABLE_TENSORFLOW END
 ABSTRACT_EXPR(ExplicitCast, Expr)
   ABSTRACT_EXPR(CheckedCast, ExplicitCastExpr)

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -521,7 +521,7 @@ public:
 
   LinearFunctionInst *createLinearFunction(
       SILLocation Loc, IndexSubset *ParameterIndices, SILValue OriginalFunction,
-      Optional<SILValue> TransposeFunction) {
+      Optional<SILValue> TransposeFunction = None) {
     return insert(LinearFunctionInst::create(
         getModule(), getSILDebugLocation(Loc), ParameterIndices,
         OriginalFunction, TransposeFunction, hasOwnership()));

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2401,9 +2401,26 @@ public:
     printRec(E->getSubExpr());
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
+  void visitLinearFunctionExpr(LinearFunctionExpr *E) {
+    printCommon(E, "linear_function") << '\n';
+    printRec(E->getSubExpr());
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
+  }
   void visitDifferentiableFunctionExtractOriginalExpr(
       DifferentiableFunctionExtractOriginalExpr *E) {
     printCommon(E, "differentiable_function_extract_original") << '\n';
+    printRec(E->getSubExpr());
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
+  }
+  void visitLinearFunctionExtractOriginalExpr(
+      LinearFunctionExtractOriginalExpr *E) {
+    printCommon(E, "linear_function_extract_original") << '\n';
+    printRec(E->getSubExpr());
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
+  }
+  void visitLinearToDifferentiableFunctionExpr(
+      LinearToDifferentiableFunctionExpr *E) {
+    printCommon(E, "linear_to_differentiable_function") << '\n';
     printRec(E->getSubExpr());
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -352,7 +352,10 @@ ConcreteDeclRef Expr::getReferencedDecl() const {
   PASS_THROUGH_REFERENCE(UnevaluatedInstance, getSubExpr);
   // SWIFT_ENABLE_TENSORFLOW
   PASS_THROUGH_REFERENCE(DifferentiableFunction, getSubExpr);
+  PASS_THROUGH_REFERENCE(LinearFunction, getSubExpr);
   PASS_THROUGH_REFERENCE(DifferentiableFunctionExtractOriginal, getSubExpr);
+  PASS_THROUGH_REFERENCE(LinearFunctionExtractOriginal, getSubExpr);
+  PASS_THROUGH_REFERENCE(LinearToDifferentiableFunction, getSubExpr);
   // SWIFT_ENABLE_TENSORFLOW END
   PASS_THROUGH_REFERENCE(BridgeToObjC, getSubExpr);
   PASS_THROUGH_REFERENCE(BridgeFromObjC, getSubExpr);
@@ -678,7 +681,10 @@ bool Expr::canAppendPostfixExpression(bool appendingPostfixOperator) const {
   case ExprKind::UnevaluatedInstance:
   // SWIFT_ENABLE_TENSORFLOW
   case ExprKind::DifferentiableFunction:
+  case ExprKind::LinearFunction:
   case ExprKind::DifferentiableFunctionExtractOriginal:
+  case ExprKind::LinearFunctionExtractOriginal:
+  case ExprKind::LinearToDifferentiableFunction:
   // SWIFT_ENABLE_TENSORFLOW END
   case ExprKind::EnumIsCase:
   case ExprKind::ConditionalBridgeFromObjC:

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -46,8 +46,8 @@ bool swift::isOwnershipForwardingValueKind(SILNodeKind kind) {
   case SILNodeKind::DestructureTupleInst:
   // SWIFT_ENABLE_TENSORFLOW
   case SILNodeKind::DifferentiableFunctionInst:
-  case SILNodeKind::DifferentiableFunctionExtractInst:
-  // SWIFT_ENABLE_TENSORFLOW
+  case SILNodeKind::LinearFunctionInst:
+  // SWIFT_ENABLE_TENSORFLOW END
     return true;
   default:
     return false;
@@ -62,6 +62,10 @@ bool swift::isGuaranteedForwardingValueKind(SILNodeKind kind) {
   case SILNodeKind::StructExtractInst:
   case SILNodeKind::OpenExistentialValueInst:
   case SILNodeKind::OpenExistentialBoxValueInst:
+  // SWIFT_ENABLE_TENSORFLOW
+  case SILNodeKind::DifferentiableFunctionExtractInst:
+  case SILNodeKind::LinearFunctionExtractInst:
+  // SWIFT_ENABLE_TENSORFLOW END
     return true;
   default:
     return isOwnershipForwardingValueKind(kind);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -513,6 +513,7 @@ namespace {
         LinearFunctionExtractOriginalExpr *E, SGFContext C);
     RValue visitLinearToDifferentiableFunctionExpr(
         LinearToDifferentiableFunctionExpr *E, SGFContext C);
+    // SWIFT_ENABLE_TENSORFLOW END
   };
 } // end anonymous namespace
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5883,9 +5883,21 @@ maybeDiagnoseUnsupportedDifferentiableConversion(ConstraintSystem &cs,
   auto &tc = cs.getTypeChecker();
   Type fromType = cs.getType(expr);
   auto fromFnType = fromType->getAs<AnyFunctionType>();
+  auto isToTypeLinear =
+      toType->getDifferentiabilityKind() == DifferentiabilityKind::Linear;
+  // Conversion from a `@differentiable` function to a `@differentiable(linear)`
+  // function is not allowed, because the from-expression will never be a
+  // closure expression or a declaration/member reference.
+  if (fromFnType->getDifferentiabilityKind() == DifferentiabilityKind::Normal &&
+      toType->getDifferentiabilityKind() == DifferentiabilityKind::Linear) {
+    tc.diagnose(expr->getLoc(),
+                diag::invalid_differentiable_function_conversion_expr,
+                isToTypeLinear);
+    return;
+  }
   // Conversion from a non-`@differentiable` function to a `@differentiable` is
   // only allowed from a closure expression or a declaration/member reference.
-  if (toType->isDifferentiable() && !fromFnType->isDifferentiable()) {
+  if (!fromFnType->isDifferentiable() && toType->isDifferentiable()) {
     auto maybeDiagnoseFunctionRef = [&](Expr *semanticExpr) {
       if (auto *capture = dyn_cast<CaptureListExpr>(semanticExpr))
         semanticExpr = capture->getClosureBody();
@@ -5897,20 +5909,15 @@ maybeDiagnoseUnsupportedDifferentiableConversion(ConstraintSystem &cs,
         // note with a fix-it.
         if (auto *paramDecl = dyn_cast<ParamDecl>(declRef->getDecl())) {
           tc.diagnose(expr->getLoc(),
-                      diag::invalid_differentiable_function_conversion_expr);
+                      diag::invalid_differentiable_function_conversion_expr,
+                      isToTypeLinear);
           if (paramDecl->getType()->is<AnyFunctionType>()) {
             auto *typeRepr = paramDecl->getTypeLoc().getTypeRepr();
             while (auto *attributed = dyn_cast<AttributedTypeRepr>(typeRepr))
               typeRepr = attributed->getTypeRepr();
             std::string attributeString = "@differentiable";
-            switch (toType->getDifferentiabilityKind()) {
-            case DifferentiabilityKind::Linear:
+            if (isToTypeLinear)
               attributeString += "(linear)";
-              break;
-            case DifferentiabilityKind::Normal:
-            case DifferentiabilityKind::NonDifferentiable:
-              break;
-            }
             auto *funcTypeRepr = cast<FunctionTypeRepr>(typeRepr);
             auto paramListLoc = funcTypeRepr->getArgsTypeRepr()->getStartLoc();
             tc.diagnose(paramDecl->getLoc(),
@@ -5930,7 +5937,8 @@ maybeDiagnoseUnsupportedDifferentiableConversion(ConstraintSystem &cs,
           return;
       }
       tc.diagnose(expr->getLoc(),
-                  diag::invalid_differentiable_function_conversion_expr);
+                  diag::invalid_differentiable_function_conversion_expr,
+                  isToTypeLinear);
     };
     maybeDiagnoseFunctionRef(getSemanticExprForDeclOrMemberRef(expr));
   }
@@ -6583,23 +6591,55 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
     // SWIFT_ENABLE_TENSORFLOW
     auto fromEI = fromFunc->getExtInfo();
+    auto isFromDifferentiable = fromEI.isDifferentiable();
+    auto isToDifferentiable = toEI.isDifferentiable();
     // Handle implicit conversion from @differentiable.
-    if (fromEI.isDifferentiable() && !toEI.isDifferentiable()) {
+    if (isFromDifferentiable && !isToDifferentiable) {
       fromFunc = fromFunc->getWithoutDifferentiability()
           ->castTo<FunctionType>();
-      expr = cs.cacheType(new (tc.Context)
-          DifferentiableFunctionExtractOriginalExpr(expr, fromFunc));
+      switch (fromEI.getDifferentiabilityKind()) {
+      case DifferentiabilityKind::Normal:
+        expr = cs.cacheType(new (tc.Context)
+            DifferentiableFunctionExtractOriginalExpr(expr, fromFunc));
+        break;
+      case DifferentiabilityKind::Linear:
+        expr = cs.cacheType(new (tc.Context)
+            LinearFunctionExtractOriginalExpr(expr, fromFunc));
+        break;
+      case DifferentiabilityKind::NonDifferentiable:
+        llvm_unreachable("Cannot be NonDifferentiable");
+      }
     }
-    // Handle implicit conversion to @differentiable.
+    // Handle implicit conversion from @differentiable(linear) to
+    // @differentiable.
+    else if (fromEI.getDifferentiabilityKind() ==
+                 DifferentiabilityKind::Linear &&
+             toEI.getDifferentiabilityKind() == DifferentiabilityKind::Normal) {
+      // TODO(TF-908): Create a `LinearToDifferentiableFunctionExpr` and SILGen
+      // it as thunk application. Remove the diagnostic.
+      tc.diagnose(expr->getLoc(),
+                  diag::unsupported_linear_to_differentiable_conversion);
+    }
+    // Handle implicit conversion from non-@differentiable to @differentiable.
     maybeDiagnoseUnsupportedDifferentiableConversion(cs, expr, toFunc);
-    if (!fromEI.isDifferentiable() && toEI.isDifferentiable()) {
+    if (!isFromDifferentiable && isToDifferentiable) {
       auto newEI =
           fromEI.withDifferentiabilityKind(toEI.getDifferentiabilityKind());
       fromFunc = FunctionType::get(toFunc->getParams(), fromFunc->getResult())
           ->withExtInfo(newEI)
           ->castTo<FunctionType>();
-      expr = cs.cacheType(new (tc.Context)
-                              DifferentiableFunctionExpr(expr, fromFunc));
+      switch (toEI.getDifferentiabilityKind()) {
+      case DifferentiabilityKind::Normal:
+        expr = cs.cacheType(new (tc.Context)
+                            DifferentiableFunctionExpr(expr, fromFunc));
+        break;
+      case DifferentiabilityKind::Linear:
+        expr = cs.cacheType(new (tc.Context)
+                            LinearFunctionExpr(expr, fromFunc));
+        break;
+      case DifferentiabilityKind::NonDifferentiable:
+        llvm_unreachable("Cannot be NonDifferentiable");
+      }
     }
 
     // If we have a ClosureExpr, then we can safely propagate the 'no escape'

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -50,6 +50,17 @@ extension Float {
 _ = gradient(of: Float.addOne) // okay
 _ = gradient(of: Float(1.0).addOne) // okay
 
+// TODO(TF-908): Remove this test once linear-to-differentiable conversion is supported.
+func linearToDifferentiable(_ f: @escaping @differentiable(linear) (Float) -> Float) {
+  // expected-error @+1 {{conversion from '@differentiable(linear)' to '@differentiable' is not yet supported}}
+  _ = f as @differentiable (Float) -> Float
+}
+
+func differentiableToLinear(_ f: @escaping @differentiable (Float) -> Float) {
+  // expected-error @+1 {{a '@differentiable(linear)' function can only be formed from a reference to a 'func' or a literal closure}}
+  _ = f as @differentiable(linear) (Float) -> Float
+}
+
 //===----------------------------------------------------------------------===//
 // Parameter selection (@nondiff)
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/differentiable_function_silgen.swift
+++ b/test/AutoDiff/differentiable_function_silgen.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s -check-prefix=CHECK-AST
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s -check-prefix=CHECK-SILGEN
-// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s -check-prefix=CHECK-SIL
 
 //===----------------------------------------------------------------------===//
 // Closure conversion
@@ -14,16 +13,14 @@ func myfunction(_ f: @escaping @differentiable (Float) -> (Float)) -> (Float) ->
   return f
 }
 
-func myfunction2(_ f: @escaping @differentiable(linear) (Float) -> (Float)) /*-> (Float) -> Float*/ {
+func myfunction2(_ f: @escaping @differentiable(linear) (Float) -> (Float)) -> (Float) -> Float {
   // @differentiable(linear) functions should be callable.
   _ = f(.zero)
-  // TODO(TF-900): Uncomment the following line to test conversion to non-differentiable function type.
-  // return f
+  return f
 }
 
 var global_f: @differentiable (Float) -> Float = {$0}
-// TODO(TF-902): Uncomment the following line to test linear function storage.
-// var global_f_linear: @differentiable(linear) (Float) -> Float = {$0}
+var global_f_linear: @differentiable(linear) (Float) -> Float = {$0}
 
 func calls_global_f() {
   _ = global_f(10)
@@ -33,8 +30,7 @@ func calls_global_f() {
 
 func apply() {
   _ = myfunction(thin)
-  // TODO(TF-900): Uncomment the following line to test direct calls to a linear function.
-  // _ = myfunction2(thin)
+  _ = myfunction2(thin)
 }
 
 // CHECK-AST-LABEL:  (func_decl {{.*}} "myfunction(_:)"
@@ -62,24 +58,27 @@ func apply() {
 // CHECK-SILGEN:   [[COPIED_ORIG:%.*]] = copy_value [[BORROWED_ORIG]] : $@callee_guaranteed (Float) -> Float
 // CHECK-SILGEN:   return [[COPIED_ORIG]] : $@callee_guaranteed (Float) -> Float
 
-// CHEK-SILGEN-LABEL: @{{.*}}myfunction2{{.*}} : $@convention(thin) (@guaranteed @differentiable(linear) @callee_guaranteed (Float) -> Float) -> () {
-// CHEK-SILGEN: bb0([[LIN:%.*]] : @guaranteed $@differentiable(linear) @callee_guaranteed (Float) -> Float):
-// CHEK-SILGEN:   [[COPIED_LIN:%.*]] = copy_value [[LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
-// CHEK-SILGEN:   apply [[COPIED_LIN]]<Float>({{%.*}}, {{%.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : AdditiveArithmetic, τ_0_0 : ExpressibleByIntegerLiteral> (@thick τ_0_0.Type) -> @out τ_0_0
-// CHEK-SILGEN:   [[BORROWED_LIN:%.*]] = begin_borrow [[COPIED_LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
-// CHEK-SILGEN:   apply [[BORROWED_LIN]]({{%.*}}) : $@differentiable(linear) @callee_guaranteed (Float) -> Float
-// CHEK-SILGEN:   end_borrow [[BORROWED_LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
-// CHEK-SILGEN:   destroy_value [[COPIED_LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float // id: %13
-// TODO(TF-900): Change this to returning the extracted original function.
-// CHEK-SILGEN:   %14 = tuple ()
-// CHEK-SILGEN:   return %14 : $()
+// CHECK-SILGEN-LABEL: @{{.*}}myfunction2{{.*}}
+// CHECK-SILGEN: bb0([[LIN:%.*]] : @guaranteed $@differentiable(linear) @callee_guaranteed (Float) -> Float):
+// CHECK-SILGEN:   [[COPIED_LIN:%.*]] = copy_value [[LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[BORROWED_LIN:%.*]] = begin_borrow [[COPIED_LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   apply [[BORROWED_LIN]]({{%.*}}) : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   end_borrow [[BORROWED_LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[COPIED_LIN:%.*]] = copy_value [[LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[BORROWED_LIN:%.*]] = begin_borrow [[COPIED_LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[BORROWED_ORIG:%.*]] = linear_function_extract [original] [[BORROWED_LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[COPIED_ORIG:%.*]] = copy_value [[BORROWED_ORIG]] : $@callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   end_borrow [[BORROWED_LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   destroy_value [[COPIED_LIN]] : $@differentiable(linear) @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   return [[COPIED_ORIG]] : $@callee_guaranteed (Float) -> Float
 
 // CHECK-SILGEN-LABEL: @{{.*}}apply{{.*}}
 // CHECK-SILGEN:       [[ORIG:%.*]] = function_ref @{{.*}}thin{{.*}} : $@convention(thin) (Float) -> Float
 // CHECK-SILGEN-NEXT:  [[ORIG_THICK:%.*]] = thin_to_thick_function [[ORIG]] : $@convention(thin) (Float) -> Float to $@callee_guaranteed (Float) -> Float
 // CHECK-SILGEN-NEXT:  [[DIFFED:%.*]] = differentiable_function [wrt 0] [[ORIG_THICK]] : $@callee_guaranteed (Float) -> Float
-
-// CHECK-SIL:  [[DIFFED:%.*]] = differentiable_function [wrt 0] {{%.*}} : $@callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:       [[ORIG:%.*]] = function_ref @{{.*}}thin{{.*}} : $@convention(thin) (Float) -> Float
+// CHECK-SILGEN-NEXT:  [[ORIG_THICK:%.*]] = thin_to_thick_function [[ORIG]] : $@convention(thin) (Float) -> Float to $@callee_guaranteed (Float) -> Float
+// CHECK-SILGEN-NEXT:  [[LIN:%.*]] = linear_function [parameters 0] [[ORIG_THICK]] : $@callee_guaranteed (Float) -> Float
 
 //===----------------------------------------------------------------------===//
 // Reabstraction
@@ -113,4 +112,4 @@ func appliesReabstraction(_ f: @escaping @differentiable (Float) -> Float) {
 // CHECK-SILGEN:   [[NEW_VJP:%.*]] = partial_apply [callee_guaranteed] [[REABS_VJP]]([[VJP_COPY]]) : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float)
 // CHECK-SILGEN:   [[NEW_DIFF_FUNC:%.*]] = differentiable_function [wrt 0] [[NEW_ORIG]] : $@callee_guaranteed (@in_guaranteed Float) -> @out Float with {[[NEW_JVP]] : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float), [[NEW_VJP]] : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float)}
 // CHECK-SILGEN:   [[DIFF_API:%.*]] = function_ref @${{.*}}pullback{{.*}}at{{.*}} : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : _Differentiable, τ_0_1 : _Differentiable> (@in_guaranteed τ_0_0, @guaranteed @differentiable @callee_guaranteed (@in_guaranteed τ_0_0) -> @out τ_0_1) -> @owned @callee_guaranteed (@in_guaranteed τ_0_1.TangentVector) -> @out τ_0_0.TangentVector
-// HECK-SILGEN:   apply [[DIFF_API]]<Float, Float>({{.*}}, [[NEW_DIFF_FUNC]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : _Differentiable, τ_0_1 : _Differentiable> (@in_guaranteed τ_0_0, @guaranteed @differentiable @callee_guaranteed (@in_guaranteed τ_0_0) -> @out τ_0_1) -> @owned @callee_guaranteed (@in_guaranteed τ_0_1.TangentVector) -> @out τ_0_0.TangentVector
+// CHECK-SILGEN:   apply [[DIFF_API]]<Float, Float>({{.*}}, [[NEW_DIFF_FUNC]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : _Differentiable, τ_0_1 : _Differentiable> (@in_guaranteed τ_0_0, @guaranteed @differentiable @callee_guaranteed (@in_guaranteed τ_0_0) -> @out τ_0_1) -> @owned @callee_guaranteed (@in_guaranteed τ_0_1.TangentVector) -> @out τ_0_0.TangentVector

--- a/test/AutoDiff/differentiation_transform_diagnostics.swift
+++ b/test/AutoDiff/differentiation_transform_diagnostics.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
 
+// This file tests SIL diagnostics during the differentiation transform.
+
 //===----------------------------------------------------------------------===//
 // Basic function
 //===----------------------------------------------------------------------===//
@@ -329,3 +331,10 @@ struct TF_675 : Differentiable {
 }
 // expected-error @+1 {{function is not differentiable}}
 let _: @differentiable (Float) -> Float = TF_675().method
+
+//===----------------------------------------------------------------------===//
+// Conversion to `@differentiable(linear)` (not yet supported)
+//===----------------------------------------------------------------------===//
+
+// expected-error @+1 {{conversion to '@differentiable(linear)' function type is not yet supported}}
+let _: @differentiable(linear) (Float) -> Float = { x in x }

--- a/test/AutoDiff/sil_diagnostics_after_differentiation.swift
+++ b/test/AutoDiff/sil_diagnostics_after_differentiation.swift
@@ -2,7 +2,7 @@
 
 // This test file contains SIL diagnostics tests for differentiable functions
 // such as escaping capture errors.
-// NOTE: Only add tests for errors that would occur after the differentiation 
+// NOTE: Only add tests for errors that would occur after the differentiation
 // transform.
 
 func nonescapingArgument(f: @differentiable (Float, Float) -> Float) -> Float {


### PR DESCRIPTION
- Support the following implicit conversions:
  - Non-differentiable to `@differentiable(linear)`
    - Sema: Emit `LinearFunctionExpr`.
    - SILGen: Lower `LinearFunctionExpr` to `linear_function`.
  - `@differentiable(linear)` to non-differentiable
    - Sema: Emit `LinearFunctionExtractOriginalExpr`.
    - SILGen: Lower `LinearFunctionExtractOriginalExpr` to `linear_function_extract [original]`.
- Reject the following implicit conversions:
  - `@differentiable` to `@differentiable(linear)`
    - This conversion is not rejected because a `@differentiable` function can never come directly from a closure expression or from a declaration/member reference.
  - `@differentiable(linear)` to `@differentiable` ([TF-908](https://bugs.swift.org/browse/TF-908))
    - This is supported by design, but is not yet implemented due to its complexity. This requires thunking `@differentiable(linear)` to a derivative (JVP) function where the derivative function returns the original result and the same linear map with `@nondiff` parameters partial-applied away.
- Properly handle `linear_function`, `differentiable_function_extract`, and `linear_function_extract` in `swift::isGuaranteedForwardingValueKind` and `swift::isOwnershipForwardingValueKind`. This fixed a previously uncaught assertion, which was because `differentiable_function_extract` was in `swift::isOwnershipForwardingValueKind` while it should really be in `swift::isGuaranteedForwardingValueKind`.

For complete conversion rules among `@differentiable` functions, see [Differentiable Programming Mega-Proposal - Type conversion](https://github.com/dan-zheng/swift/blob/differentiable-programming/docs/DifferentiableProgramming.md#type-conversion).

Resolves [TF-900](https://bugs.swift.org/browse/TF-900).