### PR TITLE
[AutoDiff] DifferentiabilityWitnessFunctionInst stores pointer to witness

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -691,6 +691,8 @@ ERROR(sil_diff_witness_expected_token,PointsToFirstBadToken,
       "expected '%0' in differentiability witness", (StringRef))
 ERROR(sil_diff_witness_serialized_declaration,none,
       "differentiability witness declaration should not be serialized", ())
+ERROR(sil_diff_witness_undefined,PointsToFirstBadToken,
+      "reference to undefined differentiability witness", ())
 
 // SIL Coverage Map
 ERROR(sil_coverage_func_not_found, none,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -551,13 +551,10 @@ public:
 
   DifferentiabilityWitnessFunctionInst *
   createDifferentiabilityWitnessFunction(
-      SILLocation Loc, SILFunction *OriginalFunction,
-      DifferentiabilityWitnessFunctionKind WitnessKind,
-      IndexSubset *ParameterIndices, IndexSubset *ResultIndices,
-      GenericSignature WitnessGenericSignature) {
+      SILLocation Loc, DifferentiabilityWitnessFunctionKind WitnessKind,
+      SILDifferentiabilityWitness *Witness) {
     return insert(new (getModule()) DifferentiabilityWitnessFunctionInst(
-        getModule(), getSILDebugLocation(Loc), OriginalFunction, WitnessKind,
-        ParameterIndices, ResultIndices, WitnessGenericSignature.getPointer()));
+        getModule(), getSILDebugLocation(Loc), WitnessKind, Witness));
   }
   // SWIFT_ENABLE_TENSORFLOW END
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1018,9 +1018,8 @@ void SILCloner<ImplClass>::visitDifferentiabilityWitnessFunctionInst(
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createDifferentiabilityWitnessFunction(
-                getOpLocation(Inst->getLoc()), Inst->getOriginalFunction(),
-                Inst->getWitnessKind(), Inst->getParameterIndices(),
-                Inst->getResultIndices(), Inst->getWitnessGenericSignature()));
+                getOpLocation(Inst->getLoc()), Inst->getWitnessKind(),
+                Inst->getWitness()));
 }
 // SWIFT_ENABLE_TENSORFLOW END
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -61,6 +61,9 @@ class SILBasicBlock;
 class SILBuilder;
 class SILDebugLocation;
 class SILDebugScope;
+// SWIFT_ENABLE_TENSORFLOW
+class SILDifferentiabilityWitness;
+// SWIFT_ENABLE_TENSORFLOW_END
 class SILFunction;
 class SILGlobalVariable;
 class SILInstructionResultArray;
@@ -8038,43 +8041,31 @@ class DifferentiabilityWitnessFunctionInst
           SingleValueInstruction> {
 private:
   friend SILBuilder;
-  /// The original function.
-  SILFunction *originalFunction;
   /// The differentiability witness function kind.
   DifferentiabilityWitnessFunctionKind witnessKind;
-  /// The autodiff config: parameter indices, result indices, and witness
-  /// derivative signature.
-  AutoDiffConfig config;
+  /// The referenced SIL differentiability witness.
+  SILDifferentiabilityWitness *witness;
 
   static SILType getDifferentiabilityWitnessType(
-      SILModule &module, SILFunction *originalFunction,
+      SILModule &module,
       DifferentiabilityWitnessFunctionKind witnessKind,
-      IndexSubset *parameterIndices, IndexSubset *resultIndices,
-      GenericSignature witnessGenericSignature);
+      SILDifferentiabilityWitness *witness);
 
 public:
   DifferentiabilityWitnessFunctionInst(
-      SILModule &module, SILDebugLocation loc, SILFunction *originalFunction,
+      SILModule &module, SILDebugLocation loc,
       DifferentiabilityWitnessFunctionKind witnessKind,
-      IndexSubset *parameterIndices, IndexSubset *resultIndices,
-      GenericSignature witnessGenericSignature);
+      SILDifferentiabilityWitness *witness);
 
   static DifferentiabilityWitnessFunctionInst *create(
-      SILModule &module, SILDebugLocation loc, SILFunction *originalFunction,
+      SILModule &module, SILDebugLocation loc,
       DifferentiabilityWitnessFunctionKind witnessKind,
-      IndexSubset *parameterIndices, IndexSubset *resultIndices,
-      GenericSignature witnessGenericSignature);
+      SILDifferentiabilityWitness *witness);
 
   DifferentiabilityWitnessFunctionKind getWitnessKind() const {
     return witnessKind;
   }
-  SILFunction *getOriginalFunction() const { return originalFunction; }
-  AutoDiffConfig const &getConfig() const { return config; }
-  IndexSubset *getParameterIndices() const { return config.parameterIndices; }
-  IndexSubset *getResultIndices() const { return config.resultIndices; }
-  GenericSignature getWitnessGenericSignature() const {
-    return config.derivativeGenericSignature;
-  }
+  SILDifferentiabilityWitness *getWitness() const { return witness; }
 
   ArrayRef<Operand> getAllOperands() const { return {}; }
   MutableArrayRef<Operand> getAllOperands() { return {}; }

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -204,11 +204,8 @@ private:
   DefaultWitnessTableListType defaultWitnessTables;
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Lookup table for SIL differentiability witnesses from original functions.
-  /// Indexed by key type: original function, parameter indices, result indices,
-  /// and derivative generic signature.
-  llvm::DenseMap<SILDifferentiabilityWitnessKey, SILDifferentiabilityWitness *>
-      DifferentiabilityWitnessMap;
+  /// Lookup table for SIL differentiability witnesses, keyed by mangled name.
+  llvm::StringMap<SILDifferentiabilityWitness *> DifferentiabilityWitnessMap;
 
   /// The list of SILDifferentiabilityWitnesses in the module.
   DifferentiabilityWitnessListType differentiabilityWitnesses;
@@ -608,6 +605,15 @@ public:
   /// Attempt to lookup the function corresponding to \p Member in the class
   /// hierarchy of \p Class.
   SILFunction *lookUpFunctionInVTable(ClassDecl *Class, SILDeclRef Member);
+
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Look up the differentiability witness with the given name.
+  SILDifferentiabilityWitness *lookUpDifferentiabilityWitness(StringRef name);
+
+  /// Look up the differentiability witness corresponding to the given key.
+  SILDifferentiabilityWitness *
+  lookUpDifferentiabilityWitness(SILDifferentiabilityWitnessKey key);
+  // SWIFT_ENABLE_TENSORFLOW_END
 
   // Given a protocol, attempt to create a default witness table declaration
   // for it.

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -326,6 +326,9 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
          Tok.isNot(tok::kw_sil_global) &&
          Tok.isNot(tok::kw_sil_witness_table) &&
          Tok.isNot(tok::kw_sil_default_witness_table) &&
+         // SWIFT_ENABLE_TENSORFLOW
+         Tok.isNot(tok::kw_sil_differentiability_witness) &&
+         // SWIFT_ENABLE_TENSORFLOW_END
          Tok.isNot(tok::kw_sil_property) &&
          (isConditionalBlock ||
           !isTerminatorForBraceItemListKind(Kind, Entries))) {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2237,7 +2237,7 @@ parseSILDifferentiabilityWitnessConfigAndFunction(Parser &P, SILParser &SP,
     // Check whether original function generic signature and parsed witness
     // generic have the same generic parameters.
     auto areGenericParametersConsistent = [&]() {
-      llvm::DenseSet<GenericParamKey> genericParamKeys;
+      llvm::SmallDenseSet<GenericParamKey, 4> genericParamKeys;
       for (auto *origGP : origGenSig->getGenericParams())
         genericParamKeys.insert(GenericParamKey(origGP));
       for (auto *witnessGP : witnessGenSig->getGenericParams())
@@ -2270,7 +2270,7 @@ parseSILDifferentiabilityWitnessConfigAndFunction(Parser &P, SILParser &SP,
   auto *resultIndexSet = IndexSubset::get(
       P.Context, origFnType->getNumResults(), resultIndices);
   AutoDiffConfig config(parameterIndexSet, resultIndexSet, witnessGenSig);
-  return {{config, originalFunction}};
+  return std::make_pair(config, originalFunction);
 }
 // SWIFT_ENABLE_TENSORFLOW_END
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -694,7 +694,6 @@ SILFunction *SILParser::getGlobalNameForReference(Identifier name,
   return fn;
 }
 
-
 /// getBBForDefinition - Return the SILBasicBlock for a definition of the
 /// specified block.
 SILBasicBlock *SILParser::getBBForDefinition(Identifier Name, SourceLoc Loc) {
@@ -2172,6 +2171,109 @@ static bool parseAssignOwnershipQualifier(AssignOwnershipQualifier &Result,
   return false;
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+/// sil-differentiability-witness-config-and-function ::=
+///   '[' 'parameters' index-subset ']'
+///   '[' 'results' index-subset ']'
+///   ('<' 'where' derivative-generic-signature-requirements '>')?
+///   sil-function-ref
+///
+/// e.g. parameters 0 1] [results 0] <T where T: Differentiable>
+///      @foo : <T> $(T) -> T
+static Optional<std::pair<AutoDiffConfig, SILFunction *>>
+parseSILDifferentiabilityWitnessConfigAndFunction(Parser &P, SILParser &SP,
+                                                  SILLocation L) {
+  SourceLoc lastLoc;
+  // Parse an index set, prefaced with the given label.
+  auto parseIndexSet = [&](StringRef label, SmallVectorImpl<unsigned> &indices,
+                           const Diagnostic &parseIndexDiag) -> bool {
+    // Parse `[<label> <integer_literal>...]`.
+    if (P.parseToken(tok::l_square, diag::sil_autodiff_expected_lsquare,
+                     "index list") ||
+        P.parseSpecificIdentifier(
+            label, diag::sil_autodiff_expected_index_list_label, label))
+      return true;
+    while (P.Tok.is(tok::integer_literal)) {
+      unsigned index;
+      if (P.parseUnsignedInteger(index, lastLoc, parseIndexDiag))
+        return true;
+      indices.push_back(index);
+    }
+    if (P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
+                     "index list"))
+      return true;
+    return false;
+  };
+  // Parse parameter and result indices.
+  SmallVector<unsigned, 8> parameterIndices;
+  SmallVector<unsigned, 8> resultIndices;
+  if (parseIndexSet("parameters", parameterIndices,
+                    diag::sil_autodiff_expected_parameter_index))
+    return {};
+  if (parseIndexSet("results", resultIndices,
+                    diag::sil_autodiff_expected_result_index))
+    return {};
+  // Parse witness generic parameter clause.
+  GenericSignature witnessGenSig = GenericSignature();
+  SourceLoc witnessGenSigStartLoc = P.getEndOfPreviousLoc();
+  {
+    // Create a new scope to avoid type redefinition errors.
+    Scope genericsScope(&P, ScopeKind::Generics);
+    auto *genericParams = P.parseSILGenericParams().getPtrOrNull();
+    if (genericParams) {
+      auto *witnessGenEnv =
+          handleSILGenericParams(P.Context, genericParams, &P.SF);
+      witnessGenSig = witnessGenEnv->getGenericSignature();
+    }
+  }
+  // Parse original function name and type.
+  SILFunction *originalFunction = nullptr;
+  if (SP.parseSILFunctionRef(L, originalFunction))
+    return {};
+  // Resolve parsed witness generic signature.
+  if (witnessGenSig) {
+    auto origGenSig = originalFunction
+        ->getLoweredFunctionType()->getGenericSignature();
+    // Check whether original function generic signature and parsed witness
+    // generic have the same generic parameters.
+    auto areGenericParametersConsistent = [&]() {
+      llvm::DenseSet<GenericParamKey> genericParamKeys;
+      for (auto *origGP : origGenSig->getGenericParams())
+        genericParamKeys.insert(GenericParamKey(origGP));
+      for (auto *witnessGP : witnessGenSig->getGenericParams())
+        if (!genericParamKeys.erase(GenericParamKey(witnessGP)))
+          return false;
+      return genericParamKeys.empty();
+    };
+    if (!areGenericParametersConsistent()) {
+      P.diagnose(witnessGenSigStartLoc,
+                 diag::sil_inst_autodiff_invalid_witness_generic_signature,
+                 witnessGenSig->getAsString(), origGenSig->getAsString());
+      return {};
+    }
+    // Combine parsed witness requirements with original function generic
+    // signature requirements to form full witness generic signature.
+    SmallVector<Requirement, 4> witnessRequirements(
+        witnessGenSig->getRequirements().begin(),
+        witnessGenSig->getRequirements().end());
+    witnessGenSig = evaluateOrDefault(
+        P.Context.evaluator,
+        AbstractGenericSignatureRequest{
+            origGenSig.getPointer(),
+            /*addedGenericParams=*/{},
+            std::move(witnessRequirements)},
+            nullptr);
+  }
+  auto origFnType = originalFunction->getLoweredFunctionType();
+  auto *parameterIndexSet = IndexSubset::get(
+      P.Context, origFnType->getNumParameters(), parameterIndices);
+  auto *resultIndexSet = IndexSubset::get(
+      P.Context, origFnType->getNumResults(), resultIndices);
+  AutoDiffConfig config(parameterIndexSet, resultIndexSet, witnessGenSig);
+  return {{config, originalFunction}};
+}
+// SWIFT_ENABLE_TENSORFLOW_END
+
 bool SILParser::parseSILDeclRef(SILDeclRef &Member, bool FnTypeRequired) {
   SourceLoc TyLoc;
   SmallVector<ValueDecl *, 4> values;
@@ -3094,10 +3196,9 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   case SILInstructionKind::DifferentiabilityWitnessFunctionInst: {
     // e.g. differentiability_witness_function
     //      [jvp] [parameters 0 1] [results 0] <T where T: Differentiable>
-    //      @foo : $(T) -> T
+    //      @foo : <T> $(T) -> T
     DifferentiabilityWitnessFunctionKind witnessKind;
     StringRef witnessKindNames[3] = {"jvp", "vjp", "transpose"};
-    SourceLoc lastLoc;
     if (P.parseToken(tok::l_square,
             diag::sil_inst_autodiff_expected_differentiability_witness_kind) ||
         parseSILIdentifierSwitch(witnessKind, witnessKindNames,
@@ -3105,94 +3206,22 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
         P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
                      "differentiability witness function kind"))
       return true;
-    // Parse an index set, prefaced with the given label.
-    auto parseIndexSet = [&](StringRef label, SmallVectorImpl<unsigned> &indices,
-                             const Diagnostic &parseIndexDiag) -> bool {
-      // Parse `[<label> <integer_literal>...]`.
-      if (P.parseToken(tok::l_square, diag::sil_autodiff_expected_lsquare,
-                       "index list") ||
-          P.parseSpecificIdentifier(
-              label, diag::sil_autodiff_expected_index_list_label, label))
-        return true;
-      while (P.Tok.is(tok::integer_literal)) {
-        unsigned index;
-        if (P.parseUnsignedInteger(index, lastLoc, parseIndexDiag))
-          return true;
-        indices.push_back(index);
-      }
-      if (P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
-                       "index list"))
-        return true;
-      return false;
-    };
-    // Parse parameter and result indices.
-    SmallVector<unsigned, 8> parameterIndices;
-    SmallVector<unsigned, 8> resultIndices;
-    if (parseIndexSet("parameters", parameterIndices,
-                      diag::sil_autodiff_expected_parameter_index))
+    SourceLoc keyStartLoc = P.Tok.getLoc();
+    auto configAndFn = parseSILDifferentiabilityWitnessConfigAndFunction(
+        P, *this, InstLoc);
+    if (!configAndFn) {
       return true;
-    if (parseIndexSet("results", resultIndices,
-                      diag::sil_autodiff_expected_result_index))
-      return true;
-    // Parse witness generic parameter clause.
-    GenericSignature witnessGenSig = GenericSignature();
-    SourceLoc witnessGenSigStartLoc = P.getEndOfPreviousLoc();
-    {
-      // Create a new scope to avoid type redefinition errors.
-      Scope genericsScope(&P, ScopeKind::Generics);
-      auto *genericParams = P.parseSILGenericParams().getPtrOrNull();
-      if (genericParams) {
-        auto *witnessGenEnv =
-            handleSILGenericParams(P.Context, genericParams, &P.SF);
-        witnessGenSig = witnessGenEnv->getGenericSignature();
-      }
     }
-    // Parse original function name and type.
-    SILFunction *originalFunction;
-    if (parseSILFunctionRef(InstLoc, originalFunction))
+    auto config = configAndFn->first;
+    auto originalFn = configAndFn->second;
+    auto *witness = SILMod.lookUpDifferentiabilityWitness(
+        {originalFn->getName(), config});
+    if (!witness) {
+      P.diagnose(keyStartLoc, diag::sil_diff_witness_undefined);
       return true;
-    // Resolve parsed witness generic signature.
-    if (witnessGenSig) {
-      auto origGenSig = originalFunction
-          ->getLoweredFunctionType()->getGenericSignature();
-      // Check whether original function generic signature and parsed witness
-      // generic have the same generic parameters.
-      auto areGenericParametersConsistent = [&]() {
-        llvm::DenseSet<GenericParamKey> genericParamKeys;
-        for (auto *origGP : origGenSig->getGenericParams())
-          genericParamKeys.insert(GenericParamKey(origGP));
-        for (auto *witnessGP : witnessGenSig->getGenericParams())
-          if (!genericParamKeys.erase(GenericParamKey(witnessGP)))
-            return false;
-        return genericParamKeys.empty();
-      };
-      if (!areGenericParametersConsistent()) {
-        P.diagnose(witnessGenSigStartLoc,
-                   diag::sil_inst_autodiff_invalid_witness_generic_signature,
-                   witnessGenSig->getAsString(), origGenSig->getAsString());
-        return true;
-      }
-      // Combine parsed witness requirements with original function generic
-      // signature requirements to form full witness generic signature.
-      SmallVector<Requirement, 4> witnessRequirements(
-          witnessGenSig->getRequirements().begin(),
-          witnessGenSig->getRequirements().end());
-      witnessGenSig = evaluateOrDefault(
-          P.Context.evaluator,
-          AbstractGenericSignatureRequest{
-              origGenSig.getPointer(),
-              /*addedGenericParams=*/{},
-              std::move(witnessRequirements)},
-              nullptr);
     }
-    auto origFnType = originalFunction->getLoweredFunctionType();
-    auto *parameterIndexSet = IndexSubset::get(
-        P.Context, origFnType->getNumParameters(), parameterIndices);
-    auto *resultIndexSet = IndexSubset::get(
-        P.Context, origFnType->getNumResults(), resultIndices);
     ResultVal = B.createDifferentiabilityWitnessFunction(
-        InstLoc, originalFunction, witnessKind, parameterIndexSet,
-        resultIndexSet, witnessGenSig);
+        InstLoc, witnessKind, witness);
     break;
   }
   // SWIFT_ENABLE_TENSORFLOW END
@@ -6930,9 +6959,7 @@ bool SILParserTUState::parseSILDefaultWitnessTable(Parser &P) {
 ///   'sil_differentiability_witness'
 ///   ('[' 'serialized' ']')?
 ///   sil-linkage?
-///   '[' 'parameters' index-subset ']'
-///   '[' 'results' index-subset ']'
-///   ('[' 'where' derivatve-generic-signature-requirements ']')?
+///   sil-differentiability-witness-config-and-function
 ///   decl-sil-differentiability-witness-body?
 ///
 /// decl-sil-differentiability-witness-body ::=
@@ -6944,7 +6971,8 @@ bool SILParserTUState::parseSILDefaultWitnessTable(Parser &P) {
 /// index-subset ::=
 ///   [0-9]+ (' ' [0-9]+)*
 bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
-  P.consumeToken(tok::kw_sil_differentiability_witness);
+  auto loc = P.consumeToken(tok::kw_sil_differentiability_witness);
+  auto silLoc = RegularLocation(loc);
   SILParser State(P);
 
   // Parse the linkage.
@@ -6954,9 +6982,11 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
 
   // Parse '[serialized]' flag (optional).
   bool isSerialized = false;
+  SourceLoc serializedTokLoc;
   if (P.Tok.is(tok::l_square) && P.peekToken().is(tok::identifier) &&
       P.peekToken().getText() == "serialized") {
     isSerialized = true;
+    serializedTokLoc = P.Tok.getLoc();
     P.consumeToken(tok::l_square);
     P.consumeToken(tok::identifier);
     if (P.parseToken(tok::r_square, diag::sil_diff_witness_expected_token, "]"))
@@ -6966,117 +6996,29 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
   Scope scope(&P, ScopeKind::TopLevel);
   Scope body(&P, ScopeKind::FunctionBody);
 
-  // Parse a SIL function name.
-  auto parseFunctionName = [&](SILFunction *&fn) -> bool {
-    Identifier name;
-    SILType ty;
-    SourceLoc fnNameLoc = P.Tok.getLoc();
-    // We need to turn on InSILBody to parse the function reference.
-    Lexer::SILBodyRAII tmp(*P.L);
-    GenericEnvironment *ignoredEnv;
-    if ((State.parseGlobalName(name)) ||
-        P.parseToken(tok::colon, diag::expected_sil_colon_value_ref) ||
-        State.parseSILType(ty, ignoredEnv, /*IsFuncDecl*/ true))
-      return true;
+  // We need to turn on InSILBody to parse the function references.
+  Lexer::SILBodyRAII tmp(*P.L);
 
-    // The function doesn't exist yet. Create a zombie forward declaration.
-    auto fnType = ty.getAs<SILFunctionType>();
-    if (!fnType || !ty.isObject()) {
-      P.diagnose(fnNameLoc, diag::expected_sil_function_type);
-      return true;
-    }
-    fn = State.getGlobalNameForReference(name, fnType, fnNameLoc);
-    return false;
-  };
-
-  SourceLoc lastLoc = P.getEndOfPreviousLoc();
-  // Parse an index set, prefaced with the given label.
-  auto parseIndexSet = [&](StringRef label, SmallVectorImpl<unsigned> &indices,
-                           const Diagnostic &parseIndexDiag) -> bool {
-    // Parse `[<label> <integer_literal>...]`.
-    if (P.parseToken(tok::l_square, diag::sil_autodiff_expected_lsquare,
-                     "index list") ||
-        P.parseSpecificIdentifier(
-            label, diag::sil_autodiff_expected_index_list_label, label))
-      return true;
-    while (P.Tok.is(tok::integer_literal)) {
-      unsigned index;
-      if (P.parseUnsignedInteger(index, lastLoc, parseIndexDiag))
-        return true;
-      indices.push_back(index);
-    }
-    if (P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
-                     "index list"))
-      return true;
-    return false;
-  };
-  // Parse parameter and result indices.
-  SmallVector<unsigned, 8> parameterIndices;
-  SmallVector<unsigned, 8> resultIndices;
-  // Parse parameter and result indices.
-  if (parseIndexSet("parameters", parameterIndices,
-                    diag::sil_autodiff_expected_parameter_index))
+  auto configAndFn = parseSILDifferentiabilityWitnessConfigAndFunction(
+      P, State, silLoc);
+  if (!configAndFn) {
     return true;
-  if (parseIndexSet("results", resultIndices,
-                    diag::sil_autodiff_expected_result_index))
-    return true;
-
-  // Parse a trailing 'where' clause (optional).
-  // This represents derivative generic signature requirements.
-  GenericSignature derivativeGenSig = GenericSignature();
-  SourceLoc whereLoc;
-  SmallVector<RequirementRepr, 4> derivativeRequirementReprs;
-  if (P.Tok.is(tok::l_square) && P.peekToken().is(tok::kw_where)) {
-    P.consumeToken(tok::l_square);
-    bool firstTypeInComplete;
-    P.parseGenericWhereClause(whereLoc, derivativeRequirementReprs,
-                              firstTypeInComplete,
-                              /*AllowLayoutConstraints*/ false);
-    if (P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
-                     "where clause"))
-      return true;
   }
-
-  // Parse original function name.
-  SILFunction *originalFn;
-  if (parseFunctionName(originalFn))
-    return true;
-
-  // Resolve derivative requirements.
-  if (!derivativeRequirementReprs.empty()) {
-    SmallVector<Requirement, 4> requirements;
-    auto *whereClause = TrailingWhereClause::create(
-        originalFn->getModule().getASTContext(), whereLoc,
-        derivativeRequirementReprs);
-    SILParser SP(P);
-    SP.convertRequirements(originalFn, whereClause->getRequirements(),
-                           requirements);
-    assert(requirements.size() == derivativeRequirementReprs.size());
-    derivativeGenSig = evaluateOrDefault(
-        P.Context.evaluator,
-        AbstractGenericSignatureRequest{
-            originalFn->getLoweredFunctionType()->getGenericSignature().getPointer(),
-            /*addedGenericParams=*/{},
-            std::move(requirements)},
-            nullptr);
-  }
-
-  auto origFnType = originalFn->getLoweredFunctionType();
-  auto *parameterIndexSet = IndexSubset::get(
-      P.Context, origFnType->getNumParameters(), parameterIndices);
-  auto *resultIndexSet = IndexSubset::get(
-      P.Context, origFnType->getNumResults(), resultIndices);
+  auto config = configAndFn->first;
+  auto originalFn = configAndFn->second;
 
   // If this is just a declaration, create the declaration now and return.
   if (!P.Tok.is(tok::l_brace)) {
     if (isSerialized) {
-      P.diagnose(lastLoc, diag::sil_diff_witness_serialized_declaration);
+      P.diagnose(serializedTokLoc,
+                 diag::sil_diff_witness_serialized_declaration);
       return true;
     }
 
     SILDifferentiabilityWitness::createDeclaration(
         M, linkage ? *linkage : SILLinkage::DefaultForDeclaration, originalFn,
-        parameterIndexSet, resultIndexSet, derivativeGenSig);
+        config.parameterIndices, config.resultIndices,
+        config.derivativeGenericSignature);
     return false;
   }
 
@@ -7093,7 +7035,7 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
       if (P.parseToken(tok::colon, diag::sil_diff_witness_expected_token, ":"))
         return true;
       Scope body(&P, ScopeKind::FunctionBody);
-      if (parseFunctionName(jvp))
+      if (State.parseSILFunctionRef(silLoc, jvp))
         return true;
     }
     // Parse VJP (optional).
@@ -7102,19 +7044,20 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
       if (P.parseToken(tok::colon, diag::sil_diff_witness_expected_token, ":"))
         return true;
       Scope body(&P, ScopeKind::FunctionBody);
-      if (parseFunctionName(vjp))
+      if (State.parseSILFunctionRef(silLoc, vjp))
         return true;
     }
     // Parse '}'.
-    if (P.parseMatchingToken(tok::r_brace, lastLoc, diag::expected_sil_rbrace,
+    SourceLoc rBraceLoc;
+    if (P.parseMatchingToken(tok::r_brace, rBraceLoc, diag::expected_sil_rbrace,
                              lBraceLoc))
       return true;
   }
 
   SILDifferentiabilityWitness::createDefinition(
       M, linkage ? *linkage : SILLinkage::DefaultForDefinition, originalFn,
-      parameterIndexSet, resultIndexSet, derivativeGenSig, jvp, vjp,
-      isSerialized);
+      config.parameterIndices, config.resultIndices,
+      config.derivativeGenericSignature, jvp, vjp, isSerialized);
   return false;
 }
 // SWIFT_ENABLE_TENSORFLOW END

--- a/lib/SIL/SILDifferentiabilityWitness.cpp
+++ b/lib/SIL/SILDifferentiabilityWitness.cpp
@@ -12,6 +12,9 @@
 
 #define DEBUG_TYPE "sil-differentiability-witness"
 
+// SWIFT_ENABLE_TENSORFLOW
+#include "swift/AST/ASTMangler.h"
+// SWIFT_ENABLE_TENSORFLOW_END
 #include "swift/SIL/SILDifferentiabilityWitness.h"
 #include "swift/SIL/SILModule.h"
 
@@ -26,9 +29,12 @@ SILDifferentiabilityWitness *SILDifferentiabilityWitness::createDeclaration(
       derivativeGenSig, /*jvp*/ nullptr, /*vjp*/ nullptr,
       /*isDeclaration*/ true, /*isSerialized*/ false, attribute);
   // Register the differentiability witness in the module.
-  assert(!module.DifferentiabilityWitnessMap.count(diffWitness->getKey()) &&
+  Mangle::ASTMangler mangler;
+  auto mangledKey = mangler.mangleSILDifferentiabilityWitnessKey(
+      diffWitness->getKey());
+  assert(!module.DifferentiabilityWitnessMap.count(mangledKey) &&
          "Cannot create duplicate differentiability witness in a module");
-  module.DifferentiabilityWitnessMap[diffWitness->getKey()] = diffWitness;
+  module.DifferentiabilityWitnessMap[mangledKey] = diffWitness;
   module.getDifferentiabilityWitnessList().push_back(diffWitness);
   return diffWitness;
 }
@@ -43,13 +49,16 @@ SILDifferentiabilityWitness *SILDifferentiabilityWitness::createDefinition(
       derivativeGenSig, jvp, vjp, /*isDeclaration*/ false, isSerialized,
       attribute);
   // Register the differentiability witness in the module.
-  assert(!module.DifferentiabilityWitnessMap.count(diffWitness->getKey()) &&
+  // Register the differentiability witness in the module.
+  Mangle::ASTMangler mangler;
+  auto mangledKey = mangler.mangleSILDifferentiabilityWitnessKey(
+      diffWitness->getKey());
+  assert(!module.DifferentiabilityWitnessMap.count(mangledKey) &&
          "Cannot create duplicate differentiability witness in a module");
-  module.DifferentiabilityWitnessMap[diffWitness->getKey()] = diffWitness;
+  module.DifferentiabilityWitnessMap[mangledKey] = diffWitness;
   module.getDifferentiabilityWitnessList().push_back(diffWitness);
   return diffWitness;
 }
-
 
 SILDifferentiabilityWitnessKey SILDifferentiabilityWitness::getKey() const {
   return std::make_pair(getOriginalFunction()->getName(), getConfig());

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -716,21 +716,22 @@ LinearFunctionExtractInst::LinearFunctionExtractInst(
       extractee(extractee), operands(this, theFunction) {}
 
 SILType DifferentiabilityWitnessFunctionInst::getDifferentiabilityWitnessType(
-    SILModule &module, SILFunction *originalFunction,
-    DifferentiabilityWitnessFunctionKind witnessKind,
-    IndexSubset *parameterIndices, IndexSubset *resultIndices,
-    GenericSignature witnessGenSig) {
-  auto fnTy = originalFunction->getLoweredFunctionType();
+    SILModule &module, DifferentiabilityWitnessFunctionKind witnessKind,
+    SILDifferentiabilityWitness *witness) {
+  auto fnTy = witness->getOriginalFunction()->getLoweredFunctionType();
   CanGenericSignature witnessCanGenSig;
-  if (witnessGenSig)
+  if (auto witnessGenSig = witness->getDerivativeGenericSignature())
     witnessCanGenSig = witnessGenSig->getCanonicalSignature();
+  auto *parameterIndices = witness->getParameterIndices();
+  auto *resultIndices = witness->getResultIndices();
   if (auto derivativeKind = witnessKind.getAsDerivativeFunctionKind()) {
     auto diffFnTy = fnTy->getAutoDiffDerivativeFunctionType(
        parameterIndices, *resultIndices->begin(), *derivativeKind, module.Types,
        LookUpConformanceInModule(module.getSwiftModule()), witnessCanGenSig);
     return SILType::getPrimitiveObjectType(diffFnTy);
   }
-  assert(witnessKind == DifferentiabilityWitnessFunctionKind::Transpose);
+  assert(witnessKind ==
+             DifferentiabilityWitnessFunctionKind::Transpose);
   auto transposeFnTy = fnTy->getAutoDiffTransposeFunctionType(
       parameterIndices, module.Types,
       LookUpConformanceInModule(module.getSwiftModule()), witnessCanGenSig);
@@ -738,15 +739,12 @@ SILType DifferentiabilityWitnessFunctionInst::getDifferentiabilityWitnessType(
 }
 
 DifferentiabilityWitnessFunctionInst::DifferentiabilityWitnessFunctionInst(
-    SILModule &module, SILDebugLocation debugLoc, SILFunction *originalFunction,
+    SILModule &module, SILDebugLocation debugLoc,
     DifferentiabilityWitnessFunctionKind witnessKind,
-    IndexSubset *parameterIndices, IndexSubset *resultIndices,
-    GenericSignature witnessGenSig)
+    SILDifferentiabilityWitness *witness)
     : InstructionBase(debugLoc, getDifferentiabilityWitnessType(
-          module, originalFunction, witnessKind, parameterIndices,
-          resultIndices, witnessGenSig)),
-      originalFunction(originalFunction), witnessKind(witnessKind),
-      config({parameterIndices, resultIndices, witnessGenSig.getPointer()}) {}
+          module, witnessKind, witness)),
+      witnessKind(witnessKind), witness(witness) {}
 // SWIFT_ENABLE_TENSORFLOW END
 
 FunctionRefBaseInst::FunctionRefBaseInst(SILInstructionKind Kind,

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -14,6 +14,9 @@
 #include "swift/SIL/SILModule.h"
 #include "Linker.h"
 #include "swift/AST/GenericEnvironment.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "swift/AST/ASTMangler.h"
+// SWIFT_ENABLE_TENSORFLOW_END
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/FormalLinkage.h"
@@ -572,6 +575,22 @@ lookUpFunctionInVTable(ClassDecl *Class, SILDeclRef Member) {
     return E->Implementation;
 
   return nullptr;
+}
+
+SILDifferentiabilityWitness *
+SILModule::lookUpDifferentiabilityWitness(StringRef name) {
+  auto it = DifferentiabilityWitnessMap.find(name);
+  if (it != DifferentiabilityWitnessMap.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+SILDifferentiabilityWitness *
+SILModule::lookUpDifferentiabilityWitness(SILDifferentiabilityWitnessKey key) {
+  Mangle::ASTMangler mangler;
+  return lookUpDifferentiabilityWitness(
+      mangler.mangleSILDifferentiabilityWitnessKey(key));
 }
 
 void SILModule::registerDeserializationNotificationHandler(

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1269,6 +1269,7 @@ public:
 
   void visitDifferentiabilityWitnessFunctionInst(
       DifferentiabilityWitnessFunctionInst *dwfi) {
+    auto *witness = dwfi->getWitness();
     *this << '[';
     switch (dwfi->getWitnessKind()) {
     case DifferentiabilityWitnessFunctionKind::JVP:
@@ -1282,18 +1283,18 @@ public:
       break;
     }
     *this << "] [parameters";
-    for (auto i : dwfi->getParameterIndices()->getIndices())
+    for (auto i : witness->getParameterIndices()->getIndices())
       *this << ' ' << i;
     *this << "] [results";
-    for (auto i : dwfi->getResultIndices()->getIndices())
+    for (auto i : witness->getResultIndices()->getIndices())
       *this << ' ' << i;
     *this << "] ";
-    if (auto witnessGenSig = dwfi->getWitnessGenericSignature()) {
+    if (auto witnessGenSig = witness->getDerivativeGenericSignature()) {
       auto subPrinter = PrintOptions::printSIL();
       witnessGenSig->print(PrintState.OS, subPrinter);
       *this << " ";
     }
-    printSILFunctionNameAndType(PrintState.OS, dwfi->getOriginalFunction());
+    printSILFunctionNameAndType(PrintState.OS, witness->getOriginalFunction());
   }
   // SWIFT_ENABLE_TENSORFLOW END
 
@@ -2938,14 +2939,14 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
   }
 
   printSILGlobals(PrintCtx, getSILGlobalList());
-  printSILFunctions(PrintCtx, getFunctionList());
-  printSILVTables(PrintCtx, getVTableList());
-  printSILWitnessTables(PrintCtx, getWitnessTableList());
-  printSILDefaultWitnessTables(PrintCtx, getDefaultWitnessTableList());
   // SWIFT_ENABLE_TENSORFLOW
   printSILDifferentiabilityWitnesses(PrintCtx,
                                      getDifferentiabilityWitnessList());
   // SWIFT_ENABLE_TENSORFLOW END
+  printSILFunctions(PrintCtx, getFunctionList());
+  printSILVTables(PrintCtx, getVTableList());
+  printSILWitnessTables(PrintCtx, getWitnessTableList());
+  printSILDefaultWitnessTables(PrintCtx, getDefaultWitnessTableList());
   printSILCoverageMaps(PrintCtx, getCoverageMaps());
   printSILProperties(PrintCtx, getPropertyList());
   
@@ -3183,37 +3184,19 @@ void SILDifferentiabilityWitness::print(
              [&](unsigned index) { OS << index; },
              [&] { OS << ' '; });
   OS << "] ";
-  // ([where ...])?
+  // (<...>)?
   if (auto derivativeGenSig = getDerivativeGenericSignature()) {
-    ArrayRef<Requirement> requirements;
-    SmallVector<Requirement, 4> requirementsScratch;
-    auto *origGenEnv = getOriginalFunction()->getGenericEnvironment();
-    if (derivativeGenSig) {
-      if (origGenEnv) {
-        requirementsScratch = derivativeGenSig->requirementsNotSatisfiedBy(
-            origGenEnv->getGenericSignature());
-        requirements = requirementsScratch;
-      } else {
-        requirements = derivativeGenSig->getRequirements();
-      }
-    }
-    if (!requirements.empty()) {
-      OS << "[where ";
-      auto subPrinter = PrintOptions::printSIL();
-      subPrinter.GenericEnv = origGenEnv;
-      interleave(requirements,
-                 [&](Requirement req) {
-                   req.print(OS, subPrinter);
-                 },
-                 [&] { OS << ", "; });
-      OS << "] ";
-    }
+    auto subPrinter = PrintOptions::printSIL();
+    derivativeGenSig->print(OS, subPrinter);
+    OS << " ";
   }
   // @original-function-name : $original-sil-type
   printSILFunctionNameAndType(OS, getOriginalFunction());
 
-  if (isDeclaration())
+  if (isDeclaration()) {
+    OS << "\n\n";
     return;
+  }
 
   // {
   //   jvp: @jvp-function-name : $jvp-sil-type

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -348,6 +348,27 @@ static SILType getSILType(Type Ty, SILValueCategory Category) {
                                    Category);
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+/// Helper function to find a SILDifferentiabilityWitness, given its mangled
+/// key.
+SILDifferentiabilityWitness *
+SILDeserializer::getSILDifferentiabilityWitnessForReference(
+    StringRef mangledKey) {
+  // Check to see if we have a witness under this key already.
+  auto *witness = SILMod.lookUpDifferentiabilityWitness(mangledKey);
+  if (witness) {
+    return witness;
+  }
+
+  // Otherwise, look for a witness under this key in the module.
+  auto iter = DifferentiabilityWitnessList->find(mangledKey);
+  if (iter == DifferentiabilityWitnessList->end()) {
+    return nullptr;
+  }
+
+  return readDifferentiabilityWitness(*iter);
+}
+
 /// Helper function to find a SILFunction, given its name and type.
 SILFunction *SILDeserializer::getFuncForReference(StringRef name,
                                                   SILType type) {
@@ -1154,14 +1175,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
         scratch, TyID, TyCategory, ValID, /*extractee*/ Attr);
     RawOpCode = (unsigned)SILInstructionKind::LinearFunctionExtractInst;
     break;
-  case SIL_INST_DIFFERENTIABILITY_WITNESS_FUNCTION:
-    SILInstDifferentiabilityWitnessFunctionLayout::readRecord(
-        scratch, /*originalFunctionName*/ ValID, /*witnessKind*/ Attr,
-        /*witnessGenSig*/ ValID2, /*numParams*/ Attr2, /*numResults*/ Attr3,
-        ListOfValues);
-    RawOpCode =
-        (unsigned)SILInstructionKind::DifferentiabilityWitnessFunctionInst;
-    break;
   // SWIFT_ENABLE_TENSORFLOW END
   case SIL_INST_NO_OPERAND:
     SILInstNoOperandLayout::readRecord(scratch, RawOpCode);
@@ -1622,29 +1635,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     break;
   }
   case SILInstructionKind::DifferentiabilityWitnessFunctionInst: {
-    auto originalName = MF->getIdentifierText(ValID);
-    auto *original = getFuncForReference(originalName);
-    assert(original && "Original function must be found");
+    StringRef mangledKey = MF->getIdentifierText(ValID);
+    auto *witness = getSILDifferentiabilityWitnessForReference(mangledKey);
+    assert(witness && "SILDifferentiabilityWitness not found");
     DifferentiabilityWitnessFunctionKind witnessKind(Attr);
-    auto numParameterIndices = Attr2;
-    auto numResultIndices = Attr3;
-    SmallVector<unsigned, 8> parameterAndResultIndices(ListOfValues.begin(),
-                                                       ListOfValues.end());
-    assert(parameterAndResultIndices.size() ==
-               numParameterIndices + numResultIndices &&
-           "Parameter/result indices count mismatch");
-    auto *parameterIndices = IndexSubset::get(
-        MF->getContext(), original->getLoweredFunctionType()->getNumParameters(),
-        ArrayRef<unsigned>(parameterAndResultIndices)
-            .take_front(numParameterIndices));
-    auto *resultIndices = IndexSubset::get(
-        MF->getContext(), original->getLoweredFunctionType()->getNumResults(),
-        ArrayRef<unsigned>(parameterAndResultIndices)
-            .take_back(numResultIndices));
-    auto witnessGenSig = MF->getGenericSignature(ValID2);
     ResultVal = Builder.createDifferentiabilityWitnessFunction(
-        Loc, original, witnessKind, parameterIndices, resultIndices,
-        witnessGenSig);
+        Loc, witnessKind, witness);
     break;
   }
   // SWIFT_ENABLE_TENSORFLOW END
@@ -3459,7 +3455,7 @@ SILDeserializer::readDifferentiabilityWitness(DeclID DId) {
     auto *diffWitness = SILDifferentiabilityWitness::createDeclaration(
         SILMod, *linkage, original, parameterIndices, resultIndices,
         derivativeGenSig);
-    diffWitnessOrOffset.set(diffWitness, /*isFullyDeserialized*/ false);
+    diffWitnessOrOffset.set(diffWitness, /*isFullyDeserialized*/ true);
     return diffWitness;
   }
 

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -117,6 +117,11 @@ namespace swift {
     SILValue getLocalValue(serialization::ValueID Id,
                            SILType Type);
 
+    // SWIFT_ENABLE_TENSORFLOW
+    SILDifferentiabilityWitness *getSILDifferentiabilityWitnessForReference(
+        StringRef mangledKey);
+    // SWIFT_ENABLE_TENSORFLOW_END
+
     SILFunction *getFuncForReference(StringRef Name, SILType Ty);
     SILFunction *getFuncForReference(StringRef Name);
     SILVTable *readVTable(serialization::DeclID);

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -182,7 +182,6 @@ namespace sil_block {
     SIL_INST_LINEAR_FUNCTION,
     SIL_INST_DIFFERENTIABLE_FUNCTION_EXTRACT,
     SIL_INST_LINEAR_FUNCTION_EXTRACT,
-    SIL_INST_DIFFERENTIABILITY_WITNESS_FUNCTION,
     SIL_DIFFERENTIABILITY_WITNESS,
     // SWIFT_ENABLE_TENSORFLOW END
 
@@ -465,16 +464,6 @@ namespace sil_block {
     SILTypeCategoryField,
     ValueIDField,
     BCFixed<1> // extractee
-  >;
-
-  using SILInstDifferentiabilityWitnessFunctionLayout = BCRecordLayout<
-    SIL_INST_DIFFERENTIABILITY_WITNESS_FUNCTION,
-    DeclIDField,             // Original function name
-    BCFixed<2>,              // Witness kind (JVP or VJP or transpose)
-    GenericSignatureIDField, // Witness generic signature
-    BCVBR<8>,                // Number of parameter indices
-    BCVBR<8>,                // Number of result indices
-    BCArray<ValueIDField>    // Parameter and result indices
   >;
   // SWIFT_ENABLE_TENSORFLOW END
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -790,7 +790,6 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(sil_block, SIL_INST_DIFFERENTIABLE_FUNCTION_EXTRACT);
   BLOCK_RECORD(sil_block, SIL_INST_LINEAR_FUNCTION_EXTRACT);
   BLOCK_RECORD(sil_block, SIL_DIFFERENTIABILITY_WITNESS);
-  BLOCK_RECORD(sil_block, SIL_INST_DIFFERENTIABILITY_WITNESS_FUNCTION);
   // SWIFT_ENABLE_TENSORFLOW END
 
   // These layouts can exist in both decl blocks and sil blocks.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1060,21 +1060,17 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   case SILInstructionKind::DifferentiabilityWitnessFunctionInst: {
     auto *dwfi = cast<DifferentiabilityWitnessFunctionInst>(&SI);
-    auto originalFnName = addSILFunctionRef(dwfi->getOriginalFunction());
+    auto *witness = dwfi->getWitness();
+    Mangle::ASTMangler mangler;
+    auto mangledKey = mangler.mangleSILDifferentiabilityWitnessKey(
+        witness->getKey());
     auto rawWitnessKind = (unsigned)dwfi->getWitnessKind();
-    SmallVector<unsigned, 8> parameterAndResultIndices(
-        dwfi->getParameterIndices()->begin(),
-        dwfi->getParameterIndices()->end());
-    parameterAndResultIndices.append(dwfi->getResultIndices()->begin(),
-                                     dwfi->getResultIndices()->end());
-    SILInstDifferentiabilityWitnessFunctionLayout::emitRecord(
-        Out, ScratchRecord,
-        SILAbbrCodes[SILInstDifferentiabilityWitnessFunctionLayout::Code],
-        originalFnName, rawWitnessKind,
-        S.addGenericSignatureRef(dwfi->getWitnessGenericSignature()),
-        dwfi->getParameterIndices()->getNumIndices(),
-        dwfi->getResultIndices()->getNumIndices(),
-        parameterAndResultIndices);
+    SILOneOperandLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneOperandLayout::Code],
+        (unsigned)dwfi->getKind(), rawWitnessKind,
+        S.addTypeRef(dwfi->getType().getASTType()),
+        (unsigned)dwfi->getType().getCategory(),
+        S.addUniquedStringRef(mangledKey));
     break;
   }
   // SWIFT_ENABLE_TENSORFLOW END
@@ -2669,7 +2665,6 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   registerSILAbbr<SILInstLinearFunctionLayout>();
   registerSILAbbr<SILInstDifferentiableFunctionExtractLayout>();
   registerSILAbbr<SILInstLinearFunctionExtractLayout>();
-  registerSILAbbr<SILInstDifferentiabilityWitnessFunctionLayout>();
   // SWIFT_ENABLE_TENSORFLOW END
 
   // Register the abbreviation codes so these layouts can exist in both

--- a/test/AutoDiff/differentiability_witness_function_inst.sil
+++ b/test/AutoDiff/differentiability_witness_function_inst.sil
@@ -10,6 +10,22 @@ sil_stage raw
 import Swift
 import Builtin
 
+sil_differentiability_witness [parameters 0] [results 0] @foo : $@convention(thin) (Float, Float, Float) -> Float
+
+sil_differentiability_witness [parameters 0 1] [results 0] @foo : $@convention(thin) (Float, Float, Float) -> Float
+
+sil_differentiability_witness [parameters 0] [results 0] @bar : $@convention(thin) (Float, Float, Float) -> (Float, Float)
+
+sil_differentiability_witness [parameters 0 1] [results 0 1] @bar : $@convention(thin) (Float, Float, Float) -> (Float, Float)
+
+sil_differentiability_witness [parameters 0] [results 0] <T where T : Differentiable> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T
+
+sil_differentiability_witness [parameters 0 1] [results 0] <T where T : Differentiable> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T
+
+sil_differentiability_witness [parameters 0 1] [results 0] <T where T : Differentiable, T == T.TangentVector> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T
+
+sil_differentiability_witness [parameters 0 1] [results 0] <T where T : Differentiable, T: AdditiveArithmetic> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T
+
 sil @foo : $@convention(thin) (Float, Float, Float) -> Float
 
 sil @bar : $@convention(thin) (Float, Float, Float) -> (Float, Float)

--- a/test/AutoDiff/sil_differentiability_witness.sil
+++ b/test/AutoDiff/sil_differentiability_witness.sil
@@ -66,13 +66,13 @@ bb0(%0 : $*τ_0_0, %1 : $*τ_0_0, %2 : $Float):
   return undef : $@callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float)
 }
 
-sil_differentiability_witness hidden [parameters 0 1] [results 0] [where T : _Differentiable] @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
+sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where τ_0_0 : _Differentiable> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
   jvp: @AD__generic__jvp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : _Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector)
   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : _Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
 }
 
 // CHECK-LABEL: // differentiability witness for generic
-// CHECK: sil_differentiability_witness hidden [parameters 0 1] [results 0] [where T : _Differentiable] @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
+// CHECK: sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where τ_0_0 : _Differentiable> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
 // CHECK:   jvp: @AD__generic__jvp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : _Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector)
 // CHECK:   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : _Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
 // CHECK: }
@@ -122,5 +122,4 @@ sil @externalFn3 : $@convention(thin) (Float) -> Float
 sil_differentiability_witness [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float
 
 // CHECK-LABEL: // differentiability witness for externalFn3
-// CHECK: sil_differentiability_witness [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float
-// CHECK-NOT: {
+// CHECK: sil_differentiability_witness [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float{{[^{]*$}}

--- a/test/AutoDiff/sil_differentiability_witness_silgen.swift
+++ b/test/AutoDiff/sil_differentiability_witness_silgen.swift
@@ -39,7 +39,7 @@ public func bar_jvp<T>(_ x: Float, _ y: T) -> (value: Float, differential: (Floa
 }
 
 // CHECK-LABEL: // differentiability witness for bar<A>(_:_:)
-// CHECK-NEXT: sil_differentiability_witness hidden [parameters 0] [results 0] @$s36sil_differentiability_witness_silgen3baryS2f_xtlF : $@convention(thin) <T> (Float, @in_guaranteed T) -> Float {
+// CHECK-NEXT: sil_differentiability_witness hidden [parameters 0] [results 0] <τ_0_0> @$s36sil_differentiability_witness_silgen3baryS2f_xtlF : $@convention(thin) <T> (Float, @in_guaranteed T) -> Float {
 // CHECK-NEXT:   jvp: @AD__$s36sil_differentiability_witness_silgen3baryS2f_xtlF__jvp_src_0_wrt_0 : $@convention(thin) <τ_0_0> (Float, @in_guaranteed τ_0_0) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // CHECK-NEXT: }
 
@@ -66,7 +66,7 @@ func generic_vjp<T: Differentiable>(_ x: T, _ y: Float) -> (
 }
 
 // CHECK-LABEL: // differentiability witness for generic<A>(_:_:)
-// CHECK-NEXT: sil_differentiability_witness hidden [parameters 0 1] [results 0] [where T : _Differentiable] @$s36sil_differentiability_witness_silgen7genericyxx_SftlF : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
+// CHECK-NEXT: sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where τ_0_0 : _Differentiable> @$s36sil_differentiability_witness_silgen7genericyxx_SftlF : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
 // CHECK-NEXT:   jvp: @AD__$s36sil_differentiability_witness_silgen7genericyxx_SftlF__jvp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : _Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector)
 // CHECK-NEXT:   vjp: @AD__$s36sil_differentiability_witness_silgen7genericyxx_SftlF__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : _Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
 // CHECK-NEXT: }


### PR DESCRIPTION
We want the `DifferentiabilityWitnessFunctionInst` to store a pointer to the witness because this makes the instruction data structure smaller and simpler, and makes misuse (e.g. referencing a witness that's not declared in the SIL module) harder. 

This PR mostly preserves the existing SIL syntax & rules. The changes are:
* `sil_differentiability_witness` declarations are now required to come before `differentiability_witness_function` instructions that reference them, so that we don't have to add "forward declaration" logic for them.
* `sil_differentiability_witness` constraints now look like `<τ_0_0 where τ_0_0 : _Differentiable>` instead of `[where T : _Differentiable]`. This allows me to share parsing logic between the `sil_differentiability_witness` constraints and the `differentiability_witness_function`, which simplifies the code and also avoids a problem [1].

This PR changes the `DifferentiabilityWitnessFunctionInst` serialization format to store the witness mangled name rather than the original function name plus indices and generic constraints.

Detailed outline of changes:
* Datastructure & utility changes:
  * `DifferentiabilityWitnessFunctionInst` now contains a `SILDifferentiabilityWitness*` instead of a pointer to original function, indices, and generic signature. (credit to @dan-zheng, I just copied these changes from his commit)
  * Added functions in `SILModule` for looking up `SILDifferentiabilityWitness*` because parsing and deserialization need to find the right `SILDifferentiabilityWitness*` to put in the inst.
* SIL printing changes:
  * Print `sil_differentiability_witness` declarations before function declarations
  * Print `<T where T ...>` instead of `[where T ...]` in `sil_differentiability_witness` declarations.
* SIL parsing changes:
  * Factor out a common `parseSILDifferentiabilityWitnessConfigAndFunction`, and use this for parsing both `sil_differentiability_witness` and `differentiability_witness_function`. This simplifies the code and avoids the problem [1].
  * When parsing a `differentiability_witness_function`, look for the `SILDifferentiabilityWitness*` in the module.
  * Bugfix in ParseStmt so that it can parse `sil_differentiability_witness` declarations that come at the beginning of the file.
* Serialization changes:
  * Deleted `SILInstDifferentiabilityWitnessFunctionLayout` from the serialization format, because the `DifferentiabilityWitnessFunctionInst` now fits into the `SILOneOperandLayout`.
  * Changed serialization to serialize `DifferentiabilityWitnessFunctionInst` a `SILOneOperandLayout` with the mangled witness name.
  * Changed deserialization to deserialize `DifferentiabilityWitnessFunctionInst` by reading the name and deserializing the corresponding witness.
  * Changed deserialization to treat declaration-only witnesses as "fully deserialized". Otherwise it tries to deserialize them twice and the module doesn't like having duplicate witnesses.

[1] The avoided problem: The previous code for parsing `sil_differentiability_witness` constraints of the form `[where T : _Differentiable]` fails to handle the case where the original function is declaration-only, because the code assumes that there is a generic environment, and declaration-only functions do not have a generic environment. Rather than fixing this code, it seemed better to delete it and use the existing code that parses `differentiability_witness_function` constraints, which does not suffer from this problem.