### PR TITLE
OpaqueArchetypeSpecializer: inlinable functions are now in this module

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4876,7 +4876,7 @@ private:
 BEGIN_CAN_TYPE_WRAPPER(OpaqueTypeArchetypeType, ArchetypeType)
 END_CAN_TYPE_WRAPPER(OpaqueTypeArchetypeType, ArchetypeType)
 
-enum OpaqueSubstitutionKind {
+enum class OpaqueSubstitutionKind {
   // Don't substitute the opaque type for the underlying type.
   DontSubstitute,
   // Substitute without looking at the type and context.
@@ -4885,7 +4885,7 @@ enum OpaqueSubstitutionKind {
   AlwaysSubstitute,
   // Substitute in the same module into a maximal resilient context.
   // Can be done if the underlying type is accessible from the context we
-  // substitute into. Private types cannot be accesses from a different TU.
+  // substitute into. Private types cannot be accessed from a different TU.
   SubstituteSameModuleMaximalResilience,
   // Substitute in a different module from the opaque definining decl. Can only
   // be done if the underlying type is public.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4898,9 +4898,9 @@ enum class OpaqueSubstitutionKind {
 /// to their underlying types.
 class ReplaceOpaqueTypesWithUnderlyingTypes {
 public:
-  DeclContext *inContext;
+  const DeclContext *inContext;
   ResilienceExpansion contextExpansion;
-  ReplaceOpaqueTypesWithUnderlyingTypes(DeclContext *inContext,
+  ReplaceOpaqueTypesWithUnderlyingTypes(const DeclContext *inContext,
                                         ResilienceExpansion contextExpansion)
       : inContext(inContext), contextExpansion(contextExpansion) {}
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2660,13 +2660,13 @@ bool canSubstituteTypeInto(Type ty, DeclContext *dc,
     return true;
 
   switch (kind) {
-  case DontSubstitute:
+  case OpaqueSubstitutionKind::DontSubstitute:
     return false;
 
-  case AlwaysSubstitute:
+  case OpaqueSubstitutionKind::AlwaysSubstitute:
     return true;
 
-  case SubstituteSameModuleMaximalResilience:
+  case OpaqueSubstitutionKind::SubstituteSameModuleMaximalResilience:
     // In the same file any visibility is okay.
     if (!dc->isModuleContext() &&
         nominal->getDeclContext()->getParentSourceFile() ==
@@ -2674,7 +2674,7 @@ bool canSubstituteTypeInto(Type ty, DeclContext *dc,
       return true;
     return nominal->getEffectiveAccess() > AccessLevel::FilePrivate;
 
-  case SubstituteNonResilientModule:
+  case OpaqueSubstitutionKind::SubstituteNonResilientModule:
     // Can't access types that are not public from a different module.
     return nominal->getEffectiveAccess() > AccessLevel::Internal;
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2653,8 +2653,14 @@ substOpaqueTypesWithUnderlyingTypes(Type ty, DeclContext *inContext,
   return ty.subst(replacer, replacer, SubstFlags::SubstituteOpaqueArchetypes);
 }
 
-bool canSubstituteTypeInto(Type ty, DeclContext *dc,
-                           OpaqueSubstitutionKind kind) {
+/// Checks that \p dc has access to \p ty for the purposes of an opaque
+/// substitution described by \p kind.
+///
+/// This is purely an implementation detail check about whether type metadata
+/// will be accessible. It's not intended to enforce any rules about what
+/// opaque substitutions are or are not allowed.
+static bool canSubstituteTypeInto(Type ty, DeclContext *dc,
+                                  OpaqueSubstitutionKind kind) {
   auto nominal = ty->getAnyNominal();
   if (!nominal)
     return true;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2647,7 +2647,7 @@ ReplaceOpaqueTypesWithUnderlyingTypes::shouldPerformSubstitution(
 }
 
 static Type
-substOpaqueTypesWithUnderlyingTypes(Type ty, DeclContext *inContext,
+substOpaqueTypesWithUnderlyingTypes(Type ty, const DeclContext *inContext,
                                     ResilienceExpansion contextExpansion) {
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(inContext, contextExpansion);
   return ty.subst(replacer, replacer, SubstFlags::SubstituteOpaqueArchetypes);
@@ -2659,7 +2659,7 @@ substOpaqueTypesWithUnderlyingTypes(Type ty, DeclContext *inContext,
 /// This is purely an implementation detail check about whether type metadata
 /// will be accessible. It's not intended to enforce any rules about what
 /// opaque substitutions are or are not allowed.
-static bool canSubstituteTypeInto(Type ty, DeclContext *dc,
+static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
                                   OpaqueSubstitutionKind kind) {
   auto nominal = ty->getAnyNominal();
   if (!nominal)
@@ -2735,7 +2735,7 @@ operator()(SubstitutableType *maybeOpaqueType) const {
 
 static ProtocolConformanceRef
 substOpaqueTypesWithUnderlyingTypes(ProtocolConformanceRef ref, Type origType,
-                                    DeclContext *inContext,
+                                    const DeclContext *inContext,
                                     ResilienceExpansion contextExpansion) {
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(inContext, contextExpansion);
   return ref.subst(origType, replacer, replacer,

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2805,8 +2805,9 @@ static bool areABICompatibleParamsOrReturns(SILType a, SILType b,
     if (inFunction) {
       auto opaqueTypesSubsituted = aa;
       auto *dc = inFunction->getDeclContext();
-      if (!dc)
-        dc = inFunction->getModule().getSwiftModule();
+      auto *currentModule = inFunction->getModule().getSwiftModule();
+      if (!dc || !dc->isChildContextOf(currentModule))
+        dc = currentModule;
       ReplaceOpaqueTypesWithUnderlyingTypes replacer(
           dc, inFunction->getResilienceExpansion());
       if (aa.getASTType()->hasOpaqueArchetype())

--- a/lib/SILOptimizer/Transforms/SpecializeOpaqueArchetypes.cpp
+++ b/lib/SILOptimizer/Transforms/SpecializeOpaqueArchetypes.cpp
@@ -31,7 +31,7 @@ llvm::cl::opt<bool>
 
 using namespace swift;
 
-static DeclContext *
+static const DeclContext *
 getDeclContextIfInCurrentModule(const SILFunction &fn) {
   auto *dc = fn.getDeclContext();
   auto *currentModule = fn.getModule().getSwiftModule();

--- a/lib/SILOptimizer/Transforms/SpecializeOpaqueArchetypes.cpp
+++ b/lib/SILOptimizer/Transforms/SpecializeOpaqueArchetypes.cpp
@@ -508,10 +508,12 @@ class OpaqueArchetypeSpecializer : public SILFunctionTransform {
           if (!dc)
             dc = context->getModule().getSwiftModule();
           auto opaque = opaqueTy->getDecl();
-          return ReplaceOpaqueTypesWithUnderlyingTypes::
+          OpaqueSubstitutionKind subKind =
+              ReplaceOpaqueTypesWithUnderlyingTypes::
               shouldPerformSubstitution(opaque,
                                         context->getModule().getSwiftModule(),
                                         context->getResilienceExpansion());
+          return subKind != OpaqueSubstitutionKind::DontSubstitute;
         }
         return false;
       });

--- a/test/SILOptimizer/Inputs/specialize_opaque_type_archetypes_3.swift
+++ b/test/SILOptimizer/Inputs/specialize_opaque_type_archetypes_3.swift
@@ -47,3 +47,19 @@ public struct ResilientContainer {
     print(x)
   }
 }
+
+public struct WrapperP2<Wrapped: ExternalP2>: ExternalP2 {
+  public init(_ wrapped: Wrapped) {}
+  public func myValue3() -> Int64 { 0 }
+}
+
+public func externalResilientWrapper<Wrapped: ExternalP2>(_ wrapped: Wrapped) -> some ExternalP2 {
+  return WrapperP2(wrapped)
+}
+
+@inlinable
+@inline(never)
+public func inlinableExternalResilientWrapper<Wrapped: ExternalP2>(_ wrapped: Wrapped) -> some ExternalP2 {
+  return WrapperP2(wrapped)
+}
+

--- a/test/SILOptimizer/specialize_opaque_type_archetypes.swift
+++ b/test/SILOptimizer/specialize_opaque_type_archetypes.swift
@@ -4,8 +4,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_4.swift -I %t -enable-library-evolution -module-name External3 -emit-module -emit-module-path %t/External3.swiftmodule
 // RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_3.swift -I %t -enable-library-evolution -module-name External2 -Osize -emit-module -o - | %target-sil-opt -module-name External2 | %FileCheck --check-prefix=RESILIENT %s
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -Osize -emit-sil -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -Osize -emit-sil  -sil-verify-all %s | %FileCheck %s
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -enable-library-evolution -Osize -emit-sil -sil-verify-all %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -enable-library-evolution -Osize -emit-sil -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 import External
 import External2
@@ -546,3 +545,43 @@ func useAbstractFunction<T: P>(_ fn: (Int64) -> T) {}
 public func testThinToThick() {
   useAbstractFunction(bar)
 }
+
+// CHECK-LABEL: sil @$s1A19rdar56410009_normalyyF
+public func rdar56410009_normal() {
+  // CHECK: [[EXTERNAL_RESILIENT_WRAPPER:%.+]] = function_ref @$s9External224externalResilientWrapperyQrxAA10ExternalP2RzlF
+  // CHECK: = apply [[EXTERNAL_RESILIENT_WRAPPER]]<@_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0) 🦸>({{%.+}}, {{%.+}}) : $@convention(thin) <τ_0_0 where τ_0_0 : ExternalP2> (@in_guaranteed τ_0_0) -> @out @_opaqueReturnTypeOf("$s9External224externalResilientWrapperyQrxAA10ExternalP2RzlF", 0) 🦸<τ_0_0>
+  _ = externalResilientWrapper(externalResilient())
+} // CHECK: end sil function '$s1A19rdar56410009_normalyyF'
+
+// CHECK-LABEL: sil @$s1A25rdar56410009_inlinedInneryyF
+public func rdar56410009_inlinedInner() {
+  // CHECK: [[EXTERNAL_RESILIENT_WRAPPER:%.+]] = function_ref @$s9External224externalResilientWrapperyQrxAA10ExternalP2RzlF
+  // CHECK: = apply [[EXTERNAL_RESILIENT_WRAPPER]]<Int64>({{%.+}}, {{%.+}}) : $@convention(thin) <τ_0_0 where τ_0_0 : ExternalP2> (@in_guaranteed τ_0_0) -> @out @_opaqueReturnTypeOf("$s9External224externalResilientWrapperyQrxAA10ExternalP2RzlF", 0) 🦸<τ_0_0>
+  _ = externalResilientWrapper(inlinableExternalResilient())
+} // CHECK: end sil function '$s1A25rdar56410009_inlinedInneryyF'
+
+// CHECK-LABEL: sil @$s1A25rdar56410009_inlinedOuteryyF
+public func rdar56410009_inlinedOuter() {
+  // CHECK: [[INLINABLE_EXTERNAL_RESILIENT_WRAPPER:%.+]] = function_ref @$s9External233inlinableExternalResilientWrapperyQrxAA0C2P2RzlFAA08externalD0QryFQOyQo__Tg5
+  // CHECK: = apply [[INLINABLE_EXTERNAL_RESILIENT_WRAPPER]]({{%.+}}, {{%.+}}) : $@convention(thin) (@in_guaranteed @_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0) 🦸) -> @out @_opaqueReturnTypeOf("$s9External233inlinableExternalResilientWrapperyQrxAA0C2P2RzlF", 0) 🦸<@_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0) 🦸>
+  _ = inlinableExternalResilientWrapper(externalResilient())
+} // CHECK: end sil function '$s1A25rdar56410009_inlinedOuteryyF'
+
+// Specialized from above
+// CHECK-LABEL: sil shared [noinline] @$s9External233inlinableExternalResilientWrapperyQrxAA0C2P2RzlFAA08externalD0QryFQOyQo__Tg5
+// CHECK: [[WRAPPER_INIT:%.+]] = function_ref @$s9External29WrapperP2VyACyxGxcfC
+// CHECK: = apply [[WRAPPER_INIT]]<@_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0) 🦸>({{%.+}}, {{%.+}}, {{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : ExternalP2> (@in τ_0_0, @thin WrapperP2<τ_0_0>.Type) -> @out WrapperP2<τ_0_0>
+// CHECK: end sil function '$s9External233inlinableExternalResilientWrapperyQrxAA0C2P2RzlFAA08externalD0QryFQOyQo__Tg5'
+
+// Specialized from below
+// CHECK-LABEL: sil shared [noinline] @$s9External233inlinableExternalResilientWrapperyQrxAA0C2P2RzlFs5Int64V_Tg5
+// CHECK: [[WRAPPER_INIT:%.+]] = function_ref @$s9External29WrapperP2VyACyxGxcfC
+// CHECK: = apply [[WRAPPER_INIT]]<Int64>({{%.+}}, {{%.+}}, {{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : ExternalP2> (@in τ_0_0, @thin WrapperP2<τ_0_0>.Type) -> @out WrapperP2<τ_0_0>
+// CHECK: end sil function '$s9External233inlinableExternalResilientWrapperyQrxAA0C2P2RzlFs5Int64V_Tg5'
+
+// CHECK-LABEL: sil @$s1A24rdar56410009_inlinedBothyyF
+public func rdar56410009_inlinedBoth() {
+  // CHECK: [[INLINABLE_EXTERNAL_RESILIENT_WRAPPER:%.+]] = function_ref @$s9External233inlinableExternalResilientWrapperyQrxAA0C2P2RzlFs5Int64V_Tg5
+  // CHECK: = apply [[INLINABLE_EXTERNAL_RESILIENT_WRAPPER]]({{%.+}}, {{%.+}}) : $@convention(thin) (Int64) -> @out @_opaqueReturnTypeOf("$s9External233inlinableExternalResilientWrapperyQrxAA0C2P2RzlF", 0) 🦸<Int64>
+  _ = inlinableExternalResilientWrapper(inlinableExternalResilient())
+} // CHECK:  end sil function '$s1A24rdar56410009_inlinedBothyyF'


### PR DESCRIPTION
...not the one they came from. This is important when specializing an inlinable function that takes an opaque type as a generic argument: that opaque type should still be considered opaque even if it came from the same module as the inlinable function.

rdar://problem/56410009. Fixes a regression introduced in #27666.