### PR TITLE
AST: repair Windows build after #27764

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2812,11 +2812,12 @@ Type ValueDecl::getInterfaceType() const {
     return TypeAndAccess.getPointer();
   }
 
-  auto ty =
-      evaluateOrDefault(getASTContext().evaluator,
-                        InterfaceTypeRequest{const_cast<ValueDecl *>(this)},
-                        ErrorType::get(getASTContext()));
-  return ty ?: ErrorType::get(getASTContext());
+  if (auto Ty =
+          evaluateOrDefault(getASTContext().evaluator,
+                            InterfaceTypeRequest{const_cast<ValueDecl *>(this)},
+                            ErrorType::get(getASTContext())))
+    return Ty;
+  return ErrorType::get(getASTContext());
 }
 
 void ValueDecl::setInterfaceType(Type type) {


### PR DESCRIPTION
Avoid the use of the GNU extension for the collapsed ternary and use the
explicit expansion.  This should repair the Windows build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
