### PR TITLE
Improve warning for inferring an undesirable type

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1018,8 +1018,8 @@ recur:
         !(options & TypeResolutionFlags::FromNonInferredPattern)) {
       diags.diagnose(NP->getLoc(), diag, NP->getDecl()->getName(), type,
                      NP->getDecl()->isLet());
-      diags.diagnose(NP->getLoc(),
-                     diag::add_explicit_type_annotation_to_silence);
+      diags.diagnose(NP->getLoc(), diag::add_explicit_type_annotation_to_silence)
+          .fixItInsertAfter(var->getNameLoc(), ": " + type->getString());
     }
 
     return false;

--- a/test/SourceKit/Sema/placeholders.swift.placeholders.response
+++ b/test/SourceKit/Sema/placeholders.swift.placeholders.response
@@ -27,5 +27,29 @@
         key.length: 9
       }
     ]
+  },
+  {
+    key.line: 8,
+    key.column: 5,
+    key.filepath: placeholders.swift,
+    key.severity: source.diagnostic.severity.warning,
+    key.description: "constant 'myArray' inferred to have type '[()]', which may be unexpected",
+    key.diagnostic_stage: source.diagnostic.stage.swift.sema,
+    key.diagnostics: [
+      {
+        key.line: 8,
+        key.column: 5,
+        key.filepath: placeholders.swift,
+        key.severity: source.diagnostic.severity.note,
+        key.description: "add an explicit type annotation to silence this warning",
+        key.fixits: [
+          {
+            key.offset: 236,
+            key.length: 0,
+            key.sourcetext: ": [()]"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -112,7 +112,7 @@ struct Outer {
 
     lazy var y = {_ = 3}()
     // expected-warning@-1 {{variable 'y' inferred to have type '()', which may be unexpected}}
-    // expected-note@-2 {{add an explicit type annotation to silence this warning}}
+    // expected-note@-2 {{add an explicit type annotation to silence this warning}} {{15-15=: ()}}
   }
 }
 

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1272,11 +1272,11 @@ class WeakFixItTest {
 
 // SR-8811 (Warning)
 
-let sr8811a = fatalError() // expected-warning {{constant 'sr8811a' inferred to have type 'Never', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}
+let sr8811a = fatalError() // expected-warning {{constant 'sr8811a' inferred to have type 'Never', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}} {{12-12=: Never}}
 
 let sr8811b: Never = fatalError() // Ok
 
-let sr8811c = (16, fatalError()) // expected-warning {{constant 'sr8811c' inferred to have type '(Int, Never)', which contains an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}
+let sr8811c = (16, fatalError()) // expected-warning {{constant 'sr8811c' inferred to have type '(Int, Never)', which contains an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}} {{12-12=: (Int, Never)}}
 
 let sr8811d: (Int, Never) = (16, fatalError()) // Ok
 
@@ -1292,11 +1292,11 @@ class SR_10995 {
   }
 
   func sr_10995_foo() {
-    let doubleOptionalNever = makeDoubleOptionalNever() // expected-warning {{constant 'doubleOptionalNever' inferred to have type 'Never??', which may be unexpected}} 
-    // expected-note@-1 {{add an explicit type annotation to silence this warning}} 
+    let doubleOptionalNever = makeDoubleOptionalNever() // expected-warning {{constant 'doubleOptionalNever' inferred to have type 'Never??', which may be unexpected}}
+    // expected-note@-1 {{add an explicit type annotation to silence this warning}} {{28-28=: Never??}}
     // expected-warning@-2 {{initialization of immutable value 'doubleOptionalNever' was never used; consider replacing with assignment to '_' or removing it}}
     let singleOptionalNever = makeSingleOptionalNever() // expected-warning {{constant 'singleOptionalNever' inferred to have type 'Never?', which may be unexpected}} 
-    // expected-note@-1 {{add an explicit type annotation to silence this warning}} 
+    // expected-note@-1 {{add an explicit type annotation to silence this warning}} {{28-28=: Never?}}
     // expected-warning@-2 {{initialization of immutable value 'singleOptionalNever' was never used; consider replacing with assignment to '_' or removing it}}
   }
 }

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -60,6 +60,16 @@ func testAnyObjectOptional() -> AnyObject? {
   return x
 }
 
+// SR-11511 Warning for inferring an array of empty tuples
+var arrayOfEmptyTuples = [""].map { print($0) } // expected-warning {{variable 'arrayOfEmptyTuples' inferred to have type '[()]'}} \
+                                                // expected-note {{add an explicit type annotation to silence this warning}} {{23-23=: [()]}}
+
+var maybeEmpty = Optional(arrayOfEmptyTuples) // expected-warning {{variable 'maybeEmpty' inferred to have type '[()]?'}} \
+                                              // expected-note {{add an explicit type annotation to silence this warning}} {{15-15=: [()]?}}
+
+var shouldWarnWithoutSugar = (arrayOfEmptyTuples as Array<()>) // expected-warning {{variable 'shouldWarnWithoutSugar' inferred to have type 'Array<()>'}} \
+                                 // expected-note {{add an explicit type annotation to silence this warning}} {{27-27=: Array<()>}}
+
 class SomeClass {}
 
 // <rdar://problem/16877304> weak let's should be rejected

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -36,7 +36,7 @@ struct Broken {
 
 // rdar://16252090 - Warning when inferring empty tuple type for declarations
 var emptyTuple = testShadowing()  // expected-warning {{variable 'emptyTuple' inferred to have type '()'}} \
-                                  // expected-note {{add an explicit type annotation to silence this warning}}
+                                  // expected-note {{add an explicit type annotation to silence this warning}} {{15-15=: ()}}
 
 // rdar://15263687 - Diagnose variables inferenced to 'AnyObject'
 var ao1 : AnyObject
@@ -44,7 +44,7 @@ var ao2 = ao1
 
 var aot1 : AnyObject.Type
 var aot2 = aot1          // expected-warning {{variable 'aot2' inferred to have type 'AnyObject.Type', which may be unexpected}} \
-                       // expected-note {{add an explicit type annotation to silence this warning}}
+                       // expected-note {{add an explicit type annotation to silence this warning}} {{9-9=: AnyObject.Type}}
 
 
 for item in [AnyObject]() {  // No warning in for-each loop.

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -588,9 +588,9 @@ func conversionTest(_ a: inout Double, b: inout Int) {
   var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
   var pi_f4 = float.init(pi_f)
 
-  var e = Empty(f) // expected-warning {{variable 'e' inferred to have type 'Empty', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}
+  var e = Empty(f) // expected-warning {{variable 'e' inferred to have type 'Empty', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}  {{8-8=: Empty}}
   var e2 = Empty(d) // expected-error{{cannot convert value of type 'Double' to expected argument type 'Float'}}
-  var e3 = Empty(Float(d)) // expected-warning {{variable 'e3' inferred to have type 'Empty', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}
+  var e3 = Empty(Float(d)) // expected-warning {{variable 'e3' inferred to have type 'Empty', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}  {{9-9=: Empty}}
 }
 
 struct Rule {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds a fixit for the warning about inferring a probably-unexpected type, and adds another case for when inferring a type of `[()]`. It would be easy to also warn for arrays of any of the existing cases but this seemed like overkill and would require some additional messages. 

Taken together, this:

```swift
let y = x.map { print($0) }
```

Now produces:

```
warning: variable 'y' inferred to have type '[()]'
add an explicit type annotation to silence this warning
```
With a fixit to add `: [()]` after `y`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-11511](https://bugs.swift.org/browse/SR-11511).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
