### PR TITLE
[SyntaxParse] Remove unnecessary verifyElementRanges() call

### DIFF
--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -146,9 +146,6 @@ ParsedSyntaxRecorder::make${node.syntax_kind}(
   for (auto &element : elements) {
     layout.push_back(element.takeRaw());
   }
-  #ifndef NDEBUG
-  ParsedRawSyntaxRecorder::verifyElementRanges(layout);
-  #endif
   if (SPCtx.shouldDefer())
     return defer${node.syntax_kind}(layout, SPCtx);
   return record${node.syntax_kind}(layout, SPCtx.getRecorder());


### PR DESCRIPTION
The layout is verified later anyways.