### PR TITLE
Reenable test: tsan-norace-deinit-run-time.swift (55880585)

### DIFF
--- a/test/Sanitizers/tsan-norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan-norace-deinit-run-time.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -target %sanitizers-target-triple -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
 // RUN: env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --dump-input=fail --implicit-check-not='ThreadSanitizer'
-// REQUIRES: rdar55880585
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
 


### PR DESCRIPTION
This test was failing because I forgot to cherry-pick a change in
compiler-rt to the `apple/stable/20190619` branch.  The reason was that
for a short time we had two active release branches: `swift-5.1-branch`
and `apple/stable/20190619`.  When Swift switched to the latter, i.e.,
`stable` switched to tracking the latter, the change was essentially
reverted.

I now cherry-picked the necessary change into `apple/stable/20190619` and it
(660f2fafbe1ef2de9a76259ecc115fcabc8f154a) has now trickled through to
`stable`, so we can re-enable this test.

This reverts commit 351c4cc73609fc0cfb6d055ae56a66ffb3752158.

rdar://55880585
