### PR TITLE
Fix flaky Driver tests

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1553,9 +1553,17 @@ if hasattr(config, 'target_cc_options'):
 else:
     config.substitutions.append(('%target-cc-options', ''))
 
-config.substitutions.append(
-    (r'%hardlink-or-copy\(from: *(.*), *to: *(.*)\)',
-     SubstituteCaptures(r'ln \1 \2 || cp \1 \2')))
+# WORKAROUND(rdar://53507844): On some macOS versions, we see flaky failures in
+# tests which create a hard link to an executable and immediately invoke it.
+# Work around this by always copying on Darwin.
+if platform.system() == 'Darwin':
+  config.substitutions.append(
+      (r'%hardlink-or-copy\(from: *(.*), *to: *(.*)\)',
+       SubstituteCaptures(r'cp \1 \2')))
+else:
+  config.substitutions.append(
+      (r'%hardlink-or-copy\(from: *(.*), *to: *(.*)\)',
+       SubstituteCaptures(r'ln \1 \2 || cp \1 \2')))
 
 config.substitutions.append(('%utils', config.swift_utils))
 config.substitutions.append(('%line-directive', '%r %s' % (sys.executable, config.line_directive)))


### PR DESCRIPTION
Several Driver tests create a hard link to the compiler in a temporary directory, then invoke it through that hard link to see how it locates items in the resource directory. This pattern can tickle a system-load-dependent macOS bug involving invocations of freshly-created hard links, causing rare test failures in CI or on contributors’ machines.

This change avoids the OS bug by always copying instead of hard linking. We already fall back to copying on Windows, so all tests should pass with a copy anyway. Removing this workaround will be tracked by rdar://problem/53507844.