### PR TITLE
SILCombine: fix a problem with thin_to_thick_function elimination.

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1586,9 +1586,17 @@ FullApplySite SILCombiner::rewriteApplyCallee(FullApplySite apply,
                                   TAI->getSubstitutionMap(), arguments,
                                   TAI->getNormalBB(), TAI->getErrorBB());
   } else {
+    auto *AI = cast<ApplyInst>(apply);
+    auto fTy = callee->getType().getAs<SILFunctionType>();
+    // The optimizer can generate a thin_to_thick_function from a throwing thin
+    // to a non-throwing thick function (in case it can prove that the function
+    // is not throwing).
+    // Therefore we have to check if the new callee (= the argument of the
+    // thin_to_thick_function) is a throwing function and set the not-throwing
+    // flag in this case.
     return Builder.createApply(apply.getLoc(), callee,
                                apply.getSubstitutionMap(), arguments,
-                               cast<ApplyInst>(apply)->isNonThrowing());
+                               AI->isNonThrowing() || fTy->hasErrorResult());
   }
 }
 

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -388,6 +388,20 @@ bb0(%0 : $*Builtin.Int32, %1 : $*Builtin.Int8):
   return %29 : $()
 }
 
+sil @actually_not_throwing: $@convention(thin) (Builtin.Int32) -> (@owned Builtin.Int32, @error Error)
+
+// CHECK-LABEL: sil @remove_throwing_thin_to_not_throwing_thick_conversion
+// CHECK: [[FN:%[0-9]+]] = function_ref
+// CHECK: apply [nothrow] [[FN]](%0)
+// CHECK: } // end sil function 'remove_throwing_thin_to_not_throwing_thick_conversion'
+sil @remove_throwing_thin_to_not_throwing_thick_conversion : $@convention(thin) (Builtin.Int32) -> @owned Builtin.Int32 {
+bb0(%0 : $Builtin.Int32):
+  %2 = function_ref @actually_not_throwing : $@convention(thin) (Builtin.Int32) -> (@owned Builtin.Int32, @error Error)
+  %3 = thin_to_thick_function %2 : $@convention(thin) (Builtin.Int32) -> (@owned Builtin.Int32, @error Error) to $@callee_guaranteed (Builtin.Int32) -> @owned Builtin.Int32
+  %5 = apply %3(%0) : $@callee_guaranteed (Builtin.Int32) -> @owned Builtin.Int32
+  return %5 : $Builtin.Int32
+}
+
 sil @testCombineClosureHelper : $(Builtin.Int32) -> ()
 
 // Test function_ref -> partial_apply -> convert_function -> apply.


### PR DESCRIPTION
The optimizer can generate a thin_to_thick_function conversion from a throwing thin to a non-throwing thick function (in case it can prove that the function is actually not throwing).
Therefore, when removing such a  conversion from the callee-argument of an apply, we have to check if the new callee (= the argument of the thin_to_thick_function) is a throwing function and set the not-throwing flag in this case.

This fixes a SILVerifier crash.
rdar://problem/56358645
