### PR TITLE
[Diagnostics] Add -enable-experimental-descriptive-diagnostics frontend flag

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -670,6 +670,9 @@ namespace swift {
     /// Print diagnostic names after their messages
     bool printDiagnosticNames = false;
 
+    /// Use descriptive diagnostic style when available.
+    bool useDescriptiveDiagnostics = false;
+
     friend class InFlightDiagnostic;
     friend class DiagnosticTransaction;
     friend class CompoundDiagnosticTransaction;
@@ -711,6 +714,13 @@ namespace swift {
     }
     bool getPrintDiagnosticNames() const {
       return printDiagnosticNames;
+    }
+
+    void setUseDescriptiveDiagnostics(bool val) {
+       useDescriptiveDiagnostics = val;
+    }
+    bool getUseDescriptiveDiagnostics() const {
+      return useDescriptiveDiagnostics;
     }
 
     void ignoreDiagnostic(DiagID id) {

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -55,6 +55,10 @@ public:
   // When printing diagnostics, include the diagnostic name at the end
   bool PrintDiagnosticNames = false;
 
+  /// If set to true, produce more descriptive diagnostic output if available.
+  /// Descriptive diagnostic output is not intended to be machine-readable.
+  bool EnableDescriptiveDiagnostics = false;
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -109,6 +109,9 @@ def verify_syntax_tree : Flag<["-"], "verify-syntax-tree">,
 
 def show_diagnostics_after_fatal : Flag<["-"], "show-diagnostics-after-fatal">,
   HelpText<"Keep emitting subsequent diagnostics after a fatal error">;
+  
+def enable_descriptive_diagnostics : Flag<["-"], "enable-descriptive-diagnostics">,
+  HelpText<"Show descriptive diagnostic information, if available.">;
 
 def enable_swiftcall : Flag<["-"], "enable-swiftcall">,
   HelpText<"Enable the use of LLVM swiftcall support">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -678,6 +678,8 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   Opts.SuppressWarnings |= Args.hasArg(OPT_suppress_warnings);
   Opts.WarningsAsErrors |= Args.hasArg(OPT_warnings_as_errors);
   Opts.PrintDiagnosticNames |= Args.hasArg(OPT_debug_diagnostic_names);
+  Opts.EnableDescriptiveDiagnostics |=
+      Args.hasArg(OPT_enable_descriptive_diagnostics);
 
   assert(!(Opts.WarningsAsErrors && Opts.SuppressWarnings) &&
          "conflicting arguments; should have been caught by driver");

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -315,6 +315,9 @@ void CompilerInstance::setUpDiagnosticOptions() {
   if (Invocation.getDiagnosticOptions().PrintDiagnosticNames) {
     Diagnostics.setPrintDiagnosticNames(true);
   }
+  if (Invocation.getDiagnosticOptions().EnableDescriptiveDiagnostics) {
+    Diagnostics.setUseDescriptiveDiagnostics(true);
+  }
 }
 
 bool CompilerInstance::setUpModuleLoaders() {


### PR DESCRIPTION
This flag will feature-gate work on producing more descriptive diagnostic messages. It will remain a hidden frontend option until these improvements are ready to ship.

Right now the flag doesn't actually do anything, but it'll make it easier to land incremental improvements in this area.

cc @xedin & @jrose-apple 