### PR TITLE
[sil] Add support for adding _semantics attributes to nominal types.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -202,7 +202,7 @@ DECL_ATTR(inline, Inline,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   20)
 DECL_ATTR(_semantics, Semantics,
-  OnAbstractFunction | OnSubscript |
+  OnAbstractFunction | OnSubscript | OnNominalType |
   AllowMultipleAttributes | UserInaccessible |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   21)

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3438,6 +3438,18 @@ public:
   /// with placeholders for unimportable stored properties.
   ArrayRef<Decl *> getStoredPropertiesAndMissingMemberPlaceholders() const;
 
+  /// Return the range of semantics attributes attached to this NominalTypeDecl.
+  auto getSemanticsAttrs() const
+      -> decltype(getAttrs().getAttributes<SemanticsAttr>()) {
+    return getAttrs().getAttributes<SemanticsAttr>();
+  }
+
+  bool hasSemanticsAttr(StringRef attrValue) const {
+    return llvm::any_of(getSemanticsAttrs(), [&](const SemanticsAttr *attr) {
+      return attrValue.equals(attr->Value);
+    });
+  }
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_NominalTypeDecl &&

--- a/test/attr/attr_semantics.swift
+++ b/test/attr/attr_semantics.swift
@@ -19,3 +19,16 @@ func func_with_nested_semantics_2() {
    func exit(_ code : UInt32) -> Void
    exit(0)
 }
+
+@_semantics("struct")
+struct StructWithSemantics {}
+
+@_semantics("class")
+class ClassWithSemantics {}
+
+@_semantics("enum")
+enum EnumWithSemantics {}
+
+@_semantics("struct1")
+@_semantics("struct2")
+struct StructWithDuplicateSemantics {}


### PR DESCRIPTION
This will make it easier to prototype diagnostics on specifically marked nominal
types. My intended usage would be to have a way to emit diagnostics if specific
instances of the nominal type are ever not on the stack.

