### PR TITLE
Many Things Don't Need a TypeChecker

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1813,15 +1813,13 @@ AssignmentFailure::getMemberRef(ConstraintLocator *locator) const {
     return member->choice;
 
   auto *DC = getDC();
-  auto &TC = getTypeChecker();
-
   auto *decl = member->choice.getDecl();
   if (isa<SubscriptDecl>(decl) &&
-      isValidDynamicMemberLookupSubscript(cast<SubscriptDecl>(decl), DC, TC)) {
+      isValidDynamicMemberLookupSubscript(cast<SubscriptDecl>(decl), DC)) {
     auto *subscript = cast<SubscriptDecl>(decl);
     // If this is a keypath dynamic member lookup, we have to
     // adjust the locator to find member referred by it.
-    if (isValidKeyPathDynamicMemberLookup(subscript, TC)) {
+    if (isValidKeyPathDynamicMemberLookup(subscript)) {
       auto &cs = getConstraintSystem();
       // Type has a following format:
       // `(Self) -> (dynamicMember: {Writable}KeyPath<T, U>) -> U`

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5218,7 +5218,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       if (memberLocator &&
           ::hasDynamicMemberLookupAttribute(instanceTy,
                                             DynamicMemberLookupCache) &&
-          isValidKeyPathDynamicMemberLookup(subscript, TC)) {
+          isValidKeyPathDynamicMemberLookup(subscript)) {
         auto info = getArgumentInfo(memberLocator);
 
         if (!(info && info->Labels.size() == 1 &&
@@ -5324,9 +5324,9 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       auto name = memberName.getBaseIdentifier();
       for (const auto &candidate : subscripts.ViableCandidates) {
         auto *SD = cast<SubscriptDecl>(candidate.getDecl());
-        bool isKeyPathBased = isValidKeyPathDynamicMemberLookup(SD, TC);
+        bool isKeyPathBased = isValidKeyPathDynamicMemberLookup(SD);
 
-        if (isValidStringDynamicMemberLookup(SD, DC, TC) || isKeyPathBased)
+        if (isValidStringDynamicMemberLookup(SD, DC) || isKeyPathBased)
           result.addViable(OverloadChoice::getDynamicMemberLookup(
               baseTy, SD, name, isKeyPathBased));
       }
@@ -5335,7 +5335,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
         auto *SD =
             cast<SubscriptDecl>(subscripts.UnviableCandidates[index].getDecl());
         auto choice = OverloadChoice::getDynamicMemberLookup(
-            baseTy, SD, name, isValidKeyPathDynamicMemberLookup(SD, TC));
+            baseTy, SD, name, isValidKeyPathDynamicMemberLookup(SD));
         result.addUnviable(choice, subscripts.UnviableReasons[index]);
       }
     }
@@ -7094,7 +7094,7 @@ lookupDynamicCallableMethods(Type type, ConstraintSystem &CS,
   auto candidates = matches.ViableCandidates;
   auto filter = [&](OverloadChoice choice) {
     auto cand = cast<FuncDecl>(choice.getDecl());
-    return !isValidDynamicCallableMethod(cand, decl, CS.TC, hasKeywordArgs);
+    return !isValidDynamicCallableMethod(cand, decl, hasKeywordArgs);
   };
   candidates.erase(
       std::remove_if(candidates.begin(), candidates.end(), filter),

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -833,7 +833,7 @@ static bool areAllStoredPropertiesDefaultInitializable(NominalTypeDecl *decl) {
   return true;
 }
 
-static void addImplicitConstructorsToStruct(StructDecl *decl, ASTContext &ctx) {
+static void addImplicitConstructorsToStruct(StructDecl *decl) {
   assert(!decl->hasClangNode() &&
          "ClangImporter is responsible for adding implicit constructors");
   assert(!decl->hasUnreferenceableStorage() &&
@@ -884,6 +884,7 @@ static void addImplicitConstructorsToStruct(StructDecl *decl, ASTContext &ctx) {
 
   if (FoundMemberwiseInitializedProperty) {
     // Create the implicit memberwise constructor.
+    auto &ctx = decl->getASTContext();
     auto ctor = createImplicitConstructor(
         decl, ImplicitConstructorKind::Memberwise, ctx);
     decl->addMember(ctor);
@@ -893,7 +894,7 @@ static void addImplicitConstructorsToStruct(StructDecl *decl, ASTContext &ctx) {
     TypeChecker::defineDefaultConstructor(decl);
 }
 
-static void addImplicitConstructorsToClass(ClassDecl *decl, ASTContext &ctx) {
+static void addImplicitConstructorsToClass(ClassDecl *decl) {
   // Bail out if we're validating one of our constructors already;
   // we'll revisit the issue later.
   if (!decl->hasClangNode()) {
@@ -911,6 +912,7 @@ static void addImplicitConstructorsToClass(ClassDecl *decl, ASTContext &ctx) {
   // variable.
   bool FoundDesignatedInit = false;
 
+  auto &ctx = decl->getASTContext();
   SmallVector<std::pair<ValueDecl *, Type>, 4> declaredInitializers;
   llvm::SmallPtrSet<ConstructorDecl *, 4> overriddenInits;
   if (decl->hasClangNode()) {
@@ -1104,9 +1106,9 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   }
 
   if (auto *structDecl = dyn_cast<StructDecl>(decl))
-    addImplicitConstructorsToStruct(structDecl, Context);
+    addImplicitConstructorsToStruct(structDecl);
   if (auto *classDecl = dyn_cast<ClassDecl>(decl))
-    addImplicitConstructorsToClass(classDecl, Context);
+    addImplicitConstructorsToClass(classDecl);
 }
 
 void TypeChecker::synthesizeMemberForLookup(NominalTypeDecl *target,

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -114,9 +114,7 @@ TypeRelationCheckRequest::evaluate(Evaluator &evaluator,
 llvm::Expected<TypePair>
 RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(Evaluator &evaluator,
                                               SubscriptDecl *subscript) const {
-  auto &TC = TypeChecker::createForContext(subscript->getASTContext());
-
-  if (!isValidKeyPathDynamicMemberLookup(subscript, TC))
+  if (!isValidKeyPathDynamicMemberLookup(subscript))
     return TypePair();
 
   const auto *param = subscript->getIndices()->get(0);

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -321,7 +321,7 @@ public:
 
         if (NB != B) {
           FD->setBody(NB);
-          TypeChecker::createForContext(Context).checkFunctionErrorHandling(FD);
+          TypeChecker::checkFunctionErrorHandling(FD);
         }
       }
     } else if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
@@ -691,9 +691,8 @@ void swift::performPCMacro(SourceFile &SF, TopLevelContext &TLC) {
             BraceStmt *NewBody = I.transformBraceStmt(Body, true);
             if (NewBody != Body) {
               TLCD->setBody(NewBody);
-              TypeChecker &TC = TypeChecker::createForContext(ctx);
-              TC.checkTopLevelErrorHandling(TLCD);
-              TC.contextualizeTopLevelCode(TLC, TLCD);
+              TypeChecker::checkTopLevelErrorHandling(TLCD);
+              TypeChecker::contextualizeTopLevelCode(TLC, TLCD);
             }
             return false;
           }

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -279,7 +279,7 @@ public:
         BraceStmt *NB = transformBraceStmt(B);
         if (NB != B) {
           FD->setBody(NB);
-          TypeChecker::createForContext(Context).checkFunctionErrorHandling(FD);
+          TypeChecker::checkFunctionErrorHandling(FD);
         }
       }
     } else if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
@@ -903,7 +903,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
             BraceStmt *NewBody = I.transformBraceStmt(Body);
             if (NewBody != Body) {
               FD->setBody(NewBody);
-              TypeChecker::createForContext(ctx).checkFunctionErrorHandling(FD);
+              TypeChecker::checkFunctionErrorHandling(FD);
             }
             return false;
           }
@@ -915,8 +915,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
             BraceStmt *NewBody = I.transformBraceStmt(Body, true);
             if (NewBody != Body) {
               TLCD->setBody(NewBody);
-              TypeChecker::createForContext(ctx)
-                .checkTopLevelErrorHandling(TLCD);
+              TypeChecker::checkTopLevelErrorHandling(TLCD);
             }
             return false;
           }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2783,7 +2783,7 @@ public:
     // Force lowering of stored properties.
     (void) SD->getStoredProperties();
 
-    TC.addImplicitConstructors(SD);
+    TypeChecker::addImplicitConstructors(SD);
 
     for (Decl *Member : SD->getMembers())
       visit(Member);
@@ -4408,7 +4408,7 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
 
   // We need to add implicit initializers because they
   // affect vtable layout.
-  TC.addImplicitConstructors(CD);
+  TypeChecker::addImplicitConstructors(CD);
 
   auto forceConformance = [&](ProtocolDecl *protocol) {
     if (auto ref = TypeChecker::conformsToProtocol(

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1643,7 +1643,7 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
       Expr *exprToCheck = prevValue;
       if (TC->typeCheckExpression(exprToCheck, ED, TypeLoc::withoutLoc(rawTy),
                                   CTP_EnumCaseRawValue)) {
-        TC->checkEnumElementErrorHandling(elt, exprToCheck);
+        TypeChecker::checkEnumElementErrorHandling(elt, exprToCheck);
       }
     }
 
@@ -1999,7 +1999,7 @@ static void checkDefaultArguments(TypeChecker &tc, ParameterList *params) {
       param->setDefaultValue(e);
     }
 
-    tc.checkInitializerErrorHandling(initContext, e);
+    TypeChecker::checkInitializerErrorHandling(initContext, e);
 
     // Walk the checked initializer and contextualize any closures
     // we saw there.
@@ -2564,7 +2564,7 @@ public:
               PBD->getInitContext(i));
           if (initContext) {
             // Check safety of error-handling in the declaration, too.
-            TC.checkInitializerErrorHandling(initContext, init);
+            TypeChecker::checkInitializerErrorHandling(initContext, init);
             (void) TC.contextualizeInitializer(initContext, init);
           }
         }

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -978,13 +978,14 @@ public:
     return InterpolatedString;
   }
 
-  static void diagnoseThrowInIllegalContext(TypeChecker &TC, ASTNode node,
+  static void diagnoseThrowInIllegalContext(DiagnosticEngine &Diags,
+                                            ASTNode node,
                                             StringRef description,
                                             bool throwInDefer = false) {
     if (auto *e = node.dyn_cast<Expr*>())
       if (isa<ApplyExpr>(e)) {
-        TC.diagnose(e->getLoc(), diag::throwing_call_in_illegal_context,
-                    description);
+        Diags.diagnose(e->getLoc(), diag::throwing_call_in_illegal_context,
+                       description);
         return;
       }
 
@@ -993,11 +994,11 @@ public:
       return;
     }
 
-    TC.diagnose(node.getStartLoc(), diag::throw_in_illegal_context,
-                description);
+    Diags.diagnose(node.getStartLoc(), diag::throw_in_illegal_context,
+                   description);
   }
 
-  static void maybeAddRethrowsNote(TypeChecker &TC, SourceLoc loc,
+  static void maybeAddRethrowsNote(DiagnosticEngine &Diags, SourceLoc loc,
                                    const PotentialReason &reason) {
     switch (reason.getKind()) {
     case PotentialReason::Kind::Throw:
@@ -1006,18 +1007,19 @@ public:
       // Already fully diagnosed.
       return;
     case PotentialReason::Kind::CallRethrowsWithExplicitThrowingArgument:
-      TC.diagnose(reason.getThrowingArgument()->getLoc(),
-                  diag::because_rethrows_argument_throws);
+      Diags.diagnose(reason.getThrowingArgument()->getLoc(),
+                     diag::because_rethrows_argument_throws);
       return;
     case PotentialReason::Kind::CallRethrowsWithDefaultThrowingArgument:
-      TC.diagnose(loc, diag::because_rethrows_default_argument_throws);
+      Diags.diagnose(loc, diag::because_rethrows_default_argument_throws);
       return;
     }
     llvm_unreachable("bad reason kind");
   }
 
-  void diagnoseUncoveredThrowSite(TypeChecker &TC, ASTNode E,
+  void diagnoseUncoveredThrowSite(ASTContext &ctx, ASTNode E,
                                   const PotentialReason &reason) {
+    auto &Diags = ctx.Diags;
     auto message = diag::throwing_call_without_try;
     auto loc = E.getStartLoc();
     SourceLoc insertLoc;
@@ -1036,14 +1038,14 @@ public:
       if (InterpolatedString &&
           e->getCalledValue() &&
           e->getCalledValue()->getBaseName() ==
-          TC.Context.Id_appendInterpolation) {
+          ctx.Id_appendInterpolation) {
         message = diag::throwing_interpolation_without_try;
         insertLoc = InterpolatedString->getLoc();
       }
     }
     
-    TC.diagnose(loc, message).highlight(highlight);
-    maybeAddRethrowsNote(TC, loc, reason);
+    Diags.diagnose(loc, message).highlight(highlight);
+    maybeAddRethrowsNote(Diags, loc, reason);
 
     // If this is a call without expected 'try[?|!]', like this:
     //
@@ -1055,15 +1057,15 @@ public:
     if (reason.getKind() != PotentialReason::Kind::CallThrows)
       return;
 
-    TC.diagnose(loc, diag::note_forgot_try)
+    Diags.diagnose(loc, diag::note_forgot_try)
         .fixItInsert(insertLoc, "try ");
-    TC.diagnose(loc, diag::note_error_to_optional)
+    Diags.diagnose(loc, diag::note_error_to_optional)
         .fixItInsert(insertLoc, "try? ");
-    TC.diagnose(loc, diag::note_disable_error_propagation)
+    Diags.diagnose(loc, diag::note_disable_error_propagation)
         .fixItInsert(insertLoc, "try! ");
   }
 
-  void diagnoseThrowInLegalContext(TypeChecker &TC, ASTNode node,
+  void diagnoseThrowInLegalContext(DiagnosticEngine &Diags, ASTNode node,
                                    bool isTryCovered,
                                    const PotentialReason &reason,
                                    Diag<> diagForThrow,
@@ -1071,7 +1073,7 @@ public:
                                    Diag<> diagForTrylessThrowingCall) {
     auto loc = node.getStartLoc();
     if (reason.isThrow()) {
-      TC.diagnose(loc, diagForThrow);
+      Diags.diagnose(loc, diagForThrow);
       return;
     }
 
@@ -1085,14 +1087,15 @@ public:
     }
 
     if (isTryCovered) {
-      TC.diagnose(loc, diagForThrowingCall);
+      Diags.diagnose(loc, diagForThrowingCall);
     } else {
-      TC.diagnose(loc, diagForTrylessThrowingCall);
+      Diags.diagnose(loc, diagForTrylessThrowingCall);
     }
-    maybeAddRethrowsNote(TC, loc, reason);
+    maybeAddRethrowsNote(Diags, loc, reason);
   }
 
-  void diagnoseUnhandledThrowSite(TypeChecker &TC, ASTNode E, bool isTryCovered,
+  void diagnoseUnhandledThrowSite(DiagnosticEngine &Diags, ASTNode E,
+                                  bool isTryCovered,
                                   const PotentialReason &reason) {
     switch (getKind()) {
     case Kind::Handled:
@@ -1103,64 +1106,64 @@ public:
     // notes for the throw sites.
 
     case Kind::RethrowingFunction:
-      diagnoseThrowInLegalContext(TC, E, isTryCovered, reason,
+      diagnoseThrowInLegalContext(Diags, E, isTryCovered, reason,
                                   diag::throw_in_rethrows_function,
                                   diag::throwing_call_in_rethrows_function,
                           diag::tryless_throwing_call_in_rethrows_function);
       return;
 
     case Kind::NonThrowingFunction:
-      diagnoseThrowInLegalContext(TC, E, isTryCovered, reason,
+      diagnoseThrowInLegalContext(Diags, E, isTryCovered, reason,
                                   diag::throw_in_nonthrowing_function,
                                   diag::throwing_call_unhandled,
                                   diag::tryless_throwing_call_unhandled);
       return;
 
     case Kind::NonThrowingAutoClosure:
-      diagnoseThrowInLegalContext(TC, E, isTryCovered, reason,
+      diagnoseThrowInLegalContext(Diags, E, isTryCovered, reason,
                                   diag::throw_in_nonthrowing_autoclosure,
                             diag::throwing_call_in_nonthrowing_autoclosure,
                     diag::tryless_throwing_call_in_nonthrowing_autoclosure);
       return;
 
     case Kind::NonExhaustiveCatch:
-      diagnoseThrowInLegalContext(TC, E, isTryCovered, reason,
+      diagnoseThrowInLegalContext(Diags, E, isTryCovered, reason,
                                   diag::throw_in_nonexhaustive_catch,
                                   diag::throwing_call_in_nonexhaustive_catch,
                           diag::tryless_throwing_call_in_nonexhaustive_catch);
       return;
 
     case Kind::EnumElementInitializer:
-      diagnoseThrowInIllegalContext(TC, E, "an enum case raw value");
+      diagnoseThrowInIllegalContext(Diags, E, "an enum case raw value");
       return;
 
     case Kind::GlobalVarInitializer:
-      diagnoseThrowInIllegalContext(TC, E, "a global variable initializer");
+      diagnoseThrowInIllegalContext(Diags, E, "a global variable initializer");
       return;
 
     case Kind::IVarInitializer:
-      diagnoseThrowInIllegalContext(TC, E, "a property initializer");
+      diagnoseThrowInIllegalContext(Diags, E, "a property initializer");
       return;
 
     case Kind::DefaultArgument:
-      diagnoseThrowInIllegalContext(TC, E, "a default argument");
+      diagnoseThrowInIllegalContext(Diags, E, "a default argument");
       return;
 
     case Kind::CatchPattern:
-      diagnoseThrowInIllegalContext(TC, E, "a catch pattern");
+      diagnoseThrowInIllegalContext(Diags, E, "a catch pattern");
       return;
 
     case Kind::CatchGuard:
-      diagnoseThrowInIllegalContext(TC, E, "a catch guard expression");
+      diagnoseThrowInIllegalContext(Diags, E, "a catch guard expression");
       return;
     case Kind::DeferBody:
-      diagnoseThrowInIllegalContext(TC, E, "a defer body", isInDefer);
+      diagnoseThrowInIllegalContext(Diags, E, "a defer body", isInDefer);
       return;
     }
     llvm_unreachable("bad context kind");
   }
 
-  void diagnoseUnhandledTry(TypeChecker &TC, TryExpr *E) {
+  void diagnoseUnhandledTry(DiagnosticEngine &Diags, TryExpr *E) {
     switch (getKind()) {
     case Kind::Handled:
     case Kind::RethrowingFunction:
@@ -1168,12 +1171,13 @@ public:
 
     case Kind::NonThrowingFunction:
       if (DiagnoseErrorOnTry)
-        TC.diagnose(E->getTryLoc(), diag::try_unhandled);
+        Diags.diagnose(E->getTryLoc(), diag::try_unhandled);
       return;
 
     case Kind::NonExhaustiveCatch:
       if (DiagnoseErrorOnTry)
-        TC.diagnose(E->getTryLoc(), diag::try_unhandled_in_nonexhaustive_catch);
+        Diags.diagnose(E->getTryLoc(),
+                       diag::try_unhandled_in_nonexhaustive_catch);
       return;
 
     case Kind::NonThrowingAutoClosure:
@@ -1197,7 +1201,7 @@ public:
 class CheckErrorCoverage : public ErrorHandlingWalker<CheckErrorCoverage> {
   friend class ErrorHandlingWalker<CheckErrorCoverage>;
 
-  TypeChecker &TC;
+  ASTContext &Ctx;
 
   ApplyClassifier Classifier;
 
@@ -1334,8 +1338,8 @@ class CheckErrorCoverage : public ErrorHandlingWalker<CheckErrorCoverage> {
   };
 
 public:
-  CheckErrorCoverage(TypeChecker &tc, Context initialContext)
-    : TC(tc), CurContext(initialContext),
+  CheckErrorCoverage(ASTContext &ctx, Context initialContext)
+    : Ctx(ctx), CurContext(initialContext),
       MaxThrowingKind(ThrowingKind::None) {
 
     if (auto rethrowsDC = initialContext.getRethrowsDC()) {
@@ -1413,8 +1417,8 @@ private:
     // implicit do/catch in a debugger function.
     if (!Flags.has(ContextFlags::HasAnyThrowSite) &&
         !scope.wasTopLevelDebuggerFunction()) {
-      TC.diagnose(S->getCatches().front()->getCatchLoc(),
-                  diag::no_throw_in_do_with_catch);
+      Ctx.Diags.diagnose(S->getCatches().front()->getCatchLoc(),
+                         diag::no_throw_in_do_with_catch);
     }
   }
 
@@ -1548,10 +1552,10 @@ private:
       bool isTryCovered =
         (!requiresTry || Flags.has(ContextFlags::IsTryCovered));
       if (!CurContext.handles(classification.getResult())) {
-        CurContext.diagnoseUnhandledThrowSite(TC, E, isTryCovered,
+        CurContext.diagnoseUnhandledThrowSite(Ctx.Diags, E, isTryCovered,
                                               classification.getThrowsReason());
       } else if (!isTryCovered) {
-        CurContext.diagnoseUncoveredThrowSite(TC, E,
+        CurContext.diagnoseUncoveredThrowSite(Ctx, E,
                                               classification.getThrowsReason());
       }
       return;
@@ -1569,12 +1573,12 @@ private:
     // Warn about 'try' expressions that weren't actually needed.
     if (!Flags.has(ContextFlags::HasTryThrowSite)) {
       if (!E->isImplicit())
-        TC.diagnose(E->getTryLoc(), diag::no_throw_in_try);
+        Ctx.Diags.diagnose(E->getTryLoc(), diag::no_throw_in_try);
 
     // Diagnose all the call sites within a single unhandled 'try'
     // at the same time.
     } else if (CurContext.handlesNothing()) {
-      CurContext.diagnoseUnhandledTry(TC, E);
+      CurContext.diagnoseUnhandledTry(Ctx.Diags, E);
     }
 
     scope.preserveCoverageFromTryOperand();
@@ -1590,7 +1594,7 @@ private:
 
     // Warn about 'try' expressions that weren't actually needed.
     if (!Flags.has(ContextFlags::HasTryThrowSite)) {
-      TC.diagnose(E->getLoc(), diag::no_throw_in_try);
+      Ctx.Diags.diagnose(E->getLoc(), diag::no_throw_in_try);
     }
     return ShouldNotRecurse;
   }
@@ -1604,7 +1608,7 @@ private:
 
     // Warn about 'try' expressions that weren't actually needed.
     if (!Flags.has(ContextFlags::HasTryThrowSite)) {
-      TC.diagnose(E->getLoc(), diag::no_throw_in_try);
+      Ctx.Diags.diagnose(E->getLoc(), diag::no_throw_in_try);
     }
     return ShouldNotRecurse;
   }
@@ -1613,10 +1617,11 @@ private:
 } // end anonymous namespace
 
 void TypeChecker::checkTopLevelErrorHandling(TopLevelCodeDecl *code) {
-  CheckErrorCoverage checker(*this, Context::forTopLevelCode(code));
+  auto &ctx = code->getDeclContext()->getASTContext();
+  CheckErrorCoverage checker(ctx, Context::forTopLevelCode(code));
 
   // In some language modes, we allow top-level code to omit 'try' marking.
-  if (Context.LangOpts.EnableThrowWithoutTry)
+  if (ctx.LangOpts.EnableThrowWithoutTry)
     checker.setTopLevelThrowWithoutTry();
 
   code->getBody()->walk(checker);
@@ -1634,7 +1639,8 @@ void TypeChecker::checkFunctionErrorHandling(AbstractFunctionDecl *fn) {
   auto isDeferBody = isa<FuncDecl>(fn) && cast<FuncDecl>(fn)->isDeferBody();
   auto context =
       isDeferBody ? Context::forDeferBody() : Context::forFunction(fn);
-  CheckErrorCoverage checker(*this, context);
+  auto &ctx = fn->getASTContext();
+  CheckErrorCoverage checker(ctx, context);
 
   // If this is a debugger function, suppress 'try' marking at the top level.
   if (fn->getAttrs().hasAttribute<LLDBDebuggerFunctionAttr>())
@@ -1650,7 +1656,8 @@ void TypeChecker::checkFunctionErrorHandling(AbstractFunctionDecl *fn) {
 
 void TypeChecker::checkInitializerErrorHandling(Initializer *initCtx,
                                                 Expr *init) {
-  CheckErrorCoverage checker(*this, Context::forInitializer(initCtx));
+  auto &ctx = initCtx->getASTContext();
+  CheckErrorCoverage checker(ctx, Context::forInitializer(initCtx));
   init->walk(checker);
 }
 
@@ -1663,12 +1670,14 @@ void TypeChecker::checkInitializerErrorHandling(Initializer *initCtx,
 /// perhaps accidentally, and (2) allows the verifier to assert that
 /// all calls have been checked.
 void TypeChecker::checkEnumElementErrorHandling(EnumElementDecl *elt, Expr *E) {
-  CheckErrorCoverage checker(*this, Context::forEnumElementInitializer(elt));
+  auto &ctx = elt->getASTContext();
+  CheckErrorCoverage checker(ctx, Context::forEnumElementInitializer(elt));
   E->walk(checker);
 }
 
 void TypeChecker::checkPropertyWrapperErrorHandling(
     PatternBindingDecl *binding, Expr *expr) {
-  CheckErrorCoverage checker(*this, Context::forPatternBinding(binding));
+  auto &ctx = binding->getASTContext();
+  CheckErrorCoverage checker(ctx, Context::forPatternBinding(binding));
   expr->walk(checker);
 }

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -280,7 +280,7 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
   auto *BS = BraceStmt::create(Context, Loc, ASTNode(TheCall),
                                EndLoc);
   newTopLevel->setBody(BS);
-  TC.checkTopLevelErrorHandling(newTopLevel);
+  TypeChecker::checkTopLevelErrorHandling(newTopLevel);
 
   SF.Decls.push_back(newTopLevel);
 }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2222,7 +2222,7 @@ static void typeCheckSynthesizedWrapperInitializer(
           dyn_cast_or_null<Initializer>(pbd->getInitContext(i))) {
     tc.contextualizeInitializer(initializerContext, initializer);
   }
-  tc.checkPropertyWrapperErrorHandling(pbd, initializer);
+  TypeChecker::checkPropertyWrapperErrorHandling(pbd, initializer);
 }
 
 static PropertyWrapperMutability::Value

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -615,7 +615,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
 GenericEnvironment *
 swift::handleSILGenericParams(ASTContext &Ctx, GenericParamList *genericParams,
                               DeclContext *DC) {
-  return createTypeChecker(Ctx).handleSILGenericParams(genericParams, DC);
+  return TypeChecker::handleSILGenericParams(genericParams, DC);
 }
 
 void swift::typeCheckPatternBinding(PatternBindingDecl *PBD,

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -209,7 +209,7 @@ Type TypeChecker::getObjectLiteralParameterType(ObjectLiteralExpr *expr,
 }
 
 ModuleDecl *TypeChecker::getStdlibModule(const DeclContext *dc) {
-  if (auto *stdlib = Context.getStdlibModule()) {
+  if (auto *stdlib = dc->getASTContext().getStdlibModule()) {
     return stdlib;
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1112,7 +1112,7 @@ public:
   ///
   /// Add any implicitly-defined constructors required for the given
   /// struct or class.
-  void addImplicitConstructors(NominalTypeDecl *typeDecl);
+  static void addImplicitConstructors(NominalTypeDecl *typeDecl);
 
   /// Synthesize the member with the given name on the target if applicable,
   /// i.e. if the member is synthesizable and has not yet been added to the

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -795,8 +795,8 @@ public:
   void checkUnsupportedProtocolType(GenericParamList *genericParams);
 
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-  GenericEnvironment *handleSILGenericParams(GenericParamList *genericParams,
-                                             DeclContext *DC);
+  static GenericEnvironment *
+  handleSILGenericParams(GenericParamList *genericParams, DeclContext *DC);
 
   /// Resolve a reference to the given type declaration within a particular
   /// context.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1976,13 +1976,12 @@ public:
 /// as one of the following: `dynamicallyCall(withArguments:)` or
 /// `dynamicallyCall(withKeywordArguments:)`.
 bool isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
-                                  TypeChecker &TC, bool hasKeywordArguments);
+                                  bool hasKeywordArguments);
 
 /// Returns true if the given subscript method is an valid implementation of
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)`.
 bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl, DeclContext *DC,
-                                         TypeChecker &TC,
                                          bool ignoreLabel = false);
 
 /// Returns true if the given subscript method is an valid implementation of
@@ -1991,7 +1990,6 @@ bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl, DeclContext *DC,
 /// takes a single non-variadic parameter that conforms to
 /// `ExpressibleByStringLiteral` protocol.
 bool isValidStringDynamicMemberLookup(SubscriptDecl *decl, DeclContext *DC,
-                                      TypeChecker &TC,
                                       bool ignoreLabel = false);
 
 /// Returns true if the given subscript method is an valid implementation of
@@ -1999,7 +1997,7 @@ bool isValidStringDynamicMemberLookup(SubscriptDecl *decl, DeclContext *DC,
 /// @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)` which
 /// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
-bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl, TypeChecker &TC,
+bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
                                        bool ignoreLabel = false);
 
 /// Compute the wrapped value type for the given property that has attached

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1878,12 +1878,12 @@ public:
   static void checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name);
 
   /// Check error handling in the given type-checked top-level code.
-  void checkTopLevelErrorHandling(TopLevelCodeDecl *D);
-  void checkFunctionErrorHandling(AbstractFunctionDecl *D);
-  void checkInitializerErrorHandling(Initializer *I, Expr *E);
-  void checkEnumElementErrorHandling(EnumElementDecl *D, Expr *expr);
-  void checkPropertyWrapperErrorHandling(PatternBindingDecl *binding,
-                                          Expr *expr);
+  static void checkTopLevelErrorHandling(TopLevelCodeDecl *D);
+  static void checkFunctionErrorHandling(AbstractFunctionDecl *D);
+  static void checkInitializerErrorHandling(Initializer *I, Expr *E);
+  static void checkEnumElementErrorHandling(EnumElementDecl *D, Expr *expr);
+  static void checkPropertyWrapperErrorHandling(PatternBindingDecl *binding,
+                                                Expr *expr);
 
   void addExprForDiagnosis(Expr *E1, Expr *Result) {
     DiagnosedExprs[E1] = Result;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1702,7 +1702,7 @@ public:
   ///
   /// This is "Swift", if that module is imported, or the current module if
   /// we're parsing the standard library.
-  ModuleDecl *getStdlibModule(const DeclContext *dc);
+  static ModuleDecl *getStdlibModule(const DeclContext *dc);
 
   /// \name Lazy resolution.
   ///


### PR DESCRIPTION
This PR removes `TypeChecker` parameters from a bunch of things that don't need it and makes a few `TypeChecker` members static.