### PR TITLE
Revert "[Diagnostics][Qol] SR-11295 Emit diagnostics for same type coercion. "

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -949,22 +949,18 @@ ERROR(super_initializer_not_in_initializer,none,
 WARNING(isa_is_always_true,none, "'%0' test is always true",
         (StringRef))
 WARNING(isa_is_foreign_check,none,
-        "'is' test is always true because %0 is a Core Foundation type",
-        (Type))
+      "'is' test is always true because %0 is a Core Foundation type",
+      (Type))
 WARNING(conditional_downcast_coercion,none,
-        "conditional cast from %0 to %1 always succeeds",
-        (Type, Type))
-WARNING(unnecessary_same_type_coercion,none,
-        "redundant cast to %0 has no effect",
-        (Type))
-WARNING(unnecessary_same_typealias_type_coercion,none,
-        "redundant cast from %0 to %1 has no effect",
-        (Type, Type))
+      "conditional cast from %0 to %1 always succeeds",
+      (Type, Type))
+
 WARNING(forced_downcast_noop,none,
         "forced cast of %0 to same type has no effect", (Type))
+
 WARNING(forced_downcast_coercion,none,
-        "forced cast from %0 to %1 always succeeds; did you mean to use 'as'?",
-        (Type, Type))
+      "forced cast from %0 to %1 always succeeds; did you mean to use 'as'?",
+      (Type, Type))
 
 // Note: the Boolean at the end indicates whether bridging is required after
 // the cast.

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -709,8 +709,8 @@ public:
   /// If we're trying to convert something to `nil`.
   bool diagnoseConversionToNil() const;
 
-  /// If we're trying to convert something of type "() -> T" to T,
-  /// then we probably meant to call the value.
+  // If we're trying to convert something of type "() -> T" to T,
+  // then we probably meant to call the value.
   bool diagnoseMissingFunctionCall() const;
 
   /// Produce a specialized diagnostic if this is an invalid conversion to Bool.
@@ -1462,11 +1462,11 @@ public:
   bool diagnoseAsError() override;
 };
 
-/// Diagnose an attempt to use AnyObject as the root type of a KeyPath
-///
-/// ```swift
-/// let keyPath = \AnyObject.bar
-/// ```
+// Diagnose an attempt to use AnyObject as the root type of a KeyPath
+//
+// ```swift
+// let keyPath = \AnyObject.bar
+// ```
 class AnyObjectKeyPathRootFailure final : public FailureDiagnostic {
 
 public:
@@ -1774,27 +1774,6 @@ public:
   bool diagnoseAsNote() override;
 
   void tryDropArrayBracketsFixIt(Expr *anchor) const;
-};
-
-/// Diagnose a situation where there is an explicit type coercion
-/// to the same type e.g.:
-///
-/// ```swift
-/// Double(1) as Double // redundant cast to 'Double' has no effect
-/// 1 as Double as Double // redundant cast to 'Double' has no effect
-/// let string = "String"
-/// let s = string as String // redundant cast to 'String' has no effect
-/// ```
-class UnnecessaryCoercionFailure final
-    : public ContextualFailure {
-      
-public:
-  UnnecessaryCoercionFailure(Expr *root, ConstraintSystem &cs,
-                             Type fromType, Type toType,
-                             ConstraintLocator *locator)
-      : ContextualFailure(root, cs, fromType, toType, locator) {}
-  
-  bool diagnoseAsError() override;
 };
 
 /// Diagnose a situation there is a mismatch between argument and parameter

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -857,38 +857,6 @@ IgnoreContextualType *IgnoreContextualType::create(ConstraintSystem &cs,
       IgnoreContextualType(cs, resultTy, specifiedTy, locator);
 }
 
-bool RemoveUnnecessaryCoercion::diagnose(Expr *root, bool asNote) const {
-  auto &cs = getConstraintSystem();
-  UnnecessaryCoercionFailure failure(root, cs, getFromType(), getToType(),
-                                     getLocator());
-  return failure.diagnose(asNote);
-}
-
-bool RemoveUnnecessaryCoercion::attempt(ConstraintSystem &cs, Type fromType,
-                                        Type toType,
-                                        ConstraintLocatorBuilder locator) {
-  auto last = locator.last();
-  bool isExplicitCoercion =
-      last && last->is<LocatorPathElt::ExplicitTypeCoercion>();
-  if (!isExplicitCoercion)
-    return false;
-
-  auto expr = cast<CoerceExpr>(locator.getAnchor());
-  auto toTypeRepr = expr->getCastTypeLoc().getTypeRepr();
-
-  // only diagnosing for coercion where the left-side is a DeclRefExpr
-  // or a explicit/implicit coercion e.g. Double(1) as Double
-  if (!isa<ImplicitlyUnwrappedOptionalTypeRepr>(toTypeRepr) &&
-      (isa<DeclRefExpr>(expr->getSubExpr()) ||
-       isa<CoerceExpr>(expr->getSubExpr()))) {
-    auto *fix = new (cs.getAllocator()) RemoveUnnecessaryCoercion(
-        cs, fromType, toType, cs.getConstraintLocator(locator));
-
-    return cs.recordFix(fix);
-  }
-  return false;
-}
-
 bool IgnoreAssignmentDestinationType::diagnose(Expr *root, bool asNote) const {
   auto &cs = getConstraintSystem();
   auto *AE = cast<AssignExpr>(getAnchor());

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -196,10 +196,6 @@ enum class FixKind : uint8_t {
   /// Allow a single tuple parameter to be matched with N arguments
   /// by forming all of the given arguments into a single tuple.
   AllowTupleSplatForSingleParameter,
-  
-  /// Remove an unnecessary coercion ('as') if the types are already equal.
-  /// e.g. Double(1) as Double
-  RemoveUnnecessaryCoercion,
 
   /// Allow a single argument type mismatch. This is the most generic
   /// failure related to argument-to-parameter conversions.
@@ -1342,24 +1338,6 @@ public:
   static IgnoreContextualType *create(ConstraintSystem &cs, Type resultTy,
                                       Type specifiedTy,
                                       ConstraintLocator *locator);
-};
-
-class RemoveUnnecessaryCoercion : public ContextualMismatch {
-protected:
-  RemoveUnnecessaryCoercion(ConstraintSystem &cs, Type fromType, Type toType,
-                            ConstraintLocator *locator)
-      : ContextualMismatch(cs, FixKind::RemoveUnnecessaryCoercion, fromType,
-                           toType, locator, /*isWarning*/ true) {}
-
-public:
-  std::string getName() const override {
-    return "remove unnecessary explicit type coercion";
-  }
-
-  bool diagnose(Expr *root, bool asNote = false) const override;
-
-  static bool attempt(ConstraintSystem &cs, Type fromType, Type toType,
-                      ConstraintLocatorBuilder locator);
 };
 
 class IgnoreAssignmentDestinationType final : public ContextualMismatch {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -86,7 +86,6 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case KeyPathRoot:
     case KeyPathValue:
     case KeyPathComponentResult:
-    case ExplicitTypeCoercion:
     case Condition:
       auto numValues = numNumericValuesInPathElement(elt.getKind());
       for (unsigned i = 0; i < numValues; ++i)
@@ -134,7 +133,6 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::KeyPathRoot:
   case ConstraintLocator::KeyPathValue:
   case ConstraintLocator::KeyPathComponentResult:
-  case ConstraintLocator::ExplicitTypeCoercion:
   case ConstraintLocator::Condition:
     return 0;
 
@@ -460,11 +458,7 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
     case KeyPathComponentResult:
       out << "key path component result";
       break;
-        
-    case ExplicitTypeCoercion:
-      out << "type coercion";
-      break;
-      
+
     case Condition:
       out << "condition expression";
       break;

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -89,7 +89,6 @@ public:
     case KeyPathRoot:
     case KeyPathValue:
     case KeyPathComponentResult:
-    case ExplicitTypeCoercion:
     case Condition:
       return 0;
 

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -164,9 +164,6 @@ SIMPLE_LOCATOR_PATH_ELT(UnresolvedMember)
 /// The candidate witness during protocol conformance checking.
 CUSTOM_LOCATOR_PATH_ELT(Witness)
 
-/// An explicit type coercion.
-SIMPLE_LOCATOR_PATH_ELT(ExplicitTypeCoercion)
-
 /// The condition associated with 'if' expression or ternary operator.
 SIMPLE_LOCATOR_PATH_ELT(Condition)
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3000,11 +3000,6 @@ void constraints::simplifyLocator(Expr *&anchor,
       path = path.slice(1);
       continue;
     }
-        
-    case ConstraintLocator::ExplicitTypeCoercion: {
-      path = path.slice(1);
-      continue;
-    }
 
     default:
       // FIXME: Lots of other cases to handle.

--- a/test/ClangImporter/Darwin_test.swift
+++ b/test/ClangImporter/Darwin_test.swift
@@ -9,8 +9,7 @@ _ = nil as Fract? // expected-error{{use of undeclared type 'Fract'}}
 _ = nil as Darwin.Fract? // okay
 
 _ = 0 as OSErr
-// noErr is from the overlay
-_ = noErr as OSStatus // expected-warning {{redundant cast to 'OSStatus' (aka 'Int32') has no effect}} {{11-23=}}
+_ = noErr as OSStatus // noErr is from the overlay
 _ = 0 as UniChar
 
 _ = ProcessSerialNumber()

--- a/test/ClangImporter/MixedSource/mixed-target-using-header.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-header.swift
@@ -53,13 +53,12 @@ func testSuppressed() {
 #endif
 
 func testMacro() {
-  _ = CONSTANT as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{16-24=}}
+  _ = CONSTANT as CInt
 }
 
 func testFoundationOverlay() {
   _ = NSUTF8StringEncoding // no ambiguity
-  // and we should get the overlay version
-  _ = NSUTF8StringEncoding as UInt // expected-warning {{redundant cast to 'UInt' has no effect}} {{28-36=}}
+  _ = NSUTF8StringEncoding as UInt // and we should get the overlay version
 }
 
 #if !SILGEN

--- a/test/ClangImporter/Security_test.swift
+++ b/test/ClangImporter/Security_test.swift
@@ -4,8 +4,8 @@
 
 import Security
 
-_ = kSecClass as CFString // expected-warning {{redundant cast to 'CFString' has no effect}} {{15-27=}}
-_ = kSecClassGenericPassword as CFString // expected-warning {{redundant cast to 'CFString' has no effect}} {{30-42=}}
+_ = kSecClass as CFString
+_ = kSecClassGenericPassword as CFString
 _ = kSecClassGenericPassword as CFDictionary // expected-error {{'CFString?' is not convertible to 'CFDictionary'}} {{30-32=as!}}
 
 func testIntegration() {

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -102,7 +102,7 @@ public func testTopLevel() {
 
 _ = __PrivAnonymousA
 _ = __E0PrivA
-_ = __PrivE1A as __PrivE1 // expected-warning {{redundant cast to '__PrivE1' has no effect}} {{15-27=}}
+_ = __PrivE1A as __PrivE1
 _ = NSEnum.__privA
 _ = NSEnum.B
 _ = NSOptions.__privA

--- a/test/ClangImporter/cf.swift
+++ b/test/ClangImporter/cf.swift
@@ -90,9 +90,9 @@ func testTollFree1(_ ccmduct: CCMutableDuct) {
 }
 
 func testChainedAliases(_ fridge: CCRefrigerator) {
-  _ = fridge as CCRefrigerator // expected-warning {{redundant cast to 'CCRefrigerator' has no effect}} {{14-32=}}
+  _ = fridge as CCRefrigerator
 
-  _ = fridge as CCFridge // expected-warning {{redundant cast to 'CCFridge' (aka 'CCRefrigerator') has no effect}} {{14-26=}}
+  _ = fridge as CCFridge
   _ = fridge as CCFridgeRef // expected-error{{'CCFridgeRef' has been renamed to 'CCFridge'}} {{17-28=CCFridge}}
 }
 

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -15,7 +15,7 @@ func test_cfunc2(_ i: Int) {
 #else
   let f = cfunc2(i, 17)
 #endif
-  _ = f as Float // expected-warning {{redundant cast to 'Float' has no effect}} {{9-18=}}
+  _ = f as Float
   cfunc2(b:17, a:i) // expected-error{{extraneous argument labels 'b:a:' in call}}
   // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'Int32'}}
   cfunc2(17, i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'Int32'}}

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -47,7 +47,7 @@ func testAnonEnum() {
 func testAnonEnumSmall() {
   var a = AnonConstSmall1
   a = AnonConstSmall2
-  _ = a as Int // expected-warning {{redundant cast to 'Int' has no effect}} {{9-16=}}
+  _ = a as Int
 }
 
 func testPoint() -> Float {
@@ -141,14 +141,14 @@ func testImportStddefTypes() {
   let t2_unqual: Int = size_t_test
   let t3_unqual: Int = rsize_t_test
 
-  _ = t1_unqual as ctypes.ptrdiff_t // expected-warning {{redundant cast to 'ptrdiff_t' (aka 'Int') has no effect}} {{17-37=}}
-  _ = t2_unqual as ctypes.size_t // expected-warning {{redundant cast to 'size_t' (aka 'Int') has no effect}} {{17-34=}}
-  _ = t3_unqual as ctypes.rsize_t // expected-warning {{redundant cast to 'rsize_t' (aka 'Int') has no effect}} {{17-35=}}
+  _ = t1_unqual as ctypes.ptrdiff_t
+  _ = t2_unqual as ctypes.size_t
+  _ = t3_unqual as ctypes.rsize_t
 }
 
 func testImportSysTypesTypes() {
   let t1_unqual: Int = ssize_t_test
-  _ = t1_unqual as ctypes.ssize_t // expected-warning {{redundant cast to 'ssize_t' (aka 'Int') has no effect}} {{17-35=}}
+  _ = t1_unqual as ctypes.ssize_t
 }
 
 func testImportOSTypesTypes() {
@@ -198,7 +198,7 @@ func testFunctionPointers() {
   let fp = getFunctionPointer()
   useFunctionPointer(fp)
 
-  _ = fp as (@convention(c) (CInt) -> CInt)? // expected-warning {{redundant cast to '(@convention(c) (CInt) -> CInt)?' (aka 'Optional<@convention(c) (Int32) -> Int32>') has no effect}} {{10-46=}}
+  _ = fp as (@convention(c) (CInt) -> CInt)?
 
   let wrapper: FunctionPointerWrapper = FunctionPointerWrapper(a: nil, b: nil)
   _ = FunctionPointerWrapper(a: fp, b: fp)

--- a/test/ClangImporter/ctypes_parse_objc.swift
+++ b/test/ClangImporter/ctypes_parse_objc.swift
@@ -71,16 +71,16 @@ func testImportMacTypes() {
 
 func testImportCFTypes() {
   let t1_unqual: UInt = CFTypeID_test
-  _ = t1_unqual as CoreFoundation.CFTypeID // expected-warning {{redundant cast to 'CFTypeID' (aka 'UInt') has no effect}} {{17-44=}}
+  _ = t1_unqual as CoreFoundation.CFTypeID
 
   let t2_unqual: UInt = CFOptionFlags_test
-  _ = t2_unqual as CoreFoundation.CFOptionFlags // expected-warning {{redundant cast to 'CFOptionFlags' (aka 'UInt') has no effect}} {{17-49=}}
+  _ = t2_unqual as CoreFoundation.CFOptionFlags
 
   let t3_unqual: UInt = CFHashCode_test
-  _ = t3_unqual as CoreFoundation.CFHashCode // expected-warning {{redundant cast to 'CFHashCode' (aka 'UInt') has no effect}} {{17-46=}}
+  _ = t3_unqual as CoreFoundation.CFHashCode
 
   let t4_unqual: Int = CFIndex_test
-  _ = t4_unqual as CoreFoundation.CFIndex // expected-warning {{redundant cast to 'CFIndex' (aka 'Int') has no effect}} {{17-43=}}
+  _ = t4_unqual as CoreFoundation.CFIndex
 }
 
 func testImportSEL() {

--- a/test/ClangImporter/macros.swift
+++ b/test/ClangImporter/macros.swift
@@ -103,15 +103,15 @@ func testNil() {
 }
 
 func testBitwiseOps() {
-  _ = DISPATCH_TIME_FOREVER as CUnsignedLongLong // expected-warning {{redundant cast to 'CUnsignedLongLong' (aka 'UInt64') has no effect}} {{29-50=}}
+  _ = DISPATCH_TIME_FOREVER as CUnsignedLongLong
   _ = (BIT_SHIFT_1 | BIT_SHIFT_2) as CInt
-  _ = BIT_SHIFT_3 as CLongLong // expected-warning {{redundant cast to 'CLongLong' (aka 'Int64') has no effect}} {{19-32=}}
-  _ = BIT_SHIFT_4 as CUnsignedInt // expected-warning {{redundant cast to 'CUnsignedInt' (aka 'UInt32') has no effect}} {{19-35=}}
+  _ = BIT_SHIFT_3 as CLongLong
+  _ = BIT_SHIFT_4 as CUnsignedInt
 
-  _ = RSHIFT_ONE as CUnsignedInt // expected-warning {{redundant cast to 'CUnsignedInt' (aka 'UInt32') has no effect}} {{18-34=}}
+  _ = RSHIFT_ONE as CUnsignedInt
   _ = RSHIFT_INVALID // expected-error {{use of unresolved identifier 'RSHIFT_INVALID'}}
 
-  _ = XOR_HIGH as CUnsignedLongLong // expected-warning {{redundant cast to 'CUnsignedLongLong' (aka 'UInt64') has no effect}} {{16-37=}}
+  _ = XOR_HIGH as CUnsignedLongLong
 
   var attributes = 0 as CInt
   attributes |= ATTR_BOLD
@@ -121,30 +121,30 @@ func testBitwiseOps() {
 }
 
 func testIntegerArithmetic() {
-  _ = ADD_ZERO as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{16-24=}}
-  _ = ADD_ONE as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{15-23=}}
-  _ = ADD_TWO as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{15-23=}}
-  _ = ADD_MINUS_TWO as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{21-29=}}
-  _ = ADD_MIXED_WIDTH as CLongLong // expected-warning {{redundant cast to 'CLongLong' (aka 'Int64') has no effect}} {{23-36=}}
-  _ = ADD_MIXED_SIGN as CLongLong // expected-warning {{redundant cast to 'CLongLong' (aka 'Int64') has no effect}} {{22-35=}}
-  _ = ADD_UNDERFLOW as CUnsignedInt // expected-warning {{redundant cast to 'CUnsignedInt' (aka 'UInt32') has no effect}} {{21-37=}}
-  _ = ADD_OVERFLOW as CUnsignedInt // expected-warning {{redundant cast to 'CUnsignedInt' (aka 'UInt32') has no effect}} {{20-36=}}
+  _ = ADD_ZERO as CInt
+  _ = ADD_ONE as CInt
+  _ = ADD_TWO as CInt
+  _ = ADD_MINUS_TWO as CInt
+  _ = ADD_MIXED_WIDTH as CLongLong
+  _ = ADD_MIXED_SIGN as CLongLong
+  _ = ADD_UNDERFLOW as CUnsignedInt
+  _ = ADD_OVERFLOW as CUnsignedInt
 
-  _ = SUB_ONE as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{15-23=}}
-  _ = SUB_ZERO as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{16-24=}}
-  _ = SUB_MINUS_ONE as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{21-29=}}
-  _ = SUB_MIXED_WIDTH as CLongLong // expected-warning {{redundant cast to 'CLongLong' (aka 'Int64') has no effect}} {{23-36=}}
-  _ = SUB_MIXED_SIGN as CUnsignedInt // expected-warning {{redundant cast to 'CUnsignedInt' (aka 'UInt32') has no effect}} {{22-38=}}
-  _ = SUB_UNDERFLOW as CUnsignedInt // expected-warning {{redundant cast to 'CUnsignedInt' (aka 'UInt32') has no effect}} {{21-37=}}
-  _ = SUB_OVERFLOW as CUnsignedInt // expected-warning {{redundant cast to 'CUnsignedInt' (aka 'UInt32') has no effect}} {{20-36=}}
+  _ = SUB_ONE as CInt
+  _ = SUB_ZERO as CInt
+  _ = SUB_MINUS_ONE as CInt
+  _ = SUB_MIXED_WIDTH as CLongLong
+  _ = SUB_MIXED_SIGN as CUnsignedInt
+  _ = SUB_UNDERFLOW as CUnsignedInt
+  _ = SUB_OVERFLOW as CUnsignedInt
 
-  _ = MULT_POS as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{16-24=}}
-  _ = MULT_NEG as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{16-24=}}
-  _ = MULT_MIXED_TYPES as CLongLong // expected-warning {{redundant cast to 'CLongLong' (aka 'Int64') has no effect}} {{24-37=}}
+  _ = MULT_POS as CInt
+  _ = MULT_NEG as CInt
+  _ = MULT_MIXED_TYPES as CLongLong
 
-  _ = DIVIDE_INTEGRAL as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{23-31=}}
-  _ = DIVIDE_NONINTEGRAL as CInt // expected-warning {{redundant cast to 'CInt' (aka 'Int32') has no effect}} {{26-34=}}
-  _ = DIVIDE_MIXED_TYPES as CLongLong // expected-warning {{redundant cast to 'CLongLong' (aka 'Int64') has no effect}} {{26-39=}}
+  _ = DIVIDE_INTEGRAL as CInt
+  _ = DIVIDE_NONINTEGRAL as CInt
+  _ = DIVIDE_MIXED_TYPES as CLongLong
   _ = DIVIDE_INVALID // expected-error {{use of unresolved identifier 'DIVIDE_INVALID'}}
 }
 

--- a/test/ClangImporter/objc_bridging.swift
+++ b/test/ClangImporter/objc_bridging.swift
@@ -26,20 +26,20 @@ extension Set {
 }
 
 func foo() {
-  _  = NSStringToNSString as (String?) -> String? // expected-warning {{redundant cast to '(String?) -> String?' has no effect}} {{27-51=}}
+  _  = NSStringToNSString as (String?) -> String?
   _ = DummyClass().nsstringProperty.onlyOnString() as String
 
-  _  = BOOLtoBOOL as (Bool) -> Bool // expected-warning {{redundant cast to '(Bool) -> Bool' has no effect}} {{19-37=}}
+  _  = BOOLtoBOOL as (Bool) -> Bool
   _  = DummyClass().boolProperty.onlyOnBool() as Bool
 
-  _  = arrayToArray as (Array<Any>?) -> (Array<Any>?) // expected-warning {{redundant cast to '(Array<Any>?) -> (Array<Any>?)' has no effect}} {{21-55=}}
+  _  = arrayToArray as (Array<Any>?) -> (Array<Any>?)
   DummyClass().arrayProperty.onlyOnArray()
 
-  _ = dictToDict as (Dictionary<AnyHashable, Any>?) -> Dictionary<AnyHashable, Any>? // expected-warning {{redundant cast to '(Dictionary<AnyHashable, Any>?) -> Dictionary<AnyHashable, Any>?' has no effect}} {{18-86=}}
+  _ = dictToDict as (Dictionary<AnyHashable, Any>?) -> Dictionary<AnyHashable, Any>?
 
   DummyClass().dictProperty.onlyOnDictionary()
 
-  _ = setToSet as (Set<AnyHashable>?) -> Set<AnyHashable>? // expected-warning {{redundant cast to '(Set<AnyHashable>?) -> Set<AnyHashable>?' has no effect}} {{16-60=}}
+  _ = setToSet as (Set<AnyHashable>?) -> Set<AnyHashable>?
   DummyClass().setProperty.onlyOnSet()
 }
 

--- a/test/ClangImporter/objc_failable_inits.swift
+++ b/test/ClangImporter/objc_failable_inits.swift
@@ -20,13 +20,13 @@ func testString() throws {
   // Implicitly unwrapped optional
   let stringIUO = NSString(path: "blah")
   if stringIUO == nil { }
-  _ = stringIUO as NSString? // expected-warning {{redundant cast to 'NSString?' has no effect}} {{17-30=}}
+  _ = stringIUO as NSString?
   let _: NSString = NSString(path: "blah")
 }
 
 func testHive() {
   let hiveIUO = Hive()
   if hiveIUO == nil { }
-  _ = hiveIUO as Hive? // expected-warning {{redundant cast to 'Hive?' has no effect}} {{15-24=}}
+  _ = hiveIUO as Hive?
   let _: Hive = Hive()
 }

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -550,8 +550,8 @@ func testProtocolQualified(_ obj: CopyableNSObject, cell: CopyableSomeCell,
   _ = cell as NSCopying
   _ = cell as SomeCell
   
-  _ = plainObj as CopyableNSObject // expected-error {{value of type 'NSObject' does not conform to 'NSCopying' in coercion}}
-  _ = plainCell as CopyableSomeCell // expected-error {{value of type 'SomeCell' does not conform to 'NSCopying' in coercion}}
+  _ = plainObj as CopyableNSObject // expected-error {{'NSObject' is not convertible to 'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol'); did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
+  _ = plainCell as CopyableSomeCell // expected-error {{'SomeCell' is not convertible to 'CopyableSomeCell' (aka 'SomeCell & NSCopying'); did you mean to use 'as!' to force downcast?}}
 }
 
 extension Printing {

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -285,9 +285,9 @@ func rdar19836341(_ ns: NSString?, vns: NSString?) {
 
 // <rdar://problem/20029786> Swift compiler sometimes suggests changing "as!" to "as?!"
 func rdar20029786(_ ns: NSString?) {
-  var s: String = ns ?? "str" as String as String // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{19-19=(}} {{50-50=) as String}} expected-warning {{redundant cast to 'String' has no effect}} {{41-51=}}
+  var s: String = ns ?? "str" as String as String // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{19-19=(}} {{50-50=) as String}}
   // expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'NSString'}} {{50-50= as NSString}}
-  var s2 = ns ?? "str" as String as String // expected-error {{cannot convert value of type 'String' to expected argument type 'NSString'}}{{43-43= as NSString}} expected-warning {{redundant cast to 'String' has no effect}} {{34-44=}}
+  var s2 = ns ?? "str" as String as String // expected-error {{cannot convert value of type 'String' to expected argument type 'NSString'}}{{43-43= as NSString}}
 
   let s3: NSString? = "str" as String? // expected-error {{cannot convert value of type 'String?' to specified type 'NSString?'}}{{39-39= as NSString?}}
 
@@ -341,7 +341,7 @@ func forceUniversalBridgeToAnyObject<T, U: KnownClassProtocol>(a: T, b: U, c: An
   z = d as AnyObject
   z = e as AnyObject
   z = f as AnyObject
-  z = g as AnyObject // expected-warning {{redundant cast to 'AnyObject' has no effect}} {{9-22=}}
+  z = g as AnyObject
   z = h as AnyObject
 
   z = a // expected-error{{does not conform to 'AnyObject'}}

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -180,7 +180,7 @@ var c2f2: C2<[Float]>? = b as! C3
 
 
 // <rdar://problem/15633178>
-var f: (Float) -> Float = { $0 as Float } // expected-warning {{redundant cast to 'Float' has no effect}} {{32-41=}}
+var f: (Float) -> Float = { $0 as Float }
 var f2: (B) -> Bool = { $0 is D }
 
 func metatype_casts<T, U>(_ b: B.Type, t:T.Type, u: U.Type) {

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -94,12 +94,13 @@ _ = b as! Derived
 // NOTE: Int and other integer-literal convertible types
 //  are special cased in the library.
 Int(i) // expected-warning{{unused}}
-_ = i as Int // expected-warning {{redundant cast to 'Int' has no effect}} {{7-14=}}
+_ = i as Int
 Z(z) // expected-error{{no exact matches in call to initializer}}
+
 Z.init(z)  // expected-error {{no exact matches in call to initializer}}
 
 
-_ = z as Z // expected-warning {{redundant cast to 'Z' has no effect}} {{7-12=}}
+_ = z as Z
 
 // Construction from inouts.
 struct FooRef { }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -303,7 +303,7 @@ _ = 4(1)  // expected-error {{cannot call value of non-function type 'Int'}}
 // <rdar://problem/21784170> Incongruous `unexpected trailing closure` error in `init` function which is cast and called without trailing closure.
 func rdar21784170() {
   let initial = (1.0 as Double, 2.0 as Double)
-  (Array.init as (Double...) -> Array<Double>)(initial as (Double, Double)) // expected-error {{cannot convert value of type '(Double, Double)' to expected argument type 'Double'}} // expected-warning {{redundant cast to '(Double, Double)' has no effect}} {{56-75=}}
+  (Array.init as (Double...) -> Array<Double>)(initial as (Double, Double)) // expected-error {{cannot convert value of type '(Double, Double)' to expected argument type 'Double'}}
 }
 
 // Diagnose passing an array in lieu of variadic parameters

--- a/test/Constraints/invalid_logicvalue_coercion.swift
+++ b/test/Constraints/invalid_logicvalue_coercion.swift
@@ -2,7 +2,7 @@
 
 class C {}
 var c = C()
-if c as C { // expected-error{{cannot convert value of type 'C' to expected condition type 'Bool'}} expected-warning {{redundant cast to 'C' has no effect}} {{6-11=}}
+if c as C { // expected-error{{cannot convert value of type 'C' to expected condition type 'Bool'}}
 }
 
 if ({1} as () -> Int) { // expected-error{{cannot convert value of type '() -> Int' to expected condition type 'Bool'}}

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -53,7 +53,7 @@ func otherExistential<T : EqualComparable>(_ t1: T) {
   otherEqComp2 = t1 // expected-error{{value of type 'T' does not conform to 'OtherEqualComparable' in assignment}}
   _ = otherEqComp2
 
-  _ = t1 as EqualComparable & OtherEqualComparable // expected-error{{value of type 'T' does not conform to 'OtherEqualComparable' in coercion}} expected-error{{protocol 'OtherEqualComparable' can only be used as a generic constraint}} expected-error{{protocol 'EqualComparable' can only be used as a generic constraint}}
+  _ = t1 as EqualComparable & OtherEqualComparable // expected-error{{'T' is not convertible to 'EqualComparable & OtherEqualComparable'; did you mean to use 'as!' to force downcast?}} {{10-12=as!}} expected-error{{protocol 'OtherEqualComparable' can only be used as a generic constraint}} expected-error{{protocol 'EqualComparable' can only be used as a generic constraint}}
 }
 
 protocol Runcible {

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -191,11 +191,11 @@ var xarray : XArray = [1, 2, 3]
 // Type parameters can be referenced only via unqualified name lookup
 struct XParam<T> { // expected-note{{'XParam' declared here}}
   func foo(_ x: T) {
-    _ = x as T // expected-warning {{redundant cast to 'T' has no effect}} {{11-16=}}
+    _ = x as T
   }
 
   static func bar(_ x: T) {
-    _ = x as T // expected-warning {{redundant cast to 'T' has no effect}} {{11-16=}}
+    _ = x as T
   }
 }
 

--- a/test/Interpreter/SDK/misc_osx.swift
+++ b/test/Interpreter/SDK/misc_osx.swift
@@ -6,8 +6,7 @@ import CoreServices
 
 func testFSEventStreamRef(stream: FSEventStreamRef) {
   // FIXME: These should be distinct types, constructible from one another.
-  // works by coincidence because both are currently OpaquePointer 
-  _ = stream as ConstFSEventStreamRef // expected-warning {{redundant cast from 'FSEventStreamRef' (aka 'OpaquePointer') to 'ConstFSEventStreamRef' (aka 'OpaquePointer') has no effect}} {{14-39=}}
+  _ = stream as ConstFSEventStreamRef // works by coincidence because both are currently OpaquePointer
   _ = ConstFSEventStreamRef(stream) // expected-error {{cannot invoke initializer for type 'ConstFSEventStreamRef' with an argument list of type '(FSEventStreamRef)'}}
   // expected-note @-1 {{overloads for 'ConstFSEventStreamRef' exist with these partially matching parameter lists:}}
 

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -212,7 +212,7 @@ func warnOptionalInStringInterpolationSegment(_ o : Int?) {
   // expected-note@-2 {{use 'String(describing:)' to silence this warning}} {{51-51=String(describing: }} {{67-67=)}} 
   // expected-note@-3 {{provide a default value to avoid this warning}} {{67-67= ?? <#default value#>}}
 
-  print("Always some, Always some, Always some: \(o as Int?)") // expected-warning {{redundant cast to 'Int?' has no effect}} {{53-60=}}
+  print("Always some, Always some, Always some: \(o as Int?)") // No warning
   print("Always some, Always some, Always some: \(o.debugDescription)") // No warning.
   
   let oST = Optional(SpecialType())

--- a/test/Sema/suppress-argument-labels-in-types.swift
+++ b/test/Sema/suppress-argument-labels-in-types.swift
@@ -207,18 +207,18 @@ let _ = min(Int(3), Float(2.5)) // expected-error{{cannot convert value of type 
 
 // SR-11429
 func testIntermediateCoercions() {
-  _ = (f1 as (Int, Int) -> Int)(a: 0, b: 1) // expected-error {{extraneous argument labels 'a:b:' in call}} expected-warning {{redundant cast to '(Int, Int) -> Int' has no effect}}
-  _ = (f1 as (Int, Int) -> Int)(0, 1) // expected-warning {{redundant cast to '(Int, Int) -> Int' has no effect}}
+  _ = (f1 as (Int, Int) -> Int)(a: 0, b: 1) // expected-error {{extraneous argument labels 'a:b:' in call}}
+  _ = (f1 as (Int, Int) -> Int)(0, 1)
 
   typealias Magic<T> = T
-  _ = (f1 as Magic)(a: 0, b: 1) // expected-error {{extraneous argument labels 'a:b:' in call}} expected-warning {{redundant cast to '(Int, Int) -> Int' has no effect}}
-  _ = (f1 as Magic)(0, 1) // expected-warning {{redundant cast to '(Int, Int) -> Int' has no effect}}
+  _ = (f1 as Magic)(a: 0, b: 1) // expected-error {{extraneous argument labels 'a:b:' in call}}
+  _ = (f1 as Magic)(0, 1)
 
   _ = (f4 as (Int, Int) -> Int)(0, 0)
   _ = (f4 as (Double, Double) -> Double)(0, 0)
 
   func iuoReturning() -> Int! {}
-  _ = (iuoReturning as () -> Int?)() // expected-warning {{redundant cast to '() -> Int?' has no effect}}
-  _ = (iuoReturning as Magic)() // expected-warning {{redundant cast to '() -> Int?' has no effect}}
+  _ = (iuoReturning as () -> Int?)()
+  _ = (iuoReturning as Magic)()
   _ = (iuoReturning as () -> Int)() // expected-error {{cannot convert value of type '() -> Int?' to type '() -> Int' in coercion}}
 }

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -118,7 +118,7 @@ struct Circle {
 func testCircular(_ circle: Circle) {
   // FIXME: It would be nice if this failure were suppressed because the protocols
   // have circular definitions.
-  _ = circle as CircleStart // expected-error{{value of type 'Circle' does not conform to 'CircleStart' in coercion}}
+  _ = circle as CircleStart // expected-error{{'Circle' is not convertible to 'CircleStart'; did you mean to use 'as!' to force downcast?}} {{14-16=as!}}
 }
 
 // <rdar://problem/14750346>
@@ -482,7 +482,7 @@ func f<T : C1>(_ x : T) {
 
 class C2 {}
 func g<T : C2>(_ x : T) {
-  x as P2 // expected-error {{value of type 'T' does not conform to 'P2' in coercion}}
+  x as P2 // expected-error{{'T' is not convertible to 'P2'; did you mean to use 'as!' to force downcast?}} {{5-7=as!}}
 }
 
 class C3 : P1 {} // expected-error{{type 'C3' does not conform to protocol 'P1'}}

--- a/test/decl/protocol/req/optional.swift
+++ b/test/decl/protocol/req/optional.swift
@@ -144,7 +144,7 @@ func optionalPropertyGeneric<T : P1>(_ t: T) {
 
   // ... and that we can use it
   let i = propertyRef!
-  _ = i as Int // expected-warning {{redundant cast to 'Int' has no effect}} {{9-16=}}
+  _ = i as Int
 }
 
 // Optional subscript references in generics.
@@ -157,7 +157,7 @@ func optionalSubscriptGeneric<T : P1>(_ t: T) {
 
   // ... and that we can use it
   let i = subscriptRef!
-  _ = i as ObjCClass? // expected-warning {{redundant cast to 'ObjCClass?' has no effect}} {{9-23=}}
+  _ = i as ObjCClass?
 }
 
 // Optional method references in existentials.
@@ -182,7 +182,7 @@ func optionalPropertyExistential(_ t: P1) {
 
   // ... and that we can use it
   let i = propertyRef!
-  _ = i as Int // expected-warning {{redundant cast to 'Int' has no effect}} {{9-16=}}
+  _ = i as Int
 }
 
 // Optional subscript references in existentials.
@@ -195,7 +195,7 @@ func optionalSubscriptExistential(_ t: P1) {
 
   // ... and that we can use it
   let i = subscriptRef!
-  _ = i as ObjCClass? // expected-warning {{redundant cast to 'ObjCClass?' has no effect}} {{9-23=}}
+  _ = i as ObjCClass?
 }
 
 // -----------------------------------------------------------------------

--- a/test/expr/cast/array_downcast.swift
+++ b/test/expr/cast/array_downcast.swift
@@ -24,7 +24,7 @@ var ta = [t]
 
 va = ta
 
-var va2: ([V])? = va as [V] // expected-warning {{redundant cast to '[V]' has no effect}} {{22-29=}}
+var va2: ([V])? = va as [V]
 var v2: V = va2![0]
 
 var ua2: ([U])? = va as? [U]

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -81,7 +81,7 @@ c3 as C4 // expected-error {{'C3' is not convertible to 'C4'; did you mean to us
 // <rdar://problem/19495142> Various incorrect diagnostics for explicit type conversions
 1 as Double as Float // expected-error{{cannot convert value of type 'Double' to type 'Float' in coercion}}
 1 as Int as String // expected-error{{cannot convert value of type 'Int' to type 'String' in coercion}}
-Double(1) as Double as String // expected-error{{cannot convert value of type 'Double' to type 'String' in coercion}} expected-warning {{redundant cast to 'Double' has no effect}} {{11-21=}}
+Double(1) as Double as String // expected-error{{cannot convert value of type 'Double' to type 'String' in coercion}}
 ["awd"] as [Int] // expected-error{{cannot convert value of type 'String' to expected element type 'Int'}}
 ([1, 2, 1.0], 1) as ([String], Int)
 // expected-error@-1 2 {{cannot convert value of type 'Int' to expected element type 'String'}}
@@ -135,41 +135,3 @@ _ = sr6022 as! AnyObject // expected-warning {{forced cast from '() -> Any' to '
 _ = sr6022 as? AnyObject // expected-warning {{conditional cast from '() -> Any' to 'AnyObject' always succeeds}}
 _ = sr6022_1 as! Any // expected-warning {{forced cast from '() -> ()' to 'Any' always succeeds; did you mean to use 'as'?}}
 _ = sr6022_1 as? Any // expected-warning {{conditional cast from '() -> ()' to 'Any' always succeeds}}
-
-// SR-11295
-let sr11295a = "Hello"
-_ = sr11295a as String // expected-warning {{redundant cast to 'String' has no effect}} {{14-24=}}
-
-let sr11295b = 1
-_ = sr11295b as Int // expected-warning {{redundant cast to 'Int' has no effect}} {{14-21=}}
-
-typealias Type = String
-
-let sr11295c: Type = "Hello Typealias"
-_ = sr11295c as String // expected-warning {{redundant cast to 'String' has no effect}} {{14-24=}}
-
-let sr11295d = "Hello Typealias"
-_ = sr11295d as Type // expected-warning {{redundant cast to 'Type' (aka 'String') has no effect}} {{14-22=}}
-
-_ = "Hello" as String // Ok
-_ = 1 as Int64 // Ok
-_ = [] as Set<Int> // Ok
-
-class SR11295A {}
-class SR11295B: SR11295A {}
-
-var sr11295ap = SR11295A()
-var sr11295bc = SR11295B()
-
-_ = sr11295bc as SR11295A // Ok 
-
-_ = 1 as Double as Double // expected-warning {{redundant cast to 'Double' has no effect}} {{17-27=}}
-_ = Double(1) as Double // expected-warning {{redundant cast to 'Double' has no effect}} {{15-25=}}
-_ = Int(1) as Int  // expected-warning {{redundant cast to 'Int' has no effect}} {{12-19=}}
-
-typealias Double1 = Double
-typealias Double2 = Double
-
-let sr11295ta1: Double1 = 1.0
-_ = sr11295ta1 as Double2 // expected-warning {{redundant cast from 'Double1' (aka 'Double') to 'Double2' (aka 'Double') has no effect}} {{16-27=}}
-_ = sr11295ta1 as Double1 // expected-warning {{redundant cast to 'Double1' (aka 'Double') has no effect}} {{16-27=}}

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -27,7 +27,7 @@ func testNonAmbiguousStringComparisons() {
   let s2 = "b"
   var x = false // expected-warning {{variable 'x' was written to, but never read}}
   x = s1 > s2
-  x = s1 as String > s2 // expected-warning {{redundant cast to 'String' has no effect}} {{10-20=}}
+  x = s1 as String > s2
 }
 
 func testAmbiguousStringComparisons(s: String) {

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -126,8 +126,8 @@ func basicSubtyping(
   let _: Derived & AnyObject = derived
 
   let _ = base as Base<Int> & P1
-  let _ = base as Base<Int> & AnyObject // expected-warning {{redundant cast to 'Base<Int>' has no effect}} {{16-41=}}
-  let _ = derived as Derived & AnyObject // expected-warning {{redundant cast to 'Derived' has no effect}} {{19-42=}}
+  let _ = base as Base<Int> & AnyObject
+  let _ = derived as Derived & AnyObject
 
   let _ = base as? Base<Int> & P1 // expected-warning {{always succeeds}}
   let _ = base as? Base<Int> & AnyObject // expected-warning {{always succeeds}}
@@ -170,7 +170,7 @@ func basicSubtyping(
   let _ = baseAndP1 as Base<Int>
   let _ = derivedAndP3 as Base<Int>
   let _ = derivedAndP2 as Derived
-  let _ = derivedAndAnyObject as Derived // expected-warning {{redundant cast to 'Derived' has no effect}} {{31-42=}}
+  let _ = derivedAndAnyObject as Derived
 
   let _ = baseAndP1 as? Base<Int> // expected-warning {{always succeeds}}
   let _ = derivedAndP3 as? Base<Int> // expected-warning {{always succeeds}}
@@ -343,8 +343,8 @@ func metatypeSubtyping(
 
   let _ = baseIntAndP2 as Base<Int>.Type
   let _ = baseIntAndP2AndAnyObject as Base<Int>.Type
-  let _ = derivedAndAnyObject as Derived.Type // expected-warning {{redundant cast to 'Derived.Type' has no effect}} {{31-47=}}
-  let _ = baseIntAndP2AndAnyObject as BaseAndP2<Int>.Type // expected-warning {{redundant cast to 'BaseAndP2<Int>.Type' (aka '(Base<Int> & P2).Type') has no effect}} {{36-59=}}
+  let _ = derivedAndAnyObject as Derived.Type
+  let _ = baseIntAndP2AndAnyObject as BaseAndP2<Int>.Type
 
   let _ = baseIntAndP2 as? Base<Int>.Type // expected-warning {{always succeeds}}
   let _ = baseIntAndP2AndAnyObject as? Base<Int>.Type // expected-warning {{always succeeds}}


### PR DESCRIPTION
Reverts apple/swift#26710

Unfortunately there are edge cases which this changes which are related to generic arguments.
They need to be addressed before original PR could be re-applied. See https://github.com/apple/swift/pull/27877 for some more details.

Resolves: rdar://problem/56608085
