### PR TITLE
[build-script] Refactor swift_build_support to prepare for moving more projects to swift_build_suppport

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -790,11 +790,11 @@ class BuildScriptInvocation(object):
                     source_dir=self.workspace.source_dir(product_source),
                     build_dir=self.workspace.build_dir(
                         host_target, product_name))
-                if product.shall_build(host_target):
+                if product.should_build(host_target):
                     product.build(host_target)
-                if product.shall_test(host_target):
+                if product.should_test(host_target):
                     product.test(host_target)
-                if product.shall_install(host_target):
+                if product.should_install(host_target):
                     product.install(host_target)
 
         # Extract symbols...

--- a/utils/build-script
+++ b/utils/build-script
@@ -790,9 +790,12 @@ class BuildScriptInvocation(object):
                     source_dir=self.workspace.source_dir(product_source),
                     build_dir=self.workspace.build_dir(
                         host_target, product_name))
-                product.build(host_target)
-                product.test(host_target)
-                product.install(host_target)
+                if product.shall_build(host_target):
+                    product.build(host_target)
+                if product.shall_test(host_target):
+                    product.test(host_target)
+                if product.shall_install(host_target):
+                    product.install(host_target)
 
         # Extract symbols...
         for host_target in all_hosts:

--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -28,13 +28,13 @@ class Benchmarks(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def shall_build(self, host_target):
+    def should_build(self, host_target):
         return True
 
     def build(self, host_target):
         run_build_script_helper(host_target, self, self.args)
 
-    def shall_test(self, host_target):
+    def should_test(self, host_target):
         return True
 
     def test(self, host_target):
@@ -51,7 +51,7 @@ class Benchmarks(product.Product):
         bench_Osize = os.path.join(self.build_dir, 'bin', 'Benchmark_Osize')
         shell.call([bench_Osize] + cmdline)
 
-    def shall_install(self, host_target):
+    def should_install(self, host_target):
         return False
 
     def install(self, host_target):

--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -28,8 +28,14 @@ class Benchmarks(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
+    def shall_build(self, host_target):
+        return True
+
     def build(self, host_target):
         run_build_script_helper(host_target, self, self.args)
+
+    def shall_test(self, host_target):
+        return True
 
     def test(self, host_target):
         """Just run a single instance of the command for both .debug and
@@ -44,6 +50,9 @@ class Benchmarks(product.Product):
 
         bench_Osize = os.path.join(self.build_dir, 'bin', 'Benchmark_Osize')
         shell.call([bench_Osize] + cmdline)
+
+    def shall_install(self, host_target):
+        return False
 
     def install(self, host_target):
         pass

--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -11,7 +11,6 @@
 # ----------------------------------------------------------------------------
 
 import os
-import platform
 
 from . import product
 from .. import shell
@@ -27,19 +26,19 @@ class IndexStoreDB(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def shall_build(self, host_target):
+    def should_build(self, host_target):
         return True
 
     def build(self, host_target):
         run_build_script_helper('build', host_target, self, self.args)
 
-    def shall_test(self, host_target):
+    def should_test(self, host_target):
         return self.args.test_indexstoredb
 
     def test(self, host_target):
         run_build_script_helper('test', host_target, self, self.args)
 
-    def shall_install(self, host_target):
+    def should_install(self, host_target):
         return False
 
     def install(self, host_target):
@@ -49,11 +48,10 @@ class IndexStoreDB(product.Product):
 def run_build_script_helper(action, host_target, product, args):
     script_path = os.path.join(
         product.source_dir, 'Utilities', 'build-script-helper.py')
-    toolchain_path = args.install_destdir
-    if platform.system() == 'Darwin':
-        # The prefix is an absolute path, so concatenate without os.path.
-        toolchain_path += \
-            targets.darwin_toolchain_prefix(args.install_prefix)
+
+    toolchain_path = targets.toolchain_path(args.install_destdir,
+                                            args.install_prefix)
+
     configuration = 'debug' if args.build_variant == 'Debug' else 'release'
     helper_cmd = [
         script_path,

--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -27,12 +27,20 @@ class IndexStoreDB(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
+    def shall_build(self, host_target):
+        return True
+
     def build(self, host_target):
         run_build_script_helper('build', host_target, self, self.args)
 
+    def shall_test(self, host_target):
+        return self.args.test_indexstoredb
+
     def test(self, host_target):
-        if self.args.test and self.args.test_indexstoredb:
-            run_build_script_helper('test', host_target, self, self.args)
+        run_build_script_helper('test', host_target, self, self.args)
+
+    def shall_install(self, host_target):
+        return False
 
     def install(self, host_target):
         pass

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -42,6 +42,13 @@ class Product(object):
         """
         return True
 
+    def shall_build(self, host_target):
+        """shall_build() -> Bool
+
+        Whether or not this product shall be built with the given arguments.
+        """
+        raise NotImplementedError
+
     def build(self, host_target):
         """build() -> void
 
@@ -49,10 +56,24 @@ class Product(object):
         """
         raise NotImplementedError
 
+    def shall_test(self, host_target):
+        """shall_test() -> Bool
+
+        Whether or not this product shall be tested with the given arguments.
+        """
+        raise NotImplementedError
+
     def test(self, host_target):
         """test() -> void
 
         Run the tests, for a non-build-script-impl product.
+        """
+        raise NotImplementedError
+
+    def shall_install(self, host_target):
+        """shall_install() -> Bool
+
+        Whether or not this product shall be installed with the given arguments
         """
         raise NotImplementedError
 

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -42,10 +42,10 @@ class Product(object):
         """
         return True
 
-    def shall_build(self, host_target):
-        """shall_build() -> Bool
+    def should_build(self, host_target):
+        """should_build() -> Bool
 
-        Whether or not this product shall be built with the given arguments.
+        Whether or not this product should be built with the given arguments.
         """
         raise NotImplementedError
 
@@ -56,10 +56,10 @@ class Product(object):
         """
         raise NotImplementedError
 
-    def shall_test(self, host_target):
-        """shall_test() -> Bool
+    def should_test(self, host_target):
+        """should_test() -> Bool
 
-        Whether or not this product shall be tested with the given arguments.
+        Whether or not this product should be tested with the given arguments.
         """
         raise NotImplementedError
 
@@ -70,10 +70,11 @@ class Product(object):
         """
         raise NotImplementedError
 
-    def shall_install(self, host_target):
-        """shall_install() -> Bool
+    def should_install(self, host_target):
+        """should_install() -> Bool
 
-        Whether or not this product shall be installed with the given arguments
+        Whether or not this product should be installed with the given
+        arguments.
         """
         raise NotImplementedError
 
@@ -85,6 +86,19 @@ class Product(object):
         raise NotImplementedError
 
     def __init__(self, args, toolchain, source_dir, build_dir):
+        """
+        Parameters
+        ----------
+        args : `argparse.Namespace`
+            The arguments passed by the user to the invocation of the script.
+        toolchain : `swift_build_support.toolchain.Toolchain`
+            The toolchain being used to build the product. The toolchain will
+            point to the tools that the builder should use to build (like the
+            compiler or the linker).
+        build_dir: string
+            The directory in which the product should put all of its build
+            products.
+        """
         self.args = args
         self.toolchain = toolchain
         self.source_dir = source_dir

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -23,16 +23,23 @@ class SourceKitLSP(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
+    def shall_build(self, host_target):
+        return True
+
     def build(self, host_target):
         indexstoredb.run_build_script_helper(
             'build', host_target, self, self.args)
 
+    def shall_test(self, host_target):
+        return self.args.test_sourcekitlsp
+
     def test(self, host_target):
-        if self.args.test_sourcekitlsp:
-            indexstoredb.run_build_script_helper(
-                'test', host_target, self, self.args)
+        indexstoredb.run_build_script_helper(
+            'test', host_target, self, self.args)
+
+    def shall_install(self, host_target):
+        return self.args.install_sourcekitlsp
 
     def install(self, host_target):
-        if self.args.install_sourcekitlsp:
-            indexstoredb.run_build_script_helper(
-                'install', host_target, self, self.args)
+        indexstoredb.run_build_script_helper(
+            'install', host_target, self, self.args)

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -23,21 +23,21 @@ class SourceKitLSP(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def shall_build(self, host_target):
+    def should_build(self, host_target):
         return True
 
     def build(self, host_target):
         indexstoredb.run_build_script_helper(
             'build', host_target, self, self.args)
 
-    def shall_test(self, host_target):
+    def should_test(self, host_target):
         return self.args.test_sourcekitlsp
 
     def test(self, host_target):
         indexstoredb.run_build_script_helper(
             'test', host_target, self, self.args)
 
-    def shall_install(self, host_target):
+    def should_install(self, host_target):
         return self.args.install_sourcekitlsp
 
     def install(self, host_target):

--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -29,6 +29,9 @@ class TSanLibDispatch(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
+    def shall_build(self, host_target):
+        return True
+
     def build(self, host_target):
         """Build TSan runtime (compiler-rt)."""
         rt_source_dir = join_path(self.source_dir, os.pardir, 'compiler-rt')
@@ -59,6 +62,9 @@ class TSanLibDispatch(product.Product):
             shell.call(config_cmd)
             shell.call(build_cmd)
 
+    def shall_test(self, host_target):
+        return True
+
     def test(self, host_target):
         """Run check-tsan target with a LIT filter for libdispatch."""
         cmd = ['ninja', 'check-tsan']
@@ -66,6 +72,9 @@ class TSanLibDispatch(product.Product):
 
         with shell.pushd(self.build_dir):
             shell.call(cmd, env=env)
+
+    def shall_install(self, host_target):
+        return False
 
     def install(self, host_target):
         pass

--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -29,7 +29,7 @@ class TSanLibDispatch(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def shall_build(self, host_target):
+    def should_build(self, host_target):
         return True
 
     def build(self, host_target):
@@ -62,7 +62,7 @@ class TSanLibDispatch(product.Product):
             shell.call(config_cmd)
             shell.call(build_cmd)
 
-    def shall_test(self, host_target):
+    def should_test(self, host_target):
         return True
 
     def test(self, host_target):
@@ -73,7 +73,7 @@ class TSanLibDispatch(product.Product):
         with shell.pushd(self.build_dir):
             shell.call(cmd, env=env)
 
-    def shall_install(self, host_target):
+    def should_install(self, host_target):
         return False
 
     def install(self, host_target):

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -283,3 +283,19 @@ def darwin_toolchain_prefix(darwin_install_prefix):
     directory.
     """
     return os.path.split(darwin_install_prefix)[0]
+
+
+def toolchain_path(install_destdir, install_prefix):
+    """
+    Given the install prefix for a Darwin system, and assuming that that path
+    is to a .xctoolchain directory, return the path to the .xctoolchain
+    directory in the given install directory.
+    This toolchain is being populated during the build-script invocation.
+    Downstream products can use products that were previously installed into
+    this toolchain.
+    """
+    built_toolchain_path = install_destdir
+    if platform.system() == 'Darwin':
+        # The prefix is an absolute path, so concatenate without os.path.
+        built_toolchain_path += darwin_toolchain_prefix(install_prefix)
+    return built_toolchain_path


### PR DESCRIPTION
This PR moves some common functionality that needs to be implemented in every `swift_build_support` product up to common locations.