### PR TITLE
[cmake] Install runtime swiftDemangle pieces.

### DIFF
--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -8,6 +8,9 @@ target_link_libraries(swiftDemangle PRIVATE
 
 add_dependencies(compiler swiftDemangle)
 swift_install_in_component(TARGETS swiftDemangle
+  RUNTIME
+    DESTINATION "bin"
+    COMPONENT compiler
   LIBRARY
     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
     COMPONENT compiler


### PR DESCRIPTION
In DLL environments (Windows) a library RUNTIME piece will be the
DLL itself (while the .lib will be the LIBRARY piece). Adding a RUNTIME
destination install swiftDemangle.dll correctly in its expected place.

This was avoiding some tests from running in the Windows CI machines. It
should also allow people use tools like swift-demangle.

The error appeared something like:

```
lit.py: C:\jenkins\workspace\oss-swift-windows-x86_64\llvm\utils\lit\lit\formats\googletest.py:43: warning: unable to discover google-tests in 'S:\\swift\\unittests\\SwiftDemangle\\.\\SwiftDemangleTests.exe': Command '['S:\\swift\\unittests\\SwiftDemangle\\.\\SwiftDemangleTests.exe', '--gtest_list_tests']' returned non-zero exit status -1073741515. Process output:
```

/cc @xiaobai (I cannot find you as a reviewer)