### PR TITLE
[NFC] Switch DeclValidation Counter to Request Counter

### DIFF
--- a/docs/CompilerPerformance.md
+++ b/docs/CompilerPerformance.md
@@ -753,7 +753,7 @@ Time,Live,IsEntry,EventName,CounterName,CounterDelta,CounterValue,EntityName,Ent
 40032,0,"entry","typecheck-decl","Sema.NumLazyIterableDeclContexts",40,40,"foo","[test.swift:1:1 - line:1:32]"
 40032,0,"entry","typecheck-decl","Sema.NumTypesDeserialized",106,106,"foo","[test.swift:1:1 - line:1:32]"
 40032,0,"entry","typecheck-decl","Sema.NumUnloadedLazyIterableDeclContexts",40,40,"foo","[test.swift:1:1 - line:1:32]"
-40135,0,"entry","typecheck-decl","Sema.NumDeclsValidated",1,1,"","[test.swift:1:13 - line:1:29]"
+40135,0,"entry","typecheck-decl","Sema.InterfaceTypeRequest",1,1,"","[test.swift:1:13 - line:1:29]"
 ...
 ```
 

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -230,9 +230,6 @@ FRONTEND_STATISTIC(Sema, NumCyclicOneWayComponentsCollapsed)
 /// of material loaded from other modules.
 FRONTEND_STATISTIC(Sema, NumDeclsDeserialized)
 
-/// Number of declarations validated.
-FRONTEND_STATISTIC(Sema, NumDeclsValidated)
-
 /// Number of declarations type checked.
 FRONTEND_STATISTIC(Sema, NumDeclsTypechecked)
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4134,9 +4134,6 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
   TypeChecker::checkForForbiddenPrefix(Context, D->getBaseName());
 
-  if (Context.Stats)
-    Context.Stats->getFrontendCounters().NumDeclsValidated++;
-
   switch (D->getKind()) {
   case DeclKind::Import:
   case DeclKind::Extension:

--- a/validation-test/compiler_scale/bind_extension_decl.gyb
+++ b/validation-test/compiler_scale/bind_extension_decl.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select InterfaceTypeRequest %s
 // REQUIRES: asserts
 
 struct Struct${N} {}

--- a/validation-test/compiler_scale/bind_nested_extension_decl.gyb
+++ b/validation-test/compiler_scale/bind_nested_extension_decl.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select InterfaceTypeRequest %s
 // REQUIRES: asserts
 
 struct Outer${N} {

--- a/validation-test/compiler_scale/class_members.gyb
+++ b/validation-test/compiler_scale/class_members.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select InterfaceTypeRequest %s
 // REQUIRES: asserts
 
 class Class${N} {

--- a/validation-test/compiler_scale/enum_indirect.gyb
+++ b/validation-test/compiler_scale/enum_indirect.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select InterfaceTypeRequest %s
 // REQUIRES: asserts
 
 indirect enum Enum${N} {

--- a/validation-test/compiler_scale/enum_members.gyb
+++ b/validation-test/compiler_scale/enum_members.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select InterfaceTypeRequest %s
 // REQUIRES: asserts
 
 enum Enum${N} {

--- a/validation-test/compiler_scale/protocol_members.gyb
+++ b/validation-test/compiler_scale/protocol_members.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select InterfaceTypeRequest %s
 // REQUIRES: asserts
 
 protocol Protocol${N} {

--- a/validation-test/compiler_scale/struct_members.gyb
+++ b/validation-test/compiler_scale/struct_members.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select InterfaceTypeRequest %s
 // REQUIRES: asserts
 
 struct Struct${N} {

--- a/validation-test/compiler_scale/struct_nested.gyb
+++ b/validation-test/compiler_scale/struct_nested.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select InterfaceTypeRequest %s
 // REQUIRES: asserts
 
 struct Struct${N} {

--- a/validation-test/compiler_scale/used_conformances.gyb
+++ b/validation-test/compiler_scale/used_conformances.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select InterfaceTypeRequest %s
 // REQUIRES: asserts
 
 struct Generic${N}<T : Protocol${N}> {}


### PR DESCRIPTION
Now that validateDecl is gone, stop duplicating work here and use the
request counter instead.