### PR TITLE
[CMake] Fix the static bindings workflow.

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -183,7 +183,7 @@ cmake -G Ninja^
   -DClang_DIR="S:/b/llvm/lib/cmake/clang"^
   -DSwift_DIR="S:/b/swift/lib/cmake/swift"^
   -DCMAKE_BUILD_TYPE=RelWithDebInfo^
-  -DLLDB_ALLOW_STATIC_BINDINGS=YES^
+  -DLLDB_USE_STATIC_BINDINGS=YES^
   -DLLVM_ENABLE_ASSERTIONS=ON^
   -DPYTHON_HOME="%ProgramFiles(x86)%\Microsoft Visual Studio\Shared\Python37_64"^
   S:\lldb

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2452,7 +2452,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
                     -DLLDB_IS_BUILDBOT_BUILD:BOOL="${LLDB_IS_BUILDBOT_BUILD}"
                     -DLLDB_BUILD_DATE:STRING="\"${LLDB_BUILD_DATE}\""
-                    -DLLDB_ALLOW_STATIC_BINDINGS:BOOL=1
                     -DLLDB_INCLUDE_TESTS:BOOL=$(false_true ${BUILD_TOOLCHAIN_ONLY})
                     -DLLDB_TEST_USER_ARGS="${DOTEST_ARGS}"
                 )

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -279,7 +279,7 @@ cmake "%source_root%\lldb"^
     -DClang_DIR:PATH=%build_root%\llvm\lib\cmake\clang^
     -DSwift_DIR:PATH=%build_root%\swift\lib\cmake\swift^
     -DLLVM_ENABLE_ASSERTIONS:BOOL=YES^
-    -DLLDB_ALLOW_STATIC_BINDINGS:BOOL=YES^
+    -DLLDB_USE_STATIC_BINDINGS:BOOL=YES^
     -DPYTHON_HOME:PATH=%PYTHON_HOME%^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
     -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^


### PR DESCRIPTION
Rename LLDB_ALLOW_STATIC_BINDINGS to LLDB_USE_STATIC_BINDINGS and make
LLDB use the static bindings unconditionally when it's set. The current
variable is opaque because it allows LLDB to use the static bindings,
but only if SWIG is not found. If an incompatible version of swig is
found, it reports a fatal error. This serves no purpose other than to
confuse the user.

The corresponding LLDB patch simplifies things and makes the variable do
what you expect. When enabled, LLDB uses the static bindings. When
disabled, we try to generate them with SWIG.

This patch modifies the build scripts to pass the new variable.