### PR TITLE
AST: limit usage of `#warning` (NFC)

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -357,7 +357,13 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
                                             Type SelfType,
                                             ModuleDecl *Module) {
   Mod = Module;
+
+#if defined(__GNUC__)
 #warning "todo: mangle substituted types"
+#else
+#pragma message("TODO: mangle substituted types")
+#endif
+
   assert(ThunkType->getSubstitutions().empty() && "not implemented");
   GenericSignature GenSig = ThunkType->getSubstGenericSignature();
   if (GenSig)
@@ -1425,7 +1431,12 @@ static char getResultConvention(ResultConvention conv) {
 };
 
 void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
+
+#if defined(__GNUC__)
 #warning "todo: handle substituted types"
+#else
+#pragma message("TODO: handle substituted types")
+#endif
 
   llvm::SmallVector<char, 32> OpArgs;
 


### PR DESCRIPTION
This adjusts the use of the `#warning` which is not supported on MSVC.
Use `#pragma message` instead.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
