### PR TITLE
omitNeedlessWords: Fix self-type-stripping regression

### DIFF
--- a/test/IDE/Inputs/custom-modules/OmitNeedlessWords.h
+++ b/test/IDE/Inputs/custom-modules/OmitNeedlessWords.h
@@ -79,3 +79,16 @@ typedef NS_OPTIONS(NSUInteger, OMWWobbleOptions) {
 -(void)conflicting1;
 @property (readonly) NSInteger conflictingProp1;
 @end
+
+@interface OMWObjectType : NSObject
+-(void)_enumerateObjectTypesWithHandler:(nonnull void (^)(void))handler;
+@end
+
+@interface OMWTerrifyingGarbage4DTypeRefMask_t : NSObject
+-(void)throwGarbageAway;
+-(void)throwGarbage4DAwayHarder;
+-(void)throwGarbage4DTypeRefMask_tAwayHardest;
+-(void)burnGarbage;
+-(void)carefullyBurnGarbage4D;
+-(void)veryCarefullyBurnGarbage4DTypeRefMask_t;
+@end

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -300,6 +300,25 @@
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func jumpSuper()
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func joinSub()
 
+// CHECK-OMIT-NEEDLESS-WORDS-LABEL: class OMWObjectType
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func _enumerateTypes(handler: @escaping () -> Void)
+
+// CHECK-OMIT-NEEDLESS-WORDS-LABEL: class OMWTerrifyingGarbage4DTypeRefMask_t
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func throwAway()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "throwAway()")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func throwGarbageAway()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func throwGarbage4DAwayHarder()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func throwGarbage4DTypeRefMask_tAwayHardest()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func burn()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "burn()")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func burnGarbage()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func carefullyBurn()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "carefullyBurn()")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func carefullyBurnGarbage4D()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func veryCarefullyBurn()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "veryCarefullyBurn()")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func veryCarefullyBurnGarbage4DTypeRefMask_t()
+
 // CHECK-OMIT-NEEDLESS-WORDS-DIAGS: inconsistent Swift name for Objective-C method 'conflicting1' in 'OMWSub' ('waggle1()' in 'OMWWaggle' vs. 'wiggle1()' in 'OMWWiggle')
 // CHECK-OMIT-NEEDLESS-WORDS-DIAGS: inconsistent Swift name for Objective-C property 'conflictingProp1' in 'OMWSub' ('waggleProp1' in 'OMWWaggle' vs. 'wiggleProp1' in 'OMWSuper')
 


### PR DESCRIPTION
Fix-up for #27602. Turns out self-type-stripping *always* operates on a type without suffixes rather than *never,* after the first match attempt. Neither of these behaviors are really what we'd want (see the inconsistent test cases), but we'll live with it! The new hack is simpler than the old hack, at least.

rdar://problem/56334797