### PR TITLE
SwiftSyntax: Commit gyb-generated files to master

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1538,6 +1538,17 @@ assertions
 sourcekit-lsp
 
 #===------------------------------------------------------------------------===#
+# Test Swift Syntax
+#===------------------------------------------------------------------------===#
+
+[preset: buildbot_swiftsyntax_macos]
+mixin-preset=mixin_swiftpm_package_macos_platform
+release
+assertions
+swiftsyntax
+swiftsyntax-verify-generated-files
+
+#===------------------------------------------------------------------------===#
 # Test Swift Stress Tester
 #===------------------------------------------------------------------------===#
 

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1125,6 +1125,10 @@ libcxx
 indexstore-db
 sourcekit-lsp
 
+# Don't generate the SwiftSyntax gyb files. Instead verify that up-to-date ones
+# are checked in.
+swiftsyntax-verify-generated-files
+
 # Build with debug info, this allows us to symbolicate crashes from
 # production builds.
 release-debuginfo
@@ -1359,6 +1363,10 @@ libcxx
 llbuild
 swiftpm
 swiftsyntax
+
+# Don't generate the SwiftSyntax gyb files. Instead verify that up-to-date ones
+# are checked in.
+swiftsyntax-verify-generated-files
 
 # Build sourcekit-lsp & indexstore-db
 indexstore-db

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -200,6 +200,7 @@ KNOWN_SETTINGS=(
     install-swiftpm             ""               "whether to install swiftpm"
     install-swiftsyntax         ""               "whether to install swiftsyntax"
     skip-install-swiftsyntax-module ""           "set to skip installing swiftsyntax modules"
+    swiftsyntax-verify-generated-files ""        "set to verify that the generated files in the source tree match the ones that would be generated from current master"
     install-xctest              ""               "whether to install xctest"
     install-foundation          ""               "whether to install foundation"
     install-libcxx              ""               "whether to install libc++"
@@ -1244,7 +1245,7 @@ PRODUCTS=("${PRODUCTS[@]}" swift)
 if [[ ! "${SKIP_BUILD_LLDB}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" lldb)
 fi
-# LLBuild, SwiftPM, SwiftSyntax and XCTest are dependent on Foundation, so 
+# LLBuild, SwiftPM, SwiftSyntax and XCTest are dependent on Foundation, so
 # Foundation must be added to the list of build products first.
 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" libdispatch)
@@ -1264,12 +1265,12 @@ fi
 if [[ ! "${SKIP_BUILD_PLAYGROUNDSUPPORT}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" playgroundsupport)
 fi
-# SwiftPM and SwiftSyntax are dependent on XCTest, so XCTest must be added to 
+# SwiftPM and SwiftSyntax are dependent on XCTest, so XCTest must be added to
 # the list of build products first.
 if [[ ! "${SKIP_BUILD_XCTEST}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" xctest)
 fi
-# SwiftSyntax is dependent on SwiftPM, so SwiftPM must be added to the list of 
+# SwiftSyntax is dependent on SwiftPM, so SwiftPM must be added to the list of
 # build products first.
 if [[ ! "${SKIP_BUILD_SWIFTPM}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" swiftpm)
@@ -1852,6 +1853,9 @@ function set_swiftsyntax_build_command() {
         --syntax-parser-lib-dir="$(build_directory ${host} swift)/lib"
         --swift-syntax-test-exec="$(build_directory_bin ${LOCAL_HOST} swift)/swift-syntax-test"
         --filecheck-exec="$(build_directory_bin ${LOCAL_HOST} llvm)/FileCheck")
+    if [[ "${SWIFTSYNTAX_VERIFY_GENERATED_FILES}" ]] ; then
+        swiftsyntax_build_command+=(--verify-generated-files)
+    fi
 }
 
 #


### PR DESCRIPTION
This is a companion PR to https://github.com/apple/swift-syntax/pull/159. It adds the necessary flags to forward `--swiftsyntax-verify-generated-files` and adds a preset with which we can test SwiftSyntax in CI. At the moment SwiftSyntax is using a hard-baked command in CI.