### PR TITLE
[ClangImporter] Fall back to Swift class names when resolving @class

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3729,6 +3729,28 @@ EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
         /// FIXME: Other type declarations should also be okay?
       }
     }
+
+    // For source compatibility reasons, fall back to the Swift name.
+    //
+    // This is how people worked around not being able to import-as-member onto
+    // Swift types by their ObjC name before the above code to handle ObjCAttr
+    // was added.
+    if (name != nominal->getName())
+      clangName = exportName(nominal->getName());
+
+    lookupResult.clear();
+    lookupResult.setLookupName(clangName);
+    // FIXME: This loop is duplicated from above, but doesn't obviously factor
+    // out in a nice way.
+    if (sema.LookupName(lookupResult, /*Scope=*/nullptr)) {
+      // FIXME: Filter based on access path? C++ access control?
+      for (auto clangDecl : lookupResult) {
+        if (auto objcClass = dyn_cast<clang::ObjCInterfaceDecl>(clangDecl))
+          return EffectiveClangContext(objcClass);
+
+        /// FIXME: Other type declarations should also be okay?
+      }
+    }
   }
 
   return EffectiveClangContext();

--- a/test/ClangImporter/MixedSource/Inputs/import-as-member-swift.h
+++ b/test/ClangImporter/MixedSource/Inputs/import-as-member-swift.h
@@ -1,5 +1,14 @@
 @class Outer;
-
-struct Nested {
-  int value;
+struct NestedInOuter {
+  int a;
 } __attribute((swift_name("Outer.Nested")));
+
+@class OuterByObjCName_ObjC;
+struct NestedInOuterByObjCName {
+  int b;
+} __attribute((swift_name("OuterByObjCName_ObjC.Nested")));
+
+@class OuterBySwiftName_Swift;
+struct NestedInOuterBySwiftName {
+  int c;
+} __attribute((swift_name("OuterBySwiftName_Swift.Nested")));

--- a/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
@@ -124,6 +124,9 @@ void consumeObjCForwardNativeTypeHasDifferentCustomNameClass(ObjCForwardNativeTy
 @class ForwardNativeTypeIsNonObjCClass;
 void consumeForwardNativeTypeIsNonObjCClass(ForwardNativeTypeIsNonObjCClass *_Nonnull obj);
 
+@class ForwardNativeTypeIsUnambiguouslyNonObjCClass;
+void consumeForwardNativeTypeIsUnambiguouslyNonObjCClass(ForwardNativeTypeIsUnambiguouslyNonObjCClass *_Nonnull obj);
+
 SWIFT_CLASS("BOGUS")
 @interface BogusClass
 @end

--- a/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.swift
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.swift
@@ -98,3 +98,7 @@ public class ForwardNativeTypeIsNonObjCClass {
 public class SwiftForwardNativeTypeIsNonObjCClass {
     public init() {}
 }
+
+public class ForwardNativeTypeIsUnambiguouslyNonObjCClass {
+    public init() {}
+}

--- a/test/ClangImporter/MixedSource/import-as-member-swift.swift
+++ b/test/ClangImporter/MixedSource/import-as-member-swift.swift
@@ -2,4 +2,12 @@
 
 @objc internal class Outer {}
 
-_ = Outer.Nested()
+@objc(OuterByObjCName_ObjC)
+internal class OuterByObjCName_Swift {}
+
+@objc(OuterBySwiftName_ObjC)
+internal class OuterBySwiftName_Swift {}
+
+_ = Outer.Nested(a: 1)
+_ = OuterByObjCName_Swift.Nested(b: 2)
+_ = OuterBySwiftName_Swift.Nested(c: 3)

--- a/test/ClangImporter/MixedSource/import-mixed-framework.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework.swift
@@ -60,3 +60,5 @@ consumeObjCForwardNativeTypeHasDifferentCustomNameClass(SwiftForwardNativeTypeHa
 
 consumeForwardNativeTypeIsNonObjCClass(SwiftForwardNativeTypeIsNonObjCClass())
 consumeForwardNativeTypeIsNonObjCClass(ForwardNativeTypeIsNonObjCClass()) // expected-error {{cannot convert value of type 'ForwardNativeTypeIsNonObjCClass' to expected argument type 'SwiftForwardNativeTypeIsNonObjCClass'}}
+
+consumeForwardNativeTypeIsUnambiguouslyNonObjCClass(ForwardNativeTypeIsUnambiguouslyNonObjCClass())


### PR DESCRIPTION
@ChristopherRogers' (good) work in #27682 caught places where the Swift compiler was allowing a `@class` to resolve to a Swift class even if that class had a conflicting Objective-C name, or wasn't intended to be exposed to Objective-C at all. Unfortunately, this broke source compatibility in projects where people were relying on this. Restore that functionality, but only as a fallback; matching the Objective-C name is better than matching the Swift name.

rdar://problem/56681046