### PR TITLE
[AutoDiff] NFC: Change `DifferentiableFunctionExtractee` to a top-level type.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -528,7 +528,7 @@ public:
   }
   
   DifferentiableFunctionExtractInst *createDifferentiableFunctionExtract(
-      SILLocation Loc, DifferentiableFunctionExtractee Extractee,
+      SILLocation Loc, NormalDifferentiableFunctionTypeComponent Extractee,
       SILValue TheFunction) {
     return insert(new (getModule()) DifferentiableFunctionExtractInst(
         getModule(), getSILDebugLocation(Loc), Extractee, TheFunction));
@@ -546,7 +546,7 @@ public:
                                               SILValue TheFunction) {
     return insert(new (getModule()) DifferentiableFunctionExtractInst(
         getModule(), getSILDebugLocation(Loc),
-        DifferentiableFunctionExtractee::Original, TheFunction));
+        NormalDifferentiableFunctionTypeComponent::Original, TheFunction));
   }
 
   BuiltinInst *createBuiltin(SILLocation Loc, Identifier Name, SILType ResultTy,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7967,42 +7967,29 @@ class DifferentiableFunctionExtractInst
     : public InstructionBase<
           SILInstructionKind::DifferentiableFunctionExtractInst,
           SingleValueInstruction> {
-public:
-  struct Extractee {
-    enum innerty : unsigned {
-      Original = 0,
-      JVP = 1,
-      VJP = 2
-    } rawValue;
-    Extractee() = default;
-    Extractee(innerty rawValue) : rawValue(rawValue) {}
-    explicit Extractee(unsigned rawValue) : Extractee((innerty)rawValue) {}
-    Extractee(AutoDiffDerivativeFunctionKind kind);
-    explicit Extractee(StringRef name);
-    operator innerty() const { return rawValue; }
-
-    Optional<AutoDiffDerivativeFunctionKind>
-    getExtracteeAsDerivativeFunction() const;
-  };
-
 private:
   /// The extractee.
-  Extractee extractee;
+  NormalDifferentiableFunctionTypeComponent extractee;
   /// The list containing the `@differentiable` function operand.
   FixedOperandList<1> operands;
 
   static SILType
-  getExtracteeType(SILValue function, Extractee extractee, SILModule &module);
+  getExtracteeType(
+      SILValue function, NormalDifferentiableFunctionTypeComponent extractee,
+      SILModule &module);
 
 public:
   explicit DifferentiableFunctionExtractInst(
-      SILModule &module, SILDebugLocation debugLoc, Extractee extractee,
+      SILModule &module, SILDebugLocation debugLoc,
+      NormalDifferentiableFunctionTypeComponent extractee,
       SILValue theFunction);
 
-  Extractee getExtractee() const { return extractee; }
+  NormalDifferentiableFunctionTypeComponent getExtractee() const {
+      return extractee;
+  }
 
   AutoDiffDerivativeFunctionKind getDerivativeFunctionKind() const {
-    auto kind = extractee.getExtracteeAsDerivativeFunction();
+    auto kind = extractee.getAsDerivativeFunctionKind();
     assert(kind);
     return *kind;
   }
@@ -8011,9 +7998,6 @@ public:
   ArrayRef<Operand> getAllOperands() const { return operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return operands.asArray(); }
 };
-
-typedef DifferentiableFunctionExtractInst::Extractee
-    DifferentiableFunctionExtractee;
 
 /// `linear_function_extract` - given an `@differentiable(linear)` function
 /// representing a bundle of the original function and the transpose function,
@@ -8047,8 +8031,6 @@ public:
   ArrayRef<Operand> getAllOperands() const { return operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return operands.asArray(); }
 };
-
-typedef LinearDifferentiableFunctionTypeComponent LinearFunctionExtractee;
 // SWIFT_ENABLE_TENSORFLOW END
 
 // This is defined out of line to work around the fact that this depends on

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -32,6 +32,33 @@ AutoDiffDerivativeFunctionKind(StringRef string) {
   rawValue = *result;
 }
 
+NormalDifferentiableFunctionTypeComponent::
+NormalDifferentiableFunctionTypeComponent(AutoDiffDerivativeFunctionKind kind) {
+  switch (kind) {
+  case AutoDiffDerivativeFunctionKind::JVP: rawValue = JVP; return;
+  case AutoDiffDerivativeFunctionKind::VJP: rawValue = VJP; return;
+  }
+}
+
+NormalDifferentiableFunctionTypeComponent::
+NormalDifferentiableFunctionTypeComponent(StringRef string) {
+  Optional<innerty> result = llvm::StringSwitch<Optional<innerty>>(string)
+      .Case("original", Original)
+      .Case("jvp", JVP)
+      .Case("vjp", VJP);
+  assert(result && "Invalid string");
+  rawValue = *result;
+}
+
+Optional<AutoDiffDerivativeFunctionKind>
+NormalDifferentiableFunctionTypeComponent::getAsDerivativeFunctionKind() const {
+  switch (rawValue) {
+  case Original: return None;
+  case JVP: return {AutoDiffDerivativeFunctionKind::JVP};
+  case VJP: return {AutoDiffDerivativeFunctionKind::VJP};
+  }
+}
+
 LinearDifferentiableFunctionTypeComponent::
 LinearDifferentiableFunctionTypeComponent(StringRef string) {
   Optional<innerty> result =

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -3041,7 +3041,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   case SILInstructionKind::DifferentiableFunctionExtractInst: {
     // Parse the rest of the instruction: an extractee, a differentiable
     // function operand, and a debug location.
-    DifferentiableFunctionExtractee extractee;
+    NormalDifferentiableFunctionTypeComponent extractee;
     StringRef extracteeNames[3] = {"original", "jvp", "vjp"};
     SILValue functionOperand;
     SourceLoc lastLoc;

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -664,45 +664,16 @@ LinearFunctionInst *LinearFunctionInst::create(
       HasOwnership);
 }
 
-DifferentiableFunctionExtractInst::Extractee::Extractee(
-    AutoDiffDerivativeFunctionKind kind) {
-  switch (kind) {
-  case AutoDiffDerivativeFunctionKind::JVP:
-    rawValue = JVP;
-    return;
-  case AutoDiffDerivativeFunctionKind::VJP:
-    rawValue = VJP;
-    return;
-  }
-}
-
-DifferentiableFunctionExtractInst::Extractee::Extractee(StringRef string) {
-  Optional<innerty> result = llvm::StringSwitch<Optional<innerty>>(string)
-      .Case("original", Original)
-      .Case("jvp", JVP)
-      .Case("vjp", VJP);
-  assert(result && "Invalid string");
-  rawValue = *result;
-}
-
-Optional<AutoDiffDerivativeFunctionKind>
-DifferentiableFunctionExtractInst::Extractee::
-getExtracteeAsDerivativeFunction() const {
-  switch (rawValue) {
-  case Original: return None;
-  case JVP: return {AutoDiffDerivativeFunctionKind::JVP};
-  case VJP: return {AutoDiffDerivativeFunctionKind::VJP};
-  }
-}
-
 SILType DifferentiableFunctionExtractInst::
-getExtracteeType(SILValue function, Extractee extractee, SILModule &module) {
+getExtracteeType(
+    SILValue function, NormalDifferentiableFunctionTypeComponent extractee,
+    SILModule &module) {
   auto fnTy = function->getType().castTo<SILFunctionType>();
   assert(fnTy->getDifferentiabilityKind() == DifferentiabilityKind::Normal);
   auto originalFnTy = fnTy->getWithoutDifferentiability();
-  auto kindOpt = extractee.getExtracteeAsDerivativeFunction();
+  auto kindOpt = extractee.getAsDerivativeFunctionKind();
   if (!kindOpt) {
-    assert(extractee == Extractee::Original);
+    assert(extractee == NormalDifferentiableFunctionTypeComponent::Original);
     return SILType::getPrimitiveObjectType(originalFnTy);
   }
   auto resultFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
@@ -713,8 +684,8 @@ getExtracteeType(SILValue function, Extractee extractee, SILModule &module) {
 }
 
 DifferentiableFunctionExtractInst::DifferentiableFunctionExtractInst(
-    SILModule &module, SILDebugLocation debugLoc, Extractee extractee,
-    SILValue theFunction)
+    SILModule &module, SILDebugLocation debugLoc,
+    NormalDifferentiableFunctionTypeComponent extractee, SILValue theFunction)
     : InstructionBase(debugLoc,
                       getExtracteeType(theFunction, extractee, module)),
       extractee(extractee), operands(this, theFunction) {}

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1194,13 +1194,13 @@ public:
       DifferentiableFunctionExtractInst *dfei) {
     *this << '[';
     switch (dfei->getExtractee()) {
-    case DifferentiableFunctionExtractee::Original:
+    case NormalDifferentiableFunctionTypeComponent::Original:
       *this << "original";
       break;
-    case DifferentiableFunctionExtractee::JVP:
+    case NormalDifferentiableFunctionTypeComponent::JVP:
       *this << "jvp";
       break;
-    case DifferentiableFunctionExtractee::VJP:
+    case NormalDifferentiableFunctionTypeComponent::VJP:
       *this << "vjp";
       break;
     }
@@ -1211,10 +1211,10 @@ public:
   void visitLinearFunctionExtractInst(LinearFunctionExtractInst *lfei) {
     *this << '[';
     switch (lfei->getExtractee()) {
-    case LinearFunctionExtractee::Original:
+    case LinearDifferentiableFunctionTypeComponent::Original:
       *this << "original";
       break;
-    case LinearFunctionExtractee::Transpose:
+    case LinearDifferentiableFunctionTypeComponent::Transpose:
       *this << "transpose";
       break;
     }

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -892,14 +892,14 @@ namespace {
   class NormalDifferentiableSILFunctionTypeLowering final
       : public LoadableAggTypeLowering<
                    NormalDifferentiableSILFunctionTypeLowering,
-                   DifferentiableFunctionExtractee> {
+                   NormalDifferentiableFunctionTypeComponent> {
   public:
     using LoadableAggTypeLowering::LoadableAggTypeLowering;
 
-    SILValue emitRValueProject(SILBuilder &B, SILLocation loc,
-                               SILValue tupleValue,
-                               DifferentiableFunctionExtractee extractee,
-                               const TypeLowering &eltLowering) const {
+    SILValue emitRValueProject(
+        SILBuilder &B, SILLocation loc, SILValue tupleValue,
+        NormalDifferentiableFunctionTypeComponent extractee,
+        const TypeLowering &eltLowering) const {
       return B.createDifferentiableFunctionExtract(
           loc, extractee, tupleValue);
     }
@@ -921,7 +921,7 @@ namespace {
       auto origFnTy = fnTy->getWithoutDifferentiability();
       auto paramIndices = fnTy->getDifferentiationParameterIndices();
       children.push_back(Child{
-        DifferentiableFunctionExtractee::Original,
+        NormalDifferentiableFunctionTypeComponent::Original,
         TC.getTypeLowering(origFnTy, getResilienceExpansion())
       });
       for (AutoDiffDerivativeFunctionKind kind :
@@ -931,12 +931,12 @@ namespace {
             paramIndices, 0, kind, TC,
             LookUpConformanceInModule(&TC.M));
         auto silTy = SILType::getPrimitiveObjectType(derivativeFnTy);
-        DifferentiableFunctionExtractee extractee(kind);
+        NormalDifferentiableFunctionTypeComponent extractee(kind);
         // Assert that we have the right extractee. A terrible bug in the past
         // was caused by implicit conversions from `unsigned` to
-        // `DifferentiableFunctionExtractee` which resulted into a wrong
-        // extractee.
-        assert(extractee.getExtracteeAsDerivativeFunction() == kind);
+        // `NormalDifferentiableFunctionTypeComponent` which resulted into a
+        // wrong extractee.
+        assert(extractee.getAsDerivativeFunctionKind() == kind);
         children.push_back(Child{
             extractee, TC.getTypeLowering(silTy, getResilienceExpansion())});
       }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4312,7 +4312,7 @@ getWitnessFunctionRef(SILGenFunction &SGF,
       auto autoDiffFn = SGF.B.createDifferentiableFunction(
           loc, loweredIndices, originalFn);
       return SGF.B.createDifferentiableFunctionExtract(
-          loc, DifferentiableFunctionExtractee(autoDiffFuncId->getKind()),
+          loc, NormalDifferentiableFunctionTypeComponent(autoDiffFuncId->getKind()),
           autoDiffFn);
     }
 

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -146,7 +146,8 @@ SILFunction *SILGenModule::getOrCreateAutoDiffClassMethodThunk(
   auto diffFn = SGF.B.createDifferentiableFunction(
       loc, loweredIndices, originalFnRef);
   auto diffDerivativeFn = SGF.B.createDifferentiableFunctionExtract(
-      loc, DifferentiableFunctionExtractee(autoDiffFuncId->getKind()), diffFn);
+      loc, NormalDifferentiableFunctionTypeComponent(autoDiffFuncId->getKind()),
+      diffFn);
   auto autoDiffDerivativeFnSILTy = SILType::getPrimitiveObjectType(constantTy);
   SmallVector<SILValue, 4> args(thunk->getArguments().begin(),
                                 thunk->getArguments().end());

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2563,7 +2563,8 @@ emitDerivativeFunctionReference(
   // derivative function, and return it.
   if (auto *inst = original->getDefiningInstruction())
     if (auto *dfei = dyn_cast<DifferentiableFunctionExtractInst>(inst))
-      if (dfei->getExtractee() == DifferentiableFunctionExtractee::Original)
+      if (dfei->getExtractee() ==
+              NormalDifferentiableFunctionTypeComponent::Original)
         functionSource = dfei->getFunctionOperand();
 
   // If `functionSource` is a `@differentiable` function, just extract the
@@ -3787,7 +3788,7 @@ public:
       }
       auto borrowedDiffFunc = builder.emitBeginBorrowOperation(loc, original);
       vjpValue = builder.createDifferentiableFunctionExtract(
-          loc, DifferentiableFunctionExtractInst::Extractee::VJP,
+          loc, NormalDifferentiableFunctionTypeComponent::VJP,
           borrowedDiffFunc);
       vjpValue = builder.emitCopyValueOperation(loc, vjpValue);
     }
@@ -3870,7 +3871,7 @@ public:
       auto borrowedADFunc =
           builder.emitBeginBorrowOperation(loc, diffFuncInst);
       auto extractedVJP = getBuilder().createDifferentiableFunctionExtract(
-          loc, DifferentiableFunctionExtractInst::Extractee::VJP,
+          loc, NormalDifferentiableFunctionTypeComponent::VJP,
           borrowedADFunc);
       vjpValue = builder.emitCopyValueOperation(loc, extractedVJP);
       builder.emitEndBorrowOperation(loc, borrowedADFunc);
@@ -5465,7 +5466,7 @@ public:
       }
       auto borrowedDiffFunc = builder.emitBeginBorrowOperation(loc, original);
       jvpValue = builder.createDifferentiableFunctionExtract(
-          loc, DifferentiableFunctionExtractInst::Extractee::JVP,
+          loc, NormalDifferentiableFunctionTypeComponent::JVP,
           borrowedDiffFunc);
       jvpValue = builder.emitCopyValueOperation(loc, jvpValue);
     }
@@ -5544,7 +5545,7 @@ public:
       auto borrowedADFunc =
           builder.emitBeginBorrowOperation(loc, diffFuncInst);
       auto extractedJVP = builder.createDifferentiableFunctionExtract(
-          loc, DifferentiableFunctionExtractInst::Extractee::JVP,
+          loc, NormalDifferentiableFunctionTypeComponent::JVP,
           borrowedADFunc);
       jvpValue = builder.emitCopyValueOperation(loc, extractedJVP);
       builder.emitEndBorrowOperation(loc, borrowedADFunc);
@@ -8712,7 +8713,8 @@ void ADContext::foldDifferentiableFunctionExtraction(
     if (!dfei)
       continue;
     // Fold original function extractors.
-    if (dfei->getExtractee() == DifferentiableFunctionExtractee::Original) {
+    if (dfei->getExtractee() ==
+            NormalDifferentiableFunctionTypeComponent::Original) {
       auto originalFnValue = source->getOriginalFunction();
       dfei->replaceAllUsesWith(originalFnValue);
       dfei->eraseFromParent();

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1599,7 +1599,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     auto astTy = MF->getType(TyID);
     auto silTy = getSILType(astTy, SILValueCategory::Object);
     auto val = getLocalValue(ValID, silTy);
-    DifferentiableFunctionExtractee extractee(Attr);
+    NormalDifferentiableFunctionTypeComponent extractee(Attr);
     ResultVal =
         Builder.createDifferentiableFunctionExtract(Loc, extractee, val);
     break;
@@ -1608,7 +1608,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     auto astTy = MF->getType(TyID);
     auto silTy = getSILType(astTy, SILValueCategory::Object);
     auto val = getLocalValue(ValID, silTy);
-    LinearFunctionExtractee extractee(Attr);
+    LinearDifferentiableFunctionTypeComponent extractee(Attr);
     ResultVal = Builder.createLinearFunctionExtract(Loc, extractee, val);
     break;
   }


### PR DESCRIPTION
Many places in the compiler that are completely unrelated to `DifferentiableFunctionExtractInst` are using `DifferentiableFunctionExtractInst::Extractee`, including `@differentiable` type lowering (IRGen/GenDiffFunc.cpp). This patch refactors it and renames it to `NormalDifferentiableFunctionTypeComponent` so that it is no longer part of `DifferentiableFunctionInst`.

Resolves [TF-904](https://bugs.swift.org/browse/TF-904).