### PR TITLE
swift-stdlib-tool: avoid VLA usage

### DIFF
--- a/tools/swift-stdlib-tool/swift-stdlib-tool.mm
+++ b/tools/swift-stdlib-tool/swift-stdlib-tool.mm
@@ -80,6 +80,7 @@ const char *usage =
 #include <libkern/OSByteOrder.h>
 
 #include <algorithm>
+#include <vector>
 using namespace std;
 
 #include <Foundation/Foundation.h>
@@ -672,9 +673,10 @@ bool operator <= (const struct timespec &lhs, const struct timespec &rhs)
 NSString *self_executable = []() -> NSString * {
     uint32_t len = 0;
     _NSGetExecutablePath(nil, &len);
-    char buf[len];
-    _NSGetExecutablePath(buf, &len);
-    return [[NSString alloc] initWithUTF8String:buf];
+    std::vector<char> buffer;
+    buffer.reserve(len);
+    _NSGetExecutablePath(buffer.data(), &len);
+    return [[NSString alloc] initWithUTF8String:buffer.data()];
 }();
 
 


### PR DESCRIPTION
Replace the use of a VLA with a `std::vector`.  This applies a RAII to
the allocation, and the allocation is a single instance so the malloc
traffic is not a concern.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
