### PR TITLE
[AutoDiff] declaration-only `SILDifferentiabilityWitness`

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -689,6 +689,8 @@ ERROR(sil_witness_protocol_conformance_not_found,none,
 // SIL differentiability witnesses
 ERROR(sil_diff_witness_expected_token,PointsToFirstBadToken,
       "expected '%0' in differentiability witness", (StringRef))
+ERROR(sil_diff_witness_serialized_declaration,none,
+      "differentiability witness declaration should not be serialized", ())
 
 // SIL Coverage Map
 ERROR(sil_coverage_func_not_found, none,

--- a/include/swift/SIL/SILDifferentiabilityWitness.h
+++ b/include/swift/SIL/SILDifferentiabilityWitness.h
@@ -123,6 +123,7 @@ public:
     }
   }
   bool isDeclaration() const { return IsDeclaration; }
+  bool isDefinition() const { return !IsDeclaration; }
   bool isSerialized() const { return IsSerialized; }
   DeclAttribute *getAttribute() const { return Attribute; }
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -6933,7 +6933,9 @@ bool SILParserTUState::parseSILDefaultWitnessTable(Parser &P) {
 ///   '[' 'parameters' index-subset ']'
 ///   '[' 'results' index-subset ']'
 ///   ('[' 'where' derivatve-generic-signature-requirements ']')?
-///   sil-function-name ':' sil-type
+///   decl-sil-differentiability-witness-body?
+///
+/// decl-sil-differentiability-witness-body ::=
 ///   '{'
 ///   ('jvp' sil-function-name ':' sil-type)?
 ///   ('vjp' sil-function-name ':' sil-type)?
@@ -7099,7 +7101,7 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
       P.Context, origFnType->getNumParameters(), parameterIndices);
   auto *resultIndexSet = IndexSubset::get(
       P.Context, origFnType->getNumResults(), resultIndices);
-  SILDifferentiabilityWitness::create(
+  SILDifferentiabilityWitness::createDefinition(
       M, *linkage, originalFn, parameterIndexSet, resultIndexSet,
       derivativeGenSig, jvp, vjp, isSerialized);
   return false;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -6951,9 +6951,6 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
   Optional<SILLinkage> linkage;
   if (parseSILLinkage(linkage, P))
     return true;
-  // Default to public linkage.
-  if (!linkage)
-    linkage = SILLinkage::Public;
 
   // Parse '[serialized]' flag (optional).
   bool isSerialized = false;
@@ -6988,8 +6985,7 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
       P.diagnose(fnNameLoc, diag::expected_sil_function_type);
       return true;
     }
-    fn = State.getGlobalNameForReference(name, fnType, fnNameLoc, true);
-    State.TUState.PotentialZombieFns.insert(fn);
+    fn = State.getGlobalNameForReference(name, fnType, fnNameLoc);
     return false;
   };
 
@@ -7065,7 +7061,26 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
             nullptr);
   }
 
-  // Parse differentiability witness body.
+  auto origFnType = originalFn->getLoweredFunctionType();
+  auto *parameterIndexSet = IndexSubset::get(
+      P.Context, origFnType->getNumParameters(), parameterIndices);
+  auto *resultIndexSet = IndexSubset::get(
+      P.Context, origFnType->getNumResults(), resultIndices);
+
+  // If this is just a declaration, create the declaration now and return.
+  if (!P.Tok.is(tok::l_brace)) {
+    if (isSerialized) {
+      P.diagnose(lastLoc, diag::sil_diff_witness_serialized_declaration);
+      return true;
+    }
+
+    SILDifferentiabilityWitness::createDeclaration(
+        M, linkage ? *linkage : SILLinkage::DefaultForDeclaration, originalFn,
+        parameterIndexSet, resultIndexSet, derivativeGenSig);
+    return false;
+  }
+
+  // This is a definition, so parse differentiability witness body.
   SILFunction *jvp = nullptr;
   SILFunction *vjp = nullptr;
   if (P.Tok.is(tok::l_brace)) {
@@ -7096,14 +7111,10 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
       return true;
   }
 
-  auto origFnType = originalFn->getLoweredFunctionType();
-  auto *parameterIndexSet = IndexSubset::get(
-      P.Context, origFnType->getNumParameters(), parameterIndices);
-  auto *resultIndexSet = IndexSubset::get(
-      P.Context, origFnType->getNumResults(), resultIndices);
   SILDifferentiabilityWitness::createDefinition(
-      M, *linkage, originalFn, parameterIndexSet, resultIndexSet,
-      derivativeGenSig, jvp, vjp, isSerialized);
+      M, linkage ? *linkage : SILLinkage::DefaultForDefinition, originalFn,
+      parameterIndexSet, resultIndexSet, derivativeGenSig, jvp, vjp,
+      isSerialized);
   return false;
 }
 // SWIFT_ENABLE_TENSORFLOW END

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3164,11 +3164,11 @@ void SILDefaultWitnessTable::dump() const {
 void SILDifferentiabilityWitness::print(
     llvm::raw_ostream &OS, bool verbose) const {
   OS << "// differentiability witness for "
-     << demangleSymbol(originalFunction->getName()) << '\n';
+     << demangleSymbol(getOriginalFunction()->getName()) << '\n';
   PrintOptions qualifiedSILTypeOptions = PrintOptions::printQualifiedSILType();
   // sil_differentiability_witness (linkage)?
   OS << "sil_differentiability_witness ";
-  printLinkage(OS, linkage, ForDefinition);
+  printLinkage(OS, getLinkage(), ForDefinition);
   // ([serialized])?
   if (isSerialized())
     OS << "[serialized] ";
@@ -3187,7 +3187,7 @@ void SILDifferentiabilityWitness::print(
   if (auto derivativeGenSig = getDerivativeGenericSignature()) {
     ArrayRef<Requirement> requirements;
     SmallVector<Requirement, 4> requirementsScratch;
-    auto *origGenEnv = originalFunction->getGenericEnvironment();
+    auto *origGenEnv = getOriginalFunction()->getGenericEnvironment();
     if (derivativeGenSig) {
       if (origGenEnv) {
         requirementsScratch = derivativeGenSig->requirementsNotSatisfiedBy(
@@ -3210,18 +3210,18 @@ void SILDifferentiabilityWitness::print(
     }
   }
   // @original-function-name : $original-sil-type
-  printSILFunctionNameAndType(OS, originalFunction);
+  printSILFunctionNameAndType(OS, getOriginalFunction());
   // {
   //   jvp: @jvp-function-name : $jvp-sil-type
   //   vjp: @vjp-function-name : $vjp-sil-type
   // }
   OS << " {\n";
-  if (jvp) {
+  if (auto *jvp = getJVP()) {
     OS << "  jvp: ";
     printSILFunctionNameAndType(OS, jvp);
     OS << '\n';
   }
-  if (vjp) {
+  if (auto *vjp = getVJP()) {
     OS << "  vjp: ";
     printSILFunctionNameAndType(OS, vjp);
     OS << '\n';

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3168,7 +3168,7 @@ void SILDifferentiabilityWitness::print(
   PrintOptions qualifiedSILTypeOptions = PrintOptions::printQualifiedSILType();
   // sil_differentiability_witness (linkage)?
   OS << "sil_differentiability_witness ";
-  printLinkage(OS, getLinkage(), ForDefinition);
+  printLinkage(OS, getLinkage(), /*isDefinition*/ isDefinition());
   // ([serialized])?
   if (isSerialized())
     OS << "[serialized] ";
@@ -3211,6 +3211,10 @@ void SILDifferentiabilityWitness::print(
   }
   // @original-function-name : $original-sil-type
   printSILFunctionNameAndType(OS, getOriginalFunction());
+
+  if (isDeclaration())
+    return;
+
   // {
   //   jvp: @jvp-function-name : $jvp-sil-type
   //   vjp: @vjp-function-name : $vjp-sil-type

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -5387,7 +5387,7 @@ void SILDifferentiabilityWitness::verify(const SILModule &M) const {
   if (!M.getOptions().VerifyAll)
     return;
 #endif
-  auto origFnType = originalFunction->getLoweredFunctionType();
+  auto origFnType = getOriginalFunction()->getLoweredFunctionType();
   CanGenericSignature derivativeCanGenSig;
   if (auto derivativeGenSig = getDerivativeGenericSignature())
     derivativeCanGenSig = derivativeGenSig->getCanonicalSignature();
@@ -5407,7 +5407,7 @@ void SILDifferentiabilityWitness::verify(const SILModule &M) const {
     else
       exit(1);
   };
-  if (jvp) {
+  if (auto *jvp = getJVP()) {
     // TODO(TF-893): Change `SILFunctionType::getAutoDiffDerivativeFunctionType`
     // to accept result indices.
     auto expectedJVPType = origFnType->getAutoDiffDerivativeFunctionType(
@@ -5417,7 +5417,7 @@ void SILDifferentiabilityWitness::verify(const SILModule &M) const {
     requireSameType(jvp->getLoweredFunctionType(), expectedJVPType,
                     "JVP type does not match expected JVP type");
   }
-  if (vjp) {
+  if (auto *vjp = getVJP()) {
     // TODO(TF-893): Change `SILFunctionType::getAutoDiffDerivativeFunctionType`
     // to result indices.
     auto expectedVJPType = origFnType->getAutoDiffDerivativeFunctionType(

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -832,7 +832,7 @@ void SILGenModule::emitDifferentiabilityWitness(
   // TODO(TF-919): Explore creating serialized differentiability witnesses.
   // Currently, differentiability witnesses are never serialized to avoid
   // deserialization issues where JVP/VJP functions cannot be found.
-  auto *diffWitness = SILDifferentiabilityWitness::create(
+  auto *diffWitness = SILDifferentiabilityWitness::createDefinition(
       M, originalFunction->getLinkage(), originalFunction,
       loweredParamIndices, config.resultIndices, derivativeCanGenSig,
       /*jvp*/ nullptr, /*vjp*/ nullptr, /*isSerialized*/ false);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3446,7 +3446,7 @@ SILDeserializer::readDifferentiabilityWitness(DeclID DId) {
       ArrayRef<unsigned>(parameterAndResultIndices)
           .take_back(numResultIndices));
 
-  auto *diffWitness = SILDifferentiabilityWitness::create(
+  auto *diffWitness = SILDifferentiabilityWitness::createDefinition(
       SILMod, *linkage, original, parameterIndices, resultIndices,
       derivativeGenSig, jvp, vjp, isSerialized);
   diffWitnessOrOffset.set(diffWitness, /*isFullyDeserialized*/ true);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3407,14 +3407,19 @@ SILDeserializer::readDifferentiabilityWitness(DeclID DId) {
   (void)kind;
 
   DeclID originalNameId, jvpNameId, vjpNameId;
-  unsigned rawLinkage, isSerialized, numParameterIndices, numResultIndices;
+  unsigned rawLinkage, isDeclaration, isSerialized, numParameterIndices,
+           numResultIndices;
   GenericSignatureID derivativeGenSigID;
   ArrayRef<uint64_t> rawParameterAndResultIndices;
 
   DifferentiabilityWitnessLayout::readRecord(
-      scratch, originalNameId, rawLinkage, isSerialized, derivativeGenSigID,
-      jvpNameId, vjpNameId, numParameterIndices, numResultIndices,
-      rawParameterAndResultIndices);
+      scratch, originalNameId, rawLinkage, isDeclaration, isSerialized,
+      derivativeGenSigID, jvpNameId, vjpNameId, numParameterIndices,
+      numResultIndices, rawParameterAndResultIndices);
+
+  if (isDeclaration) {
+    assert(!isSerialized && "declaration must not be serialized");
+  }
 
   auto linkage = fromStableSILLinkage(rawLinkage);
   assert(linkage && "Expected value linkage for sil_differentiability_witness");
@@ -3424,11 +3429,15 @@ SILDeserializer::readDifferentiabilityWitness(DeclID DId) {
   auto *original = getFuncForReference(originalName);
   assert(original && "Original function must be found");
   auto *jvp = getFuncForReference(jvpName);
-  if (!jvpName.empty())
+  if (!jvpName.empty()) {
+    assert(!isDeclaration && "JVP must not be defined in declaration");
     assert(jvp && "JVP function must be found if JVP name is not empty");
+  }
   auto *vjp = getFuncForReference(vjpName);
-  if (!vjpName.empty())
+  if (!vjpName.empty()) {
+    assert(!isDeclaration && "VJP must not be defined in declaration");
     assert(vjp && "VJP function must be found if VJP name is not empty");
+  }
   auto derivativeGenSig = MF->getGenericSignature(derivativeGenSigID);
 
   SmallVector<unsigned, 8> parameterAndResultIndices(
@@ -3445,6 +3454,14 @@ SILDeserializer::readDifferentiabilityWitness(DeclID DId) {
       MF->getContext(), original->getLoweredFunctionType()->getNumResults(),
       ArrayRef<unsigned>(parameterAndResultIndices)
           .take_back(numResultIndices));
+
+  if (isDeclaration) {
+    auto *diffWitness = SILDifferentiabilityWitness::createDeclaration(
+        SILMod, *linkage, original, parameterIndices, resultIndices,
+        derivativeGenSig);
+    diffWitnessOrOffset.set(diffWitness, /*isFullyDeserialized*/ false);
+    return diffWitness;
+  }
 
   auto *diffWitness = SILDifferentiabilityWitness::createDefinition(
       SILMod, *linkage, original, parameterIndices, resultIndices,

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -294,6 +294,7 @@ namespace sil_block {
     SIL_DIFFERENTIABILITY_WITNESS,
     DeclIDField,             // Original function name
     SILLinkageField,         // Linkage
+    BCFixed<1>,              // Is declaration?
     BCFixed<1>,              // Is serialized?
     GenericSignatureIDField, // Derivative function generic signature
     DeclIDField,             // JVP function name

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2586,6 +2586,7 @@ writeSILDifferentiabilityWitness(const SILDifferentiabilityWitness &dw) {
       Out, ScratchRecord, SILAbbrCodes[DifferentiabilityWitnessLayout::Code],
       addSILFunctionRef(original),
       toStableSILLinkage(dw.getLinkage()),
+      dw.isDeclaration(),
       dw.isSerialized(),
       S.addGenericSignatureRef(dw.getDerivativeGenericSignature()),
       jvpID, vjpID,

--- a/test/AutoDiff/sil_differentiability_witness.sil
+++ b/test/AutoDiff/sil_differentiability_witness.sil
@@ -6,8 +6,6 @@
 // RUN: %target-sil-opt %t/tmp.2.sib -module-name main | %FileCheck %s
 
 // Round-trip parsing/printing and serialization/deserialization test.
-// NOTE: deserialization currently fails if public function bodies are removed
-// so that they are only declarations. This may require investigation.
 
 sil_stage raw
 
@@ -78,3 +76,38 @@ sil_differentiability_witness hidden [parameters 0 1] [results 0] [where T : _Di
 // CHECK:   jvp: @AD__generic__jvp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : _Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector)
 // CHECK:   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : _Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
 // CHECK: }
+
+// Test SIL differentiability witness for external function.
+
+sil @externalFn1 : $@convention(thin) (Float) -> Float
+
+sil @AD__externalFn1__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  return undef : $(Float, @callee_guaranteed (Float) -> Float)
+}
+
+sil @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  return undef : $(Float, @callee_guaranteed (Float) -> Float)
+}
+
+sil_differentiability_witness [parameters 0] [results 0] @externalFn1 : $@convention(thin) (Float) -> Float {
+  jvp: @AD__externalFn1__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+  vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+}
+
+// CHECK-LABEL: // differentiability witness for externalFn1
+// CHECK: sil_differentiability_witness [parameters 0] [results 0] @externalFn1 : $@convention(thin) (Float) -> Float {
+// CHECK:   jvp: @AD__externalFn1__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:   vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK: }
+
+// Test SIL differentiability witness declaration.
+
+sil @externalFn2 : $@convention(thin) (Float) -> Float
+
+sil_differentiability_witness [parameters 0] [results 0] @externalFn2 : $@convention(thin) (Float) -> Float
+
+// CHECK-LABEL: // differentiability witness for externalFn2
+// CHECK: sil_differentiability_witness [parameters 0] [results 0] @externalFn2 : $@convention(thin) (Float) -> Float
+// CHECK-NOT: {

--- a/test/AutoDiff/sil_differentiability_witness.sil
+++ b/test/AutoDiff/sil_differentiability_witness.sil
@@ -77,7 +77,7 @@ sil_differentiability_witness hidden [parameters 0 1] [results 0] [where T : _Di
 // CHECK:   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : _Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
 // CHECK: }
 
-// Test SIL differentiability witness for external function.
+// Test SIL differentiability witness for bodiless original function, with defined jvp/vjp.
 
 sil @externalFn1 : $@convention(thin) (Float) -> Float
 
@@ -102,12 +102,25 @@ sil_differentiability_witness [parameters 0] [results 0] @externalFn1 : $@conven
 // CHECK:   vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // CHECK: }
 
-// Test SIL differentiability witness declaration.
+// Test SIL differentiability witness for bodiless original function, with bodiless jvp/vjp.
 
 sil @externalFn2 : $@convention(thin) (Float) -> Float
 
-sil_differentiability_witness [parameters 0] [results 0] @externalFn2 : $@convention(thin) (Float) -> Float
+sil @AD__externalFn2__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 
-// CHECK-LABEL: // differentiability witness for externalFn2
-// CHECK: sil_differentiability_witness [parameters 0] [results 0] @externalFn2 : $@convention(thin) (Float) -> Float
+sil @AD__externalFn2__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+
+sil_differentiability_witness [parameters 0] [results 0] @externalFn2 : $@convention(thin) (Float) -> Float {
+  jvp: @AD__externalFn2__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+  vjp: @AD__externalFn2__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+}
+
+// Test SIL differentiability witness declaration.
+
+sil @externalFn3 : $@convention(thin) (Float) -> Float
+
+sil_differentiability_witness [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float
+
+// CHECK-LABEL: // differentiability witness for externalFn3
+// CHECK: sil_differentiability_witness [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float
 // CHECK-NOT: {


### PR DESCRIPTION
We need declaration-only `SILDifferentiabilityWitness` so that we can refer to differentiability witnesses defined in other modules.

Therefore, this PR:

* Adds distinct declaration/definition `create` methods for `SILDifferentiabilityWitness`. (credit to @dan-zheng's original work on this)
* Handles the distinction in SIL printing & parsing: The definitions have a body in braces, and the declarations don't.
* Handles the distinction in serialization: There is a new bit describing whether it's a declaration or definition.
* Fixes the "deserialization currently fails if public function bodies are removed so that they are only declarations" problem noted in `test/AutoDiff/sil_differentiability_witness.sil`.
  * The overall purpose of this PR is to allow us to have decl-only differentiability witnesses referencing decl-only functions, so this fix is important to the overall purpose of this PR.
  * The change at `fn = State.getGlobalNameForReference(name, fnType, fnNameLoc);` in `ParseSIL.cpp` is what fixes this.
* Adds test for a decl differentiability witness.