### PR TITLE
[SyntaxParse] Don't discard 'typealias' without identifier

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4097,8 +4097,10 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   Status |= parseIdentifierDeclName(
       *this, Id, IdLoc, "typealias",
       [](const Token &next) { return next.isAny(tok::colon, tok::equal); });
-  if (Status.isError())
+  if (Status.isError()) {
+    TmpCtxt->setTransparent();
     return nullptr;
+  }
     
   DebuggerContextChange DCC(*this, Id, DeclKind::TypeAlias);
 

--- a/test/Syntax/round_trip_misc.swift
+++ b/test/Syntax/round_trip_misc.swift
@@ -10,6 +10,24 @@ class C {
     func f() {}
   }
 }
+do {
+  typealias Alias2 = () -> (a b: [Generic<Int
+}
+do {
+  typealias Alias3 = (a b C,
+}
+do {
+  typealias Alias3 = () -> @objc func
+}
+do {
+  typealias
+}
+do {
+  typealias Alias = A & B & C.D<>
+}
+do {
+  typealias boo bar = Int
+}
 
 // Orphan '}' at top level
 }


### PR DESCRIPTION
Fixes round trip issue

(Re-apply #26974 after the ASTGen reverting)