### PR TITLE
Mark loaded_module_trace_swiftinterface as unsupported in Windows

### DIFF
--- a/test/Driver/loaded_module_trace_swiftinterface.swift
+++ b/test/Driver/loaded_module_trace_swiftinterface.swift
@@ -1,3 +1,5 @@
+// UNSUPPORTED: -windows-msvc
+
 // 1) If there is no swiftmodule, use the swiftinterface
 //
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
Sadly, in Windows, the last invocation of the test, which mixes
`emit-loaded-module-trace` and the two frontend invocations, fails with
the compiler crashing. Instead of this being reported correctly thru
lit, it crashes the lit driver and the test is not even marked as
failed. When running several tests in parallel, it crashes one of the
workers and outputs a cryptic "Error 87".

Sadly, because of how the test seems to break, and how Windows seems to
fail, XFAILing the test is not enough, and it has to be skipped
completely in Windows and have to be mark as unsupported instead.

Hopefully this will unstuck the Windows CI machines.

This is very related to #27740, but in that other one the test was helpfully outputting the error, while in this one it was crashing even more, and hiding the exact error (and where it was happening). The output of manually running the failing line was:

```
 s:\\swift\\bin\\swiftc.exe -target x86_64-unknown-windows-msvc -swift-version 4 -Xfrontend -ignore-module-source-info -libc MD -I S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp/Main -module-cache-path S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp/MCP C:\Jenkins\workspace\oss-swift-windows-x86_64\swift\test\Driver\loaded_module_trace_swiftinterface.swift -emit-loaded-module-trace -o S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp/loaded_module_trace_swiftinterface
<unknown>:0: error: fatal error encountered during compilation; please file a bug report with your project and the crash log
<unknown>:0: note: Unexpected path for swiftinterface file:
S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp\Main\Module.swiftinterface
The module <-> path mapping we have is:
SwiftShims <-> S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp\MCP\4NGX41D4WAEL\SwiftShims-3CYIHHYIBG368.pcm
ucrt <-> S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp\MCP\4NGX41D4WAEL\ucrt-37M3AHJZWWF6Y.pcm
Swift <-> s:\swift\lib\swift\windows\x86_64\Swift.swiftmodule
Module2 <-> S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp/Main\Module2.swiftmodule
Module <-> S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp/Main\Module.swiftinterface
visualc <-> S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp\MCP\4NGX41D4WAEL\visualc-351V1A0EKNWBU.pcm
SwiftOnoneSupport <-> s:\swift\lib\swift\windows\x86_64\SwiftOnoneSupport.swiftmodule
_Builtin_stddef_max_align_t <-> S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp\MCP\4NGX41D4WAEL\_Builtin_stddef_max_align_t-20SLEUVVCVN5K.pcm

Stack dump:
0.      Program arguments: s:\swift\bin\swiftc.exe -frontend -c -primary-file C:\Jenkins\workspace\oss-swift-windows-x86_64\swift\test\Driver\loaded_module_trace_swiftinterface.swift -emit-loaded-module-trace-path S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp\loaded_module_trace_swiftinterface.trace.json -target x86_64-unknown-windows-msvc -disable-objc-interop -color-diagnostics -I S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp/Main -module-cache-path S:\swift\test-windows-x86_64\Driver\Output\loaded_module_trace_swiftinterface.swift.tmp/MCP -swift-version 4 -ignore-module-source-info -autolink-library oldnames -autolink-library msvcrt -Xcc -D_MT -Xcc -D_DLL -module-name loaded_module_trace_swiftinterface -o C:\Users\DANIEL~1\AppData\Local\Temp\loaded_module_trace_swiftinterface-d48d91.o
1.      Swift version 5.1.1-dev (Swift 1f1ceb47e4)
 #0 0x00007ff773a7dff5 (s:\swift\bin\swiftc.exe+0x388dff5)
 #1 0x00007ff96847da2d (C:\windows\System32\ucrtbase.dll+0x6da2d)
 #2 0x00007ff96847e901 (C:\windows\System32\ucrtbase.dll+0x6e901)
 #3 0x00007ff7702d1880 (s:\swift\bin\swiftc.exe+0xe1880)
 #4 0x00007ff773a36927 (s:\swift\bin\swiftc.exe+0x3846927)
 #5 0x00007ff773a368a1 (s:\swift\bin\swiftc.exe+0x38468a1)
 #6 0x00007ff7702d1235 (s:\swift\bin\swiftc.exe+0xe1235)
 #7 0x00007ff7702d30f6 (s:\swift\bin\swiftc.exe+0xe30f6)
 #8 0x00007ff7702d4c3a (s:\swift\bin\swiftc.exe+0xe4c3a)
 #9 0x00007ff7702ce4f9 (s:\swift\bin\swiftc.exe+0xde4f9)
#10 0x00007ff770545bc2 (s:\swift\bin\swiftc.exe+0x355bc2)
#11 0x00007ff7702d8044 (s:\swift\bin\swiftc.exe+0xe8044)
#12 0x00007ff7702d9b20 (s:\swift\bin\swiftc.exe+0xe9b20)
#13 0x00007ff77026e853 (s:\swift\bin\swiftc.exe+0x7e853)
#14 0x00007ff77026fe8a (s:\swift\bin\swiftc.exe+0x7fe8a)
#15 0x00007ff773abb8a4 (s:\swift\bin\swiftc.exe+0x38cb8a4)
#16 0x00007ff96a2c7974 (C:\windows\System32\KERNEL32.DLL+0x17974)
#17 0x00007ff96c3ba271 (C:\windows\SYSTEM32\ntdll.dll+0x6a271)
<unknown>:0: error: compile command failed due to signal -2147483645 (use -v to see invocation)
```

This is related to SR-11103.