### PR TITLE
IRGen: Fix MemoryLayout::offset(of:) for tail allocated C arrays

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -317,6 +317,7 @@ HeapNonFixedOffsets::HeapNonFixedOffsets(IRGenFunction &IGF,
                                     elt.getType().getAlignmentMask(IGF, eltTy));
         LLVM_FALLTHROUGH;
       case ElementLayout::Kind::Empty:
+      case ElementLayout::Kind::EmptyTailAllocatedCType:
       case ElementLayout::Kind::Fixed:
         // Don't need to dynamically calculate this offset.
         Offsets.push_back(nullptr);

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -185,6 +185,7 @@ namespace {
       switch (fieldInfo.getKind()) {
       case ElementLayout::Kind::Fixed:
       case ElementLayout::Kind::Empty:
+      case ElementLayout::Kind::EmptyTailAllocatedCType:
         return MemberAccessStrategy::getDirectFixed(
                                                fieldInfo.getFixedByteOffset());
       case ElementLayout::Kind::InitialNonFixedSize:
@@ -278,6 +279,7 @@ namespace {
           break;
         }
         case ElementLayout::Kind::Empty:
+        case ElementLayout::Kind::EmptyTailAllocatedCType:
         case ElementLayout::Kind::InitialNonFixedSize:
         case ElementLayout::Kind::NonFixed:
           continue;
@@ -789,7 +791,8 @@ private:
     ElementLayout layout = ElementLayout::getIncomplete(fieldType);
     auto isEmpty = fieldType.isKnownEmpty(ResilienceExpansion::Maximal);
     if (isEmpty)
-      layout.completeEmpty(fieldType.isPOD(ResilienceExpansion::Maximal));
+      layout.completeEmptyTailAllocatedCType(
+          fieldType.isPOD(ResilienceExpansion::Maximal), NextOffset);
     else
       layout.completeFixed(fieldType.isPOD(ResilienceExpansion::Maximal),
                            NextOffset, LLVMFields.size());

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -149,6 +149,7 @@ namespace {
       const TupleFieldInfo &field = asImpl().getFields()[fieldNo];
       switch (field.getKind()) {
       case ElementLayout::Kind::Empty:
+      case ElementLayout::Kind::EmptyTailAllocatedCType:
       case ElementLayout::Kind::Fixed:
         return field.getFixedByteOffset();
       case ElementLayout::Kind::InitialNonFixedSize:
@@ -194,6 +195,7 @@ namespace {
         }
         
         case ElementLayout::Kind::Empty:
+        case ElementLayout::Kind::EmptyTailAllocatedCType:
         case ElementLayout::Kind::InitialNonFixedSize:
         case ElementLayout::Kind::NonFixed:
           continue;

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -156,6 +156,7 @@ Address ElementLayout::project(IRGenFunction &IGF, Address baseAddr,
                                const llvm::Twine &suffix) const {
   switch (getKind()) {
   case Kind::Empty:
+  case Kind::EmptyTailAllocatedCType:
     return getType().getUndefAddress();
 
   case Kind::Fixed:

--- a/test/IRGen/Inputs/tail_allocated_c_array.h
+++ b/test/IRGen/Inputs/tail_allocated_c_array.h
@@ -1,0 +1,7 @@
+#include <stdint.h>
+
+typedef struct foo {
+  uint8_t a;
+  uint16_t b;
+  uint8_t  tailallocatedarray[0];
+} foo;

--- a/test/IRGen/tail_allocated_c_array.swift
+++ b/test/IRGen/tail_allocated_c_array.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -import-objc-header  %S/Inputs/tail_allocated_c_array.h -primary-file %s -emit-ir -o - | %FileCheck %s
+
+// 25165828 = 0x1800004 The bottom bits designate the offset = 4
+// CHECK: @keypath = private global <{{.*}}i32 0, i32 -2147483644, i32 25165828 }>
+
+_ = MemoryLayout<foo>.offset(of: \foo.tailallocatedarray)!

--- a/test/stdlib/Inputs/tail_allocated_c_array.h
+++ b/test/stdlib/Inputs/tail_allocated_c_array.h
@@ -1,0 +1,7 @@
+#include <stdint.h>
+
+typedef struct foo {
+  uint8_t a;
+  uint16_t b;
+  uint8_t  tailallocatedarray[0];
+} foo;

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 5 -g %s -o %t/a.out
+// RUN: %target-build-swift -import-objc-header %S/Inputs/tail_allocated_c_array.h -swift-version 5 -g %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
@@ -1017,6 +1017,11 @@ keyPath.test("nested generics") {
   let nestedKeyPath = nested.foo()
   typealias DictType = [UInt? : [Float]]
   expectTrue(nestedKeyPath is KeyPath<DictType, DictType.Values>)
+}
+
+keyPath.test("tail allocated c array") {
+  let offset = MemoryLayout<foo>.offset(of: \foo.tailallocatedarray)!
+  expectEqual(4, offset)
 }
 
 runAllTests()


### PR DESCRIPTION
There is no storage but an offset.

rdar://51194713