### PR TITLE
[SkipFunctionBodies] Build everything but the stdlib with function body skipping

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -333,6 +333,11 @@ function(_compile_swift_files
            "-emit-module-interface-path" "${interface_file}")
     endif()
 
+    if (NOT SWIFTFILE_IS_STDLIB_CORE)
+      list(APPEND swift_module_flags
+           "-Xfrontend" "-experimental-skip-non-inlinable-function-bodies")
+    endif()
+
     # If we have extra regexp flags, check if we match any of the regexps. If so
     # add the relevant flags to our swift_flags.
     if (SWIFT_EXPERIMENTAL_EXTRA_REGEXP_FLAGS OR SWIFT_EXPERIMENTAL_EXTRA_NEGATIVE_REGEXP_FLAGS)

--- a/lib/SILOptimizer/UtilityPasses/NonInlinableFunctionSkippingChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/NonInlinableFunctionSkippingChecker.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/LLVM.h"
+#include "swift/AST/Module.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
@@ -83,7 +84,7 @@ class NonInlinableFunctionSkippingChecker : public SILModuleTransform {
       return;
 
     // Skip this verification for SwiftOnoneSupport
-    if (getModule()->isOptimizedOnoneSupportModule())
+    if (getModule()->getSwiftModule()->isOnoneSupportModule())
       return;
 
     for (auto &F : *getModule()) {


### PR DESCRIPTION
This un-reverts #27588, which was causing failures on debug builds
because it was only disabling the NonInlinableFunctionSkippingChecker
for the *optimized* OnoneSupport module, but not the unoptimized one.