### PR TITLE
[build-support] Don't build SourceKit-LSP verbosely if verbose is not specified

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -56,11 +56,12 @@ def run_build_script_helper(action, host_target, product, args):
     helper_cmd = [
         script_path,
         action,
-        '--verbose',
         '--package-path', product.source_dir,
         '--build-path', product.build_dir,
         '--configuration', configuration,
         '--toolchain', toolchain_path,
         '--ninja-bin', product.toolchain.ninja,
     ]
+    if args.verbose_build:
+        helper_cmd.append('--verbose')
     shell.call(helper_cmd)


### PR DESCRIPTION
At the moment SourceKit-LSP and IndexstoreDB always build verbosely. However, they should only build `verbose` if `--verbose` is specified in the `build-script` invocation.