### PR TITLE
XFAIL SDKDependencies test in Windows.

### DIFF
--- a/test/ModuleInterface/ModuleCache/SDKDependencies.swift
+++ b/test/ModuleInterface/ModuleCache/SDKDependencies.swift
@@ -1,5 +1,7 @@
 // RUN: %empty-directory(%t)
 
+// XFAIL: OS=windows-msvc
+
 // 1) Build a prebuilt cache for our SDK
 //
 // RUN: mkdir %t/MCP %t/prebuilt-cache %t/my-sdk


### PR DESCRIPTION
Windows paths attack again. Some paths from the dependency tracker have mixed folder separators, so comparing textually fail. Additionally some paths seems to be extended paths (\\?\) which seems not to be liked by LLVM path utilities.

Windows builds started failing after introducing #27635 in https://ci-external.swift.org/job/oss-swift-windows-x86_64/1631/. From the failed test:

```
$ "s:\\swift\\bin\\swiftc.exe" [...snip...] "C:\jenkins\workspace\oss-swift-windows-x86_64\swift\test\ModuleInterface\ModuleCache\SDKDependencies.swift"
# command stderr:
<unknown>:0: error: fatal error encountered during compilation; please file a bug report with your project and the crash log

<unknown>:0: note: Unexpected path for swiftinterface file:

S:\swift\test-windows-x86_64\ModuleInterface\ModuleCache\Output\SDKDependencies.swift.tmp\my-sdk\ExportedLib.swiftinterface

The module <-> path mapping we have is:

SdkLib <-> S:\swift\test-windows-x86_64\ModuleInterface\ModuleCache\Output\SDKDependencies.swift.tmp/my-sdk\SdkLib.swiftinterface
```

This should fix the comparison between the two paths to use the same kind of slashes in both sides.