### PR TITLE
Delete DeclValidationRAII

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -285,7 +285,7 @@ class alignas(1 << DeclAlignInBits) Decl {
 protected:
   union { uint64_t OpaqueBits;
 
-  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+2+1,
+  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1,
     Kind : bitmax(NumDeclKindBits,8),
 
     /// Whether this declaration is invalid.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -894,6 +894,8 @@ ERROR(precedence_group_redeclared,none,
       "precedence group redeclared", ())
 NOTE(previous_precedence_group_decl,none,
      "previous precedence group declaration here", ())
+NOTE(circular_reference_through_precedence_group, none,
+     "through reference to precedence group %0 here", (Identifier))
 
 //------------------------------------------------------------------------------
 // MARK: Expression Type Checking Errors

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -883,6 +883,8 @@ NOTE(found_this_precedence_group,none,
 ERROR(unknown_precedence_group,none,
       "unknown precedence group %0", (Identifier))
 ERROR(precedence_group_cycle,none,
+      "cycle in '%select{lowerThan|higherThan}0' relation", (bool))
+ERROR(higher_than_precedence_group_cycle,none,
       "cycle in higherThan relation: %0", (StringRef))
 ERROR(precedence_group_lower_within_module,none,
       "precedence group cannot be given lower precedence than group in same"

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -278,56 +278,6 @@ public:
   void cacheResult(GenericParamList *value) const;
 };
 
-struct PrecedenceGroupDescriptor {
-  DeclContext *dc;
-  Identifier ident;
-  SourceLoc nameLoc;
-
-  SourceLoc getLoc() const;
-
-  friend llvm::hash_code hash_value(const PrecedenceGroupDescriptor &owner) {
-    return hash_combine(llvm::hash_value(owner.dc),
-                        llvm::hash_value(owner.ident.getAsOpaquePointer()),
-                        llvm::hash_value(owner.nameLoc.getOpaquePointerValue()));
-  }
-
-  friend bool operator==(const PrecedenceGroupDescriptor &lhs,
-                         const PrecedenceGroupDescriptor &rhs) {
-    return lhs.dc == rhs.dc &&
-           lhs.ident == rhs.ident &&
-           lhs.nameLoc == rhs.nameLoc;
-  }
-
-  friend bool operator!=(const PrecedenceGroupDescriptor &lhs,
-                         const PrecedenceGroupDescriptor &rhs) {
-    return !(lhs == rhs);
-  }
-};
-
-void simple_display(llvm::raw_ostream &out, const PrecedenceGroupDescriptor &d);
-
-class LookupPrecedenceGroupRequest
-    : public SimpleRequest<LookupPrecedenceGroupRequest,
-                           PrecedenceGroupDecl *(PrecedenceGroupDescriptor),
-                           CacheKind::Cached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  // Evaluation.
-  llvm::Expected<PrecedenceGroupDecl *>
-  evaluate(Evaluator &evaluator, PrecedenceGroupDescriptor descriptor) const;
-
-public:
-  // Source location
-  SourceLoc getNearestLoc() const;
-                               
-  // Separate caching.
-  bool isCached() const { return true; }
-};
-
 /// Expand the given ASTScope. Requestified to detect recursion.
 class ExpandASTScopeRequest
     : public SimpleRequest<ExpandASTScopeRequest,

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -34,9 +34,6 @@ SWIFT_REQUEST(NameLookup, InheritedDeclsReferencedRequest,
               DirectlyReferencedTypeDecls(
                   llvm::PointerUnion<TypeDecl *, ExtensionDecl *>, unsigned),
               Uncached, HasNearestLocation)
-SWIFT_REQUEST(NameLookup, LookupPrecedenceGroupRequest,
-              PrecedenceGroupDecl *(DeclContext *, Identifier, SourceLoc),
-              Cached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, SelfBoundsFromWhereClauseRequest,
               SelfBounds(llvm::PointerUnion<TypeDecl *, ExtensionDecl *>),
               Uncached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1449,11 +1449,15 @@ public:
 };
 
 struct PrecedenceGroupDescriptor {
+  enum PathDirection : bool {
+    LowerThan = false,
+    HigherThan = true,
+  };
   DeclContext *dc;
   Identifier ident;
   SourceLoc nameLoc;
   // Exists for diagnostics. Does not contribute to the descriptor otherwise.
-  Optional<bool> pathDirection;
+  Optional<PathDirection> pathDirection;
 
   SourceLoc getLoc() const;
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1448,6 +1448,62 @@ public:
   void cacheResult(Type value) const;
 };
 
+struct PrecedenceGroupDescriptor {
+  DeclContext *dc;
+  Identifier ident;
+  SourceLoc nameLoc;
+  // Exists for diagnostics. Does not contribute to the descriptor otherwise.
+  Optional<bool> pathDirection;
+
+  SourceLoc getLoc() const;
+
+  friend llvm::hash_code hash_value(const PrecedenceGroupDescriptor &owner) {
+    return llvm::hash_combine(owner.dc,
+                              owner.ident.getAsOpaquePointer(),
+                              owner.nameLoc.getOpaquePointerValue());
+  }
+
+  friend bool operator==(const PrecedenceGroupDescriptor &lhs,
+                         const PrecedenceGroupDescriptor &rhs) {
+    return lhs.dc == rhs.dc &&
+           lhs.ident == rhs.ident &&
+           lhs.nameLoc == rhs.nameLoc;
+  }
+
+  friend bool operator!=(const PrecedenceGroupDescriptor &lhs,
+                         const PrecedenceGroupDescriptor &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+void simple_display(llvm::raw_ostream &out, const PrecedenceGroupDescriptor &d);
+
+class LookupPrecedenceGroupRequest
+    : public SimpleRequest<LookupPrecedenceGroupRequest,
+                           PrecedenceGroupDecl *(PrecedenceGroupDescriptor),
+                           CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<PrecedenceGroupDecl *>
+  evaluate(Evaluator &evaluator, PrecedenceGroupDescriptor descriptor) const;
+
+public:
+  // Cycle handling.
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
+
+  // Source location
+  SourceLoc getNearestLoc() const;
+
+  // Separate caching.
+  bool isCached() const { return true; }
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -85,6 +85,9 @@ SWIFT_REQUEST(TypeChecker, IsSetterMutatingRequest, bool(AbstractStorageDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, LazyStoragePropertyRequest, VarDecl *(VarDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, LookupPrecedenceGroupRequest,
+              PrecedenceGroupDecl *(DeclContext *, Identifier, SourceLoc),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, MangleLocalTypeDeclRequest,
               std::string(const TypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, NamingPatternRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2783,8 +2783,13 @@ bool ValueDecl::hasInterfaceType() const {
   return !TypeAndAccess.getPointer().isNull();
 }
 
+static bool isComputingInterfaceType(const ValueDecl *VD) {
+  return VD->getASTContext().evaluator.hasActiveRequest(
+            InterfaceTypeRequest{const_cast<ValueDecl *>(VD)});
+}
+
 bool ValueDecl::isRecursiveValidation() const {
-  if (hasValidationStarted() && !hasInterfaceType())
+  if (isComputingInterfaceType(this) && !hasInterfaceType())
     return true;
 
   if (auto *vd = dyn_cast<VarDecl>(this))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7404,21 +7404,6 @@ PrecedenceGroupDecl::PrecedenceGroupDecl(DeclContext *dc,
          lowerThan.size() * sizeof(Relation));
 }
 
-llvm::Expected<PrecedenceGroupDecl *> LookupPrecedenceGroupRequest::evaluate(
-    Evaluator &eval, PrecedenceGroupDescriptor descriptor) const {
-  auto *dc = descriptor.dc;
-  PrecedenceGroupDecl *group = nullptr;
-  if (auto sf = dc->getParentSourceFile()) {
-    bool cascading = dc->isCascadingContextForLookup(false);
-    group = sf->lookupPrecedenceGroup(descriptor.ident, cascading,
-                                      descriptor.nameLoc);
-  } else {
-    group = dc->getParentModule()->lookupPrecedenceGroup(descriptor.ident,
-                                                         descriptor.nameLoc);
-  }
-  return group;
-}
-
 PrecedenceGroupDecl *InfixOperatorDecl::getPrecedenceGroup() const {
   return evaluateOrDefault(
       getASTContext().evaluator,

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -128,26 +128,6 @@ void GenericParamListRequest::cacheResult(GenericParamList *params) const {
   context->GenericParamsAndBit.setPointerAndInt(params, true);
 }
 
-
-//----------------------------------------------------------------------------//
-// LookupPrecedenceGroupRequest computation.
-//----------------------------------------------------------------------------//
-
-SourceLoc LookupPrecedenceGroupRequest::getNearestLoc() const {
-  auto &desc = std::get<0>(getStorage());
-  return desc.getLoc();
-}
-
-SourceLoc PrecedenceGroupDescriptor::getLoc() const {
-  return nameLoc;
-}
-
-void swift::simple_display(llvm::raw_ostream &out,
-                           const PrecedenceGroupDescriptor &desc) {
-  out << "precedence group " << desc.ident << " at ";
-  desc.nameLoc.print(out, desc.dc->getASTContext().SourceMgr);
-}
-
 // Define request evaluation functions for each of the name lookup requests.
 static AbstractRequestFunction *nameLookupRequestFunctions[] = {
 #define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1039,15 +1039,16 @@ SourceLoc LookupPrecedenceGroupRequest::getNearestLoc() const {
 void LookupPrecedenceGroupRequest::diagnoseCycle(DiagnosticEngine &diags) const {
   auto &desc = std::get<0>(getStorage());
   if (auto pathDir = desc.pathDirection) {
-    diags.diagnose(desc.nameLoc, diag::precedence_group_cycle, *pathDir);
+    diags.diagnose(desc.nameLoc, diag::precedence_group_cycle, (bool)*pathDir);
   } else {
     diags.diagnose(desc.nameLoc, diag::circular_reference);
   }
 }
 
-void LookupPrecedenceGroupRequest::noteCycleStep(DiagnosticEngine &diags) const {
+void LookupPrecedenceGroupRequest::noteCycleStep(DiagnosticEngine &diag) const {
   auto &desc = std::get<0>(getStorage());
-  diags.diagnose(desc.nameLoc, diag::circular_reference_through);
+  diag.diagnose(desc.nameLoc,
+                 diag::circular_reference_through_precedence_group, desc.ident);
 }
 
 SourceLoc PrecedenceGroupDescriptor::getLoc() const {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4242,7 +4242,6 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
   case DeclKind::Constructor:
   case DeclKind::Destructor: {
     auto *AFD = cast<AbstractFunctionDecl>(D);
-    DeclValidationRAII IBV(AFD);
 
     auto sig = AFD->getGenericSignature();
     bool hasSelf = AFD->hasImplicitSelfDecl();
@@ -4295,7 +4294,6 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
   case DeclKind::Subscript: {
     auto *SD = cast<SubscriptDecl>(D);
-    DeclValidationRAII IBV(SD);
 
     auto elementTy = SD->getElementInterfaceType();
 
@@ -4313,7 +4311,6 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
   case DeclKind::EnumElement: {
     auto *EED = cast<EnumElementDecl>(D);
-    DeclValidationRAII IBV(EED);
 
     auto *ED = EED->getParentEnum();
 

--- a/test/decl/precedencegroup/circularity.swift
+++ b/test/decl/precedencegroup/circularity.swift
@@ -18,17 +18,17 @@ precedencegroup C0 {
   higherThan: C1 // expected-error {{cycle in 'higherThan' relation}}
 }
 precedencegroup C1 {
-  higherThan: C0 // expected-note{{through reference here}}
+  higherThan: C0 // expected-note{{through reference to precedence group 'C0' here}}
 }
 
 precedencegroup D0 {
   higherThan: D1 // expected-error {{cycle in 'higherThan' relation}}
 }
 precedencegroup D1 {
-  higherThan: D2 // expected-note{{through reference here}}
+  higherThan: D2 // expected-note{{through reference to precedence group 'D2' here}}
 }
 precedencegroup D2 {
-  higherThan: D0 // expected-note{{through reference here}}
+  higherThan: D0 // expected-note{{through reference to precedence group 'D0' here}}
 }
 
 precedencegroup E0 {

--- a/test/decl/precedencegroup/circularity.swift
+++ b/test/decl/precedencegroup/circularity.swift
@@ -6,31 +6,32 @@
 import ExternPrecedences
 
 precedencegroup A {
-  higherThan: A // expected-error {{cycle in higherThan relation: A -> A}}
+  higherThan: A // expected-error {{cycle in 'higherThan' relation}}
 }
 
 precedencegroup B { // expected-note {{precedence group declared here}}
-  lowerThan: B // expected-error {{precedence group cannot be given lower precedence than group in same module; make the other precedence group higher than this one instead}}
+  lowerThan: B // expected-error {{cycle in 'lowerThan' relation}}
+  // expected-error@-1{{precedence group cannot be given lower precedence than group in same module; make the other precedence group higher than this one instead}}
 }
 
 precedencegroup C0 {
-  higherThan: C1 // expected-error {{cycle in higherThan relation: C0 -> C1 -> C0}}
+  higherThan: C1 // expected-error {{cycle in 'higherThan' relation}}
 }
 precedencegroup C1 {
-  higherThan: C0
+  higherThan: C0 // expected-note{{through reference here}}
 }
 
 precedencegroup D0 {
-  higherThan: D1 // expected-error {{cycle in higherThan relation: D0 -> D1 -> D2 -> D0}}
+  higherThan: D1 // expected-error {{cycle in 'higherThan' relation}}
 }
 precedencegroup D1 {
-  higherThan: D2
+  higherThan: D2 // expected-note{{through reference here}}
 }
 precedencegroup D2 {
-  higherThan: D0
+  higherThan: D0 // expected-note{{through reference here}}
 }
 
 precedencegroup E0 {
-  higherThan: Extern1 // expected-error {{cycle in higherThan relation: E0 -> Extern1 -> Extern0 -> E0}}
+  higherThan: Extern1 // expected-error{{cycle in higherThan relation: E0 -> Extern1 -> Extern0 -> E0}}
   lowerThan: Extern0
 }


### PR DESCRIPTION
In order to do this, we have to remove the last client which was `PrecedenceGroupDecl` validation.  Therefore, this pull request required the following:

- Promote the lookup request to a type checker request and move all the machinery
- Add custom request-evaluator-based diagnostics to catch in-module simple precedence group cycles (note that cross-module cycles and complex cycles are still caught using the old machinery)

