### PR TITLE
[NameLookup, ASTScope] Create lazily-parsed function body scopes.

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1360,8 +1360,8 @@ void AbstractFunctionDeclScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
   }
   // Create scope for the body.
   // We create body scopes when there is no body for source kit to complete
-  // erroneous code in bodies. But don't let compiler synthesize one.
-  if (decl->getBodySourceRange().isValid() && decl->getBody(false)) {
+  // erroneous code in bodies.
+  if (decl->getBodySourceRange().isValid()) {
     if (AbstractFunctionBodyScope::isAMethod(decl))
       scopeCreator.constructExpandAndInsertUncheckable<MethodBodyScope>(leaf,
                                                                         decl);
@@ -1902,6 +1902,7 @@ void AbstractFunctionBodyScope::beCurrent() {
   bodyWhenLastExpanded = decl->getBody(false);
 }
 bool AbstractFunctionBodyScope::isCurrentIfWasExpanded() const {
+  // Pass in false to keep the compiler from synthesizing one.
   return bodyWhenLastExpanded == decl->getBody(false);
 }
 

--- a/test/NameBinding/Inputs/lazy_function_body_expansion_helper.swift
+++ b/test/NameBinding/Inputs/lazy_function_body_expansion_helper.swift
@@ -1,0 +1,7 @@
+// Body of closure in parameter to call of closureTaker is created lazily
+// and this test ensures that that body scope does get expanded
+var v = closureTaker {
+  func amIFound() {}
+}
+
+func closureTaker(_: () -> Void )

--- a/test/NameBinding/lazy_function_body_expansion.swift
+++ b/test/NameBinding/lazy_function_body_expansion.swift
@@ -1,0 +1,5 @@
+// Ensure that a lazily-parsed function body gets expanded
+
+// RUN: %target-swift-frontend -typecheck -primary-file %s %S/Inputs/lazy_function_body_expansion_helper.swift
+
+let a = v


### PR DESCRIPTION
Fixes ASTScope lookup for lazily-parsed function bodies in non-primary files.
Adds a test.
Addresses rdar://56384593
Also includes better debugging printing in a separate commit.
Suggest reviewing each commit separately.