### PR TITLE
[gyb_syntax_support] Make node descriptions multi-line

### DIFF
--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -63,8 +63,8 @@ ATTRIBUTE_NODES = [
                        Child('NamedAttributeString',
                              kind='NamedAttributeStringArgument'),
                    ], description='''
-                   The arguments of the attribute. In case the attribute  \
-                   takes multiple arguments, they are gather in the \
+                   The arguments of the attribute. In case the attribute
+                   takes multiple arguments, they are gather in the
                    appropriate takes first.
                    '''),
              Child('RightParen', kind='RightParenToken', is_optional=True,
@@ -105,7 +105,7 @@ ATTRIBUTE_NODES = [
     # labeled-specialize-entry -> identifier ':' token ','?
     Node('LabeledSpecializeEntry', kind='Syntax',
          description='''
-         A labeled argument for the `@_specialize` attribute like \
+         A labeled argument for the `@_specialize` attribute like
          `exported: true`
          ''',
          traits=['WithTrailingComma'],
@@ -125,8 +125,8 @@ ATTRIBUTE_NODES = [
     # named-attribute-string-arg -> 'name': string-literal
     Node('NamedAttributeStringArgument', kind='Syntax',
          description='''
-         The argument for the `@_dynamic_replacement` or `@_private` \
-         attribute of the form `for: "function()"` or `sourceFile: \
+         The argument for the `@_dynamic_replacement` or `@_private`
+         attribute of the form `for: "function()"` or `sourceFile:
          "Src.swift"`
          ''',
          children=[
@@ -149,7 +149,7 @@ ATTRIBUTE_NODES = [
                ]),
          Child('DeclNameArguments', kind='DeclNameArguments',
                is_optional=True, description='''
-               The argument labels of the protocol\'s requirement if it \
+               The argument labels of the protocol\'s requirement if it
                is a function requirement.
                '''),
          ]),
@@ -158,12 +158,12 @@ ATTRIBUTE_NODES = [
     #                              (identifier | operator) decl-name-arguments
     Node('ImplementsAttributeArguments', kind='Syntax',
          description='''
-         The arguments for the `@_implements` attribute of the form \
+         The arguments for the `@_implements` attribute of the form
          `Type, methodName(arg1Label:arg2Label:)`
          ''',
          children=[
              Child('Type', kind='SimpleTypeIdentifier', description='''
-                   The type for which the method with this attribute \
+                   The type for which the method with this attribute
                    implements a requirement.
                    '''),
              Child('Comma', kind='CommaToken',
@@ -179,7 +179,7 @@ ATTRIBUTE_NODES = [
                    ]),
              Child('DeclNameArguments', kind='DeclNameArguments',
                    is_optional=True, description='''
-                   The argument labels of the protocol\'s requirement if it \
+                   The argument labels of the protocol\'s requirement if it
                    is a function requirement.
                    '''),
          ]),
@@ -187,8 +187,8 @@ ATTRIBUTE_NODES = [
     # objc-selector-piece -> identifier? ':'?
     Node('ObjCSelectorPiece', kind='Syntax',
          description='''
-         A piece of an Objective-C selector. Either consisiting of just an \
-         identifier for a nullary selector, an identifier and a colon for a \
+         A piece of an Objective-C selector. Either consisiting of just an
+         identifier for a nullary selector, an identifier and a colon for a
          labeled argument or just a colon for an unlabeled argument
          ''',
          children=[

--- a/utils/gyb_syntax_support/AvailabilityNodes.py
+++ b/utils/gyb_syntax_support/AvailabilityNodes.py
@@ -13,7 +13,7 @@ AVAILABILITY_NODES = [
     #                     | availability-versioned-argument ','?
     Node('AvailabilityArgument', kind='Syntax',
          description='''
-         A single argument to an `@available` argument like `*`, `iOS 10.1`, \
+         A single argument to an `@available` argument like `*`, `iOS 10.1`,
          or `message: "This has been deprecated"`.
          ''',
          children=[
@@ -31,7 +31,7 @@ AVAILABILITY_NODES = [
                    ]),
              Child('TrailingComma', kind='CommaToken', is_optional=True,
                    description='''
-                   A trailing comma if the argument is followed by another \
+                   A trailing comma if the argument is followed by another
                    argument
                    '''),
          ]),
@@ -40,7 +40,7 @@ AVAILABILITY_NODES = [
     # availability-versioned-argument -> identifier ':' version-tuple
     Node('AvailabilityLabeledArgument', kind='Syntax',
          description='''
-         A argument to an `@available` attribute that consists of a label and \
+         A argument to an `@available` attribute that consists of a label and
          a value, e.g. `message: "This has been deprecated"`.
          ''',
          children=[
@@ -59,15 +59,15 @@ AVAILABILITY_NODES = [
     # availability-version-restriction -> identifier version-tuple
     Node('AvailabilityVersionRestriction', kind='Syntax',
          description='''
-         An argument to `@available` that restricts the availability on a \
+         An argument to `@available` that restricts the availability on a
          certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
          ''',
          children=[
              Child('Platform', kind='IdentifierToken',
                    classification='Keyword',
                    description='''
-                   The name of the OS on which the availability should be \
-                   restricted or 'swift' if the availability should be \
+                   The name of the OS on which the availability should be
+                   restricted or 'swift' if the availability should be
                    restricted based on a Swift version.
                    '''),
              Child('Version', kind='VersionTuple'),
@@ -78,7 +78,7 @@ AVAILABILITY_NODES = [
     #                | float-literal '.' integer-literal
     Node('VersionTuple', kind='Syntax',
          description='''
-         A version number of the form major.minor.patch in which the minor \
+         A version number of the form major.minor.patch in which the minor
          and patch part may be ommited.
          ''',
          children=[
@@ -87,15 +87,15 @@ AVAILABILITY_NODES = [
                        Child('Major', kind='IntegerLiteralToken'),
                        Child('MajorMinor', kind='FloatingLiteralToken')
                    ], description='''
-                   In case the version consists only of the major version, an \
-                   integer literal that specifies the major version. In case \
-                   the version consists of major and minor version number, a \
-                   floating literal in which the decimal part is interpreted \
+                   In case the version consists only of the major version, an
+                   integer literal that specifies the major version. In case
+                   the version consists of major and minor version number, a
+                   floating literal in which the decimal part is interpreted
                    as the minor version.
                    '''),
              Child('PatchPeriod', kind='PeriodToken', is_optional=True,
                    description='''
-                   If the version contains a patch number, the period \
+                   If the version contains a patch number, the period
                    separating the minor from the patch number.
                    '''),
              Child('PatchVersion', kind='IntegerLiteralToken',

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -89,7 +89,7 @@ DECL_NODES = [
     #    ('#if' | '#elseif' | '#else') expr? (stmt-list | switch-case-list)
     Node('IfConfigClause', kind='Syntax',
          children=[
-             Child('PoundKeyword', kind='Token', 
+             Child('PoundKeyword', kind='Token',
                    classification='BuildConfigId',
                    token_choices=[
                        'PoundIfToken',
@@ -115,7 +115,7 @@ DECL_NODES = [
          children=[
              Child('Clauses', kind='IfConfigClauseList',
                    collection_element_name='Clause'),
-             Child('PoundEndif', kind='PoundEndifToken', 
+             Child('PoundEndif', kind='PoundEndifToken',
                    classification='BuildConfigId'),
          ]),
 
@@ -137,7 +137,7 @@ DECL_NODES = [
              Child('RightParen', kind='RightParenToken')
          ]),
 
-    Node('PoundSourceLocation', kind='Decl', 
+    Node('PoundSourceLocation', kind='Decl',
          traits=['Parenthesized'],
          children=[
              Child('PoundSourceLocation', kind='PoundSourceLocationToken'),
@@ -148,12 +148,12 @@ DECL_NODES = [
 
     Node('PoundSourceLocationArgs', kind='Syntax',
          children=[
-             Child('FileArgLabel', kind='IdentifierToken', 
+             Child('FileArgLabel', kind='IdentifierToken',
                    text_choices=['file']),
              Child('FileArgColon', kind='ColonToken'),
              Child('FileName', kind='StringLiteralToken'),
              Child('Comma', kind='CommaToken'),
-             Child('LineArgLabel', kind='IdentifierToken', 
+             Child('LineArgLabel', kind='IdentifierToken',
                    text_choices=['line']),
              Child('LineArgColon', kind='ColonToken'),
              Child('LineNumber', kind='IntegerLiteralToken'),
@@ -294,11 +294,11 @@ DECL_NODES = [
     # member-decl = decl ';'?
     Node('MemberDeclListItem', kind='Syntax', omit_when_empty=True,
          description='''
-         A member declaration of a type consisting of a declaration and an \
+         A member declaration of a type consisting of a declaration and an
          optional semicolon;
          ''',
          children=[
-             Child('Decl', kind='Decl', 
+             Child('Decl', kind='Decl',
                    description='The declaration of the type member.'),
              Child('Semicolon', kind='SemicolonToken', is_optional=True,
                    description='An optional trailing semicolon.'),
@@ -518,11 +518,11 @@ DECL_NODES = [
              Child('Modifier', kind='DeclModifier', is_optional=True),
              Child('AccessorKind', kind='Token',
                    text_choices=[
-                      'get', 'set', 'didSet', 'willSet', 'unsafeAddress', 
-                      'addressWithOwner', 'addressWithNativeOwner', 
-                      'unsafeMutableAddress', 
-                      'mutableAddressWithOwner', 
-                      'mutableAddressWithNativeOwner', 
+                      'get', 'set', 'didSet', 'willSet', 'unsafeAddress',
+                      'addressWithOwner', 'addressWithNativeOwner',
+                      'unsafeMutableAddress',
+                      'mutableAddressWithOwner',
+                      'mutableAddressWithNativeOwner',
                       '_read', '_modify'
                    ]),
              Child('Parameter', kind='AccessorParameter', is_optional=True),
@@ -572,7 +572,7 @@ DECL_NODES = [
 
     Node('EnumCaseElement', kind='Syntax',
          description='''
-         An element of an enum case, containing the name of the case and, \
+         An element of an enum case, containing the name of the case and,
          optionally, either associated values or an assignment to a raw value.
          ''',
          traits=['WithTrailingComma'],
@@ -587,7 +587,7 @@ DECL_NODES = [
                    '''),
              Child('TrailingComma', kind='CommaToken', is_optional=True,
                    description='''
-                   The trailing comma of this element, if the case has \
+                   The trailing comma of this element, if the case has
                    multiple elements.
                    '''),
          ]),
@@ -598,7 +598,7 @@ DECL_NODES = [
 
     Node('EnumCaseDecl', kind='Decl',
          description='''
-         A `case` declaration of a Swift `enum`. It can have 1 or more \
+         A `case` declaration of a Swift `enum`. It can have 1 or more
          `EnumCaseElement`s inside, each declaring a different case of the
          enum.
          ''',
@@ -649,13 +649,13 @@ DECL_NODES = [
              Child('InheritanceClause', kind='TypeInheritanceClause',
                    is_optional=True,
                    description='''
-                   The inheritance clause describing conformances or raw \
+                   The inheritance clause describing conformances or raw
                    values for this enum.
                    '''),
              Child('GenericWhereClause', kind='GenericWhereClause',
                    is_optional=True,
                    description='''
-                   The `where` clause that applies to the generic parameters of \
+                   The `where` clause that applies to the generic parameters of
                    this enum.
                    '''),
              Child('Members', kind='MemberDeclBlock',
@@ -664,7 +664,7 @@ DECL_NODES = [
                    ''')
          ]),
 
-    # operator-decl -> attribute? modifiers? 'operator' operator 
+    # operator-decl -> attribute? modifiers? 'operator' operator
     Node('OperatorDecl', kind='Decl', traits=['IdentifiedDecl'],
          description='A Swift `operator` declaration.',
          children=[
@@ -762,7 +762,7 @@ DECL_NODES = [
          groups.
          ''',
          children=[
-             Child('HigherThanOrLowerThan', kind='IdentifierToken', 
+             Child('HigherThanOrLowerThan', kind='IdentifierToken',
                    classification='Keyword',
                    text_choices=[
                       'higherThan', 'lowerThan',
@@ -823,7 +823,7 @@ DECL_NODES = [
          are grouped together in the absence of grouping parentheses.
          ''',
          children=[
-             Child('AssociativityKeyword', kind='IdentifierToken', 
+             Child('AssociativityKeyword', kind='IdentifierToken',
                    classification='Keyword', text_choices=['associativity']),
              Child('Colon', kind='ColonToken'),
              Child('Value', kind='IdentifierToken',


### PR DESCRIPTION
The node descriptions are printed as dedented multi-line strings when the corresponding files are being generated in SwiftSyntax. To do this, however, the strings need to be multi-line to begin with and not have the line break escaped.