### PR TITLE
Reactivate libdispatch tests on Linux

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1021,7 +1021,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'w
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 
     libdispatch_artifact_dir = config.libdispatch_build_path
-    libdispatch_swift_module_dir = make_path(libdispatch_artifact_dir, 'src', 'swift')
+    libdispatch_swift_module_dir = make_path(libdispatch_artifact_dir, 'src', 'swift', 'swift')
     libdispatch_artifacts = [
         make_path(libdispatch_artifact_dir, 'libdispatch.so'),
         make_path(libdispatch_artifact_dir, 'libswiftDispatch.so'),

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1020,16 +1020,16 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'w
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 
-    libdispatch_artifact_dir = make_path(config.libdispatch_build_path, 'src')
+    libdispatch_artifact_dir = config.libdispatch_build_path
+    libdispatch_swift_module_dir = make_path(libdispatch_artifact_dir, 'src', 'swift')
     libdispatch_artifacts = [
         make_path(libdispatch_artifact_dir, 'libdispatch.so'),
         make_path(libdispatch_artifact_dir, 'libswiftDispatch.so'),
-        make_path(libdispatch_artifact_dir, 'swift', 'Dispatch.swiftmodule')]
+        make_path(libdispatch_swift_module_dir, 'Dispatch.swiftmodule')]
     if (all(os.path.exists(p) for p in libdispatch_artifacts)):
         config.available_features.add('libdispatch')
         config.libdispatch_artifact_dir = libdispatch_artifact_dir
         libdispatch_source_dir = make_path(config.swift_src_root, os.pardir, 'swift-corelibs-libdispatch')
-        libdispatch_swift_module_dir = make_path(libdispatch_artifact_dir, 'swift')
         config.import_libdispatch = ('-I %s -I %s -L %s'
             % (libdispatch_source_dir, libdispatch_swift_module_dir, libdispatch_artifact_dir))
 


### PR DESCRIPTION
The swift-corelibs-libdispatch project had its build directory layout
changed [1] which silently deactivated the libdispatch tests on Linux,
because we use hard-coded paths to look for the required libdispatch
artifacts.  This change adapts the paths to the new layout.

Thanks to Jordan Rose for noticing and diagnosing this [2].
SR-11568

[2] https://bugs.swift.org/browse/SR-11568
[1] https://github.com/apple/swift-corelibs-libdispatch/pull/515
