### PR TITLE
Member Type Lookups Shouldn't Recurse

### DIFF
--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -1,0 +1,45 @@
+// RUN: %target-typecheck-verify-swift
+
+// N.B. Validating the pattern binding initializer for `pickMe` used to cause
+// recursive validation of the VarDecl. Check that we don't regress now that
+// this isn't the case.
+public struct Cyclic {
+  static func pickMe(please: Bool) -> Int { return 42 }
+  public static let pickMe = Cyclic.pickMe(please: true)
+}
+
+struct Node {}
+struct Parameterized<Value, Format> {
+  func please<NewValue>(_ transform: @escaping (_ otherValue: NewValue) -> Value) -> Parameterized<NewValue, Format> {
+    fatalError()
+  }
+}
+
+extension Parameterized where Value == [Node], Format == String {
+  static var pickMe: Parameterized {
+    fatalError()
+  }
+}
+
+extension Parameterized where Value == Node, Format == String {
+  static let pickMe = Parameterized<[Node], String>.pickMe.please { [$0] }
+}
+
+enum Loop: Circle {
+  struct DeLoop { }
+}
+
+protocol Circle {
+  typealias DeLoop = Loop.DeLoop
+}
+
+class Base {
+    static func foo(_ x: Int) {}
+}
+
+class Sub: Base {
+    var foo = { () -> Int in
+        let x = 42
+        return foo(1) // expected-error {{variable used within its own initial value}}
+    }()
+}

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -609,28 +609,3 @@ enum SR_10084_E_16 {
   typealias Z = Int // expected-note {{'Z' previously declared here}}
   case Z // expected-error {{invalid redeclaration of 'Z'}}
 }
-
-// N.B. Validating the pattern binding initializer for `pickMe` used to cause
-// recursive validation of the VarDecl. Check that we don't regress now that
-// this isn't the case.
-public struct Cyclic {
-  static func pickMe(please: Bool) -> Int { return 42 }
-  public static let pickMe = Cyclic.pickMe(please: true)
-}
-
-struct Node {}
-struct Parameterized<Value, Format> {
-  func please<NewValue>(_ transform: @escaping (_ otherValue: NewValue) -> Value) -> Parameterized<NewValue, Format> {
-    fatalError()
-  }
-}
-
-extension Parameterized where Value == [Node], Format == String {
-  static var pickMe: Parameterized {
-    fatalError()
-  }
-}
-
-extension Parameterized where Value == Node, Format == String {
-  static let pickMe = Parameterized<[Node], String>.pickMe.please { [$0] }
-}


### PR DESCRIPTION
When member type lookup is rooted at a typealias, it should not be possible for that
lookup to see the typealias itself. This prevents recursively trying
to resolve the underlying type, which used to be silently ignored when
validateDecl bounced the caller back with an error type or a null type.

Also take the opportunity to move the decl circularity regression tests into their own file.

Addresses rdar://56411408