### PR TITLE
Reenable PrintAsObjC/extensions.swift

### DIFF
--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -8,7 +8,6 @@
 // RUN: %check-in-clang %t/extensions.h
 
 // REQUIRES: objc_interop
-// REQUIRES: rdar54414986
 
 import Foundation
 import AppKit


### PR DESCRIPTION
This test was disabled to work around a bug in the ObjC generics implementation in clang. That bug was corrected by https://reviews.llvm.org/D66696, so we should now be able to turn the Swift test back on.

Fixes rdar://problem/54414986.