### PR TITLE
[WIP] Refactor function builders to rewriting statements

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -208,6 +208,14 @@ public:
     llvm_unreachable("unexpected AnyFunctionRef representation");
   }
 
+  friend bool operator==(AnyFunctionRef lhs, AnyFunctionRef rhs) {
+    return lhs.TheFunction == rhs.TheFunction;
+  }
+
+  friend bool operator!=(AnyFunctionRef lhs, AnyFunctionRef rhs) {
+    return lhs.TheFunction != rhs.TheFunction;
+  }
+
 private:
   ArrayRef<AnyFunctionType::Yield>
   getYieldResultsImpl(SmallVectorImpl<AnyFunctionType::Yield> &buffer,

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -948,8 +948,6 @@ TypeChecker::applyFunctionBuilderBodyTransform(FuncDecl *func,
                           /*calleeLocator=*/nullptr,
                           /*FIXME:*/ConstraintLocatorBuilder(nullptr));
 
-  // FIXME: Do we wire up the contextual type in the constraint system?
-
   // Solve the constraint system.
   SmallVector<Solution, 4> solutions;
   if (cs.solve(solutions) || solutions.size() != 1) {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -53,7 +53,7 @@ private:
   Expr *buildCallIfWanted(SourceLoc loc,
                           Identifier fnName, ArrayRef<Expr *> args,
                           ArrayRef<Identifier> argLabels,
-                          bool allowOneWay) {
+                          bool oneWay) {
     if (!wantExpr)
       return nullptr;
 
@@ -87,7 +87,7 @@ private:
                                     /*trailing closure*/ nullptr,
                                     /*implicit*/true);
 
-    if (allowOneWay) {
+    if (oneWay) {
       // Form a one-way constraint to prevent backward propagation.
       result = new (ctx) OneWayExpr(result);
     }
@@ -173,10 +173,10 @@ public:
         if (builderSupports(ctx.Id_buildExpression)) {
           expr = buildCallIfWanted(expr->getLoc(), ctx.Id_buildExpression,
                                    { expr }, { Identifier() },
-                                   /*allowOneWay=*/true);
-        } else {
-          expr = new (ctx) OneWayExpr(expr);
+                                   /*oneWay=*/false);
         }
+
+        expr = new (ctx) OneWayExpr(expr);
       }
 
       expressions.push_back(expr);
@@ -186,7 +186,7 @@ public:
     return buildCallIfWanted(braceStmt->getStartLoc(),
                              ctx.Id_buildBlock, expressions,
                              /*argLabels=*/{ },
-                             /*allowOneWay=*/true);
+                             /*oneWay=*/true);
   }
 
   Expr *visitReturnStmt(ReturnStmt *stmt) {
@@ -212,7 +212,7 @@ public:
       return nullptr;
 
     return buildCallIfWanted(doStmt->getStartLoc(), ctx.Id_buildDo, arg,
-                             /*argLabels=*/{ }, /*allowOneWay=*/true);
+                             /*argLabels=*/{ }, /*oneWay=*/true);
   }
 
   CONTROL_FLOW_STMT(Yield)
@@ -299,7 +299,7 @@ public:
       chainExpr = buildCallIfWanted(ifStmt->getStartLoc(),
                                     ctx.Id_buildIf, chainExpr,
                                     /*argLabels=*/{ },
-                                    /*allowOneWay=*/true);
+                                    /*oneWay=*/true);
     } else {
       // Form a one-way constraint to prevent backward propagation.
       chainExpr = new (ctx) OneWayExpr(chainExpr);
@@ -423,7 +423,7 @@ public:
       operand = buildCallIfWanted(operand->getStartLoc(),
                                   ctx.Id_buildEither, operand,
                                   {isSecond ? ctx.Id_second : ctx.Id_first},
-                                  /*allowOneWay=*/false);
+                                  /*oneWay=*/false);
     }
 
     // Inject into Optional if required.  We'll be adding the call to

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -37,24 +37,36 @@ namespace {
 
 /// Visitor to classify the contents of the given closure.
 class BuilderClosureVisitor
-    : public StmtVisitor<BuilderClosureVisitor, Expr *> {
+    : private StmtVisitor<BuilderClosureVisitor, VarDecl *> {
+
+  friend StmtVisitor<BuilderClosureVisitor, VarDecl *>;
+
   ConstraintSystem *cs;
+  DeclContext *dc;
   ASTContext &ctx;
-  bool wantExpr;
   Type builderType;
   NominalTypeDecl *builder = nullptr;
   llvm::SmallDenseMap<Identifier, bool> supportedOps;
 
-public:
   SkipUnhandledConstructInFunctionBuilder::UnhandledNode unhandledNode;
 
-private:
-  /// Produce a builder call to the given named function with the given arguments.
+  /// Whether an error occurred during application of the builder closure,
+  /// e.g., during constraint generation.
+  bool hadError = false;
+
+  /// Counter used to give unique names to the variables that are
+  /// created implicitly.
+  unsigned varCounter = 0;
+
+  /// The record of what happened when we applied the builder transform.
+  AppliedBuilderTransform applied;
+
+  /// Produce a builder call to the given named function with the given
+  /// arguments.
   Expr *buildCallIfWanted(SourceLoc loc,
                           Identifier fnName, ArrayRef<Expr *> args,
-                          ArrayRef<Identifier> argLabels,
-                          bool oneWay) {
-    if (!wantExpr)
+                          ArrayRef<Identifier> argLabels) {
+    if (!cs)
       return nullptr;
 
     // FIXME: Setting a TypeLoc on this expression is necessary in order
@@ -67,10 +79,8 @@ private:
     }
 
     auto typeExpr = new (ctx) TypeExpr(typeLoc);
-    if (cs) {
-      cs->setType(typeExpr, MetatypeType::get(builderType));
-      cs->setType(&typeExpr->getTypeLoc(), builderType);
-    }
+    cs->setType(typeExpr, MetatypeType::get(builderType));
+    cs->setType(&typeExpr->getTypeLoc(), builderType);
 
     SmallVector<SourceLoc, 4> argLabelLocs;
     for (auto i : indices(argLabels)) {
@@ -80,17 +90,13 @@ private:
     typeExpr->setImplicit();
     auto memberRef = new (ctx) UnresolvedDotExpr(
         typeExpr, loc, fnName, DeclNameLoc(loc), /*implicit=*/true);
+    memberRef->setFunctionRefKind(FunctionRefKind::SingleApply);
     SourceLoc openLoc = args.empty() ? loc : args.front()->getStartLoc();
     SourceLoc closeLoc = args.empty() ? loc : args.back()->getEndLoc();
     Expr *result = CallExpr::create(ctx, memberRef, openLoc, args,
                                     argLabels, argLabelLocs, closeLoc,
                                     /*trailing closure*/ nullptr,
                                     /*implicit*/true);
-
-    if (oneWay) {
-      // Form a one-way constraint to prevent backward propagation.
-      result = new (ctx) OneWayExpr(result);
-    }
 
     return result;
   }
@@ -127,31 +133,109 @@ private:
     return supportedOps[fnName] = found;
   }
 
+  /// Build an implicit variable in this context.
+  VarDecl *buildVar(SourceLoc loc) {
+    // Create the implicit variable.
+    Identifier name = ctx.getIdentifier(
+        ("$__builder" + Twine(varCounter++)).str());
+    auto var = new (ctx) VarDecl(/*isStatic=*/false, VarDecl::Introducer::Var,
+                                 /*isCaptureList=*/false, loc, name, dc);
+    var->setImplicit();
+    return var;
+  }
+
+  /// Capture the given expression into an implicitly-generated variable.
+  VarDecl *captureExpr(Expr *expr, bool oneWay, Stmt* forStmt = nullptr) {
+    if (!cs)
+      return nullptr;
+
+    Expr *origExpr = expr;
+
+    if (oneWay) {
+      // Form a one-way constraint to prevent backward propagation.
+      expr = new (ctx) OneWayExpr(expr);
+    }
+
+    // Generate constraints for this expression.
+    expr = cs->generateConstraints(expr, dc);
+    if (!expr) {
+      hadError = true;
+      return nullptr;
+    }
+
+    // Create the implicit variable.
+    auto var = buildVar(expr->getStartLoc());
+
+    // Record the new variable and its corresponding expression & statement.
+    if (forStmt)
+      applied.capturedStmts.insert({forStmt, { var, { expr } }});
+    else
+      applied.capturedExprs.insert({origExpr, {var, expr}});
+
+    cs->setType(var, cs->getType(expr));
+    return var;
+  }
+
+  /// Build an implicit reference to the given variable.
+  DeclRefExpr *buildVarRef(VarDecl *var, SourceLoc loc) {
+    return new (ctx) DeclRefExpr(var, DeclNameLoc(loc), /*Implicit=*/true);
+  }
+
 public:
   BuilderClosureVisitor(ASTContext &ctx, ConstraintSystem *cs,
-                        bool wantExpr, Type builderType)
-      : cs(cs), ctx(ctx), wantExpr(wantExpr), builderType(builderType) {
+                        DeclContext *dc, Type builderType)
+      : cs(cs), dc(dc), ctx(ctx), builderType(builderType) {
     assert((cs || !builderType->hasTypeVariable()) &&
            "cannot handle builder type with type variables without "
            "constraint system");
     builder = builderType->getAnyNominal();
+    applied.builderType = builderType;
   }
 
-#define CONTROL_FLOW_STMT(StmtClass)                      \
-  Expr *visit##StmtClass##Stmt(StmtClass##Stmt *stmt) { \
-    if (!unhandledNode)                                 \
-      unhandledNode = stmt;                             \
-                                                        \
-    return nullptr;                                     \
+  /// Apply the builder transform to the given statement.
+  Optional<AppliedBuilderTransform> apply(Stmt *stmt) {
+    VarDecl *bodyVar = visit(stmt);
+    if (!bodyVar)
+      return None;
+
+    applied.returnExpr = buildVarRef(bodyVar, stmt->getEndLoc());
+    applied.returnExpr = cs->generateConstraints(applied.returnExpr, dc);
+    if (!applied.returnExpr) {
+      hadError = true;
+      return None;
+    }
+
+    return std::move(applied);
   }
 
-  Expr *visitBraceStmt(BraceStmt *braceStmt) {
+  /// Check whether the function builder can be applied to this statement.
+  /// \returns the node that cannot be handled by this builder on failure.
+  SkipUnhandledConstructInFunctionBuilder::UnhandledNode check(Stmt *stmt) {
+    (void)visit(stmt);
+    return unhandledNode;
+  }
+
+protected:
+#define CONTROL_FLOW_STMT(StmtClass)                       \
+  VarDecl *visit##StmtClass##Stmt(StmtClass##Stmt *stmt) { \
+    if (!unhandledNode)                                    \
+      unhandledNode = stmt;                                \
+                                                           \
+    return nullptr;                                        \
+  }
+
+  VarDecl *visitBraceStmt(BraceStmt *braceStmt) {
     SmallVector<Expr *, 4> expressions;
+    auto addChild = [&](VarDecl *childVar) {
+      if (!childVar)
+        return;
+
+      expressions.push_back(buildVarRef(childVar, braceStmt->getEndLoc()));
+    };
+
     for (const auto &node : braceStmt->getElements()) {
       if (auto stmt = node.dyn_cast<Stmt *>()) {
-        auto expr = visit(stmt);
-        if (expr)
-          expressions.push_back(expr);
+        addChild(visit(stmt));
         continue;
       }
 
@@ -169,27 +253,28 @@ public:
       }
 
       auto expr = node.get<Expr *>();
-      if (wantExpr) {
-        if (builderSupports(ctx.Id_buildExpression)) {
-          expr = buildCallIfWanted(expr->getLoc(), ctx.Id_buildExpression,
-                                   { expr }, { Identifier() },
-                                   /*oneWay=*/false);
-        }
-
-        expr = new (ctx) OneWayExpr(expr);
+      if (cs && builderSupports(ctx.Id_buildExpression)) {
+        expr = buildCallIfWanted(expr->getLoc(), ctx.Id_buildExpression,
+                                 { expr }, { Identifier() });
       }
 
-      expressions.push_back(expr);
+      addChild(captureExpr(expr, /*oneWay=*/true));
     }
 
+    if (!cs)
+      return nullptr;
+
     // Call Builder.buildBlock(... args ...)
-    return buildCallIfWanted(braceStmt->getStartLoc(),
-                             ctx.Id_buildBlock, expressions,
-                             /*argLabels=*/{ },
-                             /*oneWay=*/true);
+    auto call = buildCallIfWanted(braceStmt->getStartLoc(),
+                                  ctx.Id_buildBlock, expressions,
+                                  /*argLabels=*/{ });
+    if (!call)
+      return nullptr;
+
+    return captureExpr(call, /*oneWay=*/true, braceStmt);
   }
 
-  Expr *visitReturnStmt(ReturnStmt *stmt) {
+  VarDecl *visitReturnStmt(ReturnStmt *stmt) {
     // Allow implicit returns due to 'return' elision.
     if (!stmt->isImplicit() || !stmt->hasResult()) {
       if (!unhandledNode)
@@ -197,22 +282,27 @@ public:
       return nullptr;
     }
 
-    return stmt->getResult();
+    return captureExpr(stmt->getResult(), /*oneWay=*/true, stmt);
   }
 
-  Expr *visitDoStmt(DoStmt *doStmt) {
+  VarDecl *visitDoStmt(DoStmt *doStmt) {
     if (!builderSupports(ctx.Id_buildDo)) {
       if (!unhandledNode)
         unhandledNode = doStmt;
       return nullptr;
     }
 
-    auto arg = visit(doStmt->getBody());
-    if (!arg)
+    auto childVar = visit(doStmt->getBody());
+    if (!childVar)
       return nullptr;
 
-    return buildCallIfWanted(doStmt->getStartLoc(), ctx.Id_buildDo, arg,
-                             /*argLabels=*/{ }, /*oneWay=*/true);
+    auto childRef = buildVarRef(childVar, doStmt->getEndLoc());
+    auto call = buildCallIfWanted(doStmt->getStartLoc(), ctx.Id_buildDo,
+                                  childRef, /*argLabels=*/{ });
+    if (!call)
+      return nullptr;
+
+    return captureExpr(call, /*oneWay=*/true, doStmt);
   }
 
   CONTROL_FLOW_STMT(Yield)
@@ -274,7 +364,7 @@ public:
     return true;
   }
 
-  Expr *visitIfStmt(IfStmt *ifStmt) {
+  VarDecl *visitIfStmt(IfStmt *ifStmt) {
     // Check whether the chain is buildable and whether it terminates
     // without an `else`.
     bool isOptional = false;
@@ -287,74 +377,56 @@ public:
 
     // Attempt to build the chain, propagating short-circuits, which
     // might arise either do to error or not wanting an expression.
-    auto chainExpr =
-      buildIfChainRecursive(ifStmt, 0, numPayloads, isOptional);
-    if (!chainExpr)
-      return nullptr;
-    assert(wantExpr);
-
-    // The operand should have optional type if we had optional results,
-    // so we just need to call `buildIf` now, since we're at the top level.
-    if (isOptional) {
-      chainExpr = buildCallIfWanted(ifStmt->getStartLoc(),
-                                    ctx.Id_buildIf, chainExpr,
-                                    /*argLabels=*/{ },
-                                    /*oneWay=*/true);
-    } else {
-      // Form a one-way constraint to prevent backward propagation.
-      chainExpr = new (ctx) OneWayExpr(chainExpr);
-    }
-
-    return chainExpr;
+    return buildIfChainRecursive(ifStmt, 0, numPayloads, isOptional,
+                                 /*isTopLevel=*/true);
   }
 
   /// Recursively build an if-chain: build an expression which will have
   /// a value of the chain result type before any call to `buildIf`.
   /// The expression will perform any necessary calls to `buildEither`,
   /// and the result will have optional type if `isOptional` is true.
-  Expr *buildIfChainRecursive(IfStmt *ifStmt, unsigned payloadIndex,
-                              unsigned numPayloads, bool isOptional) {
+  VarDecl *buildIfChainRecursive(IfStmt *ifStmt, unsigned payloadIndex,
+                                 unsigned numPayloads, bool isOptional,
+                                 bool isTopLevel = false) {
     assert(payloadIndex < numPayloads);
     // Make sure we recursively visit both sides even if we're not
     // building expressions.
 
     // Build the then clause.  This will have the corresponding payload
     // type (i.e. not wrapped in any way).
-    Expr *thenArg = visit(ifStmt->getThenStmt());
+    VarDecl *thenVar = visit(ifStmt->getThenStmt());
 
     // Build the else clause, if present.  If this is from an else-if,
     // this will be fully wrapped; otherwise it will have the corresponding
     // payload type (at index `payloadIndex + 1`).
     assert(ifStmt->getElseStmt() || isOptional);
     bool isElseIf = false;
-    Optional<Expr *> elseChain;
+    Optional<VarDecl *> elseChainVar;
     if (auto elseStmt = ifStmt->getElseStmt()) {
       if (auto elseIfStmt = dyn_cast<IfStmt>(elseStmt)) {
         isElseIf = true;
-        elseChain = buildIfChainRecursive(elseIfStmt, payloadIndex + 1,
-                                          numPayloads, isOptional);
+        elseChainVar = buildIfChainRecursive(elseIfStmt, payloadIndex + 1,
+                                             numPayloads, isOptional);
       } else {
-        elseChain = visit(elseStmt);
+        elseChainVar = visit(elseStmt);
       }
     }
 
     // Short-circuit if appropriate.
-    if (!wantExpr || !thenArg || (elseChain && !*elseChain))
+    if (!cs || !thenVar || (elseChainVar && !*elseChainVar))
       return nullptr;
 
-    // Okay, build the conditional expression.
-
     // Prepare the `then` operand by wrapping it to produce a chain result.
-    SourceLoc thenLoc = ifStmt->getThenStmt()->getStartLoc();
-    Expr *thenExpr = buildWrappedChainPayload(thenArg, payloadIndex,
-                                              numPayloads, isOptional);
+    Expr *thenExpr = buildWrappedChainPayload(
+        buildVarRef(thenVar, ifStmt->getThenStmt()->getEndLoc()),
+        payloadIndex, numPayloads, isOptional);
 
     // Prepare the `else operand:
     Expr *elseExpr;
     SourceLoc elseLoc;
 
     // - If there's no `else` clause, use `Optional.none`.
-    if (!elseChain) {
+    if (!elseChainVar) {
       assert(isOptional);
       elseLoc = ifStmt->getEndLoc();
       elseExpr = buildNoneExpr(elseLoc);
@@ -362,24 +434,75 @@ public:
     // - If there's an `else if`, the chain expression from that
     //   should already be producing a chain result.
     } else if (isElseIf) {
-      elseExpr = *elseChain;
+      elseExpr = buildVarRef(*elseChainVar, ifStmt->getEndLoc());
       elseLoc = ifStmt->getElseLoc();
 
     // - Otherwise, wrap it to produce a chain result.
     } else {
       elseLoc = ifStmt->getElseLoc();
-      elseExpr = buildWrappedChainPayload(*elseChain,
-                                          payloadIndex + 1, numPayloads,
-                                          isOptional);
+      elseExpr = buildWrappedChainPayload(
+          buildVarRef(*elseChainVar, ifStmt->getEndLoc()),
+          payloadIndex + 1, numPayloads, isOptional);
     }
 
-    Expr *condition = getTrivialBooleanCondition(ifStmt->getCond());
-    assert(condition && "checked by isBuildableIfChain");
+    // Generate constraints for the various subexpressions.
+    auto condExpr = getTrivialBooleanCondition(ifStmt->getCond());
+    assert(condExpr && "Cannot get here without a trivial Boolean condition");
+    condExpr = cs->generateConstraints(condExpr, dc);
+    if (!condExpr) {
+      hadError = true;
+      return nullptr;
+    }
 
-    auto ifExpr = new (ctx) IfExpr(condition, thenLoc, thenExpr,
-                                   elseLoc, elseExpr);
-    ifExpr->setImplicit();
-    return ifExpr;
+    // Condition must convert to Bool.
+    // FIXME: This should be folded into constraint generation for conditions.
+    auto boolDecl = ctx.getBoolDecl();
+    if (!boolDecl) {
+      hadError = true;
+      return nullptr;
+    }
+    cs->addConstraint(ConstraintKind::Conversion,
+                      cs->getType(condExpr),
+                      boolDecl->getDeclaredType(),
+                      cs->getConstraintLocator(condExpr));
+
+    // The operand should have optional type if we had optional results,
+    // so we just need to call `buildIf` now, since we're at the top level.
+    if (isOptional && isTopLevel) {
+      thenExpr = buildCallIfWanted(ifStmt->getEndLoc(), ctx.Id_buildIf,
+                                   thenExpr,  /*argLabels=*/{ });
+      elseExpr = buildCallIfWanted(ifStmt->getEndLoc(), ctx.Id_buildIf,
+                                   elseExpr,  /*argLabels=*/{ });
+    }
+
+    thenExpr = cs->generateConstraints(thenExpr, dc);
+    if (!thenExpr) {
+      hadError = true;
+      return nullptr;
+    }
+
+    elseExpr = cs->generateConstraints(elseExpr, dc);
+    if (!elseExpr) {
+      hadError = true;
+      return nullptr;
+    }
+
+    // FIXME: Need a locator for the "if" statement.
+    Type resultType = cs->addJoinConstraint(nullptr,
+        {
+          { cs->getType(thenExpr), cs->getConstraintLocator(thenExpr) },
+          { cs->getType(elseExpr), cs->getConstraintLocator(elseExpr) }
+        });
+    if (!resultType) {
+      hadError = true;
+      return nullptr;
+    }
+
+    // Create a variable to capture the result of this expression.
+    auto ifVar = buildVar(ifStmt->getStartLoc());
+    cs->setType(ifVar, resultType);
+    applied.capturedStmts.insert({ifStmt, { ifVar, { thenExpr, elseExpr }}});
+    return ifVar;
   }
 
   /// Wrap a payload value in an expression which will produce a chain
@@ -422,8 +545,7 @@ public:
       bool isSecond = (path & 1);
       operand = buildCallIfWanted(operand->getStartLoc(),
                                   ctx.Id_buildEither, operand,
-                                  {isSecond ? ctx.Id_second : ctx.Id_first},
-                                  /*oneWay=*/false);
+                                  {isSecond ? ctx.Id_second : ctx.Id_first});
     }
 
     // Inject into Optional if required.  We'll be adding the call to
@@ -477,14 +599,329 @@ public:
 #undef CONTROL_FLOW_STMT
 };
 
+/// Describes the target into which the result of a particular statement in
+/// a closure involving a function builder should be written.
+struct FunctionBuilderTarget {
+  enum Kind {
+    /// The resulting value is returned from the closure.
+    ReturnValue,
+    /// The temporary variable into which the result should be assigned.
+    TemporaryVar,
+  } kind;
+
+  /// Captured variable information.
+  std::pair<VarDecl *, llvm::TinyPtrVector<Expr *>> captured;
+
+  static FunctionBuilderTarget forReturn(Expr *expr) {
+    return FunctionBuilderTarget{ReturnValue, {nullptr, {expr}}};
+  }
+
+  static FunctionBuilderTarget forAssign(VarDecl *temporaryVar,
+                                         llvm::TinyPtrVector<Expr *> exprs) {
+    return FunctionBuilderTarget{TemporaryVar, {temporaryVar, exprs}};
+  }
+};
+
+/// Handles the rewrite of the body of a closure to which a function builder
+/// has been applied.
+class BuilderClosureRewriter
+    : public StmtVisitor<BuilderClosureRewriter, Stmt *, FunctionBuilderTarget> {
+  ASTContext &ctx;
+  const Solution &solution;
+  DeclContext *dc;
+  AppliedBuilderTransform builderTransform;
+  std::function<Expr *(Expr *)> rewriteExpr;
+
+  /// Retrieve the temporary variable that will be used to capture the
+  /// value of the given expression.
+  AppliedBuilderTransform::RecordedExpr takeCapturedExpr(Expr *expr) {
+    auto found = builderTransform.capturedExprs.find(expr);
+    assert(found != builderTransform.capturedExprs.end());
+
+    // Set the type of the temporary variable.
+    auto recorded = found->second;
+    if (auto temporaryVar = recorded.temporaryVar) {
+      Type type = solution.simplifyType(solution.getType(temporaryVar));
+      temporaryVar->setInterfaceType(type);
+    }
+
+    // Erase the captured expression, so we're sure we never do this twice.
+    builderTransform.capturedExprs.erase(found);
+    return recorded;
+  }
+
+public:
+  /// Retrieve information about a captured statement.
+  std::pair<VarDecl *, llvm::TinyPtrVector<Expr *>>
+  takeCapturedStmt(Stmt *stmt) {
+    auto found = builderTransform.capturedStmts.find(stmt);
+    assert(found != builderTransform.capturedStmts.end());
+
+    // Set the type of the temporary variable.
+    auto temporaryVar = found->second.first;
+    Type type = solution.simplifyType(solution.getType(temporaryVar));
+    temporaryVar->setInterfaceType(type);
+
+    // Take the expressions.
+    auto exprs = std::move(found->second.second);
+
+    // Erase the statement, so we're sure we never do this twice.
+    builderTransform.capturedStmts.erase(found);
+    return std::make_pair(temporaryVar, std::move(exprs));
+  }
+
+private:
+  /// Build the statement or expression to initialize the target.
+  ASTNode initializeTarget(FunctionBuilderTarget target) {
+    assert(target.captured.second.size() == 1);
+    auto capturedExpr = target.captured.second.front();
+    auto finalCapturedExpr = rewriteExpr(capturedExpr);
+    SourceLoc implicitLoc = capturedExpr->getEndLoc();
+    switch (target.kind) {
+    case FunctionBuilderTarget::ReturnValue: {
+      // Return the expression.
+      ConstraintSystem &cs = solution.getConstraintSystem();
+      finalCapturedExpr = cs.addImplicitLoadExpr(finalCapturedExpr);
+      return new (ctx) ReturnStmt(implicitLoc, finalCapturedExpr);
+    }
+
+    case FunctionBuilderTarget::TemporaryVar: {
+      // Assign the expression into a variable.
+      auto temporaryVar = target.captured.first;
+      auto declRef = new (ctx) DeclRefExpr(
+          temporaryVar, DeclNameLoc(implicitLoc), /*implicit=*/true);
+      declRef->setType(LValueType::get(temporaryVar->getType()));
+
+      auto assign = new (ctx) AssignExpr(
+          declRef, implicitLoc, finalCapturedExpr, /*implicit=*/true);
+      assign->setType(TupleType::getEmpty(ctx));
+      return assign;
+    }
+    }
+  }
+
+  /// Declare the given temporary variable, adding the appropriate
+  /// entries to the elements of a brace stmt.
+  void declareTemporaryVariable(VarDecl *temporaryVar,
+                                std::vector<ASTNode> &elements) {
+    if (!temporaryVar)
+      return;
+
+    // Form a new pattern binding to bind the temporary variable to the
+    // transformed expression.
+    auto pattern = new (ctx) NamedPattern(temporaryVar,/*implicit=*/true);
+    pattern->setType(temporaryVar->getType());
+
+    auto pbd = PatternBindingDecl::createImplicit(ctx, StaticSpellingKind::None, pattern, nullptr, dc);
+    elements.push_back(temporaryVar);
+    elements.push_back(pbd);
+  }
+
+public:
+  BuilderClosureRewriter(const Solution &solution,
+                         DeclContext *dc,
+                         const AppliedBuilderTransform &builderTransform,
+                         std::function<Expr *(Expr *)> rewriteExpr)
+    : ctx(solution.getConstraintSystem().getASTContext()),
+      solution(solution), dc(dc), builderTransform(builderTransform),
+      rewriteExpr(rewriteExpr) { }
+
+  Stmt *visitBraceStmt(BraceStmt *braceStmt, FunctionBuilderTarget target,
+                       Optional<FunctionBuilderTarget> innerTarget = None) {
+    std::vector<ASTNode> newElements;
+
+    // If there is an "inner" target corresponding to this brace, declare
+    // it's temporary variable if needed.
+    if (innerTarget) {
+      declareTemporaryVariable(innerTarget->captured.first, newElements);
+    }
+
+    for (const auto node : braceStmt->getElements()) {
+      if (auto expr = node.dyn_cast<Expr *>()) {
+        // Each expression turns into a 'let' that captures the value of
+        // the expression.
+        auto recorded = takeCapturedExpr(expr);
+
+        // Rewrite the expression
+        Expr *finalExpr = rewriteExpr(recorded.generatedExpr);
+
+        // Form a new pattern binding to bind the temporary variable to the
+        // transformed expression.
+        auto pattern = new (ctx) NamedPattern(
+            recorded.temporaryVar, /*implicit=*/true);
+        pattern->setType(recorded.temporaryVar->getType());
+        newElements.push_back(recorded.temporaryVar);
+
+        auto pbd = PatternBindingDecl::createImplicit(ctx, StaticSpellingKind::None, pattern, finalExpr, dc);
+        newElements.push_back(pbd);
+        continue;
+      }
+
+      if (auto stmt = node.dyn_cast<Stmt *>()) {
+        // Each statement turns into a (potential) temporary variable
+        // binding followed by the statement itself.
+        auto captured = takeCapturedStmt(stmt);
+
+        declareTemporaryVariable(captured.first, newElements);
+
+        Stmt *finalStmt = visit(
+            stmt,
+            FunctionBuilderTarget{FunctionBuilderTarget::TemporaryVar,
+                                  std::move(captured)});
+        newElements.push_back(finalStmt);
+        continue;
+      }
+
+      llvm_unreachable("Cannot yet handle declarations");
+    }
+
+    // If there is an "inner" target corresponding to this brace, initialize
+    // it.
+    if (innerTarget) {
+      newElements.push_back(initializeTarget(*innerTarget));
+    }
+
+    // Capture the result of the buildBlock() call in the manner requested
+    // by the caller.
+    newElements.push_back(initializeTarget(target));
+
+    return BraceStmt::create(ctx, braceStmt->getLBraceLoc(), newElements,
+                             braceStmt->getRBraceLoc());
+  }
+
+  Stmt *visitIfStmt(IfStmt *ifStmt, FunctionBuilderTarget target) {
+    // Rewrite the condition.
+    // FIXME: We should handle the whole condition within the type system.
+    auto cond = ifStmt->getCond();
+    auto condExpr = cond.front().getBoolean();
+    auto finalCondExpr = rewriteExpr(condExpr);
+    cond.front().setBoolean(finalCondExpr);
+    ifStmt->setCond(cond);
+
+    assert(target.kind == FunctionBuilderTarget::TemporaryVar);
+    auto temporaryVar = target.captured.first;
+
+    // Translate the "then" branch.
+    auto capturedThen = takeCapturedStmt(ifStmt->getThenStmt());
+    auto newThen = visitBraceStmt(cast<BraceStmt>(ifStmt->getThenStmt()),
+          FunctionBuilderTarget::forAssign(
+            temporaryVar, {target.captured.second[0]}),
+          FunctionBuilderTarget::forAssign(
+            capturedThen.first, {capturedThen.second.front()}));
+    ifStmt->setThenStmt(newThen);
+
+    if (auto elseBraceStmt =
+            dyn_cast_or_null<BraceStmt>(ifStmt->getElseStmt())) {
+      // Translate the "else" branch when it's a stmt-brace.
+      auto capturedElse = takeCapturedStmt(elseBraceStmt);
+      Stmt *newElse = visitBraceStmt(
+          elseBraceStmt,
+          FunctionBuilderTarget::forAssign(
+            temporaryVar, {target.captured.second[1]}),
+          FunctionBuilderTarget::forAssign(
+            capturedElse.first, {capturedElse.second.front()}));
+      ifStmt->setElseStmt(newElse);
+    } else if (auto elseIfStmt = cast_or_null<IfStmt>(ifStmt->getElseStmt())){
+      // Translate the "else" branch when it's an else-if.
+      auto capturedElse = takeCapturedStmt(elseIfStmt);
+      std::vector<ASTNode> newElseElements;
+      declareTemporaryVariable(capturedElse.first, newElseElements);
+      newElseElements.push_back(
+          visitIfStmt(
+            elseIfStmt,
+            FunctionBuilderTarget::forAssign(
+              capturedElse.first, capturedElse.second)));
+      newElseElements.push_back(
+          initializeTarget(
+            FunctionBuilderTarget::forAssign(
+              temporaryVar, {target.captured.second[1]})));
+
+      Stmt *newElse = BraceStmt::create(
+          ctx, elseIfStmt->getStartLoc(), newElseElements,
+          elseIfStmt->getEndLoc());
+      ifStmt->setElseStmt(newElse);
+    } else {
+      // Form an "else" brace containing an assignment to the temporary
+      // variable.
+      auto init = initializeTarget(
+          FunctionBuilderTarget::forAssign(
+            temporaryVar, {target.captured.second[1]}));
+      auto newElse = BraceStmt::create(
+          ctx, ifStmt->getEndLoc(), { init }, ifStmt->getEndLoc());
+      ifStmt->setElseStmt(newElse);
+    }
+
+    return ifStmt;
+  }
+
+  Stmt *visitDoStmt(DoStmt *doStmt, FunctionBuilderTarget target) {
+    // Each statement turns into a (potential) temporary variable
+    // binding followed by the statement itself.
+    auto body = cast<BraceStmt>(doStmt->getBody());
+    auto captured = takeCapturedStmt(body);
+
+    auto newInnerBody = cast<BraceStmt>(
+        visitBraceStmt(
+          body,
+          target,
+          FunctionBuilderTarget::forAssign(
+            captured.first, {captured.second.front()})));
+    doStmt->setBody(newInnerBody);
+    return doStmt;
+  }
+
+#define UNHANDLED_FUNCTION_BUILDER_STMT(STMT) \
+  Stmt *visit##STMT##Stmt(STMT##Stmt *stmt, FunctionBuilderTarget target) { \
+    llvm_unreachable("Function builders do not allow statement of kind " \
+                     #STMT); \
+  }
+
+  UNHANDLED_FUNCTION_BUILDER_STMT(Return)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Yield)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Guard)
+  UNHANDLED_FUNCTION_BUILDER_STMT(While)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Defer)
+  UNHANDLED_FUNCTION_BUILDER_STMT(DoCatch)
+  UNHANDLED_FUNCTION_BUILDER_STMT(RepeatWhile)
+  UNHANDLED_FUNCTION_BUILDER_STMT(ForEach)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Switch)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Case)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Catch)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Break)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Continue)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Fallthrough)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Fail)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Throw)
+  UNHANDLED_FUNCTION_BUILDER_STMT(PoundAssert)
+#undef UNHANDLED_FUNCTION_BUILDER_STMT
+};
+
 } // end anonymous namespace
+
+BraceStmt *swift::applyFunctionBuilderTransform(
+    const Solution &solution,
+    AppliedBuilderTransform applied,
+    BraceStmt *body,
+    DeclContext *dc,
+    std::function<Expr *(Expr *)> rewriteExpr) {
+  BuilderClosureRewriter rewriter(solution, dc, applied, rewriteExpr);
+  auto captured = rewriter.takeCapturedStmt(body);
+  return cast<BraceStmt>(
+    rewriter.visitBraceStmt(
+      body,
+      FunctionBuilderTarget::forReturn(applied.returnExpr),
+      FunctionBuilderTarget::forAssign(
+        captured.first, captured.second)));
+}
 
 BraceStmt *
 TypeChecker::applyFunctionBuilderBodyTransform(FuncDecl *FD,
                                                BraceStmt *body,
                                                Type builderType) {
+#if false
   // Try to build a single result expression.
-  BuilderClosureVisitor visitor(Context, nullptr,
+  // FIXME: Need a constraint system to check all of this at once. Ugh
+  BuilderClosureVisitor visitor(Context, nullptr, FD,
                                 /*wantExpr=*/true, builderType);
   Expr *returnExpr = visitor.visit(body);
   if (!returnExpr)
@@ -500,6 +937,9 @@ TypeChecker::applyFunctionBuilderBodyTransform(FuncDecl *FD,
     new (Context) ReturnStmt(loc, returnExpr, /*implicit*/ true);
   return BraceStmt::create(Context, body->getLBraceLoc(), { returnStmt },
                            body->getRBraceLoc());
+#else
+  return body;
+#endif
 }
 
 ConstraintSystem::TypeMatchResult ConstraintSystem::applyFunctionBuilder(
@@ -535,13 +975,12 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::applyFunctionBuilder(
   // function-builder translation at all.
   {
     // Check whether we can apply this specific function builder.
-    BuilderClosureVisitor visitor(getASTContext(), this,
-                                  /*wantExpr=*/false, builderType);
-    (void)visitor.visit(closure->getBody());
+    BuilderClosureVisitor visitor(getASTContext(), nullptr, closure,
+                                  builderType);
 
     // If we saw a control-flow statement or declaration that the builder
     // cannot handle, we don't have a well-formed function builder application.
-    if (visitor.unhandledNode) {
+    if (auto unhandledNode = visitor.check(closure->getBody())) {
       // If we aren't supposed to attempt fixes, fail.
       if (!shouldAttemptFixes()) {
         return getTypeMatchFailure(locator);
@@ -550,7 +989,7 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::applyFunctionBuilder(
       // Record the first unhandled construct as a fix.
       if (recordFix(
               SkipUnhandledConstructInFunctionBuilder::create(
-                *this, visitor.unhandledNode, builder,
+                *this, unhandledNode, builder,
                 getConstraintLocator(locator)))) {
         return getTypeMatchFailure(locator);
       }
@@ -573,23 +1012,13 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::applyFunctionBuilder(
     assert(!builderType->hasTypeParameter());
   }
 
-  BuilderClosureVisitor visitor(getASTContext(), this,
-                                /*wantExpr=*/true, builderType);
-  Expr *singleExpr = visitor.visit(closure->getBody());
+  BuilderClosureVisitor visitor(getASTContext(), this, closure, builderType);
 
-  // We've already pre-checked all the original expressions, but do the
-  // pre-check to the generated expression just to set up any preconditions
-  // that CSGen might have.
-  //
-  // TODO: just build the AST the way we want it in the first place.
-  if (TC.preCheckExpression(singleExpr, closure))
+  auto applied = visitor.apply(closure->getBody());
+  if (!applied)
     return getTypeMatchFailure(locator);
 
-  singleExpr = generateConstraints(singleExpr, closure);
-  if (!singleExpr)
-    return getTypeMatchFailure(locator);
-
-  Type transformedType = getType(singleExpr);
+  Type transformedType = getType(applied->returnExpr);
   assert(transformedType && "Missing type");
 
   // Record the transformation.
@@ -600,9 +1029,7 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::applyFunctionBuilder(
         return elt.first == closure;
       }) == builderTransformedClosures.end() &&
          "already transformed this closure along this path!?!");
-  builderTransformedClosures.push_back(
-      std::make_pair(closure,
-                     AppliedBuilderTransform{builderType, singleExpr}));
+  builderTransformedClosures.push_back({ closure, std::move(*applied) });
 
   // Bind the result type of the closure to the type of the transformed
   // expression.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4676,8 +4676,8 @@ namespace {
 
     const AppliedBuilderTransform *getAppliedBuilderTransform(
        ClosureExpr *closure) {
-      auto known = solution.builderTransformedClosures.find(closure);
-      return known != solution.builderTransformedClosures.end()
+      auto known = solution.builderTransformedFunctions.find(closure);
+      return known != solution.builderTransformedFunctions.end()
           ? &known->second
           : nullptr;
     }
@@ -7597,8 +7597,8 @@ bool ConstraintSystem::applySolutionFixes(Expr *E, const Solution &solution) {
 
 #if false
       if (auto *closure = dyn_cast<ClosureExpr>(E)) {
-        auto result = solution.builderTransformedClosures.find(closure);
-        if (result != solution.builderTransformedClosures.end()) {
+        auto result = solution.builderTransformedFunctions.find(closure);
+        if (result != solution.builderTransformedFunctions.end()) {
           auto *transformedExpr = result->second.singleExpr;
           // Since this closure has been transformed into something
           // else let's look inside transformed expression instead.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4369,7 +4369,7 @@ bool FailureDiagnosis::diagnoseExprFailure() {
 ///
 /// This is guaranteed to always emit an error message.
 ///
-void ConstraintSystem::diagnoseFailureForExpr(Expr *expr) {
+void ConstraintSystem::diagnoseFailureFor(SolutionApplicationTarget target) {
   // Continue simplifying any active constraints left in the system.  We can end
   // up with them because the solver bails out as soon as it sees a Failure.  We
   // don't want to leave them around in the system because later diagnostics
@@ -4378,6 +4378,12 @@ void ConstraintSystem::diagnoseFailureForExpr(Expr *expr) {
   simplify(/*ContinueAfterFailures*/true);
 
   // Look through RebindSelfInConstructorExpr to avoid weird Sema issues.
+  auto expr = target.getAsExpr();
+  if (!expr) {
+    // FIXME: Diagnostic is important here. Ugh!
+    return;
+  }
+
   if (auto *RB = dyn_cast<RebindSelfInConstructorExpr>(expr))
     expr = RB->getSubExpr();
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1082,7 +1082,9 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
               cs.getType(closure)->castTo<FunctionType>()->getResult();
           auto result =
               cs.matchFunctionBuilder(closure, functionBuilderType,
-                                      bodyResultType, calleeLocator, loc);
+                                      bodyResultType,
+                                      ConstraintKind::Conversion,
+                                      calleeLocator, loc);
           if (result.isFailure())
             return result;
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1078,9 +1078,11 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
               = paramInfo.getFunctionBuilderType(paramIdx)) {
         Expr *arg = getArgumentExpr(locator.getAnchor(), argIdx);
         if (auto closure = dyn_cast_or_null<ClosureExpr>(arg)) {
+          Type bodyResultType =
+              cs.getType(closure)->castTo<FunctionType>()->getResult();
           auto result =
-              cs.applyFunctionBuilder(closure, functionBuilderType,
-                                      calleeLocator, loc);
+              cs.matchFunctionBuilder(closure, functionBuilderType,
+                                      bodyResultType, calleeLocator, loc);
           if (result.isFailure())
             return result;
         }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -623,7 +623,7 @@ bool ConstraintSystem::Candidate::solve(
 
     // Use solve which doesn't try to filter solution list.
     // Because we want the whole set of possible domain choices.
-    cs.solve(solutions);
+    cs.solveImpl(solutions);
   }
 
   if (TC.getLangOpts().DebugConstraintSolver) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -532,7 +532,7 @@ ConstraintSystem::solveSingle(FreeTypeVariableBinding allowFreeTypeVariables,
   state.recordFixes = allowFixes;
 
   SmallVector<Solution, 4> solutions;
-  solve(solutions);
+  solveImpl(solutions);
   filterSolutions(solutions);
 
   if (solutions.size() != 1)
@@ -1236,21 +1236,20 @@ ConstraintSystem::solveImpl(Expr *&expr,
   }
 
   // Try to solve the constraint system using computed suggestions.
-  solve(expr, solutions, allowFreeTypeVariables);
+  solve(solutions, allowFreeTypeVariables);
 
   // If there are no solutions let's mark system as unsolved,
   // and solved otherwise even if there are multiple solutions still present.
   return solutions.empty() ? SolutionKind::Unsolved : SolutionKind::Solved;
 }
 
-bool ConstraintSystem::solve(Expr *const expr,
-                             SmallVectorImpl<Solution> &solutions,
+bool ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions,
                              FreeTypeVariableBinding allowFreeTypeVariables) {
   // Set up solver state.
   SolverState state(*this, allowFreeTypeVariables);
 
   // Solve the system.
-  solve(solutions);
+  solveImpl(solutions);
 
   if (TC.getLangOpts().DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
@@ -1274,7 +1273,7 @@ bool ConstraintSystem::solve(Expr *const expr,
   return solutions.empty() || getExpressionTooComplex(solutions);
 }
 
-void ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions) {
+void ConstraintSystem::solveImpl(SmallVectorImpl<Solution> &solutions) {
   assert(solverState);
 
   // If constraint system failed while trying to

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -172,8 +172,8 @@ Solution ConstraintSystem::finalize() {
   for (auto &e : CheckedConformances)
     solution.Conformances.push_back({e.first, e.second});
 
-  for (const auto &transformed : builderTransformedClosures) {
-    solution.builderTransformedClosures.insert(transformed);
+  for (const auto &transformed : builderTransformedFunctions) {
+    solution.builderTransformedFunctions.insert(transformed);
   }
 
   return solution;
@@ -244,8 +244,8 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   for (auto &conformance : solution.Conformances)
     CheckedConformances.push_back(conformance);
 
-  for (const auto &transformed : solution.builderTransformedClosures) {
-    builderTransformedClosures.push_back(transformed);
+  for (const auto &transformed : solution.builderTransformedFunctions) {
+    builderTransformedFunctions.push_back(transformed);
   }
     
   // Register any fixes produced along this path.
@@ -441,7 +441,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numCheckedConformances = cs.CheckedConformances.size();
   numDisabledConstraints = cs.solverState->getNumDisabledConstraints();
   numFavoredConstraints = cs.solverState->getNumFavoredConstraints();
-  numBuilderTransformedClosures = cs.builderTransformedClosures.size();
+  numBuilderTransformedFunctions = cs.builderTransformedFunctions.size();
 
   PreviousScore = cs.CurrentScore;
 
@@ -508,7 +508,7 @@ ConstraintSystem::SolverScope::~SolverScope() {
   truncate(cs.CheckedConformances, numCheckedConformances);
 
   /// Remove any builder transformed closures.
-  truncate(cs.builderTransformedClosures, numBuilderTransformedClosures);
+  truncate(cs.builderTransformedFunctions, numBuilderTransformedFunctions);
 
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -166,18 +166,13 @@ Solution ConstraintSystem::finalize() {
                                        DefaultedConstraints.end());
 
   for (auto &nodeType : addedNodeTypes) {
-    solution.addedNodeTypes.push_back(nodeType);
+    solution.addedNodeTypes.insert(nodeType);
   }
 
   for (auto &e : CheckedConformances)
     solution.Conformances.push_back({e.first, e.second});
 
   for (const auto &transformed : builderTransformedClosures) {
-    auto known =
-        solution.builderTransformedClosures.find(transformed.first);
-    if (known != solution.builderTransformedClosures.end()) {
-      assert(known->second.singleExpr == transformed.second.singleExpr);
-    }
     solution.builderTransformedClosures.insert(transformed);
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2465,7 +2465,7 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
 
   // If all else fails, diagnose the failure by looking through the system's
   // constraints.
-  diagnoseFailureForExpr(expr);
+  diagnoseFailureFor(expr);
   return true;
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2410,7 +2410,7 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
     state.recordFixes = true;
 
     // Solve the system.
-    solve(viable);
+    solveImpl(viable);
 
     // Check whether we have a best solution; this can happen if we found
     // a series of fixes that worked.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -817,8 +817,8 @@ Type ConstraintSystem::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
   return TC.getUnopenedTypeOfReference(
       value, baseType, UseDC,
       [&](VarDecl *var) -> Type {
-        if (auto *param = dyn_cast<ParamDecl>(var))
-          return getType(param);
+        if (Type type = getTypeIfAvailable(var))
+          return type;
 
         if (!var->hasInterfaceType()) {
           if (!var->isInvalid()) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3336,6 +3336,7 @@ public:
   /// appropriate set of constraints.
   TypeMatchResult matchFunctionBuilder(AnyFunctionRef fn, Type builderType,
                                        Type bodyResultType,
+                                       ConstraintKind bodyResultConstraintKind,
                                        ConstraintLocator *calleeLocator,
                                        ConstraintLocatorBuilder locator);
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -687,9 +687,9 @@ public:
   std::vector<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
       Conformances;
 
-  /// The set of closures that have been transformed by a function builder.
-  llvm::MapVector<ClosureExpr *, AppliedBuilderTransform>
-      builderTransformedClosures;
+  /// The set of functions that have been transformed by a function builder.
+  llvm::MapVector<AnyFunctionRef, AppliedBuilderTransform>
+      builderTransformedFunctions;
 
   /// Simplify the given type by substituting all occurrences of
   /// type variables for their fixed types.
@@ -1188,9 +1188,9 @@ private:
   std::vector<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
       CheckedConformances;
 
-  /// The set of closures that have been transformed by a function builder.
-  std::vector<std::pair<ClosureExpr *, AppliedBuilderTransform>>
-      builderTransformedClosures;
+  /// The set of functions that have been transformed by a function builder.
+  std::vector<std::pair<AnyFunctionRef, AppliedBuilderTransform>>
+      builderTransformedFunctions;
 
 public:
   /// The locators of \c Defaultable constraints whose defaults were used.
@@ -1710,7 +1710,7 @@ public:
 
     unsigned numFavoredConstraints;
 
-    unsigned numBuilderTransformedClosures;
+    unsigned numBuilderTransformedFunctions;
 
     /// The previous score.
     Score PreviousScore;
@@ -3280,10 +3280,10 @@ public:
   /// Simplify the given disjunction choice.
   void simplifyDisjunctionChoice(Constraint *choice);
 
-  /// Apply the given function builder to the closure expression.
-  /// FIXME: This is really about generating constraints for the function
-  /// builder now.
-  TypeMatchResult applyFunctionBuilder(ClosureExpr *closure, Type builderType,
+  /// Apply the given function builder to the function, generating the
+  /// appropriate set of constraints.
+  TypeMatchResult matchFunctionBuilder(AnyFunctionRef fn, Type builderType,
+                                       Type bodyResultType,
                                        ConstraintLocator *calleeLocator,
                                        ConstraintLocatorBuilder locator);
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -508,8 +508,30 @@ struct AppliedBuilderTransform {
   /// The builder type that was applied to the closure.
   Type builderType;
 
-  /// The single expression to which the closure was transformed.
-  Expr *singleExpr;
+  /// An expression whose value has been recorded for later use.
+  struct RecordedExpr {
+    /// The temporary value that captures the value of the expression, if
+    /// there is one.
+    VarDecl *temporaryVar;
+
+    /// The expression that results from generating constraints with this
+    /// particular builder.
+    Expr *generatedExpr;
+  };
+
+  /// A mapping from expressions whose values are captured by the builder
+  /// to information about the temporary variable capturing the
+  llvm::DenseMap<Expr *, RecordedExpr> capturedExprs;
+
+  /// A mapping from statements to a pair containing the implicit variable
+  /// declaration that captures the result of that expression, and the
+  /// set of expressions that can be used to produce a value for that
+  /// variable.
+  llvm::DenseMap<Stmt *, std::pair<VarDecl *, llvm::TinyPtrVector<Expr *>>>
+      capturedStmts;
+
+  /// The return expression, capturing the last value to be emitted.
+  Expr *returnExpr = nullptr;
 };
 
 /// Describes the fixed score of a solution to the constraint system.
@@ -660,7 +682,7 @@ public:
   llvm::SmallPtrSet<ConstraintLocator *, 2> DefaultedConstraints;
 
   /// The node -> type mappings introduced by this solution.
-  llvm::SmallVector<std::pair<TypedNode, Type>, 8> addedNodeTypes;
+  llvm::MapVector<TypedNode, Type> addedNodeTypes;
 
   std::vector<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
       Conformances;
@@ -737,6 +759,13 @@ public:
     if (known != overloadChoices.end())
       return known->second;
     return None;
+  }
+
+  /// Retrieve the type of the given node, as recorded in this solution.
+  Type getType(TypedNode node) const {
+    auto known = addedNodeTypes.find(node);
+    assert(known != addedNodeTypes.end());
+    return known->second;
   }
 
   LLVM_ATTRIBUTE_DEPRECATED(
@@ -1848,9 +1877,7 @@ public:
     }
 
     // Record the fact that we ascribed a type to this node.
-    if (solverState && solverState->depth > 0) {
-      addedNodeTypes.push_back({node, type});
-    }
+    addedNodeTypes.push_back({node, type});
   }
 
   /// Set the type in our type map for a given expression. The side
@@ -1931,6 +1958,15 @@ public:
   Type getType(const KeyPathExpr *KP, unsigned I) const {
     assert(hasType(KP, I) && "Expected type to have been set!");
     return KeyPathComponentTypes.find(std::make_pair(KP, I))->second;
+  }
+
+  /// Retrieve the type of the variable, if known.
+  Type getTypeIfAvailable(const VarDecl *VD) const {
+    auto known = VarTypes.find(VD);
+    if (known == VarTypes.end())
+      return Type();
+
+    return known->second;
   }
 
   /// Cache the type of the expression argument and return that same
@@ -2560,6 +2596,9 @@ public:
 
   /// Coerce the given expression to an rvalue, if it isn't already.
   Expr *coerceToRValue(Expr *expr);
+
+  /// Add implicit "load" expressions to the given expression.
+  Expr *addImplicitLoadExpr(Expr *expr);
 
   /// "Open" the given unbound type by introducing fresh type
   /// variables for generic parameters and constructing a bound generic
@@ -3242,6 +3281,8 @@ public:
   void simplifyDisjunctionChoice(Constraint *choice);
 
   /// Apply the given function builder to the closure expression.
+  /// FIXME: This is really about generating constraints for the function
+  /// builder now.
   TypeMatchResult applyFunctionBuilder(ClosureExpr *closure, Type builderType,
                                        ConstraintLocator *calleeLocator,
                                        ConstraintLocatorBuilder locator);
@@ -4431,6 +4472,25 @@ bool exprNeedsParensOutsideFollowingOperator(
 
 /// Determine whether this is a SIMD operator.
 bool isSIMDOperator(ValueDecl *value);
+
+/// Apply the given function builder transform within a specific solution
+/// to produce the rewritten body.
+///
+/// \param solution The solution to use during application, providing the
+/// specific types for each type variable.
+/// \param applied The applied builder transform.
+/// \param body The body to transform
+/// \param dc The context in which the transform occurs.
+/// \param rewriteExpr Rewrites expressions that show up in the transform
+/// to their final, type-checked versions.
+///
+/// \returns the transformed body
+BraceStmt *applyFunctionBuilderTransform(
+    const constraints::Solution &solution,
+    constraints::AppliedBuilderTransform applied,
+    BraceStmt *body,
+    DeclContext *dc,
+    std::function<Expr *(Expr *)> rewriteExpr);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2463,7 +2463,7 @@ getTypeOfCompletionOperatorImpl(TypeChecker &TC, DeclContext *DC, Expr *expr,
 
   // Attempt to solve the constraint system.
   SmallVector<Solution, 4> viable;
-  if (CS.solve(expr, viable, FreeTypeVariableBinding::Disallow))
+  if (CS.solve(viable, FreeTypeVariableBinding::Disallow))
     return nullptr;
 
   auto &solution = viable[0];
@@ -3231,7 +3231,7 @@ bool TypeChecker::typesSatisfyConstraint(Type type1, Type type2,
   if (openArchetypes) {
     assert(!unwrappedIUO && "FIXME");
     SmallVector<Solution, 4> solutions;
-    return !cs.solve(nullptr, solutions, FreeTypeVariableBinding::Allow);
+    return !cs.solve(solutions, FreeTypeVariableBinding::Allow);
   }
 
   if (auto solution = cs.solveSingle()) {
@@ -3434,7 +3434,7 @@ bool TypeChecker::convertToType(Expr *&expr, Type type, DeclContext *dc,
 
   // Attempt to solve the constraint system.
   SmallVector<Solution, 4> viable;
-  if ((cs.solve(expr, viable) || viable.size() != 1) &&
+  if ((cs.solve(viable) || viable.size() != 1) &&
       cs.salvage(viable, expr)) {
     return true;
   }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -593,7 +593,7 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
                    propertyType, emptyLocator);
 
   SmallVector<Solution, 4> solutions;
-  if (cs.solve(nullptr, solutions) || solutions.size() != 1) {
+  if (cs.solve(solutions) || solutions.size() != 1) {
     var->diagnose(diag::property_wrapper_incompatible_property,
                   propertyType, rawType);
     if (auto nominalWrapper = rawType->getAnyNominal()) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -528,14 +528,15 @@ enum class CheckedCastContextKind {
   EnumElementPattern,
 };
 
-enum class FunctionBuilderClosurePreCheck : uint8_t {
-  /// There were no problems pre-checking the closure.
+enum class FunctionBuilderBodyPrecheck : uint8_t {
+  /// There were no problems pre-checking the body for use with a function
+  /// builder.
   Okay,
 
-  /// There was an error pre-checking the closure.
+  /// There was an error pre-checking the body.
   Error,
 
-  /// The closure has a return statement.
+  /// The body has a return statement.
   HasReturnStmt,
 };
 
@@ -620,10 +621,10 @@ private:
   /// function bodies.
   bool SkipNonInlinableFunctionBodies = false;
 
-  /// Closure expressions whose bodies have already been prechecked as
+  /// Functions whose bodies have already been prechecked as
   /// part of trying to apply a function builder.
-  llvm::DenseMap<ClosureExpr *, FunctionBuilderClosurePreCheck>
-    precheckedFunctionBuilderClosures;
+  llvm::DenseMap<AnyFunctionRef, FunctionBuilderBodyPrecheck>
+    precheckedFunctionBuilderBodies;
 
   TypeChecker(ASTContext &Ctx);
   friend class ASTContext;
@@ -990,9 +991,7 @@ public:
                                           SourceLoc EndTypeCheckLoc);
   bool typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD);
 
-  BraceStmt *applyFunctionBuilderBodyTransform(FuncDecl *FD,
-                                               BraceStmt *body,
-                                               Type builderType);
+  BraceStmt *applyFunctionBuilderBodyTransform(FuncDecl *FD, Type builderType);
 
   bool typeCheckClosureBody(ClosureExpr *closure);
 
@@ -1124,15 +1123,14 @@ public:
   /// expression and folding sequence expressions.
   bool preCheckExpression(Expr *&expr, DeclContext *dc);
 
-  /// Pre-check the body of the given closure, which we are about to
+  /// Pre-check the body of the given function, which we are about to
   /// generate constraints for.
   ///
-  /// This mutates the body of the closure, but only in ways that should be
+  /// This mutates the body, but only in ways that should be
   /// valid even if we end up not actually applying the function-builder
-  /// transform: it just does a normal pre-check of all the expressions in
-  /// the closure.
-  FunctionBuilderClosurePreCheck
-  preCheckFunctionBuilderClosureBody(ClosureExpr *closure);
+  /// transform: it just does a normal pre-check of all the expressions.
+  FunctionBuilderBodyPrecheck
+  preCheckFunctionBuilderBody(AnyFunctionRef fn);
 
   /// \name Name lookup
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -993,6 +993,7 @@ public:
   BraceStmt *applyFunctionBuilderBodyTransform(FuncDecl *FD,
                                                BraceStmt *body,
                                                Type builderType);
+
   bool typeCheckClosureBody(ClosureExpr *closure);
 
   bool typeCheckTapBody(TapExpr *expr, DeclContext *DC);


### PR DESCRIPTION
Refactor the implementation of function builders so they maintain the statement structure of the closure/function body to which they are applied. This replaces the previous "fold everything into a single expression" implementation with one that is better in several regards:

* It matches better with the evolving function builder proposal/pitch document, which describes the transformation as introducing intermediate local variables to capture the results of each `buildBlock`/`buildExpression`/`buildIf`/etc. invocation. The result is easier to reason about.
* It allows generalization to statement kinds that cannot be expressed in a single expression, e.g., `if let`, although each of these will require work.
* It charts a path toward a more usable model for type checking multi-statement closures