### PR TITLE
[NFC] Add GenericTypeParamDepthRequest

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3045,6 +3045,15 @@ public:
 /// func min<T : Comparable>(x : T, y : T) -> T { ... }
 /// \endcode
 class GenericTypeParamDecl : public AbstractTypeParamDecl {
+  friend class GenericTypeParamDepthRequest;
+
+private:
+  unsigned getDepthUncached() const { return Bits.GenericTypeParamDecl.Depth; }
+  void setDepth(unsigned depth) {
+    Bits.GenericTypeParamDecl.Depth = depth;
+    assert(Bits.GenericTypeParamDecl.Depth == depth && "Truncation");
+  }
+
 public:
   static const unsigned InvalidDepth = 0xFFFF;
 
@@ -3069,15 +3078,7 @@ public:
   /// \endcode
   ///
   /// Here 'T' has depth 0 and 'U' has depth 1. Both have index 0.
-  unsigned getDepth() const { return Bits.GenericTypeParamDecl.Depth; }
-
-  /// Set the depth of this generic type parameter.
-  ///
-  /// \sa getDepth
-  void setDepth(unsigned depth) {
-    Bits.GenericTypeParamDecl.Depth = depth;
-    assert(Bits.GenericTypeParamDecl.Depth == depth && "Truncation");
-  }
+  unsigned getDepth() const;
 
   /// The index of this generic type parameter within its generic parameter
   /// list.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1668,6 +1668,27 @@ public:
   void cacheResult(bool value) const;
 };
 
+class GenericTypeParamDepthRequest
+    : public SimpleRequest<GenericTypeParamDepthRequest,
+                           unsigned(GenericTypeParamDecl *),
+                           CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<unsigned> evaluate(Evaluator &evaluator,
+                                    GenericTypeParamDecl *GTP) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<unsigned> getCachedResult() const;
+  void cacheResult(unsigned value) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -58,6 +58,9 @@ SWIFT_REQUEST(TypeChecker, FunctionOperatorRequest, OperatorDecl *(FuncDecl *),
 SWIFT_REQUEST(NameLookup, GenericSignatureRequest,
               GenericSignature (GenericContext *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GenericTypeParamDepthRequest,
+              unsigned(GenericTypeParamDecl *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
               GenericSignature (ModuleDecl *, GenericSignatureImpl *,
                                  GenericParamList *,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -924,8 +924,10 @@ void GenericParamList::addTrailingWhereClause(
 }
 
 void GenericParamList::setDepth(unsigned depth) {
-  for (auto param : *this)
-    param->setDepth(depth);
+  for (auto param : *this) {
+    param->getASTContext().evaluator.cacheOutput(
+        GenericTypeParamDepthRequest{param}, std::move(depth));
+  }
 }
 
 TrailingWhereClause::TrailingWhereClause(
@@ -3787,6 +3789,13 @@ SourceRange GenericTypeParamDecl::getSourceRange() const {
     endLoc = getInherited().back().getSourceRange().End;
   }
   return SourceRange(getNameLoc(), endLoc);
+}
+
+unsigned GenericTypeParamDecl::getDepth() const {
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      GenericTypeParamDepthRequest{const_cast<GenericTypeParamDecl *>(this)},
+      GenericTypeParamDecl::InvalidDepth);
 }
 
 AssociatedTypeDecl::AssociatedTypeDecl(DeclContext *dc, SourceLoc keywordLoc,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1141,19 +1141,7 @@ CanType TypeBase::computeCanonicalType() {
 
   case TypeKind::GenericTypeParam: {
     GenericTypeParamType *gp = cast<GenericTypeParamType>(this);
-    auto gpDecl = gp->getDecl();
-
-    // If we haven't set a depth for this generic parameter, try to do so.
-    // FIXME: This is a dreadful hack.
-    if (gpDecl->getDepth() == GenericTypeParamDecl::InvalidDepth) {
-      auto resolver = gpDecl->getASTContext().getLazyResolver();
-      assert(resolver && "Need to resolve generic parameter depth");
-      if (auto decl =
-            gpDecl->getDeclContext()->getInnermostDeclarationDeclContext())
-        if (auto valueDecl = decl->getAsGenericContext())
-          (void)valueDecl->getGenericSignature();
-    }
-
+    auto *gpDecl = gp->getDecl();
     assert(gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth &&
            "parameter hasn't been validated");
     Result = GenericTypeParamType::get(gpDecl->getDepth(), gpDecl->getIndex(),

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1071,3 +1071,21 @@ void InheritsSuperclassInitializersRequest::cacheResult(bool value) const {
   auto *decl = std::get<0>(getStorage());
   decl->setInheritsSuperclassInitializers(value);
 }
+
+//----------------------------------------------------------------------------//
+// GenericTypeParamDepthRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<unsigned> GenericTypeParamDepthRequest::getCachedResult() const {
+  auto *gpDecl = std::get<0>(getStorage());
+  const auto depth = gpDecl->getDepthUncached();
+  if (depth != GenericTypeParamDecl::InvalidDepth) {
+    return depth;
+  }
+  return None;
+}
+
+void GenericTypeParamDepthRequest::cacheResult(unsigned depth) const {
+  auto *gpDecl = std::get<0>(getStorage());
+  gpDecl->setDepth(depth);
+}

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -576,6 +576,12 @@ static unsigned getExtendedTypeGenericDepth(ExtensionDecl *ext) {
   return sig->getGenericParams().back()->getDepth();
 }
 
+llvm::Expected<unsigned>
+GenericTypeParamDepthRequest::evaluate(Evaluator &evaluator,
+                                       GenericTypeParamDecl *gpDecl) const {
+  return gpDecl->getDeclContext()->getGenericContextDepth();
+}
+
 llvm::Expected<GenericSignature>
 GenericSignatureRequest::evaluate(Evaluator &evaluator,
                                   GenericContext *GC) const {
@@ -609,7 +615,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     return GC->getParent()->getGenericSignatureOfContext();
   }
 
-  // Setup the depth of the generic parameters.
+  // Cache the depth of the generic parameters.
   gp->setDepth(GC->getGenericContextDepth());
 
   // Accessors can always use the generic context of their storage


### PR DESCRIPTION
Add a request for computing the depth of a given generic parameter so we
don't have to do this as a consequence of type canonicalization or the
generic signature request.