### PR TITLE
[ConstraintSystem] Fix not warn about some redundant coercions

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -881,6 +881,13 @@ bool RemoveUnnecessaryCoercion::attempt(ConstraintSystem &cs, Type fromType,
   if (!isa<ImplicitlyUnwrappedOptionalTypeRepr>(toTypeRepr) &&
       (isa<DeclRefExpr>(expr->getSubExpr()) ||
        isa<CoerceExpr>(expr->getSubExpr()))) {
+
+    // If coerced type is not known upfront let's not warn
+    // because the type could be inferred from coercion.
+    auto coercedType = cs.getType(expr->getSubExpr());
+    if (coercedType->is<TypeVariableType>())
+      return false;
+    
     auto *fix = new (cs.getAllocator()) RemoveUnnecessaryCoercion(
         cs, fromType, toType, cs.getConstraintLocator(locator));
 

--- a/test/ClangImporter/Security_test.swift
+++ b/test/ClangImporter/Security_test.swift
@@ -4,8 +4,8 @@
 
 import Security
 
-_ = kSecClass as CFString // expected-warning {{redundant cast to 'CFString' has no effect}} {{15-27=}}
-_ = kSecClassGenericPassword as CFString // expected-warning {{redundant cast to 'CFString' has no effect}} {{30-42=}}
+_ = kSecClass as CFString
+_ = kSecClassGenericPassword as CFString 
 _ = kSecClassGenericPassword as CFDictionary // expected-error {{'CFString?' is not convertible to 'CFDictionary'}} {{30-32=as!}}
 
 func testIntegration() {

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -180,7 +180,7 @@ var c2f2: C2<[Float]>? = b as! C3
 
 
 // <rdar://problem/15633178>
-var f: (Float) -> Float = { $0 as Float } // expected-warning {{redundant cast to 'Float' has no effect}} {{32-41=}}
+var f: (Float) -> Float = { $0 as Float } 
 var f2: (B) -> Bool = { $0 is D }
 
 func metatype_casts<T, U>(_ b: B.Type, t:T.Type, u: U.Type) {

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -173,3 +173,7 @@ typealias Double2 = Double
 let sr11295ta1: Double1 = 1.0
 _ = sr11295ta1 as Double2 // expected-warning {{redundant cast from 'Double1' (aka 'Double') to 'Double2' (aka 'Double') has no effect}} {{16-27=}}
 _ = sr11295ta1 as Double1 // expected-warning {{redundant cast to 'Double1' (aka 'Double') has no effect}} {{16-27=}}
+
+// rdar://problem/56608085
+var f56608085: (Float) -> Float = { $0 as Float } // Ok
+var f56608085_1 = { $0 as Float } // Ok


### PR DESCRIPTION
@xedin 
I just took a continuation on your #27877 
Fixed the cases on tests and added the rdar as test case is as_coercion.swift
But if you think is better to revert the original PR and fix it there, let me know :) 
I'm staying tuned on github notifications all day for this, feel free to just ping me for anything 👍 

rdar-56608085

References:  #27880 #26710 