### PR TITLE
[build-script] Don't build StdlibUnittest when building SwiftPM

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -298,9 +298,6 @@ reconfigure
 verbose-build
 build-ninja
 
-build-swift-stdlib-unittest-extra
-
-
 [preset: buildbot_incremental_base_all_platforms]
 mixin-preset=buildbot_incremental_base
 
@@ -320,6 +317,8 @@ build-subdir=buildbot_incremental
 # Build Release without debug info, because it is faster to build.
 release
 assertions
+
+build-swift-stdlib-unittest-extra
 
 libcxx
 
@@ -381,6 +380,8 @@ mixin-preset=buildbot_incremental_base
 # of the XCTest Xcode project.
 xctest
 
+build-swift-stdlib-unittest-extra
+
 dash-dash
 
 # This preset is meant to test XCTest, not Swift or Foundation. We don't
@@ -416,6 +417,8 @@ build-subdir=buildbot_incremental_asan
 release-debuginfo
 assertions
 
+build-swift-stdlib-unittest-extra
+
 dash-dash
 
 # FIXME: Swift/ASan does not support iOS yet.
@@ -442,6 +445,8 @@ release-debuginfo
 assertions
 enable-tsan
 
+build-swift-stdlib-unittest-extra
+
 dash-dash
 
 skip-build-ios
@@ -459,6 +464,8 @@ build-subdir=buildbot_incremental_asan_ubsan
 # Build Release with debug info, so that we can symbolicate backtraces.
 release-debuginfo
 assertions
+
+build-swift-stdlib-unittest-extra
 
 dash-dash
 
@@ -489,6 +496,8 @@ build-subdir=buildbot_incremental_asan_debug
 # Build Release with debug info, so that we can symbolicate backtraces.
 assertions
 
+build-swift-stdlib-unittest-extra
+
 dash-dash
 
 # FIXME: Swift/ASan does not support iOS yet.
@@ -518,6 +527,8 @@ build-subdir=buildbot_incremental
 # We build release+asserts.
 release
 assertions
+
+build-swift-stdlib-unittest-extra
 
 # We run the OS X tests and validation tests.
 test
@@ -1353,6 +1364,8 @@ build-subdir=buildbot_incremental
 release
 assertions
 
+build-swift-stdlib-unittest-extra
+
 libcxx
 
 # Build llbuild & swiftpm here
@@ -1396,6 +1409,8 @@ build-subdir=buildbot_incremental
 release
 assertions
 
+build-swift-stdlib-unittest-extra
+
 # Build llbuild & swiftpm here
 llbuild
 swiftpm
@@ -1414,6 +1429,8 @@ skip-test-osx
 [preset: mixin_swiftpm_base]
 mixin-preset=buildbot_incremental_base
 build-subdir=buildbot_incremental
+
+build-swift-stdlib-unittest-extra
 
 libcxx
 llbuild

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1430,8 +1430,6 @@ skip-test-osx
 mixin-preset=buildbot_incremental_base
 build-subdir=buildbot_incremental
 
-build-swift-stdlib-unittest-extra
-
 libcxx
 llbuild
 swiftpm


### PR DESCRIPTION
@aciidb0mb3r If you decide that the stdlib unit tests should not be built when building SwiftPM, this PR removes it from the preset.