### PR TITLE
[AutoDiff upstream] parsing for @differentiable function type

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -51,6 +51,7 @@ TYPE_ATTR(autoclosure)
 TYPE_ATTR(convention)
 TYPE_ATTR(noescape)
 TYPE_ATTR(escaping)
+TYPE_ATTR(differentiable)
 
 // SIL-specific attributes
 TYPE_ATTR(block_storage)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -65,6 +65,10 @@ public:
   Optional<StringRef> convention = None;
   Optional<StringRef> conventionWitnessMethodProtocol = None;
 
+  // Indicates whether the type's '@differentiable' attribute has a 'linear'
+  // argument.
+  bool linear = false;
+
   // For an opened existential type, the known ID.
   Optional<UUID> OpenedID;
   
@@ -79,7 +83,15 @@ public:
   TypeAttributes() {}
   
   bool isValid() const { return AtLoc.isValid(); }
-  
+
+  bool isLinear() const {
+    assert(
+        !linear ||
+        (linear && has(TAK_differentiable)) &&
+            "Linear shouldn't have been true if there's no `@differentiable`");
+    return linear;
+  }
+
   void clearAttribute(TypeAttrKind A) {
     AttrLocs[A] = SourceLoc();
   }

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1508,6 +1508,12 @@ ERROR(attr_specialize_expected_partial_or_full,none,
 ERROR(attr_implements_expected_member_name,PointsToFirstBadToken,
       "expected a member name as second parameter in '_implements' attribute", ())
 
+// differentiable
+ERROR(differentiable_attribute_expected_rparen,none,
+      "expected ')' in '@differentiable' attribute", ())
+ERROR(unexpected_argument_differentiable,none,
+      "unexpected argument '%0' in '@differentiable' attribute", (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Generics parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4683,6 +4683,13 @@ NOTE(previous_function_builder_here, none,
 ERROR(function_builder_arguments, none,
       "function builder attributes cannot have arguments", ())
 
+//------------------------------------------------------------------------------
+// MARK: differentiable programming diagnostics
+//------------------------------------------------------------------------------
+ERROR(experimental_differentiable_programming_disabled, none,
+      "differentiable programming is an experimental feature that is "
+      "currently disabled", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -299,6 +299,14 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
   if (hasAttr(TAK_escaping))
     Printer.printSimpleAttr("@escaping") << " ";
 
+  if (hasAttr(TAK_differentiable)) {
+    if (Attrs.isLinear()) {
+      Printer.printSimpleAttr("@differentiable(linear)") << " ";
+    } else {
+      Printer.printSimpleAttr("@differentiable") << " ";
+    }
+  }
+
   if (hasAttr(TAK_thin))
     Printer.printSimpleAttr("@thin") << " ";
   if (hasAttr(TAK_thick))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -355,6 +355,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_experimental_dependency_include_intrafile))
     Opts.ExperimentalDependenciesIncludeIntrafileOnes = true;
 
+  if (Args.hasArg(OPT_enable_experimental_differentiable_programming))
+    Opts.EnableExperimentalDifferentiableProgramming = true;
+
   Opts.DebuggerSupport |= Args.hasArg(OPT_debugger_support);
   if (Opts.DebuggerSupport)
     Opts.EnableDollarIdentifiers = true;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2062,7 +2062,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
   static const TypeAttrKind FunctionAttrs[] = {
     TAK_convention, TAK_pseudogeneric,
     TAK_callee_owned, TAK_callee_guaranteed, TAK_noescape, TAK_autoclosure,
-    TAK_escaping, TAK_yield_once, TAK_yield_many
+    TAK_differentiable, TAK_escaping, TAK_yield_once, TAK_yield_many
   };
 
   auto checkUnsupportedAttr = [&](TypeAttrKind attr) {
@@ -2209,6 +2209,12 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
                                          : diag::attr_only_on_parameters,
                  "@autoclosure");
         attrs.clearAttribute(TAK_autoclosure);
+      }
+
+      if (attrs.has(TAK_differentiable) &&
+          !Context.LangOpts.EnableExperimentalDifferentiableProgramming) {
+        diagnose(attrs.getLoc(TAK_differentiable),
+                 diag::experimental_differentiable_programming_disabled);
       }
 
       // Resolve the function type directly with these attributes.

--- a/test/AutoDiff/Parse/differentiable_func_type.swift
+++ b/test/AutoDiff/Parse/differentiable_func_type.swift
@@ -1,0 +1,86 @@
+// RUN: %target-swift-frontend -dump-parse -verify %s | %FileCheck %s
+
+let a: @differentiable (Float) -> Float // okay
+// CHECK: (pattern_named 'a'
+// CHECK-NEXT: (type_attributed attrs=@differentiable{{[^(]}}
+
+let b: @differentiable(linear) (Float) -> Float // okay
+// CHECK: (pattern_named 'b'
+// CHECK-NEXT: (type_attributed attrs=@differentiable(linear)
+
+// Generic type test.
+struct A<T> {
+  func foo() {
+    let local: @differentiable(linear) (T) -> T // okay
+    // CHECK: (pattern_named 'local'
+    // CHECK-NEXT: (type_attributed attrs=@differentiable(linear)
+  }
+}
+
+// expected-error @+1 {{expected ')' in '@differentiable' attribute}}
+let c: @differentiable(linear (Float) -> Float
+
+// expected-error @+1 {{expected ')' in '@differentiable' attribute}}
+let c: @differentiable(notValidArg (Float) -> Float
+
+// expected-error @+1 {{unexpected argument 'notValidArg' in '@differentiable' attribute}}
+let d: @differentiable(notValidArg) (Float) -> Float
+
+// Using 'linear' as a type
+struct B {
+  struct linear {}
+  let propertyB1: @differentiable (linear) -> Float // okay
+  // CHECK: (pattern_named 'propertyB1'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable{{[^(]}}
+
+  let propertyB2: @differentiable(linear) (linear) -> linear // okay
+  // CHECK: (pattern_named 'propertyB2'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable(linear)
+
+  let propertyB3: @differentiable (linear, linear) -> linear // okay
+  // CHECK: (pattern_named 'propertyB3'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable{{[^(]}}
+
+  let propertyB4: @differentiable (linear, Float) -> linear // okay
+  // CHECK: (pattern_named 'propertyB4'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable{{[^(]}}
+
+  let propertyB5: @differentiable (Float, linear) -> linear // okay
+  // CHECK: (pattern_named 'propertyB5'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable{{[^(]}}
+
+  let propertyB6: @differentiable(linear) (linear, linear, Float, linear)
+    -> Float // okay
+  // CHECK: (pattern_named 'propertyB6'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable(linear)
+
+  // expected-error @+1 {{expected ')' in '@differentiable' attribute}}
+  let propertyB7: @differentiable(linear (linear) -> Float
+}
+
+// Using 'linear' as a typealias
+struct C {
+  typealias linear = (C) -> C
+  let propertyC1: @differentiable (linear) -> Float // okay
+  // CHECK: (pattern_named 'propertyC1'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable{{[^(]}}
+
+  let propertyC2: @differentiable(linear) (linear) -> linear // okay
+  // CHECK: (pattern_named 'propertyC2'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable(linear)
+
+  let propertyC3: @differentiable linear // okay
+  // CHECK: (pattern_named 'propertyC3'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable{{[^(]}}
+
+  let propertyC4: linear // okay
+  // CHECK: (pattern_named 'propertyC4'
+
+  let propertyC5: @differentiable(linear) linear // okay
+  // CHECK: (pattern_named 'propertyC5'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable(linear)
+
+  let propertyC6: @differentiable(linear) @convention(c) linear // okay
+  // CHECK: (pattern_named 'propertyC6'
+  // CHECK-NEXT: (type_attributed attrs=@differentiable(linear)
+}

--- a/test/AutoDiff/Sema/differentiable_features_disabled.swift
+++ b/test/AutoDiff/Sema/differentiable_features_disabled.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// expected-error @+1 {{differentiable programming is an experimental feature that is currently disabled}}
+let _: @differentiable (Float) -> Float

--- a/test/AutoDiff/Sema/differentiable_func_type.swift
+++ b/test/AutoDiff/Sema/differentiable_func_type.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -enable-experimental-differentiable-programming -typecheck -verify %s
+
+// expected-error @+1 {{@differentiable attribute only applies to function types}}
+let _: @differentiable Float
+
+let _: @differentiable (Float) -> Float


### PR DESCRIPTION
Adds parsing for a type attribute `@differentiable`, which is optionally allowed to have argument `@differentiable(linear)`.

The typechecker currently rejects all uses of `@differentiable` with "error: attribute does not apply to type". Future work (https://bugs.swift.org/browse/TF-871 https://bugs.swift.org/browse/TF-873) will update the typechecker to allow this attribute in places where it is allowed.

Resolves https://bugs.swift.org/browse/TF-822.