### PR TITLE
[SyntaxParse] Assert that the children of syntax tree nodes have contiguous ranges

### DIFF
--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -73,6 +73,10 @@ public:
   /// Used for incremental re-parsing.
   ParsedRawSyntaxNode lookupNode(size_t lexerOffset, SourceLoc loc,
                                  syntax::SyntaxKind kind);
+
+  #ifndef NDEBUG
+  static void verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> elements);
+  #endif
 };
 
 } // end namespace swift

--- a/include/swift/Parse/ParsedSyntaxBuilders.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxBuilders.h.gyb
@@ -62,9 +62,9 @@ public:
 %     end
 
   Parsed${node.name} build();
-  Parsed${node.name} makeDeferred();
 
 private:
+  Parsed${node.name} makeDeferred();
   Parsed${node.name} record();
   void finishLayout(bool deferred);
 };

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -43,23 +43,22 @@ struct ParsedSyntaxRecorder {
 %     end
 %     child_params = ', '.join(child_params)
 private:
-  static Parsed${node.name} record${node.syntax_kind}(${child_params},
+  static Parsed${node.name} record${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxNode> layout,
                                               ParsedRawSyntaxRecorder &rec);
-public:
-  static Parsed${node.name} defer${node.syntax_kind}(${child_params},
+  static Parsed${node.name} defer${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxNode> layout,
                                               SyntaxParsingContext &SPCtx);
+public:
   static Parsed${node.name} make${node.syntax_kind}(${child_params},
                                               SyntaxParsingContext &SPCtx);
 %   elif node.is_syntax_collection():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      MutableArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<ParsedRawSyntaxNode> layout,
       ParsedRawSyntaxRecorder &rec);
-
-public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      MutableArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<ParsedRawSyntaxNode> layout,
       SyntaxParsingContext &SPCtx);
+public:
   static Parsed${node.name} make${node.syntax_kind}(
       MutableArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -532,6 +532,10 @@ public:
     return consumeToken();
   }
 
+  SourceLoc leadingTriviaLoc() {
+    return Tok.getLoc().getAdvancedLoc(-LeadingTrivia.getLength());
+  }
+
   SourceLoc consumeIdentifier(Identifier *Result = nullptr,
                               bool allowDollarIdentifier = false) {
     assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self));

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4615,9 +4615,9 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
     accessors.LBLoc = consumeToken(tok::l_brace);
     // Give syntax node an empty accessor list.
     if (SyntaxContext->isEnabled()) {
-      SourceLoc listLoc = accessors.LBLoc.getAdvancedLoc(1);
+      SourceLoc listLoc = leadingTriviaLoc();
       SyntaxContext->addSyntax(
-        ParsedSyntaxRecorder::makeBlankAccessorList(listLoc, *SyntaxContext));
+          ParsedSyntaxRecorder::makeBlankAccessorList(listLoc, *SyntaxContext));
     }
     accessors.RBLoc = consumeToken(tok::r_brace);
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1183,7 +1183,7 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         // Add dummy blank argument list to the call expression syntax.
         SyntaxContext->addSyntax(
             ParsedSyntaxRecorder::makeBlankTupleExprElementList(
-                Tok.getLoc(), *SyntaxContext));
+                leadingTriviaLoc(), *SyntaxContext));
       }
 
       ParserResult<Expr> closure =
@@ -1588,7 +1588,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
         // Add dummy blank argument list to the call expression syntax.
         SyntaxContext->addSyntax(
             ParsedSyntaxRecorder::makeBlankTupleExprElementList(
-                Tok.getLoc(), *SyntaxContext));
+                leadingTriviaLoc(), *SyntaxContext));
       }
 
       ParserResult<Expr> closure =
@@ -2102,7 +2102,7 @@ DeclName Parser::parseUnqualifiedDeclName(bool afterDot,
     if (SyntaxContext->isEnabled())
       SyntaxContext->addSyntax(
           ParsedSyntaxRecorder::makeBlankDeclNameArgumentList(
-            Tok.getLoc(), *SyntaxContext));
+              leadingTriviaLoc(), *SyntaxContext));
     consumeToken(tok::r_paren);
     loc = DeclNameLoc(baseNameLoc);
     SmallVector<Identifier, 2> argumentLabels;
@@ -3304,9 +3304,8 @@ ParserResult<Expr> Parser::parseExprCollection() {
   // [] is always an array.
   if (Tok.is(tok::r_square)) {
     if (SyntaxContext->isEnabled())
-      SyntaxContext->addSyntax(
-          ParsedSyntaxRecorder::makeBlankArrayElementList(
-                                Tok.getLoc(), *SyntaxContext));
+      SyntaxContext->addSyntax(ParsedSyntaxRecorder::makeBlankArrayElementList(
+          leadingTriviaLoc(), *SyntaxContext));
     RSquareLoc = consumeToken(tok::r_square);
     ArrayOrDictContext.setCreateSyntax(SyntaxKind::ArrayExpr);
     return makeParserResult(

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1466,6 +1466,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
         // name, not a binding, because it is the start of an enum pattern or
         // call pattern.
         peekToken().isNot(tok::period, tok::period_prefix, tok::l_paren)) {
+      DeferringContextRAII Deferring(*SyntaxContext);
       Identifier name;
       SourceLoc loc = consumeIdentifier(&name, /*allowDollarIdentifier=*/true);
       auto introducer = (InVarOrLetPattern != IVOLP_InVar
@@ -1474,10 +1475,10 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       auto pattern = createBindingFromPattern(loc, name, introducer);
       if (SyntaxContext->isEnabled()) {
         ParsedPatternSyntax PatternNode =
-            ParsedSyntaxRecorder::deferIdentifierPattern(
+            ParsedSyntaxRecorder::makeIdentifierPattern(
                                     SyntaxContext->popToken(), *SyntaxContext);
         ParsedExprSyntax ExprNode =
-            ParsedSyntaxRecorder::deferUnresolvedPatternExpr(std::move(PatternNode),
+            ParsedSyntaxRecorder::makeUnresolvedPatternExpr(std::move(PatternNode),
                                                              *SyntaxContext);
         SyntaxContext->addSyntax(std::move(ExprNode));
       }

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -21,18 +21,31 @@ ParsedRawSyntaxNode
 ParsedRawSyntaxNode::makeDeferred(SyntaxKind k,
                                   MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
                                   SyntaxParsingContext &ctx) {
+  CharSourceRange range;
   if (deferredNodes.empty()) {
-    return ParsedRawSyntaxNode(k, {});
+    return ParsedRawSyntaxNode(k, range, {});
   }
   ParsedRawSyntaxNode *newPtr =
     ctx.getScratchAlloc().Allocate<ParsedRawSyntaxNode>(deferredNodes.size());
 
-  // uninitialized move;
   auto ptr = newPtr;
-  for (auto &node : deferredNodes)
-    :: new (static_cast<void *>(ptr++)) ParsedRawSyntaxNode(std::move(node));
+  for (auto &node : deferredNodes) {
+    // Cached range.
+    if (!node.isNull() && !node.isMissing()) {
+      auto nodeRange = node.getDeferredRange();
+      if (nodeRange.isValid()) {
+        if (range.isInvalid())
+          range = nodeRange;
+        else
+          range.widen(nodeRange);
+      }
+    }
 
-  return ParsedRawSyntaxNode(k, makeMutableArrayRef(newPtr, deferredNodes.size()));
+    // uninitialized move;
+    :: new (static_cast<void *>(ptr++)) ParsedRawSyntaxNode(std::move(node));
+  }
+  return ParsedRawSyntaxNode(k, range,
+                             makeMutableArrayRef(newPtr, deferredNodes.size()));
 }
 
 ParsedRawSyntaxNode

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -28,6 +28,9 @@ ParsedRawSyntaxNode::makeDeferred(SyntaxKind k,
   ParsedRawSyntaxNode *newPtr =
     ctx.getScratchAlloc().Allocate<ParsedRawSyntaxNode>(deferredNodes.size());
 
+#ifndef NDEBUG
+  ParsedRawSyntaxRecorder::verifyElementRanges(deferredNodes);
+#endif
   auto ptr = newPtr;
   for (auto &node : deferredNodes) {
     // Cached range.

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -75,6 +75,9 @@ getRecordedNode(ParsedRawSyntaxNode node, ParsedRawSyntaxRecorder &rec) {
 ParsedRawSyntaxNode
 ParsedRawSyntaxRecorder::recordRawSyntax(SyntaxKind kind,
                                          MutableArrayRef<ParsedRawSyntaxNode> elements) {
+#ifndef NDEBUG
+  ParsedRawSyntaxRecorder::verifyElementRanges(elements);
+#endif
   CharSourceRange range;
   SmallVector<OpaqueSyntaxNode, 16> subnodes;
   if (!elements.empty()) {

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -53,7 +53,8 @@ ParsedRawSyntaxNode
 ParsedRawSyntaxRecorder::recordMissingToken(tok tokenKind, SourceLoc loc) {
   CharSourceRange range{loc, 0};
   OpaqueSyntaxNode n = SPActions->recordMissingToken(tokenKind, loc);
-  return ParsedRawSyntaxNode{SyntaxKind::Token, tokenKind, range, n};
+  return ParsedRawSyntaxNode{SyntaxKind::Token, tokenKind, range, n,
+                             /*isMissing=*/true};
 }
 
 static ParsedRawSyntaxNode
@@ -84,11 +85,11 @@ ParsedRawSyntaxRecorder::recordRawSyntax(SyntaxKind kind,
       if (subnode.isNull()) {
         subnodes.push_back(nullptr);
       } else if (subnode.isRecorded()) {
-        localRange = subnode.getRange();
+        localRange = subnode.getRecordedRange();
         subnodes.push_back(subnode.takeOpaqueNode());
       } else {
         auto recorded = getRecordedNode(subnode.copyDeferred(), *this);
-        localRange = recorded.getRange();
+        localRange = recorded.getRecordedRange();
         subnodes.push_back(recorded.takeOpaqueNode());
       }
 
@@ -128,3 +129,21 @@ ParsedRawSyntaxRecorder::lookupNode(size_t lexerOffset, SourceLoc loc,
   CharSourceRange range{loc, unsigned(length)};
   return ParsedRawSyntaxNode{kind, tok::unknown, range, n};
 }
+
+#ifndef NDEBUG
+void ParsedRawSyntaxRecorder::verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> elements) {
+  SourceLoc prevEndLoc;
+  for (const auto &elem: elements) {
+    if (elem.isMissing() || elem.isNull())
+      continue;
+    CharSourceRange range = elem.isRecorded()
+      ? elem.getRecordedRange()
+      : elem.getDeferredRange();
+    if (range.isValid()) {
+      assert((prevEndLoc.isInvalid() || range.getStart() == prevEndLoc)
+             && "Non-contiguous child ranges?");
+      prevEndLoc = range.getEnd();
+    }
+  }
+}
+#endif

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -74,7 +74,7 @@ Parsed${node.name}Builder::makeDeferred() {
 
 Parsed${node.name}
 Parsed${node.name}Builder::build() {
-  if (SPCtx.isBacktracking())
+  if (SPCtx.shouldDefer())
     return makeDeferred();
   return record();
 }
@@ -120,6 +120,10 @@ void Parsed${node.name}Builder::finishLayout(bool deferred) {
   }
 %     end
 %   end
+
+#ifndef NDEBUG
+  ParsedRawSyntaxRecorder::verifyElementRanges(Layout);
+#endif
 % end
 }
 

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -120,10 +120,6 @@ void Parsed${node.name}Builder::finishLayout(bool deferred) {
   }
 %     end
 %   end
-
-#ifndef NDEBUG
-  ParsedRawSyntaxRecorder::verifyElementRanges(Layout);
-#endif
 % end
 }
 

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -114,9 +114,6 @@ ParsedSyntaxRecorder::make${node.syntax_kind}(${child_params},
 %       end
 %     end
   };
-  #ifndef NDEBUG
-  ParsedRawSyntaxRecorder::verifyElementRanges(layout);
-  #endif
   if (SPCtx.shouldDefer())
     return defer${node.syntax_kind}(layout, SPCtx);
   return record${node.syntax_kind}(layout, SPCtx.getRecorder());

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -90,67 +90,51 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 %     child_params = ', '.join(child_params)
 %     child_move_args = ', '.join(child_move_args)
 Parsed${node.name}
-ParsedSyntaxRecorder::record${node.syntax_kind}(${child_params},
+ParsedSyntaxRecorder::record${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxNode> layout,
                                        ParsedRawSyntaxRecorder &rec) {
-  ParsedRawSyntaxNode layout[] = {
-%     for child in node.children:
-%       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
-%       else:
-    ${child.name}.takeRaw(),
-%       end
-%     end
-  };
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
-ParsedSyntaxRecorder::defer${node.syntax_kind}(${child_params}, SyntaxParsingContext &SPCtx) {
-  ParsedRawSyntaxNode layout[] = {
-%     for child in node.children:
-%       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
-%       else:
-    ${child.name}.takeRaw(),
-%       end
-%     end
-  };
-  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, llvm::makeMutableArrayRef(layout, ${len(node.children)}), SPCtx);
+ParsedSyntaxRecorder::defer${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxNode> layout, SyntaxParsingContext &SPCtx) {
+  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(${child_params},
     SyntaxParsingContext &SPCtx) {
-  if (SPCtx.isBacktracking())
-    return defer${node.syntax_kind}(${child_move_args}, SPCtx);
-  return record${node.syntax_kind}(${child_move_args}, SPCtx.getRecorder());
+  ParsedRawSyntaxNode layout[] = {
+%     for child in node.children:
+%       if child.is_optional:
+    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
+%       else:
+    ${child.name}.takeRaw(),
+%       end
+%     end
+  };
+  #ifndef NDEBUG
+  ParsedRawSyntaxRecorder::verifyElementRanges(layout);
+  #endif
+  if (SPCtx.shouldDefer())
+    return defer${node.syntax_kind}(layout, SPCtx);
+  return record${node.syntax_kind}(layout, SPCtx.getRecorder());
 }
 
 %   elif node.is_syntax_collection():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    MutableArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<ParsedRawSyntaxNode> layout,
     ParsedRawSyntaxRecorder &rec) {
-  SmallVector<ParsedRawSyntaxNode, 16> layout;
-  layout.reserve(elements.size());
-  for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
-  }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    MutableArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<ParsedRawSyntaxNode> layout,
     SyntaxParsingContext &SPCtx) {
-  SmallVector<ParsedRawSyntaxNode, 16> layout;
-  layout.reserve(elements.size());
-  for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
-  }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind},
                              layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
@@ -160,16 +144,24 @@ Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
     MutableArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
-  if (SPCtx.isBacktracking())
-    return defer${node.syntax_kind}(elements, SPCtx);
-  return record${node.syntax_kind}(elements, SPCtx.getRecorder());
+  SmallVector<ParsedRawSyntaxNode, 16> layout;
+  layout.reserve(elements.size());
+  for (auto &element : elements) {
+    layout.push_back(element.takeRaw());
+  }
+  #ifndef NDEBUG
+  ParsedRawSyntaxRecorder::verifyElementRanges(layout);
+  #endif
+  if (SPCtx.shouldDefer())
+    return defer${node.syntax_kind}(layout, SPCtx);
+  return record${node.syntax_kind}(layout, SPCtx.getRecorder());
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::makeBlank${node.syntax_kind}(SourceLoc loc,
         SyntaxParsingContext &SPCtx) {
   ParsedRawSyntaxNode raw;
-  if (SPCtx.isBacktracking()) {
+  if (SPCtx.shouldDefer()) {
     // FIXME: 'loc' is not preserved when capturing a deferred layout.
     raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, {}, SPCtx);
   } else {

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Parse/ParsedSyntax.h"
+#include "swift/Parse/ParsedRawSyntaxRecorder.h"
 #include "swift/Parse/ParsedSyntaxRecorder.h"
 #include "swift/Parse/SyntaxParseActions.h"
 #include "swift/Parse/SyntaxParsingCache.h"
@@ -58,7 +59,7 @@ size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
     return 0;
   }
   Mode = AccumulationMode::SkippedForIncrementalUpdate;
-  auto length = foundNode.getRange().getByteLength();
+  auto length = foundNode.getRecordedRange().getByteLength();
   getStorage().push_back(std::move(foundNode));
   return length;
 }

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -563,6 +563,7 @@ func testTuple(localInt: Int) {
 var ownInit1: Int = #^OWN_INIT_1^#
 // OWN_INIT_1: Begin completions
 // OWN_INIT_1-NOT: ownInit1
+func sync() {}
 var ownInit2: () -> Void = { #^OWN_INIT_2^# }
 // OWN_INIT_2: Begin completions
 // OWN_INIT_2-NOT: ownInit2

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -870,6 +870,9 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
 
   Invocation.setCodeCompletionPoint(CleanFile.get(), CodeCompletionOffset);
 
+  // Disable to build syntax tree because code-completion skips some portion of
+  // source text. That breaks an invariant of syntax tree building.
+  Invocation.getLangOptions().BuildSyntaxTree = false;
 
   std::unique_ptr<ide::OnDiskCodeCompletionCache> OnDiskCache;
   if (!options::CompletionCachePath.empty()) {


### PR DESCRIPTION
Re-apply #27406 by @nathawes 
Also apply the assertion to node creations from `SyntaxParsingContext::createSyntaxAs()` API.

(Disabled syntax tree creation for `syntax-ide-test -code-completion` because code completion skips some portion of the source text)