### PR TITLE
[build-script] Forward --skip-local-build to build-script-impl

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -552,6 +552,8 @@ class BuildScriptInvocation(object):
             impl_args += ["--long-test"]
         if args.stress_test:
             impl_args += ["--stress-test"]
+        if args.skip_local_build:
+            impl_args += ["--skip-local-build"]
         if args.only_executable_test:
             impl_args += ["--only-executable-test"]
         if not args.benchmark:

--- a/validation-test/BuildSystem/skip-local-build.test-sh
+++ b/validation-test/BuildSystem/skip-local-build.test-sh
@@ -1,0 +1,6 @@
+# RUN: %swift_src_root/utils/build-script --dump-config --skip-local-build 2>&1 | %FileCheck %s -check-prefix=CONFIG
+# CONFIG: "skip_local_build": true
+
+# RUN: %swift_src_root/utils/build-script --dry-run --verbose-build --skip-local-build 2>&1 | %FileCheck %s -check-prefix=DRY
+# DRY: build-script-impl
+# DRY-SAME: --skip-local-build


### PR DESCRIPTION
Otherwise, build-script-impl ignores --skip-local-build.

I would really appreciate advice on how to write a test for this.

Conceptually, I think I just need to do a dry run of build-script and verify that the arguments forwarded to build-script-impl look good. However, I can't work out how to fit this into the existing set of unit tests.

There's a BuildScriptImplOption expected option type I thought I could use for this, but it appears to have something to do with "migration.py", and I'm not sure how/where that fits into the whole picture.

There's an existing test that defines "ExpectedOption('--skip-local-build')", but that passes even though the argument isn't forwarded.