### PR TITLE
AST: make `isNotAfter` a strict weak ordering

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -617,7 +617,7 @@ private:
 #endif
     ASTScopeAssert(startOrder * endOrder != -1,
                    "Start order contradicts end order");
-    return startOrder + endOrder < 1;
+    return startOrder <= 0 && endOrder <= 0;
   }
 
   static bool isVarDeclInPatternBindingDecl(ASTNode n1, ASTNode n2) {


### PR DESCRIPTION
`std::stable_sort` requires that the comparator provide a strict weak
ordering, which we did not previously.  This was caught by MSVCPRT.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
