### PR TITLE
IRGen: Fix a non null terminated string error

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -444,7 +444,7 @@ private:
         Dir = CurDir;
     }
     llvm::DIFile *F = DBuilder.createFile(File, Dir, CSInfo, Source);
-    DIFileCache[FileName.data()].reset(F);
+    DIFileCache[FileName].reset(F);
     return F;
   }
 


### PR DESCRIPTION
Just use the StringRef as index to a string map. Using data() will fail
if the StringRef does not contain a null terminated string.

The problem is that we get the data of a StringRef (which is not null
terminated) to intialize a StringRef with char* which expects a null
terminated string.

Found by a ASAN bot.

rdar://56340563