### PR TITLE
Many Things Don't Need a TypeChecker Part 2

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -484,7 +484,8 @@ TypeChecker::applyFunctionBuilderBodyTransform(FuncDecl *FD,
                                                BraceStmt *body,
                                                Type builderType) {
   // Try to build a single result expression.
-  BuilderClosureVisitor visitor(Context, nullptr,
+  auto &ctx = FD->getASTContext();
+  BuilderClosureVisitor visitor(ctx, nullptr,
                                 /*wantExpr=*/true, builderType);
   Expr *returnExpr = visitor.visit(body);
   if (!returnExpr)
@@ -496,9 +497,8 @@ TypeChecker::applyFunctionBuilderBodyTransform(FuncDecl *FD,
     return nullptr;
 
   auto loc = returnExpr->getStartLoc();
-  auto returnStmt =
-    new (Context) ReturnStmt(loc, returnExpr, /*implicit*/ true);
-  return BraceStmt::create(Context, body->getLBraceLoc(), { returnStmt },
+  auto returnStmt = new (ctx) ReturnStmt(loc, returnExpr, /*implicit*/ true);
+  return BraceStmt::create(ctx, body->getLBraceLoc(), { returnStmt },
                            body->getRBraceLoc());
 }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7045,7 +7045,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, ConcreteDeclRef callee,
     apply->setIsSuper(isSuper);
 
     cs.setExprTypes(apply);
-    Expr *result = tc.substituteInputSugarTypeForResult(apply);
+    Expr *result = TypeChecker::substituteInputSugarTypeForResult(apply);
     cs.cacheExprTypes(result);
 
     // If we have a covariant result type, perform the conversion now.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -41,8 +41,8 @@ using namespace swift;
 namespace {
   /// This emits a diagnostic with a fixit to remove the attribute.
   template<typename ...ArgTypes>
-  void diagnoseAndRemoveAttr(TypeChecker &TC, Decl *D, DeclAttribute *attr,
-                             ArgTypes &&...Args) {
+  void diagnoseAndRemoveAttr(DiagnosticEngine &Diags, Decl *D,
+                             DeclAttribute *attr, ArgTypes &&...Args) {
     assert(!D->hasClangNode() && "Clang importer propagated a bogus attribute");
     if (!D->hasClangNode()) {
       SourceLoc loc = attr->getLocation();
@@ -51,7 +51,7 @@ namespace {
         loc = D->getLoc();
       }
       if (loc.isValid()) {
-        TC.diagnose(loc, std::forward<ArgTypes>(Args)...)
+        Diags.diagnose(loc, std::forward<ArgTypes>(Args)...)
           .fixItRemove(attr->getRangeWithAt());
       }
     }
@@ -62,16 +62,22 @@ namespace {
 /// This visits each attribute on a decl.  The visitor should return true if
 /// the attribute is invalid and should be marked as such.
 class AttributeChecker : public AttributeVisitor<AttributeChecker> {
-  TypeChecker &TC;
+  ASTContext &Ctx;
   Decl *D;
 
 public:
-  AttributeChecker(TypeChecker &TC, Decl *D) : TC(TC), D(D) {}
+  AttributeChecker(Decl *D) : Ctx(D->getASTContext()), D(D) {}
 
   /// This emits a diagnostic with a fixit to remove the attribute.
   template<typename ...ArgTypes>
   void diagnoseAndRemoveAttr(DeclAttribute *attr, ArgTypes &&...Args) {
-    ::diagnoseAndRemoveAttr(TC, D, attr, std::forward<ArgTypes>(Args)...);
+    ::diagnoseAndRemoveAttr(Ctx.Diags, D, attr,
+                            std::forward<ArgTypes>(Args)...);
+  }
+
+  template <typename... ArgTypes>
+  InFlightDiagnostic diagnose(ArgTypes &&... Args) const {
+    return Ctx.Diags.diagnose(std::forward<ArgTypes>(Args)...);
   }
 
   /// Deleting this ensures that all attributes are covered by the visitor
@@ -111,7 +117,7 @@ public:
     // Alignment must be a power of two.
     auto value = attr->getValue();
     if (value == 0 || (value & (value - 1)) != 0)
-      TC.diagnose(attr->getLocation(), diag::alignment_not_power_of_two);
+      diagnose(attr->getLocation(), diag::alignment_not_power_of_two);
   }
 
   void visitBorrowedAttr(BorrowedAttr *attr) {
@@ -121,8 +127,8 @@ public:
     assert(!D->hasClangNode() && "@_borrowed on imported declaration?");
 
     if (D->getAttrs().hasAttribute<DynamicAttr>()) {
-      TC.diagnose(attr->getLocation(), diag::borrowed_with_objc_dynamic,
-                  D->getDescriptiveKind())
+      diagnose(attr->getLocation(), diag::borrowed_with_objc_dynamic,
+               D->getDescriptiveKind())
         .fixItRemove(attr->getRange());
       D->getAttrs().removeAttribute(attr);
       return;
@@ -131,9 +137,8 @@ public:
     auto dc = D->getDeclContext();
     auto protoDecl = dyn_cast<ProtocolDecl>(dc);
     if (protoDecl && protoDecl->isObjC()) {
-      TC.diagnose(attr->getLocation(),
-                  diag::borrowed_on_objc_protocol_requirement,
-                  D->getDescriptiveKind())
+      diagnose(attr->getLocation(), diag::borrowed_on_objc_protocol_requirement,
+               D->getDescriptiveKind())
         .fixItRemove(attr->getRange());
       D->getAttrs().removeAttribute(attr);
       return;
@@ -151,13 +156,12 @@ public:
     if (auto caseDecl = dyn_cast<EnumElementDecl>(D)) {
       // An indirect case should have a payload.
       if (!caseDecl->hasAssociatedValues())
-        TC.diagnose(attr->getLocation(),
-                    diag::indirect_case_without_payload, caseDecl->getName());
+        diagnose(attr->getLocation(), diag::indirect_case_without_payload,
+                 caseDecl->getName());
       // If the enum is already indirect, its cases don't need to be.
       else if (caseDecl->getParentEnum()->getAttrs()
                  .hasAttribute<IndirectAttr>())
-        TC.diagnose(attr->getLocation(),
-                    diag::indirect_case_in_indirect_enum);
+        diagnose(attr->getLocation(), diag::indirect_case_in_indirect_enum);
     }
   }
 
@@ -241,12 +245,12 @@ public:
 } // end anonymous namespace
 
 void AttributeChecker::visitTransparentAttr(TransparentAttr *attr) {
-  DeclContext *Ctx = D->getDeclContext();
+  DeclContext *dc = D->getDeclContext();
   // Protocol declarations cannot be transparent.
-  if (isa<ProtocolDecl>(Ctx))
+  if (isa<ProtocolDecl>(dc))
     diagnoseAndRemoveAttr(attr, diag::transparent_in_protocols_not_supported);
   // Class declarations cannot be transparent.
-  if (isa<ClassDecl>(Ctx)) {
+  if (isa<ClassDecl>(dc)) {
     
     // @transparent is always ok on implicitly generated accessors: they can
     // be dispatched (even in classes) when the references are within the
@@ -338,9 +342,9 @@ void AttributeChecker::visitDynamicAttr(DynamicAttr *attr) {
 }
 
 static bool
-validateIBActionSignature(TypeChecker &TC, DeclAttribute *attr, const FuncDecl *FD,
-                          unsigned minParameters, unsigned maxParameters,
-                          bool hasVoidResult = true) {
+validateIBActionSignature(ASTContext &ctx, DeclAttribute *attr,
+                          const FuncDecl *FD, unsigned minParameters,
+                          unsigned maxParameters, bool hasVoidResult = true) {
   bool valid = true;
 
   auto arity = FD->getParameters()->size();
@@ -352,13 +356,14 @@ validateIBActionSignature(TypeChecker &TC, DeclAttribute *attr, const FuncDecl *
       diagID = diag::invalid_ibaction_argument_count_exact;
     else if (minParameters == 0)
       diagID = diag::invalid_ibaction_argument_count_max;
-    TC.diagnose(FD, diagID, attr->getAttrName(), minParameters, maxParameters);
+    ctx.Diags.diagnose(FD, diagID, attr->getAttrName(), minParameters,
+                       maxParameters);
     valid = false;
   }
 
   if (resultType->isVoid() != hasVoidResult) {
-    TC.diagnose(FD, diag::invalid_ibaction_result, attr->getAttrName(),
-                hasVoidResult);
+    ctx.Diags.diagnose(FD, diag::invalid_ibaction_result, attr->getAttrName(),
+                       hasVoidResult);
     valid = false;
   }
 
@@ -370,16 +375,16 @@ validateIBActionSignature(TypeChecker &TC, DeclAttribute *attr, const FuncDecl *
   return valid;
 }
 
-static bool isiOS(TypeChecker &TC) {
-  return TC.getLangOpts().Target.isiOS();
+static bool isiOS(ASTContext &ctx) {
+  return ctx.LangOpts.Target.isiOS();
 }
 
-static bool iswatchOS(TypeChecker &TC) {
-  return TC.getLangOpts().Target.isWatchOS();
+static bool iswatchOS(ASTContext &ctx) {
+  return ctx.LangOpts.Target.isWatchOS();
 }
 
-static bool isRelaxedIBAction(TypeChecker &TC) {
-  return isiOS(TC) || iswatchOS(TC);
+static bool isRelaxedIBAction(ASTContext &ctx) {
+  return isiOS(ctx) || iswatchOS(ctx);
 }
 
 void AttributeChecker::visitIBActionAttr(IBActionAttr *attr) {
@@ -391,12 +396,12 @@ void AttributeChecker::visitIBActionAttr(IBActionAttr *attr) {
     return;
   }
 
-  if (isRelaxedIBAction(TC))
+  if (isRelaxedIBAction(Ctx))
     // iOS, tvOS, and watchOS allow 0-2 parameters to an @IBAction method.
-    validateIBActionSignature(TC, attr, FD, /*minParams=*/0, /*maxParams=*/2);
+    validateIBActionSignature(Ctx, attr, FD, /*minParams=*/0, /*maxParams=*/2);
   else
     // macOS allows 1 parameter to an @IBAction method.
-    validateIBActionSignature(TC, attr, FD, /*minParams=*/1, /*maxParams=*/1);
+    validateIBActionSignature(Ctx, attr, FD, /*minParams=*/1, /*maxParams=*/1);
 }
 
 void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
@@ -406,7 +411,7 @@ void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
     diagnoseAndRemoveAttr(attr, diag::invalid_ibaction_decl,
                           attr->getAttrName());
 
-  if (!validateIBActionSignature(TC, attr, FD,
+  if (!validateIBActionSignature(Ctx, attr, FD,
                                  /*minParams=*/1, /*maxParams=*/3,
                                  /*hasVoidResult=*/false))
     return;
@@ -445,8 +450,8 @@ void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
   }
 
   // Emit the actual error.
-  TC.diagnose(FD, diag::ibsegueaction_objc_method_family,
-              attr->getAttrName(), currentSelector);
+  diagnose(FD, diag::ibsegueaction_objc_method_family, attr->getAttrName(),
+           currentSelector);
 
   // The rest of this is just fix-it generation.
 
@@ -455,7 +460,7 @@ void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
   auto replacingPrefix = [&](Identifier oldName) -> Identifier {
     SmallString<32> scratch = prefix;
     scratch += oldName.str().drop_while(clang::isLowercase);
-    return TC.Context.getIdentifier(scratch);
+    return Ctx.getIdentifier(scratch);
   };
 
   // Suggest changing the Swift name of the method, unless there is already an
@@ -464,9 +469,9 @@ void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
       !FD->getAttrs().getAttribute<ObjCAttr>()->hasName()) {
     auto newSwiftBaseName = replacingPrefix(FD->getBaseName().getIdentifier());
     auto argumentNames = FD->getFullName().getArgumentNames();
-    DeclName newSwiftName(TC.Context, newSwiftBaseName, argumentNames);
+    DeclName newSwiftName(Ctx, newSwiftBaseName, argumentNames);
 
-    auto diag = TC.diagnose(FD, diag::fixit_rename_in_swift, newSwiftName);
+    auto diag = diagnose(FD, diag::fixit_rename_in_swift, newSwiftName);
     fixDeclarationName(diag, FD, newSwiftName);
   }
 
@@ -474,9 +479,9 @@ void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
   auto oldPieces = currentSelector.getSelectorPieces();
   SmallVector<Identifier, 4> newPieces(oldPieces.begin(), oldPieces.end());
   newPieces[0] = replacingPrefix(newPieces[0]);
-  ObjCSelector newSelector(TC.Context, currentSelector.getNumArgs(), newPieces);
+  ObjCSelector newSelector(Ctx, currentSelector.getNumArgs(), newPieces);
 
-  auto diag = TC.diagnose(FD, diag::fixit_rename_in_objc, newSelector);
+  auto diag = diagnose(FD, diag::fixit_rename_in_objc, newSelector);
   fixDeclarationObjCName(diag, FD, currentSelector, newSelector);
 }
 
@@ -506,7 +511,7 @@ void AttributeChecker::visitGKInspectableAttr(GKInspectableAttr *attr) {
 }
 
 static Optional<Diag<bool,Type>>
-isAcceptableOutletType(Type type, bool &isArray, TypeChecker &TC) {
+isAcceptableOutletType(Type type, bool &isArray, ASTContext &ctx) {
   if (type->isObjCExistentialType() || type->isAny())
     return None; // @objc existential types are okay
 
@@ -518,13 +523,13 @@ isAcceptableOutletType(Type type, bool &isArray, TypeChecker &TC) {
     return diag::iboutlet_nonobjc_class;
   }
 
-  if (nominal == TC.Context.getStringDecl()) {
+  if (nominal == ctx.getStringDecl()) {
     // String is okay because it is bridged to NSString.
     // FIXME: BridgesTypes.def is almost sufficient for this.
     return None;
   }
 
-  if (nominal == TC.Context.getArrayDecl()) {
+  if (nominal == ctx.getArrayDecl()) {
     // Arrays of arrays are not allowed.
     if (isArray)
       return diag::iboutlet_nonobject_type;
@@ -536,7 +541,7 @@ isAcceptableOutletType(Type type, bool &isArray, TypeChecker &TC) {
     auto boundArgs = boundTy->getGenericArgs();
     assert(boundArgs.size() == 1 && "invalid Array declaration");
     Type elementTy = boundArgs.front();
-    return isAcceptableOutletType(elementTy, isArray, TC);
+    return isAcceptableOutletType(elementTy, isArray, ctx);
   }
 
   if (type->isExistentialType())
@@ -576,17 +581,17 @@ void AttributeChecker::visitIBOutletAttr(IBOutletAttr *attr) {
   }
 
   bool isArray = false;
-  if (auto isError = isAcceptableOutletType(type, isArray, TC))
+  if (auto isError = isAcceptableOutletType(type, isArray, Ctx))
     diagnoseAndRemoveAttr(attr, isError.getValue(),
                                  /*array=*/isArray, type);
 
   // If the type wasn't optional, an array, or unowned, complain.
   if (!wasOptional && !isArray) {
-    TC.diagnose(attr->getLocation(), diag::iboutlet_non_optional, type);
+    diagnose(attr->getLocation(), diag::iboutlet_non_optional, type);
     auto typeRange = VD->getTypeSourceRangeForDiagnostics();
     { // Only one diagnostic can be active at a time.
-      auto diag = TC.diagnose(typeRange.Start, diag::note_make_optional,
-                              OptionalType::get(type));
+      auto diag = diagnose(typeRange.Start, diag::note_make_optional,
+                           OptionalType::get(type));
       if (type->hasSimpleTypeRepr()) {
         diag.fixItInsertAfter(typeRange.End, "?");
       } else {
@@ -595,8 +600,8 @@ void AttributeChecker::visitIBOutletAttr(IBOutletAttr *attr) {
       }
     }
     { // Only one diagnostic can be active at a time.
-      auto diag = TC.diagnose(typeRange.Start,
-                              diag::note_make_implicitly_unwrapped_optional);
+      auto diag = diagnose(typeRange.Start,
+                           diag::note_make_implicitly_unwrapped_optional);
       if (type->hasSimpleTypeRepr()) {
         diag.fixItInsertAfter(typeRange.End, "!");
       } else {
@@ -704,7 +709,7 @@ bool AttributeChecker::visitAbstractAccessControlAttr(
   // Or within protocols.
   if (isa<ProtocolDecl>(D->getDeclContext())) {
     diagnoseAndRemoveAttr(attr, diag::access_control_in_protocol, attr);
-    TC.diagnose(attr->getLocation(), diag::access_control_in_protocol_detail);
+    diagnose(attr->getLocation(), diag::access_control_in_protocol_detail);
     return true;
   }
 
@@ -716,7 +721,7 @@ void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
 
   if (auto extension = dyn_cast<ExtensionDecl>(D)) {
     if (attr->getAccess() == AccessLevel::Open) {
-      TC.diagnose(attr->getLocation(), diag::access_control_extension_open)
+      diagnose(attr->getLocation(), diag::access_control_extension_open)
         .fixItReplace(attr->getRange(), "public");
       attr->setInvalid();
       return;
@@ -732,10 +737,8 @@ void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
 
     AccessLevel typeAccess = nominal->getFormalAccess();
     if (attr->getAccess() > typeAccess) {
-      TC.diagnose(attr->getLocation(), diag::access_control_extension_more,
-                  typeAccess,
-                  nominal->getDescriptiveKind(),
-                  attr->getAccess())
+      diagnose(attr->getLocation(), diag::access_control_extension_more,
+               typeAccess, nominal->getDescriptiveKind(), attr->getAccess())
         .fixItRemove(attr->getRange());
       attr->setInvalid();
       return;
@@ -746,12 +749,11 @@ void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
     if (std::min(attr->getAccess(), AccessLevel::Public) > maxAccess) {
       // FIXME: It would be nice to say what part of the requirements actually
       // end up being problematic.
-      auto diag =
-          TC.diagnose(attr->getLocation(),
-                      diag::access_control_ext_requirement_member_more,
-                      attr->getAccess(),
-                      D->getDescriptiveKind(),
-                      maxAccess);
+      auto diag = diagnose(attr->getLocation(),
+                           diag::access_control_ext_requirement_member_more,
+                           attr->getAccess(),
+                           D->getDescriptiveKind(),
+                           maxAccess);
       swift::fixItAccess(diag, cast<ValueDecl>(D), maxAccess);
       return;
     }
@@ -760,20 +762,20 @@ void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
         extension->getAttrs().getAttribute<AccessControlAttr>()) {
       AccessLevel defaultAccess = extension->getDefaultAccessLevel();
       if (attr->getAccess() > defaultAccess) {
-        auto diag = TC.diagnose(attr->getLocation(),
-                                diag::access_control_ext_member_more,
-                                attr->getAccess(),
-                                extAttr->getAccess());
+        auto diag = diagnose(attr->getLocation(),
+                             diag::access_control_ext_member_more,
+                             attr->getAccess(),
+                             extAttr->getAccess());
         // Don't try to fix this one; it's just a warning, and fixing it can
         // lead to diagnostic fights between this and "declaration must be at
         // least this accessible" checking for overrides and protocol
         // requirements.
       } else if (attr->getAccess() == defaultAccess) {
-        TC.diagnose(attr->getLocation(),
-                    diag::access_control_ext_member_redundant,
-                    attr->getAccess(),
-                    D->getDescriptiveKind(),
-                    extAttr->getAccess())
+        diagnose(attr->getLocation(),
+                 diag::access_control_ext_member_redundant,
+                 attr->getAccess(),
+                 D->getDescriptiveKind(),
+                 extAttr->getAccess())
           .fixItRemove(attr->getRange());
       }
     }
@@ -782,7 +784,7 @@ void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
   if (attr->getAccess() == AccessLevel::Open) {
     if (!isa<ClassDecl>(D) && !D->isPotentiallyOverridable() &&
         !attr->isInvalid()) {
-      TC.diagnose(attr->getLocation(), diag::access_control_open_bad_decl)
+      diagnose(attr->getLocation(), diag::access_control_open_bad_decl)
         .fixItReplace(attr->getRange(), "public");
       attr->setInvalid();
     }
@@ -832,17 +834,17 @@ void AttributeChecker::visitSetterAccessAttr(
       storageKind = SK_Property;
     else
       storageKind = SK_Variable;
-    TC.diagnose(attr->getLocation(), diag::access_control_setter_more,
-                getterAccess, storageKind, attr->getAccess());
+    diagnose(attr->getLocation(), diag::access_control_setter_more,
+             getterAccess, storageKind, attr->getAccess());
     attr->setInvalid();
     return;
 
   } else if (attr->getAccess() == getterAccess) {
-    TC.diagnose(attr->getLocation(),
-                diag::access_control_setter_redundant,
-                attr->getAccess(),
-                D->getDescriptiveKind(),
-                getterAccess)
+    diagnose(attr->getLocation(),
+             diag::access_control_setter_redundant,
+             attr->getAccess(),
+             D->getDescriptiveKind(),
+             getterAccess)
       .fixItRemove(attr->getRange());
     return;
   }
@@ -910,19 +912,19 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
       if (objcName->getNumArgs() > 0) {
         SourceLoc firstNameLoc = attr->getNameLocs().front();
         SourceLoc afterFirstNameLoc =
-          Lexer::getLocForEndOfToken(TC.Context.SourceMgr, firstNameLoc);
-        TC.diagnose(firstNameLoc, diag::objc_name_req_nullary,
-                    D->getDescriptiveKind())
+          Lexer::getLocForEndOfToken(Ctx.SourceMgr, firstNameLoc);
+        diagnose(firstNameLoc, diag::objc_name_req_nullary,
+                 D->getDescriptiveKind())
           .fixItRemoveChars(afterFirstNameLoc, attr->getRParenLoc());
         const_cast<ObjCAttr *>(attr)->setName(
-          ObjCSelector(TC.Context, 0, objcName->getSelectorPieces()[0]),
+          ObjCSelector(Ctx, 0, objcName->getSelectorPieces()[0]),
           /*implicit=*/false);
       }
     } else if (isa<SubscriptDecl>(D) || isa<DestructorDecl>(D)) {
-      TC.diagnose(attr->getLParenLoc(),
-                  isa<SubscriptDecl>(D)
-                    ? diag::objc_name_subscript
-                    : diag::objc_name_deinit);
+      diagnose(attr->getLParenLoc(),
+               isa<SubscriptDecl>(D)
+                 ? diag::objc_name_subscript
+                 : diag::objc_name_deinit);
       const_cast<ObjCAttr *>(attr)->clearName();
     } else {
       // We have a function. Make sure that the number of parameters
@@ -940,18 +942,16 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
 
       unsigned numArgumentNames = objcName->getNumArgs();
       if (numArgumentNames != numParameters) {
-        TC.diagnose(attr->getNameLocs().front(),
-                    diag::objc_name_func_mismatch,
-                    isa<FuncDecl>(func),
-                    numArgumentNames,
-                    numArgumentNames != 1,
-                    numParameters,
-                    numParameters != 1,
-                    func->hasThrows());
+        diagnose(attr->getNameLocs().front(),
+                 diag::objc_name_func_mismatch,
+                 isa<FuncDecl>(func),
+                 numArgumentNames,
+                 numArgumentNames != 1,
+                 numParameters,
+                 numParameters != 1,
+                 func->hasThrows());
         D->getAttrs().add(
-          ObjCAttr::createUnnamed(TC.Context,
-                                  attr->AtLoc,
-                                  attr->Range.Start));
+          ObjCAttr::createUnnamed(Ctx, attr->AtLoc,  attr->Range.Start));
         D->getAttrs().removeAttribute(attr);
       }
     }
@@ -997,8 +997,8 @@ void AttributeChecker::visitOptionalAttr(OptionalAttr *attr) {
   } else {
     auto objcAttr = D->getAttrs().getAttribute<ObjCAttr>();
     if (!objcAttr || objcAttr->isImplicit()) {
-      auto diag = TC.diagnose(attr->getLocation(),
-                              diag::optional_attribute_missing_explicit_objc);
+      auto diag = diagnose(attr->getLocation(),
+                           diag::optional_attribute_missing_explicit_objc);
       if (auto VD = dyn_cast<ValueDecl>(D))
         diag.fixItInsert(VD->getAttributeInsertionLoc(false), "@objc ");
     }
@@ -1006,7 +1006,7 @@ void AttributeChecker::visitOptionalAttr(OptionalAttr *attr) {
 }
 
 void TypeChecker::checkDeclAttributes(Decl *D) {
-  AttributeChecker Checker(*this, D);
+  AttributeChecker Checker(D);
   for (auto attr : D->getAttrs()) {
     if (!attr->isValid()) continue;
 
@@ -1132,13 +1132,13 @@ visitDynamicCallableAttr(DynamicCallableAttr *attr) {
 
   bool hasValidMethod = false;
   hasValidMethod |=
-    hasValidDynamicCallableMethod(decl, TC.Context.Id_withArguments,
+    hasValidDynamicCallableMethod(decl, Ctx.Id_withArguments,
                                   /*hasKeywordArgs*/ false);
   hasValidMethod |=
-    hasValidDynamicCallableMethod(decl, TC.Context.Id_withKeywordArguments,
+    hasValidDynamicCallableMethod(decl, Ctx.Id_withKeywordArguments,
                                   /*hasKeywordArgs*/ true);
   if (!hasValidMethod) {
-    TC.diagnose(attr->getLocation(), diag::invalid_dynamic_callable_type, type);
+    diagnose(attr->getLocation(), diag::invalid_dynamic_callable_type, type);
     attr->setInvalid();
   }
 }
@@ -1228,14 +1228,14 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   auto &ctx = decl->getASTContext();
 
   auto emitInvalidTypeDiagnostic = [&](const SourceLoc loc) {
-    TC.diagnose(loc, diag::invalid_dynamic_member_lookup_type, type);
+    diagnose(loc, diag::invalid_dynamic_member_lookup_type, type);
     attr->setInvalid();
   };
 
   // Look up `subscript(dynamicMember:)` candidates.
   auto subscriptName =
       DeclName(ctx, DeclBaseName::createSubscript(), ctx.Id_dynamicMember);
-  auto candidates = TC.lookupMember(decl, type, subscriptName);
+  auto candidates = TypeChecker::lookupMember(decl, type, subscriptName);
 
   if (!candidates.empty()) {
     // If no candidates are valid, then reject one.
@@ -1261,7 +1261,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   //
   // Let's do another lookup using just the base name.
   auto newCandidates =
-      TC.lookupMember(decl, type, DeclBaseName::createSubscript());
+      TypeChecker::lookupMember(decl, type, DeclBaseName::createSubscript());
 
   // Validate the candidates while ignoring the label.
   newCandidates.filter([&](const LookupResultEntry entry, bool isOuter) {
@@ -1283,13 +1283,13 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   for (auto cand : newCandidates) {
     auto SD = cast<SubscriptDecl>(cand.getValueDecl());
     auto index = SD->getIndices()->get(0);
-    TC.diagnose(SD, diag::invalid_dynamic_member_lookup_type, type);
+    diagnose(SD, diag::invalid_dynamic_member_lookup_type, type);
 
     // If we have something like `subscript(foo:)` then we want to insert
     // `dynamicMember` before `foo`.
     if (index->getParameterNameLoc().isValid() &&
         index->getArgumentNameLoc().isInvalid()) {
-      TC.diagnose(SD, diag::invalid_dynamic_member_subscript)
+      diagnose(SD, diag::invalid_dynamic_member_subscript)
           .highlight(index->getSourceRange())
           .fixItInsert(index->getParameterNameLoc(), "dynamicMember ");
     }
@@ -1311,16 +1311,16 @@ static Decl *getEnclosingDeclForDecl(Decl *D) {
 }
 
 void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
-  if (TC.getLangOpts().DisableAvailabilityChecking)
+  if (Ctx.LangOpts.DisableAvailabilityChecking)
     return;
 
   if (auto *PD = dyn_cast<ProtocolDecl>(D->getDeclContext())) {
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (VD->isProtocolRequirement()) {
-        if (attr->isActivePlatform(TC.Context) ||
+        if (attr->isActivePlatform(Ctx) ||
             attr->isLanguageVersionSpecific() ||
             attr->isPackageDescriptionVersionSpecific()) {
-          auto versionAvailability = attr->getVersionAvailability(TC.Context);
+          auto versionAvailability = attr->getVersionAvailability(Ctx);
           if (attr->isUnconditionallyUnavailable() ||
               versionAvailability == AvailableVersionComparison::Obsoleted ||
               versionAvailability == AvailableVersionComparison::Unavailable) {
@@ -1334,7 +1334,7 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
     }
   }
 
-  if (!attr->hasPlatform() || !attr->isActivePlatform(TC.Context) ||
+  if (!attr->hasPlatform() || !attr->isActivePlatform(Ctx) ||
       !attr->Introduced.hasValue()) {
     return;
   }
@@ -1342,9 +1342,9 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
   SourceLoc attrLoc = attr->getLocation();
 
   Optional<Diag<>> MaybeNotAllowed =
-      TC.diagnosticIfDeclCannotBePotentiallyUnavailable(D);
+      TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(D);
   if (MaybeNotAllowed.hasValue()) {
-    TC.diagnose(attrLoc, MaybeNotAllowed.getValue());
+    diagnose(attrLoc, MaybeNotAllowed.getValue());
   }
 
   // Find the innermost enclosing declaration with an availability
@@ -1356,8 +1356,7 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
 
   while (EnclosingDecl) {
     EnclosingAnnotatedRange =
-        AvailabilityInference::annotatedAvailableRange(EnclosingDecl,
-                                                       TC.Context);
+        AvailabilityInference::annotatedAvailableRange(EnclosingDecl, Ctx);
 
     if (EnclosingAnnotatedRange.hasValue())
       break;
@@ -1372,23 +1371,20 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
       VersionRange::allGTE(attr->Introduced.getValue())};
 
   if (!AttrRange.isContainedIn(EnclosingAnnotatedRange.getValue())) {
-    TC.diagnose(attr->getLocation(),
-                diag::availability_decl_more_than_enclosing);
-    TC.diagnose(EnclosingDecl->getLoc(),
-                diag::availability_decl_more_than_enclosing_enclosing_here);
+    diagnose(attr->getLocation(), diag::availability_decl_more_than_enclosing);
+    diagnose(EnclosingDecl->getLoc(),
+             diag::availability_decl_more_than_enclosing_enclosing_here);
   }
 }
 
 void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {
   // Only top-level func decls are currently supported.
   if (D->getDeclContext()->isTypeContext())
-    TC.diagnose(attr->getLocation(),
-                diag::cdecl_not_at_top_level);
-  
+    diagnose(attr->getLocation(), diag::cdecl_not_at_top_level);
+
   // The name must not be empty.
   if (attr->Name.empty())
-    TC.diagnose(attr->getLocation(),
-                diag::cdecl_empty_name);
+    diagnose(attr->getLocation(), diag::cdecl_empty_name);
 }
 
 void AttributeChecker::visitUnsafeNoObjCTaggedPointerAttr(
@@ -1396,15 +1392,15 @@ void AttributeChecker::visitUnsafeNoObjCTaggedPointerAttr(
   // Only class protocols can have the attribute.
   auto proto = dyn_cast<ProtocolDecl>(D);
   if (!proto) {
-    TC.diagnose(attr->getLocation(),
-                diag::no_objc_tagged_pointer_not_class_protocol);
+    diagnose(attr->getLocation(),
+             diag::no_objc_tagged_pointer_not_class_protocol);
     attr->setInvalid();
   }
   
   if (!proto->requiresClass()
       && !proto->getAttrs().hasAttribute<ObjCAttr>()) {
-    TC.diagnose(attr->getLocation(),
-                diag::no_objc_tagged_pointer_not_class_protocol);
+    diagnose(attr->getLocation(),
+             diag::no_objc_tagged_pointer_not_class_protocol);
     attr->setInvalid();    
   }
 }
@@ -1414,15 +1410,15 @@ void AttributeChecker::visitSwiftNativeObjCRuntimeBaseAttr(
   // Only root classes can have the attribute.
   auto theClass = dyn_cast<ClassDecl>(D);
   if (!theClass) {
-    TC.diagnose(attr->getLocation(),
-                diag::swift_native_objc_runtime_base_not_on_root_class);
+    diagnose(attr->getLocation(),
+             diag::swift_native_objc_runtime_base_not_on_root_class);
     attr->setInvalid();
     return;
   }
   
   if (theClass->hasSuperclass()) {
-    TC.diagnose(attr->getLocation(),
-                diag::swift_native_objc_runtime_base_not_on_root_class);
+    diagnose(attr->getLocation(),
+             diag::swift_native_objc_runtime_base_not_on_root_class);
     attr->setInvalid();
     return;
   }
@@ -1432,8 +1428,8 @@ void AttributeChecker::visitFinalAttr(FinalAttr *attr) {
   // Reject combining 'final' with 'open'.
   if (auto accessAttr = D->getAttrs().getAttribute<AccessControlAttr>()) {
     if (accessAttr->getAccess() == AccessLevel::Open) {
-      TC.diagnose(attr->getLocation(), diag::open_decl_cannot_be_final,
-                  D->getDescriptiveKind());
+      diagnose(attr->getLocation(), diag::open_decl_cannot_be_final,
+               D->getDescriptiveKind());
       return;
     }
   }
@@ -1444,7 +1440,7 @@ void AttributeChecker::visitFinalAttr(FinalAttr *attr) {
   // 'final' only makes sense in the context of a class declaration.
   // Reject it on global functions, protocols, structs, enums, etc.
   if (!D->getDeclContext()->getSelfClassDecl()) {
-    TC.diagnose(attr->getLocation(), diag::member_cannot_be_final)
+    diagnose(attr->getLocation(), diag::member_cannot_be_final)
       .fixItRemove(attr->getRange());
 
     // Remove the attribute so child declarations are not flagged as final
@@ -1456,7 +1452,7 @@ void AttributeChecker::visitFinalAttr(FinalAttr *attr) {
   // We currently only support final on var/let, func and subscript
   // declarations.
   if (!isa<VarDecl>(D) && !isa<FuncDecl>(D) && !isa<SubscriptDecl>(D)) {
-    TC.diagnose(attr->getLocation(), diag::final_not_allowed_here)
+    diagnose(attr->getLocation(), diag::final_not_allowed_here)
       .fixItRemove(attr->getRange());
     return;
   }
@@ -1466,7 +1462,7 @@ void AttributeChecker::visitFinalAttr(FinalAttr *attr) {
       unsigned Kind = 2;
       if (auto *VD = dyn_cast<VarDecl>(accessor->getStorage()))
         Kind = VD->isLet() ? 1 : 0;
-      TC.diagnose(attr->getLocation(), diag::final_not_on_accessors, Kind)
+      diagnose(attr->getLocation(), diag::final_not_on_accessors, Kind)
         .fixItRemove(attr->getRange());
       return;
     }
@@ -1490,8 +1486,8 @@ void AttributeChecker::checkOperatorAttribute(DeclAttribute *attr) {
   if (auto *OD = dyn_cast<OperatorDecl>(D)) {
     // Reject attempts to define builtin operators.
     if (isBuiltinOperator(OD->getName().str(), attr)) {
-      TC.diagnose(D->getStartLoc(), diag::redefining_builtin_operator,
-                  attr->getAttrName(), OD->getName().str());
+      diagnose(D->getStartLoc(), diag::redefining_builtin_operator,
+               attr->getAttrName(), OD->getName().str());
       attr->setInvalid();
       return;
     }
@@ -1503,7 +1499,7 @@ void AttributeChecker::checkOperatorAttribute(DeclAttribute *attr) {
   // Operators implementations may only be defined as functions.
   auto *FD = dyn_cast<FuncDecl>(D);
   if (!FD) {
-    TC.diagnose(D->getLoc(), diag::operator_not_func);
+    diagnose(D->getLoc(), diag::operator_not_func);
     attr->setInvalid();
     return;
   }
@@ -1511,24 +1507,24 @@ void AttributeChecker::checkOperatorAttribute(DeclAttribute *attr) {
   // Only functions with an operator identifier can be declared with as an
   // operator.
   if (!FD->isOperator()) {
-    TC.diagnose(D->getStartLoc(), diag::attribute_requires_operator_identifier,
-                attr->getAttrName());
+    diagnose(D->getStartLoc(), diag::attribute_requires_operator_identifier,
+             attr->getAttrName());
     attr->setInvalid();
     return;
   }
 
   // Reject attempts to define builtin operators.
   if (isBuiltinOperator(FD->getName().str(), attr)) {
-    TC.diagnose(D->getStartLoc(), diag::redefining_builtin_operator,
-                attr->getAttrName(), FD->getName().str());
+    diagnose(D->getStartLoc(), diag::redefining_builtin_operator,
+             attr->getAttrName(), FD->getName().str());
     attr->setInvalid();
     return;
   }
 
   // Otherwise, must be unary.
   if (!FD->isUnaryOperator()) {
-    TC.diagnose(attr->getLocation(), diag::attribute_requires_single_argument,
-                attr->getAttrName());
+    diagnose(attr->getLocation(), diag::attribute_requires_single_argument,
+             attr->getAttrName());
     attr->setInvalid();
     return;
   }
@@ -1541,25 +1537,25 @@ void AttributeChecker::visitNSCopyingAttr(NSCopyingAttr *attr) {
   // It may only be used on class members.
   auto classDecl = D->getDeclContext()->getSelfClassDecl();
   if (!classDecl) {
-    TC.diagnose(attr->getLocation(), diag::nscopying_only_on_class_properties);
+    diagnose(attr->getLocation(), diag::nscopying_only_on_class_properties);
     attr->setInvalid();
     return;
   }
 
   if (!VD->isSettable(VD->getDeclContext())) {
-    TC.diagnose(attr->getLocation(), diag::nscopying_only_mutable);
+    diagnose(attr->getLocation(), diag::nscopying_only_mutable);
     attr->setInvalid();
     return;
   }
 
   if (!VD->hasStorage()) {
-    TC.diagnose(attr->getLocation(), diag::nscopying_only_stored_property);
+    diagnose(attr->getLocation(), diag::nscopying_only_stored_property);
     attr->setInvalid();
     return;
   }
 
   if (VD->hasInterfaceType()) {
-    if (TC.checkConformanceToNSCopying(VD).isInvalid()) {
+    if (TypeChecker::checkConformanceToNSCopying(VD).isInvalid()) {
       attr->setInvalid();
       return;
     }
@@ -1600,9 +1596,9 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
 
   // The class cannot be generic.
   if (CD->isGenericContext()) {
-    TC.diagnose(attr->getLocation(),
-                diag::attr_generic_ApplicationMain_not_supported,
-                applicationMainKind);
+    diagnose(attr->getLocation(),
+             diag::attr_generic_ApplicationMain_not_supported,
+             applicationMainKind);
     attr->setInvalid();
     return;
   }
@@ -1627,9 +1623,9 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
   if (!ApplicationDelegateProto ||
       !TypeChecker::conformsToProtocol(CD->getDeclaredType(),
                                        ApplicationDelegateProto, CD, None)) {
-    TC.diagnose(attr->getLocation(),
-                diag::attr_ApplicationMain_not_ApplicationDelegate,
-                applicationMainKind);
+    diagnose(attr->getLocation(),
+             diag::attr_ApplicationMain_not_ApplicationDelegate,
+             applicationMainKind);
     attr->setInvalid();
   }
 
@@ -1693,14 +1689,14 @@ void AttributeChecker::visitRequiredAttr(RequiredAttr *attr) {
     // defined in Objective-C
     if (!isa<ClassDecl>(ctor->getDeclContext()) &&
         !isObjCClassExtensionInOverlay(ctor->getDeclContext())) {
-      TC.diagnose(ctor, diag::required_initializer_in_extension, parentTy)
+      diagnose(ctor, diag::required_initializer_in_extension, parentTy)
         .highlight(attr->getLocation());
       attr->setInvalid();
       return;
     }
   } else {
     if (!parentTy->hasError()) {
-      TC.diagnose(ctor, diag::required_initializer_nonclass, parentTy)
+      diagnose(ctor, diag::required_initializer_nonclass, parentTy)
         .highlight(attr->getLocation());
     }
     attr->setInvalid();
@@ -1742,7 +1738,7 @@ void AttributeChecker::visitRethrowsAttr(RethrowsAttr *attr) {
       return;
   }
 
-  TC.diagnose(attr->getLocation(), diag::rethrows_without_throwing_parameter);
+  diagnose(attr->getLocation(), diag::rethrows_without_throwing_parameter);
   attr->setInvalid();
 }
 
@@ -1769,7 +1765,7 @@ static void checkSpecializeAttrRequirements(
     SpecializeAttr *attr,
     AbstractFunctionDecl *FD,
     const SmallPtrSet<TypeBase *, 4> &constrainedGenericParams,
-    TypeChecker &TC) {
+    ASTContext &ctx) {
   auto genericSig = FD->getGenericSignature();
 
   if (!attr->isFullSpecialization())
@@ -1778,7 +1774,7 @@ static void checkSpecializeAttrRequirements(
   if (constrainedGenericParams.size() == genericSig->getGenericParams().size())
     return;
 
-  TC.diagnose(
+  ctx.Diags.diagnose(
       attr->getLocation(), diag::specialize_attr_type_parameter_count_mismatch,
       genericSig->getGenericParams().size(), constrainedGenericParams.size(),
       constrainedGenericParams.size() < genericSig->getGenericParams().size());
@@ -1790,9 +1786,9 @@ static void checkSpecializeAttrRequirements(
         continue;
       auto gpDecl = gp->getDecl();
       if (gpDecl) {
-        TC.diagnose(attr->getLocation(),
-                    diag::specialize_attr_missing_constraint,
-                    gpDecl->getFullName());
+        ctx.Diags.diagnose(attr->getLocation(),
+                           diag::specialize_attr_missing_constraint,
+                           gpDecl->getFullName());
       }
     }
   }
@@ -1823,21 +1819,21 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
   if (!trailingWhereClause) {
     // Report a missing "where" clause.
-    TC.diagnose(attr->getLocation(), diag::specialize_missing_where_clause);
+    diagnose(attr->getLocation(), diag::specialize_missing_where_clause);
     return;
   }
 
   if (trailingWhereClause->getRequirements().empty()) {
     // Report an empty "where" clause.
-    TC.diagnose(attr->getLocation(), diag::specialize_empty_where_clause);
+    diagnose(attr->getLocation(), diag::specialize_empty_where_clause);
     return;
   }
 
   if (!genericSig) {
     // Only generic functions are permitted to have trailing where clauses.
-    TC.diagnose(attr->getLocation(),
-                diag::specialize_attr_nongeneric_trailing_where,
-                FD->getFullName())
+    diagnose(attr->getLocation(),
+             diag::specialize_attr_nongeneric_trailing_where,
+             FD->getFullName())
         .highlight(trailingWhereClause->getSourceRange());
     return;
   }
@@ -1880,11 +1876,10 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
           // Exactly one type can have a type parameter.
           if (firstHasTypeParameter == secondHasTypeParameter) {
-            TC.diagnose(
-                attr->getLocation(),
-                firstHasTypeParameter
-                  ? diag::specialize_attr_non_concrete_same_type_req
-                  : diag::specialize_attr_only_one_concrete_same_type_req)
+            diagnose(attr->getLocation(),
+                     firstHasTypeParameter
+                       ? diag::specialize_attr_non_concrete_same_type_req
+                       : diag::specialize_attr_only_one_concrete_same_type_req)
               .highlight(reqRepr->getSourceRange());
             return false;
           }
@@ -1902,8 +1897,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
         }
 
         case RequirementKind::Superclass:
-          TC.diagnose(attr->getLocation(),
-                      diag::specialize_attr_non_protocol_type_constraint_req)
+          diagnose(attr->getLocation(),
+                   diag::specialize_attr_non_protocol_type_constraint_req)
             .highlight(reqRepr->getSourceRange());
           return false;
 
@@ -1915,14 +1910,14 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
           }
 
           if (!req.getSecondType()->is<ProtocolType>()) {
-            TC.diagnose(attr->getLocation(),
-                        diag::specialize_attr_non_protocol_type_constraint_req)
+            diagnose(attr->getLocation(),
+                     diag::specialize_attr_non_protocol_type_constraint_req)
               .highlight(reqRepr->getSourceRange());
             return false;
           }
 
-          TC.diagnose(attr->getLocation(),
-                      diag::specialize_attr_unsupported_kind_of_req)
+          diagnose(attr->getLocation(),
+                   diag::specialize_attr_unsupported_kind_of_req)
             .highlight(reqRepr->getSourceRange());
 
           return false;
@@ -1946,7 +1941,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
       });
 
   // Check the validity of provided requirements.
-  checkSpecializeAttrRequirements(attr, FD, constrainedGenericParams, TC);
+  checkSpecializeAttrRequirements(attr, FD, constrainedGenericParams, Ctx);
 
   // Check the result.
   auto specializedSig = std::move(Builder).computeGenericSignature(
@@ -1957,7 +1952,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
 void AttributeChecker::visitFixedLayoutAttr(FixedLayoutAttr *attr) {
   if (isa<StructDecl>(D)) {
-    TC.diagnose(attr->getLocation(), diag::fixed_layout_struct)
+    diagnose(attr->getLocation(), diag::fixed_layout_struct)
       .fixItReplace(attr->getRange(), "@frozen");
   }  
 
@@ -1991,7 +1986,7 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
 
   // On internal declarations, @inlinable implies @usableFromInline.
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
-    if (TC.Context.isSwiftVersionAtLeast(4,2))
+    if (Ctx.isSwiftVersionAtLeast(4,2))
       diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline);
     return;
   }
@@ -2125,7 +2120,7 @@ static Type getDynamicComparisonType(ValueDecl *value) {
 static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
                                       AccessorDecl *replacement,
                                       DynamicReplacementAttr *attr,
-                                      TypeChecker &TC) {
+                                      ASTContext &ctx) {
 
   // Retrieve the replaced abstract storage decl.
   SmallVector<ValueDecl *, 4> results;
@@ -2158,20 +2153,23 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
         results.end());
   }
 
+  auto &Diags = ctx.Diags;
   if (results.empty()) {
-    TC.diagnose(attr->getLocation(),
-                diag::dynamic_replacement_accessor_not_found, replacedVarName);
+    Diags.diagnose(attr->getLocation(),
+                   diag::dynamic_replacement_accessor_not_found,
+                   replacedVarName);
     attr->setInvalid();
     return nullptr;
   }
 
   if (results.size() > 1) {
-    TC.diagnose(attr->getLocation(),
-                diag::dynamic_replacement_accessor_ambiguous, replacedVarName);
+    Diags.diagnose(attr->getLocation(),
+                   diag::dynamic_replacement_accessor_ambiguous,
+                   replacedVarName);
     for (auto result : results) {
-      TC.diagnose(result,
-                  diag::dynamic_replacement_accessor_ambiguous_candidate,
-                  result->getModuleContext()->getFullName());
+      Diags.diagnose(result,
+                     diag::dynamic_replacement_accessor_ambiguous_candidate,
+                     result->getModuleContext()->getFullName());
     }
     attr->setInvalid();
     return nullptr;
@@ -2183,9 +2181,9 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
   (void)results[0]->getInterfaceType();
   auto *origStorage = cast<AbstractStorageDecl>(results[0]);
   if (!origStorage->isDynamic()) {
-    TC.diagnose(attr->getLocation(),
-                diag::dynamic_replacement_accessor_not_dynamic,
-                replacedVarName);
+    Diags.diagnose(attr->getLocation(),
+                   diag::dynamic_replacement_accessor_not_dynamic,
+                   replacedVarName);
     attr->setInvalid();
     return nullptr;
   }
@@ -2201,9 +2199,9 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
   if (origAccessor->isImplicit() &&
       !(origStorage->getReadImpl() == ReadImplKind::Stored &&
         origStorage->getWriteImpl() == WriteImplKind::Stored)) {
-    TC.diagnose(attr->getLocation(),
-                diag::dynamic_replacement_accessor_not_explicit,
-                (unsigned)origAccessor->getAccessorKind(), replacedVarName);
+    Diags.diagnose(attr->getLocation(),
+                   diag::dynamic_replacement_accessor_not_explicit,
+                   (unsigned)origAccessor->getAccessorKind(), replacedVarName);
     attr->setInvalid();
     return nullptr;
   }
@@ -2214,7 +2212,7 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
 static AbstractFunctionDecl *
 findReplacedFunction(DeclName replacedFunctionName,
                      const AbstractFunctionDecl *replacement,
-                     DynamicReplacementAttr *attr, TypeChecker *TC) {
+                     DynamicReplacementAttr *attr, DiagnosticEngine *Diags) {
 
   // Note: we might pass a constant attribute when typechecker is nullptr.
   // Any modification to attr must be guarded by a null check on TC.
@@ -2235,10 +2233,10 @@ findReplacedFunction(DeclName replacedFunctionName,
     if (result->getInterfaceType()->getCanonicalType()->matches(
             replacement->getInterfaceType()->getCanonicalType(), matchMode)) {
       if (!result->isDynamic()) {
-        if (TC) {
-          TC->diagnose(attr->getLocation(),
-                       diag::dynamic_replacement_function_not_dynamic,
-                       replacedFunctionName);
+        if (Diags) {
+          Diags->diagnose(attr->getLocation(),
+                          diag::dynamic_replacement_function_not_dynamic,
+                          replacedFunctionName);
           attr->setInvalid();
         }
         return nullptr;
@@ -2247,24 +2245,24 @@ findReplacedFunction(DeclName replacedFunctionName,
     }
   }
 
-  if (!TC)
+  if (!Diags)
     return nullptr;
 
   if (results.empty()) {
-    TC->diagnose(attr->getLocation(),
-                 diag::dynamic_replacement_function_not_found,
-                 attr->getReplacedFunctionName());
+    Diags->diagnose(attr->getLocation(),
+                    diag::dynamic_replacement_function_not_found,
+                    attr->getReplacedFunctionName());
   } else {
-    TC->diagnose(attr->getLocation(),
-                 diag::dynamic_replacement_function_of_type_not_found,
-                 attr->getReplacedFunctionName(),
-                 replacement->getInterfaceType()->getCanonicalType());
+    Diags->diagnose(attr->getLocation(),
+                    diag::dynamic_replacement_function_of_type_not_found,
+                    attr->getReplacedFunctionName(),
+                    replacement->getInterfaceType()->getCanonicalType());
 
     for (auto *result : results) {
-      TC->diagnose(SourceLoc(),
-                   diag::dynamic_replacement_found_function_of_type,
-                   attr->getReplacedFunctionName(),
-                   result->getInterfaceType()->getCanonicalType());
+      Diags->diagnose(SourceLoc(),
+                      diag::dynamic_replacement_found_function_of_type,
+                      attr->getReplacedFunctionName(),
+                      result->getInterfaceType()->getCanonicalType());
     }
   }
   attr->setInvalid();
@@ -2323,15 +2321,15 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
 
   if (!isa<ExtensionDecl>(VD->getDeclContext()) &&
       !VD->getDeclContext()->isModuleScopeContext()) {
-    TC.diagnose(attr->getLocation(), diag::dynamic_replacement_not_in_extension,
-                VD->getBaseName());
+    diagnose(attr->getLocation(), diag::dynamic_replacement_not_in_extension,
+             VD->getBaseName());
     attr->setInvalid();
     return;
   }
 
   if (VD->isNativeDynamic()) {
-    TC.diagnose(attr->getLocation(), diag::dynamic_replacement_must_not_be_dynamic,
-                VD->getBaseName());
+    diagnose(attr->getLocation(), diag::dynamic_replacement_must_not_be_dynamic,
+             VD->getBaseName());
     attr->setInvalid();
     return;
   }
@@ -2353,7 +2351,7 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
       // FIXME(InterfaceTypeRequest): Remove this.
       (void)accessor->getInterfaceType();
        auto *orig = findReplacedAccessor(attr->getReplacedFunctionName(),
-                                         accessor, attr, TC);
+                                         accessor, attr, Ctx);
        if (!orig)
          return;
 
@@ -2364,7 +2362,7 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
     // Otherwise, find the matching function.
     auto *fun = cast<AbstractFunctionDecl>(VD);
     if (auto *orig = findReplacedFunction(attr->getReplacedFunctionName(), fun,
-                                          attr, &TC)) {
+                                          attr, &Ctx.Diags)) {
       origs.push_back(orig);
       replacements.push_back(fun);
     } else
@@ -2379,16 +2377,16 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
       auto *replacedFun = origs[index];
       auto *replacement = replacements[index];
       if (replacedFun->isObjC() && !replacement->isObjC()) {
-        TC.diagnose(attr->getLocation(),
-                    diag::dynamic_replacement_replacement_not_objc_dynamic,
-                    attr->getReplacedFunctionName());
+        diagnose(attr->getLocation(),
+                 diag::dynamic_replacement_replacement_not_objc_dynamic,
+                 attr->getReplacedFunctionName());
         attr->setInvalid();
         return;
       }
       if (!replacedFun->isObjC() && replacement->isObjC()) {
-        TC.diagnose(attr->getLocation(),
-                    diag::dynamic_replacement_replaced_not_objc_dynamic,
-                    attr->getReplacedFunctionName());
+        diagnose(attr->getLocation(),
+                 diag::dynamic_replacement_replaced_not_objc_dynamic,
+                 attr->getReplacedFunctionName());
         attr->setInvalid();
         return;
       }
@@ -2405,11 +2403,11 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
     auto replacedIsConvenienceInit =
         cast<ConstructorDecl>(attr->getReplacedFunction())->isConvenienceInit();
     if (replacedIsConvenienceInit &&!CD->isConvenienceInit()) {
-      TC.diagnose(attr->getLocation(),
-                  diag::dynamic_replacement_replaced_constructor_is_convenience,
-                  attr->getReplacedFunctionName());
+      diagnose(attr->getLocation(),
+               diag::dynamic_replacement_replaced_constructor_is_convenience,
+               attr->getReplacedFunctionName());
     } else if (!replacedIsConvenienceInit && CD->isConvenienceInit()) {
-      TC.diagnose(
+      diagnose(
           attr->getLocation(),
           diag::dynamic_replacement_replaced_constructor_is_not_convenience,
           attr->getReplacedFunctionName());
@@ -2448,12 +2446,12 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     ProtocolDecl *PD = PT->getDecl();
 
     // Check that the ProtocolType has the specified member.
-    LookupResult R = TC.lookupMember(PD->getDeclContext(),
-                                     PT, attr->getMemberName());
+    LookupResult R = TypeChecker::lookupMember(PD->getDeclContext(),
+                                               PT, attr->getMemberName());
     if (!R) {
-      TC.diagnose(attr->getLocation(),
-                  diag::implements_attr_protocol_lacks_member,
-                  PD->getBaseName(), attr->getMemberName())
+      diagnose(attr->getLocation(),
+               diag::implements_attr_protocol_lacks_member,
+               PD->getBaseName(), attr->getMemberName())
         .highlight(attr->getMemberNameLoc().getSourceRange());
     }
 
@@ -2462,15 +2460,14 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     NominalTypeDecl *NTD = DC->getSelfNominalTypeDecl();
     SmallVector<ProtocolConformance *, 2> conformances;
     if (!NTD->lookupConformance(DC->getParentModule(), PD, conformances)) {
-      TC.diagnose(attr->getLocation(),
-                  diag::implements_attr_protocol_not_conformed_to,
-                  NTD->getFullName(), PD->getFullName())
+      diagnose(attr->getLocation(),
+               diag::implements_attr_protocol_not_conformed_to,
+               NTD->getFullName(), PD->getFullName())
         .highlight(ProtoTypeLoc.getTypeRepr()->getSourceRange());
     }
 
   } else {
-    TC.diagnose(attr->getLocation(),
-                diag::implements_attr_non_protocol_type)
+    diagnose(attr->getLocation(), diag::implements_attr_non_protocol_type)
       .highlight(ProtoTypeLoc.getTypeRepr()->getSourceRange());
   }
 }
@@ -2503,7 +2500,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
 
   // Figure out which nominal declaration this custom attribute refers to.
   auto nominal = evaluateOrDefault(
-    TC.Context.evaluator, CustomAttrNominalRequest{attr, dc}, nullptr);
+    Ctx.evaluator, CustomAttrNominalRequest{attr, dc}, nullptr);
 
   // If there is no nominal type with this name, complain about this being
   // an unknown attribute.
@@ -2516,8 +2513,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
       typeName = attr->getTypeLoc().getType().getString();
     }
 
-    TC.diagnose(attr->getLocation(), diag::unknown_attribute,
-                typeName);
+    diagnose(attr->getLocation(), diag::unknown_attribute, typeName);
     attr->setInvalid();
     return;
   }
@@ -2527,9 +2523,9 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   if (nominal->getPropertyWrapperTypeInfo()) {
     // property wrappers can only be applied to variables
     if (!isa<VarDecl>(D) || isa<ParamDecl>(D)) {
-      TC.diagnose(attr->getLocation(),
-                  diag::property_wrapper_attribute_not_on_property,
-                  nominal->getFullName());
+      diagnose(attr->getLocation(),
+               diag::property_wrapper_attribute_not_on_property,
+               nominal->getFullName());
       attr->setInvalid();
       return;
     }
@@ -2549,36 +2545,35 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
       decl = storage;
       auto getter = storage->getParsedAccessor(AccessorKind::Get);
       if (!getter || !getter->hasBody()) {
-        TC.diagnose(attr->getLocation(),
-                    diag::function_builder_attribute_on_storage_without_getter,
-                    nominal->getFullName(),
-                    isa<SubscriptDecl>(storage) ? 0
-                      : storage->getDeclContext()->isTypeContext() ? 1
-                      : cast<VarDecl>(storage)->isLet() ? 2 : 3);
+        diagnose(attr->getLocation(),
+                 diag::function_builder_attribute_on_storage_without_getter,
+                 nominal->getFullName(),
+                 isa<SubscriptDecl>(storage) ? 0
+                   : storage->getDeclContext()->isTypeContext() ? 1
+                   : cast<VarDecl>(storage)->isLet() ? 2 : 3);
         attr->setInvalid();
         return;
       }
     } else {
-      TC.diagnose(attr->getLocation(),
-                  diag::function_builder_attribute_not_allowed_here,
-                  nominal->getFullName());
+      diagnose(attr->getLocation(),
+               diag::function_builder_attribute_not_allowed_here,
+               nominal->getFullName());
       attr->setInvalid();
       return;
     }
 
     // Diagnose and ignore arguments.
     if (attr->getArg()) {
-      TC.diagnose(attr->getLocation(), diag::function_builder_arguments)
+      diagnose(attr->getLocation(), diag::function_builder_arguments)
         .highlight(attr->getArg()->getSourceRange());
     }
 
     // Complain if this isn't the primary function-builder attribute.
     auto attached = decl->getAttachedFunctionBuilder();
     if (attached != attr) {
-      TC.diagnose(attr->getLocation(), diag::function_builder_multiple,
-                  isa<ParamDecl>(decl));
-      TC.diagnose(attached->getLocation(),
-                  diag::previous_function_builder_here);
+      diagnose(attr->getLocation(), diag::function_builder_multiple,
+               isa<ParamDecl>(decl));
+      diagnose(attached->getLocation(), diag::previous_function_builder_here);
       attr->setInvalid();
       return;
     } else {
@@ -2590,8 +2585,8 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
     return;
   }
 
-  TC.diagnose(attr->getLocation(), diag::nominal_type_not_attribute,
-              nominal->getDescriptiveKind(), nominal->getFullName());
+  diagnose(attr->getLocation(), diag::nominal_type_not_attribute,
+           nominal->getDescriptiveKind(), nominal->getFullName());
   nominal->diagnose(diag::decl_declared_here, nominal->getFullName());
   attr->setInvalid();
 }
@@ -2663,9 +2658,9 @@ AttributeChecker::visitImplementationOnlyAttr(ImplementationOnlyAttr *attr) {
   }
 
   if (!derivedInterfaceTy->isEqual(overrideInterfaceTy)) {
-    TC.diagnose(VD, diag::implementation_only_override_changed_type,
-                overrideInterfaceTy);
-    TC.diagnose(overridden, diag::overridden_here);
+    diagnose(VD, diag::implementation_only_override_changed_type,
+             overrideInterfaceTy);
+    diagnose(overridden, diag::overridden_here);
     return;
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2578,7 +2578,7 @@ public:
     (void) SD->getGenericSignature();
 
     if (!SD->isInvalid()) {
-      TC.checkReferencedGenericParams(SD);
+      TypeChecker::checkReferencedGenericParams(SD);
       checkGenericParams(SD->getGenericParams(), SD);
       TypeChecker::checkProtocolSelfRequirements(SD);
     }
@@ -3187,7 +3187,7 @@ public:
 
     if (!FD->isInvalid()) {
       checkGenericParams(FD->getGenericParams(), FD);
-      TC.checkReferencedGenericParams(FD);
+      TypeChecker::checkReferencedGenericParams(FD);
       TypeChecker::checkProtocolSelfRequirements(FD);
     }
 
@@ -3428,7 +3428,7 @@ public:
 
     if (!CD->isInvalid()) {
       checkGenericParams(CD->getGenericParams(), CD);
-      TC.checkReferencedGenericParams(CD);
+      TypeChecker::checkReferencedGenericParams(CD);
       TypeChecker::checkProtocolSelfRequirements(CD);
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2241,7 +2241,7 @@ public:
     
     DeclVisitor<DeclChecker>::visit(decl);
 
-    TC.checkUnsupportedProtocolType(decl);
+    TypeChecker::checkUnsupportedProtocolType(decl);
 
     if (auto VD = dyn_cast<ValueDecl>(decl)) {
       auto &Context = TC.Context;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2580,7 +2580,7 @@ public:
     if (!SD->isInvalid()) {
       TC.checkReferencedGenericParams(SD);
       checkGenericParams(SD->getGenericParams(), SD);
-      TC.checkProtocolSelfRequirements(SD);
+      TypeChecker::checkProtocolSelfRequirements(SD);
     }
 
     TypeChecker::checkDeclAttributes(SD);
@@ -3188,7 +3188,7 @@ public:
     if (!FD->isInvalid()) {
       checkGenericParams(FD->getGenericParams(), FD);
       TC.checkReferencedGenericParams(FD);
-      TC.checkProtocolSelfRequirements(FD);
+      TypeChecker::checkProtocolSelfRequirements(FD);
     }
 
     checkAccessControl(TC, FD);
@@ -3429,7 +3429,7 @@ public:
     if (!CD->isInvalid()) {
       checkGenericParams(CD->getGenericParams(), CD);
       TC.checkReferencedGenericParams(CD);
-      TC.checkProtocolSelfRequirements(CD);
+      TypeChecker::checkProtocolSelfRequirements(CD);
     }
 
     TypeChecker::checkDeclAttributes(CD);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -487,12 +487,12 @@ static void checkInheritanceClause(
 /// Check the inheritance clauses generic parameters along with any
 /// requirements stored within the generic parameter list.
 static void checkGenericParams(GenericParamList *genericParams,
-                               DeclContext *owningDC, TypeChecker &tc) {
+                               DeclContext *owningDC) {
   if (!genericParams)
     return;
 
   for (auto gp : *genericParams) {
-    tc.checkDeclAttributes(gp);
+    TypeChecker::checkDeclAttributes(gp);
     checkInheritanceClause(gp);
   }
 
@@ -2289,11 +2289,11 @@ public:
   }
   
   void visitImportDecl(ImportDecl *ID) {
-    TC.checkDeclAttributes(ID);
+    TypeChecker::checkDeclAttributes(ID);
   }
 
   void visitOperatorDecl(OperatorDecl *OD) {
-    TC.checkDeclAttributes(OD);
+    TypeChecker::checkDeclAttributes(OD);
     auto &Ctx = OD->getASTContext();
     if (auto *IOD = dyn_cast<InfixOperatorDecl>(OD)) {
       (void)IOD->getPrecedenceGroup();
@@ -2311,7 +2311,7 @@ public:
   }
 
   void visitPrecedenceGroupDecl(PrecedenceGroupDecl *PGD) {
-    TC.checkDeclAttributes(PGD);
+    TypeChecker::checkDeclAttributes(PGD);
     validatePrecedenceGroup(PGD);
     checkAccessControl(TC, PGD);
   }
@@ -2377,7 +2377,7 @@ public:
       }
     }
 
-    TC.checkDeclAttributes(VD);
+    TypeChecker::checkDeclAttributes(VD);
 
     if (!checkOverrides(VD)) {
       // If a property has an override attribute but does not override
@@ -2431,7 +2431,7 @@ public:
   void visitPatternBindingDecl(PatternBindingDecl *PBD) {
     DeclContext *DC = PBD->getDeclContext();
 
-    TC.checkDeclAttributes(PBD);
+    TypeChecker::checkDeclAttributes(PBD);
 
     bool isInSILMode = false;
     if (auto sourceFile = DC->getParentSourceFile())
@@ -2529,7 +2529,7 @@ public:
       });
     }
 
-    TC.checkDeclAttributes(PBD);
+    TypeChecker::checkDeclAttributes(PBD);
 
     checkAccessControl(TC, PBD);
 
@@ -2579,11 +2579,11 @@ public:
 
     if (!SD->isInvalid()) {
       TC.checkReferencedGenericParams(SD);
-      checkGenericParams(SD->getGenericParams(), SD, TC);
+      checkGenericParams(SD->getGenericParams(), SD);
       TC.checkProtocolSelfRequirements(SD);
     }
 
-    TC.checkDeclAttributes(SD);
+    TypeChecker::checkDeclAttributes(SD);
 
     checkAccessControl(TC, SD);
 
@@ -2604,7 +2604,7 @@ public:
     (void) SD->isSetterMutating();
     (void) SD->getImplInfo();
 
-    TC.checkParameterAttributes(SD->getIndices());
+    TypeChecker::checkParameterAttributes(SD->getIndices());
     checkDefaultArguments(TC, SD->getIndices());
 
     if (SD->getDeclContext()->getSelfClassDecl()) {
@@ -2627,7 +2627,7 @@ public:
     (void) TAD->getGenericSignature();
     (void) TAD->getUnderlyingType();
 
-    TC.checkDeclAttributes(TAD);
+    TypeChecker::checkDeclAttributes(TAD);
     checkAccessControl(TC, TAD);
 
   }
@@ -2636,12 +2636,12 @@ public:
     // Force requests that can emit diagnostics.
     (void) OTD->getGenericSignature();
 
-    TC.checkDeclAttributes(OTD);
+    TypeChecker::checkDeclAttributes(OTD);
     checkAccessControl(TC, OTD);
   }
   
   void visitAssociatedTypeDecl(AssociatedTypeDecl *AT) {
-    TC.checkDeclAttributes(AT);
+    TypeChecker::checkDeclAttributes(AT);
 
     checkInheritanceClause(AT);
     auto *proto = AT->getProtocol();
@@ -2732,7 +2732,7 @@ public:
     // FIXME: Remove this once we clean up the mess involving raw values.
     (void) ED->getInterfaceType();
 
-    checkGenericParams(ED->getGenericParams(), ED, TC);
+    checkGenericParams(ED->getGenericParams(), ED);
 
     {
       // Check for circular inheritance of the raw type.
@@ -2745,7 +2745,7 @@ public:
     for (Decl *member : ED->getMembers())
       visit(member);
 
-    TC.checkDeclAttributes(ED);
+    TypeChecker::checkDeclAttributes(ED);
 
     checkInheritanceClause(ED);
 
@@ -2778,7 +2778,7 @@ public:
   void visitStructDecl(StructDecl *SD) {
     checkUnsupportedNestedType(SD);
 
-    checkGenericParams(SD->getGenericParams(), SD, TC);
+    checkGenericParams(SD->getGenericParams(), SD);
 
     // Force lowering of stored properties.
     (void) SD->getStoredProperties();
@@ -2790,7 +2790,7 @@ public:
 
     TC.checkPatternBindingCaptures(SD);
 
-    TC.checkDeclAttributes(SD);
+    TypeChecker::checkDeclAttributes(SD);
 
     checkInheritanceClause(SD);
 
@@ -2901,7 +2901,7 @@ public:
     // Force creation of the generic signature.
     (void) CD->getGenericSignature();
 
-    checkGenericParams(CD->getGenericParams(), CD, TC);
+    checkGenericParams(CD->getGenericParams(), CD);
 
     {
       // Check for circular inheritance.
@@ -3038,7 +3038,7 @@ public:
       }
     }
 
-    TC.checkDeclAttributes(CD);
+    TypeChecker::checkDeclAttributes(CD);
 
     checkInheritanceClause(CD);
 
@@ -3075,7 +3075,7 @@ public:
     for (auto Member : PD->getMembers())
       visit(Member);
 
-    TC.checkDeclAttributes(PD);
+    TypeChecker::checkDeclAttributes(PD);
 
     checkAccessControl(TC, PD);
 
@@ -3186,15 +3186,15 @@ public:
     (void) FD->getOperatorDecl();
 
     if (!FD->isInvalid()) {
-      checkGenericParams(FD->getGenericParams(), FD, TC);
+      checkGenericParams(FD->getGenericParams(), FD);
       TC.checkReferencedGenericParams(FD);
       TC.checkProtocolSelfRequirements(FD);
     }
 
     checkAccessControl(TC, FD);
 
-    TC.checkParameterAttributes(FD->getParameters());
-    TC.checkDeclAttributes(FD);
+    TypeChecker::checkParameterAttributes(FD->getParameters());
+    TypeChecker::checkDeclAttributes(FD);
 
     if (!checkOverrides(FD)) {
       // If a method has an 'override' keyword but does not
@@ -3280,10 +3280,10 @@ public:
     (void) EED->getInterfaceType();
     auto *ED = EED->getParentEnum();
 
-    TC.checkDeclAttributes(EED);
+    TypeChecker::checkDeclAttributes(EED);
 
     if (auto *PL = EED->getParameterList()) {
-      TC.checkParameterAttributes(PL);
+      TypeChecker::checkParameterAttributes(PL);
       checkDefaultArguments(TC, PL);
     }
 
@@ -3387,14 +3387,14 @@ public:
       }
     }
 
-    checkGenericParams(ED->getGenericParams(), ED, TC);
+    checkGenericParams(ED->getGenericParams(), ED);
 
     for (Decl *Member : ED->getMembers())
       visit(Member);
 
     TC.ConformanceContexts.push_back(ED);
 
-    TC.checkDeclAttributes(ED);
+    TypeChecker::checkDeclAttributes(ED);
     checkAccessControl(TC, ED);
 
     checkExplicitAvailability(ED);
@@ -3408,7 +3408,7 @@ public:
   void visitIfConfigDecl(IfConfigDecl *ICD) {
     // The active members of the #if block will be type checked along with
     // their enclosing declaration.
-    TC.checkDeclAttributes(ICD);
+    TypeChecker::checkDeclAttributes(ICD);
   }
 
   void visitPoundDiagnosticDecl(PoundDiagnosticDecl *PDD) {
@@ -3427,13 +3427,13 @@ public:
     (void) CD->getInitKind();
 
     if (!CD->isInvalid()) {
-      checkGenericParams(CD->getGenericParams(), CD, TC);
+      checkGenericParams(CD->getGenericParams(), CD);
       TC.checkReferencedGenericParams(CD);
       TC.checkProtocolSelfRequirements(CD);
     }
 
-    TC.checkDeclAttributes(CD);
-    TC.checkParameterAttributes(CD->getParameters());
+    TypeChecker::checkDeclAttributes(CD);
+    TypeChecker::checkParameterAttributes(CD->getParameters());
 
     // Check whether this initializer overrides an initializer in its
     // superclass.
@@ -3548,7 +3548,7 @@ public:
   }
 
   void visitDestructorDecl(DestructorDecl *DD) {
-    TC.checkDeclAttributes(DD);
+    TypeChecker::checkDeclAttributes(DD);
 
     if (DD->getDeclContext()->isLocalContext()) {
       // Check local function bodies right away.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -246,6 +246,7 @@ void TypeChecker::checkProtocolSelfRequirements(ValueDecl *decl) {
   // For a generic requirement in a protocol, make sure that the requirement
   // set didn't add any requirements to Self or its associated types.
   if (auto *proto = dyn_cast<ProtocolDecl>(decl->getDeclContext())) {
+    auto &ctx = proto->getASTContext();
     auto protoSelf = proto->getSelfInterfaceType();
     auto sig = decl->getInnermostDeclContext()->getGenericSignatureOfContext();
     for (auto req : sig->getRequirements()) {
@@ -261,12 +262,12 @@ void TypeChecker::checkProtocolSelfRequirements(ValueDecl *decl) {
           req.getFirstType()->is<GenericTypeParamType>())
         continue;
 
-      diagnose(decl,
-               diag::requirement_restricts_self,
-               decl->getDescriptiveKind(), decl->getFullName(),
-               req.getFirstType().getString(),
-               static_cast<unsigned>(req.getKind()),
-               req.getSecondType().getString());
+      ctx.Diags.diagnose(decl,
+                         diag::requirement_restricts_self,
+                         decl->getDescriptiveKind(), decl->getFullName(),
+                         req.getFirstType().getString(),
+                         static_cast<unsigned>(req.getKind()),
+                         req.getSecondType().getString());
     }
   }
 }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -421,6 +421,7 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
 
   // Check that every generic parameter type from the signature is
   // among referencedGenericParams.
+  auto &ctx = decl->getASTContext();
   for (auto *genParam : genericSig->getGenericParams()) {
     auto *paramDecl = genParam->getDecl();
     if (paramDecl->getDepth() != fnGenericParamsDepth)
@@ -438,9 +439,10 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
           continue;
       }
       // Produce an error that this generic parameter cannot be bound.
-      diagnose(paramDecl->getLoc(), diag::unreferenced_generic_parameter,
-               paramDecl->getNameStr());
-      decl->setInterfaceType(ErrorType::get(Context));
+      ctx.Diags.diagnose(paramDecl->getLoc(),
+                         diag::unreferenced_generic_parameter,
+                         paramDecl->getNameStr());
+      decl->setInterfaceType(ErrorType::get(ctx));
       decl->setInvalid();
     }
   }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -878,9 +878,10 @@ createPropertyLoadOrCallSuperclassGetter(AccessorDecl *accessor,
                                ctx);
 }
 
-static ProtocolConformanceRef
-checkConformanceToNSCopying(ASTContext &ctx, VarDecl *var, Type type) {
+static ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var,
+                                                          Type type) {
   auto dc = var->getDeclContext();
+  auto &ctx = dc->getASTContext();
   auto proto = ctx.getNSCopyingDecl();
 
   if (proto) {
@@ -904,7 +905,7 @@ static std::pair<Type, bool> getUnderlyingTypeOfVariable(VarDecl *var) {
 
 ProtocolConformanceRef TypeChecker::checkConformanceToNSCopying(VarDecl *var) {
   Type type = getUnderlyingTypeOfVariable(var).first;
-  return ::checkConformanceToNSCopying(Context, var, type);
+  return ::checkConformanceToNSCopying(var, type);
 }
 
 /// Synthesize the code to store 'Val' to 'VD', given that VD has an @NSCopying
@@ -921,7 +922,7 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
 
   // The element type must conform to NSCopying.  If not, emit an error and just
   // recovery by synthesizing without the copy call.
-  auto conformance = checkConformanceToNSCopying(Ctx, VD, underlyingType);
+  auto conformance = checkConformanceToNSCopying(VD, underlyingType);
   if (!conformance)
     return Val;
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -783,18 +783,20 @@ public:
                            TypeResolutionOptions options);
 
   /// Check for unsupported protocol types in the given declaration.
-  void checkUnsupportedProtocolType(Decl *decl);
+  static void checkUnsupportedProtocolType(Decl *decl);
 
   /// Check for unsupported protocol types in the given statement.
-  void checkUnsupportedProtocolType(Stmt *stmt);
+  static void checkUnsupportedProtocolType(ASTContext &ctx, Stmt *stmt);
 
   /// Check for unsupported protocol types in the given generic requirement
   /// list.
-  void checkUnsupportedProtocolType(TrailingWhereClause *whereClause);
+  static void checkUnsupportedProtocolType(ASTContext &ctx,
+                                           TrailingWhereClause *whereClause);
 
   /// Check for unsupported protocol types in the given generic requirement
   /// list.
-  void checkUnsupportedProtocolType(GenericParamList *genericParams);
+  static void checkUnsupportedProtocolType(ASTContext &ctx,
+                                           GenericParamList *genericParams);
 
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
   static GenericEnvironment *

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -994,9 +994,9 @@ public:
                                           SourceLoc EndTypeCheckLoc);
   bool typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD);
 
-  BraceStmt *applyFunctionBuilderBodyTransform(FuncDecl *FD,
-                                               BraceStmt *body,
-                                               Type builderType);
+  static BraceStmt *applyFunctionBuilderBodyTransform(FuncDecl *FD,
+                                                      BraceStmt *body,
+                                                      Type builderType);
   bool typeCheckClosureBody(ClosureExpr *closure);
 
   bool typeCheckTapBody(TapExpr *expr, DeclContext *DC);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1014,8 +1014,8 @@ public:
   void typeCheckDecl(Decl *D);
 
   static void addImplicitDynamicAttribute(Decl *D);
-  void checkDeclAttributes(Decl *D);
-  void checkParameterAttributes(ParameterList *params);
+  static void checkDeclAttributes(Decl *D);
+  static void checkParameterAttributes(ParameterList *params);
   static ValueDecl *findReplacedDynamicFunction(const ValueDecl *d);
 
   static Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
@@ -1537,7 +1537,7 @@ public:
                                   IterableDeclContext *idc);
 
   /// Check that the type of the given property conforms to NSCopying.
-  ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
+  static ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
 
   /// Derive an implicit declaration to satisfy a requirement of a derived
   /// protocol conformance.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1038,7 +1038,7 @@ public:
 
   /// All generic parameters of a generic function must be referenced in the
   /// declaration's type, otherwise we have no way to infer them.
-  void checkReferencedGenericParams(GenericContext *dc);
+  static void checkReferencedGenericParams(GenericContext *dc);
 
   /// Construct a new generic environment for the given declaration context.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -988,7 +988,7 @@ public:
   /// If the inputs to an apply expression use a consistent "sugar" type
   /// (that is, a typealias or shorthand syntax) equivalent to the result type
   /// of the function, set the result type of the expression to that sugar type.
-  Expr *substituteInputSugarTypeForResult(ApplyExpr *E);
+  static Expr *substituteInputSugarTypeForResult(ApplyExpr *E);
 
   bool typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
                                           SourceLoc EndTypeCheckLoc);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1034,7 +1034,7 @@ public:
 
   /// For a generic requirement in a protocol, make sure that the requirement
   /// set didn't add any requirements to Self or its associated types.
-  void checkProtocolSelfRequirements(ValueDecl *decl);
+  static void checkProtocolSelfRequirements(ValueDecl *decl);
 
   /// All generic parameters of a generic function must be referenced in the
   /// declaration's type, otherwise we have no way to infer them.


### PR DESCRIPTION
This PR changes `AttributeChecker` and `UnsupportedProtocolVisitor` to not store `TypeChecker` properties, and makes a handful of `TypeChecker` members `static`.