### PR TITLE
[test] XFAIL DebugInfo/self.swift when assertions are disabled

### DIFF
--- a/test/DebugInfo/self.swift
+++ b/test/DebugInfo/self.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
+// rdar://problem/56255858 - failing on no-asserts builds
+// XFAIL: no_asserts
 
 public struct stuffStruct {
     var a: Int64 = 6


### PR DESCRIPTION
Failing on CI here: https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/