### PR TITLE
[Experiment] [Do Not Merge] Always skip function bodies in -emit-module only mode

### DIFF
--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -111,6 +111,11 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.ParseStdlib |= Args.hasArg(OPT_parse_stdlib);
 
   Opts.IgnoreSwiftSourceInfo |= Args.hasArg(OPT_ignore_module_source_info);
+
+  // HACK: Enable function body skipping if we're doing -emit-module only
+  if (Opts.RequestedAction == FrontendOptions::ActionType::EmitModuleOnly)
+    Opts.SkipNonInlinableFunctionBodies = true;
+
   computeHelpOptions();
 
   if (const Arg *A = Args.getLastArg(OPT_verify_generic_signatures)) {


### PR DESCRIPTION
Just seeing what happens, and what breaks in the test suite, if we do this.