### PR TITLE
[windows] Add folder to path while testing.

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -65,7 +65,7 @@ call :build_swift %exitOnError%
 
 call :build_lldb %exitOnError%
 
-path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles%\Git\usr\bin
+path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles%\Git\usr\bin
 call :test_swift %exitOnError%
 
 goto :end


### PR DESCRIPTION
Some DLL are not installed, since they are only used for testing, but
they need to be in the PATH to allow some test binaries to execute
properly.

The test happened in CI because `_InternalSwiftSyntaxParser.dll` is not installed, and sits in `%build_root%\swift\bin`.

```
lit.py: C:\jenkins\workspace\oss-swift-windows-x86_64\llvm\utils\lit\lit\formats\googletest.py:43: warning: unable to discover google-tests in 'S:\\swift\\unittests\\SyntaxParser\\.\\SwiftSyntaxParserTests.exe': Command '['S:\\swift\\unittests\\SyntaxParser\\.\\SwiftSyntaxParserTests.exe', '--gtest_list_tests']' returned non-zero exit status -1073741515. Process output:
```