### PR TITLE
[edit] Fix racy access to SemanticInfo

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1905,6 +1905,7 @@ void SwiftEditorDocument::readSyntaxInfo(EditorConsumer &Consumer) {
 
 void SwiftEditorDocument::readSemanticInfo(ImmutableTextSnapshotRef Snapshot,
                                            EditorConsumer& Consumer) {
+  llvm::sys::ScopedLock L(Impl.AccessMtx);
   std::vector<SwiftSemanticToken> SemaToks;
   Optional<std::vector<DiagnosticEntryInfo>> SemaDiags;
   Impl.SemanticInfo->readSemanticInfo(Snapshot, SemaToks, SemaDiags,


### PR DESCRIPTION
Specifically, if the document was re-opened, we would drop the reference
and the call to readSemanticInfo could use-after-free the array of
diagnostics. This manifested as a very rare crash while testing
sourcekit-lsp.

rdar://problem/56420572