### PR TITLE
[stdlib] Switch some cold paths to inline-never

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -510,7 +510,7 @@ extension _ArrayBuffer {
 
   @inlinable
   internal var _nonNative: _CocoaArrayWrapper {
-    @inline(__always)
+    @inline(never)
     get {
       _internalInvariant(_isClassOrObjCExistential(Element.self))
       return _CocoaArrayWrapper(_storage.objCInstance)

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -133,7 +133,7 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
 
   @inlinable
   internal var objCInstance: ObjC {
-    @inline(__always) get {
+    @inline(never) get {
       _internalInvariant(isObjC)
       return Builtin.castReferenceFromBridgeObject(rawValue)
     }


### PR DESCRIPTION
Fetching the non-native implementation or creating a bridged wrapper shouldn't need to be inlinable.