### PR TITLE
[cmake] Do not override existing JOB_POOLS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
   # Make a job pool for things that can't yet be distributed
   cmake_host_system_information(
     RESULT localhost_logical_cores QUERY NUMBER_OF_LOGICAL_CORES)
-  set_property(GLOBAL PROPERTY JOB_POOLS local_jobs=${localhost_logical_cores})
+  set_property(GLOBAL APPEND PROPERTY JOB_POOLS local_jobs=${localhost_logical_cores})
   # Put linking in that category
   set(CMAKE_JOB_POOL_LINK local_jobs)
 endif()


### PR DESCRIPTION
When building Swift as part of an LLVM distribution the global property
JOB_POOLS would have been overriden by Swift. If one wanted parallel
linking in LLVM, the job pools setup by LLVM would have disappered.

This didn't happen in the standalone builds, because HandleLLVMOptions
is included in that case _after_ the JOB_POOLS property would have been
initialized without APPEND.

Related to compnerd/windows-swift#53