### PR TITLE
[build-presets] Test the stress tester and swiftevolve as downstream dependencies

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -328,6 +328,12 @@ swiftpm
 indexstore-db
 sourcekit-lsp
 
+swiftsyntax
+swiftsyntax-verify-generated-files
+
+skstresstester
+swiftevolve
+
 # Build Playground support
 playgroundsupport
 
@@ -781,6 +787,7 @@ stress-test
 test-optimized
 foundation
 libdispatch
+swiftsyntax
 indexstore-db
 sourcekit-lsp
 lit-args=-v --time-tests
@@ -1018,6 +1025,7 @@ swiftpm
 xctest
 foundation
 libdispatch
+swiftsyntax
 indexstore-db
 sourcekit-lsp
 dash-dash
@@ -1389,6 +1397,10 @@ install-llbuild
 install-swiftpm
 install-libcxx
 
+# Build the stress tester and SwiftEvolve
+skstresstester
+swiftevolve
+
 # Build Playground support
 playgroundsupport
 
@@ -1580,7 +1592,6 @@ release
 assertions
 swiftsyntax
 swiftsyntax-verify-generated-files
-
 
 #===------------------------------------------------------------------------===#
 # Test Swift Stress Tester


### PR DESCRIPTION
Test the stress tester and SwiftEvolve as downstream dependencies of both Swift and SwiftSyntax. 

To summarise, this makes the following preset changes:
- `buildbot_incremental,tools=RA,stdlib=RA` (Swift Incremental RA)
  - Build SwiftSyntax, the stress tester and SwiftEvolve 
  - None were built before
  - Adds about 5 to 7 minutes to the job's run time
- `buildbot_all_platforms,tools=RA,stdlib=RA` (PR testing on the main Swift repository, not smoke testing)
  - Also build the stress tester and SwiftEvolve
  - SwiftSyntax was already being built
  - Should add around 2 to 3 minutes to the job's run time
- `buildbot_incremental_linux` (Continuous Linux testing)
  - Build SwiftSyntax
  - We are already building SourceKit-LSP here
  - Adds about 4 to 5 minutes to the job's run time
- `buildbot_linux` (PR testing on the main Swift repository, not smoke testing)
  - Build SwiftSyntax
  - We are already building SourceKit-LSP here
  - Adds about 4 to 5 minutes to the job's run time