### PR TITLE
[OSLogOptimization][stdlib/private] Make string interpolation methods of OSLogMessage constant evaluable 

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -408,10 +408,16 @@ NOTE(constexpr_unsupported_instruction_found_here,none, "operation"
 
 NOTE(constexpr_found_callee_with_no_body, none,
     "encountered call to '%0' whose body is not available. "
-    "Imported functions must be marked '@inlinable' to constant evaluate.",
+    "Imported functions must be marked '@inlinable' to constant evaluate",
     (StringRef))
 NOTE(constexpr_callee_with_no_body, none,
     "%select{|calls a }0function whose body is not available", (bool))
+
+NOTE(constexpr_found_call_with_unknown_arg, none,
+    "encountered call to '%0' where the %1 argument is not a constant",
+    (StringRef, StringRef))
+NOTE(constexpr_call_with_unknown_arg, none,
+    "%select{|makes a }0function call with non-constant arguments", (bool))
 
 NOTE(constexpr_untracked_sil_value_use_found, none,
     "encountered use of a variable not tracked by the evaluator", ())
@@ -509,24 +515,23 @@ NOTE(try_branch_doesnt_yield, none, "missing yield when error is "
 
 // OS log optimization diagnostics.
 
-ERROR(oslog_message_argument_not_found, none, "no argument of type %0 in "
-  " the os log call", (Identifier))
+ERROR(oslog_non_const_interpolation_options, none, "interpolation arguments "
+      "like format and privacy options must be constants", ())
 
-ERROR(oslog_dynamic_message, none, "os log methods must be passed a string "
-      "interpolation literal. 'OSLogMessage' must not be constructed explicitly",
-      ())
+ERROR(oslog_const_evaluable_fun_error, none, "evaluation of constant-evaluable "
+      "function '%0' failed", (StringRef))
 
-ERROR(oslog_const_evaluation_error, none, "constant evaluating 'OSLogMessage'"
-  "implementation failed.", ())
+ERROR(oslog_fail_stop_error, none, "constant evaluation of log call failed "
+      "with fatal error", ())
 
-ERROR(oslog_non_constant_message, none, "'OSLogMessage' struct is "
-      "unoptimizable: 'init' is not constant evaluable", ())
+ERROR(oslog_non_constant_message, none, "'OSLogMessage' instance passed to the "
+      "log call is not a constant", ())
 
-ERROR(oslog_non_constant_interpolation, none, "'OSLogInterpolation' struct is "
-      "unoptimizable: 'init' is not constant evaluable", ())
+ERROR(oslog_non_constant_interpolation, none, "'OSLogInterpolation' instance "
+      "passed to 'OSLogMessage.init' is not a constant", ())
 
 ERROR(oslog_property_not_constant, none, "'OSLogInterpolation.%0' is not a "
-      "constant: formatting and privacy options must be literals", (StringRef))
+      "constant", (StringRef))
 
 ERROR(global_string_pointer_on_non_constant, none, "globalStringTablePointer "
       "builtin must used only on string literals", ())

--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -187,11 +187,6 @@ public:
 
   Optional<SymbolicValue> lookupConstValue(SILValue value);
 
-  /// Returns true if and only if `errorVal` denotes an error that requires
-  /// aborting interpretation and returning the error. Skipping an instruction
-  /// that produces such errors is not a valid behavior.
-  bool isFailStopError(SymbolicValue errorVal);
-
   /// Return the number of instructions evaluated for the last `evaluate`
   /// operation. This could be used by the clients to limit the number of
   /// instructions that should be evaluated by the step-wise evaluator.
@@ -212,7 +207,18 @@ public:
   void dumpState();
 };
 
+bool isConstantEvaluable(SILFunction *fun);
+
+/// Return true if and only if the given function \p fun is specially modeled
+/// by the constant evaluator. These are typically functions in the standard
+/// library, such as String.+=, Array.append, whose semantics is built into the
+/// evaluator.
 bool isKnownConstantEvaluableFunction(SILFunction *fun);
+
+/// Return true if and only if \p errorVal denotes an error that requires
+/// aborting interpretation and returning the error. Skipping an instruction
+/// that produces such errors is not a valid behavior.
+bool isFailStopError(SymbolicValue errorVal);
 
 } // end namespace swift
 #endif

--- a/stdlib/private/OSLog/OSLogIntegerTypes.swift
+++ b/stdlib/private/OSLog/OSLogIntegerTypes.swift
@@ -29,7 +29,8 @@ extension OSLogInterpolation {
   ///    enum `IntFormat`.
   ///  - privacy: a privacy qualifier which is either private or public.
   ///    The default is public.
-  @_transparent
+  @_semantics("constant_evaluable")
+  @inlinable
   @_optimize(none)
   public mutating func appendInterpolation(
     _ number: @autoclosure @escaping () -> Int,
@@ -46,7 +47,8 @@ extension OSLogInterpolation {
   ///    enum `IntFormat`.
   ///  - privacy: a privacy qualifier which is either private or public.
   ///    The default is public.
-  @_transparent
+  @_semantics("constant_evaluable")
+  @inlinable
   @_optimize(none)
   public mutating func appendInterpolation(
     _ number: @autoclosure @escaping () -> Int32,
@@ -59,9 +61,9 @@ extension OSLogInterpolation {
   /// Given an integer, create and append a format specifier for the integer to the
   /// format string property. Also, append the integer along with necessary headers
   /// to the OSLogArguments property.
-  @_transparent
+  @_semantics("constant_evaluable")
+  @inlinable
   @_optimize(none)
-  @usableFromInline
   internal mutating func appendInteger<T>(
     _ number: @escaping () -> T,
     format: IntFormat,
@@ -83,9 +85,9 @@ extension OSLogInterpolation {
 
   /// Update preamble and append argument headers based on the parameters of
   /// the interpolation.
-  @_transparent
+  @_semantics("constant_evaluable")
+  @inlinable
   @_optimize(none)
-  @usableFromInline
   internal mutating func addIntHeaders(_ isPrivate: Bool, _ byteCount: Int) {
     // Append argument header.
     let argumentHeader = getArgumentHeader(isPrivate: isPrivate, type: .scalar)
@@ -139,7 +141,9 @@ extension OSLogArguments {
   /// Append an (autoclosured) interpolated expression of integer type, passed to
   /// `OSLogMessage.appendInterpolation`, to the array of closures tracked
   /// by this instance.
-  @usableFromInline
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
   internal mutating func append<T>(
     _ value: @escaping () -> T
   ) where T: FixedWidthInteger {

--- a/stdlib/private/OSLog/OSLogMessage.swift
+++ b/stdlib/private/OSLog/OSLogMessage.swift
@@ -180,24 +180,13 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
   // constant evaluation and folding. Note that these methods will be inlined,
   // constant evaluated/folded and optimized in the context of a caller.
 
-  @_transparent
+  @_semantics("oslog.interpolation.init")
+  @_semantics("constant_evaluable")
+  @inlinable
   @_optimize(none)
   public init(literalCapacity: Int, interpolationCount: Int) {
-    // Since the format string is fully constructed at compile time,
-    // the parameter `literalCapacity` is ignored.
-    formatString = ""
-    arguments = OSLogArguments(capacity: interpolationCount)
-    preamble = 0
-    argumentCount = 0
-    totalBytesForSerializingArguments = 0
-  }
-
-  /// An internal initializer that should be used only when there are no
-  /// interpolated expressions. This function must be constant evaluable.
-  @inlinable
-  @_semantics("constant_evaluable")
-  @_optimize(none)
-  internal init() {
+    // Since the format string and the arguments array are fully constructed
+    // at compile time, the parameters are ignored.
     formatString = ""
     arguments = OSLogArguments()
     preamble = 0
@@ -205,7 +194,8 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
     totalBytesForSerializingArguments = 0
   }
 
-  @_transparent
+  @_semantics("constant_evaluable")
+  @inlinable
   @_optimize(none)
   public mutating func appendLiteral(_ literal: String) {
     formatString += literal.percentEscapedString
@@ -305,7 +295,7 @@ public struct OSLogMessage :
   @_semantics("oslog.message.init_stringliteral")
   @_semantics("constant_evaluable")
   public init(stringLiteral value: String) {
-    var s = OSLogInterpolation()
+    var s = OSLogInterpolation(literalCapacity: 1, interpolationCount: 0)
     s.appendLiteral(value)
     self.interpolation = s
   }
@@ -340,23 +330,18 @@ internal struct OSLogArguments {
   internal var argumentClosures: [(inout ByteBufferPointer,
     inout StorageObjects) -> ()]
 
-  /// This function must be constant evaluable.
-  @inlinable
   @_semantics("constant_evaluable")
+  @inlinable
   @_optimize(none)
   internal init() {
     argumentClosures = []
   }
 
-  @usableFromInline
-  internal init(capacity: Int) {
-    argumentClosures = []
-    argumentClosures.reserveCapacity(capacity)
-  }
-
   /// Append a byte-sized header, constructed by
   /// `OSLogMessage.appendInterpolation`, to the tracked array of closures.
-  @usableFromInline
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
   internal mutating func append(_ header: UInt8) {
     argumentClosures.append({ (position, _) in
       serialize(header, at: &position)

--- a/stdlib/private/OSLog/OSLogStringTypes.swift
+++ b/stdlib/private/OSLog/OSLogStringTypes.swift
@@ -32,7 +32,8 @@ extension OSLogInterpolation {
   ///  - argumentString: the interpolated expression of type String, which is autoclosured.
   ///  - privacy: a privacy qualifier which is either private or public. Default is private.
   ///  TODO: create a specifier to denote auto-inferred privacy level and make it default.
-  @_transparent
+  @_semantics("constant_evaluable")
+  @inlinable
   @_optimize(none)
   public mutating func appendInterpolation(
     _ argumentString: @autoclosure @escaping () -> String,
@@ -50,9 +51,9 @@ extension OSLogInterpolation {
 
   /// Update preamble and append argument headers based on the parameters of
   /// the interpolation.
-  @_transparent
+  @_semantics("constant_evaluable")
+  @inlinable
   @_optimize(none)
-  @usableFromInline
   internal mutating func addStringHeaders(_ isPrivate: Bool) {
     // Append argument header.
     let header = getArgumentHeader(isPrivate: isPrivate, type: .string)
@@ -87,7 +88,9 @@ extension OSLogArguments {
   /// Append an (autoclosured) interpolated expression of String type, passed to
   /// `OSLogMessage.appendInterpolation`, to the array of closures tracked
   /// by this instance.
-  @usableFromInline
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
   internal mutating func append(_ value: @escaping () -> String) {
     argumentClosures.append({ serialize(value(), at: &$0, using: &$1) })
   }

--- a/test/SILOptimizer/OSLogConstantEvaluableTest.swift
+++ b/test/SILOptimizer/OSLogConstantEvaluableTest.swift
@@ -24,15 +24,13 @@ func osLogMessageStringLiteralInitTest() -> OSLogMessage {
   return "A string literal"
 }
 
-// CHECK-LABEL: @isPrivate(Privacy) -> Bool
+// CHECK-LABEL: @init(literalCapacity: Int, interpolationCount: Int) -> OSLogInterpolation
 // CHECK-NOT: error:
-// CHECK-LABEL: @getIntegerFormatSpecifier<A where A: FixedWidthInteger>(A.Type, IntFormat, Bool) -> String
+// CHECK-LABEL: @appendLiteral(String) -> ()
 // CHECK-NOT: error:
-// CHECK-LABEL: @sizeForEncoding<A where A: FixedWidthInteger>(A.Type) -> Int
+// CHECK-LABEL: @appendInterpolation(_: @autoclosure () -> Int, format: IntFormat, privacy: Privacy) -> ()
 // CHECK-NOT: error:
-// CHECK-LABEL: @getArgumentHeader(isPrivate: Bool, type: ArgumentType) -> UInt8
-// CHECK-NOT: error:
-// CHECK-LABEL: @getUpdatedPreamble(isPrivate: Bool, isScalar: Bool) -> UInt8
+// CHECK-LABEL: @appendLiteral(String) -> ()
 // CHECK-NOT: error:
 // CHECK-LABEL: @init(stringInterpolation: OSLogInterpolation) -> OSLogMessage
 // CHECK-NOT: error:
@@ -41,9 +39,9 @@ func intValueInterpolationTest() -> OSLogMessage {
   return "An integer value \(10)"
 }
 
-// CHECK-LABEL: @getStringFormatSpecifier(Bool) -> String
+// CHECK-LABEL: @init(literalCapacity: Int, interpolationCount: Int) -> OSLogInterpolation
 // CHECK-NOT: error:
-// CHECK-LABEL: @sizeForEncoding() -> Int
+// CHECK-LABEL: @appendInterpolation(_: @autoclosure () -> String, privacy: Privacy) -> ()
 // CHECK-NOT: error:
 @_semantics("test_driver")
 func stringValueInterpolationTest() -> OSLogMessage {

--- a/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
@@ -20,13 +20,13 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
   func testNonconstantFormatOption(h: Logger, formatOpt: IntFormat) {
     h.log(level: .debug, "Minimum integer value: \(Int.min, format: formatOpt)")
-    // expected-error @-1 {{'OSLogInterpolation.formatString' is not a constant: formatting and privacy options must be literals}}
+    // expected-error @-1 {{interpolation arguments like format and privacy options must be constants}}
     // expected-error @-2 {{globalStringTablePointer builtin must used only on string literals}}
   }
 
   func testNonconstantPrivacyOption(h: Logger,  privacyOpt: Privacy) {
     h.log(level: .debug, "Minimum integer value: \(Int.min, privacy: privacyOpt)")
-    // expected-error @-1 {{'OSLogInterpolation.formatString' is not a constant: formatting and privacy options must be literals}}
+    // expected-error @-1 {{interpolation arguments like format and privacy options must be constants}}
     // expected-error @-2 {{globalStringTablePointer builtin must used only on string literals}}
   }
 

--- a/test/SILOptimizer/constant_evaluable_subset_test.swift
+++ b/test/SILOptimizer/constant_evaluable_subset_test.swift
@@ -253,7 +253,7 @@ internal func interpretInvalidSingedUnsignedConversions() -> UInt64 {
 @_semantics("constant_evaluable")
 internal func testIO() -> String? {
   return readLine()
-    // CHECK: note: encountered call to 'Swift.readLine(strippingNewline: Swift.Bool) -> Swift.Optional<Swift.String>' whose body is not available
+    // CHECK: note: encountered call to 'readLine(strippingNewline:)' whose body is not available
     // CHECK: note: function whose body is not available
 }
 

--- a/test/SILOptimizer/constant_evaluator_test.sil
+++ b/test/SILOptimizer/constant_evaluator_test.sil
@@ -464,7 +464,7 @@ bb0:
   // function_ref readLine(strippingNewline:)
   %2 = function_ref @$ss8readLine16strippingNewlineSSSgSb_tF : $@convention(thin) (Bool) -> @owned Optional<String>
   %3 = apply %2(%1) : $@convention(thin) (Bool) -> @owned Optional<String>
-    // CHECK: {{.*}}:[[@LINE-1]]:{{.*}}: note: encountered call to 'Swift.readLine(strippingNewline: Swift.Bool) -> Swift.Optional<Swift.String>' whose body is not available
+    // CHECK: {{.*}}:[[@LINE-1]]:{{.*}}: note: encountered call to 'readLine(strippingNewline:)' whose body is not available
   release_value %3 : $Optional<String>
   %5 = tuple ()
   return %5 : $()

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -22,9 +22,9 @@ func test_assertionFailure() {
 
 func test_nonConstant() {
   #assert(isOne(Int(readLine()!)!)) // expected-error{{#assert condition not constant}}
-    // expected-note@-1 {{cannot evaluate expression as constant here}}
+    // expected-note@-1 {{encountered call to 'isOne(_:)' where the 1st argument is not a constant}}
   #assert(isOne(Int(readLine()!)!), "input is not 1") // expected-error{{#assert condition not constant}}
-    // expected-note@-1 {{cannot evaluate expression as constant here}}
+    // expected-note@-1 {{encountered call to 'isOne(_:)' where the 1st argument is not a constant}}
 }
 
 func loops1(a: Int) -> Int {
@@ -445,7 +445,7 @@ struct SPsimp : ProtoSimple {
 func testStructPassedAsProtocols() {
   let s = SPsimp()
   #assert(callProtoSimpleMethod(s) == 0) // expected-error {{#assert condition not constant}}
-    // expected-note@-1 {{cannot evaluate top-level value as constant here}}
+    // expected-note@-1 {{encountered call to 'callProtoSimpleMethod(_:)' where the 1st argument is not a constant}}
 }
 
 //===----------------------------------------------------------------------===//
@@ -634,13 +634,13 @@ func evaluate(intExpr: IntExpr) -> Int {
 
 // TODO: The constant evaluator can't handle indirect enums yet.
 // expected-error @+2 {{#assert condition not constant}}
-// expected-note @+1 {{encountered operation not supported by the evaluator}}
+// expected-note @+1 {{encountered call to 'evaluate(intExpr:)' where the 1st argument is not a constant}}
 #assert(evaluate(intExpr: .int(5)) == 5)
 // expected-error @+2 {{#assert condition not constant}}
-// expected-note @+1 {{encountered operation not supported by the evaluator}}
+// expected-note @+1 {{encountered call to 'evaluate(intExpr:)' where the 1st argument is not a constant}}
 #assert(evaluate(intExpr: .add(.int(5), .int(6))) == 11)
 // expected-error @+2 {{#assert condition not constant}}
-// expected-note @+1 {{encountered operation not supported by the evaluator}}
+// expected-note @+1 {{encountered call to 'evaluate(intExpr:)' where the 1st argument is not a constant}}
 #assert(evaluate(intExpr: .add(.multiply(.int(2), .int(2)), .int(3))) == 7)
 
 // Test address-only enums.
@@ -688,7 +688,7 @@ func arrayInitEmptyTopLevel() {
 func arrayInitEmptyLiteralTopLevel() {
   // TODO: More work necessary for array initialization using literals to work
   // at the top level.
-  // expected-note@+1 {{cannot evaluate expression as constant here}}
+  // expected-note@+1 {{encountered call to 'ContainsArray.init(x:arr:)' where the 2nd argument is not a constant}}
   let c = ContainsArray(x: 1, arr: [])
   // expected-error @+1 {{#assert condition not constant}}
   #assert(c.x == 1)
@@ -697,14 +697,14 @@ func arrayInitEmptyLiteralTopLevel() {
 func arrayInitLiteral() {
   // TODO: More work necessary for array initialization using literals to work
   // at the top level.
-  // expected-note @+1 {{cannot evaluate expression as constant here}}
+  // expected-note @+1 {{encountered call to 'ContainsArray.init(x:arr:)' where the 2nd argument is not a constant}}
   let c = ContainsArray(x: 1, arr: [2, 3, 4])
   // expected-error @+1 {{#assert condition not constant}}
   #assert(c.x == 1)
 }
 
 func arrayInitNonConstantElementTopLevel(x: Int) {
-  // expected-note @+1 {{cannot evaluate expression as constant here}}
+  // expected-note @+1 {{encountered call to 'ContainsArray.init(x:arr:)' where the 2nd argument is not a constant}}
   let c = ContainsArray(x: 1, arr: [x])
   // expected-error @+1 {{#assert condition not constant}}
   #assert(c.x == 1)


### PR DESCRIPTION
and remove @_transparent annotation from the methods. Also, improve diagnostics in the OSLogOptimization pass as it can now rely on seeing the appendInterpolation/Literal calls, which are no longer mandatorily inlined