### PR TITLE
[Syntax] Include leading/trailing trivia size to the cache ID

### DIFF
--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -329,6 +329,8 @@ void RawSyntax::Profile(llvm::FoldingSetNodeID &ID, tok TokKind,
                         OwnedString Text, ArrayRef<TriviaPiece> LeadingTrivia,
                         ArrayRef<TriviaPiece> TrailingTrivia) {
   ID.AddInteger(unsigned(TokKind));
+  ID.AddInteger(LeadingTrivia.size());
+  ID.AddInteger(TrailingTrivia.size());
   switch (TokKind) {
 #define TOKEN_DEFAULT(NAME) case tok::NAME:
 #define PUNCTUATOR(NAME, X) TOKEN_DEFAULT(NAME)


### PR DESCRIPTION
(Re-apply 33e561a810b96b80dd0bde56652098ecd470a9bc after reverting ASTGen)

We have to differentiate cache IDs between:
```
  (Token l_brace
    (trivia space 1)
    (text="{"))
```
and:
```
  (Token l_brace
    (text="{")
    (trivia space 1))
```

This might caused roundtrip failures. But I haven't been able to find reproducer for the failure.