### PR TITLE
[MetadataReader] Adapt to newer Objective-C class_rw_t

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2613,6 +2613,13 @@ private:
     if (!Reader->readInteger(RemoteAddress(dataPtr + OffsetToROPtr), &dataPtr))
       return StoredPointer();
 
+    // Newer Objective-C runtimes implement a size optimization where the RO
+    // field is a tagged union. If the low-bit is set, then the pointer needs
+    // to be dereferenced once more to yield the real class_ro_t pointer.
+    if (dataPtr & 1)
+      if (!Reader->readInteger(RemoteAddress(dataPtr^1), &dataPtr))
+        return StoredPointer();
+
     return dataPtr;
   }
 


### PR DESCRIPTION
Newer Objective-C runtimes implement a size optimization in class_rw_t
which requires an additional indirection to get to the class_ro_t pointer.

Thanks to Davide for getting to the bottom of this!

It is unclear to me how to test this in the Swift repo. The LLDB test suite has a few failures without this change on a recent enough system.