### PR TITLE
[build-script] Don't build stdlib for iOS if --skip-build-ios is passed

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -133,6 +133,40 @@ class BuildScriptInvocation(object):
                 "a toolchain (%s)" % ", ".join(targets_needing_toolchain))
 
     @staticmethod
+    def default_stdlib_deployment_targets(args):
+        """
+        Return targets for the Swift stdlib, based on the build machine.
+        If the build machine is not one of the recognized ones, return None.
+        """
+
+        host_target = StdlibDeploymentTarget.host_target()
+        if host_target is None:
+            return None
+
+        # OS X build machines configure all Darwin platforms by default.
+        # Put iOS native targets last so that we test them last
+        # (it takes a long time).
+        if host_target == StdlibDeploymentTarget.OSX.x86_64:
+            targets = [host_target]
+            if args.build_ios and args.build_ios_simulator:
+                targets.extend(StdlibDeploymentTarget.iOSSimulator.targets)
+            if args.build_ios and args.build_ios_device:
+                targets.extend(StdlibDeploymentTarget.iOS.targets)
+            if args.build_tvos and args.build_tvos_simulator:
+                targets.extend(StdlibDeploymentTarget.AppleTVSimulator.targets)
+            if args.build_tvos and args.build_tvos_device:
+                targets.extend(StdlibDeploymentTarget.AppleTV.targets)
+            if args.build_watchos and args.build_watchos_simulator:
+                targets.extend(StdlibDeploymentTarget.AppleWatchSimulator.targets)
+            if args.build_watchos and args.build_watchos_device:
+                targets.extend(StdlibDeploymentTarget.AppleWatch.targets)
+            return targets
+        else:
+            # All other machines only configure their host stdlib by default.
+            return [host_target]
+
+
+    @staticmethod
     def apply_default_arguments(toolchain, args):
         # Infer if ninja is required
         ninja_required = (
@@ -144,7 +178,7 @@ class BuildScriptInvocation(object):
         # Set the default stdlib-deployment-targets, if none were provided.
         if args.stdlib_deployment_targets is None:
             stdlib_targets = \
-                StdlibDeploymentTarget.default_stdlib_deployment_targets()
+                BuildScriptInvocation.default_stdlib_deployment_targets(args)
             args.stdlib_deployment_targets = [
                 target.name for target in stdlib_targets]
 

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -228,32 +228,6 @@ class StdlibDeploymentTarget(object):
         raise NotImplementedError('System "%s" with architecture "%s" is not '
                                   'supported' % (system, machine))
 
-    @staticmethod
-    def default_stdlib_deployment_targets():
-        """
-        Return targets for the Swift stdlib, based on the build machine.
-        If the build machine is not one of the recognized ones, return None.
-        """
-
-        host_target = StdlibDeploymentTarget.host_target()
-        if host_target is None:
-            return None
-
-        # OS X build machines configure all Darwin platforms by default.
-        # Put iOS native targets last so that we test them last
-        # (it takes a long time).
-        if host_target == StdlibDeploymentTarget.OSX.x86_64:
-            return [host_target] + \
-                StdlibDeploymentTarget.iOSSimulator.targets + \
-                StdlibDeploymentTarget.AppleTVSimulator.targets + \
-                StdlibDeploymentTarget.AppleWatchSimulator.targets + \
-                StdlibDeploymentTarget.iOS.targets + \
-                StdlibDeploymentTarget.AppleTV.targets + \
-                StdlibDeploymentTarget.AppleWatch.targets
-        else:
-            # All other machines only configure their host stdlib by default.
-            return [host_target]
-
     @classmethod
     def get_target_for_name(cls, name):
         return cls._targets_by_name.get(name)


### PR DESCRIPTION
When `--skip-build-ios` is passed, we should not build anything that is iOS related. This includes the standard library. However, we have so far been ignoring the flag for the standard library builds. This PR fixes this. The same also applies for watchOS and tvOS.

Disclaimer: I am not quite sure if this will break some bots that relied on the standard library being there. If any break, we should go and update the presets or revert this PR.