### PR TITLE
SwiftReflectionTest: enable builds on non-Apple targets

### DIFF
--- a/stdlib/private/SwiftReflectionTest/CMakeLists.txt
+++ b/stdlib/private/SwiftReflectionTest/CMakeLists.txt
@@ -9,17 +9,15 @@ if (SWIFT_INCLUDE_TESTS)
     SWIFT_MODULE_DEPENDS_TVOS Darwin
     SWIFT_MODULE_DEPENDS_WATCHOS Darwin
     SWIFT_MODULE_DEPENDS_LINUX Glibc
+    SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
     INSTALL_IN_COMPONENT stdlib-experimental
     DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 
   foreach(SDK ${SWIFT_SDKS})
-    if("${SDK}" IN_LIST SWIFT_APPLE_PLATFORMS)
-      foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
-        set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
-        add_dependencies(
-          "swiftSwiftReflectionTest${VARIANT_SUFFIX}"
-          "swift-reflection-test${VARIANT_SUFFIX}")
-      endforeach()
-    endif()
+    foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
+      set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
+      add_dependencies("swiftSwiftReflectionTest${VARIANT_SUFFIX}"
+        "swift-reflection-test${VARIANT_SUFFIX}")
+    endforeach()
   endforeach()
 endif()


### PR DESCRIPTION
Ensure that the swift-reflection-test binary is built for Windows by
default.  This is preventing tests from executing on Windows.  There are
dependencies which were already specified for Linux even, the tool just
was disabled due to an invalid check.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
