### PR TITLE
[ConstraintSystem] Adjust keypath subscript assert to account for dyn…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7980,9 +7980,11 @@ ConstraintSystem::addKeyPathApplicationRootConstraint(Type root, ConstraintLocat
   auto subscript = dyn_cast_or_null<SubscriptExpr>(anchor);
   if (!subscript)
     return;
-  
-  assert(path.size() == 1 &&
-         path[0].getKind() == ConstraintLocator::SubscriptMember);
+
+  assert((path.size() == 1 &&
+          path[0].getKind() == ConstraintLocator::SubscriptMember) ||
+         (path.size() == 2 &&
+          path[1].getKind() == ConstraintLocator::KeyPathDynamicMember));
   auto indexTuple = dyn_cast<TupleExpr>(subscript->getIndex());
   if (!indexTuple || indexTuple->getNumElements() != 1)
     return;

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1789,3 +1789,20 @@ protocol ProtocolWithWrapper {
 struct UsesProtocolWithWrapper: ProtocolWithWrapper {
   @Wrapper var foo: Int // expected-warning{{ignoring associated type 'Wrapper' in favor of module-scoped property wrapper 'Wrapper'; please qualify the reference with 'property_wrappers'}}{{4-4=property_wrappers.}}
 }
+
+// rdar://problem/56350060 - [Dynamic key path member lookup] Assertion when subscripting with a key path
+func test_rdar56350060() {
+  @propertyWrapper
+  @dynamicMemberLookup
+  struct DynamicWrapper<Value> {
+    var wrappedValue: Value { fatalError() }
+
+    subscript<T>(keyPath keyPath: KeyPath<Value, T>) -> DynamicWrapper<T> {
+      fatalError()
+    }
+
+    subscript<T>(dynamicMember keyPath: KeyPath<Value, T>) -> DynamicWrapper<T> {
+      return self[keyPath: keyPath] // Ok
+    }
+  }
+}


### PR DESCRIPTION
…amic member lookup

It's possible to find a suitable overload choice for
key path application through keypath dynamic member
lookup and assertion inside `addKeyPathApplicationRootConstraint`
should account for that.

Resolves: rdar://problem/56350060

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
