### PR TITLE
[code-completion] Suggest module names, and handle module name bases for member completion in type position

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1728,7 +1728,7 @@ public:
       CodeCompletionResultBuilder Builder(Sink,
                                           CodeCompletionResult::ResultKind::
                                           Declaration,
-                                          SemanticContextKind::OtherModule,
+                                          SemanticContextKind::None,
                                           expectedTypeContext);
       auto MD = ModuleDecl::create(Ctx.getIdentifier(Pair.first), Ctx);
       Builder.setAssociatedDecl(MD);
@@ -1771,7 +1771,7 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink,
         CodeCompletionResult::ResultKind::Declaration,
-        SemanticContextKind::OtherModule,
+        SemanticContextKind::None,
         expectedTypeContext);
     Builder.setAssociatedDecl(MD);
     Builder.addTextChunk(MD->getNameStr());

--- a/test/IDE/complete_from_clang_framework.swift
+++ b/test/IDE/complete_from_clang_framework.swift
@@ -340,10 +340,10 @@ func testCompleteInstanceMembers1(fooObject: FooClassDerived) {
 func testExportedModuleCompletion() -> #^TYPE_MODULE_QUALIFIER^# {
   let x = #^EXPR_MODULE_QUALIFIER^#
 // MODULE_QUALIFIER: Begin completions
-// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[swift_ide_test]: swift_ide_test[#Module#]; name=swift_ide_test
-// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[Swift]:    Swift[#Module#]; name=Swift
-// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[Foo]:      Foo[#Module#]; name=Foo
-// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[FooHelper]: FooHelper[#Module#]; name=FooHelper
-// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[Bar]:      Bar[#Module#]; name=Bar
+// MODULE_QUALIFIER-DAG: Decl[Module]/None: swift_ide_test[#Module#]; name=swift_ide_test
+// MODULE_QUALIFIER-DAG: Decl[Module]/None: Swift[#Module#]; name=Swift
+// MODULE_QUALIFIER-DAG: Decl[Module]/None: Foo[#Module#]; name=Foo
+// MODULE_QUALIFIER-DAG: Decl[Module]/None: FooHelper[#Module#]; name=FooHelper
+// MODULE_QUALIFIER-DAG: Decl[Module]/None: Bar[#Module#]; name=Bar
 // MODULE_QUALIFIER: End completions
 }

--- a/test/IDE/complete_from_clang_framework.swift
+++ b/test/IDE/complete_from_clang_framework.swift
@@ -28,6 +28,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=CLANG_CLASS_MEMBERS_2 | %FileCheck %s -check-prefix=CLANG_CLASS_MEMBERS_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=CLANG_INSTANCE_MEMBERS_1 | %FileCheck %s -check-prefix=CLANG_INSTANCE_MEMBERS_1
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=TYPE_MODULE_QUALIFIER | %FileCheck %s -check-prefix=MODULE_QUALIFIER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=EXPR_MODULE_QUALIFIER | %FileCheck %s -check-prefix=MODULE_QUALIFIER
+
 import Foo
 // Don't import FooHelper directly in this test!
 // import FooHelper
@@ -331,4 +334,16 @@ func testCompleteInstanceMembers1(fooObject: FooClassDerived) {
 // CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/Super:         .nonInternalMeth()[#Any!#]
 // CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/Super:         ._internalMeth1()[#Any!#]
 // CLANG_INSTANCE_MEMBERS_1-NOT: Instance
+}
+
+// Check the FooHelper module is suggested even though it's not imported directly
+func testExportedModuleCompletion() -> #^TYPE_MODULE_QUALIFIER^# {
+  let x = #^EXPR_MODULE_QUALIFIER^#
+// MODULE_QUALIFIER: Begin completions
+// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[swift_ide_test]: swift_ide_test[#Module#]; name=swift_ide_test
+// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[Swift]:    Swift[#Module#]; name=Swift
+// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[Foo]:      Foo[#Module#]; name=Foo
+// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[FooHelper]: FooHelper[#Module#]; name=FooHelper
+// MODULE_QUALIFIER-DAG: Decl[Module]/OtherModule[Bar]:      Bar[#Module#]; name=Bar
+// MODULE_QUALIFIER: End completions
 }

--- a/test/IDE/complete_from_swift_module.swift
+++ b/test/IDE/complete_from_swift_module.swift
@@ -62,9 +62,9 @@ import corrupted_module
 func testQualifyingModulesSuggested() -> #^QUALIFYING_MODULE^# {
   let x = #^QUALIFYING_MODULE_2^#
   // QUALIFYING_MODULE: Begin completions
-  // QUALIFYING_MODULE-DAG: Decl[Module]/OtherModule[swift_ide_test]: swift_ide_test[#Module#]; name=swift_ide_test
-  // QUALIFYING_MODULE-DAG: Decl[Module]/OtherModule[Swift]:    Swift[#Module#]; name=Swift
-  // QUALIFYING_MODULE-DAG: Decl[Module]/OtherModule[foo_swift_module]: foo_swift_module[#Module#]; name=foo_swift_module
+  // QUALIFYING_MODULE-DAG: Decl[Module]/None: swift_ide_test[#Module#]; name=swift_ide_test
+  // QUALIFYING_MODULE-DAG: Decl[Module]/None: Swift[#Module#]; name=Swift
+  // QUALIFYING_MODULE-DAG: Decl[Module]/None: foo_swift_module[#Module#]; name=foo_swift_module
   // QUALIFYING_MODULE: End completions
 }
 

--- a/test/IDE/complete_from_swift_module.swift
+++ b/test/IDE/complete_from_swift_module.swift
@@ -4,6 +4,15 @@
 //
 // Note: this test checks both module import case and file import case.
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=QUALIFYING_MODULE > %t.compl.txt
+// RUN: %FileCheck %s -check-prefix=QUALIFYING_MODULE < %t.compl.txt
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=QUALIFYING_MODULE_2 > %t.compl.txt
+// RUN: %FileCheck %s -check-prefix=QUALIFYING_MODULE < %t.compl.txt
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=ALREADY_QUALIFIED > %t.compl.txt
+// RUN: %FileCheck %s -check-prefix=ALREADY_QUALIFIED < %t.compl.txt
+
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=MODULE_QUALIFIED_1 > %t.compl.txt
 // RUN: %FileCheck %s -check-prefix=MODULE_QUALIFIED_1 < %t.compl.txt
 //
@@ -20,6 +29,9 @@
 // RUN: %FileCheck %s -check-prefix=MODULE_QUALIFIED_4 < %t.compl.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=MODULE_QUALIFIED_5 | %FileCheck %s -check-prefix=ERROR_COMMON
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=STDLIB_TYPE_QUALIFIED_NESTED > %t.compl.txt
+// RUN: %FileCheck %s -check-prefix=STDLIB_TYPE_QUALIFIED_NESTED < %t.compl.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=STDLIB_TYPE_QUALIFIED > %t.compl.txt
 // RUN: %FileCheck %s -check-prefix=STDLIB_TYPE_QUALIFIED < %t.compl.txt
@@ -46,6 +58,27 @@
 
 import foo_swift_module
 import corrupted_module
+
+func testQualifyingModulesSuggested() -> #^QUALIFYING_MODULE^# {
+  let x = #^QUALIFYING_MODULE_2^#
+  // QUALIFYING_MODULE: Begin completions
+  // QUALIFYING_MODULE-DAG: Decl[Module]/OtherModule[swift_ide_test]: swift_ide_test[#Module#]; name=swift_ide_test
+  // QUALIFYING_MODULE-DAG: Decl[Module]/OtherModule[Swift]:    Swift[#Module#]; name=Swift
+  // QUALIFYING_MODULE-DAG: Decl[Module]/OtherModule[foo_swift_module]: foo_swift_module[#Module#]; name=foo_swift_module
+  // QUALIFYING_MODULE: End completions
+}
+
+struct SomeStructInThisModule {}
+func testQualifyingModulesNotSuggested() {
+  let x: swift_ide_test.#^ALREADY_QUALIFIED^#;
+  // ALREADY_QUALIFIED: Begin completions
+  // ALREADY_QUALIFIED-NOT: Decl[Module]
+  // ALREADY_QUALIFIED-NOT: name=Type
+  // ALREADY_QUALIFIED: name=SomeStructInThisModule
+  // ALREADY_QUALIFIED-NOT: Decl[Module]
+  // ALREADY_QUALIFIED-NOT: name=Type
+  // ALREADY_QUALIFIED: End completions
+}
 
 var hiddenImport : Int
 // TOP_LEVEL_1_NEGATIVE-NOT: hiddenImport()
@@ -106,11 +139,18 @@ func testPostfixOperator1(x: Int) {
 // TOP_LEVEL_1-DAG: Decl[GlobalVar]/OtherModule[foo_swift_module]:     globalVar[#Int#]{{; name=.+$}}
 // TOP_LEVEL_1: End completions
 
-struct Foo: Swift.Array.#^STDLIB_TYPE_QUALIFIED^# {}
+struct Foo: Swift.Array.#^STDLIB_TYPE_QUALIFIED_NESTED^# {}
+// STDLIB_TYPE_QUALIFIED_NESTED: Begin completions
+// STDLIB_TYPE_QUALIFIED_NESTED: Decl[TypeAlias]/CurrNominal: Index[#Int#]; name=Index
+// STDLIB_TYPE_QUALIFIED_NESTED: Decl[TypeAlias]/CurrNominal: Element[#Element#]; name=Element
+// STDLIB_TYPE_QUALIFIED_NESTED: Keyword/None: Type[#Array.Type#]; name=Type
+// STDLIB_TYPE_QUALIFIED_NESTED: End completions
+
+struct Bar: Swift.#^STDLIB_TYPE_QUALIFIED^# {}
 // STDLIB_TYPE_QUALIFIED: Begin completions
-// STDLIB_TYPE_QUALIFIED: Decl[TypeAlias]/CurrNominal: Index[#Int#]; name=Index
-// STDLIB_TYPE_QUALIFIED: Decl[TypeAlias]/CurrNominal: Element[#Element#]; name=Element
-// STDLIB_TYPE_QUALIFIED: Keyword/None: Type[#Array.Type#]; name=Type
+// STDLIB_TYPE_QUALIFIED-NOT: Decl[Module]
+// STDLIB_TYPE_QUALIFIED: Decl[Struct]/OtherModule[Swift]:    AnyCollection[#AnyCollection#]; name=AnyCollection
+// STDLIB_TYPE_QUALIFIED-NOT: Decl[Module]
 // STDLIB_TYPE_QUALIFIED: End completions
 
 func foo() -> foo_swift_module.#^MODULE_TYPE_QUALIFIED^# {}
@@ -120,5 +160,4 @@ func foo() -> foo_swift_module.#^MODULE_TYPE_QUALIFIED^# {}
 // MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: BarGenericSwiftStruct1[#BarGenericSwiftStruct1#]; name=BarGenericSwiftStruct1
 // MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: FooSwiftStruct[#FooSwiftStruct#]; name=FooSwiftStruct
 // MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: BarGenericSwiftStruct2[#BarGenericSwiftStruct2#]; name=BarGenericSwiftStruct2
-// MODULE_TYPE_QUALIFIED: Keyword/None: Type[#module<foo_swift_module>.Type#]; name=Type
 // MODULE_TYPE_QUALIFIED: End completions

--- a/test/IDE/complete_from_swift_module.swift
+++ b/test/IDE/complete_from_swift_module.swift
@@ -21,6 +21,12 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=MODULE_QUALIFIED_5 | %FileCheck %s -check-prefix=ERROR_COMMON
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=STDLIB_TYPE_QUALIFIED > %t.compl.txt
+// RUN: %FileCheck %s -check-prefix=STDLIB_TYPE_QUALIFIED < %t.compl.txt
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=MODULE_TYPE_QUALIFIED > %t.compl.txt
+// RUN: %FileCheck %s -check-prefix=MODULE_TYPE_QUALIFIED < %t.compl.txt
+
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=POSTFIX_OPERATOR_1 > %t.compl.txt
 // RUN: %FileCheck %s -check-prefix=POSTFIX_OPERATOR_1 < %t.compl.txt
 // RUN: %FileCheck %s -check-prefix=NEGATIVE_POSTFIX_OPERATOR_1 < %t.compl.txt
@@ -99,3 +105,20 @@ func testPostfixOperator1(x: Int) {
 // TOP_LEVEL_1-DAG: Decl[GlobalVar]/Local:     hiddenImport[#Int#]{{; name=.+$}}
 // TOP_LEVEL_1-DAG: Decl[GlobalVar]/OtherModule[foo_swift_module]:     globalVar[#Int#]{{; name=.+$}}
 // TOP_LEVEL_1: End completions
+
+struct Foo: Swift.Array.#^STDLIB_TYPE_QUALIFIED^# {}
+// STDLIB_TYPE_QUALIFIED: Begin completions
+// STDLIB_TYPE_QUALIFIED: Decl[TypeAlias]/CurrNominal: Index[#Int#]; name=Index
+// STDLIB_TYPE_QUALIFIED: Decl[TypeAlias]/CurrNominal: Element[#Element#]; name=Element
+// STDLIB_TYPE_QUALIFIED: Keyword/None: Type[#Array.Type#]; name=Type
+// STDLIB_TYPE_QUALIFIED: End completions
+
+func foo() -> foo_swift_module.#^MODULE_TYPE_QUALIFIED^# {}
+// MODULE_TYPE_QUALIFIED: Begin completions
+// MODULE_TYPE_QUALIFIED: Decl[Protocol]/OtherModule[foo_swift_module]: BarProtocol[#BarProtocol#]; name=BarProtocol
+// MODULE_TYPE_QUALIFIED: Decl[Enum]/OtherModule[foo_swift_module]: MyQuickLookObject[#MyQuickLookObject#]; name=MyQuickLookObject
+// MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: BarGenericSwiftStruct1[#BarGenericSwiftStruct1#]; name=BarGenericSwiftStruct1
+// MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: FooSwiftStruct[#FooSwiftStruct#]; name=FooSwiftStruct
+// MODULE_TYPE_QUALIFIED: Decl[Struct]/OtherModule[foo_swift_module]: BarGenericSwiftStruct2[#BarGenericSwiftStruct2#]; name=BarGenericSwiftStruct2
+// MODULE_TYPE_QUALIFIED: Keyword/None: Type[#module<foo_swift_module>.Type#]; name=Type
+// MODULE_TYPE_QUALIFIED: End completions

--- a/test/IDE/complete_import.swift
+++ b/test/IDE/complete_import.swift
@@ -12,9 +12,9 @@
 import #^CLANG_IMPORT1^#
 
 // CLANG_IMPORT1:	Begin completions
-// CLANG_IMPORT1-DAG:	Decl[Module]/OtherModule[Foo]:                       Foo[#Module#]; name=Foo
-// CLANG_IMPORT1-DAG:	Decl[Module]/OtherModule[FooHelper]:                 FooHelper[#Module#]; name=FooHelper
-// CLANG_IMPORT1-DAG:	Decl[Module]/OtherModule[Bar]:                       Bar[#Module#]; name=Bar
+// CLANG_IMPORT1-DAG:	Decl[Module]/None:       Foo[#Module#]; name=Foo
+// CLANG_IMPORT1-DAG:	Decl[Module]/None: FooHelper[#Module#]; name=FooHelper
+// CLANG_IMPORT1-DAG:	Decl[Module]/None:       Bar[#Module#]; name=Bar
 // CLANG_IMPORT1-NOT:	SwiftShims
 
 import Foo
@@ -22,15 +22,15 @@ import Foo
 import #^CLANG_IMPORT2^#
 
 // CLANG_IMPORT2: Begin completions
-// CLANG_IMPORT2-DAG: Decl[Module]/OtherModule[Foo]/NotRecommended: Foo[#Module#]; name=Foo
-// CLANG_IMPORT2-DAG: Decl[Module]/OtherModule[FooHelper]/NotRecommended: FooHelper[#Module#]; name=FooHelper
-// CLANG_IMPORT2-DAG:	Decl[Module]/OtherModule[Bar]:                       Bar[#Module#]; name=Bar
-// CLANG_IMPORT2-NOT:	SwiftShims
+// CLANG_IMPORT2-DAG: Decl[Module]/None/NotRecommended:       Foo[#Module#]; name=Foo
+// CLANG_IMPORT2-DAG: Decl[Module]/None/NotRecommended: FooHelper[#Module#]; name=FooHelper
+// CLANG_IMPORT2-DAG: Decl[Module]/None:                      Bar[#Module#]; name=Bar
+// CLANG_IMPORT2-NOT: SwiftShims
 
 import Foo.#^CLANG_IMPORT3^#
 
 // CLANG_IMPORT3: Begin completions
-// CLANG_IMPORT3-NEXT: Decl[Module]/OtherModule[FooSub]:   FooSub[#Module#]; name=FooSub
+// CLANG_IMPORT3-NEXT: Decl[Module]/None:   FooSub[#Module#]; name=FooSub
 
 import Foo.FooSub
 
@@ -38,7 +38,7 @@ import Foo.#^CLANG_IMPORT8^#
 
 // FIXME: This should be marked as not recommended, holding for Swift's submodules support.
 // CLANG_IMPORT8: Begin completions
-// CLANG_IMPORT8-NEXT: Decl[Module]/OtherModule[FooSub]:   FooSub[#Module#]; name=FooSub
+// CLANG_IMPORT8-NEXT: Decl[Module]/None:   FooSub[#Module#]; name=FooSub
 
 import Foo#^CLANG_IMPORT4^#
 // CLANG_IMPORT4-NOT: Begin completions

--- a/test/IDE/complete_import_multifile1.swift
+++ b/test/IDE/complete_import_multifile1.swift
@@ -5,7 +5,7 @@
 import #^CLANG_IMPORT1^#
 
 // CLANG_IMPORT1:	Begin completions
-// CLANG_IMPORT1-DAG:	Decl[Module]/OtherModule[Foo]:                       Foo[#Module#]; name=Foo
-// CLANG_IMPORT1-DAG:	Decl[Module]/OtherModule[FooHelper]:                 FooHelper[#Module#]; name=FooHelper
-// CLANG_IMPORT1-DAG:	Decl[Module]/OtherModule[Bar]:                       Bar[#Module#]; name=Bar
+// CLANG_IMPORT1-DAG:	Decl[Module]/None:                       Foo[#Module#]; name=Foo
+// CLANG_IMPORT1-DAG:	Decl[Module]/None:                 FooHelper[#Module#]; name=FooHelper
+// CLANG_IMPORT1-DAG:	Decl[Module]/None:                       Bar[#Module#]; name=Bar
 // CLANG_IMPORT1-NOT:	SwiftShims

--- a/test/SourceKit/CodeComplete/complete_filter_rules.swift
+++ b/test/SourceKit/CodeComplete/complete_filter_rules.swift
@@ -29,19 +29,19 @@ struct TestHideName {
 // RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideKeywords.json -tok=HIDE_KEYWORDS_1 %s -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=HIDE_LET
 func testHideKeyword01() {
   #^HIDE_KEYWORDS_1^#
-// HIDE_LET-NOT: let
+// HIDE_LET-NOT: {{^}}let
 // HIDE_LET: var
-// HIDE_LET-NOT: let
+// HIDE_LET-NOT: {{^}}let
 }
 
 // RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showKeywords.json -tok=HIDE_KEYWORDS_2 %s -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=SHOW_FUNC
 func testHideKeyword02() {
   #^HIDE_KEYWORDS_2^#
-// SHOW_FUNC-NOT: let
+// SHOW_FUNC-NOT: {{^}}let
 // SHOW_FUNC-NOT: var
 // SHOW_FUNC: func
 // SHOW_FUNC-NOT: var
-// SHOW_FUNC-NOT: let
+// SHOW_FUNC-NOT: {{^}}let
 }
 
 // RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideLiterals.json -tok=HIDE_LITERALS_1 %s -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=HIDE_NIL

--- a/test/SourceKit/CodeComplete/complete_requestlimit.swift
+++ b/test/SourceKit/CodeComplete/complete_requestlimit.swift
@@ -32,7 +32,6 @@ func test001() {
 // TOP_LEVEL_0_ALL-NEXT: z
 // TOP_LEVEL_0_ALL-NEXT: A
 // TOP_LEVEL_0_ALL-NEXT: B
-// TOP_LEVEL_0_ALL-NEXT: complete_requestlimit
 // TOP_LEVEL_0_ALL-NEXT: test
 
 // TOP_LEVEL_0_3: let

--- a/test/SourceKit/CodeComplete/complete_requestlimit.swift
+++ b/test/SourceKit/CodeComplete/complete_requestlimit.swift
@@ -32,6 +32,7 @@ func test001() {
 // TOP_LEVEL_0_ALL-NEXT: z
 // TOP_LEVEL_0_ALL-NEXT: A
 // TOP_LEVEL_0_ALL-NEXT: B
+// TOP_LEVEL_0_ALL-NEXT: complete_requestlimit
 // TOP_LEVEL_0_ALL-NEXT: test
 
 // TOP_LEVEL_0_3: let

--- a/test/SourceKit/CodeComplete/complete_sort_order.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order.swift
@@ -33,8 +33,6 @@ func test() {
 // CONTEXT: key.kind: source.lang.swift.decl
 // CONTEXT-NEXT: key.name: "x"
 // CONTEXT-NOT: key.name:
-// CONTEXT: key.name: "complete_sort_order",
-// CONTEXT-NOT: key.name:
 // CONTEXT: key.name: "foo(a:)"
 // CONTEXT-NOT: key.name:
 // CONTEXT: key.name: "foo(a:)"
@@ -43,6 +41,7 @@ func test() {
 // CONTEXT-NOT: key.name:
 // CONTEXT: key.name: "test()"
 // CONTEXT: key.name: "#column"
+// CONTEXT: key.name: "complete_sort_order"
 
 // RUN: %complete-test -tok=STMT_0 %s | %FileCheck %s -check-prefix=STMT
 func test1() {

--- a/test/SourceKit/CodeComplete/complete_sort_order.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order.swift
@@ -33,6 +33,8 @@ func test() {
 // CONTEXT: key.kind: source.lang.swift.decl
 // CONTEXT-NEXT: key.name: "x"
 // CONTEXT-NOT: key.name:
+// CONTEXT: key.name: "complete_sort_order",
+// CONTEXT-NOT: key.name:
 // CONTEXT: key.name: "foo(a:)"
 // CONTEXT-NOT: key.name:
 // CONTEXT: key.name: "foo(a:)"


### PR DESCRIPTION
Previous we didn't suggest modules for top-level completions, and for module type member completions we would just return if the parsed type loc didn't type-check as a type.

Resolves rdar://problem/56800640
Resolved rdar://problem/56801340