### PR TITLE
[NFC] Get rid of #include Lexer.h from ASTContext.cpp

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -47,7 +47,6 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/StringExtras.h"
-#include "swift/Parse/Lexer.h" // bad dependency
 #include "swift/Syntax/References.h"
 #include "swift/Syntax/SyntaxArena.h"
 #include "swift/Strings.h"


### PR DESCRIPTION
The only other header that depends on Lexer.h is Sema/TypeChecker.h,
so it is safe to get rid of the #include from AST cpp files if it is
not being used without worrying about accidental transitive #includes.