### PR TITLE
[AutoDiff] Simplify logic for checking unmet generic requirements.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2536,25 +2536,6 @@ reapplyFunctionConversion(
   llvm_unreachable("Unhandled function conversion instruction");
 }
 
-static SubstitutionMap getSubstitutionMap(
-    SILValue value, SubstitutionMap substMap = SubstitutionMap()) {
-  if (auto *thinToThick = dyn_cast<ThinToThickFunctionInst>(value))
-    return getSubstitutionMap(thinToThick->getOperand(), substMap);
-  if (auto *convertFn = dyn_cast<ConvertFunctionInst>(value))
-    return getSubstitutionMap(convertFn->getOperand(), substMap);
-  if (auto *partialApply = dyn_cast<PartialApplyInst>(value)) {
-    auto appliedSubstMap = partialApply->getSubstitutionMap();
-    // TODO: Combine argument `substMap` with `appliedSubstMap`.
-    return getSubstitutionMap(partialApply->getCallee(), appliedSubstMap);
-  }
-  if (auto *apply = dyn_cast<ApplyInst>(value)) {
-    auto appliedSubstMap = apply->getSubstitutionMap();
-    // TODO: Combine argument `substMap` with `appliedSubstMap`.
-    return getSubstitutionMap(apply->getCallee(), appliedSubstMap);
-  }
-  return substMap;
-}
-
 /// Emits a reference to a derivative function of `original`, differentiated
 /// with respect to a superset of `desiredIndices`. Returns the `SILValue` for
 /// the derivative function and the actual indices that the derivative function
@@ -2617,7 +2598,6 @@ emitDerivativeFunctionReference(
           peerThroughFunctionConversions<FunctionRefInst>(original)) {
     auto loc = originalFRI->getLoc();
     auto *originalFn = originalFRI->getReferencedFunctionOrNull();
-    auto substMap = getSubstitutionMap(original);
     // Attempt to look up a `[differentiable]` attribute that minimally
     // satisfies the specified indices.
     // TODO(TF-482): Change `lookUpMinimalDifferentiableAttr` to additionally
@@ -2676,6 +2656,16 @@ emitDerivativeFunctionReference(
     assert(minimalAttr);
     // TODO(TF-482): Move generic requirement checking logic to
     // `lookUpMinimalDifferentiableAttr`.
+    // Get the substitution map for checking unmet generic requirements.
+    // By default, use the forwarding substitution map of the original function.
+    // If the original callee is a `partial_apply` or `apply` instruction, use
+    // its substitution map instead.
+    auto substMap = original->getFunction()->getForwardingSubstitutionMap();
+    if (auto *pai = dyn_cast<PartialApplyInst>(original)) {
+      substMap = pai->getSubstitutionMap();
+    } else if (auto *ai = dyn_cast<ApplyInst>(original)) {
+      substMap = ai->getSubstitutionMap();
+    }
     if (diagnoseUnsatisfiedRequirements(
             context, minimalAttr->getDerivativeGenericSignature(), originalFn,
             substMap, invoker, original.getLoc().getSourceLoc()))


### PR DESCRIPTION
The `SubstitutionMap` passed to `diagnoseUnsatisfiedRequirements`
should default to the original function's forwarding substitution map.

Delete the static `getSubstitutionMap` function, whose purpose is not clear
and is not needed.

---

Resolves bug exposed during [WIP patch](https://github.com/apple/swift/tree/sil-diff-witness-e2e) for retroactive derivative registration ([TF-866](https://bugs.swift.org/browse/TF-866)).
I couldn't find a corresponding reproducer for testing on current `tensorflow` branch.