### PR TITLE
[reflection] Go back to 0/1 for bitwise_takable instead of false/true

### DIFF
--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -75,7 +75,7 @@ class PrintTypeInfo {
     printField("alignment", std::to_string(TI.getAlignment()));
     printField("stride", std::to_string(TI.getStride()));
     printField("num_extra_inhabitants", std::to_string(TI.getNumExtraInhabitants()));
-    printField("bitwise_takable", TI.isBitwiseTakable() ? "true" : "false");
+    printField("bitwise_takable", TI.isBitwiseTakable() ? "1" : "0");
   }
 
   void printFields(const RecordTypeInfo &TI) {

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -10,357 +10,357 @@
 12TypeLowering11BasicStructV
 // CHECK-64:      (struct TypeLowering.BasicStruct)
 
-// CHECK-64-NEXT: (struct size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (struct size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=i1 offset=0
-// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=i2 offset=2
-// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=i3 offset=4
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=bi1 offset=8
-// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=value offset=0
-// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=bi2 offset=10
-// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=value offset=0
-// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=bi3 offset=12
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=value offset=0
-// CHECK-64-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))))
+// CHECK-64-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
 // CHECK-32:      (struct TypeLowering.BasicStruct)
-// CHECK-32-NEXT: (struct size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=i1 offset=0
-// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=i2 offset=2
-// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=i3 offset=4
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=bi1 offset=8
-// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=value offset=0
-// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=bi2 offset=10
-// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=value offset=0
-// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=bi3 offset=12
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=value offset=0
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
 12TypeLowering05AssocA6StructV
 // CHECK-64:      (struct TypeLowering.AssocTypeStruct)
-// CHECK-64-NEXT: (struct size=36 alignment=2 stride=36 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (struct size=36 alignment=2 stride=36 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=t1 offset=0
-// CHECK-64-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=a offset=0
-// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=b offset=2
-// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=c offset=4
-// CHECK-64-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field offset=0
-// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:           (field offset=2
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))))))
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))))))
 // CHECK-64-NEXT:   (field name=t2 offset=8
-// CHECK-64-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=a offset=0
-// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=b offset=2
-// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=c offset=4
-// CHECK-64-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field offset=0
-// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:           (field offset=2
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))))))
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))))))
 // CHECK-64-NEXT:   (field name=t3 offset=16
-// CHECK-64-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=a offset=0
-// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=b offset=2
-// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=c offset=4
-// CHECK-64-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field offset=0
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:           (field offset=2
-// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))))))
+// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))))))
 // CHECK-64-NEXT:   (field name=t4 offset=24
-// CHECK-64-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=a offset=0
-// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=b offset=2
-// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=c offset=4
-// CHECK-64-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field offset=0
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:           (field offset=2
-// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))))))
+// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))))))
 // CHECK-64-NEXT:   (field name=t5 offset=32
-// CHECK-64-NEXT:     (struct size=4 alignment=1 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=1 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=a offset=0
-// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=b offset=1
-// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=value offset=0
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_value offset=0
-// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:       (field name=c offset=2
-// CHECK-64-NEXT:         (tuple size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (tuple size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field offset=0
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:           (field offset=1
-// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=value offset=0
-// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_value offset=0
-// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))))))))
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))))))))
 
 // CHECK-32:      (struct TypeLowering.AssocTypeStruct)
-// CHECK-32-NEXT: (struct size=36 alignment=2 stride=36 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=36 alignment=2 stride=36 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=t1 offset=0
-// CHECK-32-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=a offset=0
-// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=b offset=2
-// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=c offset=4
-// CHECK-32-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field offset=0
-// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:           (field offset=2
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))))))
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))))))
 // CHECK-32-NEXT:   (field name=t2 offset=8
-// CHECK-32-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=a offset=0
-// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=b offset=2
-// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=c offset=4
-// CHECK-32-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field offset=0
-// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:           (field offset=2
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))))))
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))))))
 // CHECK-32-NEXT:   (field name=t3 offset=16
-// CHECK-32-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=a offset=0
-// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=b offset=2
-// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=c offset=4
-// CHECK-32-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field offset=0
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:           (field offset=2
-// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))))))
+// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))))))
 // CHECK-32-NEXT:   (field name=t4 offset=24
-// CHECK-32-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=a offset=0
-// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=b offset=2
-// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=c offset=4
-// CHECK-32-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field offset=0
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:           (field offset=2
-// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))))))
+// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))))))
 // CHECK-32-NEXT:   (field name=t5 offset=32
-// CHECK-32-NEXT:     (struct size=4 alignment=1 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=1 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=a offset=0
-// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=b offset=1
-// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=value offset=0
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=_value offset=0
-// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:       (field name=c offset=2
-// CHECK-32-NEXT:         (tuple size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (tuple size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field offset=0
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:           (field offset=1
-// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:               (field name=value offset=0
-// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:                   (field name=_value offset=0
-// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))))))))
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))))))))
 
 12TypeLowering3BoxVys5Int16VG_s5Int32Vt
 // CHECK-64-NEXT: (tuple
@@ -373,72 +373,72 @@
 // CHECK-32-NEXT:     (struct Swift.Int16))
 // CHECK-32-NEXT:   (struct Swift.Int32))
 
-// CHECK-64-NEXT: (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field offset=0
-// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=value offset=0
-// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field offset=4
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
-// CHECK-32-NEXT: (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field offset=0
-// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=value offset=0
-// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field offset=4
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 12TypeLowering15ReferenceStructV
 // CHECK-64:      (struct TypeLowering.ReferenceStruct)
-// CHECK-64-NEXT: (struct size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI:2048|4096|2147483647]] bitwise_takable=true
+// CHECK-64-NEXT: (struct size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI:2048|4096|2147483647]] bitwise_takable=1
 // CHECK-64-NEXT:   (field name=strongRef offset=0
 // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:   (field name=optionalStrongRef offset=8
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1:2047|4095|2147483646]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1:2047|4095|2147483646]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=strongRefTuple offset=16
-// CHECK-64-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:       (field offset=8
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=optionalStrongRefTuple offset=32
-// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field offset=0
 // CHECK-64-NEXT:             (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:           (field offset=8
 // CHECK-64-NEXT:             (reference kind=strong refcounting=native)))))))
 
 // CHECK-32: (struct TypeLowering.ReferenceStruct)
-// CHECK-32-NEXT: (struct size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=strongRef offset=0
 // CHECK-32-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-32-NEXT:   (field name=optionalStrongRef offset=4
-// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-32-NEXT:   (field name=strongRefTuple offset=8
-// CHECK-32-NEXT:     (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=native))
 // CHECK-32-NEXT:       (field offset=4
 // CHECK-32-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-32-NEXT:   (field name=optionalStrongRefTuple offset=16
-// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field offset=0
 // CHECK-32-NEXT:             (reference kind=strong refcounting=native))
 // CHECK-32-NEXT:           (field offset=4
@@ -446,690 +446,690 @@
 
 12TypeLowering22UnownedReferenceStructV
 // CHECK-64:      (struct TypeLowering.UnownedReferenceStruct)
-// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:   (field name=unownedRef offset=0
 // CHECK-64-NEXT:     (reference kind=unowned refcounting=native)))
 
 // CHECK-32:      (struct TypeLowering.UnownedReferenceStruct)
-// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=unownedRef offset=0
 // CHECK-32-NEXT:     (reference kind=unowned refcounting=native)))
 
 12TypeLowering19WeakReferenceStructV
 // CHECK-64:      (struct TypeLowering.WeakReferenceStruct)
-// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-64-NEXT:   (field name=weakRef offset=0
 // CHECK-64-NEXT:     (reference kind=weak refcounting=native)))
 
 // CHECK-32:      (struct TypeLowering.WeakReferenceStruct)
-// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-32-NEXT:   (field name=weakRef offset=0
 // CHECK-32-NEXT:     (reference kind=weak refcounting=native)))
 
 12TypeLowering24UnmanagedReferenceStructV
 // CHECK-64:      (struct TypeLowering.UnmanagedReferenceStruct)
-// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:   (field name=unmanagedRef offset=0
 // CHECK-64-NEXT:     (reference kind=unmanaged refcounting=native)))
 
 // CHECK-32:      (struct TypeLowering.UnmanagedReferenceStruct)
-// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=unmanagedRef offset=0
 // CHECK-32-NEXT:     (reference kind=unmanaged refcounting=native)))
 
 12TypeLowering14FunctionStructV
 // CHECK-64:      (struct TypeLowering.FunctionStruct)
-// CHECK-64-NEXT: (struct size=64 alignment=8 stride=64 num_extra_inhabitants=[[PTR_XI_2:4096|2147483647]] bitwise_takable=true
+// CHECK-64-NEXT: (struct size=64 alignment=8 stride=64 num_extra_inhabitants=[[PTR_XI_2:4096|2147483647]] bitwise_takable=1
 // CHECK-64-NEXT:   (field name=thickFunction offset=0
-// CHECK-64-NEXT:     (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=true
+// CHECK-64-NEXT:     (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=function offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=context offset=8
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=optionalThickFunction offset=16
-// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_2_SUB_1:4095|2147483646]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_2_SUB_1:4095|2147483646]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=true
+// CHECK-64-NEXT:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=function offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=true))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=1))
 // CHECK-64-NEXT:           (field name=context offset=8
 // CHECK-64-NEXT:             (reference kind=strong refcounting=native))))))
 // CHECK-64-NEXT:   (field name=thinFunction offset=32
-// CHECK-64-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=true))
+// CHECK-64-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=optionalThinFunction offset=40
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=cFunction offset=48
-// CHECK-64-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=true))
+// CHECK-64-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=optionalCFunction offset=56
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_2]] bitwise_takable=1)))))
 
 // CHECK-32: (struct TypeLowering.FunctionStruct)
-// CHECK-32-NEXT: (struct size=32 alignment=4 stride=32 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=32 alignment=4 stride=32 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=thickFunction offset=0
-// CHECK-32-NEXT:     (thick_function size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (thick_function size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=function offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=context offset=4
 // CHECK-32-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-32-NEXT:   (field name=optionalThickFunction offset=8
-// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (thick_function size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (thick_function size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=function offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:           (field name=context offset=4
 // CHECK-32-NEXT:             (reference kind=strong refcounting=native))))))
 // CHECK-32-NEXT:   (field name=thinFunction offset=16
-// CHECK-32-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:   (field name=optionalThinFunction offset=20
-// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=cFunction offset=24
-// CHECK-32-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:   (field name=optionalCFunction offset=28
-// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1)))))
 
 12TypeLowering17ExistentialStructV
 // CHECK-64:      (struct TypeLowering.ExistentialStruct)
-// CHECK-64-NEXT: (struct size=416 alignment=8 stride=416 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT: (struct size=416 alignment=8 stride=416 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:   (field name=any offset=0
-// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAny offset=32
-// CHECK-64-NEXT:     (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=metadata offset=24
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=anyObject offset=64
 // CHECK-64-NEXT:     (class_existential size=8 alignment=8 stride=8
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))))
 // CHECK-64-NEXT:   (field name=optionalAnyObject offset=72
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=object offset=0
 // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))))))
 // CHECK-64-NEXT:   (field name=anyProto offset=80
-// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=32
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAnyProto offset=120
-// CHECK-64-NEXT:     (single_payload_enum size=40 alignment=8 stride=40 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=40 alignment=8 stride=40 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=metadata offset=24
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:           (field name=wtable offset=32
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=anyProtoComposition offset=160
-// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=32
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=40
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAnyProtoComposition offset=208
-// CHECK-64-NEXT:     (single_payload_enum size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=metadata offset=24
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:           (field name=wtable offset=32
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:           (field name=wtable offset=40
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=anyClassBoundProto1 offset=256
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAnyClassBoundProto1 offset=272
-// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=object offset=0
 // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:           (field name=wtable offset=8
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=anyClassBoundProto2 offset=288
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAnyClassBoundProto2 offset=304
-// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=object offset=0
 // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:           (field name=wtable offset=8
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=anyClassBoundProtoComposition1 offset=320
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAnyClassBoundProtoComposition1 offset=336
-// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=object offset=0
 // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:           (field name=wtable offset=8
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=anyClassBoundProtoComposition2 offset=352
-// CHECK-64-NEXT:     (class_existential size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (class_existential size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=16
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAnyClassBoundProtoComposition2 offset=376
-// CHECK-64-NEXT:     (single_payload_enum size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (class_existential size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (class_existential size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=object offset=0
 // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:           (field name=wtable offset=8
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:           (field name=wtable offset=16
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=classConstrainedP1 offset=400
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 // CHECK-32: (struct TypeLowering.ExistentialStruct)
-// CHECK-32-NEXT: (struct size=208 alignment=4 stride=208 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=208 alignment=4 stride=208 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=any offset=0
-// CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=12
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAny offset=16
-// CHECK-32-NEXT:     (single_payload_enum size=16 alignment=4 stride=16 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=16 alignment=4 stride=16 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=metadata offset=12
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=anyObject offset=32
-// CHECK-32-NEXT:     (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))))
 // CHECK-32-NEXT:   (field name=optionalAnyObject offset=36
-// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=object offset=0
 // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown))))))
 // CHECK-32-NEXT:   (field name=anyProto offset=40
-// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=12
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=16
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAnyProto offset=60
-// CHECK-32-NEXT:     (single_payload_enum size=20 alignment=4 stride=20 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=20 alignment=4 stride=20 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=metadata offset=12
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:           (field name=wtable offset=16
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=anyProtoComposition offset=80
-// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=12
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=16
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=20
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAnyProtoComposition offset=104
-// CHECK-32-NEXT:     (single_payload_enum size=24 alignment=4 stride=24 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=24 alignment=4 stride=24 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=metadata offset=12
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:           (field name=wtable offset=16
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-32-NEXT:           (field name=wtable offset=20
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=anyClassBoundProto1 offset=128
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAnyClassBoundProto1 offset=136
-// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=object offset=0
 // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:           (field name=wtable offset=4
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=anyClassBoundProto2 offset=144
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAnyClassBoundProto2 offset=152
-// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=object offset=0
 // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:           (field name=wtable offset=4
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=anyClassBoundProtoComposition1 offset=160
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAnyClassBoundProtoComposition1 offset=168
-// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=object offset=0
 // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:           (field name=wtable offset=4
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=anyClassBoundProtoComposition2 offset=176
-// CHECK-32-NEXT:     (class_existential size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=8
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAnyClassBoundProtoComposition2 offset=188
-// CHECK-32-NEXT:     (single_payload_enum size=12 alignment=4 stride=12 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=12 alignment=4 stride=12 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (class_existential size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (class_existential size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=object offset=0
 // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:           (field name=wtable offset=4
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-32-NEXT:           (field name=wtable offset=8
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=classConstrainedP1 offset=200
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=native))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 12TypeLowering24UnownedExistentialStructV
-// CHECK-64:      (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=false
+// CHECK-64:      (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=0
 // CHECK-64-NEXT:   (field name=unownedRef offset=0
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=false
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=0
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=unowned refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
-// CHECK-32:      (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=false
+// CHECK-32:      (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=0
 // CHECK-32-NEXT:   (field name=unownedRef offset=0
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=false
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=0
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=unowned refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 12TypeLowering30UnownedNativeExistentialStructV
 // CHECK-64:      (struct TypeLowering.UnownedNativeExistentialStruct)
-// CHECK-64-NEXT: (struct size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT: (struct size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:   (field name=unownedRef1 offset=0
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=unowned refcounting=native))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=unownedRef2 offset=16
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=unowned refcounting=native))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=unownedRef3 offset=32
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=unowned refcounting=native))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 // CHECK-32:      (struct TypeLowering.UnownedNativeExistentialStruct)
-// CHECK-32-NEXT: (struct size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=unownedRef1 offset=0
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=unowned refcounting=native))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=unownedRef2 offset=8
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=unowned refcounting=native))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=unownedRef3 offset=16
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=unowned refcounting=native))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 12TypeLowering21WeakExistentialStructV
 // CHECK-64-NEXT: (struct TypeLowering.WeakExistentialStruct)
-// CHECK-64-NEXT: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=false
+// CHECK-64-NEXT: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=0
 // CHECK-64-NEXT:   (field name=weakAnyObject offset=0
-// CHECK-64-NEXT:     (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=false
+// CHECK-64-NEXT:     (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=0
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=weak refcounting=unknown))))
 // CHECK-64-NEXT:   (field name=weakAnyClassBoundProto offset=8
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=false
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=0
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=weak refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 // CHECK-32-NEXT: (struct TypeLowering.WeakExistentialStruct)
-// CHECK-32-NEXT: (struct size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=false
+// CHECK-32-NEXT: (struct size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=0
 // CHECK-32-NEXT:   (field name=weakAnyObject offset=0
-// CHECK-32-NEXT:     (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=false
+// CHECK-32-NEXT:     (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=0
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=weak refcounting=unknown))))
 // CHECK-32-NEXT:   (field name=weakAnyClassBoundProto offset=4
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=false
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=0
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=weak refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 12TypeLowering26UnmanagedExistentialStructV
 // CHECK-64:      (struct TypeLowering.UnmanagedExistentialStruct)
-// CHECK-64-NEXT: (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT: (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:   (field name=unmanagedRef offset=0
-// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=unmanaged refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 // CHECK-32:      (struct TypeLowering.UnmanagedExistentialStruct)
-// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=unmanagedRef offset=0
-// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=unmanaged refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 12TypeLowering14MetatypeStructV
 // CHECK-64:      (struct TypeLowering.MetatypeStruct)
-// CHECK-64-NEXT: (struct size=152 alignment=8 stride=152 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT: (struct size=152 alignment=8 stride=152 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:   (field name=any offset=0
-// CHECK-64-NEXT:     (existential_metatype size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (existential_metatype size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAny offset=8
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (existential_metatype size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (existential_metatype size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=metadata offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=anyObject offset=16
-// CHECK-64-NEXT:     (existential_metatype size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (existential_metatype size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAnyObject offset=24
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (existential_metatype size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (existential_metatype size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=metadata offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=anyProto offset=32
-// CHECK-64-NEXT:     (existential_metatype size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (existential_metatype size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAnyProto offset=48
-// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (existential_metatype size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (existential_metatype size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=metadata offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:           (field name=wtable offset=8
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=anyProtoComposition offset=64
-// CHECK-64-NEXT:     (existential_metatype size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (existential_metatype size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=16
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=optionalAnyProtoComposition offset=88
-// CHECK-64-NEXT:     (single_payload_enum size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (existential_metatype size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:         (existential_metatype size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=metadata offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:           (field name=wtable offset=8
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:           (field name=wtable offset=16
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=structMetatype offset=112
-// CHECK-64-NEXT:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-64-NEXT:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=optionalStructMetatype offset=112
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=classMetatype offset=120
-// CHECK-64-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=optionalClassMetatype offset=128
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=abstractMetatype offset=136
-// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=t offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=u offset=8
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1)))))
 
 // CHECK-32: (struct TypeLowering.MetatypeStruct)
 // CHECK-32-NEXT: (struct size=76 alignment=4 stride=76 num_extra_inhabitants=4096
 // CHECK-32-NEXT:   (field name=any offset=0
-// CHECK-32-NEXT:     (existential_metatype size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (existential_metatype size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAny offset=4
-// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (existential_metatype size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (existential_metatype size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=metadata offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=anyObject offset=8
-// CHECK-32-NEXT:     (existential_metatype size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (existential_metatype size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAnyObject offset=12
-// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (existential_metatype size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (existential_metatype size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=metadata offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=anyProto offset=16
-// CHECK-32-NEXT:     (existential_metatype size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (existential_metatype size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAnyProto offset=24
-// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (existential_metatype size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (existential_metatype size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=metadata offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:           (field name=wtable offset=4
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=anyProtoComposition offset=32
-// CHECK-32-NEXT:     (existential_metatype size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (existential_metatype size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=8
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=optionalAnyProtoComposition offset=44
-// CHECK-32-NEXT:     (single_payload_enum size=12 alignment=4 stride=12 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=12 alignment=4 stride=12 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (existential_metatype size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:         (existential_metatype size=12 alignment=4 stride=12 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=metadata offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:           (field name=wtable offset=4
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-32-NEXT:           (field name=wtable offset=8
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=structMetatype offset=56
-// CHECK-32-NEXT:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-32-NEXT:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-32-NEXT:   (field name=optionalStructMetatype offset=56
-// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=classMetatype offset=60
-// CHECK-32-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:   (field name=optionalClassMetatype offset=64
-// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=true
+// CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=abstractMetatype offset=68
-// CHECK-32-NEXT:     (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=t offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=u offset=4
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1)))))
 
 12TypeLowering10EnumStructV
 // CHECK-64: (struct TypeLowering.EnumStruct)
-// CHECK-64-NEXT: (struct size=81 alignment=8 stride=88 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=true
+// CHECK-64-NEXT: (struct size=81 alignment=8 stride=88 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
 // CHECK-64-NEXT:   (field name=empty offset=0
-// CHECK-64-NEXT:     (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-64-NEXT:     (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=noPayload offset=0
-// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=sillyNoPayload offset=1
-// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64-NEXT:   (field name=singleton offset=8
 // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:   (field name=singlePayload offset=16
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=Indirect offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=multiPayloadConcrete offset=24
-// CHECK-64-NEXT:     (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants={{(2045|125)}} bitwise_takable=true
+// CHECK-64-NEXT:     (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants={{(2045|125)}} bitwise_takable=1
 // CHECK-64-NEXT:       (field name=Left offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:       (field name=Right offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=multiPayloadGenericFixed offset=32
-// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=Left offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:       (field name=Right offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 // CHECK-64-NEXT:   (field name=multiPayloadGenericDynamic offset=48
-// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=Left offset=0
-// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:       (field name=Right offset=0
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=optionalOptionalRef offset=64
-// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_2:2147483645|2046|4094]] bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_2:2147483645|2046|4094]] bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=true
+// CHECK-64-NEXT:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]] bitwise_takable=1
 // CHECK-64-NEXT:           (field name=some offset=0
 // CHECK-64-NEXT:             (reference kind=strong refcounting=native))))))
 // CHECK-64-NEXT:   (field name=optionalOptionalPtr offset=72
-// CHECK-64-NEXT:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=some offset=0
-// CHECK-64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_rawValue offset=0
-// CHECK-64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))))))
+// CHECK-64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))))))
 
 12TypeLowering23EnumStructWithOwnershipV
 // CHECK-64:      (struct TypeLowering.EnumStructWithOwnership)
-// CHECK-64-NEXT: (struct size=25 alignment=8 stride=32 num_extra_inhabitants=254 bitwise_takable=false
+// CHECK-64-NEXT: (struct size=25 alignment=8 stride=32 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-64-NEXT:   (field name=multiPayloadConcrete offset=0
-// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=false
+// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-64-NEXT:       (field name=Left offset=0
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-64-NEXT:           (field name=weakRef offset=0
 // CHECK-64-NEXT:             (reference kind=weak refcounting=native))))
 // CHECK-64-NEXT:       (field name=Right offset=0
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-64-NEXT:           (field name=weakRef offset=0
 // CHECK-64-NEXT:             (reference kind=weak refcounting=native))))))
 // CHECK-64-NEXT:   (field name=multiPayloadGeneric offset=16
-// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=false
+// CHECK-64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-64-NEXT:       (field name=Left offset=0
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-64-NEXT:           (field name=weakRef offset=0
 // CHECK-64-NEXT:             (reference kind=weak refcounting=native))))
 // CHECK-64-NEXT:       (field name=Right offset=0
-// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))))
+// CHECK-64-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
 // CHECK-32:      (struct TypeLowering.EnumStructWithOwnership)
-// CHECK-32-NEXT: (struct size=13 alignment=4 stride=16 num_extra_inhabitants=254 bitwise_takable=false
+// CHECK-32-NEXT: (struct size=13 alignment=4 stride=16 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-32-NEXT:   (field name=multiPayloadConcrete offset=0
-// CHECK-32-NEXT:     (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=254 bitwise_takable=false
+// CHECK-32-NEXT:     (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-32-NEXT:       (field name=Left offset=0
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-32-NEXT:           (field name=weakRef offset=0
 // CHECK-32-NEXT:             (reference kind=weak refcounting=native))))
 // CHECK-32-NEXT:       (field name=Right offset=0
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-32-NEXT:           (field name=weakRef offset=0
 // CHECK-32-NEXT:             (reference kind=weak refcounting=native))))))
 // CHECK-32-NEXT:   (field name=multiPayloadGeneric offset=8
-// CHECK-32-NEXT:     (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=254 bitwise_takable=false
+// CHECK-32-NEXT:     (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=254 bitwise_takable=0
 // CHECK-32-NEXT:       (field name=Left offset=0
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-32-NEXT:           (field name=weakRef offset=0
 // CHECK-32-NEXT:             (reference kind=weak refcounting=native))))
 // CHECK-32-NEXT:       (field name=Right offset=0
-// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))))
+// CHECK-32-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
 Bo
 // CHECK-64:      (builtin Builtin.NativeObject)
@@ -1147,48 +1147,48 @@ BO
 
 12TypeLowering22RefersToOtherAssocTypeV
 // CHECK-64:      (struct TypeLowering.RefersToOtherAssocType)
-// CHECK-64-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=x offset=0
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=y offset=4
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32:      (struct TypeLowering.RefersToOtherAssocType)
-// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=x offset=0
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=y offset=4
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 12TypeLowering18GenericOnAssocTypeVyAA13OpaqueWitnessVG
 // CHECK-64:      (bound_generic_struct TypeLowering.GenericOnAssocType
 // CHECK-64-NEXT:   (struct TypeLowering.OpaqueWitness))
-// CHECK-64-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=x offset=0
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=y offset=4
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32:      (bound_generic_struct TypeLowering.GenericOnAssocType
 // CHECK-32-NEXT:   (struct TypeLowering.OpaqueWitness))
-// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=x offset=0
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=y offset=4
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))

--- a/test/Reflection/typeref_lowering_imported.swift
+++ b/test/Reflection/typeref_lowering_imported.swift
@@ -15,19 +15,19 @@
 
 12TypeLowering9HasCTypesV
 // CHECK:     (struct TypeLowering.HasCTypes)
-// CHECK-NEXT: (struct size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-NEXT: (struct size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-NEXT:   (field name=mcs offset=0
-// CHECK-NEXT:     (builtin size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-NEXT:     (builtin size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-NEXT:   (field name=mce offset=24
-// CHECK-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-NEXT:   (field name=mcu offset=32
-// CHECK-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))
+// CHECK-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))
 
 
 12TypeLowering13AlsoHasCTypesV
-// CHECK:      (struct size=12 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK:      (struct size=12 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-NEXT:   (field name=mcu offset=0
-// CHECK-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-NEXT:   (field name=mcsbf offset=8
-// CHECK-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))
+// CHECK-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))
 

--- a/test/Reflection/typeref_lowering_objc.swift
+++ b/test/Reflection/typeref_lowering_objc.swift
@@ -7,7 +7,7 @@
 
 12TypeLowering14FunctionStructV
 // CHECK:      (struct TypeLowering.FunctionStruct)
-// CHECK-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-NEXT:   (field name=blockFunction offset=0
 // CHECK-NEXT:     (reference kind=strong refcounting=unknown)))
 
@@ -20,23 +20,23 @@
 // CHECK-NEXT: (reference kind=strong refcounting=unknown)
 
 12TypeLowering11HasObjCEnumV
-// CHECK: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-NEXT:   (field name=optionalEnum offset=0
-// CHECK-NEXT:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-NEXT:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-NEXT:       (field name=some offset=0
-// CHECK-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-NEXT:   (field name=reference offset=16
-// CHECK-NEXT:     (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-NEXT:     (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-NEXT:       (field name=object offset=0
 // CHECK-NEXT:         (reference kind=strong refcounting=unknown)))))
 
 12TypeLowering22UnownedReferenceStructV
 // CHECK-64:      (struct TypeLowering.UnownedReferenceStruct)
-// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=false
+// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=0
 // CHECK-64-NEXT:   (field name=unownedRef offset=0
 // CHECK-64-NEXT:     (reference kind=unowned refcounting=unknown)))
 
 // CHECK-32:      (struct TypeLowering.UnownedReferenceStruct)
-// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=false
+// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=0
 // CHECK-32-NEXT:   (field name=unownedRef offset=0
 // CHECK-32-NEXT:     (reference kind=unowned refcounting=unknown)))

--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -90,19 +90,19 @@ reflect(any: smallStruct)
 // CHECK-64-NEXT:   (struct Swift.Int))
 
 // CHECK-64:        Type info:
-// CHECK-64:        (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:        (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=x offset=0
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=y offset=8
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=z offset=16
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -113,19 +113,19 @@ reflect(any: smallStruct)
 // CHECK-32-NEXT:   (struct Swift.Int))
 
 // CHECK-32:        Type info:
-// CHECK-32:        (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:        (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=x offset=0
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=y offset=4
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=z offset=8
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // This value will be copied into a heap buffer, with a
 // pointer to it in the existential.
@@ -149,49 +149,49 @@ reflect(any: largeStruct)
 // CHECK-64-NEXT:     (struct Swift.Int)
 // CHECK-64-NEXT:     (struct Swift.Int)))
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (struct size=72 alignment=8 stride=72 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (struct size=72 alignment=8 stride=72 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=x offset=0
-// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field offset=0
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:       (field offset=8
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:       (field offset=16
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=y offset=24
-// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field offset=0
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:       (field offset=8
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:       (field offset=16
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-64-NEXT:   (field name=z offset=48
-// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field offset=0
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:       (field offset=8
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:       (field offset=16
-// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
-// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))))
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -210,49 +210,49 @@ reflect(any: largeStruct)
 // CHECK-32-NEXT:     (struct Swift.Int)
 // CHECK-32-NEXT:     (struct Swift.Int)))
 // CHECK-32:        Type info:
-// CHECK-32:        (struct size=36 alignment=4 stride=36 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:        (struct size=36 alignment=4 stride=36 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=x offset=0
-// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field offset=0
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:       (field offset=4
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:       (field offset=8
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=y offset=12
-// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field offset=0
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:       (field offset=4
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:       (field offset=8
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
 // CHECK-32-NEXT:   (field name=z offset=24
-// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field offset=0
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:       (field offset=4
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:       (field offset=8
-// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
-// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))))
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
 var he = HasError(singleError: MyError(), errorInComposition: MyError(), customError: MyCustomError(), customErrorInComposition: MyCustomError())
 reflect(any: he)
@@ -265,31 +265,31 @@ reflect(any: he)
 // CHECK-64:        Type info:
 // CHECK-64:        (struct size=144 alignment=8 stride=144
 // CHECK-64-NEXT:   (field name=singleError offset=0
-// CHECK-64-NEXT:     (error_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (error_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=error offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))))
 // CHECK-64-NEXT:   (field name=errorInComposition offset=8
-// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=32
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=40
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=customError offset=56
-// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=32
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=customErrorInComposition offset=96
-// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=32
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=40
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -297,33 +297,33 @@ reflect(any: he)
 // CHECK-32: (struct existentials.HasError)
 
 // CHECK-32:        Type info:
-// CHECK-32:        (struct size=72 alignment=4 stride=72 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32:        (struct size=72 alignment=4 stride=72 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=singleError offset=0
-// CHECK-32-NEXT:     (error_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (error_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=error offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))))
 // CHECK-32-NEXT:   (field name=errorInComposition offset=4
-// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=12
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=16
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=20
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=customError offset=28
-// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=12
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=16
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=customErrorInComposition offset=48
-// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=12
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=16
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=20
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 reflect(error: MyError())
 
@@ -333,11 +333,11 @@ reflect(error: MyError())
 // CHECK-64: (struct existentials.MyError)
 
 // CHECK-64:        Type info:
-// CHECK-64:        (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:        (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=i offset=0
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an error existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -345,10 +345,10 @@ reflect(error: MyError())
 // CHECK-32: (struct existentials.MyError)
 
 // CHECK-32:        Type info:
-// CHECK-32:        (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:        (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=i offset=0
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -28,18 +28,18 @@ func concrete(x: Int, y: Any) {
 // CHECK-NEXT:    (builtin Builtin.NativeObject)
 
 // CHECK-32:      Type info:
-// CHECK-32-NEXT: (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field offset=8
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-64:      Type info:
-// CHECK-64-NEXT: (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field offset=16
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
   // Here the context is a single boxed value
   reflect(function: {print(y)})
@@ -47,18 +47,18 @@ func concrete(x: Int, y: Any) {
 // CHECK-NEXT:    (builtin Builtin.NativeObject)
 
 // CHECK-32:      Type info:
-// CHECK-32-NEXT: (closure_context size=24 alignment=4 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (closure_context size=24 alignment=4 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field offset=8
-// CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=metadata offset=12
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1)))))
 
 // CHECK-64:      Type info:
-// CHECK-64-NEXT: (closure_context size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (closure_context size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field offset=16
-// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=metadata offset=24
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))
 }
 
 concrete(x: 10, y: true)
@@ -87,25 +87,25 @@ func generic<T : P, U, V : C>(x: T, y: U, z: V, i: Int) {
 // CHECK-NEXT:    (builtin Builtin.NativeObject)
 
 // CHECK-32:      Type info:
-// CHECK-32-NEXT: (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field offset=8
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-64:      Type info:
-// CHECK-64-NEXT: (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field offset=16
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
   reflect(function: {print(x); print(y); print(z)})
 // CHECK:         Type reference:
 // CHECK-NEXT:    (builtin Builtin.NativeObject)
 
 // CHECK-32:      Type info:
-// CHECK-32-NEXT: (closure_context size=36 alignment=4 stride=36 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (closure_context size=36 alignment=4 stride=36 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field offset=24
 // CHECK-32-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-32-NEXT:   (field offset=28
@@ -114,7 +114,7 @@ func generic<T : P, U, V : C>(x: T, y: U, z: V, i: Int) {
 // CHECK-32-NEXT:     (reference kind=strong refcounting=native)))
 
 // CHECK-64:      Type info:
-// CHECK-64-NEXT: (closure_context size=72 alignment=8 stride=72 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (closure_context size=72 alignment=8 stride=72 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field offset=48
 // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:   (field offset=56
@@ -189,34 +189,34 @@ class CapturingClass {
   // CHECK-64: (builtin Builtin.NativeObject)
   
   // CHECK-64:        Type info:
-  // CHECK-64:        (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:        (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:   (field offset=16
-  // CHECK-64-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:       (field offset=0
-  // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:           (field name=_value offset=0
-  // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-64-NEXT:       (field offset=8
-  // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:           (field name=_value offset=0
-  // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))))
+  // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
   // CHECK-32: Reflecting an object.
   // CHECK-32: Type reference:
   // CHECK-32: (builtin Builtin.NativeObject)
 
   // CHECK-32:        Type info:
-  // CHECK-32:        (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:        (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:   (field offset=8
-  // CHECK-32-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:       (field offset=0
-  // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:           (field name=_value offset=0
-  // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-32-NEXT:       (field offset=8
-  // CHECK-32-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:           (field name=_value offset=0
-  // CHECK-32-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))))
+  // CHECK-32-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
   @_optimize(none)
   func arity1Capture1() -> (Int) -> () {
     let pair = (2, 333.0)
@@ -232,13 +232,13 @@ class CapturingClass {
   // CHECK-64: (builtin Builtin.NativeObject)
 
   // CHECK-64:      Type info:
-  // CHECK-64:      (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:      (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT: (field offset=16
-  // CHECK-64-NEXT:   (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+  // CHECK-64-NEXT:   (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
   // CHECK-64-NEXT:     (field offset=0
-  // CHECK-64-NEXT:       (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64-NEXT:       (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:         (field name=_value offset=0
-  // CHECK-64-NEXT:           (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-64-NEXT:           (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-64-NEXT:     (field offset=8
   // CHECK-64-NEXT:       (reference kind=strong refcounting=native)))))
 
@@ -247,13 +247,13 @@ class CapturingClass {
   // CHECK-32: (builtin Builtin.NativeObject)
   
   // CHECK-32:        Type info:
-  // CHECK-32:        (closure_context size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:        (closure_context size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:   (field offset=8
-  // CHECK-32-NEXT:     (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+  // CHECK-32-NEXT:     (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
   // CHECK-32-NEXT:       (field offset=0
-  // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:           (field name=_value offset=0
-  // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-32-NEXT:       (field offset=4
   // CHECK-32-NEXT:         (reference kind=strong refcounting=native)))))
   @_optimize(none)
@@ -272,11 +272,11 @@ class CapturingClass {
   // CHECK-64: (builtin Builtin.NativeObject)
   
   // CHECK-64:        Type info:
-  // CHECK-64:        (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:        (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:   (field offset=16
-  // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=true
+  // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
   // CHECK-64-NEXT:       (field name=some offset=0
-  // CHECK-64-NEXT:         (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+  // CHECK-64-NEXT:         (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
   // CHECK-64-NEXT:           (field name=object offset=0
   // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))))))
 
@@ -285,11 +285,11 @@ class CapturingClass {
   // CHECK-32: (builtin Builtin.NativeObject)
   
   // CHECK-32:        Type info:
-  // CHECK-32:        (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:        (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:   (field offset=8
-  // CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=true
+  // CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
   // CHECK-32-NEXT:       (field name=some offset=0
-  // CHECK-32-NEXT:         (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+  // CHECK-32-NEXT:         (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
   // CHECK-32-NEXT:           (field name=object offset=0
   // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown)))))
   @_optimize(none)
@@ -308,38 +308,38 @@ class CapturingClass {
   // CHECK-64: Type reference:
   // CHECK-64: (builtin Builtin.NativeObject)
   // CHECK-64:        Type info:
-  // CHECK-64:        (closure_context size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:        (closure_context size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:   (field offset=16
   // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
   // CHECK-64-NEXT:   (field offset=24
-  // CHECK-64-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:       (field offset=0
-  // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:           (field name=_value offset=0
-  // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-64-NEXT:       (field offset=8
-  // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:           (field name=_value offset=0
-  // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))))
+  // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
   // CHECK-32: Reflecting an object.
   // CHECK-32: Type reference:
   // CHECK-32: (builtin Builtin.NativeObject)
 
   // CHECK-32:        Type info:
-  // CHECK-32:        (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:        (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:   (field offset=8
   // CHECK-32-NEXT:     (reference kind=strong refcounting=native))
   // CHECK-32-NEXT:   (field offset=16
-  // CHECK-32-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32-NEXT:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:       (field offset=0
-  // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:           (field name=_value offset=0
-  // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-32-NEXT:       (field offset=8
-  // CHECK-32-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32-NEXT:           (field name=_value offset=0
-  // CHECK-32-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))))
+  // CHECK-32-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
   @_optimize(none)
   func arity0Capture2() -> () -> () {
    let pair = (999, 1010.2)
@@ -356,11 +356,11 @@ class CapturingClass {
   // CHECK-64: (builtin Builtin.NativeObject)
   
   // CHECK-64:        Type info:
-  // CHECK-64:        (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:        (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64-NEXT:   (field offset=16
   // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
   // CHECK-64-NEXT:   (field offset=24
-  // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=true
+  // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
   // CHECK-64-NEXT:       (field name=some offset=0
   // CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
 
@@ -369,7 +369,7 @@ class CapturingClass {
   // CHECK-32: (builtin Builtin.NativeObject)
   
   // CHECK-32: Type info:
-  // CHECK-32: (closure_context size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32: (closure_context size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32:   (field offset=8
   // CHECK-32:     (reference kind=strong refcounting=native))
   // CHECK-32:   (field offset=12
@@ -390,38 +390,38 @@ class CapturingClass {
   // CHECK-64: (builtin Builtin.NativeObject)
   
   // CHECK-64: Type info:
-  // CHECK-64: (closure_context size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64: (closure_context size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64:   (field offset=16
   // CHECK-64:     (reference kind=strong refcounting=native))
   // CHECK-64:   (field offset=24
-  // CHECK-64:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64:       (field offset=0
-  // CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64:           (field name=_value offset=0
-  // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-64:       (field offset=8
-  // CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64:           (field name=_value offset=0
-  // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))))
+  // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
   // CHECK-32: Reflecting an object.
   // CHECK-32: Type reference:
   // CHECK-32: (builtin Builtin.NativeObject)
   
   // CHECK-32: Type info:
-  // CHECK-32: (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32: (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32:   (field offset=8
   // CHECK-32:     (reference kind=strong refcounting=native))
   // CHECK-32:   (field offset=16
-  // CHECK-32:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32:       (field offset=0
-  // CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32:           (field name=_value offset=0
-  // CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-32:       (field offset=8
-  // CHECK-32:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32:           (field name=_value offset=0
-  // CHECK-32:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))))
+  // CHECK-32:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
   @_optimize(none)
   func arity2Capture2() -> (Int, String) -> () {
    let pair = (999, 1010.2)
@@ -439,38 +439,38 @@ class CapturingClass {
   // CHECK-64: (builtin Builtin.NativeObject)
  
   // CHECK-64: Type info:
-  // CHECK-64: (closure_context size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64: (closure_context size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64:   (field offset=16
   // CHECK-64:     (reference kind=strong refcounting=native))
   // CHECK-64:   (field offset=24
-  // CHECK-64:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64:       (field offset=0
-  // CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64:           (field name=_value offset=0
-  // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-64:       (field offset=8
-  // CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-64:           (field name=_value offset=0
-  // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))))
+  // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
 
   // CHECK-32: Reflecting an object.
   // CHECK-32: Type reference:
   // CHECK-32: (builtin Builtin.NativeObject)
   
   // CHECK-32: Type info:
-  // CHECK-32: (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32: (closure_context size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32:   (field offset=8
   // CHECK-32:     (reference kind=strong refcounting=native))
   // CHECK-32:   (field offset=16
-  // CHECK-32:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:     (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32:       (field offset=0
-  // CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32:           (field name=_value offset=0
-  // CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+  // CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
   // CHECK-32:       (field offset=8
-  // CHECK-32:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+  // CHECK-32:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
   // CHECK-32:           (field name=_value offset=0
-  // CHECK-32:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))))
+  // CHECK-32:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
   @_optimize(none)
   func arity3Capture2() -> (Int, String, AnyObject?) -> () {
    let pair = (999, 1010.2)
@@ -502,7 +502,7 @@ reflect(function: C().captureWeakSelf())
 // CHECK-64: (builtin Builtin.NativeObject)
 
 // CHECK-64:        Type info:
-// CHECK-64:        (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-64:        (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-64-NEXT:   (field offset=16
 // CHECK-64-NEXT:     (reference kind=weak refcounting=native)))
 
@@ -512,7 +512,7 @@ reflect(function: C().captureWeakSelf())
 // CHECK-32: (builtin Builtin.NativeObject)
 
 // CHECK-32:        Type info:
-// CHECK-32:        (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=false
+// CHECK-32:        (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=0
 // CHECK-32-NEXT:   (field offset=8
 // CHECK-32-NEXT:     (reference kind=weak refcounting=native)))
 
@@ -523,7 +523,7 @@ reflect(function: C().captureUnownedSelf())
 // CHECK-64: (builtin Builtin.NativeObject)
 
 // CHECK-64:        Type info:
-// CHECK-64:        (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:        (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field offset=16
 // CHECK-64-NEXT:     (reference kind=unowned refcounting=native)))
 
@@ -533,7 +533,7 @@ reflect(function: C().captureUnownedSelf())
 // CHECK-32: (builtin Builtin.NativeObject)
 
 // CHECK-32:        Type info:
-// CHECK-32:        (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:        (closure_context size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field offset=8
 // CHECK-32-NEXT:     (reference kind=unowned refcounting=native)))
 

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -19,15 +19,15 @@ func capturesImportedTypes(x: Int, n: NSURL, r: CGRect, c: NSCoding) {
 // CHECK-32-NEXT: (builtin Builtin.NativeObject)
 
 // CHECK-32:      Type info:
-// CHECK-32-NEXT: (closure_context size=36 alignment=4 stride=36 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (closure_context size=36 alignment=4 stride=36 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field offset=8
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field offset=12
 // CHECK-32-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:   (field offset=16
-// CHECK-32-NEXT:     (builtin size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-32-NEXT:     (builtin size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-32-NEXT:   (field offset=32
 // CHECK-32-NEXT:     (reference kind=strong refcounting=unknown)))
 
@@ -35,15 +35,15 @@ func capturesImportedTypes(x: Int, n: NSURL, r: CGRect, c: NSCoding) {
 // CHECK-64-NEXT: (builtin Builtin.NativeObject)
 
 // CHECK-64:      Type info:
-// CHECK-64-NEXT: (closure_context size=72 alignment=8 stride=72 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (closure_context size=72 alignment=8 stride=72 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field offset=16
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field offset=24
 // CHECK-64-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:   (field offset=32
-// CHECK-64-NEXT:     (builtin size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true))
+// CHECK-64-NEXT:     (builtin size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64-NEXT:   (field offset=64
 // CHECK-64-NEXT:     (reference kind=strong refcounting=unknown)))
 }

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -25,30 +25,30 @@ reflect(object: baseClass)
 // CHECK-64: (class inherits_NSObject.BaseNSClass)
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (class_instance size=17 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (class_instance size=17 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=w offset=8
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=x offset=16
-// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_NSObject.BaseNSClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=9 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=9 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=w offset=4
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=x offset=8
-// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1)))))
 
 class DerivedNSClass : BaseNSClass {
   var y: Bool = false
@@ -63,30 +63,30 @@ reflect(object: derivedClass)
 // CHECK-64: (class inherits_NSObject.DerivedNSClass)
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=y offset=17
-// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=z offset=24
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_NSObject.DerivedNSClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=y offset=9
-// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=z offset=12
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // Note: dynamic layout starts at offset 8, not 16
 class GenericBaseNSClass<T> : NSObject {
@@ -102,11 +102,11 @@ reflect(object: genericBaseClass)
 // CHECK-64:   (struct Swift.Int))
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=w offset=8
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
@@ -114,11 +114,11 @@ reflect(object: genericBaseClass)
 // CHECK-32:   (struct Swift.Int))
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=8 alignment=4 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=w offset=4
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 class AlignedNSClass : NSObject {
   var w: Int = 0
@@ -133,26 +133,26 @@ reflect(object: alignedClass)
 // CHECK-64: (class inherits_NSObject.AlignedNSClass)
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=w offset=8
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=x offset=16
-// CHECK-64-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_NSObject.AlignedNSClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=w offset=4
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=x offset=16
-// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 class GenericAlignedNSClass<T> : NSObject {
   var w: T = 0 as! T
@@ -168,13 +168,13 @@ reflect(object: genericAlignedClass)
 // CHECK-64:   (struct Swift.Int))
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=w offset=16
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=x offset=32
-// CHECK-64-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
@@ -182,12 +182,12 @@ reflect(object: genericAlignedClass)
 // CHECK-32:   (struct Swift.Int))
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=w offset=16
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=x offset=32
-// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 doneReflecting()

--- a/validation-test/Reflection/inherits_ObjCClasses.swift
+++ b/validation-test/Reflection/inherits_ObjCClasses.swift
@@ -28,18 +28,18 @@ reflect(object: firstClassA)
 // CHECK-64: (class inherits_ObjCClasses.FirstClassA)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=xx offset=16
-// CHECK-64:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_ObjCClasses.FirstClassA)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=xx offset=16
-// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 // Variant B: word size alignment
 class FirstClassB : FirstClass {
@@ -53,22 +53,22 @@ reflect(object: firstClassB)
 // CHECK-64: (class inherits_ObjCClasses.FirstClassB)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=zz offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_ObjCClasses.FirstClassB)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=zz offset=8
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 //// SecondClass -- base class, has two word-sized ivars
 
@@ -84,18 +84,18 @@ reflect(object: secondClassA)
 // CHECK-64: (class inherits_ObjCClasses.SecondClassA)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=xx offset=32
-// CHECK-64:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_ObjCClasses.SecondClassA)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=xx offset=16
-// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 // Variant B: word size alignment
 class SecondClassB : SecondClass {
@@ -109,22 +109,22 @@ reflect(object: secondClassB)
 // CHECK-64: (class inherits_ObjCClasses.SecondClassB)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=zz offset=24
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_ObjCClasses.SecondClassB)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=zz offset=12
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 //// ThirdClass -- base class, has three word-sized ivars
 
@@ -140,18 +140,18 @@ reflect(object: thirdClassA)
 // CHECK-64: (class inherits_ObjCClasses.ThirdClassA)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=xx offset=32
-// CHECK-64:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_ObjCClasses.ThirdClassA)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=32 alignment=16 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=xx offset=16
-// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=16 alignment=16 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 
 // Variant B: word size alignment
 class ThirdClassB : ThirdClass {
@@ -165,21 +165,21 @@ reflect(object: thirdClassB)
 // CHECK-64: (class inherits_ObjCClasses.ThirdClassB)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=zz offset=32
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_ObjCClasses.ThirdClassB)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=zz offset=16
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()

--- a/validation-test/Reflection/inherits_Swift.swift
+++ b/validation-test/Reflection/inherits_Swift.swift
@@ -25,30 +25,30 @@ class DerivedClass : BaseClass {
 // CHECK-64: (class inherits_Swift.BaseClass)
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (class_instance size=25 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=w offset=16
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=x offset=24
-// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_Swift.BaseClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=13 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=13 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=w offset=8
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=x offset=12
-// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1)))))
 
 let baseObject = BaseClass()
 reflect(object: baseObject)
@@ -61,29 +61,29 @@ reflect(object: derivedObject)
 // CHECK-64: (class inherits_Swift.DerivedClass)
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (class_instance size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (class_instance size=40 alignment=8 stride=40 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:  (field name=y offset=25
-// CHECK-64-NEXT:    (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-64-NEXT:    (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-64-NEXT:      (field name=_value offset=0
-// CHECK-64-NEXT:        (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true))))
+// CHECK-64-NEXT:        (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
 // CHECK-64-NEXT:  (field name=z offset=32
-// CHECK-64-NEXT:    (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:    (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:      (field name=_value offset=0
-// CHECK-64-NEXT:        (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:        (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class inherits_Swift.DerivedClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=y offset=13
-// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=z offset=16
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()

--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -26,9 +26,9 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Array.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
@@ -37,9 +37,9 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Array.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // (unstable implementation details omitted)
 
 doneReflecting()

--- a/validation-test/Reflection/reflect_Bool.swift
+++ b/validation-test/Reflection/reflect_Bool.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Bool.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=17 alignment=1 stride=17 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=17 alignment=1 stride=17 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Bool.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=9 alignment=1 stride=9 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=9 alignment=1 stride=9 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -25,32 +25,32 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Character.TestClass)
 
 // CHECK-64-LABEL: Type info:
-// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT: (field name=t offset=16
-// CHECK-64-NEXT:   (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:   (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:     (field name=_str offset=0
-// CHECK-64-NEXT:       (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:       (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:         (field name=_guts offset=0
-// CHECK-64-NEXT:           (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:           (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:             (field name=_object offset=0
-// CHECK-64-NEXT:               (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:               (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:                 (field name=_countAndFlagsBits offset=0
-// CHECK-64-NEXT:                   (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                   (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                     (field name=_value offset=0
-// CHECK-64-NEXT:                       (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:                       (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:                 (field name=_object offset=8
-// CHECK-64-NEXT:                   (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true)))))))))))
+// CHECK-64-NEXT:                   (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))))))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Type reference:
 // CHECK-32: (class reflect_Character.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=t offset=8
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_str offset=0
-// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -26,9 +26,9 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Dictionary.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
@@ -37,9 +37,9 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Dictionary.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // (unstable implementation details omitted)
 
 doneReflecting()

--- a/validation-test/Reflection/reflect_Double.swift
+++ b/validation-test/Reflection/reflect_Double.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Double.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Double.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Float.swift
+++ b/validation-test/Reflection/reflect_Float.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Float.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Float.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Int.swift
+++ b/validation-test/Reflection/reflect_Int.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Int16.swift
+++ b/validation-test/Reflection/reflect_Int16.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int16.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=18 alignment=2 stride=18 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=18 alignment=2 stride=18 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int16.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=10 alignment=2 stride=10 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=10 alignment=2 stride=10 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Int32.swift
+++ b/validation-test/Reflection/reflect_Int32.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int32.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int32.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Int64.swift
+++ b/validation-test/Reflection/reflect_Int64.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int64.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int64.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Int8.swift
+++ b/validation-test/Reflection/reflect_Int8.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Int8.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=17 alignment=1 stride=17 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=17 alignment=1 stride=17 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Int8.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=9 alignment=1 stride=9 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=9 alignment=1 stride=9 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_NSArray.swift
+++ b/validation-test/Reflection/reflect_NSArray.swift
@@ -27,7 +27,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_NSArray.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (reference kind=strong refcounting=unknown)))
 
@@ -37,7 +37,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_NSArray.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
 // CHECK-32:     (reference kind=strong refcounting=unknown)))
 

--- a/validation-test/Reflection/reflect_NSNumber.swift
+++ b/validation-test/Reflection/reflect_NSNumber.swift
@@ -27,7 +27,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_NSNumber.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (reference kind=strong refcounting=unknown)))
 
@@ -37,7 +37,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_NSNumber.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
 // CHECK-32:     (reference kind=strong refcounting=unknown)))
 

--- a/validation-test/Reflection/reflect_NSSet.swift
+++ b/validation-test/Reflection/reflect_NSSet.swift
@@ -27,7 +27,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_NSSet.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (reference kind=strong refcounting=unknown)))
 
@@ -37,7 +37,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_NSSet.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
 // CHECK-32:     (reference kind=strong refcounting=unknown)))
 

--- a/validation-test/Reflection/reflect_NSString.swift
+++ b/validation-test/Reflection/reflect_NSString.swift
@@ -27,7 +27,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_NSString.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (reference kind=strong refcounting=unknown)))
 
@@ -37,7 +37,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_NSString.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
 // CHECK-32:     (reference kind=strong refcounting=unknown)))
 

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -26,9 +26,9 @@ reflect(object: obj)
 // CHECK-64: (class reflect_Set.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
@@ -37,9 +37,9 @@ reflect(object: obj)
 // CHECK-32: (class reflect_Set.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // (unstable implementation details omitted)
 
 doneReflecting()

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -26,9 +26,9 @@ reflect(object: obj)
 // CHECK-64: (class reflect_String.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64-NEXT: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=t offset=16
-// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-32: Reflecting an object.
@@ -37,22 +37,22 @@ reflect(object: obj)
 // CHECK-32: (class reflect_String.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=t offset=8
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_guts offset=0
-// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-32-NEXT:         (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_object offset=0
-// CHECK-32-NEXT:             (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-32-NEXT:             (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:               (field name=_variant offset=4
-// CHECK-32-NEXT:                 (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-32-NEXT:                 (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=253 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:               (field name=_discriminator offset=9
-// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:               (field name=_flags offset=10
-// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // (unstable implementation details omitted)
 
 doneReflecting()

--- a/validation-test/Reflection/reflect_UInt.swift
+++ b/validation-test/Reflection/reflect_UInt.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_UInt16.swift
+++ b/validation-test/Reflection/reflect_UInt16.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt16.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=18 alignment=2 stride=18 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=18 alignment=2 stride=18 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt16.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=10 alignment=2 stride=10 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=10 alignment=2 stride=10 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_UInt32.swift
+++ b/validation-test/Reflection/reflect_UInt32.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt32.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt32.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_UInt64.swift
+++ b/validation-test/Reflection/reflect_UInt64.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt64.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt64.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_UInt8.swift
+++ b/validation-test/Reflection/reflect_UInt8.swift
@@ -26,11 +26,11 @@ reflect(object: obj)
 // CHECK-64: (class reflect_UInt8.TestClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=17 alignment=1 stride=17 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=17 alignment=1 stride=17 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:       (field name=_value offset=0
-// CHECK-64:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -38,11 +38,11 @@ reflect(object: obj)
 // CHECK-32: (class reflect_UInt8.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=9 alignment=1 stride=9 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=9 alignment=1 stride=9 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:       (field name=_value offset=0
-// CHECK-32:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_empty_class.swift
+++ b/validation-test/Reflection/reflect_empty_class.swift
@@ -21,7 +21,7 @@ reflect(object: obj)
 // CHECK-64: (class reflect_empty_class.EmptyClass)
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=16 alignment=1 stride=16 num_extra_inhabitants=0 bitwise_takable=true)
+// CHECK-64: (class_instance size=16 alignment=1 stride=16 num_extra_inhabitants=0 bitwise_takable=1)
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -29,7 +29,7 @@ reflect(object: obj)
 // CHECK-32: (class reflect_empty_class.EmptyClass)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=8 alignment=1 stride=8 num_extra_inhabitants=0 bitwise_takable=true)
+// CHECK-32: (class_instance size=8 alignment=1 stride=8 num_extra_inhabitants=0 bitwise_takable=1)
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_existential.swift
+++ b/validation-test/Reflection/reflect_existential.swift
@@ -29,22 +29,22 @@ reflect(object: TestGeneric(D() as Any))
 // CHECK-64:   (protocol_composition))
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=48 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1)))))
 
 // CHECK-32: Type reference:
 // CHECK-32: (bound_generic_class reflect_existential.TestGeneric
 // CHECK-32:   (protocol_composition))
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=24 alignment=4 stride=24 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=24 alignment=4 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32:       (field name=metadata offset=12
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1)))))
 
 reflect(object: TestGeneric(D() as P))
 
@@ -54,13 +54,13 @@ reflect(object: TestGeneric(D() as P))
 // CHECK-64:     (protocol reflect_existential.P)))
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=56 alignment=8 stride=56 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=56 alignment=8 stride=56 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))
 // CHECK-64:       (field name=wtable offset=32
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 // CHECK-32: Type reference:
 // CHECK-32: (bound_generic_class reflect_existential.TestGeneric
@@ -68,13 +68,13 @@ reflect(object: TestGeneric(D() as P))
 // CHECK-32:     (protocol reflect_existential.P)))
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=28 alignment=4 stride=28 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=28 alignment=4 stride=28 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32:       (field name=metadata offset=12
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32:       (field name=wtable offset=16
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 reflect(object: TestGeneric(D() as (P & AnyObject)))
 
@@ -84,13 +84,13 @@ reflect(object: TestGeneric(D() as (P & AnyObject)))
 // CHECK-64:     (protocol reflect_existential.P)))
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64:       (field name=object offset=0
 // CHECK-64:         (reference kind=strong refcounting=unknown))
 // CHECK-64:       (field name=wtable offset=8
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 // CHECK-32: Type reference:
 // CHECK-32: (bound_generic_class reflect_existential.TestGeneric
@@ -98,13 +98,13 @@ reflect(object: TestGeneric(D() as (P & AnyObject)))
 // CHECK-32:     (protocol reflect_existential.P)))
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32:       (field name=object offset=0
 // CHECK-32:         (reference kind=strong refcounting=unknown))
 // CHECK-32:       (field name=wtable offset=4
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 reflect(object: TestGeneric(D() as CP))
 
@@ -114,13 +114,13 @@ reflect(object: TestGeneric(D() as CP))
 // CHECK-64:     (protocol reflect_existential.CP)))
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64:       (field name=object offset=0
 // CHECK-64:         (reference kind=strong refcounting=unknown))
 // CHECK-64:       (field name=wtable offset=8
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 // CHECK-32: Type reference:
 // CHECK-32: (bound_generic_class reflect_existential.TestGeneric
@@ -128,13 +128,13 @@ reflect(object: TestGeneric(D() as CP))
 // CHECK-32:     (protocol reflect_existential.CP)))
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32:       (field name=object offset=0
 // CHECK-32:         (reference kind=strong refcounting=unknown))
 // CHECK-32:       (field name=wtable offset=4
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 reflect(object: TestGeneric(D() as (C & P)))
 
@@ -145,13 +145,13 @@ reflect(object: TestGeneric(D() as (C & P)))
 // CHECK-64:     (protocol reflect_existential.P)))
 
 // CHECK-64: Type info:
-// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64:       (field name=object offset=0
 // CHECK-64:         (reference kind=strong refcounting=native))
 // CHECK-64:       (field name=wtable offset=8
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 // CHECK-32: Type reference:
 // CHECK-32: (bound_generic_class reflect_existential.TestGeneric
@@ -160,13 +160,13 @@ reflect(object: TestGeneric(D() as (C & P)))
 // CHECK-32:     (protocol reflect_existential.P)))
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32: (class_instance size=16 alignment=4 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32:       (field name=object offset=0
 // CHECK-32:         (reference kind=strong refcounting=native))
 // CHECK-32:       (field name=wtable offset=4
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=true)))))
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -115,61 +115,61 @@ reflect(object: obj)
 // CHECK-64: (class reflect_multiple_types.TestClass)
 
 // CHECK-64-LABEL: Type info:
-// CHECK-64-NEXT: (class_instance size=185 alignment=8 stride=192 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT: (class_instance size=185 alignment=8 stride=192 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:   (field name=t00 offset=16
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-64:   (field name=t01 offset=24
-// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
 
 // CHECK-64-NEXT:   (field name=t02 offset=32
-// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_str offset=0
-// CHECK-64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_guts offset=0
-// CHECK-64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:               (field name=_object offset=0
-// CHECK-64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64-NEXT:                   (field name=_countAndFlagsBits offset=0
-// CHECK-64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:                       (field name=_value offset=0
-// CHECK-64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:                   (field name=_object offset=8
-// CHECK-64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true))))))))))
+// CHECK-64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))))
 
 // CHECK-64-NEXT:   (field name=t03 offset=48
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-64:   (field name=t04 offset=56
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t05 offset=64
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t06 offset=72
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t07 offset=80
-// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t08 offset=84
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t09 offset=88
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t10 offset=96
-// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t11 offset=104
 // CHECK-64-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:   (field name=t12 offset=112
@@ -179,34 +179,34 @@ reflect(object: obj)
 // CHECK-64-NEXT:   (field name=t14 offset=128
 // CHECK-64-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:   (field name=t15 offset=136
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
 
 // (unstable implementation details omitted)
 
 // CHECK-64:   (field name=t16 offset=144
-// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647 bitwise_takable=1
 // (unstable implementation details omitted)
 
 // CHECK-64:   (field name=t17 offset=160
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t18 offset=168
-// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t19 offset=172
-// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t20 offset=176
-// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-64-NEXT:   (field name=t21 offset=184
-// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
-// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -214,49 +214,49 @@ reflect(object: obj)
 // CHECK-32: (class reflect_multiple_types.TestClass)
 
 // CHECK-32: Type info:
-// CHECK-32-NEXT: (class_instance size=121 alignment=8 stride=128 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT: (class_instance size=121 alignment=8 stride=128 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:   (field name=t00 offset=8
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t01 offset=12
-// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t02 offset=16
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_str offset=0
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t03 offset=28
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t04 offset=32
-// CHECK-32-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t05 offset=40
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t06 offset=44
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t07 offset=48
-// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t08 offset=52
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t09 offset=56
-// CHECK-32-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t10 offset=64
-// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t11 offset=68
 // CHECK-32-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:   (field name=t12 offset=72
@@ -266,31 +266,31 @@ reflect(object: obj)
 // CHECK-32-NEXT:   (field name=t14 offset=80
 // CHECK-32-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:   (field name=t15 offset=84
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t16 offset=88
-// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=12 alignment=4 stride=12 num_extra_inhabitants=253 bitwise_takable=1
 // (unstable implementation details omitted)
 // CHECK-32:   (field name=t17 offset=100
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t18 offset=104
-// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t19 offset=108
-// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t20 offset=112
-// CHECK-32-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=true))))
+// CHECK-32-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
 // CHECK-32-NEXT:   (field name=t21 offset=120
-// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true
+// CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
-// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=true)))))
+// CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))
 
 doneReflecting()
 


### PR DESCRIPTION
I wanted to make the output nicer, so I asked @ismetanin to change to false/true in #27081, but it makes it [harder to write tests that work across OS versions](https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RA-test-simulator-swift-in-the-os/252), so never mind.

rdar://problem/56350587