### PR TITLE
[ownership] Update the ownership utils infrastructure to treat mark_dependence as forwarding.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -842,11 +842,11 @@ inline SingleValueInstruction *SILNode::castToSingleValueInstruction() {
            inst->getKind() <= SILInstructionKind::Last_##ID;    \
   }
 
-/// A single value inst that also forwards either owned or guaranteed ownership.
+/// A single value inst that forwards a static ownership from one (or all) of
+/// its operands.
 ///
-/// The specific forwarded ownership is static since it is set upon
-/// construction. After that point the instruction can not have a different form
-/// of ownership.
+/// The ownership kind is set on construction and afterwards must be changed
+/// explicitly using setOwnershipKind().
 class OwnershipForwardingSingleValueInst : public SingleValueInstruction {
   ValueOwnershipKind ownershipKind;
 
@@ -5447,8 +5447,7 @@ public:
   NullablePtr<EnumElementDecl> getSingleTrueElement() const;
 };
 
-/// A select enum inst that produces a static OwnershipKind set upon the
-/// instruction's construction.
+/// A select enum inst that produces a static OwnershipKind.
 class OwnershipForwardingSelectEnumInstBase : public SelectEnumInstBase {
   ValueOwnershipKind ownershipKind;
 
@@ -6399,16 +6398,34 @@ public:
 /// the base must not be moved before any instructions which depend on the
 /// result of this instruction, exactly as if the address had been obviously
 /// derived from that operand (e.g. using ``ref_element_addr``). The result is
-/// always equal to the first operand.
+/// always equal to the first operand and thus forwards ownership through the
+/// first operand. This is a "regular" use of the second operand (i.e. the
+/// second operand must be live at the use point).
+///
+/// Example:
+///
+///   %base = ...
+///   %value = ... @trivial value ...
+///   %value_dependent_on_base = mark_dependence %value on %base
+///   ...
+///   use(%value_dependent_on_base)     (1)
+///   ...
+///   destroy_value %base               (2)
+///
+/// (2) can never move before (1). In English this is a way for the compiler
+/// writer to say to the optimizer: 'This subset of uses of "value" (the uses of
+/// result) have a dependence on "base" being alive. Do not allow for things
+/// that /may/ destroy base to be moved earlier than any of these uses of
+/// "value"'.
 class MarkDependenceInst
     : public InstructionBase<SILInstructionKind::MarkDependenceInst,
-                             SingleValueInstruction> {
+                             OwnershipForwardingSingleValueInst> {
   friend SILBuilder;
 
   FixedOperandList<2> Operands;
 
   MarkDependenceInst(SILDebugLocation DebugLoc, SILValue value, SILValue base)
-      : InstructionBase(DebugLoc, value->getType()),
+      : InstructionBase(DebugLoc, value->getType(), value.getOwnershipKind()),
         Operands{this, value, base} {}
 
 public:

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -854,7 +854,7 @@ OperandOwnershipKindMap OperandOwnershipKindClassifier::visitMarkDependenceInst(
     MarkDependenceInst *mdi) {
   // If we are analyzing "the value", we forward ownership.
   if (getValue() == mdi->getValue()) {
-    auto kind = getValue().getOwnershipKind();
+    auto kind = mdi->getOwnershipKind();
     if (kind == ValueOwnershipKind::None)
       return Map::allLive();
     auto lifetimeConstraint = kind.getForwardingLifetimeConstraint();

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -44,6 +44,7 @@ bool swift::isOwnershipForwardingValueKind(SILNodeKind kind) {
   case SILNodeKind::CondBranchInst:
   case SILNodeKind::DestructureStructInst:
   case SILNodeKind::DestructureTupleInst:
+  case SILNodeKind::MarkDependenceInst:
     return true;
   default:
     return false;

--- a/lib/SIL/ValueOwnership.cpp
+++ b/lib/SIL/ValueOwnership.cpp
@@ -293,7 +293,7 @@ ValueOwnershipKind ValueOwnershipKindClassifier::visitSILFunctionArgument(
 // This is a forwarding instruction through only one of its arguments.
 ValueOwnershipKind
 ValueOwnershipKindClassifier::visitMarkDependenceInst(MarkDependenceInst *MDI) {
-  return MDI->getValue().getOwnershipKind();
+  return MDI->getOwnershipKind();
 }
 
 ValueOwnershipKind ValueOwnershipKindClassifier::visitApplyInst(ApplyInst *ai) {

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -1187,3 +1187,12 @@ bb0(%0 : $@sil_unmanaged Builtin.NativeObject):
   %1 = strong_copy_unmanaged_value %0 : $@sil_unmanaged Builtin.NativeObject
   return %1 : $Builtin.NativeObject
 }
+
+sil [ossa] @mark_dependence_test_guaranteed : $@convention(thin) (@guaranteed Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = mark_dependence %0 : $Builtin.NativeObject on %1 : $Builtin.NativeObject
+  destroy_value %1 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+


### PR DESCRIPTION
We have already been forwarding ownership in terms of ValueOwnership and
OwnershipUtils, I just had not setup certain parts of the ownership utils to
recognize mark_dependence as forwarding of guaranteed values. We did not hit
this before since we have not had been late enough in the pipeline to get
mark_dependence on guaranteed values.

In the future, we want to move to mark_dependence only taking guaranteed
values. This is a first step in that direction that at the same time allows me
to enable ownership lowering after diagnostics sooner since fixing the bigger
issue would be a relatively medium sized project.
