### PR TITLE
[ownership] Do not RAUW destructures if replacement value is a .none non-trivial type.

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1414,9 +1414,22 @@ static bool constantFoldInstruction(Operand *Op, Optional<bool> &ResultsInError,
           [&](Operand &op) -> SILValue {
             SILValue operandValue = op.get();
             auto ownershipKind = operandValue.getOwnershipKind();
-            if (ownershipKind.isCompatibleWith(ValueOwnershipKind::Guaranteed))
-              return operandValue;
-            return SILValue();
+
+            // First check if we are not compatible with guaranteed. This means
+            // we would be Owned or Unowned. If so, return SILValue().
+            if (!ownershipKind.isCompatibleWith(ValueOwnershipKind::Guaranteed))
+              return SILValue();
+
+            // Otherwise check if our operand is non-trivial and None. In cases
+            // like that, the non-trivial type could be replacing an owned value
+            // where we lost that our underlying value is None due to
+            // intermediate aggregate literal operations. In that case, we /do
+            // not/ want to eliminate the destructure.
+            if (ownershipKind == ValueOwnershipKind::None &&
+                !operandValue->getType().isTrivial(*Struct->getFunction()))
+              return SILValue();
+
+            return operandValue;
           });
       return true;
     }
@@ -1435,9 +1448,22 @@ static bool constantFoldInstruction(Operand *Op, Optional<bool> &ResultsInError,
           [&](Operand &op) -> SILValue {
             SILValue operandValue = op.get();
             auto ownershipKind = operandValue.getOwnershipKind();
-            if (ownershipKind.isCompatibleWith(ValueOwnershipKind::Guaranteed))
-              return operandValue;
-            return SILValue();
+
+            // First check if we are not compatible with guaranteed. This means
+            // we would be Owned or Unowned. If so, return SILValue().
+            if (!ownershipKind.isCompatibleWith(ValueOwnershipKind::Guaranteed))
+              return SILValue();
+
+            // Otherwise check if our operand is non-trivial and None. In cases
+            // like that, the non-trivial type could be replacing an owned value
+            // where we lost that our underlying value is None due to
+            // intermediate aggregate literal operations. In that case, we /do
+            // not/ want to eliminate the destructure.
+            if (ownershipKind == ValueOwnershipKind::None &&
+                !operandValue->getType().isTrivial(*Tuple->getFunction()))
+              return SILValue();
+
+            return operandValue;
           });
       return true;
     }

--- a/test/SILOptimizer/constant_propagation_ownership.sil
+++ b/test/SILOptimizer/constant_propagation_ownership.sil
@@ -29,6 +29,11 @@ class Klass {}
 sil @klass_allocator : $@convention(method) (@thick Klass.Type) -> @owned Klass
 sil @generic_user : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 
+struct NativeObjectOptNativeObjectPair {
+  var lhs: Builtin.NativeObject
+  var rhs: Optional<Builtin.NativeObject>
+}
+
 ///////////
 // Tests //
 ///////////
@@ -1178,6 +1183,42 @@ bb2:
   br bb3
 
 bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @do_not_RAUW_owned_destructure_with_nontrivial_none_value_tuple : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK: ({{%.*}}, [[DESTRUCTURE_RESULT_2:%.*]]) = destructure_tuple
+// CHECK: store [[DESTRUCTURE_RESULT_2]] to [init]
+// CHECK: } // end sil function 'do_not_RAUW_owned_destructure_with_nontrivial_none_value_tuple'
+sil [ossa] @do_not_RAUW_owned_destructure_with_nontrivial_none_value_tuple : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%arg : @owned $Builtin.NativeObject):
+  %0 = alloc_stack $Optional<Builtin.NativeObject>
+  %1 = enum $Optional<Builtin.NativeObject>, #Optional.none!enumelt
+  %2 = tuple(%arg : $Builtin.NativeObject, %1 : $Optional<Builtin.NativeObject>)
+  (%3, %4) = destructure_tuple %2 : $(Builtin.NativeObject, Optional<Builtin.NativeObject>)
+  store %4 to [init] %0 : $*Optional<Builtin.NativeObject>
+  destroy_addr %0 : $*Optional<Builtin.NativeObject>
+  dealloc_stack %0 : $*Optional<Builtin.NativeObject>
+  destroy_value %3 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @do_not_RAUW_owned_destructure_with_nontrivial_none_value_struct : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK: ({{%.*}}, [[DESTRUCTURE_RESULT_2:%.*]]) = destructure_struct
+// CHECK: store [[DESTRUCTURE_RESULT_2]] to [init]
+// CHECK: } // end sil function 'do_not_RAUW_owned_destructure_with_nontrivial_none_value_struct'
+sil [ossa] @do_not_RAUW_owned_destructure_with_nontrivial_none_value_struct : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%arg : @owned $Builtin.NativeObject):
+  %0 = alloc_stack $Optional<Builtin.NativeObject>
+  %1 = enum $Optional<Builtin.NativeObject>, #Optional.none!enumelt
+  %2 = struct $NativeObjectOptNativeObjectPair (%arg : $Builtin.NativeObject, %1 : $Optional<Builtin.NativeObject>)
+  (%3, %4) = destructure_struct %2 : $NativeObjectOptNativeObjectPair
+  store %4 to [init] %0 : $*Optional<Builtin.NativeObject>
+  destroy_addr %0 : $*Optional<Builtin.NativeObject>
+  dealloc_stack %0 : $*Optional<Builtin.NativeObject>
+  destroy_value %3 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
Consider the following SIL:

```
%83 = enum $Optional<Thread>, #Optional.none!enumelt // users: %93, %84
%84 = tuple (%82 : $Result<Array<UInt8>, AnyError>, %83 : $Optional<Thread>) // user: %85
(%85, %86) = destructure_tuple %84 : $(Result<Array<UInt8>, AnyError>, Optional<Thread>) // user: %91
```

In this case, we clearly can replace all uses of %86 with %83. But since %86 is
a multiple value instruction result, despite our RAUWing, we can not eliminate
it. This implies since we have erased %83 being .none when passing it as an
argument to %84, we need to insert a destroy.

This will eventually be a no-op in the pipeline when the destructure is torn
apart by later passes.

In order to prevent constant propagation from introducing an infinite loop due
to the insertion of these destroys, I included a set in the constant folder to
ensure that we do not revisit results that have only constant folder inserted
destroy uses.