### PR TITLE
[ownership] Add an extra run of -Onone tests with diagnostics with -e…

### DIFF
--- a/test/SILGen/closure_script_global_escape.swift
+++ b/test/SILGen/closure_script_global_escape.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen -module-name foo %s | %FileCheck %s
 // RUN: %target-swift-emit-sil -module-name foo -verify %s
+// RUN: %target-swift-frontend -emit-sil -module-name foo -verify %s -enable-ownership-stripping-after-serialization
 
 // CHECK-LABEL: sil [ossa] @main
 

--- a/test/SILGen/closure_self_recursion.swift
+++ b/test/SILGen/closure_self_recursion.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen -module-name foo %s | %FileCheck %s
 // RUN: %target-swift-emit-sil -module-name foo -verify %s
+// RUN: %target-swift-frontend -emit-sil -module-name foo -verify %s -enable-ownership-stripping-after-serialization
 
 // CHECK-LABEL: sil [ossa] @main
 

--- a/test/SILGen/polymorphic_inout_aliasing.swift
+++ b/test/SILGen/polymorphic_inout_aliasing.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify %s -enable-ownership-stripping-after-serialization
 
 struct Block {}
 

--- a/test/SILOptimizer/access_enforcement_noescape_error.swift
+++ b/test/SILOptimizer/access_enforcement_noescape_error.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -module-name access_enforcement_noescape -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -verify -parse-as-library %s
+// RUN: %target-swift-frontend -module-name access_enforcement_noescape -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -verify -parse-as-library -enable-ownership-stripping-after-serialization %s
 // REQUIRES: asserts
 
 // This is the subset of tests from access_enforcement_noescape.swift

--- a/test/SILOptimizer/access_wmo_diagnose.swift
+++ b/test/SILOptimizer/access_wmo_diagnose.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -enforce-exclusivity=checked -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -parse-as-library -emit-sil -enforce-exclusivity=checked -primary-file %s -o /dev/null -verify
 
 // AccessEnforcementWMO assumes that the only way to address a global or static
 // property is via a formal begin_access. If we ever allow keypaths for static

--- a/test/SILOptimizer/constant_propagation_diagnostics.swift
+++ b/test/SILOptimizer/constant_propagation_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -o /dev/null -verify
+// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -emit-sil -sdk %S/../SILGen/Inputs %s -o /dev/null -verify
 
 // <rdar://problem/18213320> enum with raw values that are too big are not diagnosed
 enum EnumWithTooLargeElements : UInt8 {

--- a/test/SILOptimizer/definite_init_address_only_let.swift
+++ b/test/SILOptimizer/definite_init_address_only_let.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -enable-ownership-stripping-after-serialization -verify %s
 
 func foo<T>(a: Bool, t: T) {
   let x: T

--- a/test/SILOptimizer/definite_init_cross_module.swift
+++ b/test/SILOptimizer/definite_init_cross_module.swift
@@ -2,6 +2,10 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path=%t/OtherModule.swiftmodule %S/Inputs/definite_init_cross_module/OtherModule.swift
 // RUN: %target-swift-frontend -emit-sil -verify -I %t -swift-version 5 %s > /dev/null -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/definite_init_cross_module/BridgingHeader.h
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path=%t/OtherModule.swiftmodule %S/Inputs/definite_init_cross_module/OtherModule.swift -enable-ownership-stripping-after-serialization
+// RUN: %target-swift-frontend -emit-sil -verify -I %t -swift-version 5 %s > /dev/null -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/definite_init_cross_module/BridgingHeader.h -enable-ownership-stripping-after-serialization
+
 import OtherModule
 
 extension Point {

--- a/test/SILOptimizer/definite_init_cross_module_swift4.swift
+++ b/test/SILOptimizer/definite_init_cross_module_swift4.swift
@@ -2,6 +2,10 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path=%t/OtherModule.swiftmodule %S/Inputs/definite_init_cross_module/OtherModule.swift
 // RUN: %target-swift-frontend -emit-sil -verify -verify-ignore-unknown -I %t -swift-version 4 %s > /dev/null -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/definite_init_cross_module/BridgingHeader.h
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -emit-module -emit-module-path=%t/OtherModule.swiftmodule %S/Inputs/definite_init_cross_module/OtherModule.swift
+// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -emit-sil -verify -verify-ignore-unknown -I %t -swift-version 4 %s > /dev/null -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/definite_init_cross_module/BridgingHeader.h
+
 import OtherModule
 
 extension Point {

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -enable-ownership-stripping-after-serialization -primary-file %s -o /dev/null -verify
 
 import Swift
 

--- a/test/SILOptimizer/definite_init_diagnostics_globals.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_globals.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -emit-sil -primary-file %s -o /dev/null -verify
 
 import Swift
 

--- a/test/SILOptimizer/definite_init_diagnostics_objc.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_objc.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -I %S/../SILGen/Inputs -enable-source-import -parse-stdlib -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -I %S/../SILGen/Inputs -enable-source-import -parse-stdlib -o /dev/null -verify -enable-ownership-stripping-after-serialization
 // REQUIRES: objc_interop
 
 import Swift

--- a/test/SILOptimizer/definite_init_existential_let.swift
+++ b/test/SILOptimizer/definite_init_existential_let.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify %s -enable-ownership-stripping-after-serialization
 
 // rdar://problem/29716016 - Check that we properly enforce DI on `let`
 // variables and class properties.

--- a/test/SILOptimizer/definite_init_extension.swift
+++ b/test/SILOptimizer/definite_init_extension.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -verify %s -o /dev/null -enable-ownership-stripping-after-serialization
 
 struct S<T> {
   let t: T // expected-note {{'self.t.1' not initialized}}

--- a/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
+// RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s -enable-ownership-stripping-after-serialization
 
 // High-level tests that DI rejects certain invalid idioms for early
 // return from initializers.

--- a/test/SILOptimizer/definite_init_hang.swift
+++ b/test/SILOptimizer/definite_init_hang.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s -parse-as-library -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil %s -parse-as-library -o /dev/null -verify -enable-ownership-stripping-after-serialization
 
 var gg: Bool = false
 var rg: Int = 0

--- a/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
+++ b/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
+// RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s -enable-ownership-stripping-after-serialization
 
 // High-level tests that DI rejects passing let constants to
 // mutating witness methods

--- a/test/SILOptimizer/definite_init_value_types_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_value_types_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 
 struct EmptyStruct {}
 

--- a/test/SILOptimizer/di_property_wrappers_errors.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify %s -enable-ownership-stripping-after-serialization
+
 @propertyWrapper
 final class ClassWrapper<T> {
   var wrappedValue: T {

--- a/test/SILOptimizer/diagnostic_constant_propagation-swift4.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation-swift4.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 //
 // These are tests for diagnostics produced by constant propagation pass.
 // These are specific to Swift 4.

--- a/test/SILOptimizer/diagnostic_constant_propagation_floats.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_floats.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 //
 // These are tests for diagnostics produced by constant propagation pass
 // on floating-point operations.

--- a/test/SILOptimizer/diagnostic_constant_propagation_floats_nonx86.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_floats_nonx86.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 //
 // REQUIRES: !(CPU=i386 || CPU=x86_64)
 //

--- a/test/SILOptimizer/diagnostic_constant_propagation_floats_x86.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_floats_x86.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 //
 // REQUIRES: CPU=i386 || CPU=x86_64
 // UNSUPPORTED: OS=windows-msvc

--- a/test/SILOptimizer/diagnostic_constant_propagation_int_arch32.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_int_arch32.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 //
 // REQUIRES: PTRSIZE=32
 //

--- a/test/SILOptimizer/diagnostic_constant_propagation_int_arch64.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_int_arch64.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 //
 // REQUIRES: PTRSIZE=64
 //

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 
 import Swift
 

--- a/test/SILOptimizer/exclusivity_static_diagnostics_objc.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_objc.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/optional_closure_bridging.h -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/optional_closure_bridging.h -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILOptimizer/generalized_accessors.swift
+++ b/test/SILOptimizer/generalized_accessors.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 //
 // Tests for yield-once diagnostics emitted for generalized accessors.
 

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 
 func a() {  // expected-warning {{all paths through this function will call itself}}
   a()

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s -verify
+// RUN: %target-swift-frontend -emit-sil %s -verify -enable-ownership-stripping-after-serialization
 
 func takesEscaping(_: @escaping () -> ()) {}
 

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -sil-verify-all -primary-file %s -emit-sil -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend -sil-verify-all -primary-file %s -emit-sil -o - -verify -enable-ownership-stripping-after-serialization
 
 // These tests are deliberately shallow, because I do not want to depend on the
 // specifics of SIL generation, which might change for reasons unrelated to this

--- a/test/SILOptimizer/mandatory_inlining_circular.swift
+++ b/test/SILOptimizer/mandatory_inlining_circular.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -sil-verify-all -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -sil-verify-all -emit-sil %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 
 @_transparent func waldo(_ x: Double) -> Double {
   return fred(x); // expected-error {{inlining 'transparent' functions forms circular loop}} expected-note 1 {{while inlining here}}

--- a/test/SILOptimizer/noescape_param_exclusivity.swift
+++ b/test/SILOptimizer/noescape_param_exclusivity.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s -verify
+// RUN: %target-swift-frontend -emit-sil %s -verify -enable-ownership-stripping-after-serialization
 
 func test0(a: (() -> ()) -> (), b: () -> ()) {
   a(b) // expected-error {{passing a non-escaping function parameter 'b' to a call to a non-escaping function parameter can allow re-entrant modification of a variable}}

--- a/test/SILOptimizer/polymorphic_builtins_diagnostics.swift
+++ b/test/SILOptimizer/polymorphic_builtins_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -parse-stdlib -emit-sil -verify %s
+// RUN: %target-swift-frontend -parse-stdlib -emit-sil -verify %s -enable-ownership-stripping-after-serialization
 
 import Swift
 


### PR DESCRIPTION
…nable-ownership-stripping-after-serialization enabled.

Right now the stdlib/overlays can compile against -Onone tests with or without
-enable-ownership-stripping-after-serialization. This will help me to prevent
other work going on from breaking these properties.
