### PR TITLE
[Diagnostics] Refactor DiagnosticConsumer interface to remove unnecessary params

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -45,6 +45,13 @@ struct DiagnosticInfo {
   DiagnosticKind Kind;
   StringRef FormatString;
   ArrayRef<DiagnosticArgument> FormatArgs;
+
+  /// Only used when directing diagnostics to different outputs.
+  /// In batch mode a diagnostic may be
+  /// located in a non-primary file, but there will be no .dia file for a
+  /// non-primary. If valid, this argument contains a location within a buffer
+  /// that corresponds to a primary input. The .dia file for that primary can be
+  /// used for the diagnostic, as if it had occurred at this location.
   SourceLoc BufferIndirectlyCausingDiagnostic;
 
   /// DiagnosticInfo of notes which are children of this diagnostic, if any
@@ -109,29 +116,9 @@ public:
   /// \param SM The source manager associated with the source locations in
   /// this diagnostic.
   ///
-  /// \param Loc The source location associated with this diagnostic. This
-  /// location may be invalid, if the diagnostic is not directly related to
-  /// the source (e.g., if it comes from command-line parsing).
-  ///
-  /// \param Kind The severity of the diagnostic (error, warning, note).
-  ///
-  /// \param FormatArgs The diagnostic format string arguments.
-  ///
-  /// \param Info Extra information associated with the diagnostic.
-  ///
-  /// \param bufferIndirectlyCausingDiagnostic Only used when directing
-  /// diagnostics to different outputs.
-  /// In batch mode a diagnostic may be
-  /// located in a non-primary file, but there will be no .dia file for a
-  /// non-primary. If valid, this argument contains a location within a buffer
-  /// that corresponds to a primary input. The .dia file for that primary can be
-  /// used for the diagnostic, as if it had occurred at this location.
-  virtual void
-  handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                   StringRef FormatString,
-                   ArrayRef<DiagnosticArgument> FormatArgs,
-                   const DiagnosticInfo &Info,
-                   SourceLoc bufferIndirectlyCausingDiagnostic) = 0;
+  /// \param Info Information describing the diagnostic.
+  virtual void handleDiagnostic(SourceManager &SM,
+                                const DiagnosticInfo &Info) = 0;
 
   /// \returns true if an error occurred while finishing-up.
   virtual bool finishProcessing() { return false; }
@@ -149,11 +136,7 @@ public:
 /// DiagnosticConsumer that discards all diagnostics.
 class NullDiagnosticConsumer : public DiagnosticConsumer {
 public:
-  void handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                        StringRef FormatString,
-                        ArrayRef<DiagnosticArgument> FormatArgs,
-                        const DiagnosticInfo &Info,
-                        SourceLoc bufferIndirectlyCausingDiagnostic) override;
+  void handleDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) override;
 };
 
 /// DiagnosticConsumer that forwards diagnostics to the consumers of
@@ -162,11 +145,7 @@ class ForwardingDiagnosticConsumer : public DiagnosticConsumer {
   DiagnosticEngine &TargetEngine;
 public:
   ForwardingDiagnosticConsumer(DiagnosticEngine &Target);
-  void handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                        StringRef FormatString,
-                        ArrayRef<DiagnosticArgument> FormatArgs,
-                        const DiagnosticInfo &Info,
-                        SourceLoc bufferIndirectlyCausingDiagnostic) override;
+  void handleDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) override;
 };
 
 /// DiagnosticConsumer that funnels diagnostics in certain files to
@@ -228,18 +207,13 @@ public:
                 std::unique_ptr<DiagnosticConsumer> consumer)
         : inputFileName(inputFileName), consumer(std::move(consumer)) {}
 
-    void handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                          StringRef FormatString,
-                          ArrayRef<DiagnosticArgument> FormatArgs,
-                          const DiagnosticInfo &Info,
-                          const SourceLoc bufferIndirectlyCausingDiagnostic) {
+    void handleDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) {
       if (!getConsumer())
         return;
-      hasAnErrorBeenConsumed |= Kind == DiagnosticKind::Error;
-      getConsumer()->handleDiagnostic(SM, Loc, Kind, FormatString, FormatArgs,
-                                      Info, bufferIndirectlyCausingDiagnostic);
+      hasAnErrorBeenConsumed |= Info.Kind == DiagnosticKind::Error;
+      getConsumer()->handleDiagnostic(SM, Info);
     }
-    
+
     void informDriverOfIncompleteBatchModeCompilation() {
       if (!hasAnErrorBeenConsumed && getConsumer())
         getConsumer()->informDriverOfIncompleteBatchModeCompilation();
@@ -324,11 +298,7 @@ private:
       SmallVectorImpl<Subconsumer> &consumers);
 
 public:
-  void handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                        StringRef FormatString,
-                        ArrayRef<DiagnosticArgument> FormatArgs,
-                        const DiagnosticInfo &Info,
-                        SourceLoc bufferIndirectlyCausingDiagnostic) override;
+  void handleDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) override;
 
   bool finishProcessing() override;
 
@@ -348,12 +318,10 @@ private:
   subconsumerForLocation(SourceManager &SM, SourceLoc loc);
 
   Optional<FileSpecificDiagnosticConsumer::Subconsumer *>
-  findSubconsumer(SourceManager &SM, SourceLoc loc, DiagnosticKind Kind,
-                  SourceLoc bufferIndirectlyCausingDiagnostic);
+  findSubconsumer(SourceManager &SM, const DiagnosticInfo &Info);
 
   Optional<FileSpecificDiagnosticConsumer::Subconsumer *>
-  findSubconsumerForNonNote(SourceManager &SM, SourceLoc loc,
-                            SourceLoc bufferIndirectlyCausingDiagnostic);
+  findSubconsumerForNonNote(SourceManager &SM, const DiagnosticInfo &Info);
 };
   
 } // end namespace swift

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -35,12 +35,8 @@ public:
   PrintingDiagnosticConsumer(llvm::raw_ostream &stream = llvm::errs()) :
     Stream(stream) { }
 
-  virtual void
-  handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                   StringRef FormatString,
-                   ArrayRef<DiagnosticArgument> FormatArgs,
-                   const DiagnosticInfo &Info,
-                   SourceLoc bufferIndirectlyCausingDiagnostic) override;
+  virtual void handleDiagnostic(SourceManager &SM,
+                                const DiagnosticInfo &Info) override;
 
   void forceColors() {
     ForceColors = true;
@@ -52,11 +48,7 @@ public:
   }
 
 private:
-  void printDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                       StringRef FormatString,
-                       ArrayRef<DiagnosticArgument> FormatArgs,
-                       const DiagnosticInfo &Info,
-                       SourceLoc bufferIndirectlyCausingDiagnostic);
+  void printDiagnostic(SourceManager &SM, const DiagnosticInfo &Info);
 };
   
 }

--- a/include/swift/Migrator/FixitApplyDiagnosticConsumer.h
+++ b/include/swift/Migrator/FixitApplyDiagnosticConsumer.h
@@ -62,11 +62,7 @@ public:
   /// output stream.
   void printResult(llvm::raw_ostream &OS) const;
 
-  void handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                        StringRef FormatString,
-                        ArrayRef<DiagnosticArgument> FormatArgs,
-                        const DiagnosticInfo &Info,
-                        SourceLoc bufferIndirectlyCausingDiagnostic) override;
+  void handleDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) override;
 
   unsigned getNumFixitsApplied() const {
     return NumFixitsApplied;

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -25,8 +25,7 @@ namespace migrator {
 
 struct FixitFilter {
   /// Returns true if the fix-it should be applied.
-  bool shouldTakeFixit(const DiagnosticKind Kind,
-                       const DiagnosticInfo &Info) const {
+  bool shouldTakeFixit(const DiagnosticInfo &Info) const {
     // Do not add a semi or comma as it is wrong in most cases during migration
     if (Info.ID == diag::statement_same_line_without_semi.ID ||
         Info.ID == diag::declaration_same_line_without_semi.ID ||
@@ -114,7 +113,7 @@ struct FixitFilter {
       return false;
     }
 
-    if (Kind == DiagnosticKind::Error)
+    if (Info.Kind == DiagnosticKind::Error)
       return true;
 
     // Fixits from warnings/notes that should be applied.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -952,9 +952,7 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
     }
     info->ChildDiagnosticInfo = childInfoPtrs;
     for (auto &consumer : Consumers) {
-      consumer->handleDiagnostic(SourceMgr, info->Loc, info->Kind,
-                                 info->FormatString, info->FormatArgs, *info,
-                                 info->BufferIndirectlyCausingDiagnostic);
+      consumer->handleDiagnostic(SourceMgr, *info);
     }
   }
 

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -63,53 +63,44 @@ namespace {
   };
 } // end anonymous namespace
 
-void PrintingDiagnosticConsumer::handleDiagnostic(
-    SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-    StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,
-    const DiagnosticInfo &Info,
-    const SourceLoc bufferIndirectlyCausingDiagnostic) {
+void PrintingDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
+                                                  const DiagnosticInfo &Info) {
   if (Info.IsChildNote)
     return;
 
-  printDiagnostic(SM, Loc, Kind, FormatString, FormatArgs, Info,
-                  bufferIndirectlyCausingDiagnostic);
+  printDiagnostic(SM, Info);
 
   for (auto ChildInfo : Info.ChildDiagnosticInfo) {
-    printDiagnostic(SM, ChildInfo->Loc, ChildInfo->Kind,
-                    ChildInfo->FormatString, ChildInfo->FormatArgs, *ChildInfo,
-                    ChildInfo->BufferIndirectlyCausingDiagnostic);
+    printDiagnostic(SM, *ChildInfo);
   }
 }
 
-void PrintingDiagnosticConsumer::printDiagnostic(
-    SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-    StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,
-    const DiagnosticInfo &Info,
-    const SourceLoc bufferIndirectlyCausingDiagnostic) {
+void PrintingDiagnosticConsumer::printDiagnostic(SourceManager &SM,
+                                                 const DiagnosticInfo &Info) {
 
   // Determine what kind of diagnostic we're emitting.
   llvm::SourceMgr::DiagKind SMKind;
-  switch (Kind) {
-    case DiagnosticKind::Error:
-      SMKind = llvm::SourceMgr::DK_Error;
-      break;
-    case DiagnosticKind::Warning: 
-      SMKind = llvm::SourceMgr::DK_Warning; 
-      break;
+  switch (Info.Kind) {
+  case DiagnosticKind::Error:
+    SMKind = llvm::SourceMgr::DK_Error;
+    break;
+  case DiagnosticKind::Warning:
+    SMKind = llvm::SourceMgr::DK_Warning;
+    break;
 
-    case DiagnosticKind::Note:
-      SMKind = llvm::SourceMgr::DK_Note;
-      break;
+  case DiagnosticKind::Note:
+    SMKind = llvm::SourceMgr::DK_Note;
+    break;
 
-    case DiagnosticKind::Remark:
-      SMKind = llvm::SourceMgr::DK_Remark;
-      break;
+  case DiagnosticKind::Remark:
+    SMKind = llvm::SourceMgr::DK_Remark;
+    break;
   }
 
-  if (Kind == DiagnosticKind::Error) {
+  if (Info.Kind == DiagnosticKind::Error) {
     DidErrorOccur = true;
   }
-  
+
   // Translate ranges.
   SmallVector<llvm::SMRange, 2> Ranges;
   for (auto R : Info.Ranges)
@@ -129,10 +120,11 @@ void PrintingDiagnosticConsumer::printDiagnostic(
   llvm::SmallString<256> Text;
   {
     llvm::raw_svector_ostream Out(Text);
-    DiagnosticEngine::formatDiagnosticText(Out, FormatString, FormatArgs);
+    DiagnosticEngine::formatDiagnosticText(Out, Info.FormatString,
+                                           Info.FormatArgs);
   }
 
-  auto Msg = SM.GetMessage(Loc, SMKind, Text, Ranges, FixIts);
+  auto Msg = SM.GetMessage(Info.Loc, SMKind, Text, Ranges, FixIts);
   rawSM.PrintMessage(out, Msg, ForceColors);
 }
 

--- a/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
+++ b/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
@@ -32,20 +32,17 @@ void FixitApplyDiagnosticConsumer::printResult(llvm::raw_ostream &OS) const {
 }
 
 void FixitApplyDiagnosticConsumer::handleDiagnostic(
-    SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-    StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,
-    const DiagnosticInfo &Info,
-    const SourceLoc bufferIndirectlyCausingDiagnostic) {
-  if (Loc.isInvalid()) {
+    SourceManager &SM, const DiagnosticInfo &Info) {
+  if (Info.Loc.isInvalid()) {
     return;
   }
-  auto ThisBufferID = SM.findBufferContainingLoc(Loc);
+  auto ThisBufferID = SM.findBufferContainingLoc(Info.Loc);
   auto ThisBufferName = SM.getIdentifierForBuffer(ThisBufferID);
   if (ThisBufferName != BufferName) {
     return;
   }
 
-  if (!shouldTakeFixit(Kind, Info)) {
+  if (!shouldTakeFixit(Info)) {
     return;
   }
 

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -36,17 +36,13 @@ public:
     diags.addConsumer(*this);
   }
   ~ErrorGatherer() override { diags.takeConsumers(); }
-  void
-  handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                   StringRef FormatString,
-                   ArrayRef<DiagnosticArgument> FormatArgs,
-                   const DiagnosticInfo &Info,
-                   const SourceLoc bufferIndirectlyCausingDiagnostic) override {
-    if (Kind == swift::DiagnosticKind::Error) {
+  void handleDiagnostic(SourceManager &SM,
+                        const DiagnosticInfo &Info) override {
+    if (Info.Kind == swift::DiagnosticKind::Error) {
       error = true;
     }
-    DiagnosticEngine::formatDiagnosticText(llvm::errs(), FormatString,
-                                           FormatArgs);
+    DiagnosticEngine::formatDiagnosticText(llvm::errs(), Info.FormatString,
+                                           Info.FormatArgs);
     llvm::errs() << "\n";
   }
   bool hadError() { return error; }

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -46,20 +46,25 @@ class StreamDiagConsumer : public DiagnosticConsumer {
 public:
   StreamDiagConsumer(llvm::raw_ostream &OS) : OS(OS) {}
 
-  void
-  handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                   StringRef FormatString,
-                   ArrayRef<DiagnosticArgument> FormatArgs,
-                   const DiagnosticInfo &Info,
-                   const SourceLoc bufferIndirectlyCausingDiagnostic) override {
+  void handleDiagnostic(SourceManager &SM,
+                        const DiagnosticInfo &Info) override {
     // FIXME: Print location info if available.
-    switch (Kind) {
-      case DiagnosticKind::Error: OS << "error: "; break;
-      case DiagnosticKind::Warning: OS << "warning: "; break;
-      case DiagnosticKind::Note: OS << "note: "; break;
-      case DiagnosticKind::Remark: OS << "remark: "; break;
+    switch (Info.Kind) {
+    case DiagnosticKind::Error:
+      OS << "error: ";
+      break;
+    case DiagnosticKind::Warning:
+      OS << "warning: ";
+      break;
+    case DiagnosticKind::Note:
+      OS << "note: ";
+      break;
+    case DiagnosticKind::Remark:
+      OS << "remark: ";
+      break;
     }
-    DiagnosticEngine::formatDiagnosticText(OS, FormatString, FormatArgs);
+    DiagnosticEngine::formatDiagnosticText(OS, Info.FormatString,
+                                           Info.FormatArgs);
   }
 };
 } // end anonymous namespace

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1185,12 +1185,8 @@ accept(SourceManager &SM, RegionType RegionType,
 }
 
 void RequestRefactoringEditConsumer::handleDiagnostic(
-    SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-    StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,
-    const DiagnosticInfo &Info,
-    const SourceLoc bufferIndirectlyCausingDiagnostic) {
-  Impl.DiagConsumer.handleDiagnostic(SM, Loc, Kind, FormatString, FormatArgs,
-                                     Info, bufferIndirectlyCausingDiagnostic);
+    SourceManager &SM, const DiagnosticInfo &Info) {
+  Impl.DiagConsumer.handleDiagnostic(SM, Info);
 }
 
 class RequestRenameRangeConsumer::Implementation {
@@ -1244,13 +1240,9 @@ void RequestRenameRangeConsumer::accept(
   Impl.accept(SM, RegionType, Ranges);
 }
 
-void RequestRenameRangeConsumer::handleDiagnostic(
-    SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-    StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,
-    const DiagnosticInfo &Info,
-    const SourceLoc bufferIndirectlyCausingDiagnostic) {
-  Impl.DiagConsumer.handleDiagnostic(SM, Loc, Kind, FormatString, FormatArgs,
-                                     Info, bufferIndirectlyCausingDiagnostic);
+void RequestRenameRangeConsumer::handleDiagnostic(SourceManager &SM,
+                                                  const DiagnosticInfo &Info) {
+  Impl.DiagConsumer.handleDiagnostic(SM, Info);
 }
 
 static NameUsage getNameUsage(RenameType Type) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -75,13 +75,10 @@ void EditorDiagConsumer::getAllDiagnostics(
   }
 }
 
-void EditorDiagConsumer::handleDiagnostic(
-    SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-    StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,
-    const DiagnosticInfo &Info,
-    const SourceLoc bufferIndirectlyCausingDiagnostic) {
+void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
+                                          const DiagnosticInfo &Info) {
 
-  if (Kind == DiagnosticKind::Error) {
+  if (Info.Kind == DiagnosticKind::Error) {
     HadAnyError = true;
   }
 
@@ -90,13 +87,13 @@ void EditorDiagConsumer::handleDiagnostic(
       Info.ID == diag::error_doing_code_completion.ID)
     return;
 
-  bool IsNote = (Kind == DiagnosticKind::Note);
+  bool IsNote = (Info.Kind == DiagnosticKind::Note);
 
   if (IsNote && !haveLastDiag())
     // Is this possible?
     return;
 
-  if (Kind == DiagnosticKind::Remark) {
+  if (Info.Kind == DiagnosticKind::Remark) {
     // FIXME: we may want to handle optimization remarks in sourcekitd.
     LOG_WARN_FUNC("unhandled optimization remark");
     return;
@@ -108,13 +105,14 @@ void EditorDiagConsumer::handleDiagnostic(
   llvm::SmallString<256> Text;
   {
     llvm::raw_svector_ostream Out(Text);
-    DiagnosticEngine::formatDiagnosticText(Out, FormatString, FormatArgs);
+    DiagnosticEngine::formatDiagnosticText(Out, Info.FormatString,
+                                           Info.FormatArgs);
   }
   SKInfo.Description = Text.str();
 
   Optional<unsigned> BufferIDOpt;
-  if (Loc.isValid()) {
-    BufferIDOpt =  SM.findBufferContainingLoc(Loc);
+  if (Info.Loc.isValid()) {
+    BufferIDOpt = SM.findBufferContainingLoc(Info.Loc);
   }
 
   if (BufferIDOpt && !isInputBufferID(*BufferIDOpt)) {
@@ -147,9 +145,10 @@ void EditorDiagConsumer::handleDiagnostic(
   if (BufferIDOpt.hasValue()) {
     unsigned BufferID = *BufferIDOpt;
 
-    SKInfo.Offset = SM.getLocOffsetInBuffer(Loc, BufferID);
-    std::tie(SKInfo.Line, SKInfo.Column) = SM.getLineAndColumn(Loc, BufferID);
-    SKInfo.Filename = SM.getDisplayNameForLoc(Loc);
+    SKInfo.Offset = SM.getLocOffsetInBuffer(Info.Loc, BufferID);
+    std::tie(SKInfo.Line, SKInfo.Column) =
+        SM.getLineAndColumn(Info.Loc, BufferID);
+    SKInfo.Filename = SM.getDisplayNameForLoc(Info.Loc);
 
     for (auto R : Info.Ranges) {
       if (R.isInvalid() || SM.findBufferContainingLoc(R.getStart()) != BufferID)
@@ -177,16 +176,16 @@ void EditorDiagConsumer::handleDiagnostic(
     return;
   }
 
-  switch (Kind) {
-    case DiagnosticKind::Error:
-      SKInfo.Severity = DiagnosticSeverityKind::Error;
-      break;
-    case DiagnosticKind::Warning:
-      SKInfo.Severity = DiagnosticSeverityKind::Warning;
-      break;
-    case DiagnosticKind::Note:
-    case DiagnosticKind::Remark:
-      llvm_unreachable("already covered");
+  switch (Info.Kind) {
+  case DiagnosticKind::Error:
+    SKInfo.Severity = DiagnosticSeverityKind::Error;
+    break;
+  case DiagnosticKind::Warning:
+    SKInfo.Severity = DiagnosticSeverityKind::Warning;
+    break;
+  case DiagnosticKind::Note:
+  case DiagnosticKind::Remark:
+    llvm_unreachable("already covered");
   }
 
   if (!BufferIDOpt) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorDiagConsumer.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorDiagConsumer.h
@@ -66,11 +66,8 @@ public:
 
   bool hadAnyError() const { return HadAnyError; }
 
-  void handleDiagnostic(swift::SourceManager &SM, swift::SourceLoc Loc,
-                        swift::DiagnosticKind Kind, StringRef FormatString,
-                        ArrayRef<swift::DiagnosticArgument> FormatArgs,
-                        const swift::DiagnosticInfo &Info,
-                        swift::SourceLoc bufferIndirectlyCausingDiagnostic) override;
+  void handleDiagnostic(swift::SourceManager &SM,
+                        const swift::DiagnosticInfo &Info) override;
 };
 
 } // namespace SourceKit

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -258,12 +258,8 @@ public:
   ~RequestRefactoringEditConsumer();
   void accept(swift::SourceManager &SM, swift::ide::RegionType RegionType,
               ArrayRef<swift::ide::Replacement> Replacements) override;
-  void
-  handleDiagnostic(swift::SourceManager &SM, swift::SourceLoc Loc,
-                   swift::DiagnosticKind Kind, StringRef FormatString,
-                   ArrayRef<swift::DiagnosticArgument> FormatArgs,
-                   const swift::DiagnosticInfo &Info,
-                   swift::SourceLoc bufferIndirectlyCausingDiagnostic) override;
+  void handleDiagnostic(swift::SourceManager &SM,
+                        const swift::DiagnosticInfo &Info) override;
 };
 
 class RequestRenameRangeConsumer : public swift::ide::FindRenameRangesConsumer,
@@ -276,12 +272,8 @@ public:
   ~RequestRenameRangeConsumer();
   void accept(swift::SourceManager &SM, swift::ide::RegionType RegionType,
               ArrayRef<swift::ide::RenameRangeDetail> Ranges) override;
-  void
-  handleDiagnostic(swift::SourceManager &SM, swift::SourceLoc Loc,
-                   swift::DiagnosticKind Kind, StringRef FormatString,
-                   ArrayRef<swift::DiagnosticArgument> FormatArgs,
-                   const swift::DiagnosticInfo &Info,
-                   swift::SourceLoc bufferIndirectlyCausingDiagnostic) override;
+  void handleDiagnostic(swift::SourceManager &SM,
+                        const swift::DiagnosticInfo &Info) override;
 };
 
 struct SwiftStatistics {

--- a/tools/driver/swift_indent_main.cpp
+++ b/tools/driver/swift_indent_main.cpp
@@ -41,14 +41,11 @@ private:
   CompilerInvocation CompInv;
   std::unique_ptr<ParserUnit> Parser;
   class FormatterDiagConsumer : public swift::DiagnosticConsumer {
-    void handleDiagnostic(
-        SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-        StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,
-        const swift::DiagnosticInfo &Info,
-        const SourceLoc bufferIndirectlyCausingDiagnostic) override {
+    void handleDiagnostic(SourceManager &SM,
+                          const swift::DiagnosticInfo &Info) override {
       llvm::errs() << "Parse error: ";
-      DiagnosticEngine::formatDiagnosticText(llvm::errs(), FormatString,
-                                             FormatArgs);
+      DiagnosticEngine::formatDiagnosticText(llvm::errs(), Info.FormatString,
+                                             Info.FormatArgs);
       llvm::errs() << "\n";
     }
   } DiagConsumer;

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -233,21 +233,18 @@ struct SynParserDiagConsumer: public DiagnosticConsumer {
   const unsigned BufferID;
   SynParserDiagConsumer(SynParser &Parser, unsigned BufferID):
     Parser(Parser), BufferID(BufferID) {}
-  void
-  handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                   StringRef FormatString,
-                   ArrayRef<DiagnosticArgument> FormatArgs,
-                   const DiagnosticInfo &Info,
-                   const SourceLoc bufferIndirectlyCausingDiagnostic) override {
-    assert(Kind != DiagnosticKind::Remark && "Shouldn't see this in parser.");
+  void handleDiagnostic(SourceManager &SM,
+                        const DiagnosticInfo &Info) override {
+    assert(Info.Kind != DiagnosticKind::Remark &&
+           "Shouldn't see this in parser.");
     // The buffer where all char* will point into.
     llvm::SmallString<256> Buffer;
     auto getCurrentText = [&]() -> const char* {
       return Buffer.data() + Buffer.size();
     };
     DiagnosticDetail Result;
-    Result.Severity = getSeverity(Kind);
-    Result.Offset = getByteOffset(Loc, SM, BufferID);
+    Result.Severity = getSeverity(Info.Kind);
+    Result.Offset = getByteOffset(Info.Loc, SM, BufferID);
 
     // Terminate each printed text with 0 so the client-side can use char* directly.
     char NullTerm = '\0';
@@ -255,7 +252,8 @@ struct SynParserDiagConsumer: public DiagnosticConsumer {
       // Print the error message to buffer and record it.
       llvm::raw_svector_ostream OS(Buffer);
       Result.Message = getCurrentText();
-      DiagnosticEngine::formatDiagnosticText(OS, FormatString, FormatArgs);
+      DiagnosticEngine::formatDiagnosticText(OS, Info.FormatString,
+                                             Info.FormatArgs);
       OS << NullTerm;
     }
     for (auto R: Info.Ranges) {

--- a/tools/swift-api-digester/ModuleDiagsConsumer.cpp
+++ b/tools/swift-api-digester/ModuleDiagsConsumer.cpp
@@ -94,15 +94,10 @@ ModuleDifferDiagsConsumer::ModuleDifferDiagsConsumer(bool DiagnoseModuleDiff,
 }
 
 void swift::ide::api::ModuleDifferDiagsConsumer::handleDiagnostic(
-    SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-    StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,
-    const DiagnosticInfo &Info,
-    const SourceLoc bufferIndirectlyCausingDiagnostic) {
+    SourceManager &SM, const DiagnosticInfo &Info) {
   auto Category = getCategoryName((uint32_t)Info.ID);
   if (Category.empty()) {
-    PrintingDiagnosticConsumer::handleDiagnostic(
-        SM, Loc, Kind, FormatString, FormatArgs, Info,
-        bufferIndirectlyCausingDiagnostic);
+    PrintingDiagnosticConsumer::handleDiagnostic(SM, Info);
     return;
   }
   if (!DiagnoseModuleDiff)
@@ -110,7 +105,8 @@ void swift::ide::api::ModuleDifferDiagsConsumer::handleDiagnostic(
   llvm::SmallString<256> Text;
   {
     llvm::raw_svector_ostream Out(Text);
-    DiagnosticEngine::formatDiagnosticText(Out, FormatString, FormatArgs);
+    DiagnosticEngine::formatDiagnosticText(Out, Info.FormatString,
+                                           Info.FormatArgs);
   }
   AllDiags[Category].insert(Text.str().str());
 }

--- a/tools/swift-api-digester/ModuleDiagsConsumer.h
+++ b/tools/swift-api-digester/ModuleDiagsConsumer.h
@@ -39,11 +39,7 @@ public:
   ModuleDifferDiagsConsumer(bool DiagnoseModuleDiff,
                             llvm::raw_ostream &OS = llvm::errs());
   ~ModuleDifferDiagsConsumer();
-  void handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                        StringRef FormatString,
-                        ArrayRef<DiagnosticArgument> FormatArgs,
-                        const DiagnosticInfo &Info,
-                        SourceLoc bufferIndirectlyCausingDiagnostic) override;
+  void handleDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) override;
 };
 }
 }

--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -34,13 +34,10 @@ namespace {
       EXPECT_TRUE(expected.empty());
     }
 
-    void handleDiagnostic(
-        SourceManager &SM, SourceLoc loc, DiagnosticKind kind,
-        StringRef formatString, ArrayRef<DiagnosticArgument> formatArgs,
-        const DiagnosticInfo &info,
-        const SourceLoc bufferIndirectlyCausingDiagnostic) override {
+    void handleDiagnostic(SourceManager &SM,
+                          const DiagnosticInfo &Info) override {
       ASSERT_FALSE(expected.empty());
-      EXPECT_EQ(std::make_pair(loc, formatString), expected.front());
+      EXPECT_EQ(std::make_pair(Info.Loc, Info.FormatString), expected.front());
       expected.erase(expected.begin());
     }
 
@@ -52,6 +49,14 @@ namespace {
       return false;
     }
   };
+
+  DiagnosticInfo testDiagnosticInfo(SourceLoc Loc, std::string Message,
+                                    DiagnosticKind Kind) {
+    return DiagnosticInfo(DiagID(0), Loc, Kind, Message, /*args*/ {},
+                          /*indirectBuffer*/ SourceLoc(), /*childInfo*/ {},
+                          /*ranges*/ {}, /*fixIts*/ {}, /*isChild*/ false);
+  }
+
 } // end anonymous namespace
 
 TEST(FileSpecificDiagnosticConsumer, SubconsumersFinishInOrder) {
@@ -90,8 +95,9 @@ TEST(FileSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
-  topConsumer->handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Error,
-                                "dummy", {}, DiagnosticInfo(), SourceLoc());
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(SourceLoc(), "dummy", DiagnosticKind::Error));
   topConsumer->finishProcessing();
 }
 
@@ -131,18 +137,20 @@ TEST(FileSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers) {
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "front", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                                "front", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Error,
-                                "middle", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Error,
-                                "middle", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Error,
-                                "back", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Error,
-                                "back", {}, DiagnosticInfo(), SourceLoc());
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "front", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfB, "front", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(middleOfA, "middle", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(middleOfB, "middle", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "back", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfB, "back", DiagnosticKind::Error));
   topConsumer->finishProcessing();
 }
 
@@ -186,18 +194,20 @@ TEST(FileSpecificDiagnosticConsumer,
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "front", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                                "front", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Error,
-                                "middle", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Error,
-                                "middle", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Error,
-                                "back", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Error,
-                                "back", {}, DiagnosticInfo(), SourceLoc());
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "front", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfB, "front", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(middleOfA, "middle", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(middleOfB, "middle", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "back", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfB, "back", DiagnosticKind::Error));
   topConsumer->finishProcessing();
 }
 
@@ -232,14 +242,18 @@ TEST(FileSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
-                                "warning", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Warning,
-                                "warning", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Remark,
-                                "remark", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Remark,
-                                "remark", {}, DiagnosticInfo(), SourceLoc());
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(frontOfA, "warning", DiagnosticKind::Warning));
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(frontOfB, "warning", DiagnosticKind::Warning));
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(frontOfA, "remark", DiagnosticKind::Remark));
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(frontOfB, "remark", DiagnosticKind::Remark));
   topConsumer->finishProcessing();
 }
 
@@ -285,24 +299,24 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfB, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "note", DiagnosticKind::Note));
   topConsumer->finishProcessing();
 }
 
@@ -348,24 +362,27 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
-                                "warning", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Warning,
-                                "warning", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Remark,
-                                "remark", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(frontOfA, "warning", DiagnosticKind::Warning));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(frontOfB, "warning", DiagnosticKind::Warning));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr,
+      testDiagnosticInfo(frontOfA, "remark", DiagnosticKind::Remark));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "note", DiagnosticKind::Note));
   topConsumer->finishProcessing();
 }
 
@@ -408,24 +425,24 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfB, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "note", DiagnosticKind::Note));
   topConsumer->finishProcessing();
 }
 
@@ -472,24 +489,24 @@ TEST(FileSpecificDiagnosticConsumer,
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfB, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfA, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(middleOfB, "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(backOfA, "note", DiagnosticKind::Note));
   topConsumer->finishProcessing();
 }
 
@@ -528,17 +545,17 @@ TEST(FileSpecificDiagnosticConsumer,
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                                "error", {}, DiagnosticInfo(), SourceLoc());
-  topConsumer->handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
-                                "note", {}, DiagnosticInfo(), SourceLoc());
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(SourceLoc(), "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfB, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(SourceLoc(), "note", DiagnosticKind::Note));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(frontOfA, "error", DiagnosticKind::Error));
+  topConsumer->handleDiagnostic(
+      sourceMgr, testDiagnosticInfo(SourceLoc(), "note", DiagnosticKind::Note));
   topConsumer->finishProcessing();
 }

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -747,16 +747,13 @@ TEST_F(LexerTest, NestedPlaceholder) {
 
 class StringCaptureDiagnosticConsumer : public DiagnosticConsumer {
 public:
-  virtual void
-  handleDiagnostic(SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
-                   StringRef FormatString,
-                   ArrayRef<DiagnosticArgument> FormatArgs,
-                   const swift::DiagnosticInfo &Info,
-                   SourceLoc bufferIndirectlyCausingDiagnostic) override {
+  virtual void handleDiagnostic(SourceManager &SM,
+                                const swift::DiagnosticInfo &Info) override {
     std::string DiagMsg;
     llvm::raw_string_ostream DiagOS(DiagMsg);
-    DiagnosticEngine::formatDiagnosticText(DiagOS, FormatString, FormatArgs);
-    auto LC = SM.getLineAndColumn(Loc);
+    DiagnosticEngine::formatDiagnosticText(DiagOS, Info.FormatString,
+                                           Info.FormatArgs);
+    auto LC = SM.getLineAndColumn(Info.Loc);
     std::ostringstream StrOS;
     StrOS << LC.first << ", " << LC.second << ": " << DiagOS.str();
     messages.push_back(StrOS.str());


### PR DESCRIPTION
`DiagnosticInfo` now holds all the information needed to consume a diagnostic, so remove unneeded parameters from `handleDiagnostic`.

I've been meaning to clean this up for a while, it should make future changes a lot easier. I made sure everything builds and the unit tests pass, but there's always a chance I missed a consumer somewhere in one of the tools.