### PR TITLE
Sema: Fix substitutions of generic caller-side default arguments

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4980,8 +4980,8 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
   }
 
   // Convert the literal to the appropriate type.
-  auto defArgType = owner.getDecl()->getDeclContext()->mapTypeIntoContext(
-      param->getInterfaceType());
+  auto defArgType =
+      param->getInterfaceType().subst(owner.getSubstitutions());
   auto resultTy =
       tc.typeCheckParameterDefault(init, dc, defArgType,
                                    /*isAutoClosure=*/param->isAutoClosure(),

--- a/test/SILGen/stored_property_default_arg.swift
+++ b/test/SILGen/stored_property_default_arg.swift
@@ -206,3 +206,19 @@ func checkReferenceTuple() {
 // CHECK-NEXT: [[AA1:%.*]] = apply [[AA1_REF]]([[ELT0]], [[ELT1]], {{.*}}) : $@convention(method) (@owned Optional<Z>, @owned Optional<Z>, @thin AA.Type) -> @owned AA
   let ae = AA.init(ab:)()
 }
+
+struct OptionalGeneric<T> {
+  var t: T?
+  var x: Int
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s27stored_property_default_arg31checkDefaultInitGenericOptionalyyF : $@convention(thin) () -> () {
+func checkDefaultInitGenericOptional() {
+  let og = OptionalGeneric<Int>(x: 0)
+
+  // CHECK: [[VALUE:%.*]] = enum $Optional<Int>, #Optional.none!enumelt
+  // CHECK: [[NIL:%.*]] = alloc_stack $Optional<Int>
+  // CHECK: store [[VALUE]] to [trivial] [[NIL]] : $*Optional<Int>
+  // CHECK: [[FN:%.*]] =  function_ref @$s27stored_property_default_arg15OptionalGenericV1t1xACyxGxSg_SitcfC : $@convention(method) <τ_0_0> (@in Optional<τ_0_0>, Int, @thin OptionalGeneric<τ_0_0>.Type) -> @out OptionalGeneric<τ_0_0>
+  // CHECK: apply [[FN]]<Int>(%0, [[NIL]], {{%.*}}, %1)
+}


### PR DESCRIPTION
Using mapTypeIntoContext() is incorrect here, because we might not
be calling the default argument from the callee's context. Instead,
use the substitutions from the ConcreteDeclRef.

Fixes <rdar://problem/55739617>.