### PR TITLE
[windows] Use the monorepo in the Windows build script for CI.

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -79,10 +79,13 @@ setlocal enableextensions enabledelayedexpansion
 
 git config --global core.autocrlf false
 git clone --depth 1 --single-branch https://github.com/apple/swift-cmark cmark %exitOnError%
-git clone --depth 1 --single-branch https://github.com/apple/swift-clang clang %exitOnError%
-git clone --depth 1 --single-branch https://github.com/apple/swift-llvm llvm %exitOnError%
-git clone --depth 1 --single-branch https://github.com/apple/swift-lldb lldb %exitOnError%
-git clone --depth 1 --single-branch https://github.com/apple/swift-compiler-rt compiler-rt %exitOnError%
+git clone --depth 1 --single-branch --branch swift/master https://github.com/apple/llvm-project llvm-project %exitOnError%
+mklink /D "%source_root%\clang" "%source_root%\llvm-project\clang"
+mklink /D "%source_root%\llvm" "%source_root%\llvm-project\llvm"
+mklink /D "%source_root%\lldb" "%source_root%\llvm-project\lldb"
+mklink /D "%source_root%\compiler-rt" "%source_root%\llvm-project\compiler-rt"
+mklink /D "%source_root%\libcxx" "%source_root%\llvm-project\libcxx"
+mklink /D "%source_root%\clang-tools-extra" "%source_root%\llvm-project\clang-tools-extra"
 git clone --depth 1 --single-branch https://github.com/apple/swift-corelibs-libdispatch %exitOnError%
 
 goto :eof


### PR DESCRIPTION
Clone the monorepo, in the swift/master branch (since that seems to be
the one used by swift master branch), and create links for the different
parts of the LLVM project in the first level.

