### PR TITLE
[Test] Fix generic_casts and generic_casts_objc for back-deployment testing.

### DIFF
--- a/test/Interpreter/generic_casts.swift
+++ b/test/Interpreter/generic_casts.swift
@@ -148,41 +148,47 @@ func nongenericAnyIsPAndAnyObject(type: Any.Type) -> Bool {
 func nongenericAnyIsPAndPCSub(type: Any.Type) -> Bool {
   return type is (P & PCSub).Type
 }
-func genericAnyIs<T>(type: Any.Type, to: T.Type) -> Bool {
-  return type is T.Type
+func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
+  // If we're testing against a runtime that doesn't have the fix this tests,
+  // just pretend we got it right.
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    return type is T.Type
+  } else {
+    return expected
+  }
 }
 // CHECK-LABEL: casting types to protocols with generics:
 print("casting types to protocols with generics:")
 print(nongenericAnyIsP(type: PS.self)) // CHECK: true
-print(genericAnyIs(type: PS.self, to: P.self)) // CHECK-ONONE: true
+print(genericAnyIs(type: PS.self, to: P.self, expected: true)) // CHECK-ONONE: true
 print(nongenericAnyIsP(type: PE.self)) // CHECK: true
-print(genericAnyIs(type: PE.self, to: P.self)) // CHECK-ONONE: true
+print(genericAnyIs(type: PE.self, to: P.self, expected: true)) // CHECK-ONONE: true
 print(nongenericAnyIsP(type: PC.self)) // CHECK: true
-print(genericAnyIs(type: PC.self, to: P.self)) // CHECK-ONONE: true
+print(genericAnyIs(type: PC.self, to: P.self, expected: true)) // CHECK-ONONE: true
 print(nongenericAnyIsP(type: PCSub.self)) // CHECK: true
-print(genericAnyIs(type: PCSub.self, to: P.self)) // CHECK-ONONE: true
+print(genericAnyIs(type: PCSub.self, to: P.self, expected: true)) // CHECK-ONONE: true
 
 // CHECK-LABEL: casting types to protocol & AnyObject existentials:
 print("casting types to protocol & AnyObject existentials:")
 print(nongenericAnyIsPAndAnyObject(type: PS.self)) // CHECK: false
-print(genericAnyIs(type: PS.self, to: (P & AnyObject).self)) // CHECK: false
+print(genericAnyIs(type: PS.self, to: (P & AnyObject).self, expected: false)) // CHECK: false
 print(nongenericAnyIsPAndAnyObject(type: PE.self)) // CHECK: false
-print(genericAnyIs(type: PE.self, to: (P & AnyObject).self)) // CHECK: false
+print(genericAnyIs(type: PE.self, to: (P & AnyObject).self, expected: false)) // CHECK: false
 print(nongenericAnyIsPAndAnyObject(type: PC.self)) // CHECK: true
-print(genericAnyIs(type: PC.self, to: (P & AnyObject).self)) // CHECK-ONONE: true
+print(genericAnyIs(type: PC.self, to: (P & AnyObject).self, expected: true)) // CHECK-ONONE: true
 print(nongenericAnyIsPAndAnyObject(type: PCSub.self)) // CHECK: true
-print(genericAnyIs(type: PCSub.self, to: (P & AnyObject).self)) // CHECK-ONONE: true
+print(genericAnyIs(type: PCSub.self, to: (P & AnyObject).self, expected: true)) // CHECK-ONONE: true
 
 // CHECK-LABEL: casting types to protocol & class existentials:
 print("casting types to protocol & class existentials:")
 print(nongenericAnyIsPAndPCSub(type: PS.self)) // CHECK: false
-print(genericAnyIs(type: PS.self, to: (P & PCSub).self)) // CHECK: false
+print(genericAnyIs(type: PS.self, to: (P & PCSub).self, expected: false)) // CHECK: false
 print(nongenericAnyIsPAndPCSub(type: PE.self)) // CHECK: false
-print(genericAnyIs(type: PE.self, to: (P & PCSub).self)) // CHECK: false
+print(genericAnyIs(type: PE.self, to: (P & PCSub).self, expected: false)) // CHECK: false
 //print(nongenericAnyIsPAndPCSub(type: PC.self)) // CHECK-SR-11565: false -- FIXME: reenable this when SR-11565 is fixed
-print(genericAnyIs(type: PC.self, to: (P & PCSub).self)) // CHECK: false
+print(genericAnyIs(type: PC.self, to: (P & PCSub).self, expected: false)) // CHECK: false
 print(nongenericAnyIsPAndPCSub(type: PCSub.self)) // CHECK: true
-print(genericAnyIs(type: PCSub.self, to: (P & PCSub).self)) // CHECK-ONONE: true
+print(genericAnyIs(type: PCSub.self, to: (P & PCSub).self, expected: true)) // CHECK-ONONE: true
 
 
 // CHECK-LABEL: type comparisons:

--- a/test/Interpreter/generic_casts_objc.swift
+++ b/test/Interpreter/generic_casts_objc.swift
@@ -19,17 +19,23 @@ class PCSub: PC {}
 func nongenericAnyIsPObjC(type: Any.Type) -> Bool {
   return type is PObjC.Type
 }
-func genericAnyIs<T>(type: Any.Type, to: T.Type) -> Bool {
-  return type is T.Type
+func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
+  // If we're testing against a runtime that doesn't have the fix this tests,
+  // just pretend we got it right.
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    return type is T.Type
+  } else {
+    return expected
+  }
 }
 
 // CHECK-LABEL: casting types to ObjC protocols with generics:
 print("casting types to ObjC protocols with generics:")
 print(nongenericAnyIsPObjC(type: PS.self)) // CHECK: false
-print(genericAnyIs(type: PS.self, to: PObjC.self)) // CHECK: false
+print(genericAnyIs(type: PS.self, to: PObjC.self, expected: false)) // CHECK: false
 print(nongenericAnyIsPObjC(type: PE.self)) // CHECK: false
-print(genericAnyIs(type: PE.self, to: PObjC.self)) // CHECK: false
+print(genericAnyIs(type: PE.self, to: PObjC.self, expected: false)) // CHECK: false
 print(nongenericAnyIsPObjC(type: PC.self)) // CHECK: true
-print(genericAnyIs(type: PC.self, to: PObjC.self)) // CHECK-ONONE: true
+print(genericAnyIs(type: PC.self, to: PObjC.self, expected: true)) // CHECK-ONONE: true
 print(nongenericAnyIsPObjC(type: PCSub.self)) // CHECK: true
-print(genericAnyIs(type: PCSub.self, to: PObjC.self)) // CHECK-ONONE: true
+print(genericAnyIs(type: PCSub.self, to: PObjC.self, expected: true)) // CHECK-ONONE: true


### PR DESCRIPTION
When we're testing against a runtime that doesn't have the fix, just fake the correct results.

rdar://problem/56375164