### PR TITLE
[constant-folding] Remove unneeded code.

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1501,7 +1501,6 @@ bool ConstantFolder::constantFoldStringConcatenation(ApplyInst *AI) {
       assert(DeadI);
       recursivelyDeleteTriviallyDeadInstructions(DeadI, /*force*/ true,
                                                  RemoveCallback);
-      WorkList.remove(DeadI);
     }
   }
   // Schedule users of the new instruction for constant folding.


### PR DESCRIPTION
recursivelyDeleteTriviallyDeadInstructions will handle this for us when it
deletes the instruction. So in fact, this was actually a use of an invalid
pointer. Good thing we never dereferenced it.
