### PR TITLE
[MetadataReader] Adapt to newer Objective-C class_rw_t

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2432,6 +2432,13 @@ private:
     if (!Reader->readInteger(RemoteAddress(dataPtr + OffsetToROPtr), &dataPtr))
       return StoredPointer();
 
+    // Newer Objective-C runtimes implement a size optimization where the RO
+    // field is a tagged union. If the low-bit is set, then the pointer needs
+    // to be dereferenced once more to yield the real class_ro_t pointer.
+    if (dataPtr & 1)
+      if (!Reader->readInteger(RemoteAddress(dataPtr^1), &dataPtr))
+        return StoredPointer();
+
     return dataPtr;
   }
 


### PR DESCRIPTION
Newer Objective-C runtimes implement a size optimization in class_rw_t
which requires an additional indirection to get to the class_ro_t pointer.

Thanks to Davide for getting to the bottom of this!

(cherry picked from commit 20573bdbb1404052b50ec3940a2682cf7d55e1f9)
