### PR TITLE
[build-script] Add preset to set up CI testing for the stress tester

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1468,10 +1468,10 @@ skip-test-xctest
 [preset: mixin_swiftpm_package_macos_platform]
 mixin-preset=mixin_swiftpm_macos_platform
 
-# Build stdlib for all platforms.
-ios
-tvos
-watchos
+# We don't need these platforms. Skip them
+skip-ios
+skip-tvos
+skip-watchos
 
 skip-test-llbuild
 skip-test-swiftpm

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1556,15 +1556,6 @@ mixin-preset=mixin_swiftpm_package_macos_platform
 release
 assertions
 skstresstester
-
-#===------------------------------------------------------------------------===#
-# Test Swift Evolve
-#===------------------------------------------------------------------------===#
-
-[preset: buildbot_swiftevolve_macos]
-mixin-preset=mixin_swiftpm_package_macos_platform
-release
-assertions
 swiftevolve
 
 #===------------------------------------------------------------------------===#

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1468,6 +1468,9 @@ skip-test-xctest
 [preset: mixin_swiftpm_package_macos_platform]
 mixin-preset=mixin_swiftpm_macos_platform
 
+# We don't need to build the benchmark if we just want SwiftPM
+skip-build-benchmarks
+
 # We don't need these platforms. Skip them
 skip-ios
 skip-tvos


### PR DESCRIPTION
This configures a preset `buildbot_skstresstester_macos` that can be used for CI testing of the stress tester.

This does not yet set up testing the stress tester as a downstream dependency of the Swift and SwiftSyntax project.