### PR TITLE
[Diagnostics] Diagnose extraneous argument(s) via fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1129,6 +1129,11 @@ ERROR(extra_trailing_closure_in_call,none,
 ERROR(trailing_closure_bad_param,none,
       "trailing closure passed to parameter of type %0 that does not "
       "accept a closure", (Type))
+NOTE(candidate_with_extraneous_args,none,
+      "candidate %0 requires %1 argument%s1, "
+      "but %2 %select{were|was}3 %{select{provided|used in closure body}4",
+      (Type, unsigned, unsigned, bool, bool))
+
 ERROR(no_accessible_initializers,none,
       "%0 cannot be constructed because it has no accessible initializers",
       (Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1131,7 +1131,7 @@ ERROR(trailing_closure_bad_param,none,
       "accept a closure", (Type))
 NOTE(candidate_with_extraneous_args,none,
       "candidate %0 requires %1 argument%s1, "
-      "but %2 %select{were|was}3 %{select{provided|used in closure body}4",
+      "but %2 %select{were|was}3 %select{provided|used in closure body}4",
       (Type, unsigned, unsigned, bool, bool))
 
 ERROR(no_accessible_initializers,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1122,6 +1122,8 @@ ERROR(extra_argument_named,none,
       "extra argument %0 in call", (Identifier))
 ERROR(extra_argument_positional,none,
       "extra argument in call", ())
+ERROR(extra_arguments_in_call,none,
+      "extra arguments at positions %0 in call", (StringRef))
 ERROR(extra_argument_to_nullary_call,none,
       "argument passed to call that takes no arguments", ())
 ERROR(extra_trailing_closure_in_call,none,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2156,7 +2156,8 @@ public:
         ParamInfo(paramInfo), Arguments(args), CandidateInfo(CCI),
         IsSubscript(isSubscript) {}
 
-  void extraArgument(unsigned extraArgIdx) override {
+  bool extraArguments(ArrayRef<unsigned> extraArgIndices) override {
+    auto extraArgIdx = extraArgIndices.front();
     auto name = Arguments[extraArgIdx].getLabel();
     Expr *arg = ArgExpr;
 
@@ -2192,6 +2193,7 @@ public:
           .highlight(arg->getSourceRange());
 
     Diagnosed = true;
+    return true;
   }
 
   bool missingLabel(unsigned paramIdx) override {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2156,8 +2156,7 @@ public:
         ParamInfo(paramInfo), Arguments(args), CandidateInfo(CCI),
         IsSubscript(isSubscript) {}
 
-  bool extraArguments(ArrayRef<unsigned> extraArgIndices) override {
-    auto extraArgIdx = extraArgIndices.front();
+  bool extraArgument(unsigned extraArgIdx) override {
     auto name = Arguments[extraArgIdx].getLabel();
     Expr *arg = ArgExpr;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4310,11 +4310,16 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
 }
 
 bool ExtraneousArgumentsFailure::diagnoseAsNote() {
+  auto overload = getChoiceFor(getLocator());
+  if (!(overload && overload->choice.isDecl()))
+    return false;
+
+  auto *decl = overload->choice.getDecl();
   auto *anchor = getAnchor();
   auto numArgs = getTotalNumArguments();
-  emitDiagnostic(anchor->getLoc(), diag::candidate_with_extraneous_args,
-                 ContextualType, ContextualType->getNumParams(), numArgs,
-                 (numArgs == 1), isa<ClosureExpr>(anchor));
+  emitDiagnostic(decl, diag::candidate_with_extraneous_args, ContextualType,
+                 ContextualType->getNumParams(), numArgs, (numArgs == 1),
+                 isa<ClosureExpr>(anchor));
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4230,7 +4230,98 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
     addFixIts(emitDiagnostic(diagLoc, diag::argument_out_of_order_named_named,
                              first, second));
   }
+  return true;
+}
 
+bool ExtraneousArgumentsFailure::diagnoseAsError() {
+  // Simplified anchor would point directly to the
+  // argument in case of contextual mismatch.
+  auto *anchor = getAnchor();
+  if (auto *closure = dyn_cast<ClosureExpr>(anchor)) {
+    auto fnType = ContextualType;
+    auto params = closure->getParameters();
+
+    auto diag = emitDiagnostic(
+        params->getStartLoc(), diag::closure_argument_list_tuple, fnType,
+        fnType->getNumParams(), params->size(), (params->size() == 1));
+
+    bool onlyAnonymousParams =
+        std::all_of(params->begin(), params->end(),
+                    [](ParamDecl *param) { return !param->hasName(); });
+
+    // If closure expects no parameters but N was given,
+    // and all of them are anonymous let's suggest removing them.
+    if (fnType->getNumParams() == 0 && onlyAnonymousParams) {
+      auto inLoc = closure->getInLoc();
+      auto &sourceMgr = getASTContext().SourceMgr;
+
+      if (inLoc.isValid())
+        diag.fixItRemoveChars(params->getStartLoc(),
+                              Lexer::getLocForEndOfToken(sourceMgr, inLoc));
+    }
+    return true;
+  }
+
+  if (isContextualMismatch()) {
+    emitDiagnostic(anchor->getLoc(), diag::cannot_convert_argument_value,
+                   getType(anchor), ContextualType);
+    return true;
+  }
+
+  if (ExtraArgs.size() == 1) {
+    return diagnoseSingleExtraArgument();
+  }
+
+  return false;
+}
+
+bool ExtraneousArgumentsFailure::diagnoseAsNote() {
+  auto *anchor = getAnchor();
+  auto numArgs = getTotalNumArguments();
+  emitDiagnostic(anchor->getLoc(), diag::candidate_with_extraneous_args,
+                 ContextualType, ContextualType->getNumParams(), numArgs,
+                 (numArgs == 1), isa<ClosureExpr>(anchor));
+  return true;
+}
+
+bool ExtraneousArgumentsFailure::diagnoseSingleExtraArgument() const {
+  auto *arguments = getArgumentExprFor(getRawAnchor());
+  if (!arguments)
+    return false;
+
+  const auto &e = ExtraArgs.front();
+  auto index = e.first;
+  auto argument = e.second;
+
+  auto tuple = dyn_cast<TupleExpr>(arguments);
+  auto argExpr = tuple ? tuple->getElement(index)
+                       : cast<ParenExpr>(arguments)->getSubExpr();
+
+  auto loc = argExpr->getLoc();
+  if (tuple && index == tuple->getNumElements() - 1 &&
+      tuple->hasTrailingClosure()) {
+    emitDiagnostic(loc, diag::extra_trailing_closure_in_call)
+        .highlight(argExpr->getSourceRange());
+  } else if (ContextualType->getNumParams() == 0) {
+    auto *PE = dyn_cast<ParenExpr>(arguments);
+    Expr *subExpr = nullptr;
+    if (PE)
+      subExpr = PE->getSubExpr();
+
+    if (subExpr && argument.getPlainType()->isVoid()) {
+      emitDiagnostic(loc, diag::extra_argument_to_nullary_call)
+          .fixItRemove(subExpr->getSourceRange());
+    } else {
+      emitDiagnostic(loc, diag::extra_argument_to_nullary_call)
+          .highlight(argExpr->getSourceRange());
+    }
+  } else if (argument.hasLabel()) {
+    emitDiagnostic(loc, diag::extra_argument_named, argument.getLabel())
+        .highlight(argExpr->getSourceRange());
+  } else {
+    emitDiagnostic(loc, diag::extra_argument_positional)
+        .highlight(argExpr->getSourceRange());
+  }
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4273,7 +4273,7 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
   }
 
   if (ContextualType->getNumParams() == 0) {
-    if (auto argExpr = getArgumentExprFor(getRawAnchor())) {
+    if (auto argExpr = getArgumentListExprFor(getLocator())) {
       emitDiagnostic(anchor->getLoc(), diag::extra_argument_to_nullary_call)
           .highlight(argExpr->getSourceRange())
           .fixItRemove(argExpr->getSourceRange());
@@ -4294,7 +4294,7 @@ bool ExtraneousArgumentsFailure::diagnoseAsNote() {
 }
 
 bool ExtraneousArgumentsFailure::diagnoseSingleExtraArgument() const {
-  auto *arguments = getArgumentExprFor(getRawAnchor());
+  auto *arguments = getArgumentListExprFor(getLocator());
   if (!arguments)
     return false;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4263,7 +4263,11 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
   }
 
   if (isContextualMismatch()) {
-    emitDiagnostic(anchor->getLoc(), diag::cannot_convert_argument_value,
+    auto *locator = getLocator();
+    emitDiagnostic(anchor->getLoc(),
+                   locator->isLastElement<LocatorPathElt::ContextualType>()
+                       ? diag::cannot_convert_initializer_value
+                       : diag::cannot_convert_argument_value,
                    getType(anchor), ContextualType);
     return true;
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4272,6 +4272,15 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
     return diagnoseSingleExtraArgument();
   }
 
+  if (ContextualType->getNumParams() == 0) {
+    if (auto argExpr = getArgumentExprFor(getRawAnchor())) {
+      emitDiagnostic(anchor->getLoc(), diag::extra_argument_to_nullary_call)
+          .highlight(argExpr->getSourceRange())
+          .fixItRemove(argExpr->getSourceRange());
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1338,6 +1338,40 @@ public:
                                          ConstraintLocator *locator);
 };
 
+class ExtraneousArgumentsFailure final : public FailureDiagnostic {
+  FunctionType *ContextualType;
+  SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4> ExtraArgs;
+
+public:
+  ExtraneousArgumentsFailure(
+      Expr *root, ConstraintSystem &cs, FunctionType *contextualType,
+      ArrayRef<std::pair<unsigned, AnyFunctionType::Param>> extraArgs,
+      ConstraintLocator *locator)
+      : FailureDiagnostic(root, cs, locator),
+        ContextualType(resolveType(contextualType)->castTo<FunctionType>()),
+        ExtraArgs(extraArgs.begin(), extraArgs.end()) {}
+
+  bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
+
+private:
+  bool diagnoseSingleExtraArgument() const;
+
+  unsigned getTotalNumArguments() const {
+    return ContextualType->getNumParams() + ExtraArgs.size();
+  }
+
+  bool isContextualMismatch() const {
+    auto *locator = getLocator();
+    auto path = locator->getPath();
+
+    assert(!path.empty());
+    const auto &last = path.back();
+    return last.getKind() == ConstraintLocator::ContextualType ||
+           last.getKind() == ConstraintLocator::ApplyArgToParam;
+  }
+};
+
 class OutOfOrderArgumentFailure final : public FailureDiagnostic {
   using ParamBinding = SmallVector<unsigned, 1>;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1363,12 +1363,8 @@ private:
 
   bool isContextualMismatch() const {
     auto *locator = getLocator();
-    auto path = locator->getPath();
-
-    assert(!path.empty());
-    const auto &last = path.back();
-    return last.getKind() == ConstraintLocator::ContextualType ||
-           last.getKind() == ConstraintLocator::ApplyArgToParam;
+    return locator->isLastElement<LocatorPathElt::ContextualType>() ||
+           locator->isLastElement<LocatorPathElt::ApplyArgToParam>();
   }
 };
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -751,8 +751,15 @@ bool AllowTupleSplatForSingleParameter::attempt(
     //
     // We'd want to suggest argument list to be `x: (0, 1)` instead
     // of `(x: 0, 1)` which would be incorrect.
-    if (index == 0 && param.getLabel() == label)
-      label = Identifier();
+    if (param.hasLabel() && label == param.getLabel()) {
+      if (index == 0) {
+        label = Identifier();
+      } else {
+        // If label match anything other than first argument,
+        // this can't be a tuple splat.
+        return true;
+      }
+    }
 
     // Tuple can't have `inout` elements.
     if (flags.isInOut())

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -498,11 +498,13 @@ bool RemoveExtraneousArguments::diagnose(Expr *root, bool asNote) const {
 
 RemoveExtraneousArguments *
 RemoveExtraneousArguments::create(ConstraintSystem &cs,
+                                  FunctionType *contextualType,
                                   llvm::ArrayRef<unsigned> extraArgs,
                                   ConstraintLocator *locator) {
   unsigned size = totalSizeToAlloc<unsigned>(extraArgs.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(RemoveExtraneousArguments));
-  return new (mem) RemoveExtraneousArguments(cs, extraArgs, locator);
+  return new (mem)
+      RemoveExtraneousArguments(cs, contextualType, extraArgs, locator);
 }
 
 bool MoveOutOfOrderArgument::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -493,7 +493,10 @@ AddMissingArguments::create(ConstraintSystem &cs,
 }
 
 bool RemoveExtraneousArguments::diagnose(Expr *root, bool asNote) const {
-  return false;
+  ExtraneousArgumentsFailure failure(root, getConstraintSystem(),
+                                     ContextualType, getExtraArguments(),
+                                     getLocator());
+  return failure.diagnose(asNote);
 }
 
 RemoveExtraneousArguments *RemoveExtraneousArguments::create(

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -492,6 +492,19 @@ AddMissingArguments::create(ConstraintSystem &cs,
   return new (mem) AddMissingArguments(cs, synthesizedArgs, locator);
 }
 
+bool RemoveExtraneousArguments::diagnose(Expr *root, bool asNote) const {
+  return false;
+}
+
+RemoveExtraneousArguments *
+RemoveExtraneousArguments::create(ConstraintSystem &cs,
+                                  llvm::ArrayRef<unsigned> extraArgs,
+                                  ConstraintLocator *locator) {
+  unsigned size = totalSizeToAlloc<unsigned>(extraArgs.size());
+  void *mem = cs.getAllocator().Allocate(size, alignof(RemoveExtraneousArguments));
+  return new (mem) RemoveExtraneousArguments(cs, extraArgs, locator);
+}
+
 bool MoveOutOfOrderArgument::diagnose(Expr *root, bool asNote) const {
   OutOfOrderArgumentFailure failure(root, getConstraintSystem(), ArgIdx,
                                     PrevArgIdx, Bindings, getLocator());

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -496,12 +496,10 @@ bool RemoveExtraneousArguments::diagnose(Expr *root, bool asNote) const {
   return false;
 }
 
-RemoveExtraneousArguments *
-RemoveExtraneousArguments::create(ConstraintSystem &cs,
-                                  FunctionType *contextualType,
-                                  llvm::ArrayRef<unsigned> extraArgs,
-                                  ConstraintLocator *locator) {
-  unsigned size = totalSizeToAlloc<unsigned>(extraArgs.size());
+RemoveExtraneousArguments *RemoveExtraneousArguments::create(
+    ConstraintSystem &cs, FunctionType *contextualType,
+    llvm::ArrayRef<IndexedParam> extraArgs, ConstraintLocator *locator) {
+  unsigned size = totalSizeToAlloc<IndexedParam>(extraArgs.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(RemoveExtraneousArguments));
   return new (mem)
       RemoveExtraneousArguments(cs, contextualType, extraArgs, locator);

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -150,6 +150,10 @@ enum class FixKind : uint8_t {
   /// by adding new arguments to the list represented as type variables.
   AddMissingArguments,
 
+  /// If there are more arguments than parameters, let's fix that up
+  /// by removing extraneous arguments.
+  RemoveExtraneousArguments,
+
   /// Allow single tuple closure parameter destructuring into N arguments.
   AllowClosureParameterDestructuring,
 
@@ -1031,6 +1035,39 @@ public:
 private:
   MutableArrayRef<Param> getSynthesizedArgumentsBuf() {
     return {getTrailingObjects<Param>(), NumSynthesized};
+  }
+};
+
+class RemoveExtraneousArguments final
+  : public ConstraintFix,
+    private llvm::TrailingObjects<RemoveExtraneousArguments, unsigned> {
+  friend TrailingObjects;
+
+  unsigned NumExtraneous;
+
+  RemoveExtraneousArguments(ConstraintSystem &cs,
+                            llvm::ArrayRef<unsigned> extraArgs,
+                            ConstraintLocator *locator)
+    : ConstraintFix(cs, FixKind::RemoveExtraneousArguments, locator),
+      NumExtraneous(extraArgs.size()) {
+    std::uninitialized_copy(extraArgs.begin(), extraArgs.end(),
+                            getExtraArgumentsBuf().begin());
+  }
+
+  public:
+  std::string getName() const override { return "remove extraneous argument(s)"; }
+
+  ArrayRef<unsigned> getExtraArguments() {
+    return {getTrailingObjects<unsigned>(), NumExtraneous};
+  }
+
+  static RemoveExtraneousArguments *create(ConstraintSystem &cs,
+                                           llvm::ArrayRef<unsigned> extraArgs,
+                                           ConstraintLocator *locator);
+
+private:
+  MutableArrayRef<unsigned> getExtraArgumentsBuf() {
+    return {getTrailingObjects<unsigned>(), NumExtraneous};
   }
 };
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1068,6 +1068,15 @@ public:
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
+  /// FIXME(diagnostics): Once `resolveDeclRefExpr` is gone this
+  /// logic would be obsolete.
+  ///
+  /// Determine whether presence of extraneous arguments indicates
+  /// potential name shadowing problem with local `min`/`max` shadowing
+  /// global definitions with different number of arguments.
+  static bool isMinMaxNameShadowing(ConstraintSystem &cs,
+                                    ConstraintLocatorBuilder locator);
+
   static RemoveExtraneousArguments *
   create(ConstraintSystem &cs, FunctionType *contextualType,
          llvm::ArrayRef<IndexedParam> extraArgs, ConstraintLocator *locator);

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1043,13 +1043,15 @@ class RemoveExtraneousArguments final
     private llvm::TrailingObjects<RemoveExtraneousArguments, unsigned> {
   friend TrailingObjects;
 
+  FunctionType *ContextualType;
   unsigned NumExtraneous;
 
   RemoveExtraneousArguments(ConstraintSystem &cs,
+                            FunctionType *contextualType,
                             llvm::ArrayRef<unsigned> extraArgs,
                             ConstraintLocator *locator)
-    : ConstraintFix(cs, FixKind::RemoveExtraneousArguments, locator),
-      NumExtraneous(extraArgs.size()) {
+      : ConstraintFix(cs, FixKind::RemoveExtraneousArguments, locator),
+        ContextualType(contextualType), NumExtraneous(extraArgs.size()) {
     std::uninitialized_copy(extraArgs.begin(), extraArgs.end(),
                             getExtraArgumentsBuf().begin());
   }
@@ -1062,6 +1064,7 @@ class RemoveExtraneousArguments final
   }
 
   static RemoveExtraneousArguments *create(ConstraintSystem &cs,
+                                           FunctionType *contextualType,
                                            llvm::ArrayRef<unsigned> extraArgs,
                                            ConstraintLocator *locator);
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1039,16 +1039,19 @@ private:
 };
 
 class RemoveExtraneousArguments final
-  : public ConstraintFix,
-    private llvm::TrailingObjects<RemoveExtraneousArguments, unsigned> {
+    : public ConstraintFix,
+      private llvm::TrailingObjects<
+          RemoveExtraneousArguments,
+          std::pair<unsigned, AnyFunctionType::Param>> {
   friend TrailingObjects;
+
+  using IndexedParam = std::pair<unsigned, AnyFunctionType::Param>;
 
   FunctionType *ContextualType;
   unsigned NumExtraneous;
 
-  RemoveExtraneousArguments(ConstraintSystem &cs,
-                            FunctionType *contextualType,
-                            llvm::ArrayRef<unsigned> extraArgs,
+  RemoveExtraneousArguments(ConstraintSystem &cs, FunctionType *contextualType,
+                            llvm::ArrayRef<IndexedParam> extraArgs,
                             ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::RemoveExtraneousArguments, locator),
         ContextualType(contextualType), NumExtraneous(extraArgs.size()) {
@@ -1056,21 +1059,22 @@ class RemoveExtraneousArguments final
                             getExtraArgumentsBuf().begin());
   }
 
-  public:
+public:
   std::string getName() const override { return "remove extraneous argument(s)"; }
 
-  ArrayRef<unsigned> getExtraArguments() {
-    return {getTrailingObjects<unsigned>(), NumExtraneous};
+  ArrayRef<IndexedParam> getExtraArguments() const {
+    return {getTrailingObjects<IndexedParam>(), NumExtraneous};
   }
 
-  static RemoveExtraneousArguments *create(ConstraintSystem &cs,
-                                           FunctionType *contextualType,
-                                           llvm::ArrayRef<unsigned> extraArgs,
-                                           ConstraintLocator *locator);
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static RemoveExtraneousArguments *
+  create(ConstraintSystem &cs, FunctionType *contextualType,
+         llvm::ArrayRef<IndexedParam> extraArgs, ConstraintLocator *locator);
 
 private:
-  MutableArrayRef<unsigned> getExtraArgumentsBuf() {
-    return {getTrailingObjects<unsigned>(), NumExtraneous};
+  MutableArrayRef<IndexedParam> getExtraArgumentsBuf() {
+    return {getTrailingObjects<IndexedParam>(), NumExtraneous};
   }
 };
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1281,8 +1281,9 @@ namespace {
       SmallVector<AnyFunctionType::Param, 8> params;
       AnyFunctionType::decomposeInput(constrParamType, params);
 
+      auto funcType = constr->getMethodInterfaceType()->castTo<FunctionType>();
       ::matchCallArguments(
-          CS, args, params, ConstraintKind::ArgumentConversion,
+          CS, funcType, args, params, ConstraintKind::ArgumentConversion,
           CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument));
 
       Type result = tv;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -849,6 +849,14 @@ public:
     return newArgIdx;
   }
 
+  bool extraArguments(ArrayRef<unsigned> argIndices) override {
+    if (!CS.shouldAttemptFixes())
+      return true;
+
+    return CS.recordFix(RemoveExtraneousArguments::create(
+        CS, argIndices, CS.getConstraintLocator(Locator)));
+  }
+
   bool missingLabel(unsigned paramIndex) override {
     return !CS.shouldAttemptFixes();
   }
@@ -1392,6 +1400,30 @@ static bool fixMissingArguments(ConstraintSystem &cs, Expr *anchor,
   return false;
 }
 
+static bool fixExtraneousArguments(ConstraintSystem &cs,
+                                   SmallVectorImpl<AnyFunctionType::Param> &args,
+                                   int numExtraneous,
+                                   ConstraintLocatorBuilder locator) {
+  auto AnyType = cs.getASTContext().TheAnyType;
+  SmallVector<unsigned, 4> extraneous;
+
+  auto argumentLocator =
+      locator.withPathElement(ConstraintLocator::FunctionArgument);
+
+  do {
+    auto param = args.pop_back_val();
+    auto index = args.size();
+
+    extraneous.push_back(index);
+    cs.addConstraint(ConstraintKind::Defaultable, param.getPlainType(), AnyType,
+                     argumentLocator.withPathElement(
+                         LocatorPathElt::getTupleElement(index)));
+  } while (--numExtraneous);
+
+  return cs.recordFix(RemoveExtraneousArguments::create(
+      cs, extraneous, cs.getConstraintLocator(locator)));
+}
+
 ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,
@@ -1617,8 +1649,10 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                               abs(diff), locator))
         return getTypeMatchFailure(argumentLocator);
     } else {
-      // TODO(diagnostics): Add handling of extraneous arguments.
-      return getTypeMatchFailure(argumentLocator);
+      // If there are extraneous arguments, let's remove
+      // them from the list.
+      if (fixExtraneousArguments(*this, func1Params, diff, locator))
+        return getTypeMatchFailure(argumentLocator);
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -998,6 +998,9 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
 
     auto extraArguments = listener.getExtraneousArguments();
     if (!extraArguments.empty()) {
+      if (RemoveExtraneousArguments::isMinMaxNameShadowing(cs, locator))
+        return cs.getTypeMatchFailure(locator);
+
       // First let's see whether this is a situation where a single
       // parameter is a tuple, but N distinct arguments were passed in.
       if (AllowTupleSplatForSingleParameter::attempt(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7874,6 +7874,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowTypeOrInstanceMember:
   case FixKind::AllowInvalidPartialApplication:
   case FixKind::AllowInvalidInitRef:
+  case FixKind::RemoveExtraneousArguments:
   case FixKind::AllowClosureParameterDestructuring:
   case FixKind::MoveOutOfOrderArgument:
   case FixKind::AllowInaccessibleMember:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -856,8 +856,19 @@ public:
     if (!CS.shouldAttemptFixes())
       return true;
 
+    // If alleged extraneous argument has a label, the problem
+    // should be diagnosed as non-matching arguments.
+    if (llvm::any_of(argIndices, [&](const unsigned idx) {
+          return Arguments[idx].hasLabel();
+        }))
+      return true;
+
+    SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4> extraneous;
+    for (const auto index : argIndices)
+      extraneous.push_back({index, Arguments[index]});
+
     return CS.recordFix(RemoveExtraneousArguments::create(
-        CS, ContextualType, argIndices, CS.getConstraintLocator(Locator)));
+        CS, ContextualType, extraneous, CS.getConstraintLocator(Locator)));
   }
 
   bool missingLabel(unsigned paramIndex) override {
@@ -1410,7 +1421,7 @@ static bool fixExtraneousArguments(ConstraintSystem &cs,
                                    int numExtraneous,
                                    ConstraintLocatorBuilder locator) {
   auto AnyType = cs.getASTContext().TheAnyType;
-  SmallVector<unsigned, 4> extraneous;
+  SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4> extraneous;
 
   auto argumentLocator =
       locator.withPathElement(ConstraintLocator::FunctionArgument);
@@ -1419,7 +1430,7 @@ static bool fixExtraneousArguments(ConstraintSystem &cs,
     auto param = args.pop_back_val();
     auto index = args.size();
 
-    extraneous.push_back(index);
+    extraneous.push_back({index, param});
     cs.addConstraint(ConstraintKind::Defaultable, param.getPlainType(), AnyType,
                      argumentLocator.withPathElement(
                          LocatorPathElt::getTupleElement(index)));

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -281,8 +281,9 @@ CalleeCandidateInfo::ClosenessResultTy CalleeCandidateInfo::evaluateCloseness(
     CandidateCloseness getResult() const {
       return result;
     }
-    void extraArgument(unsigned argIdx) override {
+    bool extraArguments(ArrayRef<unsigned> argIndices) override {
       result = CC_ArgumentCountMismatch;
+      return true;
     }
     Optional<unsigned> missingArgument(unsigned paramIdx) override {
       result = CC_ArgumentCountMismatch;

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -281,7 +281,7 @@ CalleeCandidateInfo::ClosenessResultTy CalleeCandidateInfo::evaluateCloseness(
     CandidateCloseness getResult() const {
       return result;
     }
-    bool extraArguments(ArrayRef<unsigned> argIndices) override {
+    bool extraArgument(unsigned argIdx) override {
       result = CC_ArgumentCountMismatch;
       return true;
     }

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -314,12 +314,14 @@ CalleeCandidateInfo::ClosenessResultTy CalleeCandidateInfo::evaluateCloseness(
       return true;
     }
   } listener;
-  
+
   // Use matchCallArguments to determine how close the argument list is (in
   // shape) to the specified candidates parameters.  This ignores the concrete
   // types of the arguments, looking only at the argument labels etc.
+  SmallVector<AnyFunctionType::Param, 4> arguments(actualArgs.begin(),
+                                                   actualArgs.end());
   SmallVector<ParamBinding, 4> paramBindings;
-  if (matchCallArguments(actualArgs, candArgs,
+  if (matchCallArguments(arguments, candArgs,
                          candParamInfo,
                          hasTrailingClosure,
                          /*allowFixes:*/ true,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3963,6 +3963,7 @@ bool matchCallArguments(ArrayRef<AnyFunctionType::Param> args,
 
 ConstraintSystem::TypeMatchResult
 matchCallArguments(ConstraintSystem &cs,
+                   FunctionType *contextualType,
                    ArrayRef<AnyFunctionType::Param> args,
                    ArrayRef<AnyFunctionType::Param> params,
                    ConstraintKind subKind,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3878,11 +3878,11 @@ public:
   /// Indicates that the argument at the given index does not match any
   /// parameter.
   ///
-  /// \param argIndices The indices of the extra arguments.
+  /// \param argIdx The index of the extra argument.
   ///
   /// \returns true to indicate that this should cause a failure, false
   /// otherwise.
-  virtual bool extraArguments(ArrayRef<unsigned> argIndices);
+  virtual bool extraArgument(unsigned argIdx);
 
   /// Indicates that no argument was provided for the parameter at the given
   /// indices.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3878,8 +3878,11 @@ public:
   /// Indicates that the argument at the given index does not match any
   /// parameter.
   ///
-  /// \param argIdx The index of the extra argument.
-  virtual void extraArgument(unsigned argIdx);
+  /// \param argIndices The indices of the extra arguments.
+  ///
+  /// \returns true to indicate that this should cause a failure, false
+  /// otherwise.
+  virtual bool extraArguments(ArrayRef<unsigned> argIndices);
 
   /// Indicates that no argument was provided for the parameter at the given
   /// indices.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3953,7 +3953,7 @@ public:
 /// \param parameterBindings Will be populated with the arguments that are
 /// bound to each of the parameters.
 /// \returns true if the call arguments could not be matched to the parameters.
-bool matchCallArguments(ArrayRef<AnyFunctionType::Param> args,
+bool matchCallArguments(SmallVectorImpl<AnyFunctionType::Param> &args,
                         ArrayRef<AnyFunctionType::Param> params,
                         const ParameterListInfo &paramInfo,
                         bool hasTrailingClosure,

--- a/test/ClangImporter/objc_factory_method.swift
+++ b/test/ClangImporter/objc_factory_method.swift
@@ -23,8 +23,7 @@ func testInstanceTypeFactoryMethodInherited() {
   _ = NSObjectFactorySub(integer: 1)
   _ = NSObjectFactorySub(double: 314159)
   _ = NSObjectFactorySub(float: 314159) // expected-error{{incorrect argument label in call (have 'float:', expected 'integer:')}}
-  let a = NSObjectFactorySub(buildingWidgets: ()) // expected-error{{argument labels '(buildingWidgets:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'NSObjectFactorySub' exist with these partially matching parameter lists: (double: Double), (integer: Int)}}
+  let a = NSObjectFactorySub(buildingWidgets: ()) // expected-error{{argument passed to call that takes no arguments}}
   _ = a
 }
 
@@ -76,8 +75,7 @@ func testNSErrorFactoryMethod(_ path: String) throws {
 }
 
 func testNonInstanceTypeFactoryMethod(_ s: String) {
-  _ = NSObjectFactory(string: s) // expected-error{{argument labels '(string:)' do not match any available overloads}}
-  // expected-note @-1 {{(double: Double), (float: Float), (integer: Int)}}
+  _ = NSObjectFactory(string: s) // expected-error{{argument passed to call that takes no arguments}}
 }
 
 func testUseOfFactoryMethod(_ queen: Bee) {

--- a/test/ClangImporter/objc_implicit_with.swift
+++ b/test/ClangImporter/objc_implicit_with.swift
@@ -34,8 +34,7 @@ func testInstanceTypeFactoryMethodInherited() {
   _ = NSObjectFactorySub(integer: 1)
   _ = NSObjectFactorySub(double: 314159)
   _ = NSObjectFactorySub(float: 314159) // expected-error{{incorrect argument label in call (have 'float:', expected 'integer:')}}
-  let a = NSObjectFactorySub(buildingWidgets: ()) // expected-error{{argument labels '(buildingWidgets:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'NSObjectFactorySub' exist with these partially matching parameter lists: (double: Double), (integer: Int)}}
+  let a = NSObjectFactorySub(buildingWidgets: ()) // expected-error{{argument passed to call that takes no arguments}}
   _ = a
 }
 
@@ -44,8 +43,7 @@ func testNSErrorFactoryMethod(_ path: String) throws {
 }
 
 func testNonInstanceTypeFactoryMethod(_ s: String) {
-  _ = NSObjectFactory(string: s) // expected-error{{argument labels '(string:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'NSObjectFactory' exist with these partially matching parameter lists: (double: Double), (float: Float), (integer: Int)}}
+  _ = NSObjectFactory(string: s) // expected-error{{argument passed to call that takes no arguments}}
 }
 
 func testUseOfFactoryMethod(_ queen: Bee) {

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -304,7 +304,7 @@ func simplified1069() {
 // Make sure we cannot infer an () argument from an empty parameter list.
 func acceptNothingToInt (_: () -> Int) {}
 func testAcceptNothingToInt(ac1: @autoclosure () -> Int) {
-  acceptNothingToInt({ac1($0)})
+  acceptNothingToInt({ac1($0)}) // expected-error@:27 {{argument passed to call that takes no arguments}}
   // expected-error@-1{{contextual closure type '() -> Int' expects 0 arguments, but 1 was used in closure body}}
 }
 
@@ -372,6 +372,7 @@ func rdar21078316() {
   var foo : [String : String]?
   var bar : [(String, String)]?
   bar = foo.map { ($0, $1) }  // expected-error {{contextual closure type '([String : String]) throws -> [(String, String)]' expects 1 argument, but 2 were used in closure body}}
+  // expected-error@-1:19 {{cannot convert value of type '([String : String], Any)' to closure result type '[(String, String)]'}}
 }
 
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -452,7 +452,8 @@ _ = CurriedClass.method3(1, 2)           // expected-error {{instance member 'me
 // expected-error@-1 {{missing argument label 'b:' in call}}
 CurriedClass.method3(c)(1.0, b: 1)       // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 CurriedClass.method3(c)(1)               // expected-error {{missing argument for parameter 'b' in call}}
-CurriedClass.method3(c)(c: 1.0)          // expected-error {{missing argument for parameter #1 in call}} expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+CurriedClass.method3(c)(c: 1.0)          // expected-error {{incorrect argument labels in call (have 'c:', expected '_:b:')}}
+// expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 
 
 extension CurriedClass {
@@ -909,7 +910,7 @@ struct rdar27891805 {
 }
 
 try rdar27891805(contentsOfURL: nil, usedEncoding: nil)
-// expected-error@-1 {{incorrect argument labels in call (have 'contentsOfURL:usedEncoding:', expected 'contentsOf:encoding:')}}
+// expected-error@-1 {{incorrect argument label in call (have 'contentsOfURL:usedEncoding:', expected 'contentsOf:usedEncoding:')}}
 // expected-error@-2 {{'nil' is not compatible with expected argument type 'String'}}
 // expected-error@-3 {{'nil' is not compatible with expected argument type 'String'}}
 
@@ -931,10 +932,12 @@ func valueForKey<K>(_ key: K) -> CacheValue? {
 // SR-2242: poor diagnostic when argument label is omitted
 
 func r27212391(x: Int, _ y: Int) {
+  // expected-note@-1 {{candidate '(Int, Int) -> ()' requires 2 arguments, but 3 were provided}}
   let _: Int = x + y
 }
 
 func r27212391(a: Int, x: Int, _ y: Int) {
+  // expected-note@-1 {{incorrect labels for candidate (have: '(a:y:x:)', expected: '(a:x:_:)')}}
   let _: Int = a + x + y
 }
 
@@ -946,7 +949,7 @@ r27212391(y: 3, 5)          // expected-error {{incorrect argument label in call
 r27212391(x: 3, x: 5)       // expected-error {{extraneous argument label 'x:' in call}}
 r27212391(a: 1, 3, y: 5)    // expected-error {{incorrect argument labels in call (have 'a:_:y:', expected 'a:x:_:')}}
 r27212391(1, x: 3, y: 5)    // expected-error {{incorrect argument labels in call (have '_:x:y:', expected 'a:x:_:')}}
-r27212391(a: 1, y: 3, x: 5) // expected-error {{incorrect argument labels in call (have 'a:y:x:', expected 'a:x:_:')}} {{17-18=x}} {{23-26=}}
+r27212391(a: 1, y: 3, x: 5) // expected-error {{no exact matches in call to global function 'r27212391'}}
 r27212391(a: 1, 3, x: 5)    // expected-error {{argument 'x' must precede unnamed argument #2}} {{17-17=x: 5, }} {{18-24=}}
 
 // SR-1255

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -46,7 +46,7 @@ f1(
    ) 
 
 // Tuple element unused.
-f0(i, i,
+f0(i, i, // expected-error@:7 {{cannot convert value of type 'Int' to expected argument type 'Float'}}
    i) // expected-error{{extra argument in call}}
 
 
@@ -431,11 +431,13 @@ CurriedClass.method1(c)()
 _ = CurriedClass.method1(c)
 CurriedClass.method1(c)(1)         // expected-error {{argument passed to call that takes no arguments}}
 CurriedClass.method1(2.0)(1)       // expected-error {{cannot convert value of type 'Double' to expected argument type 'CurriedClass'}}
+// expected-error@-1:27 {{argument passed to call that takes no arguments}}
 
 CurriedClass.method2(c)(32)(b: 1) // expected-error{{extraneous argument label 'b:' in call}}
 _ = CurriedClass.method2(c)
 _ = CurriedClass.method2(c)(32)
 _ = CurriedClass.method2(1,2)      // expected-error {{extra argument in call}}
+// expected-error@-1 {{instance member 'method2' cannot be used on type 'CurriedClass'; did you mean to use a value of this type instead?}}
 CurriedClass.method2(c)(1.0)(b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 // expected-error@-1 {{extraneous argument label 'b:' in call}}
 CurriedClass.method2(c)(1)(1.0) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}

--- a/test/Constraints/diagnostics_swift4.swift
+++ b/test/Constraints/diagnostics_swift4.swift
@@ -24,7 +24,7 @@ extension C_2505 {
 class C2_2505: P_2505 {
 }
 
-let c_2505 = C_2505(arg: [C2_2505()]) // expected-error {{incorrect argument label in call (have 'arg:', expected 'from:')}}
+let c_2505 = C_2505(arg: [C2_2505()]) // expected-error {{extraneous argument label 'arg:' in call}}
 
 // rdar://problem/31898542 - Swift 4: 'type of expression is ambiguous without more context' errors, without a fixit
 

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -27,8 +27,7 @@ let _ = arr.map(E.tuple) // expected-error {{cannot invoke 'map' with an argumen
 
 let _ = arr.map(G_E<String>.foo) // Ok
 let _ = arr.map(G_E<String>.bar) // Ok
-let _ = arr.map(G_E<String>.two) // expected-error {{cannot invoke 'map' with an argument list of type '(@escaping (String, String) -> G_E<String>)'}}
-// expected-note@-1{{expected an argument list of type '((Self.Element) throws -> T)'}}
+let _ = arr.map(G_E<String>.two) // expected-error {{cannot convert value of type '(String, String) -> G_E<String>' to expected argument type '(String) throws -> G_E<String>'}}
 let _ = arr.map(G_E<Int>.tuple) // expected-error {{cannot invoke 'map' with an argument list of type '(@escaping ((x: Int, y: Int)) -> G_E<Int>)'}}
 // expected-note@-1{{expected an argument list of type '((Self.Element) throws -> T)'}}
 

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -255,22 +255,20 @@ missingargs2(x: 1, y: 2) // expected-error{{missing argument for parameter #3 in
 // -------------------------------------------
 // Extra arguments
 // -------------------------------------------
-// FIXME: Diagnostics could be improved with all extra arguments and
-// note pointing to the declaration being called.
-func extraargs1(x: Int) {}
+func extraargs1(x: Int) {} // expected-note {{'extraargs1(x:)' declared here}}
 
 extraargs1(x: 1, y: 2) // expected-error{{extra argument 'y' in call}}
-extraargs1(x: 1, 2, 3) // expected-error{{extra argument in call}}
+extraargs1(x: 1, 2, 3) // expected-error{{extra arguments at positions #2, #3 in call}}
 
 // -------------------------------------------
 // Argument name mismatch
 // -------------------------------------------
 
-func mismatch1(thisFoo: Int = 0, bar: Int = 0, wibble: Int = 0) { }
+func mismatch1(thisFoo: Int = 0, bar: Int = 0, wibble: Int = 0) { } // expected-note {{'mismatch1(thisFoo:bar:wibble:)' declared here}}
 
 mismatch1(foo: 5) // expected-error {{extra argument 'foo' in call}}
 mismatch1(baz: 1, wobble: 2) // expected-error{{incorrect argument labels in call (have 'baz:wobble:', expected 'bar:wibble:')}} {{11-14=bar}} {{19-25=wibble}}
-mismatch1(food: 1, zap: 2) // expected-error{{extra argument 'food' in call}}
+mismatch1(food: 1, zap: 2) // expected-error{{extra arguments at positions #1, #2 in call}}
 
 // -------------------------------------------
 // Subscript keyword arguments

--- a/test/Constraints/rdar42678836.swift
+++ b/test/Constraints/rdar42678836.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 func foo(chr: Character) -> String {
-  return String(repeating: String(chr)) // expected-error {{incorrect argument label in call (have 'repeating:', expected 'stringLiteral:')}}
+  return String(repeating: String(chr)) // expected-error {{missing argument for parameter 'count' in call}} {{39-39=, count: <#Int#>}}
 }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1728,7 +1728,7 @@ func autoclosureSplat() {
   // wrap the closure in a function conversion.
 
   takeFn { (fn: @autoclosure () -> Int, x: Int) in }
-  // expected-error@-1 {{contextual closure type '(_) -> ()' expects 1 argument, but 2 were used in closure body}}
+  // expected-error@-1 {{contextual closure type '(@escaping () -> Int) -> ()' expects 1 argument, but 2 were used in closure body}}
 
   takeFn { (fn: @autoclosure @escaping () -> Int) in }
   // FIXME: It looks like matchFunctionTypes() does not check @autoclosure at all.
@@ -1737,7 +1737,7 @@ func autoclosureSplat() {
   // instead of changing the test.
 
   takeFn { (fn: @autoclosure @escaping () -> Int, x: Int) in }
-  // expected-error@-1 {{contextual closure type '(_) -> ()' expects 1 argument, but 2 were used in closure body}}
+  // expected-error@-1 {{contextual closure type '(@escaping () -> Int) -> ()' expects 1 argument, but 2 were used in closure body}}
 }
 
 func noescapeSplat() {

--- a/test/NameBinding/name_lookup_min_max_conditional_conformance.swift
+++ b/test/NameBinding/name_lookup_min_max_conditional_conformance.swift
@@ -17,7 +17,6 @@ extension ContainsMinMax {
 }
 
 func foo(_: Int, _: Int) {}
-// expected-note@-1 {{'foo' declared here}}
 
 protocol ContainsFoo {}
 extension ContainsFoo {
@@ -34,9 +33,10 @@ extension NonConditional {
         _ = min(3, 4)
         // expected-error@-1{{use of 'min' refers to instance method}}
         // expected-note@-2{{use 'Swift.' to reference the global function}}
-        _ = foo(5, 6)
-        // expected-error@-1{{use of 'foo' refers to instance method}}
-        // expected-note@-2{{use 'name_lookup_min_max_conditional_conformance.' to reference the global function}}
+
+        // FIXME(diagnostics): Better diagnostic in this case would be to suggest to add `name_lookup_min_max_conditional_conformance.`
+        // to call because name `foo` is shadowed by instance method without arguments. Would be fixed by `resolveDeclRefExpr` refactoring.
+        _ = foo(5, 6) // expected-error {{argument passed to call that takes no arguments}}
     }
 }
 
@@ -52,7 +52,10 @@ extension Conditional {
         _ = min(3, 4)
         // expected-warning@-1{{use of 'min' as reference to global function in module 'Swift' will change in future versions of Swift to reference instance method in generic struct 'Conditional' which comes via a conditional conformance}}
         // expected-note@-2{{use 'Swift.' to continue to reference the global function}}
+
+        // FIXME(diagnostics): Same as line 39, there should be only one error here about shadowing.
         _ = foo(5, 6)
-        // expected-error@-1{{referencing instance method 'foo()' on 'Conditional' requires that 'T' conform to 'ContainsFoo'}}
+        // expected-error@-1 {{referencing instance method 'foo()' on 'Conditional' requires that 'T' conform to 'ContainsFoo'}}
+        // expected-error@-2 {{argument passed to call that takes no arguments}}
     }
 }

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -117,7 +117,7 @@ func genQualifiedType() {
 
 func typeOfShadowing() {
   // Try to shadow type(of:)
-  func type<T>(of t: T.Type, flag: Bool) -> T.Type {
+  func type<T>(of t: T.Type, flag: Bool) -> T.Type { // expected-note {{'type(of:flag:)' declared here}}
     return t
   }
 
@@ -133,8 +133,7 @@ func typeOfShadowing() {
     return t
   }
 
-  // TODO: Errors need improving here.
-  _ = type(of: Gen<Foo>.Bar) // expected-error{{incorrect argument label in call (have 'of:', expected 'fo:')}}
+  _ = type(of: Gen<Foo>.Bar) // expected-error{{missing argument for parameter 'flag' in call}} {{28-28=, flag: <#Bool#>}}
   _ = type(Gen<Foo>.Bar) // expected-error{{expected member name or constructor call after type name}}
   // expected-note@-1{{add arguments after the type to construct a value of the type}}
   // expected-note@-2{{use '.self' to reference the type object}}

--- a/test/Sema/call_as_function_simple.swift
+++ b/test/Sema/call_as_function_simple.swift
@@ -11,11 +11,7 @@ struct SimpleCallable {
 let foo = SimpleCallable()
 _ = foo(1)
 _ = foo(foo(1))
-
-// TODO(SR-11378): Improve this error to match the error using a direct `callAsFunction` member reference.
-// expected-error @+2 {{cannot call value of non-function type 'SimpleCallable'}}
-// expected-error @+1 {{cannot invoke 'foo' with an argument list of type '(Int, Int)'}}
-_ = foo(1, 1)
+_ = foo(1, 1) // expected-error@:12 {{extra argument in call}}
 // expected-error @+1 {{cannot convert value of type 'SimpleCallable' to specified type '(Float) -> Float'}}
 let _: (Float) -> Float = foo
 

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -235,9 +235,8 @@ struct Initialization {
   @Wrapper(stored: 17)
   var x2: Double
 
-  @Wrapper(stored: 17) // expected-error {{initializer expects a single parameter of type 'T' [with T = (wrappedValue: Int, stored: Int)]}}
-  // expected-note@-1 {{did you mean to pass a tuple?}}
-  var x3 = 42
+  @Wrapper(stored: 17)
+  var x3 = 42 // expected-error {{extra argument 'wrappedValue' in call}}
 
   @Wrapper(stored: 17)
   var x4
@@ -720,8 +719,7 @@ struct DefaultedPrivateMemberwiseLets {
 func testDefaultedPrivateMemberwiseLets() {
   _ = DefaultedPrivateMemberwiseLets()
   _ = DefaultedPrivateMemberwiseLets(y: 42)
-  _ = DefaultedPrivateMemberwiseLets(x: Wrapper(stored: false)) // expected-error{{incorrect argument label in call (have 'x:', expected 'y:')}}
-  // expected-error@-1 {{cannot convert value of type 'Wrapper<Bool>' to expected argument type 'Int'}}
+  _ = DefaultedPrivateMemberwiseLets(x: Wrapper(stored: false)) // expected-error{{argument passed to call that takes no arguments}}
 }
 
 

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1117,8 +1117,8 @@ struct MissingPropertyWrapperUnwrap {
 }
 
 struct InvalidPropertyDelegateUse {
-  @Foo var x: Int = 42 // expected-error {{cannot invoke initializer for ty}}
-  // expected-note@-1{{overloads for 'Foo<_>' exist with these partially matching paramet}}
+  // TODO(diagnostics): We need to a tailored diagnostic for extraneous arguments in property delegate initialization
+  @Foo var x: Int = 42 // expected-error@:21 {{argument passed to call that takes no arguments}}
 
   func test() {
     self.x.foo() // expected-error {{value of type 'Int' has no member 'foo'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -593,13 +593,16 @@ func conversionTest(_ a: inout Double, b: inout Int) {
   var e3 = Empty(Float(d)) // expected-warning {{variable 'e3' inferred to have type 'Empty', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}
 }
 
-struct Rule { // expected-note {{'init(target:dependencies:)' declared here}}
+struct Rule {
   var target: String
   var dependencies: String
 }
 
 var ruleVar: Rule
-ruleVar = Rule("a") // expected-error {{missing argument for parameter 'dependencies' in call}}
+// FIXME(diagnostics): To be able to suggest different candidates here we need to teach the solver how to figure out to which parameter
+// does argument belong to in this case. If the `target` was of a different type, we currently suggest to add an argument for `dependencies:`
+// which is incorrect.
+ruleVar = Rule("a") // expected-error {{cannot convert value of type 'String' to expected argument type '(target: String, dependencies: String)'}}
 
 
 class C {

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -67,8 +67,7 @@ class Z0 {
   init() { // expected-error {{designated initializer for 'Z0' cannot delegate (with 'self.init'); did you mean this to be a convenience initializer?}} {{3-3=convenience }}
     // expected-note @+2 {{delegation occurs here}}
 
-    self.init(5, 5) // expected-error{{cannot invoke 'Z0.init' with an argument list of type '(Int, Int)'}}
-    // expected-note @-1 {{overloads for 'Z0.init' exist with these partially matching parameter lists: (), (value: Double), (value: Int)}}
+    self.init(5, 5) // expected-error{{extra argument in call}}
   }
 
   init(value: Int) { /* ... */ }
@@ -77,8 +76,7 @@ class Z0 {
 
 struct Z1 {
   init() {
-    self.init(5, 5) // expected-error{{cannot invoke 'Z1.init' with an argument list of type '(Int, Int)'}}
-  // expected-note @-1 {{overloads for 'Z1.init' exist with these partially matching parameter lists: (), (value: Double), (value: Int)}}
+    self.init(5, 5) // expected-error{{extra argument in call}}
   }
 
   init(value: Int) { /* ... */ }
@@ -90,8 +88,7 @@ enum Z2 {
   case B
 
   init() {
-    self.init(5, 5) // expected-error{{cannot invoke 'Z2.init' with an argument list of type '(Int, Int)'}}
-    // expected-note @-1 {{overloads for 'Z2.init' exist with these partially matching parameter lists: (), (value: Double), (value: Int)}}
+    self.init(5, 5) // expected-error{{extra argument in call}}
   }
 
   init(value: Int) { /* ... */ }
@@ -323,8 +320,7 @@ func foo<T: C>(_ x: T, y: T.Type) where T: P {
 
 class TestOverloadSets {
   convenience init() {
-    self.init(5, 5) // expected-error{{cannot invoke 'TestOverloadSets.init' with an argument list of type '(Int, Int)'}}
-    // expected-note @-1 {{overloads for 'TestOverloadSets.init' exist with these partially matching parameter lists: (), (a: Z0), (value: Double), (value: Int)}}
+    self.init(5, 5) // expected-error{{extra argument in call}}
   }
   
   convenience init(a : Z0) {

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -504,10 +504,10 @@ func testLabeledSubscript() {
   let k = \AA.[labeled: 0]
 
   // TODO: These ought to work without errors.
-  let _ = \AA.[keyPath: k] // expected-error {{incorrect argument label in call (have 'keyPath:', expected 'labeled:')}}
+  let _ = \AA.[keyPath: k] // expected-error {{extraneous argument label 'keyPath:' in call}}
   // expected-error@-1 {{cannot convert value of type 'KeyPath<AA, Int>' to expected argument type 'Int'}}
 
-  let _ = \AA.[keyPath: \AA.[labeled: 0]] // expected-error {{incorrect argument label in call (have 'keyPath:', expected 'labeled:')}}
+  let _ = \AA.[keyPath: \AA.[labeled: 0]] // expected-error {{extraneous argument label 'keyPath:' in call}}
   // expected-error@-1 {{cannot convert value of type 'KeyPath<AA, Int>' to expected argument type 'Int'}}
 }
 

--- a/test/stdlib/PrintDiagnostics.swift
+++ b/test/stdlib/PrintDiagnostics.swift
@@ -5,11 +5,10 @@ var stream = ""
 print(3, &stream) // expected-error{{'&' used with non-inout argument of type 'Any'}}
 debugPrint(3, &stream) // expected-error{{'&' used with non-inout argument of type 'Any'}}
 
-print(3, &stream, appendNewline: false) // expected-error {{cannot invoke 'print' with an argument list of type '(Int, inout String, appendNewline: Bool)'}}
-// expected-note@-1 {{overloads for 'print' exist with these partially matching parameter lists: (Any..., separator: String, terminator: String), (Any..., separator: String, terminator: String, to: inout Target)}}
+print(3, &stream, appendNewline: false) // expected-error {{extra argument 'appendNewline' in call}}
+// expected-error@-1:10 {{'&' used with non-inout argument of type 'Any'}}
 
-debugPrint(3, &stream, appendNewline: false) // expected-error {{cannot invoke 'debugPrint' with an argument list of type '(Int, inout String, appendNewline: Bool)'}}
-// expected-note@-1 {{verloads for 'debugPrint' exist with these partially matching parameter lists: (Any..., separator: String, terminator: String), (Any..., separator: String, terminator: String, to: inout Target)}}
+debugPrint(3, &stream, appendNewline: false) // expected-error {{extra argument 'appendNewline' in call}}
+// expected-error@-1:15 {{'&' used with non-inout argument of type 'Any'}}
 
-print(4, quack: 5) // expected-error {{cannot invoke 'print' with an argument list of type '(Int, quack: Int)'}}
-// expected-note@-1 {{overloads for 'print' exist with these partially matching parameter lists: (Any..., separator: String, terminator: String), (Any..., separator: String, terminator: String, to: inout Target)}}
+print(4, quack: 5) // expected-error {{extra argument 'quack' in call}}

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -117,9 +117,9 @@ func nine() throws {
   try nine_helper(y: 0) // expected-error {{missing argument for parameter #1 in call}}
 }
 func ten_helper(_ x: Int) {}
-func ten_helper(_ x: Int, y: Int) throws {}
+func ten_helper(_ x: Int, y: Int) throws {} // expected-note {{'ten_helper(_:y:)' declared here}}
 func ten() throws {
-  try ten_helper(y: 0) // expected-error {{extraneous argument label 'y:' in call}} {{18-21=}}
+  try ten_helper(y: 0) // expected-error {{missing argument for parameter #1 in call}} {{18-18=<#Int#>, }}
 }
 
 // rdar://21074857


### PR DESCRIPTION
If there are more arguments than parameters, let's fix this by
ignoring (if possible) or removing extraneous arguments. Ignored
arguments could default to `Any` (be marked as a "hole")  if they 
don't get any other contextual type.

This also extends existing single extra argument to cover multiple
extraneous arguments.

Note that some of the diagnostics here regressed because of current
solver limitations, especially for name shadowing since it's impossible
to get access to outer overloads. I'm going to follow up with a
`resolveDeclRefExpr` refactoring to fix that problem.

Resolves: rdar://problem/23948031
Resolves: rdar://problem/38827329
Resolves: rdar://problem/43351035
Resolves: rdar://problem/43848865
Resolves: rdar://problem/50927327
Resolves: rdar://problem/55254498

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
