### PR TITLE
[SerializeDoc] Don't crash in module-merging with a group info file

### DIFF
--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -153,8 +153,16 @@ public:
     // We need the file path, so there has to be a location.
     if (VD->getLoc().isInvalid())
       return 0;
-    StringRef FullPath =
-        VD->getDeclContext()->getParentSourceFile()->getFilename();
+
+    // If the decl being serialized isn't actually from a source file, don't
+    // put it in a group.
+    // FIXME: How do we preserve group information through partial module
+    // merging for multi-frontend builds, then?
+    SourceFile *SF = VD->getDeclContext()->getParentSourceFile();
+    if (!SF)
+      return 0;
+
+    StringRef FullPath = SF->getFilename();
     if (FullPath.empty())
       return 0;
     StringRef FileName = llvm::sys::path::filename(FullPath);

--- a/test/SourceKit/InterfaceGen/gen_module_group.swift
+++ b/test/SourceKit/InterfaceGen/gen_module_group.swift
@@ -3,6 +3,12 @@
 // RUN: %sourcekitd-test -req=interface-gen -module MyModule -group-name A -- -I %t.mod -target %target-triple | %FileCheck -check-prefix=GROUPA %s
 // RUN: %sourcekitd-test -req=interface-gen -module MyModule -group-name B -- -I %t.mod -target %target-triple | %FileCheck -check-prefix=GROUPB %s
 
+// FIXME: We don't currently handle group info for multi-file builds,
+// so just make sure we don't crash.
+// RUN: %empty-directory(%t.multifrontend)
+// RUN: %target-build-swift -module-name MyModule -emit-module -emit-module-path %t.multifrontend/MyModule.swiftmodule  -Xfrontend -group-info-path -Xfrontend %S/Inputs/group.json %S/Inputs/swift_mod.swift %S/Inputs/swift_mod_syn.swift
+// RUN: %sourcekitd-test -req=interface-gen -module MyModule -group-name A -- -I %t.multifrontend -target %target-triple | %FileCheck -check-prefix=EMPTY %s
+
 // GROUPA: MyClass
 // GROUPA-NOT: P1
 // GROUPA-NOT: P2
@@ -10,3 +16,7 @@
 // GROUPB: P1
 // GROUPB: P2
 // GROUPB-NOT: MyClass
+
+// EMPTY-NOT: P1
+// EMPTY-NOT: P2
+// EMPTY-NOT: MyClass


### PR DESCRIPTION
Group info works by matching source filenames with groups, but in module merging the decls in the module no longer have associated SourceFiles. Long-term, maybe we should switch this to working on filenames directly (using the new support provided by swiftsourceinfo files), but for now just don't crash.

Fixes a bug I introduced in #26734.

rdar://problem/56592085