### PR TITLE
stdlib: remove usage of GNU extensions in the Darwin os module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,7 +455,7 @@ if(MSVC OR "${CMAKE_SIMULATE_ID}" STREQUAL MSVC)
   include(ClangClCompileRules)
 endif()
 
-if(CMAKE_C_COMPILER_ID STREQUAL Clang)
+if(CMAKE_C_COMPILER_ID MATCHES Clang)
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror=gnu>)
 endif()
 

--- a/stdlib/public/Darwin/os/os.m
+++ b/stdlib/public/Darwin/os/os.m
@@ -33,7 +33,7 @@ typedef struct os_log_pack_s {
     const void     *olp_mh;
     const void     *olp_pc;
     const char     *olp_format;
-    uint8_t         olp_data[0];
+    uint8_t         olp_data[];
 } os_log_pack_s, *os_log_pack_t;
 
 API_AVAILABLE(macosx(10.12.4), ios(10.3), tvos(10.2), watchos(3.2))


### PR DESCRIPTION
Remove the gratuitous use of the GNU extensions to implement the OS logging
module.  This allows us to enable `-Werror=gnu` globally, even on macOS builds.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
