### PR TITLE
SIL: Final methods need a subclass scope if they override something [5.1]

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -984,12 +984,13 @@ SubclassScope SILDeclRef::getSubclassScope() const {
   if (isDefaultArgGenerator())
     return SubclassScope::NotApplicable;
 
-  // Only non-final methods in non-final classes go in the vtable.
+  // Only methods in non-final classes go in the vtable.
   auto *classType = context->getSelfClassDecl();
   if (!classType || classType->isFinal())
     return SubclassScope::NotApplicable;
 
-  if (decl->isFinal())
+  // Final methods only go in the vtable if they override something.
+  if (decl->isFinal() && !decl->getOverriddenDecl())
     return SubclassScope::NotApplicable;
 
   assert(decl->getEffectiveAccess() <= classType->getEffectiveAccess() &&

--- a/test/IRGen/method_linkage.swift
+++ b/test/IRGen/method_linkage.swift
@@ -31,11 +31,23 @@ class Base {
   // RESILIENT: define hidden swiftcc void @"$s14method_linkage4Base{{.*}}5other0
   fileprivate func other() {
   }
+
+  // CHECK: define hidden swiftcc void @"$s14method_linkage4BaseC4prop{{.*}}LLytvg
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage4BaseC4prop{{.*}}LLytvg
+  fileprivate var prop: () {
+    return ()
+  }
 }
 class Derived : Base {
-  // CHECK: define internal swiftcc void @"$s14method_linkage7Derived{{.*}}3foo0
-  // RESILIENT: define internal swiftcc void @"$s14method_linkage7Derived{{.*}}3foo0
+  // CHECK: define hidden swiftcc void @"$s14method_linkage7Derived{{.*}}3foo0
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage7Derived{{.*}}3foo0
   fileprivate final override func foo() {
+  }
+
+  // CHECK: define hidden swiftcc void @"$s14method_linkage7DerivedC4prop{{.*}}LLytvg
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage7DerivedC4prop{{.*}}LLytvg
+  fileprivate final override var prop: () {
+    return ()
   }
 }
 
@@ -92,6 +104,20 @@ open class OpenClass {
   // RESILIENT: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage9OpenClassC5pquuxyyF"
   public final func pquux() {
   }
+
+  // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage9OpenClassC4prop{{.*}}LLytvg
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage9OpenClassC4prop{{.*}}LLytvg
+  fileprivate var prop: () {
+    return ()
+  }
+}
+
+open class OpenSubclass : OpenClass {
+  // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s14method_linkage12OpenSubclassC4prop{{.*}}LLytvg
+  // RESILIENT: define hidden swiftcc void @"$s14method_linkage12OpenSubclassC4prop{{.*}}LLytvg
+  fileprivate final override var prop: () {
+    return ()
+  }
 }
 
 // Just in case anyone wants to delete unused methods...
@@ -100,4 +126,5 @@ func callit(b: Base) {
   b.bar()
   b.other()
   b.extfunc()
+  _ = b.prop
 }


### PR DESCRIPTION
... otherwise we compute the wrong visibility in IRGen.

Fixes <rdar://problem/55559104>.