### PR TITLE
Back port foundation tests

### DIFF
--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -3806,30 +3806,34 @@ class TestData : TestDataSuper {
     }
 
     func test_nsdataSequence() {
-        let bytes: [UInt8] = Array(0x00...0xFF)
-        let data = bytes.withUnsafeBytes { NSData(bytes: $0.baseAddress, length: $0.count) }
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            let bytes: [UInt8] = Array(0x00...0xFF)
+            let data = bytes.withUnsafeBytes { NSData(bytes: $0.baseAddress, length: $0.count) }
 
-        for byte in bytes {
-            expectEqual(data[Int(byte)], byte)
+            for byte in bytes {
+                expectEqual(data[Int(byte)], byte)
+            }
         }
     }
 
     func test_dispatchSequence() {
-        let bytes1: [UInt8] = Array(0x00..<0xF0)
-        let bytes2: [UInt8] = Array(0xF0..<0xFF)
-        var data = DispatchData.empty
-        bytes1.withUnsafeBytes {
-            data.append($0)
-        }
-        bytes2.withUnsafeBytes {
-            data.append($0)
-        }
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            let bytes1: [UInt8] = Array(0x00..<0xF0)
+            let bytes2: [UInt8] = Array(0xF0..<0xFF)
+            var data = DispatchData.empty
+            bytes1.withUnsafeBytes {
+                data.append($0)
+            }
+            bytes2.withUnsafeBytes {
+                data.append($0)
+            }
 
-        for byte in bytes1 {
-            expectEqual(data[Int(byte)], byte)
-        }
-        for byte in bytes2 {
-            expectEqual(data[Int(byte)], byte)
+            for byte in bytes1 {
+                expectEqual(data[Int(byte)], byte)
+            }
+            for byte in bytes2 {
+                expectEqual(data[Int(byte)], byte)
+            }
         }
     }
 }
@@ -4151,9 +4155,10 @@ DataTests.test("test_validateMutation_slice_customBacking_withUnsafeMutableBytes
 DataTests.test("test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound") { TestData().test_validateMutation_slice_customMutableBacking_withUnsafeMutableBytes_lengthLessThanLowerBound() }
 DataTests.test("test_byte_access_of_discontiguousData") { TestData().test_byte_access_of_discontiguousData() }
 DataTests.test("test_rangeOfSlice") { TestData().test_rangeOfSlice() }
-DataTests.test("test_nsdataSequence") { TestData().test_nsdataSequence() }
-DataTests.test("test_dispatchSequence") { TestData().test_dispatchSequence() }
-
+if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+    DataTests.test("test_nsdataSequence") { TestData().test_nsdataSequence() }
+    DataTests.test("test_dispatchSequence") { TestData().test_dispatchSequence() }
+}
 
 // XCTest does not have a crash detection, whereas lit does
 DataTests.test("bounding failure subdata") {

--- a/test/stdlib/TestDecimal.swift
+++ b/test/stdlib/TestDecimal.swift
@@ -120,9 +120,11 @@ class TestDecimal : TestDecimalSuper {
         expectFalse(zero.isNaN)
         expectFalse(zero.isSignaling)
 
-        let d1 = Decimal(1234567890123456789 as UInt64)
-        expectEqual(d1._exponent, 0)
-        expectEqual(d1._length, 4)
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            let d1 = Decimal(1234567890123456789 as UInt64)
+            expectEqual(d1._exponent, 0)
+            expectEqual(d1._length, 4)
+        }
     }
     func test_Constants() {
         expectEqual(8, NSDecimalMaxSize)
@@ -303,7 +305,9 @@ class TestDecimal : TestDecimalSuper {
         expectEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
         expectEqual(Decimal(1.234), abs(Decimal(1.234)))
         expectEqual(Decimal(1.234), abs(Decimal(-1.234)))
-        expectTrue(Decimal.nan.magnitude.isNaN)
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            expectTrue(Decimal.nan.magnitude.isNaN)
+        }
         var a = Decimal(1234)
         var r = a
         expectEqual(.noError, NSDecimalMultiplyByPowerOf10(&r, &a, 1, .plain))
@@ -335,7 +339,9 @@ class TestDecimal : TestDecimalSuper {
                 expectEqual(.noError, NSDecimalPower(&result, &actual, j, .plain))
                 let expected = Decimal(pow(Double(i), Double(j)))
                 expectEqual(expected, result, "\(result) == \(i)^\(j)")
-                expectEqual(expected, pow(actual, j))
+                if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+                    expectEqual(expected, pow(actual, j))
+                }
             }
         }
     }


### PR DESCRIPTION
The test suite for swift's overlay fails to run when being tested pre-macOS10.15/iOS13. This is caused because of a pair of behavioral fixes that were applied expecting the underlying types to adhere to the expected characteristics. That makes testing in those scenarios invalid and report failure. This allows the tests to be adequately run on previous releases.