### PR TITLE
[Sema] Requestify default argument type checking

### DIFF
--- a/include/swift/AST/ASTTypeIDZone.def
+++ b/include/swift/AST/ASTTypeIDZone.def
@@ -45,6 +45,7 @@ SWIFT_TYPEID_NAMED(OpaqueTypeDecl *, OpaqueTypeDecl)
 SWIFT_TYPEID_NAMED(OperatorDecl *, OperatorDecl)
 SWIFT_TYPEID_NAMED(Optional<PropertyWrapperMutability>,
                    PropertyWrapperMutability)
+SWIFT_TYPEID_NAMED(ParamDecl *, ParamDecl)
 SWIFT_TYPEID_NAMED(PatternBindingEntry *, PatternBindingEntry)
 SWIFT_TYPEID_NAMED(PrecedenceGroupDecl *, PrecedenceGroupDecl)
 SWIFT_TYPEID_NAMED(ProtocolDecl *, ProtocolDecl)

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7286,6 +7286,9 @@ inline EnumElementDecl *EnumDecl::getUniqueElement(bool hasValue) const {
   return result;
 }
 
+/// Retrieve the parameter list for a given declaration.
+ParameterList *getParameterList(ValueDecl *source);
+
 /// Retrieve parameter declaration from the given source at given index.
 const ParamDecl *getParameterAt(const ValueDecl *source, unsigned index);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5198,7 +5198,7 @@ class ParamDecl : public VarDecl {
 
   /// Retrieve the cached initializer context for the parameter's default
   /// argument without triggering a request.
-  Initializer *getDefaultArgumentInitContextCached() const;
+  Optional<Initializer *> getCachedDefaultArgumentInitContext() const;
 
   enum class Flags : uint8_t {
     /// Whether or not this parameter is vargs.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5175,6 +5175,8 @@ enum class ParamSpecifier : uint8_t {
 
 /// A function parameter declaration.
 class ParamDecl : public VarDecl {
+  friend class DefaultArgumentInitContextRequest;
+
   llvm::PointerIntPair<Identifier, 1, bool> ArgumentNameAndDestructured;
   SourceLoc ParameterNameLoc;
   SourceLoc ArgumentNameLoc;
@@ -5188,6 +5190,10 @@ class ParamDecl : public VarDecl {
     StringRef StringRepresentation;
     CaptureInfo Captures;
   };
+
+  /// Retrieve the cached initializer context for the parameter's default
+  /// argument without triggering a request.
+  Initializer *getDefaultArgumentInitContextCached() const;
 
   enum class Flags : uint8_t {
     /// Whether or not this parameter is vargs.
@@ -5262,11 +5268,8 @@ public:
 
   void setStoredProperty(VarDecl *var);
 
-  Initializer *getDefaultArgumentInitContext() const {
-    if (auto stored = DefaultValueAndFlags.getPointer())
-      return stored->InitContext;
-    return nullptr;
-  }
+  /// Retrieve the initializer context for the parameter's default argument.
+  Initializer *getDefaultArgumentInitContext() const;
 
   void setDefaultArgumentInitContext(Initializer *initContext);
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1843,6 +1843,28 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Computes an initializer context for a parameter with a default argument.
+class DefaultArgumentInitContextRequest
+    : public SimpleRequest<DefaultArgumentInitContextRequest,
+                           Initializer *(ParamDecl *),
+                           CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<Initializer *> evaluate(Evaluator &evaluator,
+                                         ParamDecl *param) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<Initializer *> getCachedResult() const;
+  void cacheResult(Initializer *init) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1865,6 +1865,27 @@ public:
   void cacheResult(Initializer *init) const;
 };
 
+/// Computes the fully type-checked default argument expression for a given
+/// parameter.
+class DefaultArgumentExprRequest
+    : public SimpleRequest<DefaultArgumentExprRequest, Expr *(ParamDecl *),
+                           CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<Expr *> evaluate(Evaluator &evaluator, ParamDecl *param) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<Expr *> getCachedResult() const;
+  void cacheResult(Expr *expr) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -32,6 +32,8 @@ SWIFT_REQUEST(TypeChecker, ClassAncestryFlagsRequest,
 SWIFT_REQUEST(TypeChecker, CompareDeclSpecializationRequest,
               bool (DeclContext *, ValueDecl *, ValueDecl *, bool), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DefaultArgumentExprRequest,
+              Expr *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,
               Initializer *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -32,6 +32,8 @@ SWIFT_REQUEST(TypeChecker, ClassAncestryFlagsRequest,
 SWIFT_REQUEST(TypeChecker, CompareDeclSpecializationRequest,
               bool (DeclContext *, ValueDecl *, ValueDecl *, bool), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,
+              Initializer *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,
               Type(AssociatedTypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultTypeRequest,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -996,14 +996,14 @@ namespace {
                    getDefaultArgumentKindString(P->getDefaultArgumentKind()));
       }
 
-      if (P->getDefaultValue() &&
-        !P->getDefaultArgumentCaptureInfo().isTrivial()) {
+      if (P->hasDefaultExpr() &&
+          !P->getDefaultArgumentCaptureInfo().isTrivial()) {
         OS << " ";
         P->getDefaultArgumentCaptureInfo().print(
           PrintWithColorRAII(OS, CapturesColor).getOS());
       }
 
-      if (auto init = P->getDefaultValue()) {
+      if (auto init = P->getStructuralDefaultExpr()) {
         OS << " expression=\n";
         printRec(init);
       }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2562,7 +2562,7 @@ void PrintAST::printOneParameter(const ParamDecl *param,
     auto BodyName = param->getName();
     switch (Options.ArgAndParamPrinting) {
     case PrintOptions::ArgAndParamPrintingMode::EnumElement:
-      if (ArgName.empty() && BodyName.empty() && !param->getDefaultValue()) {
+      if (ArgName.empty() && BodyName.empty() && !param->hasDefaultExpr()) {
         // Don't print anything, in the style of a tuple element.
         return;
       }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1212,7 +1212,7 @@ ParameterListScope::expandAScopeThatCreatesANewInsertionPoint(
   // Unlike generic parameters or pattern initializers, it cannot refer to a
   // previous parameter.
   for (ParamDecl *pd : params->getArray()) {
-    if (pd->getDefaultValue())
+    if (pd->hasDefaultExpr())
       scopeCreator
           .constructExpandAndInsertUncheckable<DefaultArgumentInitializerScope>(
               this, pd);
@@ -1535,7 +1535,7 @@ void ClosureBodyScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
 void DefaultArgumentInitializerScope::
     expandAScopeThatDoesNotCreateANewInsertionPoint(
         ScopeCreator &scopeCreator) {
-  auto *initExpr = decl->getDefaultValue();
+  auto *initExpr = decl->getStructuralDefaultExpr();
   ASTScopeAssert(initExpr,
                  "Default argument initializer must have an initializer.");
   scopeCreator.addToScopeTree(initExpr, this);

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -225,7 +225,7 @@ SourceRange AbstractStmtScope::getSourceRangeOfThisASTNode(
 
 SourceRange DefaultArgumentInitializerScope::getSourceRangeOfThisASTNode(
     const bool omitAssertions) const {
-  if (auto *dv = decl->getDefaultValue())
+  if (auto *dv = decl->getStructuralDefaultExpr())
     return dv->getSourceRange();
   return SourceRange();
 }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1164,10 +1164,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         }
       }
 
-      if (auto *E = P->getDefaultValue()) {
+      if (auto *E = P->getStructuralDefaultExpr()) {
         auto res = doIt(E);
         if (!res) return true;
-        P->setDefaultValue(res);
+        P->setDefaultExpr(res, /*isTypeChecked*/ (bool)res->getType());
       }
     }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6465,17 +6465,19 @@ DeclName AbstractFunctionDecl::getEffectiveFullName() const {
   return DeclName();
 }
 
-const ParamDecl *swift::getParameterAt(const ValueDecl *source, unsigned index) {
-  const ParameterList *paramList;
+ParameterList *swift::getParameterList(ValueDecl *source) {
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(source)) {
-    paramList = AFD->getParameters();
+    return AFD->getParameters();
   } else if (auto *EED = dyn_cast<EnumElementDecl>(source)) {
-    paramList = EED->getParameterList();
+    return EED->getParameterList();
   } else {
-    paramList = cast<SubscriptDecl>(source)->getIndices();
+    return cast<SubscriptDecl>(source)->getIndices();
   }
+}
 
-  return paramList->get(index);
+const ParamDecl *swift::getParameterAt(const ValueDecl *source,
+                                       unsigned index) {
+  return getParameterList(const_cast<ValueDecl *>(source))->get(index);
 }
 
 Type AbstractFunctionDecl::getMethodInterfaceType() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6046,11 +6046,12 @@ AnyFunctionType::Param ParamDecl::toFunctionParam(Type type) const {
   return AnyFunctionType::Param(type, label, flags);
 }
 
-Initializer *ParamDecl::getDefaultArgumentInitContextCached() const {
+Optional<Initializer *> ParamDecl::getCachedDefaultArgumentInitContext() const {
   if (auto *defaultInfo = DefaultValueAndFlags.getPointer())
-      return defaultInfo->InitContextAndIsTypeChecked.getPointer();
+    if (auto *init = defaultInfo->InitContextAndIsTypeChecked.getPointer())
+      return init;
 
-  return nullptr;
+  return None;
 }
 
 Initializer *ParamDecl::getDefaultArgumentInitContext() const {
@@ -6160,7 +6161,7 @@ CustomAttr *ValueDecl::getAttachedFunctionBuilder() const {
 }
 
 void ParamDecl::setDefaultArgumentInitContext(Initializer *initContext) {
-  auto *oldContext = getDefaultArgumentInitContextCached();
+  auto oldContext = getCachedDefaultArgumentInitContext();
   assert((!oldContext || oldContext == initContext) &&
          "Cannot change init context after setting");
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1181,3 +1181,21 @@ void HasCircularRawValueRequest::noteCycleStep(DiagnosticEngine &diags) const {
   diags.diagnose(decl, diag::kind_declname_declared_here,
                  decl->getDescriptiveKind(), decl->getName());
 }
+
+//----------------------------------------------------------------------------//
+// DefaultArgumentInitContextRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<Initializer *>
+DefaultArgumentInitContextRequest::getCachedResult() const {
+  auto *param = std::get<0>(getStorage());
+  if (auto *init = param->getDefaultArgumentInitContextCached())
+    return init;
+
+  return None;
+}
+
+void DefaultArgumentInitContextRequest::cacheResult(Initializer *init) const {
+  auto *param = std::get<0>(getStorage());
+  param->setDefaultArgumentInitContext(init);
+}

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1190,10 +1190,7 @@ void HasCircularRawValueRequest::noteCycleStep(DiagnosticEngine &diags) const {
 Optional<Initializer *>
 DefaultArgumentInitContextRequest::getCachedResult() const {
   auto *param = std::get<0>(getStorage());
-  if (auto *init = param->getDefaultArgumentInitContextCached())
-    return init;
-
-  return None;
+  return param->getCachedDefaultArgumentInitContext();
 }
 
 void DefaultArgumentInitContextRequest::cacheResult(Initializer *init) const {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -13,6 +13,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsCommon.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/Initializer.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/PropertyWrappers.h"
@@ -1198,4 +1199,25 @@ DefaultArgumentInitContextRequest::getCachedResult() const {
 void DefaultArgumentInitContextRequest::cacheResult(Initializer *init) const {
   auto *param = std::get<0>(getStorage());
   param->setDefaultArgumentInitContext(init);
+}
+
+//----------------------------------------------------------------------------//
+// DefaultArgumentExprRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<Expr *> DefaultArgumentExprRequest::getCachedResult() const {
+  auto *param = std::get<0>(getStorage());
+  auto *defaultInfo = param->DefaultValueAndFlags.getPointer();
+  if (!defaultInfo)
+    return None;
+
+  if (!defaultInfo->InitContextAndIsTypeChecked.getInt())
+    return None;
+
+  return defaultInfo->DefaultArg.get<Expr *>();
+}
+
+void DefaultArgumentExprRequest::cacheResult(Expr *expr) const {
+  auto *param = std::get<0>(getStorage());
+  param->setDefaultExpr(expr, /*isTypeChecked*/ true);
 }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -654,7 +654,7 @@ mapParsedParameters(Parser &parser,
     if (param.DefaultArg) {
       DefaultArgumentKind kind = getDefaultArgKind(param.DefaultArg);
       result->setDefaultArgumentKind(kind);
-      result->setDefaultValue(param.DefaultArg);
+      result->setDefaultExpr(param.DefaultArg, /*isTypeChecked*/ false);
     } else if (param.hasInheritedDefaultArg) {
       result->setDefaultArgumentKind(DefaultArgumentKind::Inherited);
     }

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1778,7 +1778,7 @@ static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
   auto sig = vd->getInnermostDeclContext()->getGenericSignatureOfContext();
   if (auto *afd = dyn_cast<AbstractFunctionDecl>(vd)) {
     auto *param = getParameterAt(afd, c.defaultArgIndex);
-    if (param->getDefaultValue()) {
+    if (param->hasDefaultExpr()) {
       auto captureInfo = param->getDefaultArgumentCaptureInfo();
       sig = getEffectiveGenericSignature(afd, captureInfo);
     }
@@ -2285,7 +2285,7 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
     // captures for default arguments that are actually referenced.
     if (auto *AFD = curFn.getAbstractFunctionDecl()) {
       for (auto *P : *AFD->getParameters()) {
-        if (P->getDefaultValue())
+        if (P->hasDefaultExpr())
           collectCaptures(P->getDefaultArgumentCaptureInfo(), dc);
       }
     }
@@ -2298,7 +2298,7 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
       
       if (auto *afd = dyn_cast<AbstractFunctionDecl>(curFn.getDecl())) {
         auto *param = getParameterAt(afd, curFn.defaultArgIndex);
-        if (param->getDefaultValue()) {
+        if (param->hasDefaultExpr()) {
           auto dc = afd->getInnermostDeclContext();
           collectCaptures(param->getDefaultArgumentCaptureInfo(), dc);
         }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1060,7 +1060,7 @@ void SILGenModule::emitDefaultArgGenerator(SILDeclRef constant,
     llvm_unreachable("No default argument here?");
 
   case DefaultArgumentKind::Normal: {
-    auto arg = param->getDefaultValue();
+    auto arg = param->getTypeCheckedDefaultExpr();
     emitOrDelayFunction(*this, constant,
         [this,constant,arg,initDC](SILFunction *f) {
       preEmitFunction(constant, arg, f, arg);

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -612,7 +612,7 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   // Compute captures for default argument expressions.
   if (auto *AFD = AFR.getAbstractFunctionDecl()) {
     for (auto *P : *AFD->getParameters()) {
-      if (auto E = P->getDefaultValue()) {
+      if (auto E = P->getTypeCheckedDefaultExpr()) {
         FindCapturedVars finder(Context,
                                 E->getLoc(),
                                 AFD,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2066,7 +2066,7 @@ DefaultArgumentInitContextRequest::evaluate(Evaluator &eval,
       continue;
 
     // If this param already has a context, continue using it.
-    if (otherParam->getDefaultArgumentInitContextCached())
+    if (otherParam->getCachedDefaultArgumentInitContext())
       continue;
 
     // Create a new initializer context. If this is for the parameter that

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -253,14 +253,6 @@ static bool checkObjCWitnessSelector(ValueDecl *req, ValueDecl *witness) {
   return false;
 }
 
-static ParameterList *getParameterList(ValueDecl *value) {
-  if (auto func = dyn_cast<AbstractFunctionDecl>(value))
-    return func->getParameters();
-
-  auto subscript = cast<SubscriptDecl>(value);
-  return subscript->getIndices();
-}
-
 // Find a standin declaration to place the diagnostic at for the
 // given accessor kind.
 static ValueDecl *getStandinForAccessor(AbstractStorageDecl *witness,


### PR DESCRIPTION
This PR introduces two new requests, one to compute initializer contexts for default arguments, and another to type-check default arguments within this context.

This PR then splits `getDefaultValue` into 2 accessors:

- `getStructuralDefaultExpr` which retrieves the potentially un-type-checked default argument expression.

- `getTypeCheckedDefaultExpr` which retrieves a fully type-checked default argument expression.

And also adds `hasDefaultExpr`, which allows checking for the presence of a default expr without kicking off a request.

On its own, this isn't enough to resolve [SR-11085](https://bugs.swift.org/browse/SR-11085), I'm going to tackle that in a follow-up to keep the size of this PR down.