### PR TITLE
[TSan] Do not report benign race on `_swiftEmptyArrayStorage`

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1162,7 +1162,7 @@ extension Array: RangeReplaceableCollection {
       "newElements.underestimatedCount was an overestimate")
     // can't check for overflow as sequences can underestimate
 
-    // This check prevents a data race writting to _swiftEmptyArrayStorage
+    // This check prevents a data race writing to _swiftEmptyArrayStorage
     if writtenCount > 0 {
       _buffer.count += writtenCount
     }

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -953,7 +953,10 @@ extension ArraySlice: RangeReplaceableCollection {
       "newElements.underestimatedCount was an overestimate")
     // can't check for overflow as sequences can underestimate
 
-    _buffer.count += writtenCount
+    // This check prevents a data race writing to _swiftEmptyArrayStorage
+    if writtenCount > 0 {
+      _buffer.count += writtenCount
+    }
 
     if writtenUpTo == buf.endIndex {
       // there may be elements that didn't fit in the existing buffer,

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -801,7 +801,10 @@ extension ContiguousArray: RangeReplaceableCollection {
       "newElements.underestimatedCount was an overestimate")
     // can't check for overflow as sequences can underestimate
 
-    _buffer.count += writtenCount
+    // This check prevents a data race writing to _swiftEmptyArrayStorage
+    if writtenCount > 0 {
+      _buffer.count += writtenCount
+    }
 
     if writtenUpTo == buf.endIndex {
       // there may be elements that didn't fit in the existing buffer,

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -688,7 +688,7 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
       p = newResult.firstElementAddress + result.capacity
       remainingCapacity = newResult.capacity - result.capacity
       if !result.isEmpty {
-        // This check prevents a data race writting to _swiftEmptyArrayStorage
+        // This check prevents a data race writing to _swiftEmptyArrayStorage
         // Since count is always 0 there, this code does nothing anyway
         newResult.firstElementAddress.moveInitialize(
           from: result.firstElementAddress, count: result.capacity)

--- a/test/Sanitizers/tsan-emptyarraystorage.swift
+++ b/test/Sanitizers/tsan-emptyarraystorage.swift
@@ -25,31 +25,31 @@ class T: Thread {
   }
 }
 
-func runOnThread(closure: @escaping () -> Void) {
+func runOnThread(_ closure: @escaping () -> Void) {
   let t = T(closure: closure)
   t.start()
 }
 
-runOnThread(closure: {
+runOnThread {
   var oneEmptyArray: [[String:String]] = []
   oneEmptyArray.append(contentsOf: [])
-})
-runOnThread(closure: {
+}
+runOnThread {
   var aCompletelyUnrelatedOtherEmptyArray: [[Double:Double]] = []
   aCompletelyUnrelatedOtherEmptyArray.append(contentsOf: [])
-})
-runOnThread(closure: {
+}
+runOnThread {
   var array = Array<Int>()
   array.append(contentsOf: [])
-})
-runOnThread(closure: {
+}
+runOnThread {
   var arraySlice = ArraySlice<Int>()
   arraySlice.append(contentsOf: [])
-})
-runOnThread(closure: {
+}
+runOnThread {
   var contiguousArray = ContiguousArray<Int>()
   contiguousArray.append(contentsOf: [])
-})
+}
 
 for _ in 1...5 {
   sem.wait()

--- a/test/Sanitizers/tsan-emptyarraystorage.swift
+++ b/test/Sanitizers/tsan-emptyarraystorage.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=thread -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
-// RUN: %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// RUN: %target-run %t_tsan-binary 2>&1 | %FileCheck %s --implicit-check-not='ThreadSanitizer'
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
 // REQUIRES: foundation
@@ -14,28 +14,47 @@ import Foundation
 
 let sem = DispatchSemaphore(value: 0)
 
-class T1: Thread {
+class T: Thread {
+  let closure: () -> Void
+  init(closure: @escaping () -> Void) {
+    self.closure = closure
+  }
   override func main() {
-    var oneEmptyArray: [[String:String]] = []
-    oneEmptyArray.append(contentsOf: [])
+    closure()
     sem.signal()
   }
 }
-let t1 = T1()
-t1.start()
 
-class T2: Thread {
-  override func main() {
-    var aCompletelyUnrelatedOtherEmptyArray: [[Double:Double]] = []
-    aCompletelyUnrelatedOtherEmptyArray.append(contentsOf: [])
-    sem.signal()
-  }
+func runOnThread(closure: @escaping () -> Void) {
+  let t = T(closure: closure)
+  t.start()
 }
-let t2 = T2()
-t2.start()
 
-sem.wait()
-sem.wait()
+runOnThread(closure: {
+  var oneEmptyArray: [[String:String]] = []
+  oneEmptyArray.append(contentsOf: [])
+})
+runOnThread(closure: {
+  var aCompletelyUnrelatedOtherEmptyArray: [[Double:Double]] = []
+  aCompletelyUnrelatedOtherEmptyArray.append(contentsOf: [])
+})
+runOnThread(closure: {
+  var array = Array<Int>()
+  array.append(contentsOf: [])
+})
+runOnThread(closure: {
+  var arraySlice = ArraySlice<Int>()
+  arraySlice.append(contentsOf: [])
+})
+runOnThread(closure: {
+  var contiguousArray = ContiguousArray<Int>()
+  contiguousArray.append(contentsOf: [])
+})
+
+for _ in 1...5 {
+  sem.wait()
+}
+
 print("Done!")
 
 // CHECK: Done!


### PR DESCRIPTION
A previous commit [1] identified and fixed a benign race on
`_swiftEmptyArrayStorage`.  Unfortunately, we have some code duplication
and the fix was not applied to all the necessary places.  Essentially,
we need to ensure that the "empty array storage" object that backs many
"array like types" is never written to.

I tried to improve the test to capture this, however, it is very
finicky.  Currently, it does not go red on my system even when I remove
the check to avoid the benign race in Release mode.

Relevant classes: Array, ArraySlice, ContiguousArray, ArrayBuffer,
ContiguousArrayBuffer, SliceBuffer.

[1] b9b4c789f32ccd968c0cb7d64f364d819deb3096

rdar://55161564
