### PR TITLE
build-script: support CMake install steps.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3538,24 +3538,27 @@ for host in "${ALL_HOSTS[@]}"; do
                     echo "--install-destdir is required to install products."
                     exit 1
                 fi
-
-                case ${host} in
-                    linux-*)
+                if [[ "$using_xcodebuild" == "TRUE" ]] ; then
+                    case ${host} in
+                        linux-*)
                         ;;
-                    freebsd-*)
+                        freebsd-*)
                         ;;
-                    cygwin-*)
+                        cygwin-*)
                         ;;
-                    haiku-*)
+                        haiku-*)
                         ;;
-                    macosx-*)
-                        set_lldb_xcodebuild_options
-                        set_lldb_build_mode
-                        with_pushd ${LLDB_SOURCE_DIR} \
-                            call xcodebuild -target toolchain -configuration ${LLDB_BUILD_MODE} install ${lldb_xcodebuild_options[@]} DSTROOT="${host_install_destdir}" LLDB_TOOLCHAIN_PREFIX="${TOOLCHAIN_PREFIX}"
-                        continue
+                        macosx-*)
+                            set_lldb_xcodebuild_options
+                            set_lldb_build_mode
+                            with_pushd ${LLDB_SOURCE_DIR} \
+                                       call xcodebuild -target toolchain -configuration ${LLDB_BUILD_MODE} install ${lldb_xcodebuild_options[@]} DSTROOT="${host_install_destdir}" LLDB_TOOLCHAIN_PREFIX="${TOOLCHAIN_PREFIX}"
+                            continue
                         ;;
-                esac
+                    esac
+                else
+                    INSTALL_TARGETS="install-lldb"
+                fi
                 ;;
             swiftpm)
                 if [[ -z "${INSTALL_SWIFTPM}" ]] ; then


### PR DESCRIPTION
Cherry-pick Adrian's fix from master to skip an unnecessary xcodebuild invocation;
should fix the swift-5.1 bot problem eg  https://ci.swift.org/job/oss-swift-5.1-package-osx/

build-script: support CMake install steps.

Currently, bots that perfrom an installation will build LLDB once using CMake
because that is the default and then again using Xcode because the CMake
install step is not implemented by build-script. This patch adds CMake support
by calling the generic cmake install-lldb step.

<rdar://problem/51317901>

(cherry picked from commit 78218b0c2a40377d0527167ef55734a658ff6f37)
