### PR TITLE
SIL: Add fields to SILFunctionType for substituted function types.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -71,6 +71,7 @@ class NominalTypeDecl;
 class GenericTypeDecl;
 class EnumDecl;
 class EnumElementDecl;
+class SILFunctionType;
 class StructDecl;
 class ProtocolDecl;
 class TypeVariableType;
@@ -80,6 +81,8 @@ class ModuleType;
 class ProtocolConformance;
 enum PointerTypeKind : unsigned;
 struct ValueOwnershipKind;
+
+typedef CanTypeWrapper<SILFunctionType> CanSILFunctionType;
 
 enum class TypeKind : uint8_t {
 #define TYPE(id, parent) id,
@@ -3409,9 +3412,19 @@ public:
     assert(type->isLegalSILType() && "SILParameterInfo has illegal SIL type");
   }
 
-  CanType getType() const {
+  /// Return the unsubstituted parameter type that describes the abstract
+  /// calling convention of the parameter.
+  ///
+  /// For most purposes, you probably want \c getArgumentType .
+  CanType getInterfaceType() const {
     return TypeAndConvention.getPointer();
   }
+  
+  /// Return the type of a call argument matching this parameter.
+  ///
+  /// \c t must refer back to the function type this is a parameter for.
+  CanType getArgumentType(SILModule &M,
+                          const SILFunctionType *t) const;
   ParameterConvention getConvention() const {
     return TypeAndConvention.getInt();
   }
@@ -3456,10 +3469,12 @@ public:
   /// storage. Therefore they will be passed using an indirect formal
   /// convention, and this method will return an address type. However, in
   /// canonical SIL the opaque arguments might not have an address type.
-  SILType getSILStorageType() const; // in SILFunctionConventions.h
+  SILType getSILStorageType(SILModule &M,
+                            const SILFunctionType *t) const; // in SILFunctionConventions.h
+  SILType getSILStorageInterfaceType() const;
 
   /// Return a version of this parameter info with the type replaced.
-  SILParameterInfo getWithType(CanType type) const {
+  SILParameterInfo getWithInterfaceType(CanType type) const {
     return SILParameterInfo(type, getConvention());
   }
 
@@ -3470,11 +3485,11 @@ public:
   /// Type::transform does.
   template<typename F>
   SILParameterInfo map(const F &fn) const {
-    return getWithType(fn(getType()));
+    return getWithInterfaceType(fn(getInterfaceType()));
   }
 
   void profile(llvm::FoldingSetNodeID &id) {
-    id.AddPointer(getType().getPointer());
+    id.AddPointer(getInterfaceType().getPointer());
     id.AddInteger((unsigned)getConvention());
   }
 
@@ -3489,7 +3504,8 @@ public:
   }
 
   bool operator==(SILParameterInfo rhs) const {
-    return getType() == rhs.getType() && getConvention() == rhs.getConvention();
+    return getInterfaceType() == rhs.getInterfaceType()
+      && getConvention() == rhs.getConvention();
   }
   bool operator!=(SILParameterInfo rhs) const {
     return !(*this == rhs);
@@ -3541,9 +3557,20 @@ public:
     assert(type->isLegalSILType() && "SILResultInfo has illegal SIL type");
   }
 
-  CanType getType() const {
+  /// Return the unsubstituted parameter type that describes the abstract
+  /// calling convention of the parameter.
+  ///
+  /// For most purposes, you probably want \c getReturnValueType .
+  CanType getInterfaceType() const {
     return TypeAndConvention.getPointer();
   }
+  
+  /// The type of a return value corresponding to this result.
+  ///
+  /// \c t must refer back to the function type this is a parameter for.
+  CanType getReturnValueType(SILModule &M,
+                             const SILFunctionType *t) const;
+  
   ResultConvention getConvention() const {
     return TypeAndConvention.getInt();
   }
@@ -3553,10 +3580,11 @@ public:
   /// storage. Therefore they will be returned using an indirect formal
   /// convention, and this method will return an address type. However, in
   /// canonical SIL the opaque results might not have an address type.
-  SILType getSILStorageType() const; // in SILFunctionConventions.h
-
+  SILType getSILStorageType(SILModule &M,
+                            const SILFunctionType *t) const; // in SILFunctionConventions.h
+  SILType getSILStorageInterfaceType() const;
   /// Return a version of this result info with the type replaced.
-  SILResultInfo getWithType(CanType type) const {
+  SILResultInfo getWithInterfaceType(CanType type) const {
     return SILResultInfo(type, getConvention());
   }
 
@@ -3577,7 +3605,7 @@ public:
   /// Type::transform does.
   template <typename F>
   SILResultInfo map(F &&fn) const {
-    return getWithType(fn(getType()));
+    return getWithInterfaceType(fn(getInterfaceType()));
   }
 
   void profile(llvm::FoldingSetNodeID &id) {
@@ -3616,13 +3644,13 @@ public:
     : SILParameterInfo(type, conv) {
   }
 
-  SILYieldInfo getWithType(CanType type) const {
+  SILYieldInfo getWithInterfaceType(CanType type) const {
     return SILYieldInfo(type, getConvention());
   }
 
   template<typename F>
   SILYieldInfo map(const F &fn) const {
-    return getWithType(fn(getType()));
+    return getWithInterfaceType(fn(getInterfaceType()));
   }
 };
 
@@ -3641,8 +3669,6 @@ enum class SILCoroutineKind : uint8_t {
   YieldMany,
 };
   
-class SILFunctionType;
-typedef CanTypeWrapper<SILFunctionType> CanSILFunctionType;
 class SILFunctionConventions;
 
 /// SILFunctionType - The lowered type of a function value, suitable
@@ -3799,8 +3825,9 @@ private:
   //   CanType?          // if !isCoro && NumAnyResults > 1, formal result cache
   //   CanType?          // if !isCoro && NumAnyResults > 1, all result cache
 
-  CanGenericSignature GenericSig;
+  llvm::PointerIntPair<CanGenericSignature, 1, bool> GenericSigAndIsImplied;
   Optional<ProtocolConformanceRef> WitnessMethodConformance;
+  SubstitutionMap Substitutions;
 
   MutableArrayRef<SILParameterInfo> getMutableParameters() {
     return {getTrailingObjects<SILParameterInfo>(), NumParameters};
@@ -3861,6 +3888,8 @@ private:
                   ArrayRef<SILYieldInfo> yieldResults,
                   ArrayRef<SILResultInfo> normalResults,
                   Optional<SILResultInfo> errorResult,
+                  SubstitutionMap substitutions,
+                  bool genericSigIsImplied,
                   const ASTContext &ctx,
                   RecursiveTypeProperties properties,
                   Optional<ProtocolConformanceRef> witnessMethodConformance);
@@ -3874,6 +3903,8 @@ public:
                                 ArrayRef<SILYieldInfo> interfaceYields,
                                 ArrayRef<SILResultInfo> interfaceResults,
                                 Optional<SILResultInfo> interfaceErrorResult,
+                                SubstitutionMap substitutions,
+                                bool genericSigIsImplied,
                                 const ASTContext &ctx,
               Optional<ProtocolConformanceRef> witnessMethodConformance = None);
 
@@ -3894,7 +3925,7 @@ public:
   ///   - a single indirect result and no direct results.
   ///
   /// If the result is formally indirect, return the empty tuple.
-  SILType getFormalCSemanticResult();
+  SILType getFormalCSemanticResult(SILModule &M);
 
   /// Return the convention under which the callee is passed, if this
   /// is a thick non-block callee.
@@ -4003,14 +4034,15 @@ public:
   /// this function depends on the current SIL stage and is known by
   /// SILFunctionConventions. It may be a wider tuple that includes formally
   /// indirect results.
-  SILType getDirectFormalResultsType();
+  SILType getDirectFormalResultsType(SILModule &M);
 
   /// Get a single non-address SILType for all SIL results regardless of whether
   /// they are formally indirect. The actual SIL result type of an apply
   /// instruction that calls this function depends on the current SIL stage and
   /// is known by SILFunctionConventions. It may be a narrower tuple that omits
   /// formally indirect results.
-  SILType getAllResultsType();
+  SILType getAllResultsSubstType(SILModule &M);
+  SILType getAllResultsInterfaceType();
 
   /// Does this function have a blessed Swift-native error result?
   bool hasErrorResult() const {
@@ -4041,15 +4073,36 @@ public:
     return getParameters().back();
   }
 
-  bool isPolymorphic() const { return !GenericSig.isNull(); }
-  CanGenericSignature getGenericSignature() const { return GenericSig; }
+  /// Get the generic signature used to apply the substitutions of a substituted function type
+  CanGenericSignature getSubstGenericSignature() const {
+    return GenericSigAndIsImplied.getPointer();
+  }
+  /// Get the generic signature used by callers to invoke the function.
+  CanGenericSignature getInvocationGenericSignature() const {
+    if (isGenericSignatureImplied()) {
+      return CanGenericSignature();
+    } else {
+      return getSubstGenericSignature();
+    }
+  }
+                                    
+  bool isGenericSignatureImplied() const {
+    return GenericSigAndIsImplied.getInt();
+  }
+  SubstitutionMap getSubstitutions() const {
+    return Substitutions;
+  }
 
-  CanType getSelfInstanceType() const;
+  bool isPolymorphic() const {
+    return !getInvocationGenericSignature().isNull();
+  }
+
+  CanType getSelfInstanceType(SILModule &M) const;
 
   /// If this is a @convention(witness_method) function with a class
   /// constrained self parameter, return the class constraint for the
   /// Self type.
-  ClassDecl *getWitnessMethodClass() const;
+  ClassDecl *getWitnessMethodClass(SILModule &M) const;
 
   /// If this is a @convention(witness_method) function, return the conformance
   /// for which the method is a witness.
@@ -4095,7 +4148,11 @@ public:
            getRepresentation() == SILFunctionTypeRepresentation::Thick;
   }
 
-  bool isNoReturnFunction() const; // Defined in SILType.cpp
+  bool isNoReturnFunction(SILModule &M) const; // Defined in SILType.cpp
+                                    
+  /// Create a SILFunctionType with the same parameters, results, and attributes as this one, but with
+  /// a different set of substitutions.
+  CanSILFunctionType withSubstitutions(SubstitutionMap subs) const;
 
   class ABICompatibilityCheckResult {
     friend class SILFunctionType;
@@ -4139,7 +4196,7 @@ public:
   /// assertions are disabled, this just returns true.
   ABICompatibilityCheckResult
   isABICompatibleWith(CanSILFunctionType other,
-                      SILFunction *context = nullptr) const;
+                      SILFunction &context) const;
 
   CanSILFunctionType substGenericArgs(SILModule &silModule,
                                       SubstitutionMap subs);
@@ -4147,11 +4204,16 @@ public:
                                       TypeSubstitutionFn subs,
                                       LookupConformanceFn conformances);
 
+  SILType substInterfaceType(SILModule &M,
+                             SILType interfaceType) const;
+
   void Profile(llvm::FoldingSetNodeID &ID) {
-    Profile(ID, getGenericSignature(), getExtInfo(), getCoroutineKind(),
+    Profile(ID, getSubstGenericSignature(), getExtInfo(), getCoroutineKind(),
             getCalleeConvention(), getParameters(), getYields(),
             getResults(), getOptionalErrorResult(),
-            getWitnessMethodConformanceOrNone());
+            getWitnessMethodConformanceOrNone(),
+            isGenericSignatureImplied(),
+            getSubstitutions());
   }
   static void Profile(llvm::FoldingSetNodeID &ID,
                       GenericSignature genericSig,
@@ -4162,7 +4224,9 @@ public:
                       ArrayRef<SILYieldInfo> yields,
                       ArrayRef<SILResultInfo> results,
                       Optional<SILResultInfo> errorResult,
-                      Optional<ProtocolConformanceRef> conformance);
+                      Optional<ProtocolConformanceRef> conformance,
+                      bool isGenericSigImplied,
+                      SubstitutionMap substitutions);
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {

--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -37,6 +37,11 @@
 
 namespace swift {
 
+template<bool _, template<typename...> class T, typename...Args>
+struct delay_template_expansion {
+  using type = T<Args...>;
+};
+
 /// Transient wrapper for SILParameterInfo and SILResultInfo conventions. This
 /// abstraction helps handle the transition from canonical SIL conventions to
 /// lowered SIL conventions.
@@ -45,37 +50,50 @@ class SILModuleConventions {
   friend SILResultInfo;
   friend SILFunctionConventions;
 
-  static bool isIndirectSILParam(SILParameterInfo param, bool loweredAddresses);
+  static bool isIndirectSILParam(SILParameterInfo param,
+                                 bool loweredAddresses);
 
-  static bool isIndirectSILYield(SILYieldInfo yield, bool loweredAddresses);
+  static bool isIndirectSILYield(SILYieldInfo yield,
+                                 bool loweredAddresses);
 
-  static bool isIndirectSILResult(SILResultInfo result, bool loweredAddresses);
+  static bool isIndirectSILResult(SILResultInfo result,
+                                  bool loweredAddresses);
 
-  static SILType getSILParamType(SILParameterInfo param, bool loweredAddresses);
+  static SILType getSILParamInterfaceType(
+                                 SILParameterInfo yield,
+                                 bool loweredAddresses);
 
-  static SILType getSILYieldType(SILYieldInfo yield, bool loweredAddresses);
+  static SILType getSILYieldInterfaceType(
+                                 SILYieldInfo yield,
+                                 bool loweredAddresses);
 
-  static SILType getSILResultType(SILResultInfo param, bool loweredAddresses);
+  static SILType getSILResultInterfaceType(
+                                  SILResultInfo param,
+                                  bool loweredAddresses);
 
 public:
   static bool isPassedIndirectlyInSIL(SILType type, SILModule &M);
 
   static bool isReturnedIndirectlyInSIL(SILType type, SILModule &M);
 
-  static SILModuleConventions getLoweredAddressConventions() {
-    return SILModuleConventions(true);
+  static SILModuleConventions getLoweredAddressConventions(SILModule &M) {
+    return SILModuleConventions(M, true);
   }
 
 private:
+  SILModule *M;
   bool loweredAddresses;
-
-  SILModuleConventions(bool loweredAddresses)
-      : loweredAddresses(loweredAddresses) {}
-
+  
+  SILModuleConventions(SILModule &M, bool loweredAddresses)
+    : M(&M), loweredAddresses(loweredAddresses)
+  {}
+  
 public:
-  SILModuleConventions(const SILModule &M);
+  SILModuleConventions(SILModule &M);
 
   SILFunctionConventions getFunctionConventions(CanSILFunctionType funcTy);
+  
+  SILModule &getModule() const { return *M; }
 
   bool useLoweredAddresses() const { return loweredAddresses; }
 
@@ -91,16 +109,31 @@ public:
     return isIndirectSILResult(result, loweredAddresses);
   }
 
-  SILType getSILType(SILParameterInfo param) const {
-    return getSILParamType(param, loweredAddresses);
+  SILType getSILType(SILParameterInfo param,
+                     CanSILFunctionType funcTy) const {
+    auto interfaceTy = getSILParamInterfaceType(param, loweredAddresses);
+    // TODO: Always require a function type
+    if (funcTy)
+      return funcTy->substInterfaceType(*M, interfaceTy);
+    return interfaceTy;
   }
 
-  SILType getSILType(SILYieldInfo yield) const {
-    return getSILYieldType(yield, loweredAddresses);
+  SILType getSILType(SILYieldInfo yield,
+                     CanSILFunctionType funcTy) const {
+    auto interfaceTy = getSILYieldInterfaceType(yield, loweredAddresses);
+    // TODO: Always require a function type
+    if (funcTy)
+      return funcTy->substInterfaceType(*M, interfaceTy);
+    return interfaceTy;
   }
 
-  SILType getSILType(SILResultInfo result) const {
-    return getSILResultType(result, loweredAddresses);
+  SILType getSILType(SILResultInfo result,
+                     CanSILFunctionType funcTy) const {
+    auto interfaceTy = getSILResultInterfaceType(result, loweredAddresses);
+    // TODO: Always require a function type
+    if (funcTy)
+      return funcTy->substInterfaceType(*M, interfaceTy);
+    return interfaceTy;
   }
 };
 
@@ -138,15 +171,15 @@ public:
   }
 
   SILType getSILType(SILParameterInfo param) const {
-    return silConv.getSILType(param);
+    return silConv.getSILType(param, funcTy);
   }
 
   SILType getSILType(SILYieldInfo yield) const {
-    return silConv.getSILType(yield);
+    return silConv.getSILType(yield, funcTy);
   }
 
   SILType getSILType(SILResultInfo result) const {
-    return silConv.getSILType(result);
+    return silConv.getSILType(result, funcTy);
   }
 
   //===--------------------------------------------------------------------===//
@@ -157,9 +190,9 @@ public:
   /// This does not include indirect SIL results.
   SILType getSILResultType() {
     if (silConv.loweredAddresses)
-      return funcTy->getDirectFormalResultsType();
+      return funcTy->getDirectFormalResultsType(silConv.getModule());
 
-    return funcTy->getAllResultsType();
+    return funcTy->getAllResultsSubstType(silConv.getModule());
   }
 
   /// Get the SIL type for the single result which may be direct or indirect.
@@ -198,24 +231,20 @@ public:
         SILFunctionType::IndirectFormalResultFilter());
   }
 
-  struct SILResultTypeFunc {
-    SILModuleConventions silConv;
-    SILResultTypeFunc(SILModuleConventions silConv) : silConv(silConv) {}
+  struct SILResultTypeFunc;
 
-    SILType operator()(SILResultInfo result) const {
-      return silConv.getSILType(result);
-    }
-  };
-
-  using IndirectSILResultTypeIter =
-      llvm::mapped_iterator<IndirectSILResultIter, SILResultTypeFunc>;
-  using IndirectSILResultTypeRange = iterator_range<IndirectSILResultTypeIter>;
+  // Gratuitous template parameter is to delay instantiating `mapped_iterator`
+  // on the incomplete type SILParameterTypeFunc.
+  template<bool _ = false>
+  using IndirectSILResultTypeIter = typename delay_template_expansion<_, 
+      llvm::mapped_iterator, IndirectSILResultIter, SILResultTypeFunc>::type;
+  template<bool _ = false>
+  using IndirectSILResultTypeRange = iterator_range<IndirectSILResultTypeIter<_>>;
 
   /// Return a range of SILTypes for each result passed as an address-typed SIL
   /// argument.
-  IndirectSILResultTypeRange getIndirectSILResultTypes() const {
-    return llvm::map_range(getIndirectSILResults(), SILResultTypeFunc(silConv));
-  }
+  template<bool _ = false>
+  IndirectSILResultTypeRange<_> getIndirectSILResultTypes() const;
 
   /// Get the number of SIL results directly returned by SIL value.
   unsigned getNumDirectSILResults() const {
@@ -242,15 +271,16 @@ public:
         funcTy->getResults(), DirectSILResultFilter(silConv.loweredAddresses));
   }
 
-  using DirectSILResultTypeIter =
-      llvm::mapped_iterator<DirectSILResultIter, SILResultTypeFunc>;
-  using DirectSILResultTypeRange = iterator_range<DirectSILResultTypeIter>;
+  template<bool _ = false>
+  using DirectSILResultTypeIter = typename delay_template_expansion<_, 
+      llvm::mapped_iterator, DirectSILResultIter, SILResultTypeFunc>::type;
+  template<bool _ = false>
+  using DirectSILResultTypeRange = iterator_range<DirectSILResultTypeIter<_>>;
 
   /// Return a range of SILTypes for each result directly returned
   /// by SIL value.
-  DirectSILResultTypeRange getDirectSILResultTypes() const {
-    return llvm::map_range(getDirectSILResults(), SILResultTypeFunc(silConv));
-  }
+  template<bool _ = false>
+  DirectSILResultTypeRange<_> getDirectSILResultTypes() const;
 
   //===--------------------------------------------------------------------===//
   // SIL parameters types.
@@ -267,25 +297,22 @@ public:
     return funcTy->getParameters();
   }
 
-  struct SILParameterTypeFunc {
-    SILModuleConventions silConv;
-    SILParameterTypeFunc(SILModuleConventions silConv) : silConv(silConv) {}
-
-    SILType operator()(SILParameterInfo param) const {
-      return silConv.getSILType(param);
-    }
-  };
-
-  using SILParameterTypeIter =
-      llvm::mapped_iterator<const SILParameterInfo *, SILParameterTypeFunc>;
-  using SILParameterTypeRange = iterator_range<SILParameterTypeIter>;
+  struct SILParameterTypeFunc;
+  
+  // Gratuitous template parameter is to delay instantiating `mapped_iterator`
+  // on the incomplete type SILParameterTypeFunc.
+  template<bool _ = false>
+  using SILParameterTypeIter = typename
+    delay_template_expansion<_, llvm::mapped_iterator,
+                          const SILParameterInfo *, SILParameterTypeFunc>::type;
+  
+  template<bool _ = false>
+  using SILParameterTypeRange = iterator_range<SILParameterTypeIter<_>>;
 
   /// Return a range of SILTypes for each function parameter, not including
   /// indirect results.
-  SILParameterTypeRange getParameterSILTypes() const {
-    return llvm::map_range(funcTy->getParameters(),
-                           SILParameterTypeFunc(silConv));
-  }
+  template<bool _ = false>
+  SILParameterTypeRange<_> getParameterSILTypes() const;
 
   //===--------------------------------------------------------------------===//
   // SIL yield types.
@@ -297,13 +324,15 @@ public:
     return funcTy->getYields();
   }
 
-  using SILYieldTypeIter =
-      llvm::mapped_iterator<const SILYieldInfo *, SILParameterTypeFunc>;
-  using SILYieldTypeRange = iterator_range<SILYieldTypeIter>;
+  template<bool _ = false>
+  using SILYieldTypeIter = typename
+    delay_template_expansion<_, llvm::mapped_iterator,
+                              const SILYieldInfo *, SILParameterTypeFunc>::type;
+  template<bool _ = false>
+  using SILYieldTypeRange = iterator_range<SILYieldTypeIter<_>>;
 
-  SILYieldTypeRange getYieldSILTypes() const {
-    return llvm::map_range(funcTy->getYields(), SILParameterTypeFunc(silConv));
-  }
+  template<bool _ = false>
+  SILYieldTypeRange<_> getYieldSILTypes() const;
 
   SILYieldInfo getYieldInfoForOperandIndex(unsigned opIndex) const {
     return getYields()[opIndex];
@@ -359,15 +388,64 @@ public:
   // See SILArgument.h.
 
   /// Return the SIL type of the apply/entry argument at the given index.
-  SILType getSILArgumentType(unsigned index) const {
-    assert(index <= getNumSILArguments());
-    if (index < getNumIndirectSILResults()) {
-      return *std::next(getIndirectSILResultTypes().begin(), index);
-    }
-    return getSILType(
-        funcTy->getParameters()[index - getNumIndirectSILResults()]);
+  SILType getSILArgumentType(unsigned index) const;
+};
+
+struct SILFunctionConventions::SILResultTypeFunc {
+  SILFunctionConventions silConv;
+  SILResultTypeFunc(const SILFunctionConventions &silConv)
+    : silConv(silConv) {}
+
+  SILType operator()(SILResultInfo result) const {
+    return silConv.getSILType(result);
   }
 };
+
+template<bool _>
+SILFunctionConventions::IndirectSILResultTypeRange<_>
+SILFunctionConventions::getIndirectSILResultTypes() const {
+    return llvm::map_range(getIndirectSILResults(), SILResultTypeFunc(*this));
+  }
+
+template<bool _>
+SILFunctionConventions::DirectSILResultTypeRange<_>
+SILFunctionConventions::getDirectSILResultTypes() const {
+  return llvm::map_range(getDirectSILResults(), SILResultTypeFunc(*this));
+}
+
+struct SILFunctionConventions::SILParameterTypeFunc {
+  SILFunctionConventions silConv;
+  SILParameterTypeFunc(const SILFunctionConventions &silConv)
+    : silConv(silConv) {}
+
+  SILType operator()(SILParameterInfo param) const {
+    return silConv.getSILType(param);
+  }
+};
+
+template<bool _>
+SILFunctionConventions::SILParameterTypeRange<_>
+SILFunctionConventions::getParameterSILTypes() const {
+  return llvm::map_range(funcTy->getParameters(),
+                         SILParameterTypeFunc(*this));
+}
+
+template<bool _>
+SILFunctionConventions::SILYieldTypeRange<_>
+SILFunctionConventions::getYieldSILTypes() const {
+  return llvm::map_range(funcTy->getYields(),
+                         SILParameterTypeFunc(*this));
+}
+
+inline SILType
+SILFunctionConventions::getSILArgumentType(unsigned index) const {
+  assert(index <= getNumSILArguments());
+  if (index < getNumIndirectSILResults()) {
+    return *std::next(getIndirectSILResultTypes().begin(), index);
+  }
+  return getSILType(
+      funcTy->getParameters()[index - getNumIndirectSILResults()]);
+}
 
 inline SILFunctionConventions
 SILModuleConventions::getFunctionConventions(CanSILFunctionType funcTy) {
@@ -386,7 +464,7 @@ inline bool SILModuleConventions::isIndirectSILParam(SILParameterInfo param,
   case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Indirect_In_Guaranteed:
     return (loweredAddresses ||
-            param.getType()->isOpenedExistentialWithError());
+            param.getInterfaceType()->isOpenedExistentialWithError());
   case ParameterConvention::Indirect_Inout:
   case ParameterConvention::Indirect_InoutAliasable:
     return true;
@@ -404,7 +482,7 @@ inline bool SILModuleConventions::isIndirectSILResult(SILResultInfo result,
   switch (result.getConvention()) {
   case ResultConvention::Indirect:
     return (loweredAddresses ||
-            result.getType()->isOpenedExistentialWithError());
+            result.getInterfaceType()->isOpenedExistentialWithError());
   case ResultConvention::Owned:
   case ResultConvention::Unowned:
   case ResultConvention::UnownedInnerPointer:
@@ -415,31 +493,48 @@ inline bool SILModuleConventions::isIndirectSILResult(SILResultInfo result,
   llvm_unreachable("Unhandled ResultConvention in switch.");
 }
 
-inline SILType SILModuleConventions::getSILParamType(SILParameterInfo param,
+inline SILType SILModuleConventions::getSILParamInterfaceType(
+                                                     SILParameterInfo param,
                                                      bool loweredAddresses) {
-  return SILModuleConventions::isIndirectSILParam(param, loweredAddresses)
-             ? SILType::getPrimitiveAddressType(param.getType())
-             : SILType::getPrimitiveObjectType(param.getType());
+  return SILModuleConventions::isIndirectSILParam(param,loweredAddresses)
+             ? SILType::getPrimitiveAddressType(param.getInterfaceType())
+             : SILType::getPrimitiveObjectType(param.getInterfaceType());
 }
 
-inline SILType SILModuleConventions::getSILYieldType(SILYieldInfo yield,
+inline SILType SILModuleConventions::getSILYieldInterfaceType(
+                                                     SILYieldInfo yield,
                                                      bool loweredAddresses) {
-  return getSILParamType(yield, loweredAddresses);
+  return getSILParamInterfaceType(yield, loweredAddresses);
 }
 
-inline SILType SILModuleConventions::getSILResultType(SILResultInfo result,
+inline SILType SILModuleConventions::getSILResultInterfaceType(
+                                                      SILResultInfo result,
                                                       bool loweredAddresses) {
   return SILModuleConventions::isIndirectSILResult(result, loweredAddresses)
-             ? SILType::getPrimitiveAddressType(result.getType())
-             : SILType::getPrimitiveObjectType(result.getType());
+             ? SILType::getPrimitiveAddressType(result.getInterfaceType())
+             : SILType::getPrimitiveObjectType(result.getInterfaceType());
 }
 
-inline SILType SILParameterInfo::getSILStorageType() const {
-  return SILModuleConventions::getSILParamType(*this, true);
+inline SILType
+SILParameterInfo::getSILStorageInterfaceType() const {
+  return SILModuleConventions::getSILParamInterfaceType(*this, true);
 }
 
-inline SILType SILResultInfo::getSILStorageType() const {
-  return SILModuleConventions::getSILResultType(*this, true);
+inline SILType
+SILResultInfo::getSILStorageInterfaceType() const {
+  return SILModuleConventions::getSILResultInterfaceType(*this, true);
+}
+
+inline SILType
+SILParameterInfo::getSILStorageType(SILModule &M,
+                                    const SILFunctionType *funcTy) const {
+    return funcTy->substInterfaceType(M, getSILStorageInterfaceType());
+}
+
+inline SILType
+SILResultInfo::getSILStorageType(SILModule &M,
+                                 const SILFunctionType *funcTy) const {
+    return funcTy->substInterfaceType(M, getSILStorageInterfaceType());
 }
 
 } // end swift namespace

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1928,7 +1928,7 @@ public:
   }
 
   bool isCalleeNoReturn() const {
-    return getSubstCalleeSILType().isNoReturnFunction();
+    return getSubstCalleeSILType().isNoReturnFunction(this->getModule());
   }
 
   bool isCalleeThin() const {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -291,7 +291,7 @@ public:
 
   /// Returns true if the referenced type is a function type that never
   /// returns.
-  bool isNoReturnFunction() const;
+  bool isNoReturnFunction(SILModule &M) const;
 
   /// Returns true if the referenced type has reference semantics.
   bool hasReferenceSemantics() const {

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1008,11 +1008,13 @@ public:
   /// The ABI compatible relation is not symmetric on function types -- while
   /// T and T! are both subtypes of each other, a calling convention conversion
   /// of T! to T always requires a thunk.
-  ABIDifference checkForABIDifferences(SILType type1, SILType type2,
+  ABIDifference checkForABIDifferences(SILModule &M,
+                                       SILType type1, SILType type2,
                                        bool thunkOptionals = true);
 
   /// Same as above but for SIL function types.
-  ABIDifference checkFunctionForABIDifferences(SILFunctionType *fnTy1,
+  ABIDifference checkFunctionForABIDifferences(SILModule &M,
+                                               SILFunctionType *fnTy1,
                                                SILFunctionType *fnTy2);
 
 

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -76,7 +76,7 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
           // are the same.
           auto LoweredFnTy = Builder.getFunction().getLoweredFunctionType();
           auto RecursiveSubstCalleeSILType = LoweredFnTy;
-          auto GenSig = LoweredFnTy->getGenericSignature();
+          auto GenSig = LoweredFnTy->getInvocationGenericSignature();
           if (GenSig) {
             // Compute substitutions for the specialized function. These
             // substitutions may be different from the original ones, e.g.
@@ -84,7 +84,7 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
             RecursiveSubs = SubstitutionMap::get(
               AI.getFunction()
                 ->getLoweredFunctionType()
-                ->getGenericSignature(),
+                ->getInvocationGenericSignature(),
               Subs);
 
             // Use the new set of substitutions to compute the new

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -505,10 +505,11 @@ Type ASTBuilder::createImplFunctionType(
     auto conv = getResultConvention(errorResult->getConvention());
     funcErrorResult.emplace(type, conv);
   }
-
+#warning "todo: demangle substituted silfunctiontype fields"
   return SILFunctionType::get(genericSig, einfo, funcCoroutineKind,
                               funcCalleeConvention, funcParams, funcYields,
-                              funcResults, funcErrorResult, Ctx);
+                              funcResults, funcErrorResult,
+                              SubstitutionMap(), false, Ctx);
 }
 
 Type ASTBuilder::createProtocolCompositionType(

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -357,7 +357,9 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
                                             Type SelfType,
                                             ModuleDecl *Module) {
   Mod = Module;
-  GenericSignature GenSig = ThunkType->getGenericSignature();
+#warning "todo: mangle substituted types"
+  assert(ThunkType->getSubstitutions().empty() && "not implemented");
+  GenericSignature GenSig = ThunkType->getSubstGenericSignature();
   if (GenSig)
     CurGenericSignature = GenSig->getCanonicalSignature();
 
@@ -1423,6 +1425,7 @@ static char getResultConvention(ResultConvention conv) {
 };
 
 void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
+#warning "todo: handle substituted types"
 
   llvm::SmallVector<char, 32> OpArgs;
 
@@ -1466,13 +1469,13 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
   // Mangle the parameters.
   for (auto param : fn->getParameters()) {
     OpArgs.push_back(getParamConvention(param.getConvention()));
-    appendType(param.getType());
+    appendType(param.getInterfaceType());
   }
 
   // Mangle the results.
   for (auto result : fn->getResults()) {
     OpArgs.push_back(getResultConvention(result.getConvention()));
-    appendType(result.getType());
+    appendType(result.getInterfaceType());
   }
 
   // Mangle the error result if present.
@@ -1480,10 +1483,10 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
     auto error = fn->getErrorResult();
     OpArgs.push_back('z');
     OpArgs.push_back(getResultConvention(error.getConvention()));
-    appendType(error.getType());
+    appendType(error.getInterfaceType());
   }
   if (fn->isPolymorphic())
-    appendGenericSignature(fn->getGenericSignature());
+    appendGenericSignature(fn->getSubstGenericSignature());
 
   OpArgs.push_back('_');
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3927,6 +3927,17 @@ public:
     PrintAST(Printer, Options).printGenericSignature(genericSig, flags);
   }
 
+  void printSubstitutions(SubstitutionMap subs) {
+    Printer << " <";
+    interleave(subs.getReplacementTypes(),
+               [&](Type type) {
+                 visit(type);
+               }, [&]{
+                 Printer << ", ";
+               });
+    Printer << ">";
+  }
+  
   void visitGenericFunctionType(GenericFunctionType *T) {
     Printer.callPrintStructurePre(PrintStructureKind::FunctionType);
     SWIFT_DEFER {
@@ -3989,11 +4000,14 @@ public:
     printFunctionExtInfo(T->getExtInfo(),
                          T->getWitnessMethodConformanceOrNone());
     printCalleeConvention(T->getCalleeConvention());
-    if (auto sig = T->getGenericSignature()) {
+    if (auto sig = T->getSubstGenericSignature()) {
       printGenericSignature(sig,
                             PrintAST::PrintParams |
                             PrintAST::PrintRequirements);
       Printer << " ";
+      if (T->isGenericSignatureImplied()) {
+        Printer << "in ";
+      }
     }
 
     Printer << "(";
@@ -4027,10 +4041,15 @@ public:
       assert(T->getErrorResult().getConvention() == ResultConvention::Owned);
       Printer.printSeparator(first, ", ");
       Printer << "@error ";
-      T->getErrorResult().getType().print(Printer, Options);
+      T->getErrorResult().getInterfaceType().print(Printer, Options);
     }
 
     if (totalResults != 1) Printer << ")";
+  
+    if (auto substitutions = T->getSubstitutions()) {
+      Printer << " for ";
+      printSubstitutions(substitutions);
+    }
   }
 
   void visitSILBlockStorageType(SILBlockStorageType *T) {
@@ -4070,14 +4089,7 @@ public:
 
     // The arguments to the layout, if any, do come from the outer environment.
     if (auto subMap = T->getSubstitutions()) {
-      Printer << " <";
-      interleave(subMap.getReplacementTypes(),
-                 [&](Type type) {
-                   visit(type);
-                 }, [&]{
-                   Printer << ", ";
-                 });
-      Printer << ">";
+      printSubstitutions(subMap);
     }
   }
 
@@ -4476,7 +4488,7 @@ void SILParameterInfo::print(raw_ostream &OS, const PrintOptions &Opts) const {
 void SILParameterInfo::print(ASTPrinter &Printer,
                              const PrintOptions &Opts) const {
   Printer << getStringForParameterConvention(getConvention());
-  getType().print(Printer, Opts);
+  getInterfaceType().print(Printer, Opts);
 }
 
 static StringRef getStringForResultConvention(ResultConvention conv) {
@@ -4500,7 +4512,7 @@ void SILResultInfo::print(raw_ostream &OS, const PrintOptions &Opts) const {
 }
 void SILResultInfo::print(ASTPrinter &Printer, const PrintOptions &Opts) const {
   Printer << getStringForResultConvention(getConvention());
-  getType().print(Printer, Opts);
+  getInterfaceType().print(Printer, Opts);
 }
 
 std::string Type::getString(const PrintOptions &PO) const {

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -117,14 +117,24 @@ class Traversal : public TypeVisitor<Traversal, bool>
   }
 
   bool visitSILFunctionType(SILFunctionType *ty) {
+    // TODO: Should this be the only kind of walk we allow?
+    if (auto subs = ty->getSubstitutions()) {
+      for (auto paramTy : subs.getReplacementTypes()) {
+        if (doIt(paramTy))
+          return true;
+      }
+      
+      return false;
+    }
+    
     for (auto param : ty->getParameters())
-      if (doIt(param.getType()))
+      if (doIt(param.getInterfaceType()))
         return true;
     for (auto result : ty->getResults())
-      if (doIt(result.getType()))
+      if (doIt(result.getInterfaceType()))
         return true;
     if (ty->hasErrorResult())
-      if (doIt(ty->getErrorResult().getType()))
+      if (doIt(ty->getErrorResult().getInterfaceType()))
         return true;
     return false;
   }

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1066,7 +1066,8 @@ void SignatureExpansion::expandExternalSignatureTypes() {
   assert(FnType->getLanguage() == SILFunctionLanguage::C);
 
   // Convert the SIL result type to a Clang type.
-  auto clangResultTy = IGM.getClangType(FnType->getFormalCSemanticResult());
+  auto clangResultTy =
+    IGM.getClangType(FnType->getFormalCSemanticResult(IGM.getSILModule()));
 
   // Now convert the parameters to Clang types.
   auto params = FnType->getParameters();
@@ -1079,7 +1080,7 @@ void SignatureExpansion::expandExternalSignatureTypes() {
     // ObjC methods take their 'self' argument first, followed by an
     // implicit _cmd argument.
     auto &self = params.back();
-    auto clangTy = IGM.getClangType(self);
+    auto clangTy = IGM.getClangType(self, FnType);
     paramTys.push_back(clangTy);
     paramTys.push_back(clangCtx.VoidPtrTy);
     params = params.drop_back();
@@ -1110,7 +1111,7 @@ void SignatureExpansion::expandExternalSignatureTypes() {
 
   // Convert each parameter to a Clang type.
   for (auto param : params) {
-    auto clangTy = IGM.getClangType(param);
+    auto clangTy = IGM.getClangType(param, FnType);
     paramTys.push_back(clangTy);
   }
 
@@ -1310,7 +1311,7 @@ bool irgen::hasSelfContextParameter(CanSILFunctionType fnType) {
   }
 
   // Direct conventions depend on the type.
-  CanType type = param.getType();
+  CanType type = param.getInterfaceType();
 
   // Thick or @objc metatypes (but not existential metatypes).
   if (auto metatype = dyn_cast<MetatypeType>(type)) {
@@ -1471,7 +1472,7 @@ Signature SignatureExpansion::getSignature() {
 
 Signature Signature::getUncached(IRGenModule &IGM,
                                  CanSILFunctionType formalType) {
-  GenericContextScope scope(IGM, formalType->getGenericSignature());
+  GenericContextScope scope(IGM, formalType->getInvocationGenericSignature());
   SignatureExpansion expansion(IGM, formalType);
   expansion.expandFunctionType();
   return expansion.getSignature();
@@ -1534,7 +1535,7 @@ void CallEmission::emitToUnmappedExplosion(Explosion &out) {
   // Specially handle noreturn c function which would return a 'Never' SIL result
   // type.
   if (origFnType->getLanguage() == SILFunctionLanguage::C &&
-      origFnType->isNoReturnFunction()) {
+      origFnType->isNoReturnFunction(IGF.getSILModule())) {
     auto clangResultTy = result->getType();
     extractScalarResults(IGF, clangResultTy, result, out);
     return;
@@ -1680,8 +1681,10 @@ void CallEmission::emitToMemory(Address addr,
   // result that's actually being passed indirectly.
   //
   // TODO: SIL address lowering should be able to handle such cases earlier.
-  auto origResultType = origFnType->getDirectFormalResultsType().getASTType();
-  auto substResultType = substFnType->getDirectFormalResultsType().getASTType();
+  auto origResultType = origFnType->getDirectFormalResultsType(IGF.IGM.getSILModule())
+                                  .getASTType();
+  auto substResultType = substFnType->getDirectFormalResultsType(IGF.IGM.getSILModule())
+                                    .getASTType();
 
   if (origResultType->hasTypeParameter())
     origResultType = IGF.IGM.getGenericEnvironment()
@@ -1809,7 +1812,7 @@ void CallEmission::emitToExplosion(Explosion &out, bool isOutlined) {
   auto origFnType = getCallee().getOrigFunctionType();
   auto isNoReturnCFunction =
       origFnType->getLanguage() == SILFunctionLanguage::C &&
-      origFnType->isNoReturnFunction();
+      origFnType->isNoReturnFunction(IGF.getSILModule());
 
   // If the call is naturally to memory, emit it that way and then
   // explode that temporary.
@@ -1884,7 +1887,8 @@ Callee::Callee(CalleeInfo &&info, const FunctionPointer &fn,
     break;
   case SILFunctionTypeRepresentation::Method:
   case SILFunctionTypeRepresentation::WitnessMethod:
-    assert((FirstData != nullptr) == hasSelfContextParameter(Info.OrigFnType));
+    assert((FirstData != nullptr) ==
+           hasSelfContextParameter(Info.OrigFnType));
     assert(!SecondData);
     break;
   case SILFunctionTypeRepresentation::Thick:
@@ -2275,8 +2279,8 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
                                  Explosion &in, Explosion &out,
                                  TemporarySet &temporaries,
                                  bool isOutlined) {
-  auto silConv = IGF.IGM.silConv;
   auto fnType = callee.getOrigFunctionType();
+  auto silConv = SILFunctionConventions(fnType, IGF.IGM.silConv);
   auto params = fnType->getParameters();
 
   assert(callee.getForeignInfo().ClangInfo);
@@ -2384,7 +2388,9 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
 }
 
 /// Returns whether allocas are needed.
-bool irgen::addNativeArgument(IRGenFunction &IGF, Explosion &in,
+bool irgen::addNativeArgument(IRGenFunction &IGF,
+                              Explosion &in,
+                              CanSILFunctionType fnTy,
                               SILParameterInfo origParamInfo, Explosion &out,
                               bool isOutlined) {
   // Addresses consist of a single pointer argument.
@@ -2392,7 +2398,7 @@ bool irgen::addNativeArgument(IRGenFunction &IGF, Explosion &in,
     out.add(in.claimNext());
     return false;
   }
-  auto paramType = IGF.IGM.silConv.getSILType(origParamInfo);
+  auto paramType = IGF.IGM.silConv.getSILType(origParamInfo, fnTy);
   auto &ti = cast<LoadableTypeInfo>(IGF.getTypeInfo(paramType));
   auto schema = ti.getSchema();
   auto &nativeSchema = ti.nativeParameterValueSchema(IGF.IGM);
@@ -2646,7 +2652,8 @@ llvm::Value *irgen::emitYield(IRGenFunction &IGF,
   // Translate the arguments to an unsubstituted form.
   Explosion allComponents;
   for (auto yield : coroutineType->getYields())
-    addNativeArgument(IGF, substValues, yield, allComponents, false);
+    addNativeArgument(IGF, substValues, coroutineType,
+                      yield, allComponents, false);
 
   // Figure out which arguments need to be yielded directly.
   SmallVector<llvm::Value*, 8> yieldArgs;
@@ -2779,7 +2786,8 @@ void CallEmission::setArgs(Explosion &original, bool isOutlined,
       params = params.drop_back();
     }
     for (auto param : params) {
-      addNativeArgument(IGF, original, param, adjusted, isOutlined);
+      addNativeArgument(IGF, original,
+                        origCalleeType, param, adjusted, isOutlined);
     }
 
     // Anything else, just pass along.  This will include things like

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -96,7 +96,9 @@ namespace irgen {
                                   SILType swiftType,
                                   const LoadableTypeInfo &swiftTI);
 
-  bool addNativeArgument(IRGenFunction &IGF, Explosion &in,
+  bool addNativeArgument(IRGenFunction &IGF,
+                         Explosion &in,
+                         CanSILFunctionType fnTy,
                          SILParameterInfo origParamInfo, Explosion &args,
                          bool isOutlined);
 

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -580,14 +580,17 @@ IRGenModule::getForeignFunctionInfo(CanSILFunctionType type) {
 }
 
 static void emitApplyArgument(IRGenFunction &IGF,
+                              CanSILFunctionType origFnTy,
                               SILParameterInfo origParam,
+                              CanSILFunctionType substFnTy,
                               SILParameterInfo substParam,
                               Explosion &in,
                               Explosion &out) {
   auto silConv = IGF.IGM.silConv;
 
   bool isSubstituted =
-      (silConv.getSILType(substParam) != silConv.getSILType(origParam));
+      (silConv.getSILType(substParam, substFnTy)
+         != silConv.getSILType(origParam, origFnTy));
 
   // For indirect arguments, we just need to pass a pointer.
   if (silConv.isSILIndirect(origParam)) {
@@ -597,7 +600,7 @@ static void emitApplyArgument(IRGenFunction &IGF,
     // If a substitution is in play, just bitcast the address.
     if (isSubstituted) {
       auto origType =
-          IGF.IGM.getStoragePointerType(silConv.getSILType(origParam));
+          IGF.IGM.getStoragePointerType(silConv.getSILType(origParam, origFnTy));
       addr = IGF.Builder.CreateBitCast(addr, origType);
     }
     
@@ -612,14 +615,14 @@ static void emitApplyArgument(IRGenFunction &IGF,
 
   // Handle the last unsubstituted case.
   if (!isSubstituted) {
-    auto &substArgTI =
-        cast<LoadableTypeInfo>(IGF.getTypeInfo(silConv.getSILType(substParam)));
+    auto &substArgTI = cast<LoadableTypeInfo>(
+      IGF.getTypeInfo(silConv.getSILType(substParam, substFnTy)));
     substArgTI.reexplode(IGF, in, out);
     return;
   }
 
-  reemitAsUnsubstituted(IGF, silConv.getSILType(origParam),
-                        silConv.getSILType(substParam), in, out);
+  reemitAsUnsubstituted(IGF, silConv.getSILType(origParam, origFnTy),
+                        silConv.getSILType(substParam, substFnTy), in, out);
 }
 
 static CanType getArgumentLoweringType(CanType type,
@@ -650,7 +653,7 @@ static bool isABIIgnoredParameterWithoutStorage(IRGenModule &IGM,
   if (param.isFormalIndirect())
     return false;
 
-  SILType argType = IGM.silConv.getSILType(param);
+  SILType argType = IGM.silConv.getSILType(param, substType);
   auto &ti = IGF.getTypeInfoForLowered(argType.getASTType());
   // Empty values don't matter.
   return ti.getSchema().empty();
@@ -730,7 +733,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 
   {
     // Lower the forwarded arguments in the original function's generic context.
-    GenericContextScope scope(IGM, origType->getGenericSignature());
+    GenericContextScope scope(IGM, origType->getInvocationGenericSignature());
 
     SILFunctionConventions origConv(origType, IGM.getSILModule());
     auto &outResultTI = IGM.getTypeInfo(outConv.getSILResultType());
@@ -767,10 +770,11 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
     // Reemit the parameters as unsubstituted.
     for (unsigned i = 0; i < outType->getParameters().size(); ++i) {
       auto origParamInfo = origType->getParameters()[i];
-      auto &ti = IGM.getTypeInfoForLowered(origParamInfo.getType());
+      auto &ti = IGM.getTypeInfoForLowered(
+                   origParamInfo.getArgumentType(IGM.getSILModule(), origType));
       auto schema = ti.getSchema();
       
-      auto origParamSILType = IGM.silConv.getSILType(origParamInfo);
+      auto origParamSILType = IGM.silConv.getSILType(origParamInfo, origType);
       // Forward the address of indirect value params.
       auto &nativeSchemaOrigParam = ti.nativeParameterValueSchema(IGM);
       bool isIndirectParam = origConv.isSILIndirect(origParamInfo);
@@ -787,13 +791,17 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
       // Indirect parameters need no mapping through the native calling
       // convention.
       if (isIndirectParam) {
-        emitApplyArgument(subIGF, origParamInfo, outTypeParamInfo, origParams,
-                          args);
+        emitApplyArgument(subIGF,
+                          origType,
+                          origParamInfo,
+                          outType,
+                          outTypeParamInfo,
+                          origParams, args);
         continue;
       }
 
       // Map from the native calling convention into the explosion schema.
-      auto outTypeParamSILType = IGM.silConv.getSILType(origParamInfo);
+      auto outTypeParamSILType = IGM.silConv.getSILType(origParamInfo, origType);
       auto &nativeSchemaOutTypeParam =
           IGM.getTypeInfo(outTypeParamSILType).nativeParameterValueSchema(IGM);
       Explosion nativeParam;
@@ -807,7 +815,10 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 
       // Emit unsubstituted argument for call.
       Explosion nonNativeApplyArg;
-      emitApplyArgument(subIGF, origParamInfo, outTypeParamInfo, nonNativeParam,
+      emitApplyArgument(subIGF,
+                        origType, origParamInfo,
+                        outType, outTypeParamInfo,
+                        nonNativeParam,
                         nonNativeApplyArg);
       assert(nonNativeParam.empty());
       // Map back from the explosion scheme to the native calling convention for
@@ -847,7 +858,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   }
 
   // Lower the captured arguments in the original function's generic context.
-  GenericContextScope scope(IGM, origType->getGenericSignature());
+  GenericContextScope scope(IGM, origType->getInvocationGenericSignature());
 
   // This is where the context parameter appears.
   llvm::Value *rawData = nullptr;
@@ -903,7 +914,8 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
           findSinglePartiallyAppliedParameterIndexIgnoringEmptyTypes(
               subIGF, substType, outType);
       auto paramInfo = substType->getParameters()[paramI];
-      auto &ti = IGM.getTypeInfoForLowered(paramInfo.getType());
+      auto &ti = IGM.getTypeInfoForLowered(
+                     paramInfo.getArgumentType(IGM.getSILModule(), substType));
       Explosion param;
       auto ref = rawData;
       // We can get a '{ swift.refcounted* }' type for AnyObject on linux.
@@ -1089,13 +1101,14 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
         if (hasPolymorphicParams)
           bindPolymorphicParameter(subIGF, origType, substType, param,
                                    origParamI);
-        emitApplyArgument(subIGF, origParamInfo,
-                          substType->getParameters()[origParamI],
+        emitApplyArgument(subIGF,
+                          origType, origParamInfo,
+                          substType, substType->getParameters()[origParamI],
                           param, origParam);
         bool isWitnessMethodCalleeSelf = (isWitnessMethodCallee &&
             origParamI + 1 == origType->getParameters().size());
         needsAllocas |= addNativeArgument(
-            subIGF, origParam, origParamInfo,
+            subIGF, origParam, origType, origParamInfo,
             isWitnessMethodCalleeSelf ? witnessMethodSelfValue : args, false);
         ++origParamI;
       } else {
@@ -1290,7 +1303,7 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
 
   // Collect the type infos for the context parameters.
   for (auto param : params) {
-    SILType argType = IGF.IGM.silConv.getSILType(param);
+    SILType argType = IGF.IGM.silConv.getSILType(param, origType);
 
     auto argLoweringTy = getArgumentLoweringType(argType.getASTType(), param);
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -773,7 +773,7 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
     assert(origMethodType->getNumIndirectFormalResults() == 1);
     formalIndirectResult = params.claimNext();
   } else {
-    SILType appliedResultTy = origMethodType->getDirectFormalResultsType();
+    SILType appliedResultTy = origMethodType->getDirectFormalResultsType(IGM.getSILModule());
     indirectedResultTI =
       &cast<LoadableTypeInfo>(IGM.getTypeInfo(appliedResultTy));
     auto &nativeSchema = indirectedResultTI->nativeReturnValueSchema(IGM);
@@ -802,8 +802,8 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
     }
     // Otherwise, we have a loadable type that can either be passed directly or
     // indirectly.
-    assert(info.getSILStorageType().isObject());
-    auto curSILType = info.getSILStorageType();
+    assert(info.getSILStorageType(IGM.getSILModule(), origMethodType).isObject());
+    auto curSILType = info.getSILStorageType(IGM.getSILModule(), origMethodType);
     auto &ti = cast<LoadableTypeInfo>(IGM.getTypeInfo(curSILType));
 
     // Load the indirectly passed parameter.
@@ -857,7 +857,7 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
     cleanup();
     auto &callee = emission.getCallee();
     auto resultType =
-        callee.getOrigFunctionType()->getDirectFormalResultsType();
+    callee.getOrigFunctionType()->getDirectFormalResultsType(IGM.getSILModule());
     subIGF.emitScalarReturn(resultType, result, true /*isSwiftCCReturn*/,
                             false);
   }
@@ -1028,7 +1028,7 @@ static clang::CanQualType getObjCPropertyType(IRGenModule &IGM,
   auto getter = property->getOpaqueAccessor(AccessorKind::Get);
   CanSILFunctionType methodTy = getObjCMethodType(IGM, getter);
   return IGM.getClangType(
-      methodTy->getFormalCSemanticResult().getASTType());
+    methodTy->getFormalCSemanticResult(IGM.getSILModule()).getASTType());
 }
 
 void irgen::getObjCEncodingForPropertyType(IRGenModule &IGM,
@@ -1049,11 +1049,12 @@ HelperGetObjCEncodingForType(const clang::ASTContext &Context,
 }
 
 static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
-                                               SILType resultType,
+                                               CanSILFunctionType fnType,
                                                ArrayRef<SILParameterInfo> params,
                                                StringRef fixedParamsString,
                                                Size::int_type parmOffset,
                                                bool useExtendedEncoding) {
+  auto resultType = fnType->getFormalCSemanticResult(IGM.getSILModule());
   auto &clangASTContext = IGM.getClangASTContext();
   
   std::string encodingString;
@@ -1071,7 +1072,8 @@ static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
   // TODO. Encode type qualifier, 'in', 'inout', etc. for the parameter.
   std::string paramsString;
   for (auto param : params) {
-    auto clangType = IGM.getClangType(param.getType());
+    auto clangType = IGM.getClangType(
+                            param.getArgumentType(IGM.getSILModule(), fnType));
     if (clangType.isNull())
       return llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
     
@@ -1093,8 +1095,6 @@ static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
 static llvm::Constant *getObjCEncodingForMethodType(IRGenModule &IGM,
                                                     CanSILFunctionType fnType,
                                                     bool useExtendedEncoding) {
-  SILType resultType = fnType->getFormalCSemanticResult();
-
   // Get the inputs without 'self'.
   auto inputs = fnType->getParameters().drop_back();
 
@@ -1103,8 +1103,8 @@ static llvm::Constant *getObjCEncodingForMethodType(IRGenModule &IGM,
   specialParams += "@0:";
   auto ptrSize = IGM.getPointerSize().getValue();
   specialParams += llvm::itostr(ptrSize);
-  GenericContextScope scope(IGM, fnType->getGenericSignature());
-  return getObjCEncodingForTypes(IGM, resultType, inputs, specialParams,
+  GenericContextScope scope(IGM, fnType->getInvocationGenericSignature());
+  return getObjCEncodingForTypes(IGM, fnType, inputs, specialParams,
                                  ptrSize * 2, useExtendedEncoding);
 }
 
@@ -1356,13 +1356,11 @@ irgen::getMethodTypeExtendedEncoding(IRGenModule &IGM,
 llvm::Constant *
 irgen::getBlockTypeExtendedEncoding(IRGenModule &IGM,
                                     CanSILFunctionType invokeTy) {
-  SILType resultType = invokeTy->getFormalCSemanticResult();
-
   // Skip the storage pointer, which is encoded as '@?' to avoid the infinite
   // recursion of the usual '@?<...>' rule for blocks.
   auto paramTypes = invokeTy->getParameters().slice(1);
   
-  return getObjCEncodingForTypes(IGM, resultType, paramTypes,
+  return getObjCEncodingForTypes(IGM, invokeTy, paramTypes,
                                  "@?0", IGM.getPointerSize().getValue(),
                                  /*extended*/ true);
 }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -293,7 +293,7 @@ enumerateUnfulfilledRequirements(const RequirementCallback &callback) {
 }
 
 void PolymorphicConvention::initGenerics() {
-  Generics = FnType->getGenericSignature();
+  Generics = FnType->getInvocationGenericSignature();
 }
 
 void PolymorphicConvention::considerNewTypeSource(MetadataSource::Kind kind,
@@ -322,7 +322,7 @@ bool PolymorphicConvention::considerType(CanType type, IsExact_t isExact,
 }
 
 void PolymorphicConvention::considerWitnessSelf(CanSILFunctionType fnType) {
-  CanType selfTy = fnType->getSelfInstanceType();
+  CanType selfTy = fnType->getSelfInstanceType(IGM.getSILModule());
   auto conformance = fnType->getWitnessMethodConformance();
 
   // First, bind type metadata for Self.
@@ -330,7 +330,7 @@ void PolymorphicConvention::considerWitnessSelf(CanSILFunctionType fnType) {
                        MetadataSource::InvalidSourceIndex,
                        selfTy);
 
-  if (fnType->getSelfInstanceType()->is<GenericTypeParamType>()) {
+  if (selfTy->is<GenericTypeParamType>()) {
     // The Self type is abstract, so we can fulfill its metadata from
     // the Self metadata parameter.
     addSelfMetadataFulfillment(selfTy);
@@ -347,7 +347,7 @@ void PolymorphicConvention::considerWitnessSelf(CanSILFunctionType fnType) {
 
 void PolymorphicConvention::considerObjCGenericSelf(CanSILFunctionType fnType) {
   // If this is a static method, get the instance type.
-  CanType selfTy = fnType->getSelfInstanceType();
+  CanType selfTy = fnType->getSelfInstanceType(IGM.getSILModule());
   unsigned paramIndex = fnType->getParameters().size() - 1;
 
   // Bind type metadata for Self.
@@ -364,7 +364,7 @@ void PolymorphicConvention::considerObjCGenericSelf(CanSILFunctionType fnType) {
 void PolymorphicConvention::considerParameter(SILParameterInfo param,
                                               unsigned paramIndex,
                                               bool isSelfParameter) {
-  auto type = param.getType();
+  auto type = param.getArgumentType(IGM.getSILModule(), FnType);
   switch (param.getConvention()) {
       // Indirect parameters do give us a value we can use, but right now
       // we don't bother, for no good reason. But if this is 'self',
@@ -454,7 +454,7 @@ void irgen::enumerateGenericParamFulfillments(IRGenModule &IGM,
 
   // Check if any requirements were fulfilled by metadata stored inside a
   // captured value.
-  auto generics = fnType->getGenericSignature();
+  auto generics = fnType->getInvocationGenericSignature();
 
   for (auto genericParam : generics->getGenericParams()) {
     auto genericParamType = genericParam->getCanonicalType();
@@ -514,7 +514,8 @@ CanType EmitPolymorphicParameters::getTypeInContext(CanType type) const {
 }
 
 CanType EmitPolymorphicParameters::getArgTypeInContext(unsigned paramIndex) const {
-  return getTypeInContext(FnType->getParameters()[paramIndex].getType());
+  return getTypeInContext(FnType->getParameters()[paramIndex]
+                          .getArgumentType(IGM.getSILModule(), FnType));
 }
 
 void EmitPolymorphicParameters::bindExtraSource(const MetadataSource &source,
@@ -543,7 +544,7 @@ void EmitPolymorphicParameters::bindExtraSource(const MetadataSource &source,
       assert(metadata && "no Self metadata for witness method");
 
       // Mark this as the cached metatype for Self.
-      auto selfTy = FnType->getSelfInstanceType();
+      auto selfTy = FnType->getSelfInstanceType(IGM.getSILModule());
       CanType argTy = getTypeInContext(selfTy);
       setTypeMetadataName(IGF.IGM, metadata, argTy);
       auto *CD = selfTy.getClassOrBoundGenericClass();
@@ -566,7 +567,7 @@ void EmitPolymorphicParameters::bindExtraSource(const MetadataSource &source,
       auto conformance = FnType->getWitnessMethodConformance();
       auto selfProto = conformance.getRequirement();
 
-      auto selfTy = FnType->getSelfInstanceType();
+      auto selfTy = FnType->getSelfInstanceType(IGM.getSILModule());
       CanType argTy = getTypeInContext(selfTy);
 
       setProtocolWitnessTableName(IGF.IGM, selfTable, argTy, selfProto);
@@ -697,7 +698,8 @@ void BindPolymorphicParameter::emit(Explosion &nativeParam, unsigned paramIndex)
     return;
 
   assert(nativeParam.size() == 1);
-  auto paramType = SubstFnType->getParameters()[paramIndex].getType();
+  auto paramType = SubstFnType->getParameters()[paramIndex]
+                            .getArgumentType(IGM.getSILModule(), SubstFnType);
   llvm::Value *instanceRef = nativeParam.getAll()[0];
   SILType instanceType = SILType::getPrimitiveObjectType(paramType);
   llvm::Value *metadata =
@@ -2777,14 +2779,15 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
   return wtable;
 }
 
-static CanType getSubstSelfType(CanSILFunctionType origFnType,
+static CanType getSubstSelfType(IRGenModule &IGM,
+                                CanSILFunctionType origFnType,
                                 SubstitutionMap subs) {
   // Grab the apparent 'self' type.  If there isn't a 'self' type,
   // we're not going to try to access this anyway.
   assert(!origFnType->getParameters().empty());
 
   auto selfParam = origFnType->getParameters().back();
-  CanType inputType = selfParam.getType();
+  CanType inputType = selfParam.getArgumentType(IGM.getSILModule(), origFnType);
   // If the parameter is a direct metatype parameter, this is a static method
   // of the instance type. We can assume this because:
   // - metatypes cannot directly conform to protocols
@@ -2833,7 +2836,8 @@ namespace {
 
         // Needs a special argument.
         case MetadataSource::Kind::GenericLValueMetadata: {
-          out.add(IGF.emitTypeMetadataRef(getSubstSelfType(FnType, subs)));
+          out.add(
+              IGF.emitTypeMetadataRef(getSubstSelfType(IGF.IGM, FnType, subs)));
           continue;
         }
 
@@ -2886,7 +2890,8 @@ void EmitPolymorphicArguments::emit(SubstitutionMap subs,
 
     case MetadataSource::Kind::SelfMetadata: {
       assert(witnessMetadata && "no metadata structure for witness method");
-      auto self = IGF.emitTypeMetadataRef(getSubstSelfType(FnType, subs));
+      auto self = IGF.emitTypeMetadataRef(
+                                      getSubstSelfType(IGF.IGM, FnType, subs));
       witnessMetadata->SelfMetadata = self;
       continue;
     }
@@ -2935,11 +2940,11 @@ NecessaryBindings::forFunctionInvocations(IRGenModule &IGM,
       continue;
 
     case MetadataSource::Kind::GenericLValueMetadata:
-      bindings.addTypeMetadata(getSubstSelfType(origType, subs));
+      bindings.addTypeMetadata(getSubstSelfType(IGM, origType, subs));
       continue;
 
     case MetadataSource::Kind::SelfMetadata:
-      bindings.addTypeMetadata(getSubstSelfType(origType, subs));
+      bindings.addTypeMetadata(getSubstSelfType(IGM, origType, subs));
       continue;
 
     case MetadataSource::Kind::SelfWitnessTable:
@@ -2971,6 +2976,7 @@ GenericTypeRequirements::GenericTypeRequirements(IRGenModule &IGM,
                                 /*callee*/ ParameterConvention::Direct_Unowned,
                                 /*params*/ {}, /*yields*/ {},
                                 /*results*/ {}, /*error*/ None,
+                                /*subs*/ SubstitutionMap(), /*implied*/ false,
                                 IGM.Context);
 
   // Figure out what we're actually still required to pass 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1094,9 +1094,10 @@ public:
     B.addInt32(CaptureTypes.size());
     B.addInt32(MetadataSources.size());
     B.addInt32(Layout.getBindings().size());
-
-    auto sig = OrigCalleeType->getGenericSignature()
-              ? OrigCalleeType->getGenericSignature()->getCanonicalSignature()
+    
+    auto sig = OrigCalleeType->getSubstGenericSignature()
+              ? OrigCalleeType->getSubstGenericSignature()
+                              ->getCanonicalSignature()
               : CanGenericSignature();
     
     // Now add typerefs of all of the captures.

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -82,7 +82,8 @@ static FunctionPointer lookupMethod(IRGenFunction &IGF,
   else
     self = (IGF.CurFn->arg_end() - 1);
 
-  auto selfTy = funcTy->getSelfParameter().getSILStorageType();
+  auto selfTy = funcTy->getSelfParameter()
+                      .getSILStorageType(IGF.IGM.getSILModule(), funcTy);
 
   llvm::Value *metadata;
   if (selfTy.is<MetatypeType>()) {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -584,15 +584,16 @@ private:
 
   // This is different from SILFunctionType::getAllResultsType() in some subtle
   // ways.
-  static SILType getResultTypeForDebugInfo(CanSILFunctionType fnTy) {
+  static SILType getResultTypeForDebugInfo(IRGenModule &IGM,
+                                           CanSILFunctionType fnTy) {
     if (fnTy->getNumResults() == 1) {
-      return fnTy->getResults()[0].getSILStorageType();
+      return fnTy->getResults()[0].getSILStorageType(IGM.getSILModule(), fnTy);
     } else if (!fnTy->getNumIndirectFormalResults()) {
-      return fnTy->getDirectFormalResultsType();
+      return fnTy->getDirectFormalResultsType(IGM.getSILModule());
     } else {
       SmallVector<TupleTypeElt, 4> eltTys;
       for (auto &result : fnTy->getResults()) {
-        eltTys.push_back(result.getType());
+        eltTys.push_back(result.getReturnValueType(IGM.getSILModule(), fnTy));
       }
       return SILType::getPrimitiveAddressType(
           CanType(TupleType::get(eltTys, fnTy->getASTContext())));
@@ -608,16 +609,16 @@ private:
   llvm::DITypeRefArray createParameterTypes(CanSILFunctionType FnTy) {
     SmallVector<llvm::Metadata *, 16> Parameters;
 
-    GenericContextScope scope(IGM, FnTy->getGenericSignature());
+    GenericContextScope scope(IGM, FnTy->getInvocationGenericSignature());
 
     // The function return type is the first element in the list.
-    createParameterType(Parameters, getResultTypeForDebugInfo(FnTy));
+    createParameterType(Parameters, getResultTypeForDebugInfo(IGM, FnTy));
 
     // Actually, the input type is either a single type or a tuple
     // type. We currently represent a function with one n-tuple argument
     // as an n-ary function.
     for (auto Param : FnTy->getParameters())
-      createParameterType(Parameters, IGM.silConv.getSILType(Param));
+      createParameterType(Parameters, IGM.silConv.getSILType(Param, FnTy));
 
     return DBuilder.getOrCreateTypeArray(Parameters);
   }
@@ -2082,8 +2083,8 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
   if (FnTy)
     if (auto ErrorInfo = FnTy->getOptionalErrorResult()) {
       auto DTI = DebugTypeInfo::getFromTypeInfo(
-          ErrorInfo->getType(),
-          IGM.getTypeInfo(IGM.silConv.getSILType(*ErrorInfo)));
+          ErrorInfo->getReturnValueType(IGM.getSILModule(), FnTy),
+          IGM.getTypeInfo(IGM.silConv.getSILType(*ErrorInfo, FnTy)));
       Error = DBuilder.getOrCreateArray({getOrCreateType(DTI)}).get();
     }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -813,7 +813,8 @@ public:
   llvm::StructType *createNominalType(ProtocolCompositionType *T);
   clang::CanQual<clang::Type> getClangType(CanType type);
   clang::CanQual<clang::Type> getClangType(SILType type);
-  clang::CanQual<clang::Type> getClangType(SILParameterInfo param);
+  clang::CanQual<clang::Type> getClangType(SILParameterInfo param,
+                                           CanSILFunctionType funcTy);
 
   const clang::ASTContext &getClangASTContext() {
     assert(ClangASTContext &&

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -37,7 +37,7 @@ using namespace swift;
 using namespace swift::irgen;
 
 static GenericEnvironment *getGenericEnvironment(CanSILFunctionType loweredTy) {
-  return loweredTy->getGenericSignature()->getGenericEnvironment();
+  return loweredTy->getSubstGenericSignature()->getGenericEnvironment();
 }
 
 class LargeSILTypeMapper {
@@ -207,7 +207,7 @@ bool LargeSILTypeMapper::newResultsDiffer(GenericEnvironment *GenericEnv,
                                           irgen::IRGenModule &Mod) {
   SmallVector<SILResultInfo, 2> newResults;
   for (auto result : origResults) {
-    SILType currResultTy = result.getSILStorageType();
+    SILType currResultTy = result.getSILStorageInterfaceType();
     SILType newSILType = getNewSILType(GenericEnv, currResultTy, Mod);
     // We (currently) only care about function signatures
     if (containsDifferentFunctionSignature(GenericEnv, Mod, currResultTy,
@@ -228,7 +228,7 @@ static bool modNonFuncTypeResultType(GenericEnvironment *genEnv,
     return false;
   }
   auto singleResult = loweredTy->getSingleResult();
-  auto resultStorageType = singleResult.getSILStorageType();
+  auto resultStorageType = singleResult.getSILStorageInterfaceType();
   if (isLargeLoadableType(genEnv, resultStorageType, Mod)) {
     return true;
   }
@@ -245,7 +245,7 @@ LargeSILTypeMapper::getNewResults(GenericEnvironment *GenericEnv,
   auto origResults = fnType->getResults();
   SmallVector<SILResultInfo, 2> newResults;
   for (auto result : origResults) {
-    SILType currResultTy = result.getSILStorageType();
+    SILType currResultTy = result.getSILStorageInterfaceType();
     SILType newSILType = getNewSILType(GenericEnv, currResultTy, Mod);
     if (modNonFuncTypeResultType(GenericEnv, fnType, Mod)) {
       // Case (2) Above
@@ -275,7 +275,7 @@ LargeSILTypeMapper::getNewSILFunctionType(GenericEnvironment *env,
   auto newYields = getNewYields(env, fnType, IGM);
   auto newResults = getNewResults(env, fnType, IGM);
   auto newFnType = SILFunctionType::get(
-      fnType->getGenericSignature(),
+      fnType->getSubstGenericSignature(),
       fnType->getExtInfo(),
       fnType->getCoroutineKind(),
       fnType->getCalleeConvention(),
@@ -283,6 +283,8 @@ LargeSILTypeMapper::getNewSILFunctionType(GenericEnvironment *env,
       newYields,
       newResults,
       fnType->getOptionalErrorResult(),
+      fnType->getSubstitutions(),
+      fnType->isGenericSignatureImplied(),
       fnType->getASTContext(),
       fnType->getWitnessMethodConformanceOrNone());
   return newFnType;
@@ -314,13 +316,13 @@ bool LargeSILTypeMapper::shouldTransformResults(GenericEnvironment *genEnv,
   }
 
   if (loweredTy->getNumResults() != 1) {
-    auto resultType = loweredTy->getAllResultsType();
+    auto resultType = loweredTy->getAllResultsInterfaceType();
     auto newResultType = getNewSILType(genEnv, resultType, Mod);
     return resultType != newResultType;
   }
 
   auto singleResult = loweredTy->getSingleResult();
-  auto resultStorageType = singleResult.getSILStorageType();
+  auto resultStorageType = singleResult.getSILStorageInterfaceType();
   auto newResultStorageType = getNewSILType(genEnv, resultStorageType, Mod);
   if (resultStorageType != newResultStorageType) {
     return true;
@@ -344,7 +346,7 @@ static bool shouldTransformYields(GenericEnvironment *genEnv,
     return false;
   }
   for (auto &yield : loweredTy->getYields()) {
-    auto yieldStorageType = yield.getSILStorageType();
+    auto yieldStorageType = yield.getSILStorageInterfaceType();
     auto newYieldStorageType =
         Mapper.getNewSILType(genEnv, yieldStorageType, Mod);
     if (yieldStorageType != newYieldStorageType)
@@ -364,17 +366,17 @@ static bool modYieldType(SILFunction *F, irgen::IRGenModule &Mod,
 SILParameterInfo LargeSILTypeMapper::getNewParameter(GenericEnvironment *env,
                                                      SILParameterInfo param,
                                                      irgen::IRGenModule &IGM) {
-  SILType storageType = param.getSILStorageType();
+  SILType storageType = param.getSILStorageInterfaceType();
   SILType newOptFuncType =
       getNewOptionalFunctionType(env, storageType, IGM);
   if (newOptFuncType != storageType) {
-    return param.getWithType(newOptFuncType.getASTType());
+    return param.getWithInterfaceType(newOptFuncType.getASTType());
   }
 
   if (auto paramFnType = storageType.getAs<SILFunctionType>()) {
     if (shouldTransformFunctionType(env, paramFnType, IGM)) {
       auto newFnType = getNewSILFunctionType(env, paramFnType, IGM);
-      return param.getWithType(newFnType);
+      return param.getWithInterfaceType(newFnType);
     } else {
       return param;
     }
@@ -411,7 +413,7 @@ LargeSILTypeMapper::getNewYields(GenericEnvironment *env,
   SmallVector<SILYieldInfo, 2> newYields;
   for (auto oldYield : fnType->getYields()) {
     auto newYieldAsParam = getNewParameter(env, oldYield, IGM);
-    newYields.push_back(SILYieldInfo(newYieldAsParam.getType(),
+    newYields.push_back(SILYieldInfo(newYieldAsParam.getInterfaceType(),
                                      newYieldAsParam.getConvention()));
   }
   return newYields;
@@ -1365,7 +1367,7 @@ SILArgument *LoadableStorageAllocation::replaceArgType(SILBuilder &argBuilder,
 void LoadableStorageAllocation::insertIndirectReturnArgs() {
   GenericEnvironment *genEnv = pass.F->getGenericEnvironment();
   auto loweredTy = pass.F->getLoweredFunctionType();
-  SILType resultStorageType = loweredTy->getAllResultsType();
+  SILType resultStorageType = loweredTy->getAllResultsInterfaceType();
   auto canType = resultStorageType.getASTType();
   if (canType->hasTypeParameter()) {
     assert(genEnv && "Expected a GenericEnv");
@@ -1459,12 +1461,12 @@ void LoadableStorageAllocation::convertApplyResults() {
                                               pass.Mod)) {
         continue;
       }
-      auto resultStorageType = origSILFunctionType->getAllResultsType();
+      auto resultStorageType = origSILFunctionType->getAllResultsInterfaceType();
       if (!pass.isLargeLoadableType(resultStorageType)) {
         // Make sure it contains a function type
         auto numFuncTy = llvm::count_if(origSILFunctionType->getResults(),
             [](const SILResultInfo &origResult) {
-              auto resultStorageTy = origResult.getSILStorageType();
+              auto resultStorageTy = origResult.getSILStorageInterfaceType();
               return containsFunctionType(resultStorageTy.getASTType());
             });
         assert(numFuncTy != 0 &&
@@ -1848,7 +1850,7 @@ static void castTupleInstr(SingleValueInstruction *instr, IRGenModule &Mod,
   auto funcType = getInnerFunctionType(currSILType);
   assert(funcType && "Expected a function Type");
   GenericEnvironment *genEnv = instr->getFunction()->getGenericEnvironment();
-  if (!genEnv && funcType->isPolymorphic()) {
+  if (!genEnv && funcType->getSubstGenericSignature()) {
     genEnv = getGenericEnvironment(funcType);
   }
   SILType newSILType = Mapper.getNewSILType(genEnv, currSILType, Mod);
@@ -2282,7 +2284,7 @@ static void rewriteFunction(StructLoweringState &pass,
 static bool rewriteFunctionReturn(StructLoweringState &pass) {
   auto loweredTy = pass.F->getLoweredFunctionType();
   SILFunction *F = pass.F;
-  SILType resultTy = loweredTy->getAllResultsType();
+  SILType resultTy = loweredTy->getAllResultsInterfaceType();
   SILType newSILType = pass.getNewSILType(resultTy);
   // We (currently) only care about function signatures
   if (pass.isLargeLoadableType(resultTy)) {
@@ -2306,11 +2308,14 @@ static bool rewriteFunctionReturn(StructLoweringState &pass) {
     }
 
     auto NewTy = SILFunctionType::get(
-        loweredTy->getGenericSignature(), loweredTy->getExtInfo(),
+        loweredTy->getSubstGenericSignature(),
+        loweredTy->getExtInfo(),
         loweredTy->getCoroutineKind(),
-        loweredTy->getCalleeConvention(), loweredTy->getParameters(),
+        loweredTy->getCalleeConvention(),
+        loweredTy->getParameters(),
         loweredTy->getYields(),
         newSILResultInfo, loweredTy->getOptionalErrorResult(),
+        loweredTy->getSubstitutions(), loweredTy->isGenericSignatureImplied(),
         F->getModule().getASTContext(),
         loweredTy->getWitnessMethodConformanceOrNone());
     F->rewriteLoweredTypeUnsafe(NewTy);
@@ -2330,7 +2335,7 @@ void LoadableByAddress::runOnFunction(SILFunction *F) {
     // External function - re-write external declaration - this is ABI!
     GenericEnvironment *genEnv = F->getGenericEnvironment();
     auto loweredTy = F->getLoweredFunctionType();
-    if (!genEnv && loweredTy->isPolymorphic()) {
+    if (!genEnv && loweredTy->getSubstGenericSignature()) {
       genEnv = getGenericEnvironment(loweredTy);
     }
     if (MapperCache.shouldTransformFunctionType(genEnv, loweredTy,
@@ -2777,7 +2782,7 @@ void LoadableByAddress::updateLoweredTypes(SILFunction *F) {
   IRGenModule *currIRMod = getIRGenModule()->IRGen.getGenModule(F);
   CanSILFunctionType funcType = F->getLoweredFunctionType();
   GenericEnvironment *genEnv = F->getGenericEnvironment();
-  if (!genEnv && funcType->isPolymorphic()) {
+  if (!genEnv && funcType->getSubstGenericSignature()) {
     genEnv = getGenericEnvironment(funcType);
   }
   auto newFuncTy =

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -603,12 +603,12 @@ OperandOwnershipKindMap OperandOwnershipKindClassifier::visitCallee(
   case ParameterConvention::Indirect_In:
   case ParameterConvention::Indirect_In_Constant:
     assert(!SILModuleConventions(mod).isSILIndirect(
-        SILParameterInfo(substCalleeType, conv)));
+                                      SILParameterInfo(substCalleeType, conv)));
     return Map::compatibilityMap(ValueOwnershipKind::Owned,
                                  UseLifetimeConstraint::MustBeInvalidated);
   case ParameterConvention::Indirect_In_Guaranteed:
     assert(!SILModuleConventions(mod).isSILIndirect(
-        SILParameterInfo(substCalleeType, conv)));
+                                      SILParameterInfo(substCalleeType, conv)));
     return Map::compatibilityMap(ValueOwnershipKind::Guaranteed,
                                  UseLifetimeConstraint::MustBeLive);
   case ParameterConvention::Indirect_Inout:

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -44,7 +44,8 @@ SILSpecializeAttr *SILSpecializeAttr::create(SILModule &M,
 }
 
 void SILFunction::addSpecializeAttr(SILSpecializeAttr *Attr) {
-  if (getLoweredFunctionType()->getGenericSignature()) {
+#warning "todo: base on decl type params?"
+  if (getLoweredFunctionType()->getInvocationGenericSignature()) {
     Attr->F = this;
     SpecializeAttrSet.push_back(Attr);
   }
@@ -229,7 +230,7 @@ SILType GenericEnvironment::mapTypeIntoContext(SILModule &M,
 
 bool SILFunction::isNoReturnFunction() const {
   return SILType::getPrimitiveObjectType(getLoweredFunctionType())
-      .isNoReturnFunction();
+      .isNoReturnFunction(getModule());
 }
 
 const TypeLowering &

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -40,12 +40,42 @@
 using namespace swift;
 using namespace swift::Lowering;
 
-SILType SILFunctionType::getDirectFormalResultsType() {
+SILType SILFunctionType::substInterfaceType(SILModule &M,
+                                            SILType interfaceType) const {
+  if (getSubstitutions().empty())
+    return interfaceType;
+  
+  return interfaceType.subst(M, getSubstitutions());
+}
+
+CanType SILParameterInfo::getArgumentType(SILModule &M,
+                                          const SILFunctionType *t) const {
+  // TODO: We should always require a function type.
+  if (t)
+    return t->substInterfaceType(M,
+                          SILType::getPrimitiveAddressType(getInterfaceType()))
+            .getASTType();
+  
+  return getInterfaceType();
+}
+
+CanType SILResultInfo::getReturnValueType(SILModule &M,
+                                          const SILFunctionType *t) const {
+  // TODO: We should always require a function type.
+  if (t)
+    return t->substInterfaceType(M,
+                          SILType::getPrimitiveAddressType(getInterfaceType()))
+            .getASTType();
+
+  return getInterfaceType();
+}
+
+SILType SILFunctionType::getDirectFormalResultsType(SILModule &M) {
   CanType type;
   if (getNumDirectFormalResults() == 0) {
     type = getASTContext().TheEmptyTupleType;
   } else if (getNumDirectFormalResults() == 1) {
-    type = getSingleDirectFormalResult().getType();
+    type = getSingleDirectFormalResult().getReturnValueType(M, this);
   } else {
     auto &cache = getMutableFormalResultsCache();
     if (cache) {
@@ -54,7 +84,7 @@ SILType SILFunctionType::getDirectFormalResultsType() {
       SmallVector<TupleTypeElt, 4> elts;
       for (auto result : getResults())
         if (!result.isFormalIndirect())
-          elts.push_back(result.getType());
+          elts.push_back(result.getReturnValueType(M, this));
       type = CanType(TupleType::get(elts, getASTContext()));
       cache = type;
     }
@@ -62,12 +92,12 @@ SILType SILFunctionType::getDirectFormalResultsType() {
   return SILType::getPrimitiveObjectType(type);
 }
 
-SILType SILFunctionType::getAllResultsType() {
+SILType SILFunctionType::getAllResultsInterfaceType() {
   CanType type;
   if (getNumResults() == 0) {
     type = getASTContext().TheEmptyTupleType;
   } else if (getNumResults() == 1) {
-    type = getResults()[0].getType();
+    type = getResults()[0].getInterfaceType();
   } else {
     auto &cache = getMutableAllResultsCache();
     if (cache) {
@@ -75,7 +105,7 @@ SILType SILFunctionType::getAllResultsType() {
     } else {
       SmallVector<TupleTypeElt, 4> elts;
       for (auto result : getResults())
-        elts.push_back(result.getType());
+        elts.push_back(result.getInterfaceType());
       type = CanType(TupleType::get(elts, getASTContext()));
       cache = type;
     }
@@ -83,14 +113,18 @@ SILType SILFunctionType::getAllResultsType() {
   return SILType::getPrimitiveObjectType(type);
 }
 
-SILType SILFunctionType::getFormalCSemanticResult() {
-  assert(getLanguage() == SILFunctionLanguage::C);
-  assert(getNumResults() <= 1);
-  return getDirectFormalResultsType();
+SILType SILFunctionType::getAllResultsSubstType(SILModule &M) {
+  return substInterfaceType(M, getAllResultsInterfaceType());
 }
 
-CanType SILFunctionType::getSelfInstanceType() const {
-  auto selfTy = getSelfParameter().getType();
+SILType SILFunctionType::getFormalCSemanticResult(SILModule &M) {
+  assert(getLanguage() == SILFunctionLanguage::C);
+  assert(getNumResults() <= 1);
+  return getDirectFormalResultsType(M);
+}
+
+CanType SILFunctionType::getSelfInstanceType(SILModule &M) const {
+  auto selfTy = getSelfParameter().getArgumentType(M, this);
 
   // If this is a static method, get the instance type.
   if (auto metaTy = dyn_cast<AnyMetatypeType>(selfTy))
@@ -100,9 +134,11 @@ CanType SILFunctionType::getSelfInstanceType() const {
 }
 
 ClassDecl *
-SILFunctionType::getWitnessMethodClass() const {
-  auto selfTy = getSelfInstanceType();
-  auto genericSig = getGenericSignature();
+SILFunctionType::getWitnessMethodClass(SILModule &M) const {
+  // TODO: When witnesses use substituted types, we'd get this from the
+  // substitution map.
+  auto selfTy = getSelfInstanceType(M);
+  auto genericSig = getSubstGenericSignature();
   if (auto paramTy = dyn_cast<GenericTypeParamType>(selfTy)) {
     assert(paramTy->getDepth() == 0 && paramTy->getIndex() == 0);
     auto superclass = genericSig->getSuperclassBound(paramTy);
@@ -180,11 +216,13 @@ CanSILFunctionType Lowering::adjustFunctionType(
       type->getWitnessMethodConformanceOrNone() == witnessMethodConformance)
     return type;
 
-  return SILFunctionType::get(type->getGenericSignature(),
+  return SILFunctionType::get(type->getSubstGenericSignature(),
                               extInfo, type->getCoroutineKind(), callee,
                               type->getParameters(), type->getYields(),
                               type->getResults(),
                               type->getOptionalErrorResult(),
+                              type->getSubstitutions(),
+                              type->isGenericSignatureImplied(),
                               type->getASTContext(),
                               witnessMethodConformance);
 }
@@ -206,9 +244,11 @@ CanSILFunctionType SILFunctionType::getWithExtInfo(ExtInfo newExt) {
             : Lowering::DefaultThickCalleeConvention)
        : ParameterConvention::Direct_Unowned);
 
-  return get(getGenericSignature(), newExt, getCoroutineKind(),
+  return get(getSubstGenericSignature(), newExt, getCoroutineKind(),
              calleeConvention, getParameters(), getYields(),
-             getResults(), getOptionalErrorResult(), getASTContext(),
+             getResults(), getOptionalErrorResult(),
+             getSubstitutions(), isGenericSignatureImplied(),
+             getASTContext(),
              getWitnessMethodConformanceOrNone());
 }
 
@@ -1019,10 +1059,13 @@ static CanSILFunctionType getSILFunctionType(
     .withIsPseudogeneric(pseudogeneric)
     .withNoEscape(extInfo.isNoEscape());
   
+#warning "todo: substituted function types?"
+  
   return SILFunctionType::get(genericSig, silExtInfo, coroutineKind,
                               calleeConvention, inputs, yields,
-                              results, errorResult, TC.Context,
-                              witnessMethodConformance);
+                              results, errorResult,
+                              SubstitutionMap(), false,
+                              TC.Context, witnessMethodConformance);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2342,41 +2385,52 @@ public:
   // When a function appears inside of another type, we only perform
   // substitutions if it does not have a generic signature.
   CanSILFunctionType visitSILFunctionType(CanSILFunctionType origType) {
-    if (origType->getGenericSignature())
+    if (origType->getSubstGenericSignature()) {
+      if (auto subs = origType->getSubstitutions()) {
+        // Substitute the substitutions.
+        auto newSubs = subs.subst(Subst, Conformances);
+        return origType->withSubstitutions(newSubs);
+      }
+      
       return origType;
+    }
 
     return substSILFunctionType(origType);
   }
 
   // Entry point for use by SILType::substGenericArgs().
   CanSILFunctionType substSILFunctionType(CanSILFunctionType origType) {
+    // TODO: Maybe this can be retired once substituted function types are
+    // used pervasively.
+    assert(!origType->getSubstitutions());
+    
     SmallVector<SILResultInfo, 8> substResults;
     substResults.reserve(origType->getNumResults());
     for (auto origResult : origType->getResults()) {
-      substResults.push_back(subst(origResult));
+      substResults.push_back(substInterface(origResult));
     }
 
     auto substErrorResult = origType->getOptionalErrorResult();
     assert(!substErrorResult ||
-           (!substErrorResult->getType()->hasTypeParameter() &&
-            !substErrorResult->getType()->hasArchetype()));
+           (!substErrorResult->getInterfaceType()->hasTypeParameter() &&
+            !substErrorResult->getInterfaceType()->hasArchetype()));
 
     SmallVector<SILParameterInfo, 8> substParams;
     substParams.reserve(origType->getParameters().size());
     for (auto &origParam : origType->getParameters()) {
-      substParams.push_back(subst(origParam));
+      substParams.push_back(substInterface(origParam));
     }
 
     SmallVector<SILYieldInfo, 8> substYields;
     substYields.reserve(origType->getYields().size());
     for (auto &origYield : origType->getYields()) {
-      substYields.push_back(subst(origYield));
+      substYields.push_back(substInterface(origYield));
     }
 
     Optional<ProtocolConformanceRef> witnessMethodConformance;
     if (auto conformance = origType->getWitnessMethodConformanceOrNone()) {
       assert(origType->getExtInfo().hasSelfParam());
-      auto selfType = origType->getSelfParameter().getType();
+      auto selfType = origType->getSelfParameter().getInterfaceType();
       // The Self type can be nested in a few layers of metatypes (etc.).
       while (auto metatypeType = dyn_cast<MetatypeType>(selfType)) {
         auto next = metatypeType.getInstanceType();
@@ -2396,6 +2450,7 @@ public:
                                 origType->getCoroutineKind(),
                                 origType->getCalleeConvention(), substParams,
                                 substYields, substResults, substErrorResult,
+                                SubstitutionMap(), false,
                                 TC.Context, witnessMethodConformance);
   }
 
@@ -2404,16 +2459,17 @@ public:
                                      type.getCategory());
   }
 
-  SILResultInfo subst(SILResultInfo orig) {
-    return SILResultInfo(visit(orig.getType()), orig.getConvention());
+  SILResultInfo substInterface(SILResultInfo orig) {
+    return SILResultInfo(visit(orig.getInterfaceType()), orig.getConvention());
   }
 
-  SILYieldInfo subst(SILYieldInfo orig) {
-    return SILYieldInfo(visit(orig.getType()), orig.getConvention());
+  SILYieldInfo substInterface(SILYieldInfo orig) {
+    return SILYieldInfo(visit(orig.getInterfaceType()), orig.getConvention());
   }
 
-  SILParameterInfo subst(SILParameterInfo orig) {
-    return SILParameterInfo(visit(orig.getType()), orig.getConvention());
+  SILParameterInfo substInterface(SILParameterInfo orig) {
+    return SILParameterInfo(visit(orig.getInterfaceType()),
+                            orig.getConvention());
   }
 
   /// Tuples need to have their component types substituted by these
@@ -2532,8 +2588,9 @@ SILFunctionType::substGenericArgs(SILModule &silModule,
                                   TypeSubstitutionFn subs,
                                   LookupConformanceFn conformances) {
   if (!isPolymorphic()) return CanSILFunctionType(this);
+#warning "todo: should produce a substituted function type"
   SILTypeSubstituter substituter(silModule.Types, subs, conformances,
-                                 getGenericSignature(),
+                                 getSubstGenericSignature(),
                                  /*shouldSubstituteOpaqueTypes*/ false);
   return substituter.substSILFunctionType(CanSILFunctionType(this));
 }
@@ -2870,7 +2927,7 @@ static bool areABICompatibleParamsOrReturns(SILType a, SILType b,
         // *NOTE* We swallow the specific error here for now. We will still get
         // that the function types are incompatible though, just not more
         // specific information.
-        return aFunc->isABICompatibleWith(bFunc, inFunction).isCompatible();
+        return aFunc->isABICompatibleWith(bFunc, *inFunction).isCompatible();
       }
     }
 
@@ -2896,7 +2953,7 @@ using ABICompatibilityCheckResult =
 
 ABICompatibilityCheckResult
 SILFunctionType::isABICompatibleWith(CanSILFunctionType other,
-                                     SILFunction *context) const {
+                                     SILFunction &context) const {
   // The calling convention and function representation can't be changed.
   if (getRepresentation() != other->getRepresentation())
     return ABICompatibilityCheckResult::DifferentFunctionRepresentations;
@@ -2912,9 +2969,10 @@ SILFunctionType::isABICompatibleWith(CanSILFunctionType other,
     if (result1.getConvention() != result2.getConvention())
       return ABICompatibilityCheckResult::DifferentReturnValueConventions;
 
-    if (!areABICompatibleParamsOrReturns(result1.getSILStorageType(),
-                                         result2.getSILStorageType(),
-                                         context)) {
+    if (!areABICompatibleParamsOrReturns(
+                         result1.getSILStorageType(context.getModule(), this),
+                         result2.getSILStorageType(context.getModule(), other),
+                         &context)) {
       return ABICompatibilityCheckResult::ABIIncompatibleReturnValues;
     }
   }
@@ -2928,8 +2986,10 @@ SILFunctionType::isABICompatibleWith(CanSILFunctionType other,
     if (error1.getConvention() != error2.getConvention())
       return ABICompatibilityCheckResult::DifferentErrorResultConventions;
 
-    if (!areABICompatibleParamsOrReturns(error1.getSILStorageType(),
-                                         error2.getSILStorageType(), context))
+    if (!areABICompatibleParamsOrReturns(
+                           error1.getSILStorageType(context.getModule(), this),
+                           error2.getSILStorageType(context.getModule(), other),
+                           &context))
       return ABICompatibilityCheckResult::ABIIncompatibleErrorResults;
   }
 
@@ -2945,8 +3005,10 @@ SILFunctionType::isABICompatibleWith(CanSILFunctionType other,
 
     if (param1.getConvention() != param2.getConvention())
       return {ABICompatibilityCheckResult::DifferingParameterConvention, i};
-    if (!areABICompatibleParamsOrReturns(param1.getSILStorageType(),
-                                         param2.getSILStorageType(), context))
+    if (!areABICompatibleParamsOrReturns(
+                           param1.getSILStorageType(context.getModule(), this),
+                           param2.getSILStorageType(context.getModule(), other),
+                           &context))
       return {ABICompatibilityCheckResult::ABIIncompatibleParameterType, i};
   }
 
@@ -2988,4 +3050,15 @@ StringRef SILFunctionType::ABICompatibilityCheckResult::getMessage() const {
     return "Escape to no escape conversion";
   }
   llvm_unreachable("Covered switch isn't completely covered?!");
+}
+
+CanSILFunctionType
+SILFunctionType::withSubstitutions(SubstitutionMap subs) const {
+  return SILFunctionType::get(getSubstGenericSignature(),
+                          getExtInfo(), getCoroutineKind(),
+                          getCalleeConvention(),
+                          getParameters(), getYields(), getResults(),
+                          getErrorResult(),
+                          subs, isGenericSignatureImplied(),
+                          const_cast<SILFunctionType*>(this)->getASTContext());
 }

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -2062,7 +2062,7 @@ ConvertFunctionInst *ConvertFunctionInst::create(
     (void)opTI;
     CanSILFunctionType resTI = CFI->getType().castTo<SILFunctionType>();
     (void)resTI;
-    assert(opTI->isABICompatibleWith(resTI, &F).isCompatible() &&
+    assert(opTI->isABICompatibleWith(resTI, F).isCompatible() &&
            "Can not convert in between ABI incompatible function types");
   }
   return CFI;
@@ -2092,7 +2092,7 @@ ConvertEscapeToNoEscapeInst *ConvertEscapeToNoEscapeInst::create(
     (void)opTI;
     CanSILFunctionType resTI = CFI->getType().castTo<SILFunctionType>();
     (void)resTI;
-    assert(opTI->isABICompatibleWith(resTI, &F)
+    assert(opTI->isABICompatibleWith(resTI, F)
                .isCompatibleUpToNoEscapeConversion() &&
            "Can not convert in between ABI incompatible function types");
   }

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1083,7 +1083,7 @@ public:
   void visitApplyInstBase(Inst *AI) {
     *this << Ctx.getID(AI->getCallee());
     printSubstitutions(AI->getSubstitutionMap(),
-                       AI->getOrigCalleeType()->getGenericSignature());
+                       AI->getOrigCalleeType()->getInvocationGenericSignature());
     *this << '(';
     interleave(AI->getArguments(),
                [&](const SILValue &arg) { *this << Ctx.getID(arg); },
@@ -2417,7 +2417,7 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   llvm::DenseMap<CanType, Identifier> Aliases;
   llvm::DenseSet<Identifier> UsedNames;
   
-  auto sig = getLoweredFunctionType()->getGenericSignature();
+  auto sig = getLoweredFunctionType()->getSubstGenericSignature();
   auto *env = getGenericEnvironment();
   if (sig && env) {
     llvm::SmallString<16> disambiguatedNameBuf;

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -90,9 +90,9 @@ bool SILType::isReferenceCounted(SILModule &M) const {
     .isReferenceCounted();
 }
 
-bool SILType::isNoReturnFunction() const {
+bool SILType::isNoReturnFunction(SILModule &M) const {
   if (auto funcTy = dyn_cast<SILFunctionType>(getASTType()))
-    return funcTy->isNoReturnFunction();
+    return funcTy->isNoReturnFunction(M);
 
   return false;
 }
@@ -410,10 +410,11 @@ swift::getSILBoxFieldLoweredType(SILBoxType *type, TypeConverter &TC,
 ValueOwnershipKind
 SILResultInfo::getOwnershipKind(SILFunction &F) const {
   auto &M = F.getModule();
-  auto sig = F.getLoweredFunctionType()->getGenericSignature();
+  auto FTy = F.getLoweredFunctionType();
+  auto sig = FTy->getInvocationGenericSignature();
   GenericContextScope GCS(M.Types, sig);
 
-  bool IsTrivial = getSILStorageType().isTrivial(F);
+  bool IsTrivial = getSILStorageType(M, FTy).isTrivial(F);
   switch (getConvention()) {
   case ResultConvention::Indirect:
     return SILModuleConventions(M).isSILIndirect(*this)
@@ -432,9 +433,11 @@ SILResultInfo::getOwnershipKind(SILFunction &F) const {
   llvm_unreachable("Unhandled ResultConvention in switch.");
 }
 
-SILModuleConventions::SILModuleConventions(const SILModule &M)
-    : loweredAddresses(!M.getASTContext().LangOpts.EnableSILOpaqueValues
-                       || M.getStage() == SILStage::Lowered) {}
+SILModuleConventions::SILModuleConventions(SILModule &M)
+    : M(&M),
+      loweredAddresses(!M.getASTContext().LangOpts.EnableSILOpaqueValues
+                       || M.getStage() == SILStage::Lowered)
+{}
 
 bool SILModuleConventions::isReturnedIndirectlyInSIL(SILType type,
                                                      SILModule &M) {
@@ -458,9 +461,9 @@ bool SILModuleConventions::isPassedIndirectlyInSIL(SILType type, SILModule &M) {
 }
 
 
-bool SILFunctionType::isNoReturnFunction() const {
+bool SILFunctionType::isNoReturnFunction(SILModule &M) const {
   for (unsigned i = 0, e = getNumResults(); i < e; ++i) {
-    if (getResults()[i].getType()->isUninhabited())
+    if (getResults()[i].getReturnValueType(M, this)->isUninhabited())
       return true;
   }
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -162,7 +162,7 @@ void verifyKeyPathComponent(SILModule &M,
           require(param.getConvention()
                     == ParameterConvention::Direct_Unowned,
                   "indices pointer should be trivial");
-          require(param.getType()->getAnyNominal()
+          require(param.getInterfaceType()->getAnyNominal()
                     == C.getUnsafeRawPointerDecl(),
                   "indices pointer should be an UnsafeRawPointer");
         }
@@ -173,7 +173,8 @@ void verifyKeyPathComponent(SILModule &M,
         require(substEqualsType->getResults()[0].getConvention()
                   == ResultConvention::Unowned,
                 "result should be unowned");
-        require(substEqualsType->getResults()[0].getType()->getAnyNominal()
+        require(substEqualsType->getResults()[0].getInterfaceType()
+                               ->getAnyNominal()
                   == C.getBoolDecl(),
                 "result should be Bool");
       }
@@ -193,7 +194,7 @@ void verifyKeyPathComponent(SILModule &M,
         require(param.getConvention()
                   == ParameterConvention::Direct_Unowned,
                 "indices pointer should be trivial");
-        require(param.getType()->getAnyNominal()
+        require(param.getInterfaceType()->getAnyNominal()
                   == C.getUnsafeRawPointerDecl(),
                 "indices pointer should be an UnsafeRawPointer");
         
@@ -203,7 +204,8 @@ void verifyKeyPathComponent(SILModule &M,
         require(substHashType->getResults()[0].getConvention()
                   == ResultConvention::Unowned,
                 "result should be unowned");
-        require(substHashType->getResults()[0].getType()->getAnyNominal()
+        require(substHashType->getResults()[0].getInterfaceType()
+                             ->getAnyNominal()
                   == C.getIntDecl(),
                 "result should be Int");
       }
@@ -278,7 +280,8 @@ void verifyKeyPathComponent(SILModule &M,
       auto baseParam = substGetterType->getParameters()[0];
       require(baseParam.getConvention() == normalArgConvention,
               "getter base parameter should have normal arg convention");
-      require(baseParam.getType() == loweredBaseTy.getASTType(),
+      require(baseParam.getArgumentType(M, substGetterType)
+                == loweredBaseTy.getASTType(),
               "getter base parameter should match base of component");
       
       if (hasIndices) {
@@ -286,7 +289,7 @@ void verifyKeyPathComponent(SILModule &M,
         require(indicesParam.getConvention()
                   == ParameterConvention::Direct_Unowned,
                 "indices pointer should be trivial");
-        require(indicesParam.getType()->getAnyNominal()
+        require(indicesParam.getArgumentType(M, substGetterType)->getAnyNominal()
                   == C.getUnsafeRawPointerDecl(),
                 "indices pointer should be an UnsafeRawPointer");
       }
@@ -296,7 +299,8 @@ void verifyKeyPathComponent(SILModule &M,
       auto result = substGetterType->getResults()[0];
       require(result.getConvention() == ResultConvention::Indirect,
               "getter result should be @out");
-      require(result.getType() == loweredComponentTy.getASTType(),
+      require(result.getReturnValueType(M, substGetterType)
+                == loweredComponentTy.getASTType(),
               "getter result should match the maximal abstraction of the "
               "formal component type");
     }
@@ -340,12 +344,12 @@ void verifyKeyPathComponent(SILModule &M,
         require(indicesParam.getConvention()
                   == ParameterConvention::Direct_Unowned,
                 "indices pointer should be trivial");
-        require(indicesParam.getType()->getAnyNominal()
+        require(indicesParam.getArgumentType(M, substSetterType)->getAnyNominal()
                   == C.getUnsafeRawPointerDecl(),
                 "indices pointer should be an UnsafeRawPointer");
       }
 
-      require(newValueParam.getType() ==
+      require(newValueParam.getArgumentType(M, substSetterType) ==
                 loweredComponentTy.getASTType(),
               "setter value should match the maximal abstraction of the "
               "formal component type");
@@ -764,7 +768,7 @@ public:
   void requireABICompatibleFunctionTypes(CanSILFunctionType type1,
                                          CanSILFunctionType type2,
                                          const Twine &what,
-                                         SILFunction *inFunction = nullptr) {
+                                         SILFunction &inFunction) {
     auto complain = [=](const char *msg) -> std::function<void()> {
       return [=]{
         llvm::dbgs() << "  " << msg << '\n'
@@ -1571,8 +1575,9 @@ public:
       // lifetime-extending 'self'.
       if (expectedResult.getConvention()
             == ResultConvention::UnownedInnerPointer) {
-        expectedResult = SILResultInfo(expectedResult.getType(),
-                                       ResultConvention::Unowned);
+        expectedResult = SILResultInfo(
+                   expectedResult.getReturnValueType(F.getModule(), substTy),
+                   ResultConvention::Unowned);
         require(originalResult == expectedResult,
                 "result type of result function type for partially applied "
                 "@unowned_inner_pointer function should have @unowned"
@@ -1583,8 +1588,9 @@ public:
       // retaining the return value.
       } else if (expectedResult.getConvention()
             == ResultConvention::Autoreleased) {
-        expectedResult = SILResultInfo(expectedResult.getType(),
-                                       ResultConvention::Owned);
+        expectedResult = SILResultInfo(
+                     expectedResult.getReturnValueType(F.getModule(), substTy),
+                     ResultConvention::Owned);
         require(originalResult == expectedResult,
                 "result type of result function type for partially applied "
                 "@autoreleased function should have @owned convention");
@@ -2821,7 +2827,7 @@ public:
     require(methodType->isPolymorphic(),
             "result of witness_method must be polymorphic");
 
-    auto genericSig = methodType->getGenericSignature();
+    auto genericSig = methodType->getInvocationGenericSignature();
 
     auto selfGenericParam = genericSig->getGenericParams()[0];
     require(selfGenericParam->getDepth() == 0
@@ -2898,7 +2904,8 @@ public:
         auto anyObjectTy = C.getAnyObjectType();
         for (auto &dynResult : dynResults) {
           auto newResultTy
-            = dynResult.getType()->replaceCovariantResultType(anyObjectTy, 0);
+            = dynResult.getReturnValueType(F.getModule(), methodTy)
+                       ->replaceCovariantResultType(anyObjectTy, 0);
           dynResult = SILResultInfo(newResultTy->getCanonicalType(),
                                     dynResult.getConvention());
         }
@@ -2913,6 +2920,7 @@ public:
                                      methodTy->getYields(),
                                      dynResults,
                                      methodTy->getOptionalErrorResult(),
+                                     SubstitutionMap(), false,
                                      F.getASTContext());
     return SILType::getPrimitiveObjectType(fnTy);
   }
@@ -3826,7 +3834,7 @@ public:
     // convert_function is required to be an ABI-compatible conversion.
     requireABICompatibleFunctionTypes(
         opTI, resTI, "convert_function cannot change function ABI",
-        ICI->getFunction());
+        *ICI->getFunction());
   }
 
   void checkConvertEscapeToNoEscapeInst(ConvertEscapeToNoEscapeInst *ICI) {
@@ -3843,7 +3851,7 @@ public:
     requireABICompatibleFunctionTypes(
         opTI, resTI->getWithExtInfo(resTI->getExtInfo().withNoEscape(false)),
         "convert_escape_to_noescape cannot change function ABI",
-        ICI->getFunction());
+        *ICI->getFunction());
 
     // After mandatory passes convert_escape_to_noescape should not have the
     // '[not_guaranteed]' or '[escaped]' attributes.
@@ -4351,7 +4359,7 @@ public:
             "invoke function operand must be a c function");
     require(invokeTy->getParameters().size() >= 1,
             "invoke function must take at least one parameter");
-    require(!invokeTy->getGenericSignature() ||
+    require(!invokeTy->getInvocationGenericSignature() ||
             invokeTy->getExtInfo().isPseudogeneric(),
             "invoke function must not take reified generic parameters");
     
@@ -4363,7 +4371,7 @@ public:
             ParameterConvention::Indirect_InoutAliasable,
             "invoke function must take block storage as @inout_aliasable "
             "parameter");
-    require(storageParam.getType() == storageTy,
+    require(storageParam.getArgumentType(F.getModule(), invokeTy) == storageTy,
             "invoke function must take block storage type as first parameter");
     
     require(IBSHI->getType().isObject(), "result must be a value");
@@ -5175,7 +5183,8 @@ void SILVTable::verify(const SILModule &M) const {
           .requireABICompatibleFunctionTypes(
               baseInfo.getSILType().castTo<SILFunctionType>(),
               entry.Implementation->getLoweredFunctionType(),
-              "vtable entry for " + baseName + " must be ABI-compatible");
+              "vtable entry for " + baseName + " must be ABI-compatible",
+              *entry.Implementation);
     }
   }
 }

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2347,7 +2347,8 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
 /// Given that type1 is known to be a subtype of type2, check if the two
 /// types have the same calling convention representation.
 TypeConverter::ABIDifference
-TypeConverter::checkForABIDifferences(SILType type1, SILType type2,
+TypeConverter::checkForABIDifferences(SILModule &M,
+                                      SILType type1, SILType type2,
                                       bool thunkOptionals) {
   // Unwrap optionals, but remember that we did.
   bool type1WasOptional = false;
@@ -2402,7 +2403,7 @@ TypeConverter::checkForABIDifferences(SILType type1, SILType type2,
             fnTy1->getRepresentation() != SILFunctionTypeRepresentation::Block)
           return ABIDifference::NeedsThunk;
 
-      return checkFunctionForABIDifferences(fnTy1, fnTy2);
+      return checkFunctionForABIDifferences(M, fnTy1, fnTy2);
     }
   }
   
@@ -2437,7 +2438,8 @@ TypeConverter::checkForABIDifferences(SILType type1, SILType type2,
           return ABIDifference::NeedsThunk;
         
         for (unsigned i = 0, e = tuple1->getNumElements(); i < e; i++) {
-          if (checkForABIDifferences(type1.getTupleElementType(i),
+          if (checkForABIDifferences(M,
+                                     type1.getTupleElementType(i),
                                      type2.getTupleElementType(i))
                 != ABIDifference::Trivial)
             return ABIDifference::NeedsThunk;
@@ -2455,7 +2457,8 @@ TypeConverter::checkForABIDifferences(SILType type1, SILType type2,
 }
 
 TypeConverter::ABIDifference
-TypeConverter::checkFunctionForABIDifferences(SILFunctionType *fnTy1,
+TypeConverter::checkFunctionForABIDifferences(SILModule &M,
+                                              SILFunctionType *fnTy1,
                                               SILFunctionType *fnTy2) {
   // Fast path -- if both functions were unwrapped from a CanSILFunctionType,
   // we might have pointer equality here.
@@ -2484,8 +2487,9 @@ TypeConverter::checkFunctionForABIDifferences(SILFunctionType *fnTy1,
     if (result1.getConvention() != result2.getConvention())
       return ABIDifference::NeedsThunk;
 
-    if (checkForABIDifferences(result1.getSILStorageType(),
-                               result2.getSILStorageType(),
+    if (checkForABIDifferences(M,
+                               result1.getSILStorageType(M, fnTy1),
+                               result2.getSILStorageType(M, fnTy2),
              /*thunk iuos*/ fnTy1->getLanguage() == SILFunctionLanguage::Swift)
         != ABIDifference::Trivial)
       return ABIDifference::NeedsThunk;
@@ -2498,8 +2502,9 @@ TypeConverter::checkFunctionForABIDifferences(SILFunctionType *fnTy1,
     if (yield1.getConvention() != yield2.getConvention())
       return ABIDifference::NeedsThunk;
 
-    if (checkForABIDifferences(yield1.getSILStorageType(),
-                               yield2.getSILStorageType(),
+    if (checkForABIDifferences(M,
+                               yield1.getSILStorageType(M, fnTy1),
+                               yield2.getSILStorageType(M, fnTy2),
              /*thunk iuos*/ fnTy1->getLanguage() == SILFunctionLanguage::Swift)
         != ABIDifference::Trivial)
       return ABIDifference::NeedsThunk;
@@ -2514,8 +2519,9 @@ TypeConverter::checkFunctionForABIDifferences(SILFunctionType *fnTy1,
     if (error1.getConvention() != error2.getConvention())
       return ABIDifference::NeedsThunk;
 
-    if (checkForABIDifferences(error1.getSILStorageType(),
-                               error2.getSILStorageType(),
+    if (checkForABIDifferences(M,
+                               error1.getSILStorageType(M, fnTy1),
+                               error2.getSILStorageType(M, fnTy2),
               /*thunk iuos*/ fnTy1->getLanguage() == SILFunctionLanguage::Swift)
         != ABIDifference::Trivial)
       return ABIDifference::NeedsThunk;
@@ -2531,8 +2537,9 @@ TypeConverter::checkFunctionForABIDifferences(SILFunctionType *fnTy1,
     // make sure to flip the relation around.
     std::swap(param1, param2);
 
-    if (checkForABIDifferences(param1.getSILStorageType(),
-                               param2.getSILStorageType(),
+    if (checkForABIDifferences(M,
+                               param1.getSILStorageType(M, fnTy1),
+                               param2.getSILStorageType(M, fnTy2),
               /*thunk iuos*/ fnTy1->getLanguage() == SILFunctionLanguage::Swift)
         != ABIDifference::Trivial)
       return ABIDifference::NeedsThunk;

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -468,11 +468,12 @@ public:
       : loc(loc), subPlan(std::move(subPlan)) {
     unsigned errorParamIndex =
         calleeTypeInfo.foreignError->getErrorParameterIndex();
+    auto substFnType = calleeTypeInfo.substFnType;
     SILParameterInfo errorParameter =
-        calleeTypeInfo.substFnType->getParameters()[errorParamIndex];
+        substFnType->getParameters()[errorParamIndex];
     // We assume that there's no interesting reabstraction here beyond a layer
     // of optional.
-    errorPtrType = errorParameter.getType();
+    errorPtrType = errorParameter.getArgumentType(SGF.SGM.M, substFnType);
     unwrappedPtrType = errorPtrType;
     Type unwrapped = errorPtrType->getOptionalObjectType();
     isOptional = (bool) unwrapped;
@@ -570,8 +571,10 @@ ResultPlanPtr ResultPlanBuilder::buildTopLevelResult(Initialization *init,
   // need to make our own make SILResultInfo array.
   case ForeignErrorConvention::NilResult: {
     assert(allResults.size() == 1);
-    CanType objectType = allResults[0].getType().getOptionalObjectType();
-    SILResultInfo optResult = allResults[0].getWithType(objectType);
+    auto substFnTy = calleeTypeInfo.substFnType;
+    CanType objectType = allResults[0].getReturnValueType(SGF.SGM.M, substFnTy)
+                                      .getOptionalObjectType();
+    SILResultInfo optResult = allResults[0].getWithInterfaceType(objectType);
     allResults.clear();
     allResults.push_back(optResult);
     break;
@@ -598,12 +601,15 @@ ResultPlanPtr ResultPlanBuilder::build(Initialization *init,
   // Otherwise, grab the next result.
   auto result = allResults.pop_back_val();
 
+  auto calleeTy = calleeTypeInfo.substFnType;
+  
   // If the result is indirect, and we have an address to emit into, and
   // there are no abstraction differences, then just do it.
   if (init && init->canPerformInPlaceInitialization() &&
       SGF.silConv.isSILIndirect(result) &&
       !SGF.getLoweredType(substType).getAddressType().hasAbstractionDifference(
-            calleeTypeInfo.getOverrideRep(), result.getSILStorageType())) {
+            calleeTypeInfo.getOverrideRep(),
+            result.getSILStorageType(SGF.SGM.M, calleeTy))) {
     return ResultPlanPtr(new InPlaceInitializationResultPlan(init));
   }
 
@@ -618,7 +624,7 @@ ResultPlanPtr ResultPlanBuilder::build(Initialization *init,
   // then we need to evaluate the arguments first in order to have access to
   // the opened Self type. A special result plan defers allocating the stack
   // slot to the point the call is emitted.
-  if (result.getType()->hasOpenedExistential()
+  if (result.getReturnValueType(SGF.SGM.M, calleeTy)->hasOpenedExistential()
       && SGF.silConv.isSILIndirect(result)) {
     return ResultPlanPtr(
       new IndirectOpenedSelfResultPlan(SGF, origType, substType));
@@ -627,7 +633,8 @@ ResultPlanPtr ResultPlanBuilder::build(Initialization *init,
   // Create a temporary if the result is indirect.
   std::unique_ptr<TemporaryInitialization> temporary;
   if (SGF.silConv.isSILIndirect(result)) {
-    auto &resultTL = SGF.getTypeLowering(result.getType());
+    auto &resultTL = SGF.getTypeLowering(
+                               result.getReturnValueType(SGF.SGM.M, calleeTy));
     temporary = SGF.emitTemporary(loc, resultTL);
   }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -418,6 +418,7 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
                              /*pseudogeneric*/false,
                              /*non-escaping*/false);
 
+#warning "todo: should be a substituted function type of the common key path interface"
   auto functionTy = SILFunctionType::get(sig, extInfo,
                                          SILCoroutineKind::YieldOnce,
                                          ParameterConvention::Direct_Unowned,
@@ -425,6 +426,7 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
                                          yields,
                                          /*results*/ {},
                                          /*error result*/ {},
+                                         SubstitutionMap(), false,
                                          getASTContext());
 
   auto env = sig->getGenericEnvironment();
@@ -485,6 +487,7 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
                                    SILResultInfo(Int32Ty,
                                                  ResultConvention::Unowned),
                                    None,
+                                   SubstitutionMap(), false,
                                    C);
 
   SILGenFunctionBuilder builder(*this);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1787,7 +1787,8 @@ static void emitRawApply(SILGenFunction &SGF,
     rawResults.push_back(result);
 
     SILBasicBlock *errorBB =
-      SGF.getTryApplyErrorDest(loc, substFnType->getErrorResult(),
+      SGF.getTryApplyErrorDest(loc, substFnType,
+                               substFnType->getErrorResult(),
                                options & ApplyOptions::DoesNotThrow);
 
     SGF.B.createTryApply(loc, fnValue, subs, argValues,
@@ -1868,15 +1869,17 @@ class ClaimedParamsRef {
 public:
   static constexpr const unsigned NoSkip = (unsigned)-1;
 private:
+  CanSILFunctionType FnTy;
   ArrayRef<SILParameterInfo> Params;
   
   // The index of the param excluded from this range, if any, or ~0.
   unsigned SkipParamIndex;
   
   friend struct ParamLowering;
-  explicit ClaimedParamsRef(ArrayRef<SILParameterInfo> params,
+  explicit ClaimedParamsRef(CanSILFunctionType fnTy,
+                            ArrayRef<SILParameterInfo> params,
                             unsigned skip)
-    : Params(params), SkipParamIndex(skip)
+    : FnTy(fnTy), Params(params), SkipParamIndex(skip)
   {
     // Eagerly chop a skipped parameter off either end.
     if (SkipParamIndex == 0) {
@@ -1890,10 +1893,13 @@ private:
     return SkipParamIndex != (unsigned)NoSkip;
   }
 public:
-  ClaimedParamsRef() : Params({}), SkipParamIndex(-1) {}
-  explicit ClaimedParamsRef(ArrayRef<SILParameterInfo> params)
-    : Params(params), SkipParamIndex(NoSkip)
+  ClaimedParamsRef() : FnTy(), Params({}), SkipParamIndex(-1) {}
+  explicit ClaimedParamsRef(CanSILFunctionType fnTy,
+                            ArrayRef<SILParameterInfo> params)
+    : FnTy(fnTy), Params(params), SkipParamIndex(NoSkip)
   {}
+  
+  CanSILFunctionType getFunctionType() const { return FnTy; }
 
   struct iterator : public std::iterator<std::random_access_iterator_tag,
                                          SILParameterInfo>
@@ -2003,20 +2009,21 @@ public:
   
   ClaimedParamsRef slice(unsigned start) const {
     if (start >= SkipParamIndex)
-      return ClaimedParamsRef(Params.slice(start + 1), NoSkip);
-    return ClaimedParamsRef(Params.slice(start),
+      return ClaimedParamsRef(FnTy, Params.slice(start + 1), NoSkip);
+    return ClaimedParamsRef(FnTy,
+                            Params.slice(start),
                             hasSkip() ? SkipParamIndex - start : NoSkip);
   }
   ClaimedParamsRef slice(unsigned start, unsigned count) const {
     if (start >= SkipParamIndex)
-      return ClaimedParamsRef(Params.slice(start + 1, count), NoSkip);
+      return ClaimedParamsRef(FnTy, Params.slice(start + 1, count), NoSkip);
     unsigned newSkip = SkipParamIndex;
     if (hasSkip())
       newSkip -= start;
     
     if (newSkip < count)
-      return ClaimedParamsRef(Params.slice(start, count+1), newSkip);
-    return ClaimedParamsRef(Params.slice(start, count), NoSkip);
+      return ClaimedParamsRef(FnTy, Params.slice(start, count+1), newSkip);
+    return ClaimedParamsRef(FnTy, Params.slice(start, count), NoSkip);
   }
 };
 
@@ -2686,9 +2693,9 @@ private:
       loweredSubstArgType =
         SILType::getPrimitiveAddressType(loweredSubstArgType.getASTType());
     }
-    SILType loweredSubstParamType =
-      SILType::getPrimitiveType(param.getType(),
-                                loweredSubstArgType.getCategory());
+    SILType loweredSubstParamType = SILType::getPrimitiveType(
+                param.getArgumentType(SGF.SGM.M, ParamInfos.getFunctionType()),
+                loweredSubstArgType.getCategory());
 
     // If the caller takes the argument indirectly, the argument has an
     // inout type.
@@ -2705,7 +2712,7 @@ private:
         return;
     }
 
-     if (SGF.silConv.isSILIndirect(param)) {
+    if (SGF.silConv.isSILIndirect(param)) {
       emitIndirect(std::move(arg), loweredSubstArgType, origParamType, param);
       return;
     }
@@ -2812,7 +2819,7 @@ private:
     // Otherwise, simultaneously emit and reabstract.
     } else {
       result = std::move(arg).materialize(SGF, origParamType,
-                                          SGF.getSILType(param));
+                          SGF.getSILType(param, ParamInfos.getFunctionType()));
     }
 
     Args.push_back(result);
@@ -2920,9 +2927,9 @@ private:
                                             arg.getSubstRValueType());
         case SILFunctionLanguage::C:
           return Conversion::getBridging(Conversion::BridgeToObjC,
-                                         arg.getSubstRValueType(),
-                                         origParamType.getType(),
-                                         param.getSILStorageType());
+             arg.getSubstRValueType(),
+             origParamType.getType(),
+             param.getSILStorageType(SGF.SGM.M, ParamInfos.getFunctionType()));
         }
         llvm_unreachable("bad language");
       }();
@@ -3144,10 +3151,10 @@ private:
     /// If the context requires reabstraction
     bool RequiresReabstraction;
   };
-  static EmissionContexts getRValueEmissionContexts(SILType loweredArgType,
-                                                    SILParameterInfo param) {
-    bool requiresReabstraction =
-        loweredArgType.getASTType() != param.getType();
+  EmissionContexts getRValueEmissionContexts(SILType loweredArgType,
+                                             SILParameterInfo param) {
+    bool requiresReabstraction = loweredArgType.getASTType()
+      != param.getArgumentType(SGF.SGM.M, ParamInfos.getFunctionType());
     // If the parameter is consumed, we have to emit at +1.
     if (param.isConsumed()) {
       return {SGFContext(), requiresReabstraction};
@@ -3235,7 +3242,8 @@ static void emitBorrowedLValueRecursive(SILGenFunction &SGF,
     value = SGF.B.createFormalAccessLoadBorrow(loc, value);
   }
 
-  assert(param.getType() == value.getType().getASTType());
+  assert(param.getArgumentType(SGF.SGM.M, params.getFunctionType())
+            == value.getType().getASTType());
   args[argIndex++] = value;
 }
 
@@ -3372,7 +3380,8 @@ struct ParamLowering {
         return {};
       }
       ClaimedForeignSelf = foreignSelf.getSelfIndex();
-      return ClaimedParamsRef(Params[ClaimedForeignSelf],
+      return ClaimedParamsRef(fnConv.funcTy,
+                              Params[ClaimedForeignSelf],
                               ClaimedParamsRef::NoSkip);
     }
 
@@ -3381,13 +3390,13 @@ struct ParamLowering {
              "not claiming all params after foreign self?!");
       auto result = Params;
       Params = {};
-      return ClaimedParamsRef(result, ClaimedForeignSelf);
+      return ClaimedParamsRef(fnConv.funcTy, result, ClaimedForeignSelf);
     }
 
     assert(count <= Params.size());
     auto result = Params.slice(Params.size() - count, count);
     Params = Params.slice(0, Params.size() - count);
-    return ClaimedParamsRef(result, (unsigned)-1);
+    return ClaimedParamsRef(fnConv.funcTy, result, (unsigned)-1);
   }
 
   ArrayRef<SILParameterInfo>
@@ -4431,7 +4440,7 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
 
   // Emit the raw application.
   GenericSignature genericSig =
-    fn.getType().castTo<SILFunctionType>()->getGenericSignature();
+    fn.getType().castTo<SILFunctionType>()->getInvocationGenericSignature();
 
   // When calling a closure that's defined in a generic context but does not
   // capture any generic parameters, we will have substitutions, but the
@@ -4457,7 +4466,7 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
   // Pop the argument scope.
   argScope.pop();
 
-  if (substFnType->isNoReturnFunction())
+  if (substFnType->isNoReturnFunction(SGM.M))
     loc.markAutoGenerated();
 
   // Explode the direct results.
@@ -4465,7 +4474,8 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
   SmallVector<ManagedValue, 4> directResults;
   auto addManagedDirectResult = [&](SILValue result,
                                     const SILResultInfo &resultInfo) {
-    auto &resultTL = getTypeLowering(resultInfo.getType());
+    auto &resultTL =
+      getTypeLowering(resultInfo.getReturnValueType(SGM.M, substFnType));
 
     switch (resultInfo.getConvention()) {
     case ResultConvention::Indirect:
@@ -4636,13 +4646,15 @@ void SILGenFunction::emitYield(SILLocation loc,
   SmallVector<SILParameterInfo, 4> substYieldTys;
   for (auto origYield : fnType->getYields()) {
     substYieldTys.push_back({
-      F.mapTypeIntoContext(origYield.getType())->getCanonicalType(),
+      F.mapTypeIntoContext(origYield.getArgumentType(SGM.M, fnType))
+       ->getCanonicalType(),
       origYield.getConvention()
     });
   }
 
   ArgEmitter emitter(*this, fnType->getRepresentation(), /*yield*/ true,
-                     /*isForCoroutine*/ false, ClaimedParamsRef(substYieldTys),
+                     /*isForCoroutine*/ false,
+                     ClaimedParamsRef(fnType, substYieldTys),
                      yieldArgs, delayedArgs,
                      /*foreign error*/ None, ImportAsMemberStatus());
 
@@ -4871,7 +4883,8 @@ RValue SILGenFunction::emitApplyAllocatingInitializer(SILLocation loc,
     // Determine the self metatype type.
     CanSILFunctionType substFnType =
       initConstant.SILFnType->substGenericArgs(SGM.M, subs);
-    SILType selfParamMetaTy = getSILType(substFnType->getSelfParameter());
+    SILType selfParamMetaTy = getSILType(substFnType->getSelfParameter(),
+                                         substFnType);
 
     if (overriddenSelfType) {
       // If the 'self' type has been overridden, form a metatype to the
@@ -4974,7 +4987,8 @@ RValue SILGenFunction::emitApplyMethod(SILLocation loc, ConcreteDeclRef declRef,
     // Determine the self metatype type.
     CanSILFunctionType substFnType =
         declRefConstant.SILFnType->substGenericArgs(SGM.M, subs);
-    SILType selfParamMetaTy = getSILType(substFnType->getSelfParameter());
+    SILType selfParamMetaTy = getSILType(substFnType->getSelfParameter(),
+                                         substFnType);
     selfMetaTy = selfParamMetaTy;
   }
 
@@ -5543,6 +5557,7 @@ static void emitPseudoFunctionArguments(SILGenFunction &SGF,
                                         SmallVectorImpl<ManagedValue> &outVals,
                                         PreparedArguments &&args) {
   auto substParams = substFnType->getParams();
+  auto &tl = SGF.getTypeLowering(origFnType, substFnType);
 
   SmallVector<SILParameterInfo, 4> substParamTys;
   for (auto substParam : substParams) {
@@ -5554,10 +5569,12 @@ static void emitPseudoFunctionArguments(SILGenFunction &SGF,
   SmallVector<DelayedArgument, 2> delayedArgs;
 
   ArgEmitter emitter(SGF, SILFunctionTypeRepresentation::Thin,
-                     /*yield*/ false,
-                     /*isForCoroutine*/ false, ClaimedParamsRef(substParamTys),
-                     argValues, delayedArgs,
-                     /*foreign error*/ None, ImportAsMemberStatus());
+     /*yield*/ false,
+     /*isForCoroutine*/ false,
+     ClaimedParamsRef(tl.getLoweredType().castTo<SILFunctionType>(),
+                      substParamTys),
+     argValues, delayedArgs,
+     /*foreign error*/ None, ImportAsMemberStatus());
 
   emitter.emitPreparedArgs(std::move(args), origFnType);
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -557,6 +557,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
                   SILResultInfo(OptNSStringTy,
                                 ResultConvention::Autoreleased),
                   /*error result*/ None,
+                  SubstitutionMap(), false,
                   ctx);
     auto NSStringFromClassFn = builder.getOrCreateFunction(
         mainClass, "NSStringFromClass", SILLinkage::PublicExternal,
@@ -643,6 +644,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
                   SILResultInfo(argc->getType().getASTType(),
                                 ResultConvention::Unowned),
                   /*error result*/ None,
+                  SubstitutionMap(), false,
                   getASTContext());
 
     SILGenFunctionBuilder builder(SGM);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -517,11 +517,11 @@ public:
     return F.getTypeLowering(type);
   }
 
-  SILType getSILType(SILParameterInfo param) const {
-    return silConv.getSILType(param);
+  SILType getSILType(SILParameterInfo param, CanSILFunctionType fnTy) const {
+    return silConv.getSILType(param, fnTy);
   }
-  SILType getSILType(SILResultInfo result) const {
-    return silConv.getSILType(result);
+  SILType getSILType(SILResultInfo result, CanSILFunctionType fnTy) const {
+    return silConv.getSILType(result, fnTy);
   }
 
   const SILConstantInfo &getConstantInfo(SILDeclRef constant) {
@@ -1513,6 +1513,7 @@ public:
   RValue emitLiteral(LiteralExpr *literal, SGFContext C);
 
   SILBasicBlock *getTryApplyErrorDest(SILLocation loc,
+                                      CanSILFunctionType fnTy,
                                       SILResultInfo exnResult,
                                       bool isSuppressed);
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1209,7 +1209,8 @@ namespace {
     bool doesAccessorMutateSelf(SILGenFunction &SGF,
                                 SILDeclRef accessor) const {
       auto accessorSelf = SGF.SGM.Types.getConstantSelfParameter(accessor);
-      return accessorSelf.getType() && accessorSelf.isIndirectMutating();
+      return accessorSelf.getInterfaceType()
+        && accessorSelf.isIndirectMutating();
     }
     
     void printBase(raw_ostream &OS, unsigned indent, StringRef name) const {
@@ -2011,8 +2012,9 @@ namespace {
       auto projectFnType = projectFn->getLoweredFunctionType();
 
       auto keyPathTy = keyPathValue.getType().castTo<BoundGenericType>();
-      auto subs = SubstitutionMap::get(projectFnType->getGenericSignature(),
-                                       keyPathTy->getGenericArgs(), {});
+      auto subs = SubstitutionMap::get(
+                                 projectFnType->getInvocationGenericSignature(),
+                                 keyPathTy->getGenericArgs(), {});
 
       auto substFnType = projectFnType->substGenericArgs(SGF.SGM.M, subs);
 

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -370,7 +370,9 @@ namespace {
 } // end anonymous namespace
 
 static InitializationPtr
-prepareIndirectResultInit(SILGenFunction &SGF, CanType resultType,
+prepareIndirectResultInit(SILGenFunction &SGF,
+                          CanSILFunctionType fnTypeForResults,
+                          CanType resultType,
                           ArrayRef<SILResultInfo> &allResults,
                           MutableArrayRef<SILValue> &directResults,
                           ArrayRef<SILArgument*> &indirectResultAddrs,
@@ -381,7 +383,8 @@ prepareIndirectResultInit(SILGenFunction &SGF, CanType resultType,
     tupleInit->SubInitializations.reserve(resultTupleType->getNumElements());
 
     for (auto resultEltType : resultTupleType.getElementTypes()) {
-      auto eltInit = prepareIndirectResultInit(SGF, resultEltType, allResults,
+      auto eltInit = prepareIndirectResultInit(SGF, fnTypeForResults,
+                                               resultEltType, allResults,
                                                directResults,
                                                indirectResultAddrs, cleanups);
       tupleInit->SubInitializations.push_back(std::move(eltInit));
@@ -439,7 +442,9 @@ SILGenFunction::prepareIndirectResultInit(CanType formalResultType,
   MutableArrayRef<SILValue> directResults = directResultsBuffer;
   ArrayRef<SILArgument*> indirectResultAddrs = F.getIndirectResults();
 
-  auto init = ::prepareIndirectResultInit(*this, formalResultType, allResults,
+  auto init = ::prepareIndirectResultInit(*this,
+                                          fnConv.funcTy,
+                                          formalResultType, allResults,
                                           directResults, indirectResultAddrs,
                                           cleanups);
 
@@ -1143,6 +1148,7 @@ void StmtEmitter::visitFailStmt(FailStmt *S) {
 /// try_apply instruction.  The block is implicitly emitted and filled in.
 SILBasicBlock *
 SILGenFunction::getTryApplyErrorDest(SILLocation loc,
+                                     CanSILFunctionType fnTy,
                                      SILResultInfo exnResult,
                                      bool suppressErrorPath) {
   assert(exnResult.getConvention() == ResultConvention::Owned);
@@ -1150,7 +1156,7 @@ SILGenFunction::getTryApplyErrorDest(SILLocation loc,
   // For now, don't try to re-use destination blocks for multiple
   // failure sites.
   SILBasicBlock *destBB = createBasicBlock(FunctionSection::Postmatter);
-  SILValue exn = destBB->createPhiArgument(getSILType(exnResult),
+  SILValue exn = destBB->createPhiArgument(getSILType(exnResult, fnTy),
                                            ValueOwnershipKind::Owned);
 
   assert(B.hasValidInsertionPoint() && B.insertingAtEndOfBlock());

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -185,7 +185,7 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
   if (resultTy != toClosure.getType()) {
     CanSILFunctionType resultFnTy = resultTy.castTo<SILFunctionType>();
     CanSILFunctionType closureFnTy = toClosure.getType().castTo<SILFunctionType>();
-    if (resultFnTy->isABICompatibleWith(closureFnTy).isCompatible()) {
+    if (resultFnTy->isABICompatibleWith(closureFnTy, F).isCompatible()) {
       toClosure = B.createConvertFunction(loc, toClosure, resultTy);
     } else {
       // Compute the partially-applied abstraction pattern for the callee:

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -122,7 +122,8 @@ SILGenModule::emitVTableMethod(ClassDecl *theClass,
   // member type. If the override is ABI compatible, we do not need
   // a thunk.
   if (doesNotHaveGenericRequirementDifference && !baseLessVisibleThanDerived &&
-      M.Types.checkFunctionForABIDifferences(derivedInfo.SILFnType,
+      M.Types.checkFunctionForABIDifferences(M,
+                                             derivedInfo.SILFnType,
                                              overrideInfo.SILFnType) ==
           TypeConverter::ABIDifference::Trivial)
     return SILVTable::Entry(base, implFn, implKind);

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -744,7 +744,8 @@ bool swift::ArraySemanticsCall::replaceByAppendingValues(
       ReserveFnRef->getType().castTo<SILFunctionType>();
     assert(ReserveFnTy->getNumParameters() == 2);
     StructType *IntType =
-      ReserveFnTy->getParameters()[0].getType()->castTo<StructType>();
+      ReserveFnTy->getParameters()[0].getArgumentType(F->getModule(), ReserveFnTy)
+                 ->castTo<StructType>();
     StructDecl *IntDecl = IntType->getDecl();
     VarDecl *field = IntDecl->getStoredProperties()[0];
     SILType BuiltinIntTy =SILType::getPrimitiveObjectType(

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -143,7 +143,7 @@ void ExistentialSpecializerCloner::cloneArguments(
     auto iter = ArgToGenericTypeMap.find(ArgDesc.Index);
     if (iter == ArgToGenericTypeMap.end()) {
       // Clone arguments that are not rewritten.
-      auto Ty = params[ArgDesc.Index].getType();
+      auto Ty = params[ArgDesc.Index].getArgumentType(M, NewFTy);
       auto LoweredTy = NewF.getLoweredType(NewF.mapTypeIntoContext(Ty));
       auto MappedTy =
           LoweredTy.getCategoryType(ArgDesc.Arg->getType().getCategory());
@@ -266,7 +266,7 @@ void ExistentialTransform::convertExistentialArgTypesToGenericArgTypes(
   auto FTy = F->getLoweredFunctionType();
 
   /// If the original function is generic, then maintain the same.
-  auto OrigGenericSig = FTy->getGenericSignature();
+  auto OrigGenericSig = FTy->getInvocationGenericSignature();
 
   /// Original list of parameters
   SmallVector<SILParameterInfo, 4> params;
@@ -285,7 +285,7 @@ void ExistentialTransform::convertExistentialArgTypesToGenericArgTypes(
   for (auto const &IdxIt : ExistentialArgDescriptor) {
     int Idx = IdxIt.first;
     auto &param = params[Idx];
-    auto PType = param.getType();
+    auto PType = param.getArgumentType(M, FTy);
     assert(PType.isExistentialType());
     /// Generate new generic parameter.
     auto *NewGenericParam = GenericTypeParamType::get(Depth, GPIdx++, Ctx);
@@ -310,7 +310,7 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
   GenericEnvironment *NewGenericEnv;
 
   /// If the original function is generic, then maintain the same.
-  auto OrigGenericSig = FTy->getGenericSignature();
+  auto OrigGenericSig = FTy->getInvocationGenericSignature();
 
   SmallVector<GenericTypeParamType *, 2> GenericParams;
   SmallVector<Requirement, 2> Requirements;
@@ -368,7 +368,9 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
   return SILFunctionType::get(
       NewGenericSig, ExtInfo, FTy->getCoroutineKind(),
       FTy->getCalleeConvention(), InterfaceParams, FTy->getYields(),
-      FTy->getResults(), InterfaceErrorResult, Ctx, witnessMethodConformance);
+      FTy->getResults(), InterfaceErrorResult,
+      SubstitutionMap(), false,
+      Ctx, witnessMethodConformance);
 }
 
 /// Create the Thunk Body with always_inline attribute.
@@ -405,9 +407,10 @@ void ExistentialTransform::populateThunkBody() {
   auto *FRI = Builder.createFunctionRefFor(Loc, NewF);
 
   auto GenCalleeType = NewF->getLoweredFunctionType();
-  auto CalleeGenericSig = GenCalleeType->getGenericSignature();
+  auto CalleeGenericSig = GenCalleeType->getInvocationGenericSignature();
   auto OrigGenCalleeType = F->getLoweredFunctionType();
-  auto OrigCalleeGenericSig = OrigGenCalleeType->getGenericSignature();
+  auto OrigCalleeGenericSig =
+    OrigGenCalleeType->getInvocationGenericSignature();
 
   /// Determine arguments to Apply.
   /// Generate opened existentials for generics.
@@ -582,7 +585,7 @@ void ExistentialTransform::createExistentialSpecializedFunction() {
   /// Create devirtualized function type.
   auto NewFTy = createExistentialSpecializedFunctionType();
 
-  auto NewFGenericSig = NewFTy->getGenericSignature();
+  auto NewFGenericSig = NewFTy->getInvocationGenericSignature();
   auto NewFGenericEnv = NewFGenericSig->getGenericEnvironment();
 
   /// Step 1: Create the new protocol constrained generic function.

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -203,8 +203,9 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionName() {
 static bool usesGenerics(SILFunction *F,
                          ArrayRef<SILParameterInfo> InterfaceParams,
                          ArrayRef<SILResultInfo> InterfaceResults) {
+#warning "todo: rework for subst function types and silfunction generic sigs"
   CanSILFunctionType FTy = F->getLoweredFunctionType();
-  auto HasGenericSignature = FTy->getGenericSignature() != nullptr;
+  auto HasGenericSignature = FTy->getSubstGenericSignature() != nullptr;
   if (!HasGenericSignature)
     return false;
 
@@ -218,11 +219,11 @@ static bool usesGenerics(SILFunction *F,
   };
 
   for (auto Param : InterfaceParams) {
-    Param.getType().visit(FindArchetypesAndGenericTypes);
+    Param.getInterfaceType().visit(FindArchetypesAndGenericTypes);
   }
 
   for (auto Result : InterfaceResults) {
-    Result.getType().visit(FindArchetypesAndGenericTypes);
+    Result.getInterfaceType().visit(FindArchetypesAndGenericTypes);
   }
 
   if (UsesGenerics)
@@ -278,26 +279,26 @@ static void mapInterfaceTypes(SILFunction *F,
                               Optional<SILResultInfo> &InterfaceErrorResult) {
 
   for (auto &Param : InterfaceParams) {
-    if (!Param.getType()->hasArchetype())
+    if (!Param.getInterfaceType()->hasArchetype())
       continue;
     Param = SILParameterInfo(
-        Param.getType()->mapTypeOutOfContext()->getCanonicalType(),
+        Param.getInterfaceType()->mapTypeOutOfContext()->getCanonicalType(),
         Param.getConvention());
   }
 
   for (auto &Result : InterfaceResults) {
-    if (!Result.getType()->hasArchetype())
+    if (!Result.getInterfaceType()->hasArchetype())
       continue;
-    auto InterfaceResult = Result.getWithType(
-        Result.getType()->mapTypeOutOfContext()->getCanonicalType());
+    auto InterfaceResult = Result.getWithInterfaceType(
+        Result.getInterfaceType()->mapTypeOutOfContext()->getCanonicalType());
     Result = InterfaceResult;
   }
 
   if (InterfaceErrorResult.hasValue()) {
-    if (InterfaceErrorResult.getValue().getType()->hasArchetype()) {
+    if (InterfaceErrorResult.getValue().getInterfaceType()->hasArchetype()) {
       InterfaceErrorResult =
           SILResultInfo(InterfaceErrorResult.getValue()
-                            .getType()
+                            .getInterfaceType()
                             ->mapTypeOutOfContext()
                             ->getCanonicalType(),
                         InterfaceErrorResult.getValue().getConvention());
@@ -310,7 +311,7 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
   SILFunction *F = OriginalFunction;
   CanSILFunctionType FTy = F->getLoweredFunctionType();
   auto ExpectedFTy = F->getLoweredType().castTo<SILFunctionType>();
-  auto HasGenericSignature = FTy->getGenericSignature() != nullptr;
+  auto HasGenericSignature = FTy->getSubstGenericSignature() != nullptr;
 
   // The only way that we modify the arity of function parameters is here for
   // dead arguments. Doing anything else is unsafe since by definition non-dead
@@ -330,7 +331,7 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
       auto &RV = ResultDescList[0];
       if (!RV.CalleeRetain.empty()) {
         ++NumOwnedConvertedToNotOwnedResult;
-        InterfaceResults.push_back(SILResultInfo(InterfaceResult.getType(),
+        InterfaceResults.push_back(SILResultInfo(InterfaceResult.getInterfaceType(),
                                                  ResultConvention::Unowned));
         continue;
       }
@@ -366,12 +367,12 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
                               << F->getName() << "\n";
                  llvm::dbgs() << "Interface params:\n";
                  for (auto Param : InterfaceParams) {
-                   Param.getType().dump();
+                   Param.getInterfaceType().dump();
                  }
 
                  llvm::dbgs() << "Interface results:\n";
                  for (auto Result : InterfaceResults) {
-                   Result.getType().dump();
+                   Result.getInterfaceType().dump();
                  });
     }
   }
@@ -394,11 +395,12 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
   mapInterfaceTypes(F, InterfaceParams, InterfaceResults, InterfaceErrorResult);
 
   GenericSignature GenericSig =
-      UsesGenerics ? FTy->getGenericSignature() : nullptr;
+      UsesGenerics ? FTy->getSubstGenericSignature() : nullptr;
 
   return SILFunctionType::get(
       GenericSig, ExtInfo, FTy->getCoroutineKind(), FTy->getCalleeConvention(),
       InterfaceParams, InterfaceYields, InterfaceResults, InterfaceErrorResult,
+      FTy->getSubstitutions(), FTy->isGenericSignatureImplied(),
       F->getModule().getASTContext(), witnessMethodConformance);
 }
 
@@ -467,7 +469,7 @@ void FunctionSignatureTransformDescriptor::computeOptimizedArgInterface(
       llvm_unreachable("Unknown parameter convention transformation");
     }
 
-    SILParameterInfo NewInfo(AD.PInfo.getValue().getType(),
+    SILParameterInfo NewInfo(AD.PInfo.getValue().getInterfaceType(),
                              ParameterConvention);
     Out.push_back(NewInfo);
     return;
@@ -498,7 +500,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
 
   auto NewFTy = TransformDescriptor.createOptimizedSILFunctionType();
   GenericEnvironment *NewFGenericEnv;
-  if (NewFTy->getGenericSignature()) {
+  if (NewFTy->getSubstGenericSignature()) {
     NewFGenericEnv = F->getGenericEnvironment();
   } else {
     NewFGenericEnv = nullptr;
@@ -595,7 +597,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
         NormalBlock->createPhiArgument(ResultType, ValueOwnershipKind::Owned);
     SILBasicBlock *ErrorBlock = Thunk->createBasicBlock();
     SILType Error =
-        SILType::getPrimitiveObjectType(FunctionTy->getErrorResult().getType());
+        SILType::getPrimitiveObjectType(FunctionTy->getErrorResult().getInterfaceType());
     auto *ErrorArg =
         ErrorBlock->createPhiArgument(Error, ValueOwnershipKind::Owned);
     Builder.createTryApply(Loc, FRI, Subs, ThunkArgs, NormalBlock, ErrorBlock);

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -255,8 +255,9 @@ SILFunction *CapturePropagation::specializeConstClosure(PartialApplyInst *PAI,
   auto NewFTy = getPartialApplyInterfaceResultType(PAI);
   NewFTy = NewFTy->getWithRepresentation(SILFunctionType::Representation::Thin);
 
+#warning "todo: preserve substituted type"
   GenericEnvironment *GenericEnv = nullptr;
-  if (NewFTy->getGenericSignature())
+  if (NewFTy->getInvocationGenericSignature())
     GenericEnv = OrigF->getGenericEnvironment();
   SILOptFunctionBuilder FuncBuilder(*this);
   SILFunction *NewF = FuncBuilder.createFunction(

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -345,7 +345,7 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
   // the specialized attribute's substitution list. Visit only
   // SubstitutableTypes, skipping DependentTypes.
   auto GenericSig =
-    GenericFunc->getLoweredFunctionType()->getGenericSignature();
+    GenericFunc->getLoweredFunctionType()->getInvocationGenericSignature();
   auto SubMap = ReInfo.getClonerParamSubstitutionMap();
 
   GenericSig->forEachParam([&](GenericTypeParamType *ParamTy, bool Canonical) {
@@ -713,7 +713,7 @@ static SILFunction *eagerSpecialize(SILOptFunctionBuilder &FuncBuilder,
 
   LLVM_DEBUG(auto FT = GenericFunc->getLoweredFunctionType();
              dbgs() << "  Generic Sig:";
-             dbgs().indent(2); FT->getGenericSignature()->print(dbgs());
+             dbgs().indent(2); FT->getInvocationGenericSignature()->print(dbgs());
              dbgs() << "  Generic Env:";
              dbgs().indent(2);
              GenericFunc->getGenericEnvironment()->dump(dbgs());
@@ -752,7 +752,7 @@ void EagerSpecializerTransform::run() {
     if (F.isDynamicallyReplaceable())
       continue;
 
-    if (!F.getLoweredFunctionType()->getGenericSignature())
+    if (!F.getLoweredFunctionType()->getInvocationGenericSignature())
       continue;
 
     // Create a specialized function with ReabstractionInfo for each attribute.

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -276,6 +276,7 @@ static SILFunction *getGlobalGetterFunction(SILOptFunctionBuilder &FunctionBuild
                          SILCoroutineKind::None,
                          ParameterConvention::Direct_Unowned,
                          /*params*/ {}, /*yields*/ {}, Results, None,
+                         SubstitutionMap(), false,
                          M.getASTContext());
   auto getterName = M.allocateCopy(getterNameTmp);
   return FunctionBuilder.getOrCreateFunction(

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -494,7 +494,8 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
 
   // Bail if the result type of the converted callee is different from the callee's
   // result type of the apply instruction.
-  if (SubstCalleeTy->getAllResultsType() != ConvertCalleeTy->getAllResultsType()) {
+  if (SubstCalleeTy->getAllResultsSubstType(AI.getModule())
+        != ConvertCalleeTy->getAllResultsSubstType(AI.getModule())) {
     return nullptr;
   }
 
@@ -546,8 +547,10 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
   bool setNonThrowing = FRI->getFunctionType()->hasErrorResult();
   SILInstruction *NAI = Builder.createApply(AI.getLoc(), FRI, SubstitutionMap(),
                                             Args, setNonThrowing);
-  assert(FullApplySite::isa(NAI).getSubstCalleeType()->getAllResultsType() ==
-             AI.getSubstCalleeType()->getAllResultsType() &&
+  assert(FullApplySite::isa(NAI).getSubstCalleeType()
+                               ->getAllResultsSubstType(AI.getModule())
+           == AI.getSubstCalleeType()
+               ->getAllResultsSubstType(AI.getModule()) &&
          "Function types should be the same");
   return NAI;
 }

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -577,14 +577,14 @@ SILFunction *PromotedParamCloner::initCloned(SILOptFunctionBuilder &FuncBuilder,
   unsigned Index = Orig->getConventions().getSILArgIndexOfFirstParam();
   for (auto &param : OrigFTI->getParameters()) {
     if (count(PromotedArgIndices, Index)) {
-      auto boxTy = param.getSILStorageType().castTo<SILBoxType>();
+      auto boxTy = param.getSILStorageInterfaceType().castTo<SILBoxType>();
       assert(boxTy->getLayout()->getFields().size() == 1
              && "promoting compound box not implemented");
       SILType paramTy;
       {
         auto &TC = Orig->getModule().Types;
         Lowering::GenericContextScope scope(TC,
-                                            OrigFTI->getGenericSignature());
+                                      OrigFTI->getSubstGenericSignature());
         paramTy = getSILBoxFieldType(boxTy, TC, 0);
       }
       auto promotedParam = SILParameterInfo(paramTy.getASTType(),
@@ -599,10 +599,11 @@ SILFunction *PromotedParamCloner::initCloned(SILOptFunctionBuilder &FuncBuilder,
   // Create the new function type for the cloned function with some of
   // the parameters promoted.
   auto ClonedTy = SILFunctionType::get(
-      OrigFTI->getGenericSignature(), OrigFTI->getExtInfo(),
+      OrigFTI->getSubstGenericSignature(), OrigFTI->getExtInfo(),
       OrigFTI->getCoroutineKind(), OrigFTI->getCalleeConvention(),
       ClonedInterfaceArgTys, OrigFTI->getYields(),
       OrigFTI->getResults(), OrigFTI->getOptionalErrorResult(),
+      OrigFTI->getSubstitutions(), OrigFTI->isGenericSignatureImplied(),
       M.getASTContext(), OrigFTI->getWitnessMethodConformanceOrNone());
 
   assert((Orig->isTransparent() || Orig->isBare() || Orig->getLocation())

--- a/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
+++ b/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
@@ -506,7 +506,8 @@ void ObjectOutliner::replaceFindStringCall(ApplyInst *FindStringCall) {
   if (FTy->getNumParameters() != 3)
     return;
 
-  SILType cacheType = FTy->getParameters()[2].getSILStorageType().getObjectType();
+  SILType cacheType = FTy->getParameters()[2].getSILStorageType(*Module, FTy)
+                                             .getObjectType();
   NominalTypeDecl *cacheDecl = cacheType.getNominalOrBoundGenericNominal();
   if (!cacheDecl)
     return;

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -292,7 +292,9 @@ CanSILFunctionType BridgedProperty::getOutlinedFunctionType(SILModule &M) {
   auto FunctionType = SILFunctionType::get(
       nullptr, ExtInfo, SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned, Parameters, /*yields*/ {},
-      Results, None, M.getASTContext());
+      Results, None,
+      SubstitutionMap(), false,
+      M.getASTContext());
   return FunctionType;
 }
 
@@ -1117,7 +1119,7 @@ CanSILFunctionType ObjCMethodCall::getOutlinedFunctionType(SILModule &M) {
   if (!BridgedReturn) {
     if (FunTy->getNumResults()) {
       auto OrigResultInfo = FunTy->getSingleResult();
-      Results.push_back(SILResultInfo(OrigResultInfo.getType(),
+      Results.push_back(SILResultInfo(OrigResultInfo.getInterfaceType(),
                                       OrigResultInfo.getConvention() ==
                                               ResultConvention::Autoreleased
                                           ? ResultConvention::Owned
@@ -1131,7 +1133,9 @@ CanSILFunctionType ObjCMethodCall::getOutlinedFunctionType(SILModule &M) {
   auto FunctionType = SILFunctionType::get(
       nullptr, ExtInfo, SILCoroutineKind::None,
       ParameterConvention::Direct_Unowned, Parameters, {},
-      Results, None, M.getASTContext());
+      Results, None,
+      SubstitutionMap(), false,
+      M.getASTContext());
   return FunctionType;
 }
 

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -278,7 +278,8 @@ bool SILPerformanceInliner::isProfitableToInline(
 
     // Don't inline class methods.
     if (Callee->hasSelfParam()) {
-      auto SelfTy = Callee->getLoweredFunctionType()->getSelfInstanceType();
+      auto SelfTy = Callee->getLoweredFunctionType()
+                          ->getSelfInstanceType(FuncBuilder.getModule());
       if (SelfTy->mayHaveSuperclass() &&
           Callee->getRepresentation() == SILFunctionTypeRepresentation::Method)
         isClassMethodAtOsize = true;

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -192,7 +192,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
   SILArgument *Arg =
       Continue->createPhiArgument(AI.getType(), ValueOwnershipKind::Owned);
   if (!isa<TryApplyInst>(AI)) {
-    if (AI.getSubstCalleeType()->isNoReturnFunction()) {
+    if (AI.getSubstCalleeType()->isNoReturnFunction(F->getModule())) {
       IdenBuilder.createUnreachable(AI.getLoc());
       VirtBuilder.createUnreachable(AI.getLoc());
     } else {

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -88,7 +88,9 @@ class BugReducerTester : public SILFunctionTransform {
                                           false /*noescape*/),
         SILCoroutineKind::None, ParameterConvention::Direct_Unowned,
         ArrayRef<SILParameterInfo>(), ArrayRef<SILYieldInfo>(),
-        ResultInfoArray, None, getFunction()->getModule().getASTContext());
+        ResultInfoArray, None,
+        SubstitutionMap(), false,
+        getFunction()->getModule().getASTContext());
 
     SILOptFunctionBuilder FunctionBuilder(*this);
     SILFunction *F = FunctionBuilder.getOrCreateSharedFunction(

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1122,9 +1122,10 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
   auto calleeFnType = callee->getLoweredFunctionType();
   assert(
       !calleeFnType->hasSelfParam() ||
-      !calleeFnType->getSelfInstanceType()->getClassOrBoundGenericClass() &&
+      !calleeFnType->getSelfInstanceType(callee->getModule())
+                   ->getClassOrBoundGenericClass() &&
       "class methods are not supported");
-  if (calleeFnType->getGenericSignature()) {
+  if (calleeFnType->getInvocationGenericSignature()) {
     // Get the substitution map of the call.  This maps from the callee's space
     // into the caller's world. Witness methods require additional work to
     // compute a mapping that is valid for the callee.

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -412,7 +412,8 @@ getSubstitutionsForCallee(SILModule &module, CanSILFunctionType baseCalleeType,
     return SubstitutionMap();
 
   // Add any generic substitutions for the base class.
-  Type baseSelfType = baseCalleeType->getSelfParameter().getType();
+  Type baseSelfType = baseCalleeType->getSelfParameter()
+                                    .getArgumentType(module, baseCalleeType);
   if (auto metatypeType = baseSelfType->getAs<MetatypeType>())
     baseSelfType = metatypeType->getInstanceType();
 
@@ -437,7 +438,8 @@ getSubstitutionsForCallee(SILModule &module, CanSILFunctionType baseCalleeType,
   SubstitutionMap origSubMap = applySite.getSubstitutionMap();
 
   Type calleeSelfType =
-      applySite.getOrigCalleeType()->getSelfParameter().getType();
+      applySite.getOrigCalleeType()->getSelfParameter()
+               .getArgumentType(module, applySite.getOrigCalleeType());
   if (auto metatypeType = calleeSelfType->getAs<MetatypeType>())
     calleeSelfType = metatypeType->getInstanceType();
   auto *calleeClassDecl = calleeSelfType->getClassOrBoundGenericClass();
@@ -449,7 +451,7 @@ getSubstitutionsForCallee(SILModule &module, CanSILFunctionType baseCalleeType,
   if (auto calleeClassSig = calleeClassDecl->getGenericSignatureOfContext())
     origDepth = calleeClassSig->getGenericParams().back()->getDepth() + 1;
 
-  auto baseCalleeSig = baseCalleeType->getGenericSignature();
+  auto baseCalleeSig = baseCalleeType->getInvocationGenericSignature();
 
   return
     SubstitutionMap::combineSubstitutionMaps(baseSubMap,
@@ -938,15 +940,15 @@ swift::getWitnessMethodSubstitutions(SILModule &module, ApplySite applySite,
   assert(witnessFnTy->getRepresentation() ==
          SILFunctionTypeRepresentation::WitnessMethod);
 
-  auto requirementSig = applySite.getOrigCalleeType()->getGenericSignature();
-  auto witnessThunkSig = witnessFnTy->getGenericSignature();
+  auto requirementSig = applySite.getOrigCalleeType()->getInvocationGenericSignature();
+  auto witnessThunkSig = witnessFnTy->getInvocationGenericSignature();
 
   SubstitutionMap origSubs = applySite.getSubstitutionMap();
 
   auto *mod = module.getSwiftModule();
   bool isSelfAbstract =
-    witnessFnTy->getSelfInstanceType()->is<GenericTypeParamType>();
-  auto *classWitness = witnessFnTy->getWitnessMethodClass();
+    witnessFnTy->getSelfInstanceType(module)->is<GenericTypeParamType>();
+  auto *classWitness = witnessFnTy->getWitnessMethodClass(module);
 
   return ::getWitnessMethodSubstitutions(mod, cRef, requirementSig,
                                          witnessThunkSig, origSubs,

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -183,7 +183,7 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
   else if (ParentFunction)
     ParentFunction = remapParentFunction(
         FuncBuilder, M, ParentFunction, SubsMap,
-        Original.getLoweredFunctionType()->getGenericSignature());
+        Original.getLoweredFunctionType()->getInvocationGenericSignature());
 
   auto *ParentScope = DS->Parent.dyn_cast<const SILDebugScope *>();
   auto *RemappedScope =

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -123,7 +123,8 @@ static std::pair<unsigned, unsigned> getTypeDepthAndWidth(Type t) {
     for (auto Param : Params) {
       unsigned TypeWidth;
       unsigned TypeDepth;
-      std::tie(TypeDepth, TypeWidth) = getTypeDepthAndWidth(Param.getType());
+      std::tie(TypeDepth, TypeWidth) =
+        getTypeDepthAndWidth(Param.getInterfaceType());
       if (TypeDepth > MaxTypeDepth)
         MaxTypeDepth = TypeDepth;
       Width += TypeWidth;
@@ -133,7 +134,8 @@ static std::pair<unsigned, unsigned> getTypeDepthAndWidth(Type t) {
     for (auto Result : Results) {
       unsigned TypeWidth;
       unsigned TypeDepth;
-      std::tie(TypeDepth, TypeWidth) = getTypeDepthAndWidth(Result.getType());
+      std::tie(TypeDepth, TypeWidth) =
+        getTypeDepthAndWidth(Result.getInterfaceType());
       if (TypeDepth > MaxTypeDepth)
         MaxTypeDepth = TypeDepth;
       Width += TypeWidth;
@@ -143,11 +145,12 @@ static std::pair<unsigned, unsigned> getTypeDepthAndWidth(Type t) {
       unsigned TypeWidth;
       unsigned TypeDepth;
       std::tie(TypeDepth, TypeWidth) =
-          getTypeDepthAndWidth(FnTy->getErrorResult().getType());
+          getTypeDepthAndWidth(FnTy->getErrorResult().getInterfaceType());
       if (TypeDepth > MaxTypeDepth)
         MaxTypeDepth = TypeDepth;
       Width += TypeWidth;
     }
+#warning "todo: include substitution replacement types?"
     Depth += MaxTypeDepth;
     return std::make_pair(Depth, Width);
   }
@@ -401,7 +404,8 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
 
   SpecializedGenericEnv = nullptr;
   SpecializedGenericSig = nullptr;
-  auto CalleeGenericSig = Callee->getLoweredFunctionType()->getGenericSignature();
+  auto CalleeGenericSig = Callee->getLoweredFunctionType()
+                                ->getInvocationGenericSignature();
   auto CalleeGenericEnv = Callee->getGenericEnvironment();
 
   this->Callee = Callee;
@@ -687,7 +691,7 @@ void ReabstractionInfo::createSubstitutedAndSpecializedTypes() {
       auto &TL = M.Types.getTypeLowering(ResultTy,
                                          getResilienceExpansion());
 
-      if (TL.isLoadable() && !RI.getType()->isVoid() &&
+      if (TL.isLoadable() && !RI.getReturnValueType(M, SubstitutedType)->isVoid() &&
           shouldExpand(M, ResultTy)) {
         Conversions.set(IdxForResult);
         break;
@@ -767,12 +771,14 @@ ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
   }
   assert(FnTy);
 
+#warning "todo: eliminate substituted function types"
   // Use the new specialized generic signature.
   auto NewFnTy = SILFunctionType::get(
       CanSpecializedGenericSig, FnTy->getExtInfo(),
       FnTy->getCoroutineKind(), FnTy->getCalleeConvention(),
       FnTy->getParameters(), FnTy->getYields(),
       FnTy->getResults(), FnTy->getOptionalErrorResult(),
+      SubstitutionMap(), false,
       M.getASTContext(), FnTy->getWitnessMethodConformanceOrNone());
 
   // This is an interface type. It should not have any archetypes.
@@ -793,7 +799,8 @@ createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
     if (RI.isFormalIndirect()) {
       if (isFormalResultConverted(IndirectResultIdx++)) {
         // Convert the indirect result to a direct result.
-        SILType SILResTy = SILType::getPrimitiveObjectType(RI.getType());
+        SILType SILResTy =
+          SILType::getPrimitiveObjectType(RI.getReturnValueType(M, SubstFTy));
         auto &TL = M.Types.getTypeLowering(SILResTy,
                                            getResilienceExpansion());
 
@@ -802,7 +809,7 @@ createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
         auto C = (TL.isTrivial()
                   ? ResultConvention::Unowned
                   : ResultConvention::Owned);
-        SpecializedResults.push_back(SILResultInfo(RI.getType(), C));
+        SpecializedResults.push_back(SILResultInfo(RI.getReturnValueType(M, SubstFTy), C));
         continue;
       }
     }
@@ -818,7 +825,8 @@ createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
     }
 
     // Convert the indirect parameter to a direct parameter.
-    SILType SILParamTy = SILType::getPrimitiveObjectType(PI.getType());
+    SILType SILParamTy =
+      SILType::getPrimitiveObjectType(PI.getArgumentType(M, SubstFTy));
     auto &TL = M.Types.getTypeLowering(SILParamTy,
                                        getResilienceExpansion());
 
@@ -833,18 +841,19 @@ createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
         C = ParameterConvention::Direct_Owned;
       }
     }
-    SpecializedParams.push_back(SILParameterInfo(PI.getType(), C));
+    SpecializedParams.push_back(SILParameterInfo(PI.getArgumentType(M, SubstFTy), C));
   }
   for (SILYieldInfo YI : SubstFTy->getYields()) {
     // For now, always just use the original, substituted parameter info.
     SpecializedYields.push_back(YI);
   }
   return SILFunctionType::get(
-      SubstFTy->getGenericSignature(),
+      SubstFTy->getInvocationGenericSignature(),
       SubstFTy->getExtInfo(), SubstFTy->getCoroutineKind(),
       SubstFTy->getCalleeConvention(),
       SpecializedParams, SpecializedYields, SpecializedResults,
-      SubstFTy->getOptionalErrorResult(), M.getASTContext(),
+      SubstFTy->getOptionalErrorResult(),
+      SubstitutionMap(), false, M.getASTContext(),
       SubstFTy->getWitnessMethodConformanceOrNone());
 }
 
@@ -1681,13 +1690,14 @@ void ReabstractionInfo::performPartialSpecializationPreparation(
   CanGenericSignature CallerGenericSig;
   GenericEnvironment *CallerGenericEnv = nullptr;
   if (Caller) {
-    CallerGenericSig = Caller->getLoweredFunctionType()->getGenericSignature();
+    CallerGenericSig = Caller->getLoweredFunctionType()
+                             ->getInvocationGenericSignature();
     CallerGenericEnv = Caller->getGenericEnvironment();
   }
 
   // Callee is the generic function being called by the apply instruction.
   auto CalleeFnTy = Callee->getLoweredFunctionType();
-  auto CalleeGenericSig = CalleeFnTy->getGenericSignature();
+  auto CalleeGenericSig = CalleeFnTy->getInvocationGenericSignature();
   auto CalleeGenericEnv = Callee->getGenericEnvironment();
 
   LLVM_DEBUG(llvm::dbgs() << "\n\nTrying partial specialization for: "
@@ -1761,7 +1771,7 @@ ReabstractionInfo::ReabstractionInfo(SILFunction *Callee,
   SILModule &M = Callee->getModule();
 
   auto CalleeGenericSig =
-      Callee->getLoweredFunctionType()->getGenericSignature();
+      Callee->getLoweredFunctionType()->getInvocationGenericSignature();
   auto *CalleeGenericEnv = Callee->getGenericEnvironment();
 
   FunctionSignaturePartialSpecializer FSPS(M,
@@ -1979,7 +1989,7 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
                                       A->isNonThrowing());
     if (StoreResultTo) {
       assert(substConv.useLoweredAddresses());
-      if (!CalleeSILSubstFnTy.isNoReturnFunction()) {
+      if (!CalleeSILSubstFnTy.isNoReturnFunction(Builder.getModule())) {
         // Store the direct result to the original result address.
         fixUsedVoidType(A, Loc, Builder);
         Builder.createStore(Loc, NewAI, StoreResultTo,
@@ -2082,7 +2092,7 @@ SILFunction *ReabstractionThunkGenerator::createThunk() {
   // Set proper generic context scope for the type lowering.
   CanSILFunctionType SpecType = SpecializedFunc->getLoweredFunctionType();
   Lowering::GenericContextScope GenericScope(M.Types,
-                                             SpecType->getGenericSignature());
+                                     SpecType->getInvocationGenericSignature());
 
   SILBasicBlock *EntryBB = Thunk->createBasicBlock();
   SILBuilder Builder(EntryBB);
@@ -2119,7 +2129,8 @@ SILFunction *ReabstractionThunkGenerator::createThunk() {
     Builder.createStore(Loc, ReturnValue, ReturnValueAddr,
                         StoreOwnershipQualifier::Unqualified);
     SILType VoidTy =
-        OrigPAI->getSubstCalleeType()->getDirectFormalResultsType();
+        OrigPAI->getSubstCalleeType()
+               ->getDirectFormalResultsType(M);
     assert(VoidTy.isVoid());
     ReturnValue = Builder.createTuple(Loc, VoidTy, {});
   }

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -633,7 +633,8 @@ static bool isCallerAndCalleeLayoutConstraintsCompatible(FullApplySite AI) {
   SILFunction *Callee = AI.getReferencedFunctionOrNull();
   assert(Callee && "Trying to optimize a dynamic function!?");
 
-  auto CalleeSig = Callee->getLoweredFunctionType()->getGenericSignature();
+  auto CalleeSig = Callee->getLoweredFunctionType()
+                         ->getInvocationGenericSignature();
   auto AISubs = AI.getSubstitutionMap();
 
   SmallVector<GenericTypeParamType *, 4> SubstParams;

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -609,7 +609,8 @@ SILInlineCloner::getOrCreateInlineScope(const SILDebugScope *CalleeScope) {
   if (ParentFunction)
     ParentFunction = remapParentFunction(
         FuncBuilder, M, ParentFunction, SubsMap,
-        getCalleeFunction()->getLoweredFunctionType()->getGenericSignature(),
+        getCalleeFunction()->getLoweredFunctionType()
+                           ->getInvocationGenericSignature(),
         ForInlining);
 
   auto *ParentScope = CalleeScope->Parent.dyn_cast<const SILDebugScope *>();

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -79,7 +79,7 @@ std::string GenericSpecializationMangler::mangle(GenericSignature Sig) {
 
   if (!Sig) {
     SILFunctionType *FTy = Function->getLoweredFunctionType();
-    Sig = FTy->getGenericSignature();
+    Sig = FTy->getInvocationGenericSignature();
   }
 
   bool First = true;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5044,11 +5044,13 @@ public:
     }
 
     GenericSignature genericSig = MF.getGenericSignature(rawGenericSig);
-
+#warning "todo: serialize/deserialize subst function types"
     return SILFunctionType::get(genericSig, extInfo, coroutineKind.getValue(),
                                 calleeConvention.getValue(),
                                 allParams, allYields, allResults,
-                                errorResult, ctx, witnessMethodConformance);
+                                errorResult,
+                                SubstitutionMap(), false,
+                                ctx, witnessMethodConformance);
   }
 
   Expected<Type> deserializeArraySliceType(ArrayRef<uint64_t> scratch,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3941,30 +3941,31 @@ public:
     auto stableRepresentation =
       getRawStableSILFunctionTypeRepresentation(representation);
 
+#warning "todo: serialize subst types"
     SmallVector<TypeID, 8> variableData;
     for (auto param : fnTy->getParameters()) {
-      variableData.push_back(S.addTypeRef(param.getType()));
+      variableData.push_back(S.addTypeRef(param.getInterfaceType()));
       unsigned conv = getRawStableParameterConvention(param.getConvention());
       variableData.push_back(TypeID(conv));
     }
     for (auto yield : fnTy->getYields()) {
-      variableData.push_back(S.addTypeRef(yield.getType()));
+      variableData.push_back(S.addTypeRef(yield.getInterfaceType()));
       unsigned conv = getRawStableParameterConvention(yield.getConvention());
       variableData.push_back(TypeID(conv));
     }
     for (auto result : fnTy->getResults()) {
-      variableData.push_back(S.addTypeRef(result.getType()));
+      variableData.push_back(S.addTypeRef(result.getInterfaceType()));
       unsigned conv = getRawStableResultConvention(result.getConvention());
       variableData.push_back(TypeID(conv));
     }
     if (fnTy->hasErrorResult()) {
       auto abResult = fnTy->getErrorResult();
-      variableData.push_back(S.addTypeRef(abResult.getType()));
+      variableData.push_back(S.addTypeRef(abResult.getInterfaceType()));
       unsigned conv = getRawStableResultConvention(abResult.getConvention());
       variableData.push_back(TypeID(conv));
     }
 
-    auto sig = fnTy->getGenericSignature();
+    auto sig = fnTy->getSubstGenericSignature();
 
     auto stableCoroutineKind =
       getRawStableSILCoroutineKind(fnTy->getCoroutineKind());


### PR DESCRIPTION
https://forums.swift.org/t/improving-the-representation-of-polymorphic-interfaces-in-sil-with-substituted-function-types/29711

This prepares SIL to be able to more accurately preserve the calling convention of
polymorphic generic interfaces by letting the type system represent "substituted function types".
We add a couple of fields to SILFunctionType to support this:

- A substitution map, accessed by `getSubstitutions()`, which maps the generic signature
  of the function to its concrete implementation. This will allow, for instance, a protocol
  witness for a requirement of type `<Self: P> (Self, ...) -> ...` for a concrete conforming
  type `Foo` to express its type as `<Self: P> (Self, ...) -> ... for <Foo>`, preserving the relation
  to the protocol interface without relying on the pile of hacks that is the `witness_method`
  protocol.

- A bool for whether the generic signature of the function is "implied" by the substitutions.
  If true, the generic signature isn't really part of the calling convention of the function.
  This will allow closure types to distinguish a closure being passed to a generic function, like
  `<T, U> in (*T, *U) -> T for <Int, String>`, from the concrete type `(*Int, *String) -> Int`,
  which will make it easier for us to differentiate the representation of those as types, for
  instance by giving them different pointer authentication discriminators to harden arm64e
  code.

This patch is currently NFC, it just introduces the new APIs and takes a first pass at updating
code to use them. Much more work will need to be done once we start exercising these new
fields.

This does bifurcate some existing APIs:

- SILFunctionType now has two accessors to get its generic signature.
  `getSubstGenericSignature` gets the generic signature that is used to apply its
  substitution map, if any. `getInvocationGenericSignature` gets the generic signature
  used to invoke the function at apply sites. These differ if the generic signature is
  implied.
- SILParameterInfo and SILResultInfo values carry the unsubstituted types of the parameters
  and results of the function. They now have two APIs to get that type. `getInterfaceType`
  returns the unsubstituted type of the generic interface, and
  `getArgumentType`/`getReturnValueType` produce the substituted type that is used at
  apply sites.