### PR TITLE
[NFC] Refactor the Interface to Pattern Bindings (1/n)

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -1270,8 +1270,7 @@ public:
   PatternEntryInitializerScope(PatternBindingDecl *pbDecl, unsigned entryIndex,
                                DeclVisibilityKind vis)
       : AbstractPatternEntryScope(pbDecl, entryIndex, vis),
-        initAsWrittenWhenCreated(
-            pbDecl->getPatternList()[entryIndex].getOriginalInit()) {}
+        initAsWrittenWhenCreated(pbDecl->getOriginalInit(entryIndex)) {}
   virtual ~PatternEntryInitializerScope() {}
 
 protected:

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2212,7 +2212,7 @@ public:
   /// Determines whether this binding either has an initializer expression, or is
   /// default initialized, without performing any type checking on it.
   bool isDefaultInitializable() const {
-    for (unsigned i = 0, e = getNumPatternEntries(); i < e; ++i)
+    for (unsigned i : range(getNumPatternEntries()))
       if (!isDefaultInitializable(i))
         return false;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -895,7 +895,7 @@ namespace {
     void visitPatternBindingDecl(PatternBindingDecl *PBD) {
       printCommon(PBD, "pattern_binding_decl");
 
-      for (auto idx : indices(PBD->getPatternList())) {
+      for (auto idx : range(PBD->getNumPatternEntries())) {
         OS << '\n';
         printRec(PBD->getPattern(idx));
         if (PBD->getOriginalInit(idx)) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -895,20 +895,20 @@ namespace {
     void visitPatternBindingDecl(PatternBindingDecl *PBD) {
       printCommon(PBD, "pattern_binding_decl");
 
-      for (auto entry : PBD->getPatternList()) {
+      for (auto idx : indices(PBD->getPatternList())) {
         OS << '\n';
-        printRec(entry.getPattern());
-        if (entry.getOriginalInit()) {
+        printRec(PBD->getPattern(idx));
+        if (PBD->getOriginalInit(idx)) {
           OS << '\n';
           OS.indent(Indent + 2);
           OS << "Original init:\n";
-          printRec(entry.getOriginalInit());
+          printRec(PBD->getOriginalInit(idx));
         }
-        if (entry.getInit()) {
+        if (PBD->getInit(idx)) {
           OS << '\n';
           OS.indent(Indent + 2);
           OS << "Processed init:\n";
-          printRec(entry.getInit());
+          printRec(PBD->getInit(idx));
         }
       }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1606,7 +1606,7 @@ namespace {
 /// least one name, which is probably a reasonable assumption but may
 /// not be adequately enforced.
 static Optional<VarDecl*> findFirstVariable(PatternBindingDecl *binding) {
-  for (auto idx : indices(binding->getPatternList())) {
+  for (auto idx : range(binding->getNumPatternEntries())) {
     auto var = FindFirstVariable().visit(binding->getPattern(idx));
     if (var) return var;
   }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1606,8 +1606,8 @@ namespace {
 /// least one name, which is probably a reasonable assumption but may
 /// not be adequately enforced.
 static Optional<VarDecl*> findFirstVariable(PatternBindingDecl *binding) {
-  for (auto entry : binding->getPatternList()) {
-    auto var = FindFirstVariable().visit(entry.getPattern());
+  for (auto idx : indices(binding->getPatternList())) {
+    auto var = FindFirstVariable().visit(binding->getPattern(idx));
     if (var) return var;
   }
   // Pattern-binding bound without variables exists in erroneous code, e.g.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1665,7 +1665,7 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
   // attributes can only be retrieved from the inside VarDecls.
   if (auto *PD = dyn_cast<PatternBindingDecl>(D)) {
     auto ShouldPrint = false;
-    for (auto idx : indices(PD->getPatternList())) {
+    for (auto idx : range(PD->getNumPatternEntries())) {
       ShouldPrint |= shouldPrint(PD->getPattern(idx), Options);
       if (ShouldPrint)
         return true;
@@ -2162,7 +2162,7 @@ void PrintAST::visitPatternBindingDecl(PatternBindingDecl *decl) {
   // variables are immutable, and if so, we print as 'let'.  This allows us to
   // handle the 'let x = 4' case properly at least.
   const VarDecl *anyVar = nullptr;
-  for (auto idx : indices(decl->getPatternList())) {
+  for (auto idx : range(decl->getNumPatternEntries())) {
     decl->getPattern(idx)->forEachVariable([&](VarDecl *V) {
       anyVar = V;
     });
@@ -2190,7 +2190,7 @@ void PrintAST::visitPatternBindingDecl(PatternBindingDecl *decl) {
   }
 
   bool isFirst = true;
-  for (auto idx : indices(decl->getPatternList())) {
+  for (auto idx : range(decl->getNumPatternEntries())) {
     auto *pattern = decl->getPattern(idx);
     if (!shouldPrintPattern(pattern))
       continue;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1665,8 +1665,8 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
   // attributes can only be retrieved from the inside VarDecls.
   if (auto *PD = dyn_cast<PatternBindingDecl>(D)) {
     auto ShouldPrint = false;
-    for (auto entry : PD->getPatternList()) {
-      ShouldPrint |= shouldPrint(entry.getPattern(), Options);
+    for (auto idx : indices(PD->getPatternList())) {
+      ShouldPrint |= shouldPrint(PD->getPattern(idx), Options);
       if (ShouldPrint)
         return true;
     }
@@ -2162,8 +2162,8 @@ void PrintAST::visitPatternBindingDecl(PatternBindingDecl *decl) {
   // variables are immutable, and if so, we print as 'let'.  This allows us to
   // handle the 'let x = 4' case properly at least.
   const VarDecl *anyVar = nullptr;
-  for (auto entry : decl->getPatternList()) {
-    entry.getPattern()->forEachVariable([&](VarDecl *V) {
+  for (auto idx : indices(decl->getPatternList())) {
+    decl->getPattern(idx)->forEachVariable([&](VarDecl *V) {
       anyVar = V;
     });
     if (anyVar) break;
@@ -2190,29 +2190,29 @@ void PrintAST::visitPatternBindingDecl(PatternBindingDecl *decl) {
   }
 
   bool isFirst = true;
-  for (auto &entry : decl->getPatternList()) {
-    if (!shouldPrintPattern(entry.getPattern()))
+  for (auto idx : indices(decl->getPatternList())) {
+    auto *pattern = decl->getPattern(idx);
+    if (!shouldPrintPattern(pattern))
       continue;
     if (isFirst)
       isFirst = false;
     else
       Printer << ", ";
 
-    printPattern(entry.getPattern());
+    printPattern(pattern);
 
     // We also try to print type for named patterns, e.g. var Field = 10;
     // and tuple patterns, e.g. var (T1, T2) = (10, 10)
-    if (isa<NamedPattern>(entry.getPattern()) ||
-        isa<TuplePattern>(entry.getPattern())) {
-      printPatternType(entry.getPattern());
+    if (isa<NamedPattern>(pattern) || isa<TuplePattern>(pattern)) {
+      printPatternType(pattern);
     }
 
     if (Options.VarInitializers) {
-      auto vd = entry.getAnchoringVarDecl();
-      if (entry.hasInitStringRepresentation() &&
+      auto *vd = decl->getAnchoringVarDecl(idx);
+      if (decl->hasInitStringRepresentation(idx) &&
           vd->isInitExposedToClients()) {
         SmallString<128> scratch;
-        Printer << " = " << entry.getInitStringRepresentation(scratch);
+        Printer << " = " << decl->getInitStringRepresentation(idx, scratch);
       }
     }
 
@@ -3401,7 +3401,7 @@ bool Decl::shouldPrintInContext(const PrintOptions &PO) const {
     if (auto pbd = dyn_cast<PatternBindingDecl>(this)) {
       if (pbd->getPatternList().size() == 1) {
         auto pattern =
-          pbd->getPatternList()[0].getPattern()->getSemanticsProvidingPattern();
+          pbd->getPattern(0)->getSemanticsProvidingPattern();
         if (auto named = dyn_cast<NamedPattern>(pattern)) {
           if (!named->getDecl()->hasStorage())
             return false;

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -190,10 +190,7 @@ NullablePtr<DeclContext> CaptureListScope::getDeclContext() const {
 }
 
 NullablePtr<DeclContext> AttachedPropertyWrapperScope::getDeclContext() const {
-  return decl->getParentPatternBinding()
-      ->getPatternList()
-      .front()
-      .getInitContext();
+  return decl->getParentPatternBinding()->getInitContext(0);
 }
 
 NullablePtr<DeclContext> AbstractFunctionDeclScope::getDeclContext() const {

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -920,7 +920,7 @@ public:
         isInTypeDecl ? DeclVisibilityKind::MemberOfCurrentNominal
                      : DeclVisibilityKind::LocalVariable;
     auto *insertionPoint = parentScope;
-    for (auto i : indices(patternBinding->getPatternList())) {
+    for (auto i : range(patternBinding->getNumPatternEntries())) {
       // TODO: Won't need to do so much work to avoid creating one without
       // a SourceRange once parser is fixed to not create two
       // PatternBindingDecls with same locaiton and getSourceRangeOfThisASTNode
@@ -2054,7 +2054,7 @@ private:
   }
 
   void recordInitializers(PatternBindingDecl *pbd) {
-    for (auto idx : indices(pbd->getPatternList()))
+    for (auto idx : range(pbd->getNumPatternEntries()))
       record(pbd->getInitContext(idx));
   }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -920,16 +920,15 @@ public:
         isInTypeDecl ? DeclVisibilityKind::MemberOfCurrentNominal
                      : DeclVisibilityKind::LocalVariable;
     auto *insertionPoint = parentScope;
-    for (unsigned i = 0; i < patternBinding->getPatternList().size(); ++i) {
+    for (auto i : indices(patternBinding->getPatternList())) {
       // TODO: Won't need to do so much work to avoid creating one without
       // a SourceRange once parser is fixed to not create two
       // PatternBindingDecls with same locaiton and getSourceRangeOfThisASTNode
       // for PatternEntryDeclScope is simplified to use the PatternEntry's
       // source range.
-      auto &patternEntry = patternBinding->getPatternList()[i];
-      if (!patternEntry.getOriginalInit()) {
+      if (!patternBinding->getOriginalInit(i)) {
         bool found = false;
-        patternEntry.getPattern()->forEachVariable([&](VarDecl *vd) {
+        patternBinding->getPattern(i)->forEachVariable([&](VarDecl *vd) {
           if (!vd->isImplicit())
             found = true;
           else
@@ -1913,27 +1912,22 @@ bool TopLevelCodeScope::isCurrentIfWasExpanded() const {
 // Try to avoid the work of counting
 static const bool assumeVarsDoNotGetAdded = true;
 
-static unsigned countVars(const PatternBindingEntry &entry) {
-  unsigned varCount = 0;
-  entry.getPattern()->forEachVariable([&](VarDecl *) { ++varCount; });
-  return varCount;
-}
-
 void PatternEntryDeclScope::beCurrent() {
   initWhenLastExpanded = getPatternEntry().getOriginalInit();
   if (assumeVarsDoNotGetAdded && varCountWhenLastExpanded)
     return;
-  varCountWhenLastExpanded = countVars(getPatternEntry());
+  varCountWhenLastExpanded = getPatternEntry().getNumBoundVariables();
 }
 bool PatternEntryDeclScope::isCurrentIfWasExpanded() const {
   if (initWhenLastExpanded != getPatternEntry().getOriginalInit())
     return false;
   if (assumeVarsDoNotGetAdded && varCountWhenLastExpanded) {
-    ASTScopeAssert(varCountWhenLastExpanded == countVars(getPatternEntry()),
+    ASTScopeAssert(varCountWhenLastExpanded ==
+                       getPatternEntry().getNumBoundVariables(),
                    "Vars were not supposed to be added to a pattern entry.");
     return true;
   }
-  return countVars(getPatternEntry()) == varCountWhenLastExpanded;
+  return getPatternEntry().getNumBoundVariables() == varCountWhenLastExpanded;
 }
 
 void WholeClosureScope::beCurrent() {
@@ -2060,8 +2054,8 @@ private:
   }
 
   void recordInitializers(PatternBindingDecl *pbd) {
-    for (auto entry : pbd->getPatternList())
-      record(entry.getInitContext());
+    for (auto idx : indices(pbd->getPatternList()))
+      record(pbd->getInitContext(idx));
   }
 
   void catchForDebugging(Decl *D, const char *file, const unsigned line) {

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -457,7 +457,7 @@ bool PatternEntryInitializerScope::lookupLocalsOrMembers(
     ArrayRef<const ASTScopeImpl *>, DeclConsumer consumer) const {
   // 'self' is available within the pattern initializer of a 'lazy' variable.
   auto *initContext = cast_or_null<PatternBindingInitializer>(
-      decl->getPatternList()[0].getInitContext());
+      decl->getInitContext(0));
   if (initContext) {
     if (auto *selfParam = initContext->getImplicitSelfDecl()) {
       return consumer.consume({selfParam},

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2357,8 +2357,8 @@ public:
 
     void verifyChecked(PatternBindingDecl *binding) {
       // Look at all of the VarDecls being bound.
-      for (auto entry : binding->getPatternList())
-        if (auto *P = entry.getPattern())
+      for (auto idx : indices(binding->getPatternList()))
+        if (auto *P = binding->getPattern(idx))
           P->forEachVariable([&](VarDecl *VD) {
             // ParamDecls never get PBD's.
             assert(!isa<ParamDecl>(VD) && "ParamDecl has a PatternBindingDecl?");

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2357,7 +2357,7 @@ public:
 
     void verifyChecked(PatternBindingDecl *binding) {
       // Look at all of the VarDecls being bound.
-      for (auto idx : indices(binding->getPatternList()))
+      for (auto idx : range(binding->getNumPatternEntries()))
         if (auto *P = binding->getPattern(idx))
           P->forEachVariable([&](VarDecl *VD) {
             // ParamDecls never get PBD's.

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -171,21 +171,19 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         singleVar->getOriginalWrappedProperty() != nullptr;
     }
 
-    unsigned idx = 0U-1;
-    for (auto entry : PBD->getPatternList()) {
-      ++idx;
-      if (Pattern *Pat = doIt(entry.getPattern()))
-        PBD->setPattern(idx, Pat, entry.getInitContext());
+    for (auto idx : indices(PBD->getPatternList())) {
+      if (Pattern *Pat = doIt(PBD->getPattern(idx)))
+        PBD->setPattern(idx, Pat, PBD->getInitContext(idx));
       else
         return true;
-      if (entry.getInit() &&
+      if (PBD->getInit(idx) &&
           !isPropertyWrapperBackingProperty &&
-          (!entry.isInitializerSubsumed() ||
+          (!PBD->isInitializerSubsumed(idx) ||
            Walker.shouldWalkIntoLazyInitializers())) {
 #ifndef NDEBUG
         PrettyStackTraceDecl debugStack("walking into initializer for", PBD);
 #endif
-        if (Expr *E2 = doIt(entry.getInit()))
+        if (Expr *E2 = doIt(PBD->getInit(idx)))
           PBD->setInit(idx, E2);
         else
           return true;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -171,7 +171,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         singleVar->getOriginalWrappedProperty() != nullptr;
     }
 
-    for (auto idx : indices(PBD->getPatternList())) {
+    for (auto idx : range(PBD->getNumPatternEntries())) {
       if (Pattern *Pat = doIt(PBD->getPattern(idx)))
         PBD->setPattern(idx, Pat, PBD->getInitContext(idx));
       else

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -459,7 +459,7 @@ SourceRange Decl::getSourceRangeIncludingAttrs() const {
 
   // Attributes on PatternBindingDecls are attached to VarDecls in AST.
   if (auto *PBD = dyn_cast<PatternBindingDecl>(this)) {
-    for (auto i : indices(PBD->getPatternList()))
+    for (auto i : range(PBD->getNumPatternEntries()))
       PBD->getPattern(i)->forEachVariable([&](VarDecl *VD) {
         for (auto Attr : VD->getAttrs())
           if (Attr->getRange().isValid())

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -686,7 +686,7 @@ class ExprContextAnalyzer {
     switch (D->getKind()) {
     case DeclKind::PatternBinding: {
       auto PBD = cast<PatternBindingDecl>(D);
-      for (unsigned I = 0; I < PBD->getNumPatternEntries(); ++I) {
+      for (unsigned I : range(PBD->getNumPatternEntries())) {
         if (auto Init = PBD->getInit(I)) {
           if (containsTarget(Init)) {
             if (PBD->getPattern(I)->hasType()) {

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2841,11 +2841,10 @@ collectMembersForInit(ResolvedCursorInfo CursorInfo,
       continue;
     }
 
-    auto &entry = patternBinding->getPatternEntryForVarDecl(varDecl);
-    bool isExplicitlyInitialized =
-      entry.isInitialized() && entry.getEqualLoc().isValid();
+    const auto i = patternBinding->getPatternEntryIndexForVarDecl(varDecl);
     Expr *defaultInit = nullptr;
-    if (isExplicitlyInitialized || patternBinding->isDefaultInitializable()) {
+    if (patternBinding->isExplicitlyInitialized(i) ||
+        patternBinding->isDefaultInitializable()) {
       defaultInit = varDecl->getParentInitializer();
     }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5101,12 +5101,12 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
     // Now that we've parsed all of our patterns, initializers and accessors, we
     // can finally create our PatternBindingDecl to represent the
     // pattern/initializer pairs.
-    auto PBD = PatternBindingDecl::create(Context, StaticLoc, StaticSpelling,
-                                          VarLoc, PBDEntries, BaseContext);
+    auto *PBD = PatternBindingDecl::create(Context, StaticLoc, StaticSpelling,
+                                           VarLoc, PBDEntries, BaseContext);
 
     // Wire up any initializer contexts we needed.
     for (unsigned i : indices(PBDEntries)) {
-      if (auto initContext = PBDEntries[i].getInitContext())
+      if (auto initContext = PBD->getInitContext(i))
         cast<PatternBindingInitializer>(initContext)->setBinding(PBD, i);
     }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -930,7 +930,7 @@ static bool requiresIVarInitialization(SILGenModule &SGM, ClassDecl *cd) {
     auto pbd = dyn_cast<PatternBindingDecl>(member);
     if (!pbd) continue;
 
-    for (auto i : indices(pbd->getPatternList()))
+    for (auto i : range(pbd->getNumPatternEntries()))
       if (pbd->getExecutableInit(i))
         return true;
   }
@@ -1304,7 +1304,7 @@ void SILGenModule::emitObjCDestructorThunk(DestructorDecl *destructor) {
 
 void SILGenModule::visitPatternBindingDecl(PatternBindingDecl *pd) {
   assert(!TopLevelSGF && "script mode PBDs should be in TopLevelCodeDecls");
-  for (unsigned i = 0, e = pd->getNumPatternEntries(); i != e; ++i)
+  for (auto i : range(pd->getNumPatternEntries()))
     if (pd->getExecutableInit(i))
       emitGlobalInitialization(pd, i);
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -930,8 +930,8 @@ static bool requiresIVarInitialization(SILGenModule &SGM, ClassDecl *cd) {
     auto pbd = dyn_cast<PatternBindingDecl>(member);
     if (!pbd) continue;
 
-    for (auto entry : pbd->getPatternList())
-      if (entry.getExecutableInit())
+    for (auto i : indices(pbd->getPatternList()))
+      if (pbd->getExecutableInit(i))
         return true;
   }
 
@@ -1096,12 +1096,11 @@ void SILGenModule::emitDefaultArgGenerator(SILDeclRef constant,
 
 void SILGenModule::
 emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
-  const PatternBindingEntry &pbdEntry = pbd->getPatternList()[i];
-  auto *var = pbdEntry.getAnchoringVarDecl();
-  auto *init = pbdEntry.getInit();
-  auto *initDC = pbdEntry.getInitContext();
-  auto captureInfo = pbdEntry.getCaptureInfo();
-  assert(!pbdEntry.isInitializerSubsumed());
+  auto *var = pbd->getAnchoringVarDecl(i);
+  auto *init = pbd->getInit(i);
+  auto *initDC = pbd->getInitContext(i);
+  auto captureInfo = pbd->getCaptureInfo(i);
+  assert(!pbd->isInitializerSubsumed(i));
 
   // If this is the backing storage for a property with an attached wrapper
   // that was initialized with `=`, use that expression as the initializer.

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -914,7 +914,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
     if (auto pbd = dyn_cast<PatternBindingDecl>(member)) {
       if (pbd->isStatic()) continue;
 
-      for (auto i : indices(pbd->getPatternList())) {
+      for (auto i : range(pbd->getNumPatternEntries())) {
         auto init = pbd->getExecutableInit(i);
         if (!init) continue;
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -914,12 +914,13 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
     if (auto pbd = dyn_cast<PatternBindingDecl>(member)) {
       if (pbd->isStatic()) continue;
 
-      for (auto entry : pbd->getPatternList()) {
-        auto init = entry.getExecutableInit();
+      for (auto i : indices(pbd->getPatternList())) {
+        auto init = pbd->getExecutableInit(i);
         if (!init) continue;
 
+        auto *varPattern = pbd->getPattern(i);
         // Cleanup after this initialization.
-        FullExpr scope(Cleanups, entry.getPattern());
+        FullExpr scope(Cleanups, varPattern);
 
         // We want a substitution list written in terms of the generic
         // signature of the type, with replacement archetypes from the
@@ -948,13 +949,13 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         // Get the type of the initialization result, in terms
         // of the constructor context's archetypes.
         CanType resultType = getInitializationTypeInContext(
-            pbd->getDeclContext(), dc, entry.getPattern())->getCanonicalType();
+            pbd->getDeclContext(), dc, varPattern)->getCanonicalType();
         AbstractionPattern origResultType(resultType);
 
         // FIXME: Can emitMemberInit() share code with
         // InitializationForPattern in SILGenDecl.cpp?
         RValue result = emitApplyOfStoredPropertyInitializer(
-                                  init, entry, subs,
+                                  init, pbd->getAnchoringVarDecl(i), subs,
                                   resultType, origResultType,
                                   SGFContext());
 
@@ -970,7 +971,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
           }
         }
 
-        emitMemberInit(*this, selfDecl, entry.getPattern(), std::move(result));
+        emitMemberInit(*this, selfDecl, varPattern, std::move(result));
       }
     }
   }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1166,14 +1166,13 @@ SILGenFunction::emitInitializationForVarDecl(VarDecl *vd, bool forceImmutable) {
 }
 
 void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
-                                        unsigned pbdEntry) {
-  auto &entry = PBD->getPatternList()[pbdEntry];
-  auto initialization = emitPatternBindingInitialization(entry.getPattern(),
+                                        unsigned idx) {
+  auto initialization = emitPatternBindingInitialization(PBD->getPattern(idx),
                                                          JumpDest::invalid());
 
   // If an initial value expression was specified by the decl, emit it into
   // the initialization. Otherwise, mark it uninitialized for DI to resolve.
-  if (auto *Init = entry.getExecutableInit()) {
+  if (auto *Init = PBD->getExecutableInit(idx)) {
     FullExpr Scope(Cleanups, CleanupLocation(Init));
     emitExprInto(Init, initialization.get(), SILLocation(PBD));
   } else {

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1184,7 +1184,7 @@ void SILGenFunction::visitPatternBindingDecl(PatternBindingDecl *PBD) {
 
   // Allocate the variables and build up an Initialization over their
   // allocated storage.
-  for (unsigned i : indices(PBD->getPatternList())) {
+  for (unsigned i : range(PBD->getNumPatternEntries())) {
     emitPatternBinding(PBD, i);
   }
 }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2214,13 +2214,12 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
 
 RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(
     SILLocation loc,
-    const PatternBindingEntry &entry,
+    VarDecl *var,
     SubstitutionMap subs,
     CanType resultType,
     AbstractionPattern origResultType,
     SGFContext C) {
 
-  VarDecl *var = entry.getAnchoringVarDecl();
   SILDeclRef constant(var, SILDeclRef::Kind::StoredPropertyInitializer);
   auto fnRef = ManagedValue::forUnmanaged(emitGlobalFunctionRef(loc, constant));
   auto fnType = fnRef.getType().castTo<SILFunctionType>();

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -791,7 +791,8 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, VarDecl *var) {
   prepareEpilog(varType, false, CleanupLocation::get(loc));
 
   auto pbd = var->getParentPatternBinding();
-  auto entry = pbd->getPatternEntryForVarDecl(var);
+  const auto i = pbd->getPatternEntryIndexForVarDecl(var);
+  auto *anchorVar = pbd->getAnchoringVarDecl(i);
   auto subs = getForwardingSubstitutionMap();
   auto contextualType = dc->mapTypeIntoContext(interfaceType);
   auto resultType = contextualType->getCanonicalType();
@@ -805,7 +806,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, VarDecl *var) {
     SmallVector<CleanupHandle, 4> cleanups;
     auto init = prepareIndirectResultInit(resultType, directResults, cleanups);
 
-    emitApplyOfStoredPropertyInitializer(loc, entry, subs, resultType,
+    emitApplyOfStoredPropertyInitializer(loc, anchorVar, subs, resultType,
                                          origResultType,
                                          SGFContext(init.get()));
 
@@ -816,7 +817,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, VarDecl *var) {
     Scope scope(Cleanups, CleanupLocation(var));
 
     // If we have no indirect results, just return the result.
-    auto result = emitApplyOfStoredPropertyInitializer(loc, entry, subs,
+    auto result = emitApplyOfStoredPropertyInitializer(loc, anchorVar, subs,
                                                        resultType,
                                                        origResultType,
                                                        SGFContext())

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1454,7 +1454,7 @@ public:
 
   RValue emitApplyOfStoredPropertyInitializer(
       SILLocation loc,
-      const PatternBindingEntry &entry,
+      VarDecl *anchoringVar,
       SubstitutionMap subs,
       CanType resultType,
       AbstractionPattern origResultType,

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1019,7 +1019,7 @@ public:
 
   void visitPatternBindingDecl(PatternBindingDecl *pd) {
     // Emit initializers.
-    for (unsigned i = 0, e = pd->getNumPatternEntries(); i != e; ++i) {
+    for (auto i : range(pd->getNumPatternEntries())) {
       if (pd->getExecutableInit(i)) {
         if (pd->isStatic())
           SGM.emitGlobalInitialization(pd, i);
@@ -1154,7 +1154,7 @@ public:
 
   void visitPatternBindingDecl(PatternBindingDecl *pd) {
     // Emit initializers for static variables.
-    for (unsigned i = 0, e = pd->getNumPatternEntries(); i != e; ++i) {
+    for (auto i : range(pd->getNumPatternEntries())) {
       if (pd->getExecutableInit(i)) {
         assert(pd->isStatic() && "stored property in extension?!");
         SGM.emitGlobalInitialization(pd, i);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2635,15 +2635,15 @@ void ContextualFailure::tryComputedPropertyFixIts(Expr *expr) const {
 
   if (PBD) {
     if (auto VD = PBD->getSingleVar()) {
-      auto entry = PBD->getPatternEntryForVarDecl(VD);
-
+      const auto i = PBD->getPatternEntryIndexForVarDecl(VD);
+      auto *initExpr = PBD->getInit(i);
       if (!VD->isStatic() &&
           !VD->getAttrs().getAttribute<DynamicReplacementAttr>() &&
-          entry.getInit() && isa<ClosureExpr>(entry.getInit())) {
+          initExpr && isa<ClosureExpr>(initExpr)) {
         auto diag = emitDiagnostic(expr->getLoc(),
                                    diag::extension_stored_property_fixit,
                                    VD->getName());
-        diag.fixItRemove(entry.getEqualLoc());
+        diag.fixItRemove(PBD->getEqualLoc(i));
 
         if (VD->isLet()) {
           diag.fixItReplace(PBD->getStartLoc(), getTokenText(tok::kw_var));

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -810,7 +810,7 @@ static bool areAllStoredPropertiesDefaultInitializable(NominalTypeDecl *decl) {
     // generation of the default initializer.
     if (auto pbd = dyn_cast<PatternBindingDecl>(member)) {
       if (pbd->hasStorage() && !pbd->isStatic()) {
-        for (auto idx : indices(pbd->getPatternList())) {
+        for (auto idx : range(pbd->getNumPatternEntries())) {
           if (pbd->isInitialized(idx)) continue;
 
           // If one of the bound variables is @NSManaged, go ahead no matter

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -121,9 +121,8 @@ static void maybeAddMemberwiseDefaultArg(ParamDecl *arg, VarDecl *var,
   // Whether we have explicit initialization.
   bool isExplicitlyInitialized = false;
   if (auto pbd = var->getParentPatternBinding()) {
-    auto &entry = pbd->getPatternEntryForVarDecl(var);
-    isExplicitlyInitialized =
-      entry.isInitialized() && entry.getEqualLoc().isValid();
+    const auto i = pbd->getPatternEntryIndexForVarDecl(var);
+    isExplicitlyInitialized = pbd->isExplicitlyInitialized(i);
   }
 
   // Whether we can default-initialize this property.
@@ -811,13 +810,13 @@ static bool areAllStoredPropertiesDefaultInitializable(NominalTypeDecl *decl) {
     // generation of the default initializer.
     if (auto pbd = dyn_cast<PatternBindingDecl>(member)) {
       if (pbd->hasStorage() && !pbd->isStatic()) {
-        for (auto entry : pbd->getPatternList()) {
-          if (entry.isInitialized()) continue;
+        for (auto idx : indices(pbd->getPatternList())) {
+          if (pbd->isInitialized(idx)) continue;
 
           // If one of the bound variables is @NSManaged, go ahead no matter
           // what.
           bool CheckDefaultInitializer = true;
-          entry.getPattern()->forEachVariable([&](VarDecl *vd) {
+          pbd->getPattern(idx)->forEachVariable([&](VarDecl *vd) {
             if (vd->getAttrs().hasAttribute<NSManagedAttr>())
               CheckDefaultInitializer = false;
           });

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2079,8 +2079,8 @@ public:
     if (!PBD) return false;
 
     bool sawMutation = false;
-    for (const auto &PBE : PBD->getPatternList()) {
-      PBE.getPattern()->forEachVariable([&](VarDecl *VD) {
+    for (auto idx : indices(PBD->getPatternList())) {
+      PBD->getPattern(idx)->forEachVariable([&](VarDecl *VD) {
         auto it = VarDecls.find(VD);
         sawMutation |= it != VarDecls.end() && (it->second & RK_Written);
       });
@@ -2199,8 +2199,8 @@ public:
           Decl *D = node.get<Decl *>();
           auto *PBD = dyn_cast<PatternBindingDecl>(D);
           if (!PBD) continue;
-          for (PatternBindingEntry PBE : PBD->getPatternList()) {
-            PBE.getPattern()->forEachVariable([&](VarDecl *VD) {
+          for (auto idx : indices(PBD->getPatternList())) {
+            PBD->getPattern(idx)->forEachVariable([&](VarDecl *VD) {
               VarDecls[VD] = RK_Read|RK_Written;
             });
           }
@@ -2496,11 +2496,11 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       //    _ = foo()
       if (auto *pbd = var->getParentPatternBinding())
         if (pbd->getSingleVar() == var && pbd->getInit(0) != nullptr &&
-            !isa<TypedPattern>(pbd->getPatternList()[0].getPattern())) {
+            !isa<TypedPattern>(pbd->getPattern(0))) {
           unsigned varKind = var->isLet();
           SourceRange replaceRange(
               pbd->getStartLoc(),
-              pbd->getPatternList()[0].getPattern()->getEndLoc());
+              pbd->getPattern(0)->getEndLoc());
           Diags.diagnose(var->getLoc(), diag::pbd_never_used,
                          var->getName(), varKind)
             .fixItReplace(replaceRange, "_");

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2079,7 +2079,7 @@ public:
     if (!PBD) return false;
 
     bool sawMutation = false;
-    for (auto idx : indices(PBD->getPatternList())) {
+    for (auto idx : range(PBD->getNumPatternEntries())) {
       PBD->getPattern(idx)->forEachVariable([&](VarDecl *VD) {
         auto it = VarDecls.find(VD);
         sawMutation |= it != VarDecls.end() && (it->second & RK_Written);
@@ -2199,7 +2199,7 @@ public:
           Decl *D = node.get<Decl *>();
           auto *PBD = dyn_cast<PatternBindingDecl>(D);
           if (!PBD) continue;
-          for (auto idx : indices(PBD->getPatternList())) {
+          for (auto idx : range(PBD->getNumPatternEntries())) {
             PBD->getPattern(idx)->forEachVariable([&](VarDecl *VD) {
               VarDecls[VD] = RK_Read|RK_Written;
             });

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -156,8 +156,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   // Property initializers that are not exposed to clients are OK.
   if (auto pattern = dyn_cast<PatternBindingInitializer>(DC)) {
     auto bindingIndex = pattern->getBindingIndex();
-    auto &patternEntry = pattern->getBinding()->getPatternList()[bindingIndex];
-    auto varDecl = patternEntry.getAnchoringVarDecl();
+    auto *varDecl = pattern->getBinding()->getAnchoringVarDecl(bindingIndex);
     if (!varDecl->isInitExposedToClients())
       return false;
   }

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -551,8 +551,8 @@ public:
     bool isTypeContext = PBD->getDeclContext()->isTypeContext();
 
     llvm::DenseSet<const VarDecl *> seenVars;
-    for (auto entry : PBD->getPatternList()) {
-      entry.getPattern()->forEachNode([&](const Pattern *P) {
+    for (auto idx : indices(PBD->getPatternList())) {
+      PBD->getPattern(idx)->forEachNode([&](const Pattern *P) {
         if (auto *NP = dyn_cast<NamedPattern>(P)) {
           // Only check individual variables if we didn't check an enclosing
           // TypedPattern.
@@ -1174,8 +1174,8 @@ public:
         getFixedLayoutStructContext(PBD);
 
     llvm::DenseSet<const VarDecl *> seenVars;
-    for (auto entry : PBD->getPatternList()) {
-      entry.getPattern()->forEachNode([&](const Pattern *P) {
+    for (auto idx : indices(PBD->getPatternList())) {
+      PBD->getPattern(idx)->forEachNode([&](const Pattern *P) {
         if (auto *NP = dyn_cast<NamedPattern>(P)) {
           checkNamedPattern(NP, fixedLayoutStructContext, isTypeContext,
                             seenVars);
@@ -1816,8 +1816,8 @@ public:
 
   void visitPatternBindingDecl(PatternBindingDecl *PBD) {
     llvm::DenseSet<const VarDecl *> seenVars;
-    for (auto entry : PBD->getPatternList()) {
-      entry.getPattern()->forEachNode([&](const Pattern *P) {
+    for (auto idx : indices(PBD->getPatternList())) {
+      PBD->getPattern(idx)->forEachNode([&](const Pattern *P) {
         if (auto *NP = dyn_cast<NamedPattern>(P)) {
           checkNamedPattern(NP, seenVars);
           return;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -551,7 +551,7 @@ public:
     bool isTypeContext = PBD->getDeclContext()->isTypeContext();
 
     llvm::DenseSet<const VarDecl *> seenVars;
-    for (auto idx : indices(PBD->getPatternList())) {
+    for (auto idx : range(PBD->getNumPatternEntries())) {
       PBD->getPattern(idx)->forEachNode([&](const Pattern *P) {
         if (auto *NP = dyn_cast<NamedPattern>(P)) {
           // Only check individual variables if we didn't check an enclosing
@@ -1174,7 +1174,7 @@ public:
         getFixedLayoutStructContext(PBD);
 
     llvm::DenseSet<const VarDecl *> seenVars;
-    for (auto idx : indices(PBD->getPatternList())) {
+    for (auto idx : range(PBD->getNumPatternEntries())) {
       PBD->getPattern(idx)->forEachNode([&](const Pattern *P) {
         if (auto *NP = dyn_cast<NamedPattern>(P)) {
           checkNamedPattern(NP, fixedLayoutStructContext, isTypeContext,
@@ -1816,7 +1816,7 @@ public:
 
   void visitPatternBindingDecl(PatternBindingDecl *PBD) {
     llvm::DenseSet<const VarDecl *> seenVars;
-    for (auto idx : indices(PBD->getPatternList())) {
+    for (auto idx : range(PBD->getNumPatternEntries())) {
       PBD->getPattern(idx)->forEachNode([&](const Pattern *P) {
         if (auto *NP = dyn_cast<NamedPattern>(P)) {
           checkNamedPattern(NP, seenVars);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -957,15 +957,8 @@ abstractSyntaxDeclForAvailableAttribute(const Decl *ConcreteSyntaxDecl) {
     // all parsed attribute that appear in the concrete syntax upon on the
     // PatternBindingDecl are added to all of the VarDecls for the pattern
     // binding.
-    ArrayRef<PatternBindingEntry> Entries = PBD->getPatternList();
-    if (!Entries.empty()) {
-      const VarDecl *AnyVD = nullptr;
-      // FIXME: This is wasteful; we only need the first variable.
-      Entries.front().getPattern()->forEachVariable([&](const VarDecl *VD) {
-        AnyVD = VD;
-      });
-      if (AnyVD)
-        return AnyVD;
+    if (PBD->getNumPatternEntries() != 0) {
+      return PBD->getAnchoringVarDecl(0);
     }
   } else if (auto *ECD = dyn_cast<EnumCaseDecl>(ConcreteSyntaxDecl)) {
     // Similar to the PatternBindingDecl case above, we return the

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -672,7 +672,7 @@ void TypeChecker::checkPatternBindingCaptures(NominalTypeDecl *typeDecl) {
     if (!PBD) continue;
     // Walk the initializers for all properties declared in the type with
     // an initializer.
-    for (unsigned i = 0, e = PBD->getNumPatternEntries(); i < e; ++i) {
+    for (unsigned i : range(PBD->getNumPatternEntries())) {
       if (PBD->isInitializerSubsumed(i))
         continue;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2834,7 +2834,6 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
 bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
                                           unsigned patternNumber) {
-  const auto &pbe = PBD->getPatternList()[patternNumber];
   Pattern *pattern = PBD->getPattern(patternNumber);
   Expr *init = PBD->getInit(patternNumber);
 
@@ -2842,7 +2841,8 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
   PatternBindingInitializer *initContext = nullptr;
   DeclContext *DC = PBD->getDeclContext();
   if (!DC->isLocalContext()) {
-    initContext = cast_or_null<PatternBindingInitializer>(pbe.getInitContext());
+    initContext = cast_or_null<PatternBindingInitializer>(
+        PBD->getInitContext(patternNumber));
     if (initContext)
       DC = initContext;
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2401,7 +2401,7 @@ public:
       isInSILMode = sourceFile->Kind == SourceFileKind::SIL;
     bool isTypeContext = DC->isTypeContext();
 
-    for (auto i : indices(PBD->getPatternList())) {
+    for (auto i : range(PBD->getNumPatternEntries())) {
       const auto *entry = evaluateOrDefault(TC.Context.evaluator,
                                             PatternBindingEntryRequest{PBD, i},
                                             nullptr);
@@ -2497,7 +2497,7 @@ public:
     checkAccessControl(TC, PBD);
 
     // If the initializers in the PBD aren't checked yet, do so now.
-    for (auto i : indices(PBD->getPatternList())) {
+    for (auto i : range(PBD->getNumPatternEntries())) {
       if (!PBD->isInitialized(i))
         continue;
 
@@ -2799,7 +2799,7 @@ public:
       // initialized. Diagnose the lack of initial value.
       pbd->setInvalid();
       SmallVector<VarDecl *, 4> vars;
-      for (auto idx : indices(pbd->getPatternList()))
+      for (auto idx : range(pbd->getNumPatternEntries()))
         pbd->getPattern(idx)->collectVariables(vars);
       bool suggestNSManaged = propertiesCanBeNSManaged(cd, vars);
       switch (vars.size()) {
@@ -4698,7 +4698,7 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
         pbd->isDefaultInitializable() || pbd->isInvalid())
       continue;
    
-    for (auto idx : indices(pbd->getPatternList())) {
+    for (auto idx : range(pbd->getNumPatternEntries())) {
       if (pbd->isInitialized(idx)) continue;
 
       auto *pattern = pbd->getPattern(idx);

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -346,7 +346,7 @@ void REPLChecker::processREPLTopLevelPatternBinding(PatternBindingDecl *PBD) {
   // This would just cause a confusing definite initialization error.  Some
   // day we will do some high level analysis of uninitialized variables
   // (rdar://15157729) but until then, output a specialized error.
-  for (auto entryIdx : indices(PBD->getPatternList())) {
+  for (auto entryIdx : range(PBD->getNumPatternEntries())) {
     auto *entryInit = PBD->getInit(entryIdx);
     if (!entryInit) {
       TC.diagnose(PBD->getStartLoc(), diag::repl_must_be_initialized);

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -346,15 +346,14 @@ void REPLChecker::processREPLTopLevelPatternBinding(PatternBindingDecl *PBD) {
   // This would just cause a confusing definite initialization error.  Some
   // day we will do some high level analysis of uninitialized variables
   // (rdar://15157729) but until then, output a specialized error.
-  unsigned entryIdx = 0U-1;
-  for (auto patternEntry : PBD->getPatternList()) {
-    ++entryIdx;
-    if (!patternEntry.getInit()) {
+  for (auto entryIdx : indices(PBD->getPatternList())) {
+    auto *entryInit = PBD->getInit(entryIdx);
+    if (!entryInit) {
       TC.diagnose(PBD->getStartLoc(), diag::repl_must_be_initialized);
       continue;
     }
 
-    auto pattern = patternEntry.getPattern();
+    auto *pattern = PBD->getPattern(entryIdx);
     
     llvm::SmallString<16> PatternString;
     PatternBindingPrintLHS(PatternString).visit(pattern);
@@ -395,10 +394,10 @@ void REPLChecker::processREPLTopLevelPatternBinding(PatternBindingDecl *PBD) {
     // Create a PatternBindingDecl to bind the expression into the decl.
     Pattern *metavarPat = new (Context) NamedPattern(vd);
     metavarPat->setType(vd->getType());
-    PatternBindingDecl *metavarBinding = PatternBindingDecl::create(
+    auto *metavarBinding = PatternBindingDecl::create(
         Context, /*StaticLoc*/ SourceLoc(), StaticSpellingKind::None,
         /*VarLoc*/ PBD->getStartLoc(), metavarPat, /*EqualLoc*/ SourceLoc(),
-        patternEntry.getInit(), &SF);
+        entryInit, &SF);
 
     auto MVBrace = BraceStmt::create(Context, metavarBinding->getStartLoc(),
                                      ASTNode(metavarBinding),

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2718,7 +2718,7 @@ public:
     if (binding->getDeclContext()->isTypeContext())
       owningDC = binding->getDeclContext();
 
-    for (auto entryIdx : indices(binding->getPatternList())) {
+    for (auto entryIdx : range(binding->getNumPatternEntries())) {
       writePattern(binding->getPattern(entryIdx));
       // Ignore initializer; external clients don't need to know about it.
     }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1851,11 +1851,10 @@ void Serializer::writePatternBindingInitializer(PatternBindingDecl *binding,
 
   StringRef initStr;
   SmallString<128> scratch;
-  auto &entry = binding->getPatternList()[bindingIndex];
-  auto varDecl = entry.getAnchoringVarDecl();
-  if (entry.hasInitStringRepresentation() &&
+  auto varDecl = binding->getAnchoringVarDecl(bindingIndex);
+  if (binding->hasInitStringRepresentation(bindingIndex) &&
       varDecl->isInitExposedToClients()) {
-    initStr = entry.getInitStringRepresentation(scratch);
+    initStr = binding->getInitStringRepresentation(bindingIndex, scratch);
   }
 
   PatternBindingInitializerLayout::emitRecord(Out, ScratchRecord,
@@ -2698,7 +2697,7 @@ public:
     SmallVector<uint64_t, 2> initContextIDs;
     for (unsigned i : range(binding->getNumPatternEntries())) {
       auto initContextID =
-          S.addDeclContextRef(binding->getPatternList()[i].getInitContext());
+          S.addDeclContextRef(binding->getInitContext(i));
       if (!initContextIDs.empty()) {
         initContextIDs.push_back(initContextID.getOpaqueValue());
       } else if (initContextID) {
@@ -2719,8 +2718,8 @@ public:
     if (binding->getDeclContext()->isTypeContext())
       owningDC = binding->getDeclContext();
 
-    for (auto entry : binding->getPatternList()) {
-      writePattern(entry.getPattern());
+    for (auto entryIdx : indices(binding->getPatternList())) {
+      writePattern(binding->getPattern(entryIdx));
       // Ignore initializer; external clients don't need to know about it.
     }
   }


### PR DESCRIPTION
For the eventual requestification of `PatternBindingDecl`'s API, hide raw accesses to the `PatternBindingEntry` from callers that don't need it.  Force all of these accesses to go through the `PatternBindingDecl` instead.

To support this effort, `PatternBindingDecl` has gained a few utility APIs and lost an API that returned a reference to the stored `PatternBindingEntry` associated with a given `VarDecl`.  

There are now no callers that index directly into the pattern list outside of the `ASTScope` and request, and no callers that mutate `PatternBindingEntry`s directly outside of the parser and request.