### PR TITLE
[mandatory-inlining] Make cleanupLoadedCalleeValue more conservative.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -253,8 +253,12 @@ static void fixupReferenceCounts(
 }
 
 static SILValue cleanupLoadedCalleeValue(SILValue calleeValue, LoadInst *li) {
-  auto *pbi = cast<ProjectBoxInst>(li->getOperand());
-  auto *abi = cast<AllocBoxInst>(pbi->getOperand());
+  auto *pbi = dyn_cast<ProjectBoxInst>(li->getOperand());
+  if (!pbi)
+    return SILValue();
+  auto *abi = dyn_cast<AllocBoxInst>(pbi->getOperand());
+  if (!abi)
+    return SILValue();
 
   // The load instruction must have no more uses or a single destroy left to
   // erase it.

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -1401,3 +1401,30 @@ bb6:
   %tuple = tuple()
   return %tuple : $()
 }
+
+sil [transparent] @escaping_thunk : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> () {
+bb0(%1 : $@callee_guaranteed () -> ()):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we do not crash here.
+//
+// CHECK-LABEL: sil @partial_apply_stack_failure : $@convention(thin) (@callee_guaranteed () -> ()) -> () {
+// CHECK: } // end sil function 'partial_apply_stack_failure'
+sil @partial_apply_stack_failure : $@convention(thin) (@callee_guaranteed () -> ()) -> () {
+bb0(%0 : $@callee_guaranteed () -> ()):
+  %1 = alloc_stack $@callee_guaranteed () -> ()
+  store %0 to %1 : $*@callee_guaranteed () -> ()
+  %2 = load %1 : $*@callee_guaranteed () -> ()
+  strong_retain %2 : $@callee_guaranteed () -> ()
+  %thunk = function_ref @escaping_thunk : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> ()
+  %2a = partial_apply [callee_guaranteed] [on_stack] %thunk(%2) : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> ()
+  %2b = mark_dependence %2a : $@noescape @callee_guaranteed () -> () on %2 : $@callee_guaranteed () -> ()
+  apply %2b() : $@noescape @callee_guaranteed () -> ()
+  dealloc_stack %2a : $@noescape @callee_guaranteed () -> ()
+  destroy_addr %1 : $*@callee_guaranteed () -> ()
+  dealloc_stack %1 : $*@callee_guaranteed () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
Specifically, we may have a loaded callee value from a stack value. This change
just makes it so that we do not optimize if we do not actually have the box.

rdar://56386236
