### PR TITLE
Break Another Overload Resolution Cycle

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4970,8 +4970,13 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     if (auto *PBI = dyn_cast<PatternBindingInitializer>(DC)) {
       if (auto *VD = dyn_cast<VarDecl>(decl)) {
         if (PBI->getBinding() == VD->getParentPatternBinding()) {
-          result.addUnviable(candidate,
-                             MemberLookupResult::UR_InstanceMemberOnType);
+          // If this is a recursive reference to an instance variable,
+          // try to see if we can give a good diagnostic by adding it as
+          // an unviable candidate.
+          if (!VD->isStatic()) {
+            result.addUnviable(candidate,
+                               MemberLookupResult::UR_InstanceMemberOnType);
+          }
           return;
         }
       }

--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -43,3 +43,15 @@ class Sub: Base {
         return foo(1) // expected-error {{variable used within its own initial value}}
     }()
 }
+
+extension Float {
+    static let pickMe: Float = 1
+}
+
+extension SIMD3 {
+  init(_ scalar: Scalar) { self.init(repeating: scalar) }
+}
+
+extension SIMD3 where SIMD3.Scalar == Float {
+    static let pickMe = SIMD3(.pickMe)
+}


### PR DESCRIPTION
Resolve a cycle caused by overload resolution considering recursive
static candidates where before it would silently reject them.  In
a world before the InterfaceTypeRequest, the overload resolution
machinery would attempt to validate the declaration and would recieve
a bad answer.  This caused circular candidates to be ignored as a side
effect.  This behavior was partially restored by the fixes in #27725 and #27668
but that isn't enough for recursive static variables.  Even if it were,
the constraint fix kind doesn't make sense.

Luckily, the right answer is to just reject recursive static VarDecl
candidates entirely.

Addresses rdar://56410015