### PR TITLE
Define InterfaceTypeRequest

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2467,6 +2467,7 @@ class ValueDecl : public Decl {
   friend class IsFinalRequest;
   friend class IsDynamicRequest;
   friend class IsImplicitlyUnwrappedOptionalRequest;
+  friend class InterfaceTypeRequest;
   friend class Decl;
   SourceLoc getLocFromSource() const { return NameLoc; }
 protected:

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -53,13 +53,6 @@ public:
   virtual void resolveWitness(const NormalProtocolConformance *conformance,
                               ValueDecl *requirement) = 0;
 
-  /// Resolve the type and declaration attributes of a value.
-  ///
-  /// This can be called when the type or signature of a value is needed.
-  /// It does not perform full type-checking, only checks for basic
-  /// consistency and provides the value a type.
-  virtual void resolveDeclSignature(ValueDecl *VD) = 0;
-
   /// Resolve any implicitly-declared constructors within the given nominal.
   virtual void resolveImplicitConstructors(NominalTypeDecl *nominal) = 0;
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1427,6 +1427,27 @@ public:
   void cacheResult(NamedPattern *P) const;
 };
 
+class InterfaceTypeRequest :
+    public SimpleRequest<InterfaceTypeRequest,
+                         Type (ValueDecl *),
+                         CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<Type>
+  evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<Type> getCachedResult() const;
+  void cacheResult(Type value) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -67,6 +67,8 @@ SWIFT_REQUEST(TypeChecker, InheritedTypeRequest,
               SeparatelyCached, HasNearestLocation)
 SWIFT_REQUEST(TypeChecker, InitKindRequest,
               CtorInitializerKind(ConstructorDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, InterfaceTypeRequest,
+              Type(ValueDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsAccessorTransparentRequest, bool(AccessorDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDynamicRequest, bool(ValueDecl *),

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1001,3 +1001,28 @@ void NamingPatternRequest::cacheResult(NamedPattern *value) const {
   auto *VD = std::get<0>(getStorage());
   VD->NamingPattern = value;
 }
+
+//----------------------------------------------------------------------------//
+// InterfaceTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<Type> InterfaceTypeRequest::getCachedResult() const {
+  auto *decl = std::get<0>(getStorage());
+  if (auto Ty = decl->TypeAndAccess.getPointer()) {
+    return Ty;
+  }
+  return None;
+}
+
+void InterfaceTypeRequest::cacheResult(Type type) const {
+  auto *decl = std::get<0>(getStorage());
+  if (type) {
+    assert(!type->hasTypeVariable() && "Type variable in interface type");
+    assert(!type->is<InOutType>() && "Interface type must be materializable");
+    assert(!type->hasArchetype() && "Archetype in interface type");
+
+    if (type->hasError())
+      decl->setInvalid();
+  }
+  decl->TypeAndAccess.setPointer(type);
+}

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -39,7 +39,7 @@ void swift::setBoundVarsTypeError(Pattern *pattern, ASTContext &ctx) {
   pattern->forEachVariable([&](VarDecl *var) {
     // Don't change the type of a variable that we've been able to
     // compute a type for.
-    if (var->hasInterfaceType() && !var->getType()->hasError())
+    if (var->hasInterfaceType())
       return;
 
     var->setInterfaceType(ErrorType::get(var->getASTContext()));

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -798,8 +798,6 @@ public:
   GenericEnvironment *handleSILGenericParams(GenericParamList *genericParams,
                                              DeclContext *DC);
 
-  void validateDecl(ValueDecl *D);
-
   /// Resolve a reference to the given type declaration within a particular
   /// context.
   ///
@@ -1018,10 +1016,6 @@ public:
 
   static Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
                                           ReferenceOwnershipAttr *attr);
-
-  virtual void resolveDeclSignature(ValueDecl *VD) override {
-    validateDecl(VD);
-  }
 
   virtual void resolveImplicitConstructors(NominalTypeDecl *nominal) override {
     addImplicitConstructors(nominal);

--- a/test/CircularReferences/global_typealias.swift
+++ b/test/CircularReferences/global_typealias.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-typealias A = B // expected-error {{type alias 'A' references itself}}
-typealias C = D // expected-note {{through reference here}}
-typealias D = (A, Int) // expected-note {{through reference here}}
-typealias B = C // expected-note {{through reference here}}
+typealias A = B // expected-error {{type alias 'A' references itself}} expected-note {{through reference here}}
+typealias C = D // expected-note {{through reference here}} expected-note {{through reference here}}
+typealias D = (A, Int) // expected-note {{through reference here}} expected-note {{through reference here}}
+typealias B = C // expected-note {{through reference here}} expected-note {{through reference here}}

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -628,6 +628,6 @@ struct PatternBindingWithTwoVars3 { var x = y, y = x }
 
 // https://bugs.swift.org/browse/SR-9015
 func sr9015() {
-  let closure1 = { closure2() } // expected-error {{circular reference}} expected-error{{variable 'closure1' is not bound by any pattern}} expected-note {{through reference here}}
-  let closure2 = { closure1() } // expected-note {{through reference here}} expected-note {{through reference here}}
+  let closure1 = { closure2() } // expected-error {{circular reference}} expected-error{{variable 'closure1' is not bound by any pattern}} expected-note {{through reference here}} expected-note {{through reference here}}
+  let closure2 = { closure1() } // expected-note {{through reference here}} expected-note {{through reference here}} expected-note {{through reference here}}
 }

--- a/test/Sema/diag_typealias.swift
+++ b/test/Sema/diag_typealias.swift
@@ -2,4 +2,4 @@
 
 struct S {}
 
-typealias S = S // expected-error {{type alias 'S' references itself}}
+typealias S = S // expected-error {{type alias 'S' references itself}} expected-note {{through reference here}}

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -10,7 +10,7 @@ class C {
 	init() {}
 }
 
-typealias t = t // expected-error {{type alias 't' references itself}}
+typealias t = t // expected-error {{type alias 't' references itself}} expected-note {{through reference here}}
 
 extension Foo {
   convenience init() {} // expected-error{{invalid redeclaration of synthesized 'init()'}}

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -71,6 +71,8 @@ let a = b ; let b = a
 // expected-note@-3 {{through reference here}}
 // expected-note@-4 {{through reference here}}
 // expected-note@-5 {{through reference here}}
+// expected-note@-6 {{through reference here}}
+// expected-note@-7 {{through reference here}}
 
 // <rdar://problem/17501765> Swift should warn about immutable default initialized values
 let uselessValue : String?


### PR DESCRIPTION
Now that VarDecl's interface type computation is rationalized, the final piece was formalizing the `ParamDecl` case returning the null `Type`. 

Define a request for the interface type. This is not the end of this story by a long shot.  The pattern binding request needs to be divided into a checked initializer request and a checked pattern request.  The naming pattern request needs to do a lot less work by just checking one or the other.  A bunch of places in the compiler have ad-hoc circularity breaking code that also needs to be swept up under the evaluator.  The decl validation machinery still needs to be expunged.

There's a lot to do, but we can at least celebrate the little things.

🎉 **validateDecl is dead!** 🎉  