### PR TITLE
[TBDGen] Skip non-inlinable function bodies in InstallAPI

### DIFF
--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -228,6 +228,12 @@ void ArgsToFrontendOptionsConverter::computeDebugTimeOptions() {
   Opts.DebugTimeCompilation |= Args.hasArg(OPT_debug_time_compilation);
   Opts.SkipNonInlinableFunctionBodies |=
       Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies);
+
+  // If asked to perform InstallAPI, go ahead and enable non-inlinable function
+  // body skipping.
+  Opts.SkipNonInlinableFunctionBodies |=
+      Args.hasArg(OPT_tbd_is_installapi);
+
   if (const Arg *A = Args.getLastArg(OPT_stats_output_dir)) {
     Opts.StatsOutputDir = A->getValue();
     if (Args.getLastArg(OPT_trace_stats_events)) {

--- a/test/TBD/installapi-flag.swift
+++ b/test/TBD/installapi-flag.swift
@@ -3,8 +3,8 @@
 
 // 1. Emit two TBDs, one with -tbd-is-installapi set, and one without
 
-// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-is-installapi -emit-tbd -emit-tbd-path %t/flag-provided.tbd
-// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -emit-tbd -emit-tbd-path %t/flag-omitted.tbd
+// RUN: %target-swift-frontend -typecheck %s -tbd-is-installapi -emit-tbd -emit-tbd-path %t/flag-provided.tbd
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/flag-omitted.tbd
 
 // 2. Ensure that the file with -tbd-is-installapi passed includes the installapi flag
 


### PR DESCRIPTION
For now, until we figure out the right way to present
-experimental-skip-non-inlinable-function-bodies, make
-tbd-is-installapi imply that, for testing.