### PR TITLE
[build-script] Teach cross-compile hosts check about --skip-local-build

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1050,7 +1050,7 @@ fi
 ALL_HOSTS=("${ALL_HOSTS[@]}" "${CROSS_COMPILE_HOSTS[@]}")
 
 function has_cross_compile_hosts() {
-    if [[ ${#ALL_HOSTS[@]} -gt 1 ]]; then
+    if [[ ${#CROSS_COMPILE_HOSTS[@]} -ge 1 ]]; then
         echo "1"
     fi
 }


### PR DESCRIPTION
Check whether there are any cross compile hosts by looking at the
CROSS_COMPILE_HOSTS array, not at ALL_HOSTS, as these can be different
due to --skip-local-build.