### PR TITLE
[ClangImporter] Diagnose bad swift_name attributes better

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -86,6 +86,10 @@ WARNING(unresolvable_clang_decl,none,
         "imported declaration '%0' could not be mapped to '%1'",
         (StringRef, StringRef))
 
+NOTE(unresolvable_clang_decl_is_a_framework_bug,none,
+     "please report this issue to the owners of '%0'",
+     (StringRef))
+
 WARNING(implicit_bridging_header_imported_from_module,none,
         "implicit import of bridging header '%0' via module %1 "
         "is deprecated and will be removed in a later version of Swift",

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -9,6 +9,7 @@ add_swift_host_library(swiftClangImporter STATIC
   ClangAdapter.cpp
   ClangDiagnosticConsumer.cpp
   ClangImporter.cpp
+  ClangSourceBufferImporter.cpp
   DWARFImporter.cpp
   IAMInference.cpp
   ImportDecl.cpp

--- a/lib/ClangImporter/ClangDiagnosticConsumer.h
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.h
@@ -55,18 +55,6 @@ private:
 
   ClangImporter::Implementation &ImporterImpl;
 
-  /// Keeps alive the Clang source managers where diagnostics have been
-  /// reported.
-  ///
-  /// This is a bit of a hack, but LLVM's source manager (and by extension
-  /// Swift's) does not support buffers going away.
-  //
-  // This is not using SmallPtrSet or similar because we need the
-  // IntrusiveRefCntPtr to stay a ref-counting pointer.
-  SmallVector<llvm::IntrusiveRefCntPtr<const clang::SourceManager>, 4>
-    sourceManagersWithDiagnostics;
-  llvm::DenseMap<const llvm::MemoryBuffer *, unsigned> mirroredBuffers;
-
   const clang::IdentifierInfo *CurrentImport = nullptr;
   SourceLoc DiagLoc;
   const bool DumpToStderr;
@@ -81,12 +69,6 @@ public:
     DiagLoc = diagLoc;
     return LoadModuleRAII(*this, name);
   }
-
-  /// Returns a Swift source location that points into a Clang buffer.
-  ///
-  /// This will keep the Clang buffer alive as long as this diagnostic consumer.
-  SourceLoc resolveSourceLocation(const clang::SourceManager &clangSrcMgr,
-                                  clang::SourceLocation clangLoc);
 
   void HandleDiagnostic(clang::DiagnosticsEngine::Level diagLevel,
                         const clang::Diagnostic &info) override;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1844,6 +1844,7 @@ ClangImporter::Implementation::Implementation(
     ASTContext &ctx, const ClangImporterOptions &opts,
     DWARFImporterDelegate *dwarfImporterDelegate)
     : SwiftContext(ctx),
+      BuffersForDiagnostics(ctx.SourceMgr),
       ImportForwardDeclarations(opts.ImportForwardDeclarations),
       InferImportAsMember(opts.InferImportAsMember),
       DisableSwiftBridgeAttr(opts.DisableSwiftBridgeAttr),

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1000,6 +1000,7 @@ ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
       std::make_shared<SwiftNameLookupExtension>(
           importer->Impl.BridgingHeaderLookupTable,
           importer->Impl.LookupTables, importer->Impl.SwiftContext,
+          importer->Impl.getBufferImporterForDiagnostics(),
           importer->Impl.platformAvailability,
           importer->Impl.InferImportAsMember));
 
@@ -1330,7 +1331,8 @@ bool ClangImporter::Implementation::importHeader(
   }
 
   // Finalize the lookup table, which may fail.
-  finalizeLookupTable(*BridgingHeaderLookupTable, getNameImporter());
+  finalizeLookupTable(*BridgingHeaderLookupTable, getNameImporter(),
+                      getBufferImporterForDiagnostics());
 
   // FIXME: What do we do if there was already an error?
   if (!hadError && clangDiags.hasErrorOccurred()) {
@@ -1844,7 +1846,6 @@ ClangImporter::Implementation::Implementation(
     ASTContext &ctx, const ClangImporterOptions &opts,
     DWARFImporterDelegate *dwarfImporterDelegate)
     : SwiftContext(ctx),
-      BuffersForDiagnostics(ctx.SourceMgr),
       ImportForwardDeclarations(opts.ImportForwardDeclarations),
       InferImportAsMember(opts.InferImportAsMember),
       DisableSwiftBridgeAttr(opts.DisableSwiftBridgeAttr),
@@ -1853,6 +1854,7 @@ ClangImporter::Implementation::Implementation(
       IsReadingBridgingPCH(false),
       CurrentVersion(ImportNameVersion::fromOptions(ctx.LangOpts)),
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
+      BuffersForDiagnostics(ctx.SourceMgr),
       platformAvailability(ctx.LangOpts), nameImporter(),
       DWARFImporter(dwarfImporterDelegate) {}
 

--- a/lib/ClangImporter/ClangSourceBufferImporter.cpp
+++ b/lib/ClangImporter/ClangSourceBufferImporter.cpp
@@ -1,0 +1,91 @@
+//===--- ClangSourceBufferImporter.cpp - Map Clang buffers to Swift -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "ClangSourceBufferImporter.h"
+#import "swift/Basic/SourceManager.h"
+#import "clang/Basic/SourceManager.h"
+#import "llvm/Support/MemoryBuffer.h"
+
+using namespace swift;
+using namespace swift::importer;
+
+static SourceLoc findEndOfLine(SourceManager &SM, SourceLoc loc,
+                               unsigned bufferID) {
+  CharSourceRange entireBuffer = SM.getRangeForBuffer(bufferID);
+  CharSourceRange rangeFromLoc{SM, loc, entireBuffer.getEnd()};
+  StringRef textFromLoc = SM.extractText(rangeFromLoc);
+  size_t newlineOffset = textFromLoc.find_first_of({"\r\n\0", 3});
+  if (newlineOffset == StringRef::npos)
+    return entireBuffer.getEnd();
+  return loc.getAdvancedLoc(newlineOffset);
+}
+
+SourceLoc ClangSourceBufferImporter::resolveSourceLocation(
+    const clang::SourceManager &clangSrcMgr,
+    clang::SourceLocation clangLoc) {
+  SourceLoc loc;
+
+  clangLoc = clangSrcMgr.getFileLoc(clangLoc);
+  auto decomposedLoc = clangSrcMgr.getDecomposedLoc(clangLoc);
+  if (decomposedLoc.first.isInvalid())
+    return loc;
+
+  auto buffer = clangSrcMgr.getBuffer(decomposedLoc.first);
+  unsigned mirrorID;
+
+  auto mirrorIter = mirroredBuffers.find(buffer);
+  if (mirrorIter != mirroredBuffers.end()) {
+    mirrorID = mirrorIter->second;
+  } else {
+    std::unique_ptr<llvm::MemoryBuffer> mirrorBuffer{
+      llvm::MemoryBuffer::getMemBuffer(buffer->getBuffer(),
+                                       buffer->getBufferIdentifier(),
+                                       /*RequiresNullTerminator=*/true)
+    };
+    mirrorID = swiftSourceManager.addNewSourceBuffer(std::move(mirrorBuffer));
+    mirroredBuffers[buffer] = mirrorID;
+  }
+  loc = swiftSourceManager.getLocForOffset(mirrorID, decomposedLoc.second);
+
+  auto presumedLoc = clangSrcMgr.getPresumedLoc(clangLoc);
+  if (!presumedLoc.getFilename())
+    return loc;
+  if (presumedLoc.getLine() == 0)
+    return SourceLoc();
+
+  unsigned bufferLineNumber =
+    clangSrcMgr.getLineNumber(decomposedLoc.first, decomposedLoc.second);
+
+  StringRef presumedFile = presumedLoc.getFilename();
+  SourceLoc startOfLine = loc.getAdvancedLoc(-presumedLoc.getColumn() + 1);
+  bool isNewVirtualFile = swiftSourceManager.openVirtualFile(
+      startOfLine, presumedFile, presumedLoc.getLine() - bufferLineNumber);
+  if (isNewVirtualFile) {
+    SourceLoc endOfLine = findEndOfLine(swiftSourceManager, loc, mirrorID);
+    swiftSourceManager.closeVirtualFile(endOfLine);
+  }
+
+  using SourceManagerRef = llvm::IntrusiveRefCntPtr<const clang::SourceManager>;
+  auto iter = std::lower_bound(sourceManagersWithDiagnostics.begin(),
+                               sourceManagersWithDiagnostics.end(),
+                               &clangSrcMgr,
+                               [](const SourceManagerRef &inArray,
+                                  const clang::SourceManager *toInsert) {
+    return std::less<const clang::SourceManager *>()(inArray.get(), toInsert);
+  });
+  if (iter == sourceManagersWithDiagnostics.end() ||
+      iter->get() != &clangSrcMgr) {
+    sourceManagersWithDiagnostics.insert(iter, &clangSrcMgr);
+  }
+
+  return loc;
+}

--- a/lib/ClangImporter/ClangSourceBufferImporter.h
+++ b/lib/ClangImporter/ClangSourceBufferImporter.h
@@ -1,0 +1,64 @@
+//===--- ClangSourceBufferImporter.h - Map Clang buffers over ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_CLANGIMPORTER_CLANGSOURCEBUFFERIMPORTER_H
+#define SWIFT_CLANGIMPORTER_CLANGSOURCEBUFFERIMPORTER_H
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceLoc.h"
+#include "clang/Basic/SourceLocation.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace llvm {
+class MemoryBuffer;
+}
+
+namespace clang {
+class SourceManager;
+}
+
+namespace swift {
+class SourceManager;
+
+namespace importer {
+
+/// A helper class used to keep alive the Clang source managers where
+/// diagnostics have been reported.
+///
+/// This is a bit of a hack, but LLVM's source manager (and by extension
+/// Swift's) does not support buffers going away, so if we want to report
+/// diagnostics in them we have to do it this way.
+class ClangSourceBufferImporter {
+  // This is not using SmallPtrSet or similar because we need the
+  // IntrusiveRefCntPtr to stay a ref-counting pointer.
+  SmallVector<llvm::IntrusiveRefCntPtr<const clang::SourceManager>, 4>
+    sourceManagersWithDiagnostics;
+  llvm::DenseMap<const llvm::MemoryBuffer *, unsigned> mirroredBuffers;
+  SourceManager &swiftSourceManager;
+
+public:
+  explicit ClangSourceBufferImporter(SourceManager &sourceMgr)
+    : swiftSourceManager(sourceMgr) {}
+
+  /// Returns a Swift source location that points into a Clang buffer.
+  ///
+  /// This will keep the Clang buffer alive as long as this object.
+  SourceLoc resolveSourceLocation(const clang::SourceManager &clangSrcMgr,
+                                  clang::SourceLocation clangLoc);
+};
+
+} // end namespace importer
+} // end namespace swift
+
+#endif

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2202,6 +2202,12 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
       SwiftContext.Diags.diagnose(methodLoc, diag::invalid_swift_name_method,
                                   swiftParams.size() < argNames.size(),
                                   swiftParams.size(), argNames.size());
+      ModuleDecl *parentModule = dc->getParentModule();
+      if (parentModule != ImportedHeaderUnit->getParentModule()) {
+        SwiftContext.Diags.diagnose(
+            methodLoc, diag::unresolvable_clang_decl_is_a_framework_bug,
+            parentModule->getName().str());
+      }
     }
     return {Type(), false};
   }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2194,10 +2194,10 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
   if (importedName.hasCustomName() && argNames.size() != swiftParams.size()) {
     // Note carefully: we're emitting a warning in the /Clang/ buffer.
     auto &srcMgr = getClangASTContext().getSourceManager();
-    auto &rawDiagClient = Instance->getDiagnosticClient();
-    auto &diagClient = static_cast<ClangDiagnosticConsumer &>(rawDiagClient);
+    ClangSourceBufferImporter &bufferImporter =
+        getBufferImporterForDiagnostics();
     SourceLoc methodLoc =
-        diagClient.resolveSourceLocation(srcMgr, clangDecl->getLocation());
+        bufferImporter.resolveSourceLocation(srcMgr, clangDecl->getLocation());
     if (methodLoc.isValid()) {
       SwiftContext.Diags.diagnose(methodLoc, diag::invalid_swift_name_method,
                                   swiftParams.size() < argNames.size(),

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1380,15 +1380,18 @@ class SwiftNameLookupExtension : public clang::ModuleFileExtension {
   std::unique_ptr<SwiftLookupTable> &pchLookupTable;
   LookupTableMap &lookupTables;
   ASTContext &swiftCtx;
+  ClangSourceBufferImporter &buffersForDiagnostics;
   const PlatformAvailability &availability;
   const bool inferImportAsMember;
 
 public:
   SwiftNameLookupExtension(std::unique_ptr<SwiftLookupTable> &pchLookupTable,
                            LookupTableMap &tables, ASTContext &ctx,
+                           ClangSourceBufferImporter &buffersForDiagnostics,
                            const PlatformAvailability &avail, bool inferIAM)
       : pchLookupTable(pchLookupTable), lookupTables(tables), swiftCtx(ctx),
-        availability(avail), inferImportAsMember(inferIAM) {}
+        buffersForDiagnostics(buffersForDiagnostics), availability(avail),
+        inferImportAsMember(inferIAM) {}
 
   clang::ModuleFileExtensionMetadata getExtensionMetadata() const override;
   llvm::hash_code hashExtension(llvm::hash_code code) const override;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -18,6 +18,7 @@
 #define SWIFT_CLANG_IMPORTER_IMPL_H
 
 #include "ClangAdapter.h"
+#include "ClangSourceBufferImporter.h"
 #include "ImportEnumInfo.h"
 #include "ImportName.h"
 #include "SwiftLookupTable.h"
@@ -345,6 +346,13 @@ private:
   /// (through the Swift name lookup module file extension).
   LookupTableMap LookupTables;
 
+  /// A helper class used to bring Clang buffers into Swift's SourceManager
+  /// for the purpose of emitting diagnostics.
+  ///
+  /// Listed early so that it gets torn down after the underlying Clang
+  /// instances that also use these buffers.
+  importer::ClangSourceBufferImporter BuffersForDiagnostics;
+
   /// The fake buffer used to import modules.
   ///
   /// \see getNextIncludeLoc
@@ -649,6 +657,10 @@ public:
   
   clang::CodeGenOptions &getClangCodeGenOpts() const {
     return Instance->getCodeGenOpts();
+  }
+
+  importer::ClangSourceBufferImporter &getBufferImporterForDiagnostics() {
+    return BuffersForDiagnostics;
   }
 
   /// Imports the given header contents into the Clang context.

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -520,6 +520,7 @@ public:
 };
 
 namespace importer {
+class ClangSourceBufferImporter;
 class NameImporter;
 
 /// Add the given named declaration as an entry to the given Swift name
@@ -533,7 +534,8 @@ void addMacrosToLookupTable(SwiftLookupTable &table, NameImporter &);
 
 /// Finalize a lookup table, handling any as-yet-unresolved entries
 /// and emitting diagnostics if necessary.
-void finalizeLookupTable(SwiftLookupTable &table, NameImporter &);
+void finalizeLookupTable(SwiftLookupTable &table, NameImporter &,
+                         ClangSourceBufferImporter &buffersForDiagnostics);
 }
 }
 

--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember.apinotes
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember.apinotes
@@ -12,6 +12,8 @@ Functions:
 Typedefs:
 - Name: IAMStruct1APINoteType
   SwiftName: Struct1.NewApiNoteType
+- Name: IAMBadInnerIntAPINotes
+  SwiftName: IAMNonexistent.Inner2
 SwiftVersions:
 - Version: 3
   Globals:

--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
@@ -68,4 +68,12 @@ struct IAMMultipleNested {
 typedef int MNInnerInt __attribute__((swift_name("IAMMultipleNested.Inner")));
 typedef float MNInnerFloat __attribute__((swift_name("IAMMultipleNested.Inner")));
 
+typedef int IAMBadInnerInt
+    __attribute__((swift_name("IAMNonexistent.Inner")));
+// CHECK: ImportAsMember.h:[[@LINE-1]]:{{[0-9]+}}: warning: imported declaration 'IAMBadInnerInt' could not be mapped to 'IAMNonexistent.Inner'
+// CHECK: ImportAsMember.h:[[@LINE-2]]:{{[0-9]+}}: note: please report this issue to the owners of 'ImportAsMember'
+typedef int IAMBadInnerIntAPINotes;
+// CHECK: ImportAsMember.h:[[@LINE-1]]:{{[0-9]+}}: warning: imported declaration 'IAMBadInnerIntAPINotes' could not be mapped to 'IAMNonexistent.Inner2'
+// CHECK: ImportAsMember.h:[[@LINE-2]]:{{[0-9]+}}: note: please report this issue to the owners of 'ImportAsMember'
+
 #endif // IMPORT_AS_MEMBER_H

--- a/test/ClangImporter/attr-swift_name.swift
+++ b/test/ClangImporter/attr-swift_name.swift
@@ -19,11 +19,13 @@ func test(_ i: Int) {
   
   // CHECK: warning: too few parameters in swift_name attribute (expected 2; got 1)
   // CHECK: + (instancetype)g:(id)x outParam:(int *)foo SWIFT_NAME(init(g:));
-
+  // CHECK-NOT: warning:
+  // CHECK: note: please report this issue to the owners of 'ObjCIRExtras'
   // CHECK-NOT: warning:
 
   // CHECK: warning: too few parameters in swift_name attribute (expected 2; got 1)
   // CHECK: + (instancetype)testW:(id)x out:(id *)outObject SWIFT_NAME(ww(_:));
+  // CHECK-NOT: warning:
+  // CHECK: note: please report this issue to the owners of 'ObjCIRExtras'
+  // CHECK-NOT: warning:
 }
-
-// CHECK-NOT: warning:

--- a/test/ClangImporter/attr-swift_name.swift
+++ b/test/ClangImporter/attr-swift_name.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -Xcc -w -typecheck %s 2>&1 | %FileCheck %s
+// RUN: %empty-directory(%t.mcp)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -Xcc -w -typecheck %s -module-cache-path %t.mcp 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/import-as-member.swift
+++ b/test/ClangImporter/import-as-member.swift
@@ -1,5 +1,6 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules %s 2>&1 | %FileCheck %S/Inputs/custom-modules/ImportAsMember.h
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules %s -verify
+// RUN: %empty-directory(%t.mcp)
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules -module-cache-path %t.mcp %s 2>&1 | %FileCheck %S/Inputs/custom-modules/ImportAsMember.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules -module-cache-path %t.mcp %s -verify
 
 import ImportAsMember
 import ImportAsMemberSubmodules

--- a/test/ClangImporter/import-as-member.swift
+++ b/test/ClangImporter/import-as-member.swift
@@ -1,3 +1,4 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules %s 2>&1 | %FileCheck %S/Inputs/custom-modules/ImportAsMember.h
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules %s -verify
 
 import ImportAsMember


### PR DESCRIPTION
1. Set the diagnostic location to where the attribute was written (or to the Clang decl's source, if the attribute came from API notes). This required a bit of reworking in the first commit to make it easier to emit Swift diagnostics in Clang buffers.

2. Add a note to contact the owners of the framework to make it clear that the client of the framework didn't do anything wrong.

rdar://problem/52736145