### PR TITLE
[AutoDiff upstream] NFC: update `IndexSubset` print/dump utilities.

### DIFF
--- a/include/swift/AST/IndexSubset.h
+++ b/include/swift/AST/IndexSubset.h
@@ -201,19 +201,10 @@ public:
       id.AddInteger(index);
   }
 
-  void print(llvm::raw_ostream &s = llvm::outs()) const {
-    s << '{';
-    interleave(range(capacity), [this, &s](unsigned i) { s << contains(i); },
-               [&s] { s << ", "; });
-    s << '}';
-  }
-
-  void dump(llvm::raw_ostream &s = llvm::errs()) const {
-    s << "(index_subset capacity=" << capacity << " indices=(";
-    interleave(getIndices(), [&s](unsigned i) { s << i; },
-               [&s] { s << ", "; });
-    s << "))";
-  }
+  void print(llvm::raw_ostream &s = llvm::outs()) const;
+  LLVM_ATTRIBUTE_DEPRECATED(void dump(llvm::raw_ostream &s = llvm::errs())
+                                const LLVM_ATTRIBUTE_USED,
+                            "only for use within the debugger");
 
   int findNext(int startIndex) const;
   int findFirst() const { return findNext(-1); }

--- a/lib/AST/IndexSubset.cpp
+++ b/lib/AST/IndexSubset.cpp
@@ -79,6 +79,20 @@ IndexSubset *IndexSubset::extendingCapacity(
   return IndexSubset::get(ctx, indices);
 }
 
+void IndexSubset::print(llvm::raw_ostream &s) const {
+  s << '{';
+  interleave(range(capacity), [this, &s](unsigned i) { s << contains(i); },
+             [&s] { s << ", "; });
+  s << '}';
+}
+
+void IndexSubset::dump(llvm::raw_ostream &s) const {
+  s << "(index_subset capacity=" << capacity << " indices=(";
+  interleave(getIndices(), [&s](unsigned i) { s << i; },
+             [&s] { s << ", "; });
+  s << "))\n";
+}
+
 int IndexSubset::findNext(int startIndex) const {
   assert(startIndex < (int)capacity && "Start index cannot be past the end");
   unsigned bitWordIndex = 0, offset = 0;


### PR DESCRIPTION
Minor cherry-pick from `tensorflow` branch: https://github.com/apple/swift/pull/27772.