### PR TITLE
[AutoDiff] Destroy all pullback indirect results after adjoint accumulation.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -6955,7 +6955,6 @@ public:
       auto tan = *allResultsIt++;
       if (tan->getType().isAddress()) {
         addToAdjointBuffer(bb, origArg, tan, loc);
-        builder.emitDestroyAddrAndFold(loc, tan);
       } else {
         if (origArg->getType().isAddress()) {
           auto *tmpBuf = builder.createAllocStack(loc, tan->getType());
@@ -6971,9 +6970,11 @@ public:
         }
       }
     }
-    // Deallocate pullback indirect results.
-    for (auto *alloc : reversed(pullbackIndirectResults))
+    // Destroy and deallocate pullback indirect results.
+    for (auto *alloc : reversed(pullbackIndirectResults)) {
+      builder.emitDestroyAddrAndFold(loc, alloc);
       builder.createDeallocStack(loc, alloc);
+    }
   }
 
   /// Handle `struct` instruction.

--- a/test/AutoDiff/superset_adjoint.swift
+++ b/test/AutoDiff/superset_adjoint.swift
@@ -41,6 +41,14 @@ SupersetVJPTests.test("SubsetOfSubset") {
   expectEqual(0, gradient(at: 0, in: { x in foo(x, 0, 0) }))
 }
 
+SupersetVJPTests.test("ApplySubset") {
+  @differentiable(wrt: x)
+  func foo<T: Differentiable>(_ x: T, _ y: T, apply: @differentiable (T, T) -> T) -> T {
+    return apply(x, y)
+  }
+  expectEqual(1, gradient(at: Float(0)) { x in foo(x, 0) { $0 + $1 } })
+}
+
 // FIXME: The expression `(+) as @differentiable (Float, @nondiff Float) -> Float)`
 // forms a curry thunk of `Float.+` before conversion to @differentiable, and AD
 // doesn't know how to differentiate the curry thunk, so it produces a


### PR DESCRIPTION
When we differentiate a function (example below) with respect to a proper subset of its indirect parameters and when the function only has a derivative with respect to a proper superset of those indirect parameters, the pullback returns more indirect results than we need. However, unneeded indirect results are not destroyed, which causes a memory lifetime verification failure. This patch fixes this bug by releasing all pullback indirect results instead of just releasing the ones needed for calculating the derivative.

```swift
@differentiable(wrt: x)
func foo<T: Differentiable>(_ x: T, _ y: T, apply: @differentiable (T, T) -> T) -> T {
  return apply(x, y)
}
```

This patch also uncomments a test in test/AutoDiff/superset_adjoint.swift which is now passing. This fixed a FIXME.

Resolves [TF-914](https://bugs.swift.org/browse/TF-914).