### PR TITLE
[AutoDiff] Use `TransposingAttr::getParameterIndices`.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1761,7 +1761,7 @@ class TransposingAttr final
   /// The number of parsed parameters specified in 'wrt:'.
   unsigned NumParsedParameters = 0;
   /// The differentiation parameters' indices, resolved by the type checker.
-  IndexSubset *ParameterIndexSubset = nullptr;
+  IndexSubset *ParameterIndices = nullptr;
   
   explicit TransposingAttr(ASTContext &context, bool implicit,
                            SourceLoc atLoc, SourceRange baseRange,
@@ -1802,11 +1802,11 @@ public:
     return NumParsedParameters;
   }
   
-  IndexSubset *getParameterIndexSubset() const {
-    return ParameterIndexSubset;
+  IndexSubset *getParameterIndices() const {
+    return ParameterIndices;
   }
   void setParameterIndices(IndexSubset *pi) {
-    ParameterIndexSubset = pi;
+    ParameterIndices = pi;
   }
   
   static bool classof(const DeclAttribute *DA) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -932,8 +932,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     auto *transpose = dyn_cast_or_null<AbstractFunctionDecl>(D);
     Printer << attr->getOriginal().Name;
     auto diffParamsString = getTransposingParametersClauseString(
-        transpose, attr->getParameterIndexSubset(),
-        attr->getParsedParameters());
+        transpose, attr->getParameterIndices(), attr->getParsedParameters());
     if (!diffParamsString.empty())
       Printer << ", " << diffParamsString;
     Printer << ')';
@@ -1584,7 +1583,7 @@ TransposingAttr::TransposingAttr(ASTContext &context, bool implicit,
                                  IndexSubset *indices)
     : DeclAttribute(DAK_Transposing, atLoc, baseRange, implicit),
       BaseType(baseType), Original(std::move(original)),
-      ParameterIndexSubset(indices) {}
+      ParameterIndices(indices) {}
 
 TransposingAttr *
 TransposingAttr::create(ASTContext &context, bool implicit, SourceLoc atLoc,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3920,7 +3920,7 @@ void AttributeChecker::visitTransposingAttr(TransposingAttr *attr) {
                                      ->castTo<AnyFunctionType>();
   
   // Get checked wrt param indices.
-  auto *wrtParamIndices = attr->getParameterIndexSubset();
+  auto *wrtParamIndices = attr->getParameterIndices();
 
   // Get the parsed wrt param indices, which have not yet been checked.
   // This is defined for parsed attributes.


### PR DESCRIPTION
Rename `TransposingAttr::getParameterIndexSubset` to `getParameterIndices`,
for consistency with `DifferentiableAttr` and `DifferentiatingAttr`.