### PR TITLE
[SyntaxParse] Re-apply move-only ParsedRawSyntaxNode to master

### DIFF
--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -117,8 +117,20 @@ public:
     assert(getTokenKind() == tokKind && "Token kind with too large value!");
   }
 
+#ifndef NDEBUG
+  bool ensureDataIsNotRecorded() {
+    if (DK != DataKind::Recorded)
+      return true;
+    llvm::dbgs() << "Leaking node: ";
+    dump(llvm::dbgs());
+    llvm::dbgs() << "\n";
+    return false;
+  }
+#endif
+
   ParsedRawSyntaxNode &operator=(ParsedRawSyntaxNode &&other) {
-    assert(DK != DataKind::Recorded);
+    assert(ensureDataIsNotRecorded() &&
+           "recorded data is being destroyed by assignment");
     switch (other.DK) {
     case DataKind::Null:
       break;
@@ -143,7 +155,7 @@ public:
     *this = std::move(other);
   }
   ~ParsedRawSyntaxNode() {
-    assert(DK != DataKind::Recorded);
+    assert(ensureDataIsNotRecorded() && "recorded data is being destructed");
   }
 
   syntax::SyntaxKind getKind() const { return syntax::SyntaxKind(SynKind); }

--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -51,7 +51,7 @@ class ParsedRawSyntaxNode {
     CharSourceRange Range;
   };
   struct DeferredLayoutNode {
-    ArrayRef<ParsedRawSyntaxNode> Children;
+    MutableArrayRef<ParsedRawSyntaxNode> Children;
   };
   struct DeferredTokenNode {
     const ParsedTriviaPiece *TriviaPieces;
@@ -73,8 +73,8 @@ class ParsedRawSyntaxNode {
   bool IsMissing = false;
 
   ParsedRawSyntaxNode(syntax::SyntaxKind k,
-                      ArrayRef<ParsedRawSyntaxNode> deferredNodes)
-    : DeferredLayout{deferredNodes},
+                      MutableArrayRef<ParsedRawSyntaxNode> deferredNodes)
+    : DeferredLayout({deferredNodes}),
       SynKind(uint16_t(k)), TokKind(uint16_t(tok::unknown)),
       DK(DataKind::DeferredLayout) {
     assert(getKind() == k && "Syntax kind with too large value!");
@@ -97,6 +97,8 @@ class ParsedRawSyntaxNode {
     assert(DeferredToken.NumTrailingTrivia == numTrailingTrivia &&
            "numLeadingTrivia is too large value!");
   }
+  ParsedRawSyntaxNode(ParsedRawSyntaxNode &other) = delete;
+  ParsedRawSyntaxNode &operator=(ParsedRawSyntaxNode &other) = delete;
 
 public:
   ParsedRawSyntaxNode()
@@ -113,6 +115,35 @@ public:
       DK(DataKind::Recorded) {
     assert(getKind() == k && "Syntax kind with too large value!");
     assert(getTokenKind() == tokKind && "Token kind with too large value!");
+  }
+
+  ParsedRawSyntaxNode &operator=(ParsedRawSyntaxNode &&other) {
+    assert(DK != DataKind::Recorded);
+    switch (other.DK) {
+    case DataKind::Null:
+      break;
+    case DataKind::Recorded:
+      RecordedData = std::move(other.RecordedData);
+      break;
+    case DataKind::DeferredLayout:
+      DeferredLayout = std::move(other.DeferredLayout);
+      break;
+    case DataKind::DeferredToken:
+      DeferredToken = std::move(other.DeferredToken);
+      break;
+    }
+    SynKind = std::move(other.SynKind);
+    TokKind = std::move(other.TokKind);
+    DK = std::move(other.DK);
+    IsMissing = std::move(other.IsMissing);
+    other.reset();
+    return *this;
+  }
+  ParsedRawSyntaxNode(ParsedRawSyntaxNode &&other) : ParsedRawSyntaxNode() {
+    *this = std::move(other);
+  }
+  ~ParsedRawSyntaxNode() {
+    assert(DK != DataKind::Recorded);
   }
 
   syntax::SyntaxKind getKind() const { return syntax::SyntaxKind(SynKind); }
@@ -136,15 +167,51 @@ public:
   /// Primary used for a deferred missing token.
   bool isMissing() const { return IsMissing; }
 
+  void reset() {
+    RecordedData = {};
+    SynKind = uint16_t(syntax::SyntaxKind::Unknown);
+    TokKind = uint16_t(tok::unknown);
+    DK = DataKind::Null;
+    IsMissing = false;
+  }
+
+  ParsedRawSyntaxNode unsafeCopy() const {
+    ParsedRawSyntaxNode copy;
+    switch (DK) {
+    case DataKind::DeferredLayout:
+      copy.DeferredLayout = DeferredLayout;
+      break;
+    case DataKind::DeferredToken:
+      copy.DeferredToken = DeferredToken;
+      break;
+    case DataKind::Recorded:
+      copy.RecordedData = RecordedData;
+      break;
+    case DataKind::Null:
+      break;
+    }
+    copy.SynKind = SynKind;
+    copy.TokKind = TokKind;
+    copy.DK = DK;
+    copy.IsMissing = IsMissing;
+    return copy;
+  }
+
   // Recorded Data ===========================================================//
 
   CharSourceRange getRange() const {
     assert(isRecorded());
     return RecordedData.Range;
   }
-  OpaqueSyntaxNode getOpaqueNode() const {
+  const OpaqueSyntaxNode &getOpaqueNode() const {
     assert(isRecorded());
     return RecordedData.OpaqueNode;
+  }
+  OpaqueSyntaxNode takeOpaqueNode() {
+    assert(isRecorded());
+    auto opaque = RecordedData.OpaqueNode;
+    reset();
+    return opaque;
   }
 
   // Deferred Layout Data ====================================================//
@@ -152,6 +219,30 @@ public:
   ArrayRef<ParsedRawSyntaxNode> getDeferredChildren() const {
     assert(DK == DataKind::DeferredLayout);
     return DeferredLayout.Children;
+  }
+
+  MutableArrayRef<ParsedRawSyntaxNode> getDeferredChildren() {
+    assert(DK == DataKind::DeferredLayout);
+    return DeferredLayout.Children;
+  }
+
+  ParsedRawSyntaxNode copyDeferred() const {
+    ParsedRawSyntaxNode copy;
+    switch (DK) {
+    case DataKind::DeferredLayout:
+      copy.DeferredLayout = DeferredLayout;
+      break;
+    case DataKind::DeferredToken:
+      copy.DeferredToken = DeferredToken;
+      break;
+    default:
+      llvm_unreachable("node not deferred");
+    }
+    copy.SynKind = SynKind;
+    copy.TokKind = TokKind;
+    copy.DK = DK;
+    copy.IsMissing = IsMissing;
+    return copy;
   }
 
   // Deferred Token Data =====================================================//
@@ -176,7 +267,7 @@ public:
 
   /// Form a deferred syntax layout node.
   static ParsedRawSyntaxNode makeDeferred(syntax::SyntaxKind k,
-                        ArrayRef<ParsedRawSyntaxNode> deferredNodes,
+                        MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
                                           SyntaxParsingContext &ctx);
 
   /// Form a deferred token node.

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -60,13 +60,15 @@ public:
   /// \p kind. Missing optional elements are represented with a null
   /// ParsedRawSyntaxNode object.
   ParsedRawSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
-                                     ArrayRef<ParsedRawSyntaxNode> elements);
+                                      MutableArrayRef<ParsedRawSyntaxNode> elements);
 
   /// Record a raw syntax collecton without eny elements. \p loc can be invalid
   /// or an approximate location of where an element of the collection would be
   /// if not missing.
   ParsedRawSyntaxNode recordEmptyRawSyntaxCollection(syntax::SyntaxKind kind,
                                                      SourceLoc loc);
+
+  void discardRecordedNode(ParsedRawSyntaxNode &node);
 
   /// Used for incremental re-parsing.
   ParsedRawSyntaxNode lookupNode(size_t lexerOffset, SourceLoc loc,

--- a/include/swift/Parse/ParsedSyntax.h
+++ b/include/swift/Parse/ParsedSyntax.h
@@ -26,6 +26,7 @@ public:
     : RawNode(std::move(rawNode)) {}
 
   const ParsedRawSyntaxNode &getRaw() const { return RawNode; }
+  ParsedRawSyntaxNode takeRaw() { return std::move(RawNode); }
   syntax::SyntaxKind getKind() const { return RawNode.getKind(); }
 
   /// Returns true if the syntax node is of the given type.
@@ -39,7 +40,7 @@ public:
   template <typename T>
   T castTo() const {
     assert(is<T>() && "castTo<T>() node of incompatible type!");
-    return T { RawNode };
+    return T { RawNode.copyDeferred() };
   }
 
   /// If this Syntax node is of the right kind, cast and return it,
@@ -50,6 +51,10 @@ public:
       return castTo<T>();
     }
     return llvm::None;
+  }
+
+  ParsedSyntax copyDeferred() const {
+    return ParsedSyntax { RawNode.copyDeferred() };
   }
 
   static bool kindof(syntax::SyntaxKind Kind) {
@@ -65,7 +70,7 @@ public:
 class ParsedTokenSyntax final : public ParsedSyntax {
 public:
   explicit ParsedTokenSyntax(ParsedRawSyntaxNode rawNode)
-    : ParsedSyntax(rawNode) {}
+    : ParsedSyntax(std::move(rawNode)) {}
 
   tok getTokenKind() const {
     return getRaw().getTokenKind();

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -53,15 +53,15 @@ public:
 %   elif node.is_syntax_collection():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      ArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<Parsed${node.collection_element_type}> elts,
       ParsedRawSyntaxRecorder &rec);
 
 public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      ArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);
   static Parsed${node.name} make${node.syntax_kind}(
-      ArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);
 
   static Parsed${node.name} makeBlank${node.syntax_kind}(SourceLoc loc,
@@ -75,8 +75,8 @@ public:
   /// optional trailing comma.
   static ParsedTupleTypeElementSyntax
   makeTupleTypeElement(ParsedTypeSyntax Type,
-                         Optional<ParsedTokenSyntax> TrailingComma,
-                         SyntaxParsingContext &SPCtx);
+                       Optional<ParsedTokenSyntax> TrailingComma,
+                       SyntaxParsingContext &SPCtx);
 
   /// The provided \c elements are in the appropriate order for the syntax
   /// \c kind's layout but optional elements are not be included.
@@ -84,9 +84,12 @@ public:
   /// substituting missing parts with a null ParsedRawSyntaxNode object.
   ///
   /// \returns true if the layout could be formed, false otherwise.
-  static bool formExactLayoutFor(syntax::SyntaxKind kind,
-                                 ArrayRef<ParsedRawSyntaxNode> elements,
-         function_ref<void(syntax::SyntaxKind, ArrayRef<ParsedRawSyntaxNode>)> receiver);
+  static bool
+  formExactLayoutFor(syntax::SyntaxKind kind,
+                     MutableArrayRef<ParsedRawSyntaxNode> elements,
+                     function_ref<void(syntax::SyntaxKind,
+                                       MutableArrayRef<ParsedRawSyntaxNode>)>
+                         receiver);
 };
 }
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -358,6 +358,22 @@ public:
   };
   friend class StructureMarkerRAII;
 
+  /// A RAII object that tells the SyntaxParsingContext to defer Syntax nodes.
+  class DeferringContextRAII {
+    SyntaxParsingContext &Ctx;
+    bool WasDeferring;
+
+  public:
+    explicit DeferringContextRAII(SyntaxParsingContext &SPCtx)
+        : Ctx(SPCtx), WasDeferring(Ctx.shouldDefer()) {
+      Ctx.setShouldDefer();
+    }
+
+    ~DeferringContextRAII() {
+      Ctx.setShouldDefer(WasDeferring);
+    }
+  };
+
   /// The stack of structure markers indicating the locations of
   /// structural elements actively being parsed, including the start
   /// of declarations, statements, and opening operators of various
@@ -390,7 +406,7 @@ public:
 
   /// Calling this function to finalize libSyntax tree creation without destroying
   /// the parser instance.
-  ParsedRawSyntaxNode finalizeSyntaxTree() {
+  OpaqueSyntaxNode finalizeSyntaxTree() {
     assert(Tok.is(tok::eof) && "not done parsing yet");
     return SyntaxContext->finalizeRoot();
   }

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -55,6 +55,13 @@ public:
                                            ArrayRef<OpaqueSyntaxNode> elements,
                                            CharSourceRange range) = 0;
 
+  /// Discard raw syntax node.
+  /// 
+  /// FIXME: This breaks invariant that any recorded node will be a part of the
+  /// result SourceFile syntax. This method is a temporary workaround, and
+  /// should be removed when we fully migrate to libSyntax parsing.
+  virtual void discardRecordedNode(OpaqueSyntaxNode node) = 0;
+
   /// Used for incremental re-parsing.
   virtual std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {

--- a/include/swift/Parse/SyntaxParserResult.h
+++ b/include/swift/Parse/SyntaxParserResult.h
@@ -29,17 +29,17 @@ public:
       : SyntaxNode(None), ASTResult(nullptr) {}
   SyntaxParserResult(ParserStatus Status)
       : SyntaxNode(None), ASTResult(Status) {}
-  SyntaxParserResult(llvm::Optional<Syntax> SyntaxNode, AST *ASTNode)
-      : SyntaxNode(SyntaxNode), ASTResult(ASTNode) {}
-  SyntaxParserResult(ParserStatus Status, llvm::Optional<Syntax> SyntaxNode,
+  SyntaxParserResult(llvm::Optional<Syntax> &&SyntaxNode, AST *ASTNode)
+      : SyntaxNode(std::move(SyntaxNode)), ASTResult(ASTNode) {}
+  SyntaxParserResult(ParserStatus Status, llvm::Optional<Syntax> &&SyntaxNode,
                      AST *ASTNode)
-      : SyntaxNode(SyntaxNode), ASTResult(makeParserResult(Status, ASTNode)) {}
+      : SyntaxNode(std::move(SyntaxNode)), ASTResult(makeParserResult(Status, ASTNode)) {}
 
   /// Convert from a different but compatible parser result.
   template <typename U, typename Enabler = typename std::enable_if<
                             std::is_base_of<AST, U>::value>::type>
-  SyntaxParserResult(SyntaxParserResult<Syntax, U> Other)
-      : SyntaxNode(Other.SyntaxNode), ASTResult(Other.ASTResult) {}
+  SyntaxParserResult(SyntaxParserResult<Syntax, U> &&Other)
+      : SyntaxNode(std::move(Other.SyntaxNode)), ASTResult(Other.ASTResult) {}
 
 
   bool isNull() const { return ASTResult.isNull(); }
@@ -58,9 +58,9 @@ public:
     return SyntaxNode.hasValue();
   }
 
-  Syntax getSyntax() const {
+  Syntax getSyntax() {
     assert(SyntaxNode.hasValue() && "getSyntax from None value");
-    return *SyntaxNode;
+    return std::move(*SyntaxNode);
   }
 
   SyntaxParserResult<Syntax, AST> &
@@ -73,16 +73,16 @@ public:
 /// Create a successful parser result.
 template <typename Syntax, typename AST>
 static inline SyntaxParserResult<Syntax, AST>
-makeSyntaxResult(llvm::Optional<Syntax> SyntaxNode, AST *ASTNode) {
-  return SyntaxParserResult<Syntax, AST>(SyntaxNode, ASTNode);
+makeSyntaxResult(llvm::Optional<Syntax> &&SyntaxNode, AST *ASTNode) {
+  return SyntaxParserResult<Syntax, AST>(std::move(SyntaxNode), ASTNode);
 }
 
 /// Create a result with the specified status.
 template <typename Syntax, typename AST>
 static inline SyntaxParserResult<Syntax, AST>
-makeSyntaxResult(ParserStatus Status, llvm::Optional<Syntax> SyntaxNode,
+makeSyntaxResult(ParserStatus Status, llvm::Optional<Syntax> &&SyntaxNode,
                  AST *ASTNode) {
-  return SyntaxParserResult<Syntax, AST>(Status, SyntaxNode, ASTNode);
+  return SyntaxParserResult<Syntax, AST>(Status, std::move(SyntaxNode), ASTNode);
 }
 
 /// Create a result (null or non-null) with error and code completion bits set.

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -162,6 +162,10 @@ private:
   /// true if it's in backtracking context.
   bool IsBacktracking = false;
 
+  /// true if ParsedSyntaxBuilders and ParsedSyntaxRecorder should create
+  /// deferred nodes
+  bool ShouldDefer = false;
+
   // If false, context does nothing.
   bool Enabled;
 
@@ -173,14 +177,17 @@ private:
   ArrayRef<ParsedRawSyntaxNode> getParts() const {
     return llvm::makeArrayRef(getStorage()).drop_front(Offset);
   }
+  MutableArrayRef<ParsedRawSyntaxNode> getParts() {
+    return llvm::makeMutableArrayRef(getStorage().data(), getStorage().size()).drop_front(Offset);
+  }
 
   ParsedRawSyntaxNode makeUnknownSyntax(SyntaxKind Kind,
-                                  ArrayRef<ParsedRawSyntaxNode> Parts);
+                                  MutableArrayRef<ParsedRawSyntaxNode> Parts);
   ParsedRawSyntaxNode createSyntaxAs(SyntaxKind Kind,
-                                     ArrayRef<ParsedRawSyntaxNode> Parts,
+                                     MutableArrayRef<ParsedRawSyntaxNode> Parts,
                                      SyntaxNodeCreationKind nodeCreateK);
   Optional<ParsedRawSyntaxNode> bridgeAs(SyntaxContextKind Kind,
-                              ArrayRef<ParsedRawSyntaxNode> Parts);
+                              MutableArrayRef<ParsedRawSyntaxNode> Parts);
 
 public:
   /// Construct root context.
@@ -193,6 +200,7 @@ public:
       : RootDataOrParent(CtxtHolder), CtxtHolder(CtxtHolder),
         RootData(CtxtHolder->RootData), Offset(RootData->Storage.size()),
         IsBacktracking(CtxtHolder->IsBacktracking),
+        ShouldDefer(CtxtHolder->ShouldDefer),
         Enabled(CtxtHolder->isEnabled()) {
     assert(CtxtHolder->isTopOfContextStack() &&
            "SyntaxParsingContext cannot have multiple children");
@@ -258,17 +266,16 @@ public:
   /// Add Syntax to the parts.
   void addSyntax(ParsedSyntax Node);
 
-
   template<typename SyntaxNode>
   llvm::Optional<SyntaxNode> popIf() {
     auto &Storage = getStorage();
-    assert(Storage.size() > Offset);
-    if (SyntaxNode::kindof(Storage.back().getKind())) {
-      auto rawNode = std::move(Storage.back());
-      Storage.pop_back();
-      return SyntaxNode(rawNode);
-    }
-    return None;
+    if (Storage.size() <= Offset)
+      return llvm::None;
+    if (!SyntaxNode::kindof(Storage.back().getKind()))
+      return llvm::None;
+    auto rawNode = std::move(Storage.back());
+    Storage.pop_back();
+    return SyntaxNode(std::move(rawNode));
   }
 
   ParsedTokenSyntax popToken();
@@ -320,11 +327,17 @@ public:
 
   bool isBacktracking() const { return IsBacktracking; }
 
+  void setShouldDefer(bool Value = true) { ShouldDefer = Value; }
+
+  bool shouldDefer() const {
+    return ShouldDefer || IsBacktracking || Mode == AccumulationMode::Discard;
+  }
+
   /// Explicitly finalizing syntax tree creation.
   /// This function will be called during the destroying of a root syntax
   /// parsing context. However, we can explicitly call this function to get
   /// the syntax tree before closing the root context.
-  ParsedRawSyntaxNode finalizeRoot();
+  OpaqueSyntaxNode finalizeRoot();
 
   /// Make a missing node corresponding to the given token kind and
   /// push this node into the context. The synthesized node can help

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -65,6 +65,8 @@ private:
                                    ArrayRef<OpaqueSyntaxNode> elements,
                                    CharSourceRange range) override;
 
+  void discardRecordedNode(OpaqueSyntaxNode node) override;
+
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
 };

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1474,12 +1474,12 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       auto pattern = createBindingFromPattern(loc, name, introducer);
       if (SyntaxContext->isEnabled()) {
         ParsedPatternSyntax PatternNode =
-            ParsedSyntaxRecorder::makeIdentifierPattern(
+            ParsedSyntaxRecorder::deferIdentifierPattern(
                                     SyntaxContext->popToken(), *SyntaxContext);
         ParsedExprSyntax ExprNode =
-            ParsedSyntaxRecorder::deferUnresolvedPatternExpr(PatternNode,
+            ParsedSyntaxRecorder::deferUnresolvedPatternExpr(std::move(PatternNode),
                                                              *SyntaxContext);
-        SyntaxContext->addSyntax(ExprNode);
+        SyntaxContext->addSyntax(std::move(ExprNode));
       }
       return makeParserResult(new (Context) UnresolvedPatternExpr(pattern));
     }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -123,6 +123,7 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
 
   if (Tok.is(tok::pound) && Tok.isAtStartOfLine() &&
       peekToken().is(tok::code_complete)) {
+    SyntaxParsingContext CCCtxt(SyntaxContext, SyntaxContextKind::Decl);
     consumeToken();
     if (CodeCompletion)
       CodeCompletion->completeAfterPoundDirective();
@@ -250,6 +251,8 @@ bool Parser::isTerminatorForBraceItemListKind(BraceItemListKind Kind,
 
 void Parser::consumeTopLevelDecl(ParserPosition BeginParserPosition,
                                  TopLevelCodeDecl *TLCD) {
+  SyntaxParsingContext Discarding(SyntaxContext);
+  Discarding.disable();
   SourceLoc EndLoc = PreviousLoc;
   backtrackToPosition(BeginParserPosition);
   SourceLoc BeginLoc = Tok.getLoc();

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -56,37 +56,36 @@ void ParsedRawSyntaxNode::dump() const {
 }
 
 void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
-  auto indent = [&](unsigned Amount) {
-    for (decltype(Amount) i = 0; i < Amount; ++i) {
-      OS << ' ';
-    }
-  };
-
-  indent(Indent);
-
-  if (isNull()) {
-    OS << "(<NULL>)";
-    return;
-  }
-
+  for (decltype(Indent) i = 0; i < Indent; ++i)
+    OS << ' ';
   OS << '(';
-  dumpSyntaxKind(OS, getKind());
 
-  if (isToken()) {
-    dumpTokenKind(OS, getTokenKind());
-
-  } else {
-    if (isRecorded()) {
-      OS << " [recorded]";
-    } else if (isDeferredLayout()) {
+  switch (DK) {
+    case DataKind::Null:
+      OS << "<NULL>";
+      break;
+    case DataKind::Recorded:
+      dumpSyntaxKind(OS, getKind());
+      OS << " [recorded] ";
+      if (isToken()) {
+        dumpTokenKind(OS, getTokenKind());
+      } else {
+        OS << "<layout>";
+      }
+      break;
+    case DataKind::DeferredLayout:
+      dumpSyntaxKind(OS, getKind());
+      OS << " [deferred]";
       for (const auto &child : getDeferredChildren()) {
         OS << "\n";
-        child.dump(OS, Indent + 1);
+        child.dump(OS, Indent + 2);
       }
-    } else {
-      assert(isDeferredToken());
-      OS << " [deferred token]";
-    }
+      break;
+    case DataKind::DeferredToken:
+      dumpSyntaxKind(OS, getKind());
+      OS << " [deferred] ";
+      dumpTokenKind(OS, getTokenKind());
+      break;
   }
   OS << ')';
 }

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -57,9 +57,8 @@ ParsedRawSyntaxRecorder::recordMissingToken(tok tokenKind, SourceLoc loc) {
 }
 
 static ParsedRawSyntaxNode
-getRecordedNode(const ParsedRawSyntaxNode &node, ParsedRawSyntaxRecorder &rec) {
-  if (node.isNull() || node.isRecorded())
-    return node;
+getRecordedNode(ParsedRawSyntaxNode node, ParsedRawSyntaxRecorder &rec) {
+  assert(!node.isNull() && !node.isRecorded());
   if (node.isDeferredLayout())
     return rec.recordRawSyntax(node.getKind(), node.getDeferredChildren());
   assert(node.isDeferredToken());
@@ -74,24 +73,29 @@ getRecordedNode(const ParsedRawSyntaxNode &node, ParsedRawSyntaxRecorder &rec) {
 
 ParsedRawSyntaxNode
 ParsedRawSyntaxRecorder::recordRawSyntax(SyntaxKind kind,
-                                    ArrayRef<ParsedRawSyntaxNode> elements) {
+                                         MutableArrayRef<ParsedRawSyntaxNode> elements) {
   CharSourceRange range;
   SmallVector<OpaqueSyntaxNode, 16> subnodes;
   if (!elements.empty()) {
     SourceLoc offset;
     unsigned length = 0;
-    for (const auto &elem : elements) {
-      auto subnode = getRecordedNode(elem, *this);
+    for (auto &subnode : elements) {
+      CharSourceRange localRange;
       if (subnode.isNull()) {
         subnodes.push_back(nullptr);
+      } else if (subnode.isRecorded()) {
+        localRange = subnode.getRange();
+        subnodes.push_back(subnode.takeOpaqueNode());
       } else {
-        subnodes.push_back(subnode.getOpaqueNode());
-        auto range = subnode.getRange();
-        if (range.isValid()) {
-          if (offset.isInvalid())
-            offset = range.getStart();
-          length += subnode.getRange().getByteLength();
-        }
+        auto recorded = getRecordedNode(subnode.copyDeferred(), *this);
+        localRange = recorded.getRange();
+        subnodes.push_back(recorded.takeOpaqueNode());
+      }
+
+      if (localRange.isValid()) {
+        if (offset.isInvalid())
+          offset = localRange.getStart();
+        length += localRange.getByteLength();
       }
     }
     range = CharSourceRange{offset, length};
@@ -106,6 +110,10 @@ ParsedRawSyntaxRecorder::recordEmptyRawSyntaxCollection(SyntaxKind kind,
   CharSourceRange range{loc, 0};
   OpaqueSyntaxNode n = SPActions->recordRawSyntax(kind, {}, range);
   return ParsedRawSyntaxNode{kind, tok::unknown, range, n};
+}
+
+void ParsedRawSyntaxRecorder::discardRecordedNode(ParsedRawSyntaxNode &node) {
+  SPActions->discardRecordedNode(node.takeOpaqueNode());
 }
 
 ParsedRawSyntaxNode

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -43,14 +43,14 @@ Parsed${node.name}Builder::use${child.name}(Parsed${child.type_name} ${child.nam
   assert(${child_elt_name}s.empty() && "use either 'use' function or 'add', not both");
 %       end
   Layout[cursorIndex(${node.name}::Cursor::${child.name})] =
-    ${child.name}.getRaw();
+    ${child.name}.takeRaw();
   return *this;
 }
 %       if child_elt:
 Parsed${node.name}Builder &
 Parsed${node.name}Builder::add${child_elt_name}(Parsed${child_elt_type} ${child_elt}) {
   assert(Layout[cursorIndex(${node.name}::Cursor::${child.name})].isNull() && "use either 'use' function or 'add', not both");
-  ${child_elt_name}s.push_back(std::move(${child_elt}.getRaw()));
+  ${child_elt_name}s.push_back(${child_elt}.takeRaw());
   return *this;
 }
 %       end

--- a/lib/Parse/ParsedSyntaxNodes.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxNodes.cpp.gyb
@@ -28,14 +28,14 @@ using namespace swift::syntax;
 %     if child.is_optional:
 Optional<Parsed${child.type_name}>
 Parsed${node.name}::getDeferred${child.name}() {
-  auto RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
+  auto &RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
   if (RawChild.isNull())
     return None;
-  return Parsed${child.type_name} {RawChild};
+  return Parsed${child.type_name} {RawChild.copyDeferred()};
 }
 %     else:
 Parsed${child.type_name} Parsed${node.name}::getDeferred${child.name}() {
-  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}]};
+  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}].copyDeferred()};
 }
 %     end
 

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -26,8 +26,8 @@ using namespace swift;
 using namespace swift::syntax;
 
 bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
-        ArrayRef<ParsedRawSyntaxNode> Elements,
-        function_ref<void(syntax::SyntaxKind, ArrayRef<ParsedRawSyntaxNode>)> receiver) {
+        MutableArrayRef<ParsedRawSyntaxNode> Elements,
+        function_ref<void(syntax::SyntaxKind, MutableArrayRef<ParsedRawSyntaxNode>)> receiver) {
   switch (Kind) {
 % for node in SYNTAX_NODES:
   case SyntaxKind::${node.syntax_kind}: {
@@ -42,16 +42,23 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 %     if child.is_optional:
       Layout[${child_idx}] = ParsedRawSyntaxNode::null();
 %     else:
+      for (unsigned i = 0, e = ${child_count}; i != e; ++i)
+        Layout[i].reset();
       return false;
 %     end
     } else {
-      Layout[${child_idx}] = Elements[I];
+      Layout[${child_idx}] = Elements[I].unsafeCopy();
       ++I;
     }
 %   end
-    if (I != Elements.size())
+    if (I != Elements.size()) {
+      for (unsigned i = 0, e = ${child_count}; i != e; ++i)
+        Layout[i].reset();
       return false;
+    }
     receiver(Kind, Layout);
+    for (unsigned i = 0, e = Elements.size(); i != e; ++i)
+      Elements[i].reset();
     return true;
 % elif node.is_syntax_collection():
     for (auto &E : Elements) {
@@ -85,29 +92,31 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(${child_params},
                                        ParsedRawSyntaxRecorder &rec) {
-  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, {
+  ParsedRawSyntaxNode layout[] = {
 %     for child in node.children:
 %       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->getRaw() : ParsedRawSyntaxNode::null(),
+    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
 %       else:
-    ${child.name}.getRaw(),
+    ${child.name}.takeRaw(),
 %       end
 %     end
-  });
+  };
+  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(${child_params}, SyntaxParsingContext &SPCtx) {
-  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, {
+  ParsedRawSyntaxNode layout[] = {
 %     for child in node.children:
 %       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->getRaw() : ParsedRawSyntaxNode::null(),
+    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
 %       else:
-    ${child.name}.getRaw(),
+    ${child.name}.takeRaw(),
 %       end
 %     end
-  }, SPCtx);
+  };
+  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, llvm::makeMutableArrayRef(layout, ${len(node.children)}), SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
 
@@ -122,12 +131,12 @@ ParsedSyntaxRecorder::make${node.syntax_kind}(${child_params},
 %   elif node.is_syntax_collection():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    ArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<Parsed${node.collection_element_type}> elements,
     ParsedRawSyntaxRecorder &rec) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
@@ -135,12 +144,12 @@ ParsedSyntaxRecorder::record${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    ArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind},
                              layout, SPCtx);
@@ -149,7 +158,7 @@ ParsedSyntaxRecorder::defer${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
-    ArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
   if (SPCtx.isBacktracking())
     return defer${node.syntax_kind}(elements, SPCtx);
@@ -175,6 +184,6 @@ ParsedTupleTypeElementSyntax
 ParsedSyntaxRecorder::makeTupleTypeElement(ParsedTypeSyntax Type,
                                     llvm::Optional<ParsedTokenSyntax> TrailingComma,
                                     SyntaxParsingContext &SPCtx) {
-  return makeTupleTypeElement(None, None, None, None, Type, None, None,
-                              TrailingComma, SPCtx);
+  return makeTupleTypeElement(None, None, None, None, std::move(Type), None, None,
+                              std::move(TrailingComma), SPCtx);
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1209,11 +1209,7 @@ OpaqueSyntaxNode ParserUnit::parse() {
     P.parseTopLevel();
     Done = P.Tok.is(tok::eof);
   }
-  auto rawNode = P.finalizeSyntaxTree();
-  if (rawNode.isNull()) {
-    return nullptr;
-  }
-  return rawNode.getOpaqueNode();
+  return P.finalizeSyntaxTree();
 }
 
 Parser &ParserUnit::getParser() {

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -58,15 +58,16 @@ size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
     return 0;
   }
   Mode = AccumulationMode::SkippedForIncrementalUpdate;
-  getStorage().push_back(foundNode);
-  return foundNode.getRange().getByteLength();
+  auto length = foundNode.getRange().getByteLength();
+  getStorage().push_back(std::move(foundNode));
+  return length;
 }
 
 ParsedRawSyntaxNode
 SyntaxParsingContext::makeUnknownSyntax(SyntaxKind Kind,
-                                        ArrayRef<ParsedRawSyntaxNode> Parts) {
+                                        MutableArrayRef<ParsedRawSyntaxNode> Parts) {
   assert(isUnknownKind(Kind));
-  if (IsBacktracking)
+  if (shouldDefer())
     return ParsedRawSyntaxNode::makeDeferred(Kind, Parts, *this);
   else
     return getRecorder().recordRawSyntax(Kind, Parts);
@@ -74,13 +75,13 @@ SyntaxParsingContext::makeUnknownSyntax(SyntaxKind Kind,
 
 ParsedRawSyntaxNode
 SyntaxParsingContext::createSyntaxAs(SyntaxKind Kind,
-                                     ArrayRef<ParsedRawSyntaxNode> Parts,
+                                     MutableArrayRef<ParsedRawSyntaxNode> Parts,
                                      SyntaxNodeCreationKind nodeCreateK) {
   // Try to create the node of the given syntax.
   ParsedRawSyntaxNode rawNode;
   auto &rec = getRecorder();
-  auto formNode = [&](SyntaxKind kind, ArrayRef<ParsedRawSyntaxNode> layout) {
-    if (nodeCreateK == SyntaxNodeCreationKind::Deferred || IsBacktracking) {
+  auto formNode = [&](SyntaxKind kind, MutableArrayRef<ParsedRawSyntaxNode> layout) {
+    if (nodeCreateK == SyntaxNodeCreationKind::Deferred || shouldDefer()) {
       rawNode = ParsedRawSyntaxNode::makeDeferred(kind, layout, *this);
     } else {
       rawNode = rec.recordRawSyntax(kind, layout);
@@ -95,9 +96,9 @@ SyntaxParsingContext::createSyntaxAs(SyntaxKind Kind,
 
 Optional<ParsedRawSyntaxNode>
 SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
-                               ArrayRef<ParsedRawSyntaxNode> Parts) {
+                               MutableArrayRef<ParsedRawSyntaxNode> Parts) {
   if (Parts.size() == 1) {
-    auto RawNode = Parts.front();
+    auto &RawNode = Parts.front();
     SyntaxKind RawNodeKind = RawNode.getKind();
     switch (Kind) {
     case SyntaxContextKind::Stmt:
@@ -124,7 +125,7 @@ SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
       // We don't need to coerce in this case.
       break;
     }
-    return RawNode;
+    return std::move(RawNode);
   } else if (Parts.empty()) {
     // Just omit the unknown node if it does not have any children
     return None;
@@ -167,7 +168,8 @@ const SyntaxParsingContext *SyntaxParsingContext::getRoot() const {
 }
 
 ParsedTokenSyntax SyntaxParsingContext::popToken() {
-  return popIf<ParsedTokenSyntax>().getValue();
+  auto tok = popIf<ParsedTokenSyntax>();
+  return std::move(tok.getValue());
 }
 
 /// Add Token with Trivia to the parts.
@@ -178,7 +180,7 @@ void SyntaxParsingContext::addToken(Token &Tok,
     return;
 
   ParsedRawSyntaxNode raw;
-  if (IsBacktracking)
+  if (shouldDefer())
     raw = ParsedRawSyntaxNode::makeDeferred(Tok, LeadingTrivia, TrailingTrivia,
                                             *this);
   else
@@ -190,7 +192,7 @@ void SyntaxParsingContext::addToken(Token &Tok,
 void SyntaxParsingContext::addSyntax(ParsedSyntax Node) {
   if (!Enabled)
     return;
-  addRawSyntax(Node.getRaw());
+  addRawSyntax(Node.takeRaw());
 }
 
 void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind, size_t N,
@@ -201,12 +203,10 @@ void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind, size_t N,
     return;
   }
 
-  auto I = getStorage().end() - N;
-  *I = createSyntaxAs(Kind, getParts().take_back(N), nodeCreateK);
-
-  // Remove consumed parts.
-  if (N != 1)
-    getStorage().erase(I + 1, getStorage().end());
+  auto node = createSyntaxAs(Kind, getParts().take_back(N), nodeCreateK);
+  auto &storage = getStorage();
+  getStorage().erase(storage.end() - N, getStorage().end());
+  getStorage().emplace_back(std::move(node));
 }
 
 void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind,
@@ -262,38 +262,34 @@ void SyntaxParsingContext::collectNodesInPlace(SyntaxKind ColletionKind,
 }
 
 static ParsedRawSyntaxNode finalizeSourceFile(RootContextData &RootData,
-                                           ArrayRef<ParsedRawSyntaxNode> Parts) {
+                                           MutableArrayRef<ParsedRawSyntaxNode> Parts) {
   ParsedRawSyntaxRecorder &Recorder = RootData.Recorder;
-  std::vector<ParsedRawSyntaxNode> AllTopLevel;
+  ParsedRawSyntaxNode Layout[2];
 
   assert(!Parts.empty() && Parts.back().isToken(tok::eof));
-  ParsedRawSyntaxNode EOFToken = Parts.back();
+  Layout[1] = std::move(Parts.back());
   Parts = Parts.drop_back();
 
-  for (auto RawNode : Parts) {
-    if (RawNode.getKind() != SyntaxKind::CodeBlockItem)
-      // FIXME: Skip toplevel garbage nodes for now. we shouldn't emit them in
-      // the first place.
-      continue;
 
-    AllTopLevel.push_back(RawNode);
-  }
+  assert(llvm::all_of(Parts, [](const ParsedRawSyntaxNode& node) {
+    return node.getKind() == SyntaxKind::CodeBlockItem;
+  }) && "all top level element must be 'CodeBlockItem'");
 
-  auto itemList = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList,
-                                           Parts);
+  Layout[0] = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList, Parts);
+
   return Recorder.recordRawSyntax(SyntaxKind::SourceFile,
-                                  { itemList, EOFToken });
+                                  llvm::makeMutableArrayRef(Layout, 2));
 }
 
-ParsedRawSyntaxNode SyntaxParsingContext::finalizeRoot() {
+OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
   if (!Enabled)
-    return ParsedRawSyntaxNode::null();
+    return nullptr;
   assert(isTopOfContextStack() && "some sub-contexts are not destructed");
   assert(isRoot() && "only root context can finalize the tree");
   assert(Mode == AccumulationMode::Root);
   auto parts = getParts();
   if (parts.empty()) {
-    return ParsedRawSyntaxNode::null(); // already finalized.
+    return nullptr; // already finalized.
   }
   ParsedRawSyntaxNode root = finalizeSourceFile(*getRootData(), parts);
 
@@ -301,7 +297,7 @@ ParsedRawSyntaxNode SyntaxParsingContext::finalizeRoot() {
   // the root context.
   getStorage().clear();
 
-  return root;
+  return root.takeOpaqueNode();
 }
 
 void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {
@@ -309,7 +305,7 @@ void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {
     return;
 
   ParsedRawSyntaxNode raw;
-  if (IsBacktracking)
+  if (shouldDefer())
     raw = ParsedRawSyntaxNode::makeDeferredMissing(Kind, Loc);
   else
     raw = getRecorder().recordMissingToken(Kind, Loc);
@@ -318,9 +314,12 @@ void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {
 
 void SyntaxParsingContext::dumpStorage() const  {
   llvm::errs() << "======================\n";
-  for (auto Node : getStorage()) {
-    Node.dump(llvm::errs());
-    llvm::errs() << "\n--------------\n";
+  auto &storage = getStorage();
+  for (unsigned i = 0; i != storage.size(); ++i) {
+    storage[i].dump(llvm::errs());
+    llvm::errs() << "\n";
+    if (i + 1 == Offset)
+      llvm::errs() << "--------------\n";
   }
 }
 
@@ -355,14 +354,12 @@ SyntaxParsingContext::~SyntaxParsingContext() {
     assert(!isRoot());
     if (Storage.size() == Offset) {
       if (auto BridgedNode = bridgeAs(CtxtKind, {})) {
-        Storage.push_back(BridgedNode.getValue());
+        Storage.push_back(std::move(BridgedNode.getValue()));
       }
     } else {
-      auto I = Storage.begin() + Offset;
-      *I = bridgeAs(CtxtKind, getParts()).getValue();
-      // Remove used parts.
-      if (Storage.size() > Offset + 1)
-        Storage.erase(Storage.begin() + (Offset + 1), Storage.end());
+      auto node(std::move(bridgeAs(CtxtKind, getParts()).getValue()));
+      Storage.erase(Storage.begin() + Offset, Storage.end());
+      Storage.emplace_back(std::move(node));
     }
     break;
   }
@@ -375,6 +372,12 @@ SyntaxParsingContext::~SyntaxParsingContext() {
   // Remove all parts in this context.
   case AccumulationMode::Discard: {
     auto &nodes = getStorage();
+    for (auto i = nodes.begin()+Offset, e = nodes.end(); i != e; ++i) {
+      // FIXME: This should not be needed. This breaks invariant that any
+      // recorded node must be a part of result souce syntax tree.
+      if (i->isRecorded())
+        getRecorder().discardRecordedNode(*i);
+    }
     nodes.erase(nodes.begin()+Offset, nodes.end());
     break;
   }

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -319,7 +319,7 @@ void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {
 void SyntaxParsingContext::dumpStorage() const  {
   llvm::errs() << "======================\n";
   for (auto Node : getStorage()) {
-    Node.dump();
+    Node.dump(llvm::errs());
     llvm::errs() << "\n--------------\n";
   }
 }

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -157,7 +157,7 @@ static bool parseIntoSourceFileImpl(SourceFile &SF,
 
   if (STreeCreator) {
     auto rawNode = P.finalizeSyntaxTree();
-    STreeCreator->acceptSyntaxRoot(rawNode.getOpaqueNode(), SF);
+    STreeCreator->acceptSyntaxRoot(rawNode, SF);
   }
 
   return FoundSideEffects;

--- a/lib/SyntaxParse/RawSyntaxTokenCache.h
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.h
@@ -39,7 +39,8 @@ class RawSyntaxCacheNode : public llvm::FoldingSetNode {
   llvm::FoldingSetNodeIDRef IDRef;
 
 public:
-  RawSyntaxCacheNode(RC<syntax::RawSyntax> Obj, const llvm::FoldingSetNodeIDRef IDRef)
+  RawSyntaxCacheNode(RC<syntax::RawSyntax> &Obj,
+                     const llvm::FoldingSetNodeIDRef IDRef)
       : Obj(Obj), IDRef(IDRef) {}
 
   /// Retrieve assciated RawSyntax.

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -174,3 +174,9 @@ SyntaxTreeCreator::lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
   raw.resetWithoutRelease();
   return {length, opaqueN};
 }
+
+void SyntaxTreeCreator::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
+  if (!opaqueN)
+    return;
+  static_cast<RawSyntax *>(opaqueN)->Release();
+}

--- a/test/Syntax/serialize_tupletype.swift.result
+++ b/test/Syntax/serialize_tupletype.swift.result
@@ -17,7 +17,7 @@
                 null,
                 null,
                 {
-                  "id": 1,
+                  "id": 18,
                   "tokenKind": {
                     "kind": "kw_typealias"
                   },
@@ -48,7 +48,7 @@
                   "presence": "Present"
                 },
                 {
-                  "id": 2,
+                  "id": 19,
                   "tokenKind": {
                     "kind": "identifier",
                     "text": "x"
@@ -64,11 +64,11 @@
                 },
                 null,
                 {
-                  "id": 19,
+                  "id": 17,
                   "kind": "TypeInitializerClause",
                   "layout": [
                     {
-                      "id": 3,
+                      "id": 1,
                       "tokenKind": {
                         "kind": "equal"
                       },
@@ -82,11 +82,11 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 18,
+                      "id": 16,
                       "kind": "TupleType",
                       "layout": [
                         {
-                          "id": 4,
+                          "id": 2,
                           "tokenKind": {
                             "kind": "l_paren"
                           },
@@ -95,16 +95,16 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 16,
+                          "id": 14,
                           "kind": "TupleTypeElementList",
                           "layout": [
                             {
-                              "id": 11,
+                              "id": 9,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 5,
+                                  "id": 3,
                                   "tokenKind": {
                                     "kind": "kw__"
                                   },
@@ -118,7 +118,7 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 6,
+                                  "id": 4,
                                   "tokenKind": {
                                     "kind": "identifier",
                                     "text": "b"
@@ -128,7 +128,7 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 7,
+                                  "id": 5,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -142,11 +142,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 9,
+                                  "id": 7,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 8,
+                                      "id": 6,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "Int"
@@ -162,7 +162,7 @@
                                 null,
                                 null,
                                 {
-                                  "id": 10,
+                                  "id": 8,
                                   "tokenKind": {
                                     "kind": "comma"
                                   },
@@ -179,12 +179,12 @@
                               "presence": "Present"
                             },
                             {
-                              "id": 15,
+                              "id": 13,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 12,
+                                  "id": 10,
                                   "tokenKind": {
                                     "kind": "kw__"
                                   },
@@ -194,7 +194,7 @@
                                 },
                                 null,
                                 {
-                                  "id": 7,
+                                  "id": 5,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -208,11 +208,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 14,
+                                  "id": 12,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 13,
+                                      "id": 11,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "String"
@@ -235,7 +235,7 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 17,
+                          "id": 15,
                           "tokenKind": {
                             "kind": "r_paren"
                           },

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -189,6 +189,10 @@ private:
     return getNodeHandler()(&node);
   }
 
+  void discardRecordedNode(OpaqueSyntaxNode node) override {
+    // FIXME: This method should not be called at all.
+  }
+
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, SyntaxKind kind) override {
     auto NodeLookup = getNodeLookup();


### PR DESCRIPTION
After reverting ASTGen changes (#27675).
This is still valuable for the master to prevent memory leaks. 