### PR TITLE
[Diagnostics] Improve if/ternary condition expression diagnostics

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1918,6 +1918,16 @@ bool ContextualFailure::diagnoseAsError() {
     break;
   }
 
+  case ConstraintLocator::Condition: {
+    // Tailored diagnostics for optional or assignment use
+    // in condition expression.
+    if (diagnoseConversionToBool())
+      return true;
+
+    diagnostic = diag::cannot_convert_condition_value;
+    break;
+  }
+
   case ConstraintLocator::ContextualType: {
     if (diagnoseConversionToBool())
       return true;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2578,10 +2578,10 @@ namespace {
       if (!boolDecl)
         return Type();
 
-      CS.addConstraint(ConstraintKind::Conversion,
-                       CS.getType(expr->getCondExpr()),
-                       boolDecl->getDeclaredType(),
-                       CS.getConstraintLocator(expr->getCondExpr()));
+      CS.addConstraint(
+          ConstraintKind::Conversion, CS.getType(expr->getCondExpr()),
+          boolDecl->getDeclaredType(),
+          CS.getConstraintLocator(expr, LocatorPathElt::Condition()));
 
       // The branches must be convertible to a common type.
       return CS.addJoinConstraint(CS.getConstraintLocator(expr),

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3186,6 +3186,12 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::Condition: {
+    conversionsOrFixes.push_back(IgnoreContextualType::create(
+        *this, lhs, rhs, getConstraintLocator(locator)));
+    break;
+  }
+
   default:
     break;
   }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -86,6 +86,7 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case KeyPathRoot:
     case KeyPathValue:
     case KeyPathComponentResult:
+    case Condition:
       auto numValues = numNumericValuesInPathElement(elt.getKind());
       for (unsigned i = 0; i < numValues; ++i)
         id.AddInteger(elt.getValue(i));
@@ -132,6 +133,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::KeyPathRoot:
   case ConstraintLocator::KeyPathValue:
   case ConstraintLocator::KeyPathComponentResult:
+  case ConstraintLocator::Condition:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -455,6 +457,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case KeyPathComponentResult:
       out << "key path component result";
+      break;
+
+    case Condition:
+      out << "condition expression";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -89,6 +89,7 @@ public:
     case KeyPathRoot:
     case KeyPathValue:
     case KeyPathComponentResult:
+    case Condition:
       return 0;
 
     case ContextualType:

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -164,6 +164,9 @@ SIMPLE_LOCATOR_PATH_ELT(UnresolvedMember)
 /// The candidate witness during protocol conformance checking.
 CUSTOM_LOCATOR_PATH_ELT(Witness)
 
+/// The condition associated with 'if' expression or ternary operator.
+SIMPLE_LOCATOR_PATH_ELT(Condition)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2992,6 +2992,12 @@ void constraints::simplifyLocator(Expr *&anchor,
       break;
     }
 
+    case ConstraintLocator::Condition: {
+      anchor = cast<IfExpr>(anchor)->getCondExpr();
+      path = path.slice(1);
+      continue;
+    }
+
     default:
       // FIXME: Lots of other cases to handle.
       break;

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1260,22 +1260,15 @@ func rdar17170728() {
   var j: Int?
   var k: Int? = 2
 
-  let _ = [i, j, k].reduce(0 as Int?) { // expected-error 3 {{cannot convert value of type 'Int?' to expected element type 'Bool'}}
-  // expected-error@-1 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
+  let _ = [i, j, k].reduce(0 as Int?) {
     $0 && $1 ? $0! + $1! : ($0 ? $0! : ($1 ? $1! : nil))
-    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
-    // expected-error@-2 4 {{cannot force unwrap value of non-optional type 'Bool'}}
-    // expected-error@-3 {{value of optional type 'Bool?' must be unwrapped to a value of type 'Bool'}}
-    // expected-note@-4 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
-    // expected-note@-5 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+    // expected-error@-1 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   }
 
-  let _ = [i, j, k].reduce(0 as Int?) { // expected-error 3 {{cannot convert value of type 'Int?' to expected element type 'Bool'}}
-    // expected-error@-1 {{missing argument label 'into:' in call}}
-    // expected-error@-2 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
+  let _ = [i, j, k].reduce(0 as Int?) {
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
-    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
-    // expected-error@-2 {{'nil' cannot be used in context expecting type 'Bool'}}
+    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Int?' operands}}
+    // expected-error@-2 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   }
 }
 

--- a/test/Constraints/if_expr.swift
+++ b/test/Constraints/if_expr.swift
@@ -28,7 +28,7 @@ useDouble(c)
 useDouble(d)
 
 var z = true ? a : b // expected-error{{result values in '? :' expression have mismatching types 'Int' and 'Double'}}
-var _ = a ? b : b // expected-error{{'Int' is not convertible to 'Bool'}}
+var _ = a ? b : b // expected-error{{cannot convert value of type 'Int' to expected condition type 'Bool'}}
 
 
 
@@ -51,13 +51,13 @@ useD1(i) // expected-error{{cannot convert value of type 'B' to expected argumen
 useD2(i) // expected-error{{cannot convert value of type 'B' to expected argument type 'D2'}}
 
 var x = true ? 1 : 0
-var y = 22 ? 1 : 0 // expected-error{{'Int' is not convertible to 'Bool'}}
+var y = 22 ? 1 : 0 // expected-error{{cannot convert value of type 'Int' to expected condition type 'Bool'}}
 
-_ = x ? x : x // expected-error {{'Int' is not convertible to 'Bool'}}
+_ = x ? x : x // expected-error {{cannot convert value of type 'Int' to expected condition type 'Bool'}}
 _ = true ? x : 1.2 // expected-error {{result values in '? :' expression have mismatching types 'Int' and 'Double'}}
 
-_ = (x: true) ? true : false // expected-error {{'(x: Bool)' is not convertible to 'Bool'}}
-_ = (x: 1) ? true : false // expected-error {{'(x: Int)' is not convertible to 'Bool'}}
+_ = (x: true) ? true : false // expected-error {{cannot convert value of type '(x: Bool)' to expected condition type 'Bool'}}
+_ = (x: 1) ? true : false // expected-error {{cannot convert value of type '(x: Int)' to expected condition type 'Bool'}}
 
 let ib: Bool! = false
 let eb: Bool? = .some(false)

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -219,6 +219,6 @@ struct T {
 }
 
 func select(i: Int!, m: Int, t: T) {
-  let _ = i ? i : m // expected-error {{result values in '? :' expression have mismatching types 'Int?' and 'Int'}}
-  let _ = t.i ? t.j : t.k // expected-error {{result values in '? :' expression have mismatching types 'Int?' and 'Int'}}
+  let _ = i ? i : m // expected-error {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}} {{11-11=(}} {{12-12= != nil)}}
+  let _ = t.i ? t.j : t.k // expected-error {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}} {{11-11=(}} {{14-14= != nil)}}
 }


### PR DESCRIPTION
- Add a new locator path element "condition" to represent condition expression of `if` expression and ternary operator.
- While generating constraints switch to use `if` as a anchor for conditional expression conversion to `Bool`.
- Use contextual mismatch diagnostics we already have for `while`, `guard` etc. to diagnose `if`/ternary conditional mismatches.

Resolves: rdar://problem/56559847

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
