### PR TITLE
TF-917: fix irgen for witness method partial_apply

### DIFF
--- a/test/AutoDiff/irgen_crashers.swift
+++ b/test/AutoDiff/irgen_crashers.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+// TF-917: `partial_apply` IRGen crash.
+public protocol TF_917: Differentiable {
+  @differentiable
+  func r<A>(_ a: A) -> Float
+}
+@differentiable
+public func tf_917<B: TF_917>(_ b: B) -> Float {
+  return b.r(0.0)
+}
+


### PR DESCRIPTION
IRGen emits invalid IR for certain `partial_apply` instructions, and this PR fixes this. As far as I can tell, this is a latent issue in upstream Swift, but I can't think of any non-AD test case that would trigger this.

Explanation:

The `func tf_917` in the test case has the following SIL in its VJP:
```
  %6 = witness_method $τ_0_0, #TF_917.r!1 : <Self where Self : TF_917><A> (Self) -> (A) -> Float : $@convention(witness_method: TF_917) <τ_0_0 where τ_0_0 : TF_917><τ_1_0> (@in_guaranteed τ_1_0, @in_guaranteed τ_0_0) -> Float // user: %7
  %7 = partial_apply [callee_guaranteed] %6<τ_0_0, Double>() : $@convention(witness_method: TF_917) <τ_0_0 where τ_0_0 : TF_917><τ_1_0> (@in_guaranteed τ_1_0, @in_guaranteed τ_0_0) -> Float // user: %12
```

The `partial_apply` applies the witness method to generic arguments but does not apply it to any values.

So IRGen tries to create a forwarder that takes all the value arguments and forwards them to the witness method.

The IR signature for the witness method is `(opaque ptr to b, metatype of B, opaque ptr to self, metatype of Self, witness table for Self: TF_917)`. The fact that the self stuff goes at the end is special for witness methods. A normal function would have all the opaque ptrs first, followed by the metatypes.

However, IRGen did not have logic for handling this special case while forwarding forwarder args, so it tried to call the witness method incorrectly with `(opaque ptr to b, opaque ptr to self, metatype of B, metatype of Self, witness table for Self: TF_917)`.

This PR adds handling for this special case.