### PR TITLE
[AST] Simplify Expr::forEachImmediateChildExpr

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -454,7 +454,7 @@ public:
   /// Enumerate each immediate child expression of this node, invoking the
   /// specific functor on it.  This ignores statements and other non-expression
   /// children.
-  void forEachImmediateChildExpr(llvm::function_ref<Expr *(Expr *)> callback);
+  void forEachImmediateChildExpr(llvm::function_ref<void(Expr *)> callback);
 
   /// Enumerate each expr node within this expression subtree, invoking the
   /// specific functor on it.  This ignores statements and other non-expression

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -383,12 +383,12 @@ ConcreteDeclRef Expr::getReferencedDecl() const {
 /// specific functor on it.  This ignores statements and other non-expression
 /// children.
 void Expr::
-forEachImmediateChildExpr(llvm::function_ref<Expr *(Expr *)> callback) {
+forEachImmediateChildExpr(llvm::function_ref<void(Expr *)> callback) {
   struct ChildWalker : ASTWalker {
-    llvm::function_ref<Expr *(Expr *)> callback;
+    llvm::function_ref<void(Expr *)> callback;
     Expr *ThisNode;
     
-    ChildWalker(llvm::function_ref<Expr *(Expr *)> callback, Expr *ThisNode)
+    ChildWalker(llvm::function_ref<void(Expr *)> callback, Expr *ThisNode)
       : callback(callback), ThisNode(ThisNode) {}
     
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
@@ -398,7 +398,8 @@ forEachImmediateChildExpr(llvm::function_ref<Expr *(Expr *)> callback) {
         return { true, E };
 
       // Otherwise we must be a child of our expression, enumerate it!
-      return { false, callback(E) };
+      callback(E);
+      return { false, E };
     }
     
     std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -805,7 +805,6 @@ static Expr* getSingleNonImplicitChild(Expr *Parent) {
   llvm::SmallVector<Expr*, 4> Children;
   Parent->forEachImmediateChildExpr([&](Expr *E) {
     Children.push_back(E);
-    return E;
   });
 
   // If more than one children are found, we are not sure the non-implicit node.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4328,19 +4328,18 @@ bool FailureDiagnosis::visitExpr(Expr *E) {
   // independently invalid.
   bool errorInSubExpr = false;
   
-  E->forEachImmediateChildExpr([&](Expr *Child) -> Expr* {
+  E->forEachImmediateChildExpr([&](Expr *Child) {
     // If we already found an error, stop checking.
-    if (errorInSubExpr) return Child;
+    if (errorInSubExpr) return;
 
     // Otherwise just type check the subexpression independently.  If that
     // succeeds, then we stitch the result back into our expression.
     if (typeCheckChildIndependently(Child, TCC_AllowLValue))
-      return Child;
+      return;
 
     // Otherwise, it failed, which emitted a diagnostic.  Keep track of this
     // so that we don't emit multiple diagnostics.
     errorInSubExpr = true;
-    return Child;
   });
   
   // If any of the children were errors, we're done.


### PR DESCRIPTION
The callback's return value is going to go unused anyway, so don't even ask for one.