### PR TITLE
SR-6717 Builtin types are always be printed with Builtin prefix

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3513,9 +3513,6 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
     if (Options.FullyQualifiedTypes)
       return true;
 
-    if (!Options.FullyQualifiedTypesIfAmbiguous)
-      return false;
-
     Decl *D;
     if (auto *TAT = dyn_cast<TypeAliasType>(T))
       D = TAT->getDecl();
@@ -3528,6 +3525,11 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
       return true;
 
     ModuleDecl *M = D->getDeclContext()->getParentModule();
+    if (M->isBuiltinModule())
+      return true;
+
+    if (!Options.FullyQualifiedTypesIfAmbiguous)
+      return false;
 
     if (Options.CurrentModule && M == Options.CurrentModule) {
       return false;

--- a/test/SILOptimizer/lslocation_expansion.sil
+++ b/test/SILOptimizer/lslocation_expansion.sil
@@ -105,12 +105,12 @@ bb0(%0 : $B):
 // CHECK-NEXT: [[RET0:%.+]] = alloc_stack
 // CHECK-NEXT: Projection Path [$*S1
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK: #1 store
 // CHECK-NEXT: [[RET0:%.+]] = alloc_stack
 // CHECK-NEXT: Projection Path [$*S1
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 sil @store_after_store_struct : $@convention(thin) () -> () {
   %1 = alloc_stack $S1
   %9 = integer_literal $Builtin.Int64, 0          // user: %10
@@ -130,95 +130,95 @@ sil @store_after_store_struct : $@convention(thin) () -> () {
 // CHECK-NEXT: alloc_stack $S2
 // CHECK-NEXT: Projection Path [$*S2
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S2
 // CHECK-NEXT: Projection Path [$*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK: #1 store
 // CHECK-NEXT: alloc_stack $S3
 // CHECK-NEXT: Projection Path [$*S3
 // CHECK-NEXT:   Field: var c: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S3
 // CHECK-NEXT: Projection Path [$*S3
 // CHECK-NEXT:   Field: var c: S2 in: $*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S3
 // CHECK-NEXT: Projection Path [$*S3
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S3
 // CHECK-NEXT: Projection Path [$*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S3
 // CHECK-NEXT: Projection Path [$*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK: #2 store
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var y: S3 in: $*S3
 // CHECK-NEXT:   Field: var c: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var y: S3 in: $*S3
 // CHECK-NEXT:   Field: var c: S2 in: $*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var y: S3 in: $*S3
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var y: S3 in: $*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var y: S3 in: $*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var x: S3 in: $*S3
 // CHECK-NEXT:   Field: var c: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var x: S3 in: $*S3
 // CHECK-NEXT:   Field: var c: S2 in: $*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var x: S3 in: $*S3
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var x: S3 in: $*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: alloc_stack $S4
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var x: S3 in: $*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 sil hidden @many_struct_allocs : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $S2, var, name "a"                  // users: %6, %18

--- a/test/SILOptimizer/lslocation_type_only_expansion.sil
+++ b/test/SILOptimizer/lslocation_type_only_expansion.sil
@@ -83,22 +83,22 @@ sil @S6_init : $@convention(thin) (@thin S6.Type) -> S6
 // CHECK: #0  store
 // CHECK-NEXT: Projection Path [$*S1
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S1
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK: #1  store
 // CHECK-NEXT: Projection Path [$*S2
 // CHECK-NEXT:   Field: var b: S1 in: $*S1
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S2
 // CHECK-NEXT:   Field: var b: S1 in: $*S1
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 sil hidden @test_struct_type_expansion : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $S1, var, name "a"                   // users: %5, %12
@@ -145,16 +145,16 @@ bb0:
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: S1 in: $*S1
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: S1 in: $*S1
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S3
 // CHECK-NEXT:   Field: var c: C1 in: $*C1]
 sil hidden @test_struct_and_class_slot : $@convention(thin) () -> () {
@@ -179,20 +179,20 @@ bb0:
 // CHECK-NEXT:   Field: var c: (Int, Int, S1) in: $*(Int, Int, S1)
 // CHECK-NEXT:   Index: 2 in: $*S1
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var c: (Int, Int, S1) in: $*(Int, Int, S1)
 // CHECK-NEXT:   Index: 2 in: $*S1
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var c: (Int, Int, S1) in: $*(Int, Int, S1)
 // CHECK-NEXT:   Index: 1 in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S4
 // CHECK-NEXT:   Field: var c: (Int, Int, S1) in: $*(Int, Int, S1)
 // CHECK-NEXT:   Index: 0 in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 sil hidden @test_tuple : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $S4, var, name "x"                  // users: %4, %7
@@ -219,20 +219,20 @@ bb0:
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: S1 in: $*S1
 // CHECK-NEXT:   Field: var b: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S5
 // CHECK-NEXT:   Field: var c: (Int, Int, S3) in: $*(Int, Int, S3)
 // CHECK-NEXT:   Index: 2 in: $*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var b: S1 in: $*S1
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S5
 // CHECK-NEXT:   Field: var c: (Int, Int, S3) in: $*(Int, Int, S3)
 // CHECK-NEXT:   Index: 2 in: $*S3
 // CHECK-NEXT:   Field: var a: S2 in: $*S2
 // CHECK-NEXT:   Field: var a: Int in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S5
 // CHECK-NEXT:   Field: var c: (Int, Int, S3) in: $*(Int, Int, S3)
 // CHECK-NEXT:   Index: 2 in: $*S3
@@ -240,11 +240,11 @@ bb0:
 // CHECK-NEXT: Projection Path [$*S5
 // CHECK-NEXT:   Field: var c: (Int, Int, S3) in: $*(Int, Int, S3)
 // CHECK-NEXT:   Index: 1 in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 // CHECK-NEXT: Projection Path [$*S5
 // CHECK-NEXT:   Field: var c: (Int, Int, S3) in: $*(Int, Int, S3)
 // CHECK-NEXT:   Index: 0 in: $*Int
-// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 sil hidden @tuple_test_with_reference : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $S5, var, name "x"                  // users: %4, %7
@@ -264,11 +264,11 @@ bb0:
 /// CHECK-NEXT: Projection Path [$*S6
 /// CHECK-NEXT:   Field: var tuple: (Int, Int) in: $*(Int, Int)
 /// CHECK-NEXT:   Index: 1 in: $*Int
-/// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+/// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 /// CHECK-NEXT: Projection Path [$*S6
 /// CHECK-NEXT:   Field: var tuple: (Int, Int) in: $*(Int, Int)
 /// CHECK-NEXT:   Index: 0 in: $*Int
-/// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+/// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 sil hidden @tuple_inside_struct : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $S6, var, name "x"                  // users: %4, %7
@@ -292,7 +292,7 @@ bb0:
 /// CHECK-NOT: Int32
 /// CHECK: #1  store
 /// CHECK-NEXT: Projection Path [$*Int
-/// CHECK-NEXT:   Field: var value: Int64 in: $*Builtin.Int64]
+/// CHECK-NEXT:   Field: var value: Builtin.Int64 in: $*Builtin.Int64]
 sil hidden @enum_test : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $Example, var, name "ee"       // users: %5, %11

--- a/test/TypeCoercion/integer_literals.swift
+++ b/test/TypeCoercion/integer_literals.swift
@@ -31,9 +31,9 @@ func overflow_check() {
 }
 
 // Coercion chaining.
-struct meters : ExpressibleByIntegerLiteral { 
+struct meters : ExpressibleByIntegerLiteral {
   var value : Int8
-  
+
   init(_ value: Int8) {
     self.value = value
   }
@@ -46,7 +46,7 @@ struct meters : ExpressibleByIntegerLiteral {
 
 struct supermeters : ExpressibleByIntegerLiteral { // expected-error{{type 'supermeters' does not conform to protocol 'ExpressibleByIntegerLiteral'}} expected-note {{do you want to add protocol stubs?}}
   var value : meters
-  
+
   typealias IntegerLiteralType = meters // expected-note{{possibly intended match 'supermeters.IntegerLiteralType' (aka 'meters') does not conform to '_ExpressibleByBuiltinIntegerLiteral'}}
   init(_integerLiteral value: meters) {
     self.value = value
@@ -63,6 +63,6 @@ func chaining() {
 func memberaccess() {
   Int32(5._value) // expected-warning{{unused}}
   // This diagnostic is actually better than it looks, because the inner type is Builtin.Int32, not actually Int32.
-  let x : Int32 = 7._value // expected-error{{cannot convert value of type 'Builtin.Int32' to specified type 'Swift.Int32'}}
+  let x : Int32 = 7._value // expected-error{{cannot convert value of type 'Builtin.Int32' to specified type 'Int32'}}
   _ = x
 }

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -67,8 +67,8 @@ func unsafePointerConversionAvailability(
   _ = UnsafeMutablePointer<Void>(umpi) // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
   _ = UnsafeMutablePointer<Void>(umps) // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
 
-  _ = UnsafePointer<Void>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'RawPointer'}} expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
-  _ = UnsafePointer<Void>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'RawPointer'}} expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
+  _ = UnsafePointer<Void>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'Builtin.RawPointer'}} expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
+  _ = UnsafePointer<Void>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'Builtin.RawPointer'}} expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
   _ = UnsafePointer<Void>(umpv) // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
   _ = UnsafePointer<Void>(upv) // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
   _ = UnsafePointer<Void>(umpi) // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
@@ -81,10 +81,10 @@ func unsafePointerConversionAvailability(
   _ = UnsafeMutablePointer<Int>(orp) // expected-error {{no exact matches in call to initializer}}
   _ = UnsafeMutablePointer<Int>(omrp) // expected-error {{no exact matches in call to initializer}}
 
-  _ = UnsafePointer<Int>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'RawPointer'}}
-  _ = UnsafePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'RawPointer'}}
-  _ = UnsafePointer<Int>(orp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'RawPointer'}}
-  _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'RawPointer'}}
+  _ = UnsafePointer<Int>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'Builtin.RawPointer'}}
+  _ = UnsafePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'Builtin.RawPointer'}}
+  _ = UnsafePointer<Int>(orp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'Builtin.RawPointer'}}
+  _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'Builtin.RawPointer'}}
 
   _ = UnsafePointer<Int>(ups) // expected-error {{cannot convert value of type 'UnsafePointer<String>' to expected argument type 'UnsafePointer<Int>'}}
   // expected-note@-1 {{arguments to generic parameter 'Pointee' ('String' and 'Int') are expected to be equal}}

--- a/test/type/builtin_types.swift
+++ b/test/type/builtin_types.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib
+
+import Swift
+
+func testBuiltinModulePrint(_ builtin: Builtin.Int64) -> Bool {
+  let x = 35
+  return x == builtin // expected-error {{operator function '==' requires that 'Builtin.Int64' conform to 'BinaryInteger'}}
+}


### PR DESCRIPTION
ASTPrinter now ignore the Options.FullyQualifiedTypesIfAmbiguous value if the containing module is the builtin one.

As stated in the bug report, I've implemented the test in the description to validate the fix but if someone has a more self-contained example I will swap it in no time.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6717](https://bugs.swift.org/browse/SR-6717).