### PR TITLE
[PropertyWrappers] Fix lvalue computation in buildStorageReference

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -738,11 +738,13 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
 
   // If we're acessing a property wrapper, determine if the
   // intermediate access requires an lvalue.
-  if (auto var = dyn_cast<VarDecl>(accessor->getStorage())) {
-    if (auto mut = var->getPropertyWrapperMutability()) {
-      isMemberLValue = mut->Getter == PropertyWrapperMutability::Mutating;
-      if (isLValue)
-        isMemberLValue |= mut->Setter == PropertyWrapperMutability::Mutating;
+  if (!accessor->isCoroutine()) {
+    if (auto var = dyn_cast<VarDecl>(accessor->getStorage())) {
+      if (auto mut = var->getPropertyWrapperMutability()) {
+        isMemberLValue = mut->Getter == PropertyWrapperMutability::Mutating;
+        if (isLValue)
+          isMemberLValue |= mut->Setter == PropertyWrapperMutability::Mutating;
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -738,10 +738,12 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
 
   // If we're acessing a property wrapper, determine if the
   // intermediate access requires an lvalue.
-  if (underlyingVars.size() > 0) {
-    isMemberLValue = underlyingVars[0]->isGetterMutating();
-    if (isLValue)
-      isMemberLValue |= underlyingVars[0]->isSetterMutating();
+  if (auto var = dyn_cast<VarDecl>(accessor->getStorage())) {
+    if (auto mut = var->getPropertyWrapperMutability()) {
+      isMemberLValue = mut->Getter == PropertyWrapperMutability::Mutating;
+      if (isLValue)
+        isMemberLValue |= mut->Setter == PropertyWrapperMutability::Mutating;
+    }
   }
 
   bool isSelfLValue = storage->isGetterMutating();

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -735,22 +735,39 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
   }
 
   bool isMemberLValue = isLValue;
+  auto propertyWrapperMutability =
+      [&](Decl *decl) -> Optional<std::pair<bool, bool>> {
+    if (accessor->isCoroutine())
+      return None;
+    auto var = dyn_cast<VarDecl>(decl);
+    if (!var)
+      return None;
+    auto mut = var->getPropertyWrapperMutability();
+    if (!mut)
+      return None;
+    return std::make_pair(mut->Getter == PropertyWrapperMutability::Mutating,
+                          mut->Setter == PropertyWrapperMutability::Mutating);
+  };
 
-  // If we're acessing a property wrapper, determine if the
+  // If we're accessing a property wrapper, determine if the
   // intermediate access requires an lvalue.
-  if (!accessor->isCoroutine()) {
-    if (auto var = dyn_cast<VarDecl>(accessor->getStorage())) {
-      if (auto mut = var->getPropertyWrapperMutability()) {
-        isMemberLValue = mut->Getter == PropertyWrapperMutability::Mutating;
-        if (isLValue)
-          isMemberLValue |= mut->Setter == PropertyWrapperMutability::Mutating;
-      }
-    }
+  if (auto mut = propertyWrapperMutability(accessor->getStorage())) {
+    isMemberLValue = mut->first;
+    if (isLValue)
+      isMemberLValue |= mut->second;
   }
 
   bool isSelfLValue = storage->isGetterMutating();
   if (isMemberLValue)
     isSelfLValue |= storage->isSetterMutating();
+
+  // If we're accessing a property wrapper, determine if
+  // the self requires an lvalue.
+  if (auto mut = propertyWrapperMutability(storage)) {
+    isSelfLValue = mut->first;
+    if (isMemberLValue)
+      isSelfLValue |= mut->second;
+  }
 
   Expr *selfDRE =
     buildSelfReference(selfDecl, selfAccessKind, isSelfLValue,

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -535,7 +535,6 @@ class ClassWrapper<T> {
 
 
 struct SR_11603 {
-  // CHECK: @StructWrapper @ClassWrapper var prop: Int { get nonmutating set }
   @StructWrapper @ClassWrapper var prop: Int
 
   func foo() {

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -519,6 +519,30 @@ extension UsesMyPublished {
   }
 }
 
+// SR-11603 - crash due to incorrect lvalue computation
+@propertyWrapper
+struct StructWrapper<T> {
+  var wrappedValue: T
+}
+
+@propertyWrapper
+class ClassWrapper<T> {
+  var wrappedValue: T
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+
+struct SR_11603 {
+  // CHECK: @StructWrapper @ClassWrapper var prop: Int { get nonmutating set }
+  @StructWrapper @ClassWrapper var prop: Int
+
+  func foo() {
+    prop = 1234
+  }
+}
+
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK-NEXT:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter
 // CHECK-NEXT:  #ClassUsingWrapper.x!setter.1: (ClassUsingWrapper) -> (Int) -> () : @$s17property_wrappers17ClassUsingWrapperC1xSivs // ClassUsingWrapper.x.setter

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -533,31 +533,12 @@ class ClassWrapper<T> {
   }
 }
 
-
-struct SR_11603_1 {
+struct SR_11603 {
   @StructWrapper @ClassWrapper var prop: Int
 
   func foo() {
     prop = 1234
   }
-}
-
-@propertyWrapper
-struct MutatingGetNonMutatingSetWrapper<T> {
-  private var fixed: T
-  
-  var wrappedValue: T {
-    mutating get { fixed }
-    nonmutating set { }
-  }
-  
-  init(wrappedValue initialValue: T) {
-    fixed = initialValue
-  }
-}
-
-struct SR_11603_2 {
-  @MutatingGetNonMutatingSetWrapper var text: String = "" 
 }
 
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -534,12 +534,30 @@ class ClassWrapper<T> {
 }
 
 
-struct SR_11603 {
+struct SR_11603_1 {
   @StructWrapper @ClassWrapper var prop: Int
 
   func foo() {
     prop = 1234
   }
+}
+
+@propertyWrapper
+struct MutatingGetNonMutatingSetWrapper<T> {
+  private var fixed: T
+  
+  var wrappedValue: T {
+    mutating get { fixed }
+    nonmutating set { }
+  }
+  
+  init(wrappedValue initialValue: T) {
+    fixed = initialValue
+  }
+}
+
+struct SR_11603_2 {
+  @MutatingGetNonMutatingSetWrapper var text: String = "" 
 }
 
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {

--- a/validation-test/compiler_crashers_2/sr11637.swift
+++ b/validation-test/compiler_crashers_2/sr11637.swift
@@ -1,0 +1,21 @@
+// RUN: not --crash %target-swift-frontend -primary-file %s -emit-silgen
+
+// REQUIRES: asserts
+
+@propertyWrapper
+struct MutatingGetNonMutatingSetWrapper<T> {
+  private var fixed: T
+  
+  var wrappedValue: T {
+    mutating get { fixed }
+    nonmutating set { }
+  }
+  
+  init(wrappedValue initialValue: T) {
+    fixed = initialValue
+  }
+}
+
+struct Foo {
+  @MutatingGetNonMutatingSetWrapper var text: String
+}


### PR DESCRIPTION
When computing whether the immediate access to a property wrapper requires an lvalue, use `getPropertyWrapperMutability()` (which takes wrapper composition into consideration), instead of the first underlying property's mutating-ness. Otherwise, we will crash in SILGen if the first wrapper is a struct and the second is a class for example.

Resolves [SR-11603](https://bugs.swift.org/browse/SR-11603).
Resolves rdar://problem/56255391