### PR TITLE
[NFC] Add a "StringLiteralInitializerInfo" utility class.

### DIFF
--- a/include/swift/AST/SemanticAttrs.h
+++ b/include/swift/AST/SemanticAttrs.h
@@ -24,7 +24,8 @@
 
 namespace swift {
 namespace semantics {
-#define SEMANTICS_ATTR(NAME, C_STR) constexpr static const StringLiteral NAME = C_STR;
+#define SEMANTICS_ATTR(NAME, C_STR)                                            \
+  constexpr static const StringLiteral NAME = C_STR;
 #include "SemanticAttrs.def"
 }
 }

--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -24,9 +24,12 @@
 #ifndef SWIFT_SILOPTIMIZER_CONSTEXPR_H
 #define SWIFT_SILOPTIMIZER_CONSTEXPR_H
 
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILFunction.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 namespace swift {
@@ -39,6 +42,132 @@ class SymbolicValue;
 class SymbolicValueAllocator;
 class ConstExprFunctionState;
 class UnknownReason;
+
+/// This class is a utility used for evaluating string literals. It retrieves
+/// info about the string and allows conversion from a swift string literal to a
+/// StringRef. The class is designed to be used in conjunction with
+/// SILInstructions or SILValues.
+class StringLiteralInitializerInfo {
+  StringLiteralInitializerInfo() = default;
+
+public:
+  bool isAscii;
+  StringRef value;
+  StringLiteralInst *inst;
+
+  /// Create an instance of StringLiteralInitializerInfo by casting v to an
+  /// ApplyInst.
+  ///
+  /// \param v SILValue to be cast to ApplyInst and used in creation of the
+  /// string literal. v should be an ApplyInst that calls a function with the
+  /// semantic attribute "string.makeUTF8".
+  static Optional<StringLiteralInitializerInfo> getFromCallsite(SILValue v) {
+    if (auto *inst = dyn_cast<ApplyInst>(v))
+      return getFromCallsite(inst);
+    return {};
+  }
+
+  /// Create an instance of StringLiteralInitializerInfo using inst.
+  ///
+  /// \param inst The instruction to be used in creation of the string literal.
+  /// inst should be an ApplyInst that calls a function with the semantic
+  /// attribute "string.makeUTF8".
+  static Optional<StringLiteralInitializerInfo>
+  getFromCallsite(SILInstruction *inst) {
+    ApplyInst *makeStr = getStringMakeUTF8Apply(inst);
+    if (!makeStr)
+      return {};
+
+    auto strVal = getUTF8StringValue(makeStr);
+    if (!strVal)
+      return {};
+
+    StringLiteralInitializerInfo info;
+    info.value = strVal.getValue();
+    info.isAscii = getIsAscii(makeStr);
+    info.inst = getUTF8String(makeStr);
+    return info;
+  }
+
+  /// If the given instruction is a call to the compiler-intrinsic initializer
+  /// of String that accepts string literals, return the called function.
+  /// Otherwise, return nullptr.
+  ///
+  /// \param inst Should be an ApplyInst that calls the string init function:
+  /// \code
+  ///  String(_builtinStringLiteral start: Builtin.RawPointer,
+  ///         utf8CodeUnitCount: Builtin.Word,
+  ///         isASCII: Builtin.Int1)
+  /// \endcode
+  /// with the semantic attribute "string.makeUTF8"
+  static SILFunction *getStringMakeUTF8InitFunction(SILInstruction *inst) {
+    if (auto apply = getStringMakeUTF8Apply(inst))
+      return apply->getCalleeFunction();
+    return nullptr;
+  }
+
+  /// Similar to getStringMakeUTF8Init but, gets the apply instruction instead.
+  static ApplyInst *getStringMakeUTF8Apply(SILInstruction *inst) {
+    auto *apply = dyn_cast<ApplyInst>(inst);
+    if (!apply)
+      return nullptr;
+
+    SILFunction *callee = apply->getCalleeFunction();
+    if (!callee || !callee->hasSemanticsAttr(semantics::STRING_MAKE_UTF8))
+      return nullptr;
+    return apply;
+  }
+
+  /// \returns a StringLiteralInst pointer from a string init function if \p
+  /// makeStr is an ApplyInst that calls a function with the semantics attribute
+  /// 'string.makeUTF8', and if its first argument is a StringLiteralInst.
+  /// Otherwise, the pointer will be null.
+  static StringLiteralInst *getUTF8String(ApplyInst *makeStr) {
+    SILFunction *callee = makeStr->getCalleeFunction();
+    if (!callee || !callee->hasSemanticsAttr(semantics::STRING_MAKE_UTF8))
+      return nullptr;
+
+    if (makeStr->getNumArguments() < 1)
+      return nullptr;
+
+    return dyn_cast<StringLiteralInst>(makeStr->getOperand(1));
+  }
+
+  /// \returns an optional StringRef from a string init function if \p makeStr
+  /// is an ApplyInst that calls a function with the semantics attribute
+  /// 'string.makeUTF8', and if its first argument is a StringLiteralInst.
+  static Optional<StringRef> getUTF8StringValue(ApplyInst *makeStr) {
+    if (auto stringLiteralInst = getUTF8String(makeStr)) {
+      return stringLiteralInst->getValue();
+    }
+
+    return {};
+  }
+
+  /// \returns the third argument of the string initialization function, which
+  /// describes whether the string is ASCII, only if \p makeStr is an ApplyInst
+  /// that calls a function with the semantics attribute 'string.makeUTF8', and
+  /// if its third argument is an IntegerLiteralInst. Otherwise, returns false.
+  ///
+  /// \p makeStr must call a function with the following form:
+  /// \code
+  ///  String(_builtinStringLiteral start: Builtin.RawPointer,
+  ///         utf8CodeUnitCount: Builtin.Word,
+  ///         isASCII: Builtin.Int1)
+  /// \endcode
+  static bool getIsAscii(ApplyInst *makeStr) {
+    SILFunction *callee = makeStr->getCalleeFunction();
+    if (!callee || !callee->hasSemanticsAttr(semantics::STRING_MAKE_UTF8))
+      return {};
+
+    if (makeStr->getNumArguments() < 3)
+      return false;
+
+    if (auto *isAscii = dyn_cast<IntegerLiteralInst>(makeStr->getOperand(3)))
+      return isAscii->getValue().getBoolValue();
+    return false;
+  }
+};
 
 /// This class is the main entrypoint for evaluating constant expressions.  It
 /// also handles caching of previously computed constexpr results.

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -117,20 +117,6 @@ static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
 
 namespace {
 
-/// If the given instruction is a call to the compiler-intrinsic initializer
-/// of String that accepts string literals, return the called function.
-/// Otherwise, return nullptr.
-static SILFunction *getStringMakeUTF8Init(SILInstruction *inst) {
-  auto *apply = dyn_cast<ApplyInst>(inst);
-  if (!apply)
-    return nullptr;
-
-  SILFunction *callee = apply->getCalleeFunction();
-  if (!callee || !callee->hasSemanticsAttr(semantics::STRING_MAKE_UTF8))
-    return nullptr;
-  return callee;
-}
-
 // A cache of string-related, SIL information that is needed to create and
 // initalize strings from raw string literals. This information is
 // extracted from instructions while they are constant evaluated. Though the
@@ -152,7 +138,8 @@ public:
     if (stringInitIntrinsic)
       return;
 
-    SILFunction *callee = getStringMakeUTF8Init(inst);
+    SILFunction *callee =
+        StringLiteralInitializerInfo::getStringMakeUTF8InitFunction(inst);
     if (!callee)
       return;
 
@@ -298,7 +285,8 @@ static bool isFoldableIntOrBool(SILValue value, ASTContext &astContext) {
 static bool isFoldableString(SILValue value, ASTContext &astContext) {
   return isStringType(value->getType(), astContext) &&
          (!isa<ApplyInst>(value) ||
-          !getStringMakeUTF8Init(cast<ApplyInst>(value)));
+          !StringLiteralInitializerInfo::getStringMakeUTF8InitFunction(
+              cast<ApplyInst>(value)));
 }
 
 /// Return true iff the given value is an array and is not an initialization


### PR DESCRIPTION
This is the `StringLiteralInfo` utility class from #27551. I broke it out of that PR for ease of reviewing. I'm happy to move this into another place if that's better, too. 
