### PR TITLE
Add a bailout path to protocol requirement source formation

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1442,6 +1442,10 @@ void RequirementSource::print(llvm::raw_ostream &out,
 static Type formProtocolRelativeType(ProtocolDecl *proto,
                                      Type baseType,
                                      Type type) {
+  // Error case: hand back the erroneous type.
+  if (type->hasError())
+    return type;
+
   // Basis case: we've hit the base potential archetype.
   if (baseType->isEqual(type))
     return proto->getSelfInterfaceType();

--- a/validation-test/compiler_crashers_2_fixed/rdar56116278.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar56116278.swift
@@ -1,0 +1,3 @@
+// RUN: not %target-typecheck-verify-swift
+
+protocol P where A : Int {}


### PR DESCRIPTION
The GSB will try to form and note invalid constraints, but there are
a few paths that aren't prepared for error types to pop up.  Add
a defensive check to formProtocolRelativeType to make sure we don't wind
up force-casting an error type.

Fixes rdar://56116278
