### PR TITLE
[CS] Make resolveLocatorToDecl simpler and more robust

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -534,6 +534,11 @@ namespace {
     /// A stack of expressions being walked, used to compute existential depth.
     llvm::SmallVector<Expr *, 8> ExprStack;
 
+    /// A map of apply exprs to their callee locators. This is necessary
+    /// because after rewriting an apply's function expr, its callee locator
+    /// will no longer be equivalent to the one stored in the solution.
+    llvm::DenseMap<ApplyExpr *, ConstraintLocator *> CalleeLocators;
+
     /// Members which are AbstractFunctionDecls but not FuncDecls cannot
     /// mutate self.
     bool isNonMutatingMember(ValueDecl *member) {
@@ -1003,7 +1008,7 @@ namespace {
         }
       }
 
-      return finishApply(apply, openedType, locator);
+      return finishApply(apply, memberRef, openedType, locator);
     }
     
     /// Describes either a type or the name of a type to be resolved.
@@ -1062,12 +1067,14 @@ namespace {
     /// \param apply The function application to finish type-checking, which
     /// may be a newly-built expression.
     ///
+    /// \param callee The callee for the function being applied.
+    ///
     /// \param openedType The "opened" type this expression had during
     /// type checking, which will be used to specialize the resulting,
     /// type-checked expression appropriately.
     ///
     /// \param locator The locator for the original expression.
-    Expr *finishApply(ApplyExpr *apply, Type openedType,
+    Expr *finishApply(ApplyExpr *apply, ConcreteDeclRef callee, Type openedType,
                       ConstraintLocatorBuilder locator);
 
     // Resolve `@dynamicCallable` applications.
@@ -1131,6 +1138,7 @@ namespace {
     ///
     /// \param arg The argument expression.
     /// \param funcType The function type.
+    /// \param callee The callee for the function being applied.
     /// \param apply The ApplyExpr that forms the call.
     /// \param argLabels The argument labels provided for the call.
     /// \param hasTrailingClosure Whether the last argument is a trailing
@@ -1140,7 +1148,7 @@ namespace {
     /// \returns the coerced expression, which will have type \c ToType.
     Expr *
     coerceCallArguments(Expr *arg, AnyFunctionType *funcType,
-                        ApplyExpr *apply,
+                        ConcreteDeclRef callee, ApplyExpr *apply,
                         ArrayRef<Identifier> argLabels,
                         bool hasTrailingClosure,
                         ConstraintLocatorBuilder locator);
@@ -1364,14 +1372,17 @@ namespace {
 
       // If we opened up an existential when performing the subscript, open
       // the base accordingly.
+      auto memberLoc = locator.withPathElement(locatorKind);
       auto knownOpened = solution.OpenedExistentialTypes.find(
-                           getConstraintSystem().getConstraintLocator(
-                             locator.withPathElement(locatorKind)));
+          cs.getConstraintLocator(memberLoc));
       if (knownOpened != solution.OpenedExistentialTypes.end()) {
         base = openExistentialReference(base, knownOpened->second, subscript);
         baseTy = knownOpened->second;
       }
- 
+
+      // Compute the concrete reference to the subscript.
+      auto subscriptRef = solution.resolveConcreteDeclRef(subscript, memberLoc);
+
       // Figure out the index and result types.
       Type resultTy;
       if (choice.getKind() != OverloadChoiceKind::DynamicMemberLookup &&
@@ -1381,7 +1392,7 @@ namespace {
         resultTy = subscriptFnTy->getResult();
 
         // Coerce the index argument.
-        index = coerceCallArguments(index, subscriptFnTy, nullptr,
+        index = coerceCallArguments(index, subscriptFnTy, subscriptRef, nullptr,
                                     argLabels, hasTrailingClosure,
                                     locator.withPathElement(
                                       ConstraintLocator::ApplyArgument));
@@ -1399,12 +1410,6 @@ namespace {
       auto getType = [&](const Expr *E) -> Type {
         return cs.getType(E);
       };
-
-      // Form the subscript expression.
-
-      // Compute the concrete reference to the subscript.
-      auto subscriptRef = solution.resolveConcreteDeclRef(
-          subscript, locator.withPathElement(locatorKind));
 
       // Handle dynamic lookup.
       if (choice.getKind() == OverloadChoiceKind::DeclViaDynamic ||
@@ -1471,15 +1476,12 @@ namespace {
 
     /// Build a new reference to another constructor.
     Expr *buildOtherConstructorRef(Type openedFullType,
-                                   ConstructorDecl *ctor, Expr *base,
+                                   ConcreteDeclRef ref, Expr *base,
                                    DeclNameLoc loc,
                                    ConstraintLocatorBuilder locator,
                                    bool implicit) {
       auto &tc = cs.getTypeChecker();
       auto &ctx = tc.Context;
-
-      // Compute the concrete reference.
-      auto ref = solution.resolveConcreteDeclRef(ctor, locator);
 
       // The constructor was opened with the allocating type, not the
       // initializer type. Map the former into the latter.
@@ -2394,10 +2396,11 @@ namespace {
       // Build the member reference.
       bool isDynamic
         = selected.choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
+      auto *exprLoc = cs.getConstraintLocator(expr);
       auto result = buildMemberRef(
           base, selected.openedFullType, expr->getDotLoc(), selected.choice,
           expr->getNameLoc(), selected.openedType,
-          cs.getConstraintLocator(expr), memberLocator, expr->isImplicit(),
+          exprLoc, memberLocator, expr->isImplicit(),
           selected.choice.getFunctionRefKind(), AccessSemantics::Ordinary,
           isDynamic);
       if (!result)
@@ -2409,11 +2412,13 @@ namespace {
 
       // If there was an argument, apply it.
       if (auto arg = expr->getArgument()) {
+        auto callee = solution.resolveConcreteDeclRef(selected.choice.getDecl(),
+                                                      memberLocator);
         ApplyExpr *apply = CallExpr::create(
             tc.Context, result, arg, expr->getArgumentLabels(),
             expr->getArgumentLabelLocs(), expr->hasTrailingClosure(),
             /*implicit=*/expr->isImplicit(), Type(), getType);
-        result = finishApply(apply, Type(), cs.getConstraintLocator(expr));
+        result = finishApply(apply, callee, Type(), exprLoc);
 
         // FIXME: Application could fail, because some of the solutions
         // are not expressible in AST (yet?), like certain tuple-to-tuple
@@ -2588,12 +2593,13 @@ namespace {
       }
 
       // Build a partial application of the delegated initializer.
-      Expr *ctorRef = buildOtherConstructorRef(openedType, ctor, base, nameLoc,
-                                               ctorLocator, implicit);
+      auto callee = solution.resolveConcreteDeclRef(ctor, ctorLocator);
+      Expr *ctorRef = buildOtherConstructorRef(openedType, callee, base,
+                                               nameLoc, ctorLocator, implicit);
       auto *call = new (cs.getASTContext()) DotSyntaxCallExpr(ctorRef, dotLoc,
                                                               base);
 
-      return finishApply(call, cs.getType(expr),
+      return finishApply(call, callee, cs.getType(expr),
                          ConstraintLocatorBuilder(
                            cs.getConstraintLocator(expr)));
     }
@@ -3018,9 +3024,13 @@ namespace {
     }
 
     Expr *visitApplyExpr(ApplyExpr *expr) {
-      return finishApply(expr, cs.getType(expr),
-                         ConstraintLocatorBuilder(
-                           cs.getConstraintLocator(expr)));
+      auto *calleeLoc = CalleeLocators[expr];
+      assert(calleeLoc);
+
+      // Resolve the callee for the application if we have one.
+      auto callee = solution.resolveLocatorToDecl(calleeLoc);
+      return finishApply(expr, callee, cs.getType(expr),
+                         cs.getConstraintLocator(expr));
     }
 
     Expr *visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *expr) {
@@ -4589,7 +4599,7 @@ namespace {
 
       // Coerce the indices to the type the subscript expects.
       auto *newIndexExpr =
-          coerceCallArguments(indexExpr, subscriptType,
+          coerceCallArguments(indexExpr, subscriptType, ref,
                               /*applyExpr*/ nullptr, labels,
                               /*hasTrailingClosure*/ false, locator);
 
@@ -4644,6 +4654,12 @@ namespace {
 
     /// Interface for ExprWalker
     void walkToExprPre(Expr *expr) {
+      // If we have an apply, make a note of its callee locator prior to
+      // rewriting.
+      if (auto *apply = dyn_cast<ApplyExpr>(expr)) {
+        auto *calleeLoc = cs.getCalleeLocator(cs.getConstraintLocator(expr));
+        CalleeLocators[apply] = calleeLoc;
+      }
       ExprStack.push_back(expr);
     }
 
@@ -4700,201 +4716,17 @@ namespace {
   };
 } // end anonymous namespace
 
-
-/// Resolve a locator to the specific declaration it references, if possible.
-///
-/// \param cs The constraint system in which the locator will be resolved.
-///
-/// \param locator The locator to resolve.
-///
-/// \param findOvlChoice A function that searches for the overload choice
-/// associated with the given locator, or an empty optional if there is no such
-/// overload.
-///
-/// \returns the decl to which the locator resolved.
-///
-static ConcreteDeclRef resolveLocatorToDecl(
-    ConstraintSystem &cs, ConstraintLocator *locator,
-    llvm::function_ref<Optional<SelectedOverload>(ConstraintLocator *)>
-        findOvlChoice,
-    llvm::function_ref<ConcreteDeclRef(ValueDecl *decl, Type openedType,
-                                       ConstraintLocator *declLocator)>
-        getConcreteDeclRef) {
-  assert(locator && "Null locator");
-  if (!locator->getAnchor())
+ConcreteDeclRef
+Solution::resolveLocatorToDecl(ConstraintLocator *locator) const {
+  // Get the callee locator without looking through applies, ensuring we only
+  // return a decl for a direct reference.
+  auto *calleeLoc =
+      constraintSystem->getCalleeLocator(locator, /*lookThroughApply*/ false);
+  auto overload = getOverloadChoiceIfAvailable(calleeLoc);
+  if (!overload)
     return ConcreteDeclRef();
 
-  auto anchor = locator->getAnchor();
-  // Unwrap any specializations, constructor calls, implicit conversions, and
-  // '.'s.
-  // FIXME: This is brittle.
-  do {
-    if (auto specialize = dyn_cast<UnresolvedSpecializeExpr>(anchor)) {
-      anchor = specialize->getSubExpr();
-      continue;
-    }
-
-    if (auto implicit = dyn_cast<ImplicitConversionExpr>(anchor)) {
-      anchor = implicit->getSubExpr();
-      continue;
-    }
-
-    if (auto identity = dyn_cast<IdentityExpr>(anchor)) {
-      anchor = identity->getSubExpr();
-      continue;
-    }
-
-    if (auto tryExpr = dyn_cast<AnyTryExpr>(anchor)) {
-      if (isa<OptionalTryExpr>(tryExpr))
-        break;
-
-      anchor = tryExpr->getSubExpr();
-      continue;
-    }
-
-    if (auto selfApply = dyn_cast<SelfApplyExpr>(anchor)) {
-      anchor = selfApply->getFn();
-      continue;
-    }
-
-    if (auto dotSyntax = dyn_cast<DotSyntaxBaseIgnoredExpr>(anchor)) {
-      anchor = dotSyntax->getRHS();
-      continue;
-    }
-
-    if (auto *OEE = dyn_cast<OpenExistentialExpr>(anchor)) {
-      anchor = OEE->getSubExpr();
-      continue;
-    }
-
-    break;
-  } while (true);
-  
-  // Simple case: direct reference to a declaration.
-  if (auto dre = dyn_cast<DeclRefExpr>(anchor))
-    return dre->getDeclRef();
-    
-  // Simple case: direct reference to a declaration.
-  if (auto mre = dyn_cast<MemberRefExpr>(anchor))
-    return mre->getMember();
-  
-  if (auto ctorRef = dyn_cast<OtherConstructorDeclRefExpr>(anchor))
-    return ctorRef->getDeclRef();
-
-  if (isa<OverloadedDeclRefExpr>(anchor) ||
-      isa<UnresolvedDeclRefExpr>(anchor)) {
-    // Overloaded and unresolved cases: find the resolved overload.
-    auto anchorLocator = cs.getConstraintLocator(anchor);
-    if (auto selected = findOvlChoice(anchorLocator)) {
-      if (auto *decl = selected->choice.getDeclOrNull())
-        return getConcreteDeclRef(decl, selected->openedType, anchorLocator);
-    }
-  }
-  
-  if (isa<UnresolvedMemberExpr>(anchor)) {
-    // Unresolved member: find the resolved overload.
-    auto anchorLocator = cs.getConstraintLocator(anchor,
-                           ConstraintLocator::UnresolvedMember);
-    if (auto selected = findOvlChoice(anchorLocator)) {
-      if (auto *decl = selected->choice.getDeclOrNull())
-        return getConcreteDeclRef(decl, selected->openedType, anchorLocator);
-    }
-  }
-
-  if (isa<UnresolvedDotExpr>(anchor)) {
-    // Unresolved member: find the resolved overload.
-    auto anchorLocator = cs.getConstraintLocator(anchor,
-                                                 ConstraintLocator::Member);
-    if (auto selected = findOvlChoice(anchorLocator)) {
-      if (auto *decl = selected->choice.getDeclOrNull())
-        return getConcreteDeclRef(decl, selected->openedType, anchorLocator);
-    }
-  }
-
-  if (auto subscript = dyn_cast<SubscriptExpr>(anchor)) {
-    // Subscript expressions may have a declaration. If so, use it.
-    if (subscript->hasDecl())
-      return subscript->getDecl();
-
-    // Otherwise, find the resolved overload.
-    auto anchorLocator =
-      cs.getConstraintLocator(anchor, ConstraintLocator::SubscriptMember);
-    if (auto selected = findOvlChoice(anchorLocator)) {
-      if (auto *decl = selected->choice.getDeclOrNull())
-        return getConcreteDeclRef(decl, selected->openedType, anchorLocator);
-    }
-  }
-
-  if (auto subscript = dyn_cast<DynamicSubscriptExpr>(anchor)) {
-    // Dynamic subscripts are always resolved.
-    return subscript->getMember();
-  }
-
-  return ConcreteDeclRef();
-}
-
-ConcreteDeclRef Solution::resolveLocatorToDecl(
-                  ConstraintLocator *locator) const {
-  auto &cs = getConstraintSystem();
-
-  // Simplify the locator.
-  SourceRange range;
-  locator = simplifyLocator(cs, locator, range);
-
-  // If we didn't map down to a specific expression, we can't handle a default
-  // argument.
-  if (!locator->getAnchor() || !locator->getPath().empty())
-    return nullptr;
-
-  if (auto resolved
-        = ::resolveLocatorToDecl(cs, locator,
-            [&](ConstraintLocator *locator) -> Optional<SelectedOverload> {
-              auto known = overloadChoices.find(locator);
-              if (known == overloadChoices.end()) {
-                return None;
-              }
-
-              return known->second;
-            },
-            [&](ValueDecl *decl, Type openedType, ConstraintLocator *locator)
-                  -> ConcreteDeclRef {
-              SubstitutionMap subs =
-                computeSubstitutions(
-                  decl->getInnermostDeclContext()
-                      ->getGenericSignatureOfContext(),
-                locator);
-              return ConcreteDeclRef(decl, subs);
-            })) {
-    return resolved;
-  }
-
-  return ConcreteDeclRef();
-}
-
-/// Given a constraint locator, find the declaration reference
-/// to the callee, it is a call to a declaration.
-static ConcreteDeclRef
-findCalleeDeclRef(ConstraintSystem &cs, const Solution &solution,
-                  ConstraintLocator *locator) {
-  if (locator->getPath().empty() || !locator->getAnchor())
-    return nullptr;
-
-  // If the locator points to a function application, find the function itself.
-  if (locator->getPath().back().getKind() == ConstraintLocator::ApplyArgument) {
-    assert(locator->getPath().back().getNewSummaryFlags() == 0 &&
-           "ApplyArgument adds no flags");
-    SmallVector<LocatorPathElt, 4> newPath;
-    newPath.append(locator->getPath().begin(), locator->getPath().end()-1);
-
-    unsigned newFlags = locator->getSummaryFlags();
-    newPath.push_back(ConstraintLocator::ApplyFunction);
-
-    assert(newPath.back().getNewSummaryFlags() == 0 &&
-           "added element that changes the flags?");
-    locator = cs.getConstraintLocator(locator->getAnchor(), newPath, newFlags);
-  }
-
-  return solution.resolveLocatorToDecl(locator);
+  return resolveConcreteDeclRef(overload->choice.getDeclOrNull(), locator);
 }
 
 /// Produce the caller-side default argument for this default argument, or
@@ -5364,7 +5196,7 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
 }
 
 Expr *ExprRewriter::coerceCallArguments(
-    Expr *arg, AnyFunctionType *funcType,
+    Expr *arg, AnyFunctionType *funcType, ConcreteDeclRef callee,
     ApplyExpr *apply,
     ArrayRef<Identifier> argLabels,
     bool hasTrailingClosure,
@@ -5384,10 +5216,6 @@ Expr *ExprRewriter::coerceCallArguments(
       llvm::any_of(params, [](const AnyFunctionType::Param &param) {
         return param.getPlainType()->hasUnresolvedType();
       });
-
-  // Find the callee declaration.
-  ConcreteDeclRef callee =
-    findCalleeDeclRef(cs, solution, cs.getConstraintLocator(locator));
 
   // Determine whether this application has curried self.
   bool skipCurriedSelf = apply ? hasCurriedSelf(cs, callee, apply) : true;
@@ -6858,9 +6686,11 @@ static Expr *finishApplyCallAsFunctionMethod(
   declRef->setImplicit(apply->isImplicit());
   apply->setFn(declRef);
   // Coerce argument to input type of the `callAsFunction` method.
+  auto callee = rewriter.solution.resolveConcreteDeclRef(choice.getDecl(),
+                                                         applyFunctionLoc);
   SmallVector<Identifier, 2> argLabelsScratch;
   auto *arg = rewriter.coerceCallArguments(
-      apply->getArg(), openedMethodType, apply,
+      apply->getArg(), openedMethodType, callee, apply,
       apply->getArgumentLabels(argLabelsScratch), apply->hasTrailingClosure(),
       applyFunctionLoc);
   if (!arg)
@@ -6957,7 +6787,8 @@ ExprRewriter::finishApplyDynamicCallable(ApplyExpr *apply,
   return result;
 }
 
-Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
+Expr *ExprRewriter::finishApply(ApplyExpr *apply, ConcreteDeclRef callee,
+                                Type openedType,
                                 ConstraintLocatorBuilder locator) {
   TypeChecker &tc = cs.getTypeChecker();
   
@@ -6968,9 +6799,9 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
 
   auto finishApplyOfDeclWithSpecialTypeCheckingSemantics
     = [&](ApplyExpr *apply,
-          ValueDecl *decl,
+          ConcreteDeclRef declRef,
           Type openedType) -> Expr* {
-      switch (cs.TC.getDeclTypeCheckingSemantics(decl)) {
+      switch (cs.TC.getDeclTypeCheckingSemantics(declRef.getDecl())) {
       case DeclTypeCheckingSemantics::TypeOf: {
         // Resolve into a DynamicTypeExpr.
         auto arg = apply->getArg();
@@ -6978,7 +6809,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         SmallVector<Identifier, 2> argLabelsScratch;
 
         auto fnType = cs.getType(fn)->getAs<FunctionType>();
-        arg = coerceCallArguments(arg, fnType,
+        arg = coerceCallArguments(arg, fnType, declRef,
                                   apply,
                                   apply->getArgumentLabels(argLabelsScratch),
                                   hasTrailingClosure,
@@ -7128,7 +6959,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
       dyn_cast<DeclRefExpr>(getSemanticExprForDeclOrMemberRef(fn))) {
     if (auto special =
         finishApplyOfDeclWithSpecialTypeCheckingSemantics(apply,
-                                                          declRef->getDecl(),
+                                                          declRef->getDeclRef(),
                                                           openedType)) {
       return special;
     }
@@ -7173,7 +7004,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   SmallVector<Identifier, 2> argLabelsScratch;
   if (auto fnType = cs.getType(fn)->getAs<FunctionType>()) {
     auto origArg = apply->getArg();
-    Expr *arg = coerceCallArguments(origArg, fnType,
+    Expr *arg = coerceCallArguments(origArg, fnType, callee,
                                     apply,
                                     apply->getArgumentLabels(argLabelsScratch),
                                     hasTrailingClosure,
@@ -7250,6 +7081,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   // Consider the constructor decl reference expr 'implicit', but the
   // constructor call expr itself has the apply's 'implicitness'.
   bool isDynamic = choice.getKind() == OverloadChoiceKind::DeclViaDynamic;
+  auto ctorRef = solution.resolveConcreteDeclRef(choice.getDecl(), ctorLocator);
   Expr *declRef = buildMemberRef(fn, selected->openedFullType,
                                  /*dotLoc=*/SourceLoc(), choice,
                                  DeclNameLoc(fn->getEndLoc()),
@@ -7263,7 +7095,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   apply->setFn(declRef);
 
   // Tail-recur to actually call the constructor.
-  return finishApply(apply, openedType, locator);
+  return finishApply(apply, ctorRef, openedType, locator);
 }
 
 // Return the precedence-yielding parent of 'expr', along with the index of

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -697,13 +697,12 @@ public:
   /// \param locator The locator that describes where the substitutions came
   /// from.
   SubstitutionMap computeSubstitutions(GenericSignature sig,
-                                       ConstraintLocatorBuilder locator) const;
+                                       ConstraintLocator *locator) const;
 
   /// Resolves the contextual substitutions for a reference to a declaration
   /// at a given locator.
   ConcreteDeclRef
-  resolveConcreteDeclRef(ValueDecl *decl,
-                         ConstraintLocatorBuilder locator) const;
+  resolveConcreteDeclRef(ValueDecl *decl, ConstraintLocator *locator) const;
 
   /// Return the disjunction choice for the given constraint location.
   unsigned getDisjunctionChoice(ConstraintLocator *locator) const {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2050,7 +2050,13 @@ public:
   /// anchored on \c functionA(functionB()) with path elements pointing to the
   /// argument \c functionB(), the returned callee locator will describe
   /// \c functionA rather than \c functionB.
-  ConstraintLocator *getCalleeLocator(ConstraintLocator *locator);
+  ///
+  /// \param locator The input locator.
+  /// \param lookThroughApply Whether to look through applies. If false, a
+  /// callee locator will only be returned for a direct reference such as
+  /// \c x.foo rather than \c x.foo().
+  ConstraintLocator *getCalleeLocator(ConstraintLocator *locator,
+                                      bool lookThroughApply = true);
 
 public:
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -721,7 +721,8 @@ public:
   Type getFixedType(TypeVariableType *typeVar) const;
 
   /// Try to resolve the given locator to a declaration within this
-  /// solution.
+  /// solution. Note that this only returns a decl for a direct reference such
+  /// as \c x.foo and will not return a decl for \c x.foo().
   ConcreteDeclRef resolveLocatorToDecl(ConstraintLocator *locator) const;
 
   /// Retrieve the overload choice associated with the given

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -699,6 +699,12 @@ public:
   SubstitutionMap computeSubstitutions(GenericSignature sig,
                                        ConstraintLocatorBuilder locator) const;
 
+  /// Resolves the contextual substitutions for a reference to a declaration
+  /// at a given locator.
+  ConcreteDeclRef
+  resolveConcreteDeclRef(ValueDecl *decl,
+                         ConstraintLocatorBuilder locator) const;
+
   /// Return the disjunction choice for the given constraint location.
   unsigned getDisjunctionChoice(ConstraintLocator *locator) const {
     assert(DisjunctionChoices.count(locator));

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -389,3 +389,12 @@ func testAnyObjectAmbiguity(_ x: AnyObject) {
   // FIX-ME(SR-8611): This is currently ambiguous but shouldn't be.
   _ = x[unambiguousSubscript: ""] // expected-error {{ambiguous use of 'subscript(unambiguousSubscript:)'}}
 }
+
+// SR-11648
+class HasMethodWithDefault {
+  @objc func hasDefaultParam(_ x: Int = 0) {}
+}
+
+func testAnyObjectWithDefault(_ x: AnyObject) {
+  x.hasDefaultParam()
+}

--- a/test/IDE/complete_after_super.swift
+++ b/test/IDE/complete_after_super.swift
@@ -266,13 +266,13 @@ class SuperDerivedA : SuperBaseA {
   init (a: Float) {
     super.init#^CONSTRUCTOR_SUPER_INIT_1^#
 // CONSTRUCTOR_SUPER_INIT_1: Begin completions
-// CONSTRUCTOR_SUPER_INIT_1-DAG: Pattern/CurrModule: ()[#SuperBaseA#];
+// CONSTRUCTOR_SUPER_INIT_1-DAG: Decl[Constructor]/CurrNominal: ()[#SuperBaseA#]; name=()
 // CONSTRUCTOR_SUPER_INIT_1: End completions
   }
   init (b: Float) {
     super.init(#^CONSTRUCTOR_SUPER_INIT_PAREN_1^#
 // CONSTRUCTOR_SUPER_INIT_PAREN_1: Begin completions, 1 items
-// CONSTRUCTOR_SUPER_INIT_PAREN_1: Pattern/CurrModule: ['('][')'][#SuperBaseA#]; name=
+// CONSTRUCTOR_SUPER_INIT_PAREN_1: Decl[Constructor]/CurrNominal: ['('][')'][#SuperBaseA#]; name=
 // CONSTRUCTOR_SUPER_INIT_PAREN_1: End completions
   }
 

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -14,6 +14,8 @@ class X {
     }
     set {}
   }
+
+  @objc func hasDefaultParam(_ x: Int = 0) {}
 }
 
 @objc protocol P {
@@ -356,3 +358,13 @@ func getIUOPropertyDynamically(x: AnyObject) -> Any {
   return x.iuoProperty
 }
 
+// SR-11648
+// CHECK-LABEL: sil hidden [ossa] @$s14dynamic_lookup24testAnyObjectWithDefaultyyyXlF
+func testAnyObjectWithDefault(_ x: AnyObject) {
+  // CHECK: function_ref default argument 0 of X.hasDefaultParam(_:)
+  // CHECK: [[DEFGEN:%[0-9]+]] = function_ref @$s14dynamic_lookup1XC15hasDefaultParamyySiFfA_ : $@convention(thin) () -> Int
+  // CHECK: [[DEFARG:%[0-9]+]] = apply %4() : $@convention(thin) () -> Int
+  // CHECK: [[METHOD:%[0-9]+]] = objc_method [[OPENEDX:%[0-9]+]] : $@opened("{{.*}}") AnyObject, #X.hasDefaultParam!1.foreign : (X) -> (Int) -> (), $@convention(objc_method) (Int, @opened("{{.*}}") AnyObject) -> ()
+  // CHECK: apply [[METHOD]]([[DEFARG]], [[OPENEDX]])
+  x.hasDefaultParam()
+}


### PR DESCRIPTION
Rather than attempting to pull out a concrete callee reference from the rewritten function expression, this PR changes the logic such that we retrieve the callee from the solution using a callee locator computed before the apply is rewritten, and then pass this callee down through `finishApply` and `coerceCallArguments`.

Resolves SR-11648.