### PR TITLE
[NFC] Change ValueOwnershipKind::Any to ValueOwnershipKind::None in comments.

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -181,7 +181,7 @@ struct ValueOwnershipKind {
   /// that the two ownership kinds are "compatibile".
   ///
   /// The reason why we do not compare directy is to allow for
-  /// ValueOwnershipKind::Any to merge into other forms of ValueOwnershipKind.
+  /// ValueOwnershipKind::None to merge into other forms of ValueOwnershipKind.
   bool isCompatibleWith(ValueOwnershipKind other) const {
     return merge(other).hasValue();
   }
@@ -449,7 +449,7 @@ struct OperandOwnershipKindMap {
 
   /// Return the OperandOwnershipKindMap that tests for compatibility with
   /// ValueOwnershipKind kind. This means that it will accept a element whose
-  /// ownership is ValueOwnershipKind::Any.
+  /// ownership is ValueOwnershipKind::None.
   static OperandOwnershipKindMap
   compatibilityMap(ValueOwnershipKind kind, UseLifetimeConstraint constraint) {
     OperandOwnershipKindMap set;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5319,7 +5319,7 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
 
     BB = getBBForDefinition(BBName, NameLoc);
     // For now, since we always assume that PhiArguments have
-    // ValueOwnershipKind::Any, do not parse or do anything special. Eventually
+    // ValueOwnershipKind::None, do not parse or do anything special. Eventually
     // we will parse the convention.
     bool IsEntry = BB->isEntry();
 

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -318,7 +318,7 @@ static bool stripOwnership(SILFunction &F) {
   OwnershipModelEliminatorVisitor Visitor(B);
 
   for (auto &BB : F) {
-    // Change all arguments to have ValueOwnershipKind::Any.
+    // Change all arguments to have ValueOwnershipKind::None.
     for (auto *Arg : BB.getArguments()) {
       Arg->setOwnershipKind(ValueOwnershipKind::None);
     }


### PR DESCRIPTION
Follow-up to PR #27879; the renaming there changed the code but missed a few spots in the comments.