### PR TITLE
DestroyHoisting: support of begin_apply and end_apply instructions

### DIFF
--- a/lib/SIL/MemoryLifetime.cpp
+++ b/lib/SIL/MemoryLifetime.cpp
@@ -297,6 +297,7 @@ bool MemoryLocations::analyzeLocationUsesRecursively(SILValue V, unsigned locIdx
       case SILInstructionKind::DestroyAddrInst:
       case SILInstructionKind::ApplyInst:
       case SILInstructionKind::TryApplyInst:
+      case SILInstructionKind::BeginApplyInst:
       case SILInstructionKind::DebugValueAddrInst:
       case SILInstructionKind::CopyAddrInst:
       case SILInstructionKind::YieldInst:

--- a/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
@@ -318,6 +318,10 @@ void DestroyHoisting::getUsedLocationsOfInst(Bits &bits, SILInstruction *I) {
         getUsedLocationsOfAddr(bits, LBI->getOperand());
       }
       break;
+    case SILInstructionKind::EndApplyInst:
+      // Operands passed to begin_apply are alive throughout the end_apply.
+      I = cast<EndApplyInst>(I)->getBeginApply();
+      LLVM_FALLTHROUGH;
     case SILInstructionKind::LoadInst:
     case SILInstructionKind::StoreInst:
     case SILInstructionKind::CopyAddrInst:

--- a/test/SILOptimizer/destroy_hoisting.sil
+++ b/test/SILOptimizer/destroy_hoisting.sil
@@ -209,3 +209,24 @@ bb1:
   destroy_addr %0 : $*Mixed
   return %v : $Int
 }
+
+sil @coro : $@yield_once @convention(thin) (@in S) -> @yields @inout Int
+
+// CHECK-LABEL: sil [ossa] @test_begin_apply
+// CHECK:        end_apply
+// CHECK-NEXT:   destroy_addr %0
+// CHECK-NEXT:   br bb1
+// CHECK:      bb1:
+// CHECK:        return
+sil [ossa] @test_begin_apply : $@convention(thin) (@in S, Int) -> () {
+bb0(%0 : $*S, %1 : $Int):
+  %f = function_ref @coro : $@yield_once @convention(thin) (@in S) -> @yields @inout Int
+  (%i, %t) = begin_apply %f(%0) : $@yield_once @convention(thin) (@in S) -> @yields @inout Int
+  store %1 to [trivial] %i : $*Int
+  end_apply %t
+  br bb1
+bb1:
+  destroy_addr %0 : $*S
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
This enables destroy hoisting when accessor co-routines are not yet inlined.

https://bugs.swift.org/browse/SR-11675
rdar://problem/56704059
