### PR TITLE
[test] Add test case for convenience init inheritance

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.apinotes
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.apinotes
@@ -1,0 +1,7 @@
+Name: ObjCParseExtras
+Classes:
+- Name: SubclassWithSwiftPrivateDesignatedInit
+  Methods:
+  - Selector: "initWithI:"
+    MethodKind: Instance
+    SwiftPrivate: true

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -249,3 +249,14 @@ struct TrivialToCopy {
 
 @interface OverrideInExtensionSub : OverrideInExtensionBase
 @end
+
+@interface SuperclassWithDesignatedInitInCategory
+@end
+
+@interface SubclassWithSwiftPrivateDesignatedInit : SuperclassWithDesignatedInitInCategory
+-(instancetype) initWithI:(NSInteger)i __attribute__((objc_designated_initializer));
+@end
+
+@interface SuperclassWithDesignatedInitInCategory ()
+-(instancetype) initWithI:(NSInteger)i __attribute__((objc_designated_initializer));
+@end

--- a/test/ClangImporter/objc_init.swift
+++ b/test/ClangImporter/objc_init.swift
@@ -197,3 +197,16 @@ func classPropertiesAreNotInit() -> ProcessInfo {
   procInfo = ProcessInfo.processInfo // okay
   return procInfo
 }
+
+// Make sure we can still inherit a convenience initializer when we have a
+// designated initializer override in Obj-C that isn't considered a proper
+// override in Swift. In this case, both the superclass and subclass have a
+// designed init with the selector `initWithI:`, however the Swift signature for
+// the subclass' init is `init(__i:)` rather than `init(i:)`.
+extension SuperclassWithDesignatedInitInCategory {
+  convenience init(y: Int) { self.init(i: y) }
+}
+
+func testConvenienceInitInheritance() {
+  _ = SubclassWithSwiftPrivateDesignatedInit(y: 5)
+}


### PR DESCRIPTION
This test case tripped up an attempt I made to simplify `addImplicitInheritedConstructorsToClass` for clang decls. Add it to the test suite to make sure we don't regress it.
