### PR TITLE
[sil-opt] Enable sil-opt to manually enable/disable the flag StripOwnershipAfterSerialization

### DIFF
--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -81,6 +81,11 @@ static llvm::cl::opt<bool> DisableSILOwnershipVerifier(
     llvm::cl::desc(
         "Do not verify SIL ownership invariants during SIL verification"));
 
+static llvm::cl::opt<bool> EnableOwnershipLoweringAfterDiagnostics(
+    "enable-ownership-lowering-after-diagnostics",
+    llvm::cl::desc("Enable ownership lowering after diagnostics"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<bool>
 EnableSILOpaqueValues("enable-sil-opaque-values",
                       llvm::cl::desc("Compile the module with sil-opaque-values enabled."));
@@ -333,6 +338,8 @@ int main(int argc, char **argv) {
   if (OptimizationGroup != OptGroup::Diagnostics)
     SILOpts.OptMode = OptimizationMode::ForSpeed;
   SILOpts.VerifySILOwnership = !DisableSILOwnershipVerifier;
+  SILOpts.StripOwnershipAfterSerialization =
+      EnableOwnershipLoweringAfterDiagnostics;
 
   SILOpts.VerifyExclusivity = VerifyExclusivity;
   if (EnforceExclusivity.getNumOccurrences() != 0) {


### PR DESCRIPTION
This is done via the flag -enable-ownership-lowering-after-diagnostics. This
will let me control this option for certain sil-opt tests that are expected to
always compile with/without the flag set. In most cases, I will turn it off for
the test currently in tree and add an additional ownership one with this flag
set.

The specific test cases where this is interesting is when we are using sil-opt
to simulate the diagnostics pipeline on a test containing already emitted
SILGen. This will let me ensure those tests do not start failing when I flip the
switch.
