### PR TITLE
TempRValueOptPass: accept try_apply as user of the temporary object

### DIFF
--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -1714,12 +1714,10 @@ bool TempRValueOptPass::collectLoads(
 
   case SILInstructionKind::LoadInst:
   case SILInstructionKind::LoadBorrowInst:
-  case SILInstructionKind::WitnessMethodInst: {
     // Loads are the end of the data flow chain. The users of the load can't
     // access the temporary storage.
     loadInsts.insert(user);
     return true;
-  }
 
   case SILInstructionKind::CopyAddrInst: {
     // copy_addr which read from the temporary are like loads.
@@ -1834,17 +1832,9 @@ bool TempRValueOptPass::tryOptimizeCopyIntoTemp(CopyAddrInst *copyInst) {
       use->set(copyInst->getSrc());
       break;
     }
-    case SILInstructionKind::StructElementAddrInst:
-    case SILInstructionKind::TupleElementAddrInst:
-    case SILInstructionKind::LoadInst:
-    case SILInstructionKind::LoadBorrowInst:
-    case SILInstructionKind::ApplyInst:
-    case SILInstructionKind::OpenExistentialAddrInst:
+    default:
       use->set(copyInst->getSrc());
       break;
-
-    default:
-      llvm_unreachable("unhandled instruction");
     }
   }
   tempObj->eraseFromParent();

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -1645,7 +1645,8 @@ bool TempRValueOptPass::collectLoads(
                             << *user);
     return false;
 
-  case SILInstructionKind::ApplyInst: {
+  case SILInstructionKind::ApplyInst:
+  case SILInstructionKind::TryApplyInst: {
     ApplySite apply(user);
 
     // Check if the function can just read from userOp.

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -31,6 +31,8 @@ bb0(%0 : $*Klass, %1 : $*Klass):
   return %9999 : $()
 }
 
+sil @throwing_function : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error)
+
 ///////////
 // Tests //
 ///////////
@@ -383,6 +385,26 @@ bb0(%0 : $*Klass):
   return %9 : $()
 }
 
+// CHECK-LABEL: sil @try_apply_argument : $@convention(thin) (@inout Klass) -> () {
+// CHECK-NOT: copy_addr
+// CHECK: try_apply {{%[0-9]+}}(%0)
+// CHECK: } // end sil function 'try_apply_argument'
+sil @try_apply_argument : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = alloc_stack $Klass
+  copy_addr %0 to [initialization] %1 : $*Klass
+  %5 = function_ref @throwing_function : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error)
+  try_apply %5(%1) : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error), normal bb1, error bb2
+bb1(%r : $()):
+  br bb3
+bb2(%e : $Error):
+  br bb3
+bb3:
+  destroy_addr %1 : $*Klass
+  dealloc_stack %1 : $*Klass
+  %9 = tuple ()
+  return %9 : $()
+}
 
 // Make sure that we can eliminate temporaries passed via a temporary rvalue to
 // an @in_guaranteed function.


### PR DESCRIPTION
So far we only handled apply, but not try_apply.

Also: some small cosmetic changes