### PR TITLE
build: try to ban GNU extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,10 @@ if(MSVC OR "${CMAKE_SIMULATE_ID}" STREQUAL MSVC)
   include(ClangClCompileRules)
 endif()
 
+if(CMAKE_C_COMPILER_ID STREQUAL Clang)
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror=gnu>)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin OR
     EXISTS "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}")
   set(SWIFT_BUILD_SYNTAXPARSERLIB_default TRUE)


### PR DESCRIPTION
GNU extensions are inherently non-portable, and can cause regressions on
other platforms.  Attempt to catch the accidental use of GNU extensions
early by using clang to identify them.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
