### PR TITLE
[TBDGen] Use TAPI's defaults for compatibility_version and current_version

### DIFF
--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -40,14 +40,12 @@ struct TBDGenOptions {
   std::string ModuleLinkName;
 
   /// The current project version to use in the generated TBD file. Defaults
-  /// to 1, which matches the default if the DYLIB_CURRENT_VERSION build setting
-  /// is not set.
-  version::Version CurrentVersion = {1, 0, 0};
+  /// to None.
+  llvm::Optional<version::Version> CurrentVersion = None;
 
   /// The dylib compatibility-version to use in the generated TBD file. Defaults
-  /// to 1, which matches the default if the DYLIB_COMPATIBILITY_VERSION build
-  /// setting is not set.
-  version::Version CompatibilityVersion = {1, 0, 0};
+  /// to None.
+  llvm::Optional<version::Version> CompatibilityVersion = None;
 };
 
 void enumeratePublicSymbols(FileUnit *module, llvm::StringSet<> &symbols,

--- a/test/TBD/dylib-version.swift
+++ b/test/TBD/dylib-version.swift
@@ -12,16 +12,6 @@
 // BOTH: current-version: 2.0.3
 // BOTH: compatibility-version: 1.7
 // CURRENT: current-version: 2
-
-// Compatibility version defaults to 1 if not present in TBD file, and
-// tapi does not write field if compatibility version is 1
-
-// CURRENT-NOT: compatibility-version: 1
-
 // COMPAT: compatibility-version: 2
-
-// Same as above -- current version defaults to 1 and is not present in
-// emitted TBD file if it's 1.
-// COMPAT-NOT: current-version: 1
 
 // BOGUS: version component contains non-numeric characters


### PR DESCRIPTION
Stop hard-coding the default to 1.0.0 for dylibs and let TAPI pick the
right one.