### PR TITLE
[ConstraintSystem] Don't warn about some redundant coercions

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -881,6 +881,13 @@ bool RemoveUnnecessaryCoercion::attempt(ConstraintSystem &cs, Type fromType,
   if (!isa<ImplicitlyUnwrappedOptionalTypeRepr>(toTypeRepr) &&
       (isa<DeclRefExpr>(expr->getSubExpr()) ||
        isa<CoerceExpr>(expr->getSubExpr()))) {
+
+    // If coerced type is not known upfront let's not warn
+    // because the type could be inferred from coercion.
+    auto coercedType = cs.getType(expr->getSubExpr());
+    if (coercedType->is<TypeVariableType>())
+      return false;
+
     auto *fix = new (cs.getAllocator()) RemoveUnnecessaryCoercion(
         cs, fromType, toType, cs.getConstraintLocator(locator));
 


### PR DESCRIPTION
Let's not warn about possible redundant coercions if the
"coerced type" is not known upfront, because that would
mean that solver would infer it from coercion.

Resolves: rdar://problem/56608085

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
