### PR TITLE
Revert "Remove Some Users of -solver-enable-operator-designated-types"

### DIFF
--- a/test/Constraints/add_with_nil.swift
+++ b/test/Constraints/add_with_nil.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -solver-enable-operator-designated-types -solver-disable-shrink -disable-constraint-solver-performance-hacks
 
 func test(_ x: Int) -> Int {
   return x + nil

--- a/test/attr/attr_implements_fp.swift
+++ b/test/attr/attr_implements_fp.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'main()' >%t/main.swift
-// RUN: %target-swiftc_driver -o %t/a.out %s %t/main.swift -Xfrontend -enable-operator-designated-types
+// RUN: %target-swiftc_driver -o %t/a.out %s %t/main.swift -Xfrontend -enable-operator-designated-types -Xfrontend -solver-enable-operator-designated-types
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/attr/attr_implements_serial.swift
+++ b/test/attr/attr_implements_serial.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'client()' >%t/main.swift
-// RUN: %target-build-swift-dylib(%t/%target-library-name(AttrImplFP)) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift -Xfrontend -enable-operator-designated-types
+// RUN: %target-build-swift-dylib(%t/%target-library-name(AttrImplFP)) -module-name AttrImplFP -emit-module -emit-module-path %t/AttrImplFP.swiftmodule %S/attr_implements_fp.swift -Xfrontend -enable-operator-designated-types -Xfrontend -solver-enable-operator-designated-types
 // RUN: %target-build-swift -I %t -o %t/a.out %s %t/main.swift -L %t %target-rpath(%t) -lAttrImplFP
 // RUN: %target-codesign %t/a.out
 // RUN: %target-codesign %t/%target-library-name(AttrImplFP)

--- a/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
+++ b/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -swift-version 4 -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(_ i: Int, _ j: Int) -> Int {

--- a/validation-test/Sema/type_checker_perf/fast/rdar17170728.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17170728.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let i: Int? = 1

--- a/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(strings: [String]) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let _: (Character) -> Bool = { c in

--- a/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test(n: Int) -> Int {

--- a/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let _ = [0].reduce([Int]()) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 let a = 1

--- a/validation-test/Sema/type_checker_perf/fast/rdar31742586.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31742586.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func rdar31742586() -> Double {

--- a/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func rdar32998180(value: UInt16) -> UInt16 {

--- a/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
 // REQUIRES: tools-release,no_asserts
 
 func test() {


### PR DESCRIPTION
This reverts commit 46ae4757d255d6a0d924317cd6100689c62e3f0b.

These all failed in the non-asserts build of the compiler.  Clearly we have more work to do to rip this out entirely.

Resolves rdar://56709951