### PR TITLE
[windows] Adapt test to pass on Windows.

### DIFF
--- a/test/IRGen/opaque_result_type_private_underlying.swift
+++ b/test/IRGen/opaque_result_type_private_underlying.swift
@@ -10,9 +10,9 @@
 import Repo1
 #endif
 
-// SINGLEMODULE: s37opaque_result_type_private_underlying18UsePublicInlinableVAA1AAAMA" = internal constant { {{.*}}symbolic _____ 37opaque_result_type_private_underlying7PublicSV
-// NONRESILIENT: s37opaque_result_type_private_underlying18UsePublicInlinableV5Repo11AAAMA" = internal constant { {{.*}}symbolic _____ 5Repo17PublicSV
-// RESILIENT: s37opaque_result_type_private_underlying18UsePublicInlinableV5Repo11AAAMA" = internal constant { {{.*}}symbolic _____ 5Repo17PublicSV
+// SINGLEMODULE: s37opaque_result_type_private_underlying18UsePublicInlinableVAA1AAAMA" = internal constant { {{.*}}symbolic {{(_____ )?}}37opaque_result_type_private_underlying7PublicSV
+// NONRESILIENT: s37opaque_result_type_private_underlying18UsePublicInlinableV5Repo11AAAMA" = internal constant { {{.*}}symbolic {{(_____ )?}}5Repo17PublicSV
+// RESILIENT: s37opaque_result_type_private_underlying18UsePublicInlinableV5Repo11AAAMA" = internal constant { {{.*}}symbolic {{(_____ )?}}5Repo17PublicSV
 public struct UsePublicInlinable : A {
   public init() {}
   public func bindAssoc() -> some Q {
@@ -20,8 +20,8 @@ public struct UsePublicInlinable : A {
   }
 }
 
-// SINGLEMODULE: s37opaque_result_type_private_underlying9UsePublicVAA1AAAMA" = internal constant { {{.*}}symbolic _____ 37opaque_result_type_private_underlying7PublicSV
-// NONRESILIENT: s37opaque_result_type_private_underlying9UsePublicV5Repo11AAAMA" = internal constant { {{.*}}symbolic _____ 5Repo17PublicSV
+// SINGLEMODULE: s37opaque_result_type_private_underlying9UsePublicVAA1AAAMA" = internal constant { {{.*}}symbolic {{(_____ )?}}37opaque_result_type_private_underlying7PublicSV
+// NONRESILIENT: s37opaque_result_type_private_underlying9UsePublicV5Repo11AAAMA" = internal constant { {{.*}}symbolic {{(_____ )?}}5Repo17PublicSV
 // RESILIENT: s37opaque_result_type_private_underlying9UsePublicV5Repo11AAAMA" = internal constant {  {{.*}}symbolic _____y_Qo_ 5Repo116PublicUnderlyingV9bindAssocQryFQO
 public struct UsePublic : A {
   public init() {}
@@ -30,7 +30,7 @@ public struct UsePublic : A {
   }
 }
 
-// SINGLEMODULE: s37opaque_result_type_private_underlying11UseInternalVAA1AAAMA" = internal constant { {{.*}}symbolic _____ 37opaque_result_type_private_underlying9InternalSV
+// SINGLEMODULE: s37opaque_result_type_private_underlying11UseInternalVAA1AAAMA" = internal constant { {{.*}}symbolic {{(_____ )?}}37opaque_result_type_private_underlying9InternalSV
 // NONRESILIENT: s37opaque_result_type_private_underlying11UseInternalV5Repo11AAAMA" = internal constant { {{.*}}symbolic _____y_Qo_ 5Repo118InternalUnderlyingV9bindAssocQryFQO
 // RESILIENT: s37opaque_result_type_private_underlying11UseInternalV5Repo11AAAMA" = internal constant { {{.*}}symbolic _____y_Qo_ 5Repo118InternalUnderlyingV9bindAssocQryFQO
 public struct UseInternal: A {


### PR DESCRIPTION
The underscores weren't printed while compiling for Windows between the
symbolic and the mangled name tokens. Make the underscores optional, to
allow the test pass on Windows.

This should fix the failing test on Windows.

I am not sure this is the right fix. I am just uploading in order to find out the best way. I don't understand what those underscores mean, but since they were added in 3ca0859611124110b823c9af8b9394c132d3242b, I imagine they are important. I reviewed the code of #27666, and I don't obviously see where the difference in Windows might come from or what those underscores actually mean. Any alternative solution would be greatly appreciated.