### PR TITLE
[update-checkout] Error message if monorepo symlinks cannot be created

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -413,7 +413,15 @@ def symlink_llvm_monorepo(args):
                                 project)
         dst_path = os.path.join(args.source_root, project)
         if not os.path.islink(dst_path):
-            os.symlink(src_path, dst_path)
+            try:
+                os.symlink(src_path, dst_path)
+            except OSError as e:
+                if e.errno == 17:
+                    print("File '%s' already exists. Remove it, so "
+                          "update-checkout can create the symlink to the "
+                          "llvm-monorepo." % dst_path)
+                else:
+                    raise e
 
 
 def main():


### PR DESCRIPTION
If `update-checkout` is trying to create the symlinks to the monorepo but the projects are already checked out, it fails with a pretty ambiguous `OSError: [Errno 17] File exists`. This adds a nicer error message, telling you what happened and what to do: 

```
File '/Users/alex/swift-src/clang' already exists. Remove it, so update-checkout can create the symlink to the llvm-monorepo.
```