### PR TITLE
[NFC] Fold The Tri-State In Optional<ProtocolConformanceRef>

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4380,9 +4380,9 @@ public:
 
   /// Returns the default associated conformance witness for an associated
   /// type, or \c None if there is no default.
-  Optional<ProtocolConformanceRef> getDefaultAssociatedConformanceWitness(
-                                              CanType association,
-                                              ProtocolDecl *requirement) const;
+  ProtocolConformanceRef
+  getDefaultAssociatedConformanceWitness(CanType association,
+                                         ProtocolDecl *requirement) const;
 
   /// Set the default associated conformance witness for the given
   /// associated conformance.

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -269,8 +269,8 @@ public:
   /// Look up a stored conformance in the generic signature. These are formed
   /// from same-type constraints placed on associated types of generic
   /// parameters which have conformance constraints on them.
-  Optional<ProtocolConformanceRef>
-  lookupConformance(CanType depTy, ProtocolDecl *proto) const;
+  ProtocolConformanceRef lookupConformance(CanType depTy,
+                                           ProtocolDecl *proto) const;
 
   /// Iterate over all generic parameters, passing a flag to the callback
   /// indicating if the generic parameter is canonical or not.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -519,10 +519,9 @@ public:
     explicit LookUpConformanceInBuilder(GenericSignatureBuilder *builder)
       : builder(builder) {}
 
-    Optional<ProtocolConformanceRef>
-    operator()(CanType dependentType,
-               Type conformingReplacementType,
-               ProtocolDecl *conformedProtocol) const {
+    ProtocolConformanceRef operator()(CanType dependentType,
+                                      Type conformingReplacementType,
+                                      ProtocolDecl *conformedProtocol) const {
       return builder->lookupConformance(dependentType,
                                         conformingReplacementType,
                                         conformedProtocol);
@@ -534,10 +533,9 @@ public:
   LookUpConformanceInBuilder getLookupConformanceFn();
 
   /// Lookup a protocol conformance in a module-agnostic manner.
-  Optional<ProtocolConformanceRef>
-  lookupConformance(CanType dependentType, Type conformingReplacementType,
-                    ProtocolDecl *conformedProtocol);
-
+  ProtocolConformanceRef lookupConformance(CanType dependentType,
+                                           Type conformingReplacementType,
+                                           ProtocolDecl *conformedProtocol);
 
   /// Retrieve the lazy resolver, if there is one.
   LazyResolver *getLazyResolver() const;

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -409,19 +409,18 @@ public:
   /// \returns The result of the conformance search, which will be
   /// None if the type does not conform to the protocol or contain a
   /// ProtocolConformanceRef if it does conform.
-  Optional<ProtocolConformanceRef>
-  lookupConformance(Type type, ProtocolDecl *protocol);
+  ProtocolConformanceRef lookupConformance(Type type, ProtocolDecl *protocol);
 
   /// Look for the conformance of the given existential type to the given
   /// protocol.
-  Optional<ProtocolConformanceRef>
-  lookupExistentialConformance(Type type, ProtocolDecl *protocol);
+  ProtocolConformanceRef lookupExistentialConformance(Type type,
+                                                      ProtocolDecl *protocol);
 
   /// Exposes TypeChecker functionality for querying protocol conformance.
   /// Returns a valid ProtocolConformanceRef only if all conditional
   /// requirements are successfully resolved.
-  Optional<ProtocolConformanceRef>
-  conformsToProtocol(Type sourceTy, ProtocolDecl *targetProtocol);
+  ProtocolConformanceRef conformsToProtocol(Type sourceTy,
+                                            ProtocolDecl *targetProtocol);
 
   /// Find a member named \p name in \p container that was declared in this
   /// module.

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -63,13 +63,18 @@ public:
            "cannot construct ProtocolConformanceRef with null");
   }
 
+  ProtocolConformanceRef(std::nullptr_t = nullptr)
+      : Union((ProtocolDecl *)nullptr) {}
+
   static ProtocolConformanceRef forInvalid() {
-    return ProtocolConformanceRef(UnionType((ProtocolDecl *)nullptr));
+    return ProtocolConformanceRef();
   }
 
   bool isInvalid() const {
     return !Union;
   }
+
+  explicit operator bool() const { return !isInvalid(); }
 
   /// Create either a concrete or an abstract protocol conformance reference,
   /// depending on whether ProtocolConformance is null.

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -805,8 +805,7 @@ class ForEachStmt : public LabeledStmt {
   BraceStmt *Body;
 
   // Set by Sema:
-  ProtocolConformanceRef sequenceConformance =
-      ProtocolConformanceRef::forInvalid();
+  ProtocolConformanceRef sequenceConformance = ProtocolConformanceRef();
   ConcreteDeclRef makeIterator;
   ConcreteDeclRef iteratorNext;
   VarDecl *iteratorVar = nullptr;

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -805,7 +805,8 @@ class ForEachStmt : public LabeledStmt {
   BraceStmt *Body;
 
   // Set by Sema:
-  Optional<ProtocolConformanceRef> sequenceConformance;
+  ProtocolConformanceRef sequenceConformance =
+      ProtocolConformanceRef::forInvalid();
   ConcreteDeclRef makeIterator;
   ConcreteDeclRef iteratorNext;
   VarDecl *iteratorVar = nullptr;
@@ -842,10 +843,10 @@ public:
   void setIteratorNext(ConcreteDeclRef declRef) { iteratorNext = declRef; }
   ConcreteDeclRef getIteratorNext() const { return iteratorNext; }
 
-  void setSequenceConformance(Optional<ProtocolConformanceRef> conformance) {
+  void setSequenceConformance(ProtocolConformanceRef conformance) {
     sequenceConformance = conformance;
   }
-  Optional<ProtocolConformanceRef> getSequenceConformance() const {
+  ProtocolConformanceRef getSequenceConformance() const {
     return sequenceConformance;
   }
 

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -128,8 +128,8 @@ public:
   ArrayRef<ProtocolConformanceRef> getConformances() const;
 
   /// Look up a conformance for the given type to the given protocol.
-  Optional<ProtocolConformanceRef>
-  lookupConformance(CanType type, ProtocolDecl *proto) const;
+  ProtocolConformanceRef lookupConformance(CanType type,
+                                           ProtocolDecl *proto) const;
 
   /// Whether the substitution map is empty.
   bool empty() const;
@@ -290,11 +290,10 @@ class LookUpConformanceInSubstitutionMap {
 public:
   explicit LookUpConformanceInSubstitutionMap(SubstitutionMap Subs)
     : Subs(Subs) {}
-  
-  Optional<ProtocolConformanceRef>
-  operator()(CanType dependentType,
-             Type conformingReplacementType,
-             ProtocolDecl *conformedProtocol) const;
+
+  ProtocolConformanceRef operator()(CanType dependentType,
+                                    Type conformingReplacementType,
+                                    ProtocolDecl *conformedProtocol) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -93,7 +93,7 @@ struct QueryTypeSubstitutionMapOrIdentity {
 using GenericFunction = auto(CanType dependentType,
                              Type conformingReplacementType,
                              ProtocolDecl *conformedProtocol)
-  -> Optional<ProtocolConformanceRef>;
+                            -> ProtocolConformanceRef;
 using LookupConformanceFn = llvm::function_ref<GenericFunction>;
   
 /// Functor class suitable for use as a \c LookupConformanceFn to look up a
@@ -103,11 +103,10 @@ class LookUpConformanceInModule {
 public:
   explicit LookUpConformanceInModule(ModuleDecl *M)
     : M(M) {}
-  
-  Optional<ProtocolConformanceRef>
-  operator()(CanType dependentType,
-             Type conformingReplacementType,
-             ProtocolDecl *conformedProtocol) const;
+
+  ProtocolConformanceRef operator()(CanType dependentType,
+                                    Type conformingReplacementType,
+                                    ProtocolDecl *conformedProtocol) const;
 };
 
 /// Functor class suitable for use as a \c LookupConformanceFn that provides
@@ -115,10 +114,9 @@ public:
 /// type is an opaque generic type.
 class MakeAbstractConformanceForGenericType {
 public:
-  Optional<ProtocolConformanceRef>
-  operator()(CanType dependentType,
-             Type conformingReplacementType,
-             ProtocolDecl *conformedProtocol) const;
+  ProtocolConformanceRef operator()(CanType dependentType,
+                                    Type conformingReplacementType,
+                                    ProtocolDecl *conformedProtocol) const;
 };
 
 /// Functor class suitable for use as a \c LookupConformanceFn that fetches
@@ -130,11 +128,10 @@ public:
     : Sig(Sig) {
       assert(Sig && "Cannot lookup conformance in null signature!");
     }
-  
-  Optional<ProtocolConformanceRef>
-  operator()(CanType dependentType,
-             Type conformingReplacementType,
-             ProtocolDecl *conformedProtocol) const;
+
+    ProtocolConformanceRef operator()(CanType dependentType,
+                                      Type conformingReplacementType,
+                                      ProtocolDecl *conformedProtocol) const;
 };
   
 /// Flags that can be passed when substituting into a type.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3903,7 +3903,7 @@ public:
       SubstitutionMap substitutions, bool genericSigIsImplied,
       const ASTContext &ctx,
       ProtocolConformanceRef witnessMethodConformance =
-          ProtocolConformanceRef::forInvalid());
+          ProtocolConformanceRef());
 
   /// Return a structurally-identical function type with a slightly tweaked
   /// ExtInfo.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4104,7 +4104,7 @@ public:
   /// If this is a @convention(witness_method) function, return the conformance
   /// for which the method is a witness. If it isn't that convention, return
   /// an invalid conformance.
-  ProtocolConformanceRef getWitnessMethodConformanceOrNone() const {
+  ProtocolConformanceRef getWitnessMethodConformanceOrInvalid() const {
     return WitnessMethodConformance;
   }
 
@@ -4199,11 +4199,9 @@ public:
 
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, getSubstGenericSignature(), getExtInfo(), getCoroutineKind(),
-            getCalleeConvention(), getParameters(), getYields(),
-            getResults(), getOptionalErrorResult(),
-            getWitnessMethodConformanceOrNone(),
-            isGenericSignatureImplied(),
-            getSubstitutions());
+            getCalleeConvention(), getParameters(), getYields(), getResults(),
+            getOptionalErrorResult(), getWitnessMethodConformanceOrInvalid(),
+            isGenericSignatureImplied(), getSubstitutions());
   }
   static void
   Profile(llvm::FoldingSetNodeID &ID, GenericSignature genericSig, ExtInfo info,

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -590,8 +590,7 @@ CanSILFunctionType getNativeSILFunctionType(
     CanAnyFunctionType substType, Optional<SILDeclRef> origConstant = None,
     Optional<SILDeclRef> constant = None,
     Optional<SubstitutionMap> reqtSubs = None,
-    ProtocolConformanceRef witnessMethodConformance =
-        ProtocolConformanceRef::forInvalid());
+    ProtocolConformanceRef witnessMethodConformance = ProtocolConformanceRef());
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, SILType T) {
   T.print(OS);

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -587,11 +587,11 @@ NON_SIL_TYPE(LValue)
 
 CanSILFunctionType getNativeSILFunctionType(
     Lowering::TypeConverter &TC, Lowering::AbstractionPattern origType,
-    CanAnyFunctionType substType,
-    Optional<SILDeclRef> origConstant = None,
+    CanAnyFunctionType substType, Optional<SILDeclRef> origConstant = None,
     Optional<SILDeclRef> constant = None,
     Optional<SubstitutionMap> reqtSubs = None,
-    Optional<ProtocolConformanceRef> witnessMethodConformance = None);
+    ProtocolConformanceRef witnessMethodConformance =
+        ProtocolConformanceRef::forInvalid());
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, SILType T) {
   T.print(OS);

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -72,16 +72,16 @@ inline CanAnyFunctionType adjustFunctionType(CanAnyFunctionType t,
 CanSILFunctionType
 adjustFunctionType(CanSILFunctionType type, SILFunctionType::ExtInfo extInfo,
                    ParameterConvention calleeConv,
-                   Optional<ProtocolConformanceRef> witnessMethodConformance);
+                   ProtocolConformanceRef witnessMethodConformance);
 inline CanSILFunctionType
 adjustFunctionType(CanSILFunctionType type, SILFunctionType::ExtInfo extInfo,
-                   Optional<ProtocolConformanceRef> witnessMethodConformance) {
+                   ProtocolConformanceRef witnessMethodConformance) {
   return adjustFunctionType(type, extInfo, type->getCalleeConvention(),
                             witnessMethodConformance);
 }
 inline CanSILFunctionType
 adjustFunctionType(CanSILFunctionType t, SILFunctionType::Representation rep,
-                   Optional<ProtocolConformanceRef> witnessMethodConformance) {
+                   ProtocolConformanceRef witnessMethodConformance) {
   if (t->getRepresentation() == rep) return t;
   auto extInfo = t->getExtInfo().withRepresentation(rep);
   auto contextConvention = DefaultThickCalleeConvention;

--- a/include/swift/SILOptimizer/Utils/Existential.h
+++ b/include/swift/SILOptimizer/Utils/Existential.h
@@ -98,8 +98,7 @@ struct ConcreteExistentialInfo {
   // Do a conformance lookup on ConcreteType with the given requirement, P. If P
   // is satisfiable based on the existential's conformance, return the new
   // conformance on P. Otherwise return None.
-  Optional<ProtocolConformanceRef>
-  lookupExistentialConformance(ProtocolDecl *P) const {
+  ProtocolConformanceRef lookupExistentialConformance(ProtocolDecl *P) const {
     CanType selfTy = P->getSelfInterfaceType()->getCanonicalType();
     return ExistentialSubs.lookupConformance(selfTy, P);
   }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1060,14 +1060,14 @@ ASTContext::getBuiltinInitDecl(NominalTypeDecl *decl,
   auto builtinProtocol = getProtocol(builtinProtocolKind);
   auto builtinConformance = getStdlibModule()->lookupConformance(
       type, builtinProtocol);
-  if (!builtinConformance) {
+  if (builtinConformance.isInvalid()) {
     assert(false && "Missing required conformance");
     witness = ConcreteDeclRef();
     return witness;
   }
 
   auto *ctx = const_cast<ASTContext *>(this);
-  witness = builtinConformance->getWitnessByName(type, initName(*ctx));
+  witness = builtinConformance.getWitnessByName(type, initName(*ctx));
   if (!witness) {
     assert(false && "Missing required witness");
     witness = ConcreteDeclRef();
@@ -1711,16 +1711,14 @@ void ProtocolDecl::setDefaultTypeWitness(AssociatedTypeDecl *assocType,
   (void)pair;
 }
 
-Optional<ProtocolConformanceRef>
-ProtocolDecl::getDefaultAssociatedConformanceWitness(
-                                             CanType association,
-                                             ProtocolDecl *requirement) const {
+ProtocolConformanceRef ProtocolDecl::getDefaultAssociatedConformanceWitness(
+    CanType association, ProtocolDecl *requirement) const {
   auto &ctx = getASTContext();
   auto found =
     ctx.getImpl().DefaultAssociatedConformanceWitnesses.find(
       std::make_tuple(this, association, requirement));
   if (found == ctx.getImpl().DefaultAssociatedConformanceWitnesses.end())
-    return None;
+    return ProtocolConformanceRef::forInvalid();
 
   return found->second;
 }
@@ -3138,18 +3136,19 @@ ArrayRef<Requirement> GenericFunctionType::getRequirements() const {
   return Signature->getRequirements();
 }
 
-void SILFunctionType::Profile(llvm::FoldingSetNodeID &id,
-                              GenericSignature genericParams,
-                              ExtInfo info,
-                              SILCoroutineKind coroutineKind,
-                              ParameterConvention calleeConvention,
-                              ArrayRef<SILParameterInfo> params,
-                              ArrayRef<SILYieldInfo> yields,
-                              ArrayRef<SILResultInfo> results,
-                              Optional<SILResultInfo> errorResult,
-                              Optional<ProtocolConformanceRef> conformance,
-                              bool isGenericSignatureImplied,
-                              SubstitutionMap substitutions) {
+void SILFunctionType::Profile(
+    llvm::FoldingSetNodeID &id,
+    GenericSignature genericParams,
+    ExtInfo info,
+    SILCoroutineKind coroutineKind,
+    ParameterConvention calleeConvention,
+    ArrayRef<SILParameterInfo> params,
+    ArrayRef<SILYieldInfo> yields,
+    ArrayRef<SILResultInfo> results,
+    Optional<SILResultInfo> errorResult,
+    ProtocolConformanceRef conformance,
+    bool isGenericSignatureImplied,
+    SubstitutionMap substitutions) {
   id.AddPointer(genericParams.getPointer());
   id.AddInteger(info.getFuncAttrKey());
   id.AddInteger(unsigned(coroutineKind));
@@ -3169,23 +3168,25 @@ void SILFunctionType::Profile(llvm::FoldingSetNodeID &id,
   if (errorResult) errorResult->profile(id);
   id.AddBoolean(isGenericSignatureImplied);
   substitutions.profile(id);
-  id.AddBoolean((bool)conformance);
-  if (conformance)
-    id.AddPointer(conformance->getRequirement());
+  id.AddBoolean(!conformance.isInvalid());
+  if (!conformance.isInvalid())
+    id.AddPointer(conformance.getRequirement());
 }
 
-SILFunctionType::SILFunctionType(GenericSignature genericSig, ExtInfo ext,
-                                 SILCoroutineKind coroutineKind,
-                                 ParameterConvention calleeConvention,
-                                 ArrayRef<SILParameterInfo> params,
-                                 ArrayRef<SILYieldInfo> yields,
-                                 ArrayRef<SILResultInfo> normalResults,
-                                 Optional<SILResultInfo> errorResult,
-                                 SubstitutionMap substitutions,
-                                 bool genericSigIsImplied,
-                                 const ASTContext &ctx,
-                                 RecursiveTypeProperties properties,
-                      Optional<ProtocolConformanceRef> witnessMethodConformance)
+SILFunctionType::SILFunctionType(
+    GenericSignature genericSig,
+    ExtInfo ext,
+    SILCoroutineKind coroutineKind,
+    ParameterConvention calleeConvention,
+    ArrayRef<SILParameterInfo> params,
+    ArrayRef<SILYieldInfo> yields,
+    ArrayRef<SILResultInfo> normalResults,
+    Optional<SILResultInfo> errorResult,
+    SubstitutionMap substitutions,
+    bool genericSigIsImplied,
+    const ASTContext &ctx,
+    RecursiveTypeProperties properties,
+    ProtocolConformanceRef witnessMethodConformance)
     : TypeBase(TypeKind::SILFunction, &ctx, properties),
       GenericSigAndIsImplied(CanGenericSignature(genericSig),
                              genericSigIsImplied),
@@ -3232,10 +3233,10 @@ SILFunctionType::SILFunctionType(GenericSignature genericSig, ExtInfo ext,
   }
 #ifndef NDEBUG
   if (ext.getRepresentation() == Representation::WitnessMethod)
-    assert(WitnessMethodConformance &&
+    assert(!WitnessMethodConformance.isInvalid() &&
            "witness_method SIL function without a conformance");
   else
-    assert(!WitnessMethodConformance &&
+    assert(WitnessMethodConformance.isInvalid() &&
            "non-witness_method SIL function with a conformance");
 
   // Make sure the type follows invariants.
@@ -3313,18 +3314,18 @@ CanSILBlockStorageType SILBlockStorageType::get(CanType captureType) {
   return CanSILBlockStorageType(storageTy);
 }
 
-CanSILFunctionType SILFunctionType::get(GenericSignature genericSig,
-                                        ExtInfo ext,
-                                        SILCoroutineKind coroutineKind,
-                                        ParameterConvention callee,
-                                        ArrayRef<SILParameterInfo> params,
-                                        ArrayRef<SILYieldInfo> yields,
-                                        ArrayRef<SILResultInfo> normalResults,
-                                        Optional<SILResultInfo> errorResult,
-                                        SubstitutionMap substitutions,
-                                        bool genericSigIsImplied,
-                                        const ASTContext &ctx,
-                    Optional<ProtocolConformanceRef> witnessMethodConformance) {
+CanSILFunctionType SILFunctionType::get(
+    GenericSignature genericSig,
+    ExtInfo ext, SILCoroutineKind coroutineKind,
+    ParameterConvention callee,
+    ArrayRef<SILParameterInfo> params,
+    ArrayRef<SILYieldInfo> yields,
+    ArrayRef<SILResultInfo> normalResults,
+    Optional<SILResultInfo> errorResult,
+    SubstitutionMap substitutions,
+    bool genericSigIsImplied,
+    const ASTContext &ctx,
+    ProtocolConformanceRef witnessMethodConformance) {
   assert(coroutineKind == SILCoroutineKind::None || normalResults.empty());
   assert(coroutineKind != SILCoroutineKind::None || yields.empty());
   assert(!ext.isPseudogeneric() || genericSig);
@@ -3383,7 +3384,6 @@ CanSILFunctionType SILFunctionType::get(GenericSignature genericSig,
   ctx.getImpl().SILFunctionTypes.InsertNode(fnType, insertPos);
   return CanSILFunctionType(fnType);
 }
-
 
 ArraySliceType *ArraySliceType::get(Type base) {
   auto properties = base->getRecursiveProperties();
@@ -4165,11 +4165,11 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
     if (nominal != dc->getASTContext().getOptionalDecl()) {
       if (auto objcBridgeable
             = getProtocol(KnownProtocolKind::ObjectiveCBridgeable)) {
-        if (auto conformance
-              = dc->getParentModule()->lookupConformance(
-                  nominal->getDeclaredType(), objcBridgeable)) {
+        auto conformance = dc->getParentModule()->lookupConformance(
+            nominal->getDeclaredType(), objcBridgeable);
+        if (!conformance.isInvalid()) {
           result =
-              ForeignRepresentationInfo::forBridged(conformance->getConcrete());
+              ForeignRepresentationInfo::forBridged(conformance.getConcrete());
         }
       }
     }
@@ -4305,32 +4305,33 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
 
   // Try to find a conformance that will enable bridging.
   auto findConformance =
-    [&](KnownProtocolKind known) -> Optional<ProtocolConformanceRef> {
-      // Don't ascribe any behavior to Optional other than what we explicitly
-      // give it. We don't want things like AnyObject?? to work.
-      if (type->getAnyNominal() == getOptionalDecl())
-        return None;
-      
-      // Find the protocol.
-      auto proto = getProtocol(known);
-      if (!proto) return None;
+      [&](KnownProtocolKind known) -> ProtocolConformanceRef {
+    // Don't ascribe any behavior to Optional other than what we explicitly
+    // give it. We don't want things like AnyObject?? to work.
+    if (type->getAnyNominal() == getOptionalDecl())
+      return ProtocolConformanceRef::forInvalid();
 
-      return dc->getParentModule()->lookupConformance(type, proto);
-    };
+    // Find the protocol.
+    auto proto = getProtocol(known);
+    if (!proto)
+      return ProtocolConformanceRef::forInvalid();
+
+    return dc->getParentModule()->lookupConformance(type, proto);
+  };
 
   // Do we conform to _ObjectiveCBridgeable?
-  if (auto conformance
-        = findConformance(KnownProtocolKind::ObjectiveCBridgeable)) {
+  auto conformance = findConformance(KnownProtocolKind::ObjectiveCBridgeable);
+  if (!conformance.isInvalid()) {
     // The corresponding value type is... the type.
     if (bridgedValueType)
       *bridgedValueType = type;
 
     // Find the Objective-C class type we bridge to.
-    return conformance->getTypeWitnessByName(type, Id_ObjectiveCType);
+    return conformance.getTypeWitnessByName(type, Id_ObjectiveCType);
   }
 
   // Do we conform to Error?
-  if (findConformance(KnownProtocolKind::Error)) {
+  if (!findConformance(KnownProtocolKind::Error).isInvalid()) {
     // The corresponding value type is Error.
     if (bridgedValueType)
       *bridgedValueType = getErrorDecl()->getDeclaredInterfaceType();
@@ -4463,8 +4464,9 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
 
   auto lookupConformanceFn =
       [&](CanType depTy, Type substTy,
-          ProtocolDecl *proto) -> Optional<ProtocolConformanceRef> {
-    if (auto conf = subMap.lookupConformance(depTy, proto))
+          ProtocolDecl *proto) -> ProtocolConformanceRef {
+    auto conf = subMap.lookupConformance(depTy, proto);
+    if (!conf.isInvalid())
       return conf;
 
     return ProtocolConformanceRef(proto);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1334,16 +1334,15 @@ static bool containsRetroactiveConformance(
       continue;
     ProtocolDecl *proto =
         requirement.getSecondType()->castTo<ProtocolType>()->getDecl();
-    Optional<ProtocolConformanceRef> conformance =
-        subMap.lookupConformance(requirement.getFirstType()->getCanonicalType(),
-                                 proto);
-    if (!conformance) {
+    auto conformance = subMap.lookupConformance(
+        requirement.getFirstType()->getCanonicalType(), proto);
+    if (conformance.isInvalid()) {
       // This should only happen when mangling invalid ASTs, but that happens
       // for indexing purposes.
       continue;
     }
-    if (conformance->isConcrete() &&
-        containsRetroactiveConformance(conformance->getConcrete(), module)) {
+    if (conformance.isConcrete() &&
+        containsRetroactiveConformance(conformance.getConcrete(), module)) {
       return true;
     }
   }
@@ -2707,7 +2706,7 @@ void ASTMangler::appendConcreteProtocolConformance(
         appendOperator("HO");
       } else {
         auto conditionalConf = module->lookupConformance(canType, proto);
-        appendConcreteProtocolConformance(conditionalConf->getConcrete());
+        appendConcreteProtocolConformance(conditionalConf.getConcrete());
       }
       appendListSeparator(firstRequirement);
       break;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3818,9 +3818,8 @@ public:
     }
   }
 
-  void printFunctionExtInfo(
-      SILFunctionType::ExtInfo info,
-      Optional<ProtocolConformanceRef> witnessMethodConformance) {
+  void printFunctionExtInfo(SILFunctionType::ExtInfo info,
+                            ProtocolConformanceRef witnessMethodConformance) {
     if (Options.SkipAttributes)
       return;
 
@@ -3851,7 +3850,7 @@ public:
       case SILFunctionType::Representation::WitnessMethod:
         Printer << "witness_method: ";
         printTypeDeclName(
-            witnessMethodConformance->getRequirement()->getDeclaredType());
+            witnessMethodConformance.getRequirement()->getDeclaredType());
         break;
       case SILFunctionType::Representation::Closure:
         Printer << "closure";

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4000,7 +4000,7 @@ public:
   void visitSILFunctionType(SILFunctionType *T) {
     printSILCoroutineKind(T->getCoroutineKind());
     printFunctionExtInfo(T->getExtInfo(),
-                         T->getWitnessMethodConformanceOrNone());
+                         T->getWitnessMethodConformanceOrInvalid());
     printCalleeConvention(T->getCalleeConvention());
     if (auto sig = T->getSubstGenericSignature()) {
       printGenericSignature(sig,

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -819,7 +819,7 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
 
     // Form the inherited conformance.
     entry->Conformance =
-        ctx.getInheritedConformance(type, inheritedConformance->getConcrete());
+        ctx.getInheritedConformance(type, inheritedConformance.getConcrete());
   } else {
     // Create or find the normal conformance.
     Type conformingType = conformingDC->getDeclaredInterfaceType();

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -358,8 +358,9 @@ ASTContext &GenericSignatureImpl::getASTContext() const {
   return GenericSignature::getASTContext(getGenericParams(), getRequirements());
 }
 
-Optional<ProtocolConformanceRef>
-GenericSignatureImpl::lookupConformance(CanType type, ProtocolDecl *proto) const {
+ProtocolConformanceRef
+GenericSignatureImpl::lookupConformance(CanType type,
+                                        ProtocolDecl *proto) const {
   // FIXME: Actually implement this properly.
   auto *M = proto->getParentModule();
 
@@ -535,8 +536,9 @@ bool GenericSignatureImpl::isRequirementSatisfied(Requirement requirement) {
     if (canFirstType->isTypeParameter())
       return conformsToProtocol(canFirstType, protocol);
     else
-      return (bool)GSB->lookupConformance(/*dependentType=*/CanType(),
-                                          canFirstType, protocol);
+      return !GSB->lookupConformance(/*dependentType=*/CanType(), canFirstType,
+                                     protocol)
+                  .isInvalid();
   }
 
   case RequirementKind::SameType: {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -536,9 +536,8 @@ bool GenericSignatureImpl::isRequirementSatisfied(Requirement requirement) {
     if (canFirstType->isTypeParameter())
       return conformsToProtocol(canFirstType, protocol);
     else
-      return !GSB->lookupConformance(/*dependentType=*/CanType(), canFirstType,
-                                     protocol)
-                  .isInvalid();
+      return (bool)GSB->lookupConformance(/*dependentType=*/CanType(),
+                                          canFirstType, protocol);
   }
 
   case RequirementKind::SameType: {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4416,8 +4416,8 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
         auto conformance =
             getLookupConformanceFn()(dependentType, subjectType, proto->getDecl());
 
-        // FIXME: diagnose if there's an invalid conformance.
-        if (!conformance.isInvalid()) {
+        // FIXME: diagnose if there's no conformance.
+        if (conformance) {
           if (addConditionalRequirements(conformance, inferForModule,
                                          source.getLoc()))
             return ConstraintResult::Conflicting;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2316,7 +2316,7 @@ GenericSignatureBuilder::resolveConcreteConformance(ResolvedType type,
   auto conformance =
       lookupConformance(type.getDependentType(*this)->getCanonicalType(),
                         concrete, proto);
-  if (!conformance) {
+  if (conformance.isInvalid()) {
     if (!concrete->hasError() && concreteSource->getLoc().isValid()) {
       Impl->HadAnyError = true;
 
@@ -2330,9 +2330,9 @@ GenericSignatureBuilder::resolveConcreteConformance(ResolvedType type,
     return nullptr;
   }
 
-  concreteSource = concreteSource->viaConcrete(*this, *conformance);
+  concreteSource = concreteSource->viaConcrete(*this, conformance);
   equivClass->recordConformanceConstraint(*this, type, proto, concreteSource);
-  if (addConditionalRequirements(*conformance, /*inferForModule=*/nullptr,
+  if (addConditionalRequirements(conformance, /*inferForModule=*/nullptr,
                                  concreteSource->getLoc()))
     return nullptr;
 
@@ -2350,7 +2350,8 @@ const RequirementSource *GenericSignatureBuilder::resolveSuperConformance(
   auto conformance =
     lookupConformance(type.getDependentType(*this)->getCanonicalType(),
                       superclass, proto);
-  if (!conformance) return nullptr;
+  if (conformance.isInvalid())
+    return nullptr;
 
   // Conformance to this protocol is redundant; update the requirement source
   // appropriately.
@@ -2361,10 +2362,9 @@ const RequirementSource *GenericSignatureBuilder::resolveSuperConformance(
   else
     superclassSource = equivClass->superclassConstraints.front().source;
 
-  superclassSource =
-    superclassSource->viaSuperclass(*this, *conformance);
+  superclassSource = superclassSource->viaSuperclass(*this, conformance);
   equivClass->recordConformanceConstraint(*this, type, proto, superclassSource);
-  if (addConditionalRequirements(*conformance, /*inferForModule=*/nullptr,
+  if (addConditionalRequirements(conformance, /*inferForModule=*/nullptr,
                                  superclassSource->getLoc()))
     return nullptr;
 
@@ -3501,7 +3501,7 @@ GenericSignatureBuilder::getLookupConformanceFn()
   return LookUpConformanceInBuilder(this);
 }
 
-Optional<ProtocolConformanceRef>
+ProtocolConformanceRef
 GenericSignatureBuilder::lookupConformance(CanType dependentType,
                                            Type conformingReplacementType,
                                            ProtocolDecl *conformedProtocol) {
@@ -4416,9 +4416,9 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
         auto conformance =
             getLookupConformanceFn()(dependentType, subjectType, proto->getDecl());
 
-        // FIXME: diagnose if there's no conformance.
-        if (conformance) {
-          if (addConditionalRequirements(*conformance, inferForModule,
+        // FIXME: diagnose if there's an invalid conformance.
+        if (!conformance.isInvalid()) {
+          if (addConditionalRequirements(conformance, inferForModule,
                                          source.getLoc()))
             return ConstraintResult::Conflicting;
         }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -748,8 +748,7 @@ ModuleDecl::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
   // If the existential is class-constrained, the class might conform
   // concretely.
   if (auto superclass = layout.explicitSuperclass) {
-    auto result = lookupConformance(superclass, protocol);
-    if (!result.isInvalid())
+    if (auto result = lookupConformance(superclass, protocol))
       return result;
   }
 
@@ -765,8 +764,7 @@ ModuleDecl::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
     // If the protocol has a superclass constraint, we might conform
     // concretely.
     if (auto superclass = protoDecl->getSuperclass()) {
-      auto result = lookupConformance(superclass, protocol);
-      if (!result.isInvalid())
+      if (auto result = lookupConformance(superclass, protocol))
         return result;
     }
 
@@ -800,8 +798,7 @@ ProtocolConformanceRef ModuleDecl::lookupConformance(Type type,
     // able to be resolved by a substitution that makes the archetype
     // concrete.
     if (auto super = archetype->getSuperclass()) {
-      auto inheritedConformance = lookupConformance(super, protocol);
-      if (!inheritedConformance.isInvalid()) {
+      if (auto inheritedConformance = lookupConformance(super, protocol)) {
         return ProtocolConformanceRef(ctx.getInheritedConformance(
             type, inheritedConformance.getConcrete()));
       }
@@ -860,7 +857,7 @@ ProtocolConformanceRef ModuleDecl::lookupConformance(Type type,
 
     // Compute the conformance for the inherited type.
     auto inheritedConformance = lookupConformance(superclassTy, protocol);
-    assert(!inheritedConformance.isInvalid() &&
+    assert(inheritedConformance &&
            "We already found the inherited conformance");
 
     // Create the inherited conformance entry.

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -131,7 +131,7 @@ ProtocolConformanceRef::subst(Type origType,
     auto optConformance =
         proto->getModuleContext()->lookupExistentialConformance(substType,
                                                                 proto);
-    if (!optConformance.isInvalid())
+    if (optConformance)
       return optConformance;
 
     return ProtocolConformanceRef::forInvalid();

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -128,21 +128,17 @@ ProtocolConformanceRef::subst(Type origType,
 
   // If the type is an existential, it must be self-conforming.
   if (substType->isExistentialType()) {
-    if (auto optConformance =
-          proto->getModuleContext()->lookupExistentialConformance(
-            substType, proto))
-      return *optConformance;
+    auto optConformance =
+        proto->getModuleContext()->lookupExistentialConformance(substType,
+                                                                proto);
+    if (!optConformance.isInvalid())
+      return optConformance;
 
     return ProtocolConformanceRef::forInvalid();
   }
 
   // Check the conformance map.
-  if (auto result = conformances(origType->getCanonicalType(),
-                                 substType, proto)) {
-    return *result;
-  }
-
-  return ProtocolConformanceRef::forInvalid();
+  return conformances(origType->getCanonicalType(), substType, proto);
 }
 
 ProtocolConformanceRef ProtocolConformanceRef::mapConformanceOutOfContext() const {
@@ -841,8 +837,8 @@ recursivelySubstituteBaseType(ModuleDecl *module,
 
   // If we have an inherited protocol just look up the conformance.
   if (reqProto != conformance->getProtocol()) {
-    reqConformance = module->lookupConformance(
-        conformance->getType(), reqProto)->getConcrete();
+    reqConformance = module->lookupConformance(conformance->getType(), reqProto)
+                         .getConcrete();
   }
 
   return reqConformance->getTypeWitness(depMemTy->getAssocType());
@@ -894,12 +890,8 @@ void NormalProtocolConformance::finishSignatureConformances() {
     if (substTy->hasTypeParameter())
       substTy = getDeclContext()->mapTypeIntoContext(substTy);
 
-    auto reqConformance = module->lookupConformance(substTy, reqProto);
-    if (!reqConformance)
-      reqConformance = ProtocolConformanceRef::forInvalid();
-
-    reqConformance = reqConformance->mapConformanceOutOfContext();
-    reqConformances.push_back(*reqConformance);
+    reqConformances.push_back(module->lookupConformance(substTy, reqProto)
+                                  .mapConformanceOutOfContext());
   }
   setSignatureConformances(reqConformances);
 }

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -111,7 +111,7 @@ RequirementEnvironment::RequirementEnvironment(
     },
     [selfType, substConcreteType, conformance, conformanceDC, &ctx](
         CanType type, Type replacement, ProtocolDecl *proto)
-          -> Optional<ProtocolConformanceRef> {
+          -> ProtocolConformanceRef {
       // The protocol 'Self' conforms concretely to the conforming type.
       if (type->isEqual(selfType)) {
         ProtocolConformance *specialized = conformance;

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -368,7 +368,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
     genericSig->getConformanceAccessPath(type, proto);
 
   // Fall through because we cannot yet evaluate an access path.
-  auto conformance = ProtocolConformanceRef::forInvalid();
+  ProtocolConformanceRef conformance;
   for (const auto &step : accessPath) {
     // For the first step, grab the initial conformance.
     if (conformance.isInvalid()) {

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -355,8 +355,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   // Check whether the superclass conforms.
   if (auto superclass = genericSig->getSuperclassBound(type)) {
     LookUpConformanceInSignature lookup(getGenericSignature().getPointer());
-    auto conformance = lookup(type->getCanonicalType(), superclass, proto);
-    if (!conformance.isInvalid())
+    if (auto conformance = lookup(type->getCanonicalType(), superclass, proto))
       return conformance;
   }
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -222,8 +222,7 @@ SubstitutionMap SubstitutionMap::get(GenericSignature genericSig,
     auto replacement = depTy.subst(subs, lookupConformance);
     auto protoType = req.getSecondType()->castTo<ProtocolType>();
     auto proto = protoType->getDecl();
-    auto conformance = lookupConformance(depTy, replacement, proto)
-                         .getValueOr(ProtocolConformanceRef::forInvalid());
+    auto conformance = lookupConformance(depTy, replacement, proto);
     conformances.push_back(conformance);
   }
 
@@ -301,9 +300,10 @@ Type SubstitutionMap::lookupSubstitution(CanSubstitutableType type) const {
   return replacementType;
 }
 
-Optional<ProtocolConformanceRef>
+ProtocolConformanceRef
 SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
-  if (empty()) return None;
+  if (empty())
+    return ProtocolConformanceRef::forInvalid();
 
   // If we have an archetype, map out of the context so we can compute a
   // conformance access path.
@@ -316,7 +316,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   // Error path: if we don't have a type parameter, there is no conformance.
   // FIXME: Query concrete conformances in the generic signature?
   if (!type->isTypeParameter())
-    return None;
+    return ProtocolConformanceRef::forInvalid();
 
   auto genericSig = getGenericSignature();
 
@@ -334,58 +334,59 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
   // Retrieve the starting conformance from the conformance map.
   auto getInitialConformance =
-    [&](Type type, ProtocolDecl *proto) -> Optional<ProtocolConformanceRef> {
-      unsigned conformanceIndex = 0;
-      for (const auto &req : getGenericSignature()->getRequirements()) {
-        if (req.getKind() != RequirementKind::Conformance)
-          continue;
+      [&](Type type, ProtocolDecl *proto) -> ProtocolConformanceRef {
+    unsigned conformanceIndex = 0;
+    for (const auto &req : getGenericSignature()->getRequirements()) {
+      if (req.getKind() != RequirementKind::Conformance)
+        continue;
 
-        // Is this the conformance we're looking for?
-        if (req.getFirstType()->isEqual(type) &&
-            req.getSecondType()->castTo<ProtocolType>()->getDecl() == proto) {
-          return getConformances()[conformanceIndex];
-        }
-
-        ++conformanceIndex;
+      // Is this the conformance we're looking for?
+      if (req.getFirstType()->isEqual(type) &&
+          req.getSecondType()->castTo<ProtocolType>()->getDecl() == proto) {
+        return getConformances()[conformanceIndex];
       }
 
-      return None;
-    };
+      ++conformanceIndex;
+    }
+
+    return ProtocolConformanceRef::forInvalid();
+  };
 
   // Check whether the superclass conforms.
   if (auto superclass = genericSig->getSuperclassBound(type)) {
     LookUpConformanceInSignature lookup(getGenericSignature().getPointer());
-    if (auto conformance = lookup(type->getCanonicalType(), superclass, proto))
+    auto conformance = lookup(type->getCanonicalType(), superclass, proto);
+    if (!conformance.isInvalid())
       return conformance;
   }
 
   // If the type doesn't conform to this protocol, the result isn't formed
   // from these requirements.
   if (!genericSig->conformsToProtocol(type, proto))
-    return None;
+    return ProtocolConformanceRef::forInvalid();
 
   auto accessPath =
     genericSig->getConformanceAccessPath(type, proto);
 
   // Fall through because we cannot yet evaluate an access path.
-  Optional<ProtocolConformanceRef> conformance;
+  auto conformance = ProtocolConformanceRef::forInvalid();
   for (const auto &step : accessPath) {
     // For the first step, grab the initial conformance.
-    if (!conformance) {
+    if (conformance.isInvalid()) {
       conformance = getInitialConformance(step.first, step.second);
-      if (!conformance)
-        return None;
+      if (conformance.isInvalid())
+        return ProtocolConformanceRef::forInvalid();
 
       continue;
     }
 
-    if (conformance->isInvalid())
+    if (conformance.isInvalid())
       return conformance;
 
     // If we've hit an abstract conformance, everything from here on out is
     // abstract.
     // FIXME: This may not always be true, but it holds for now.
-    if (conformance->isAbstract()) {
+    if (conformance.isAbstract()) {
       // FIXME: Rip this out once we can get a concrete conformance from
       // an archetype.
       auto substType = type.subst(*this);
@@ -405,7 +406,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
     // For the second step, we're looking into the requirement signature for
     // this protocol.
-    auto concrete = conformance->getConcrete();
+    auto concrete = conformance.getConcrete();
     auto normal = concrete->getRootNormalConformance();
 
     // If we haven't set the signature conformances yet, force the issue now.
@@ -415,7 +416,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
       // FIXME: Seems like we should be able to get at the intermediate state
       // to use that.
       if (normal->getState() == ProtocolConformanceState::CheckingTypeWitnesses)
-        return None;
+        return ProtocolConformanceRef::forInvalid();
     }
 
     // Get the associated conformance.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2107,7 +2107,7 @@ public:
         auto *Module = NTD->getParentModule();
         auto Conformance = Module->lookupConformance(
             BaseTy, ATD->getProtocol());
-        if (!Conformance.isInvalid() && Conformance.isConcrete()) {
+        if (Conformance.isConcrete()) {
           return Conformance.getConcrete()->getTypeWitness(
               const_cast<AssociatedTypeDecl *>(ATD));
         }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2107,9 +2107,9 @@ public:
         auto *Module = NTD->getParentModule();
         auto Conformance = Module->lookupConformance(
             BaseTy, ATD->getProtocol());
-        if (Conformance && Conformance->isConcrete()) {
-          return Conformance->getConcrete()
-              ->getTypeWitness(const_cast<AssociatedTypeDecl *>(ATD));
+        if (!Conformance.isInvalid() && Conformance.isConcrete()) {
+          return Conformance.getConcrete()->getTypeWitness(
+              const_cast<AssociatedTypeDecl *>(ATD));
         }
       }
     }

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -141,7 +141,7 @@ void ConformingMethodListCallbacks::getMatchingMethods(
 
       // The return type conforms to any of the requested protocols.
       for (auto Proto : ExpectedTypes) {
-        if (CurModule->conformsToProtocol(declTy, Proto))
+        if (!CurModule->conformsToProtocol(declTy, Proto).isInvalid())
           return true;
       }
 

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -141,7 +141,7 @@ void ConformingMethodListCallbacks::getMatchingMethods(
 
       // The return type conforms to any of the requested protocols.
       for (auto Proto : ExpectedTypes) {
-        if (!CurModule->conformsToProtocol(declTy, Proto).isInvalid())
+        if (CurModule->conformsToProtocol(declTy, Proto))
           return true;
       }
 

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -307,11 +307,10 @@ struct SynthesizedExtensionAnalyzer::Implementation {
         case RequirementKind::Conformance: {
           auto *M = DC->getParentModule();
           auto *Proto = Second->castTo<ProtocolType>()->getDecl();
-          if (!First->isTypeParameter() &&
-              !First->is<ArchetypeType>() &&
-              !M->conformsToProtocol(First, Proto))
+          if (!First->isTypeParameter() && !First->is<ArchetypeType>() &&
+              M->conformsToProtocol(First, Proto).isInvalid())
             return true;
-          if (!M->conformsToProtocol(First, Proto))
+          if (M->conformsToProtocol(First, Proto).isInvalid())
             MergeInfo.addRequirement(GenericSig, First, Second, Kind);
           break;
         }
@@ -620,7 +619,7 @@ class ExpressionTypeCollector: public SourceEntityWalker {
 
     // Collecting protocols conformed by this expressions that are in the list.
     for (auto Proto: InterestedProtocols) {
-      if (Module.conformsToProtocol(E->getType(), Proto.first)) {
+      if (!Module.conformsToProtocol(E->getType(), Proto.first).isInvalid()) {
         Conformances.push_back(Proto.second);
       }
     }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -619,7 +619,7 @@ class ExpressionTypeCollector: public SourceEntityWalker {
 
     // Collecting protocols conformed by this expressions that are in the list.
     for (auto Proto: InterestedProtocols) {
-      if (!Module.conformsToProtocol(E->getType(), Proto.first).isInvalid()) {
+      if (Module.conformsToProtocol(E->getType(), Proto.first)) {
         Conformances.push_back(Proto.second);
       }
     }

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -857,10 +857,10 @@ emitKeyPathComponent(IRGenModule &IGM,
               // Protocol requirement.
               auto conformance = subs.lookupConformance(
                            reqt.TypeParameter->getCanonicalType(), reqt.Protocol);
-              externalSubArgs.push_back(
-                IGM.emitWitnessTableRefString(substType, *conformance,
-                      genericEnv ? genericEnv->getGenericSignature() : nullptr,
-                      /*shouldSetLowBit*/ true));
+              externalSubArgs.push_back(IGM.emitWitnessTableRefString(
+                  substType, conformance,
+                  genericEnv ? genericEnv->getGenericSignature() : nullptr,
+                  /*shouldSetLowBit*/ true));
             }
           });
       }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -956,8 +956,7 @@ emitConditionalConformancesBuffer(IRGenFunction &IGF,
       rootConformance, [&](unsigned, CanType type, ProtocolDecl *proto) {
         auto substType = type.subst(subMap)->getCanonicalType();
         auto reqConformance = subMap.lookupConformance(type, proto);
-        assert(!reqConformance.isInvalid() &&
-               "conditional conformance must be valid");
+        assert(reqConformance && "conditional conformance must be valid");
 
         tables.push_back(emitWitnessTableRef(IGF, substType, reqConformance));
         return /*finished?*/ false;

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -323,7 +323,7 @@ bool PolymorphicConvention::considerType(CanType type, IsExact_t isExact,
 
 void PolymorphicConvention::considerWitnessSelf(CanSILFunctionType fnType) {
   CanType selfTy = fnType->getSelfInstanceType(IGM.getSILModule());
-  auto conformance = fnType->getWitnessMethodConformanceOrNone();
+  auto conformance = fnType->getWitnessMethodConformanceOrInvalid();
 
   // First, bind type metadata for Self.
   Sources.emplace_back(MetadataSource::Kind::SelfMetadata,
@@ -564,7 +564,7 @@ void EmitPolymorphicParameters::bindExtraSource(const MetadataSource &source,
       assert(selfTable && "no Self witness table for witness method");
 
       // Mark this as the cached witness table for Self.
-      auto conformance = FnType->getWitnessMethodConformanceOrNone();
+      auto conformance = FnType->getWitnessMethodConformanceOrInvalid();
       auto selfProto = conformance.getRequirement();
 
       auto selfTy = FnType->getSelfInstanceType(IGM.getSILModule());

--- a/lib/IRGen/GenericRequirement.h
+++ b/lib/IRGen/GenericRequirement.h
@@ -137,10 +137,8 @@ public:
 
   bool empty() const { return Requirements.empty(); }
 
-  using FulfillmentCallback =
-    llvm::function_ref<void(unsigned requirementIndex,
-                            CanType type,
-                            Optional<ProtocolConformanceRef> conf)>;
+  using FulfillmentCallback = llvm::function_ref<void(
+      unsigned requirementIndex, CanType type, ProtocolConformanceRef conf)>;
   void enumerateFulfillments(IRGenModule &IGM, SubstitutionMap subs,
                              FulfillmentCallback callback);
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2123,7 +2123,7 @@ emitWitnessTableForLoweredCallee(IRGenSILFunction &IGF,
   // This use of getSelfInstanceType() assumes that the instance type is
   // always a meaningful formal type.
   auto substSelfType = substCalleeType->getSelfInstanceType(IGF.IGM.getSILModule());
-  auto substConformance = substCalleeType->getWitnessMethodConformance();
+  auto substConformance = substCalleeType->getWitnessMethodConformanceOrNone();
 
   llvm::Value *argMetadata = IGF.emitTypeMetadataRef(substSelfType);
   llvm::Value *wtable =

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2123,7 +2123,8 @@ emitWitnessTableForLoweredCallee(IRGenSILFunction &IGF,
   // This use of getSelfInstanceType() assumes that the instance type is
   // always a meaningful formal type.
   auto substSelfType = substCalleeType->getSelfInstanceType(IGF.IGM.getSILModule());
-  auto substConformance = substCalleeType->getWitnessMethodConformanceOrNone();
+  auto substConformance =
+      substCalleeType->getWitnessMethodConformanceOrInvalid();
 
   llvm::Value *argMetadata = IGF.emitTypeMetadataRef(substSelfType);
   llvm::Value *wtable =

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -286,7 +286,7 @@ LargeSILTypeMapper::getNewSILFunctionType(GenericEnvironment *env,
       fnType->getSubstitutions(),
       fnType->isGenericSignatureImplied(),
       fnType->getASTContext(),
-      fnType->getWitnessMethodConformanceOrNone());
+      fnType->getWitnessMethodConformanceOrInvalid());
   return newFnType;
 }
 
@@ -2317,7 +2317,7 @@ static bool rewriteFunctionReturn(StructLoweringState &pass) {
         newSILResultInfo, loweredTy->getOptionalErrorResult(),
         loweredTy->getSubstitutions(), loweredTy->isGenericSignatureImplied(),
         F->getModule().getASTContext(),
-        loweredTy->getWitnessMethodConformanceOrNone());
+        loweredTy->getWitnessMethodConformanceOrInvalid());
     F->rewriteLoweredTypeUnsafe(NewTy);
     return true;
   }

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -473,7 +473,7 @@ namespace {
       requirements.enumerateFulfillments(
           IGF.IGM, subs,
           [&](unsigned reqtIndex, CanType type, ProtocolConformanceRef conf) {
-            if (!conf.isInvalid()) {
+            if (conf) {
               Values.push_back(emitWitnessTableRef(IGF, type, conf));
             } else {
               Values.push_back(IGF.emitAbstractTypeMetadataRef(type));

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -470,15 +470,15 @@ namespace {
 
       auto subs =
         type->getContextSubstitutionMap(IGF.IGM.getSwiftModule(), decl);
-      requirements.enumerateFulfillments(IGF.IGM, subs,
-                                [&](unsigned reqtIndex, CanType type,
-                                    Optional<ProtocolConformanceRef> conf) {
-        if (conf) {
-          Values.push_back(emitWitnessTableRef(IGF, type, *conf));
-        } else {
-          Values.push_back(IGF.emitAbstractTypeMetadataRef(type));
-        }
-      });
+      requirements.enumerateFulfillments(
+          IGF.IGM, subs,
+          [&](unsigned reqtIndex, CanType type, ProtocolConformanceRef conf) {
+            if (!conf.isInvalid()) {
+              Values.push_back(emitWitnessTableRef(IGF, type, conf));
+            } else {
+              Values.push_back(IGF.emitAbstractTypeMetadataRef(type));
+            }
+          });
 
       collectTypes(IGF.IGM, decl);
       assert(Types.size() == Values.size());

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -6322,7 +6322,7 @@ bool SILParserTUState::parseSILWitnessTable(Parser &P) {
 
   // FIXME: should we really allow a specialized or inherited conformance here?
   RootProtocolConformance *theConformance = nullptr;
-  if (!conf.isInvalid() && conf.isConcrete())
+  if (conf.isConcrete())
     theConformance = conf.getConcrete()->getRootConformance();
 
   SILWitnessTable *wt = nullptr;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -243,11 +243,10 @@ namespace {
     void convertRequirements(SILFunction *F, ArrayRef<RequirementRepr> From,
                              SmallVectorImpl<Requirement> &To);
 
-    Optional<ProtocolConformanceRef>
-    parseProtocolConformanceHelper(ProtocolDecl *&proto,
-                                   GenericEnvironment *GenericEnv,
-                                   ConformanceContext context,
-                                   ProtocolDecl *defaultForProto);
+    ProtocolConformanceRef parseProtocolConformanceHelper(
+        ProtocolDecl *&proto, GenericEnvironment *GenericEnv,
+        ConformanceContext context, ProtocolDecl *defaultForProto);
+
   public:
     SILParser(Parser &P)
         : P(P), SILMod(static_cast<SILParserTUState *>(P.SIL)->M),
@@ -477,12 +476,10 @@ namespace {
                             GenericEnvironment *GenericEnv=nullptr,
                             ProtocolDecl *defaultForProto = nullptr);
 
-    Optional<ProtocolConformanceRef>
-    parseProtocolConformance(ProtocolDecl *&proto,
-                             GenericEnvironment *&genericEnv,
-                             ConformanceContext context,
-                             ProtocolDecl *defaultForProto);
-    Optional<ProtocolConformanceRef>
+    ProtocolConformanceRef parseProtocolConformance(
+        ProtocolDecl *&proto, GenericEnvironment *&genericEnv,
+        ConformanceContext context, ProtocolDecl *defaultForProto);
+    ProtocolConformanceRef
     parseProtocolConformance(ProtocolDecl *defaultForProto,
                              ConformanceContext context) {
       ProtocolDecl *dummy;
@@ -1769,8 +1766,8 @@ static bool getConformancesForSubstitution(Parser &P,
   for (auto protoTy : protocols) {
     auto conformance = M->lookupConformance(subReplacement,
                                             protoTy->getDecl());
-    if (conformance) {
-      conformances.push_back(*conformance);
+    if (!conformance.isInvalid()) {
+      conformances.push_back(conformance);
       continue;
     }
 
@@ -1808,30 +1805,32 @@ SubstitutionMap getApplySubstitutionsFromParsed(
 
   bool failed = false;
   auto subMap = SubstitutionMap::get(
-    genericSig,
-    [&](SubstitutableType *type) -> Type {
-      auto genericParam = dyn_cast<GenericTypeParamType>(type);
-      if (!genericParam) return nullptr;
+      genericSig,
+      [&](SubstitutableType *type) -> Type {
+        auto genericParam = dyn_cast<GenericTypeParamType>(type);
+        if (!genericParam)
+          return nullptr;
 
-      auto index = genericSig->getGenericParamOrdinal(genericParam);
-      assert(index < genericSig->getGenericParams().size());
-      assert(index < parses.size());
+        auto index = genericSig->getGenericParamOrdinal(genericParam);
+        assert(index < genericSig->getGenericParams().size());
+        assert(index < parses.size());
 
-      // Provide the replacement type.
-      return parses[index].replacement;
-    },
-    [&](CanType dependentType, Type replacementType,
-        ProtocolDecl *proto) ->Optional<ProtocolConformanceRef> {
-      auto M = SP.P.SF.getParentModule();
-      auto conformance = M->lookupConformance(replacementType, proto);
-      if (conformance) return conformance;
+        // Provide the replacement type.
+        return parses[index].replacement;
+      },
+      [&](CanType dependentType, Type replacementType,
+          ProtocolDecl *proto) -> ProtocolConformanceRef {
+        auto M = SP.P.SF.getParentModule();
+        auto conformance = M->lookupConformance(replacementType, proto);
+        if (!conformance.isInvalid())
+          return conformance;
 
-      SP.P.diagnose(loc, diag::sil_substitution_mismatch, replacementType,
-                    proto->getDeclaredType());
-      failed = true;
+        SP.P.diagnose(loc, diag::sil_substitution_mismatch, replacementType,
+                      proto->getDeclaredType());
+        failed = true;
 
-      return ProtocolConformanceRef(proto);
-    });
+        return ProtocolConformanceRef(proto);
+      });
 
   return failed ? SubstitutionMap() : subMap;
 }
@@ -2133,14 +2132,14 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
            contextFormalTy = patternEnv->mapTypeIntoContext(formalTy);
          auto lookup = P.SF.getParentModule()->lookupConformance(
                                                  contextFormalTy, proto);
-         if (!lookup) {
+         if (lookup.isInvalid()) {
            P.diagnose(formalTyLoc,
                       diag::sil_keypath_index_not_hashable,
                       formalTy);
            return true;
          }
-         auto conformance = ProtocolConformanceRef(*lookup);
-         
+         auto conformance = ProtocolConformanceRef(lookup);
+
          indexes.push_back({index, formalTy, loweredTy, conformance});
          
          if (operandTypes.size() <= index)
@@ -4325,13 +4324,13 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       return true;
     }
     auto conformance = P.SF.getParentModule()->lookupConformance(LookupTy, proto);
-    if (!conformance) {
+    if (conformance.isInvalid()) {
       P.diagnose(TyLoc, diag::sil_witness_method_type_does_not_conform);
       return true;
     }
 
-    ResultVal = B.createWitnessMethod(InstLoc, LookupTy, *conformance, Member,
-                                      MethodTy);
+    ResultVal =
+        B.createWitnessMethod(InstLoc, LookupTy, conformance, Member, MethodTy);
     break;
   }
   case SILInstructionKind::CopyAddrInst: {
@@ -5967,24 +5966,24 @@ static bool isSelfConformance(Type conformingType, ProtocolDecl *protocol) {
   return false;
 }
 
-static Optional<ProtocolConformanceRef> parseRootProtocolConformance(Parser &P,
-           SILParser &SP, Type ConformingTy, ProtocolDecl *&proto,
-           ConformanceContext context) {
+static ProtocolConformanceRef
+parseRootProtocolConformance(Parser &P, SILParser &SP, Type ConformingTy,
+                             ProtocolDecl *&proto, ConformanceContext context) {
   Identifier ModuleKeyword, ModuleName;
   SourceLoc Loc, KeywordLoc;
   proto = parseProtocolDecl(P, SP);
   if (!proto)
-    return None;
-      
+    return ProtocolConformanceRef::forInvalid();
+
   if (P.parseIdentifier(ModuleKeyword, KeywordLoc,
                         diag::expected_tok_in_sil_instr, "module") ||
       SP.parseSILIdentifier(ModuleName, Loc,
                             diag::expected_sil_value_name))
-    return None;
+    return ProtocolConformanceRef::forInvalid();
 
   if (ModuleKeyword.str() != "module") {
     P.diagnose(KeywordLoc, diag::expected_tok_in_sil_instr, "module");
-    return None;
+    return ProtocolConformanceRef::forInvalid();
   }
 
   // Calling lookupConformance on a BoundGenericType will return a specialized
@@ -5993,14 +5992,13 @@ static Optional<ProtocolConformanceRef> parseRootProtocolConformance(Parser &P,
   if (auto bound = lookupTy->getAs<BoundGenericType>())
     lookupTy = bound->getDecl()->getDeclaredType();
   auto lookup = P.SF.getParentModule()->lookupConformance(lookupTy, proto);
-  if (!lookup) {
+  if (lookup.isInvalid()) {
     P.diagnose(KeywordLoc, diag::sil_witness_protocol_conformance_not_found);
-    return None;
+    return ProtocolConformanceRef::forInvalid();
   }
 
   // Use a concrete self-conformance if we're parsing this for a witness table.
-  if (context == ConformanceContext::WitnessTable &&
-      !lookup->isConcrete() &&
+  if (context == ConformanceContext::WitnessTable && !lookup.isConcrete() &&
       isSelfConformance(ConformingTy, proto)) {
     lookup = ProtocolConformanceRef(P.Context.getSelfConformance(proto));
   }
@@ -6017,11 +6015,9 @@ static Optional<ProtocolConformanceRef> parseRootProtocolConformance(Parser &P,
 ///  normal-protocol-conformance ::=
 ///    generic-parameter-list? type: protocolName module ModuleName
 /// Note that generic-parameter-list is already parsed before calling this.
-Optional<ProtocolConformanceRef> SILParser::parseProtocolConformance(
-           ProtocolDecl *&proto,
-           GenericEnvironment *&genericEnv,
-           ConformanceContext context,
-           ProtocolDecl *defaultForProto) {
+ProtocolConformanceRef SILParser::parseProtocolConformance(
+    ProtocolDecl *&proto, GenericEnvironment *&genericEnv,
+    ConformanceContext context, ProtocolDecl *defaultForProto) {
   // Parse generic params for the protocol conformance. We need to make sure
   // they have the right scope.
   Optional<Scope> GenericsScope;
@@ -6045,15 +6041,13 @@ Optional<ProtocolConformanceRef> SILParser::parseProtocolConformance(
   return retVal;
 }
 
-Optional<ProtocolConformanceRef> SILParser::parseProtocolConformanceHelper(
-                                    ProtocolDecl *&proto,
-                                    GenericEnvironment *witnessEnv,
-                                    ConformanceContext context,
-                                    ProtocolDecl *defaultForProto) {
+ProtocolConformanceRef SILParser::parseProtocolConformanceHelper(
+    ProtocolDecl *&proto, GenericEnvironment *witnessEnv,
+    ConformanceContext context, ProtocolDecl *defaultForProto) {
   // Parse AST type.
   ParserResult<TypeRepr> TyR = P.parseType();
   if (TyR.isNull())
-    return None;
+    return ProtocolConformanceRef::forInvalid();
   TypeLoc Ty = TyR.get();
   if (defaultForProto) {
     bindProtocolSelfInTypeRepr(Ty, defaultForProto);
@@ -6061,11 +6055,11 @@ Optional<ProtocolConformanceRef> SILParser::parseProtocolConformanceHelper(
 
   if (performTypeLocChecking(Ty, /*IsSILType=*/ false, witnessEnv,
                              defaultForProto))
-    return None;
+    return ProtocolConformanceRef::forInvalid();
   auto ConformingTy = Ty.getType();
 
   if (P.parseToken(tok::colon, diag::expected_sil_witness_colon))
-    return None;
+    return ProtocolConformanceRef::forInvalid();
 
   if (P.Tok.is(tok::identifier) && P.Tok.getText() == "specialize") {
     P.consumeToken();
@@ -6073,28 +6067,28 @@ Optional<ProtocolConformanceRef> SILParser::parseProtocolConformanceHelper(
     // Parse substitutions for specialized conformance.
     SmallVector<ParsedSubstitution, 4> parsedSubs;
     if (parseSubstitutions(parsedSubs, witnessEnv, defaultForProto))
-      return None;
+      return ProtocolConformanceRef::forInvalid();
 
     if (P.parseToken(tok::l_paren, diag::expected_sil_witness_lparen))
-      return None;
+      return ProtocolConformanceRef::forInvalid();
     ProtocolDecl *dummy;
     GenericEnvironment *specializedEnv;
     auto genericConform =
         parseProtocolConformance(dummy, specializedEnv,
                                  ConformanceContext::Ordinary,
                                  defaultForProto);
-    if (!genericConform || !genericConform->isConcrete())
-      return None;
+    if (genericConform.isInvalid() || !genericConform.isConcrete())
+      return ProtocolConformanceRef::forInvalid();
     if (P.parseToken(tok::r_paren, diag::expected_sil_witness_rparen))
-      return None;
+      return ProtocolConformanceRef::forInvalid();
 
     SubstitutionMap subMap =
       getApplySubstitutionsFromParsed(*this, specializedEnv, parsedSubs);
     if (!subMap)
-      return None;
+      return ProtocolConformanceRef::forInvalid();
 
     auto result = P.Context.getSpecializedConformance(
-      ConformingTy, genericConform->getConcrete(), subMap);
+        ConformingTy, genericConform.getConcrete(), subMap);
     return ProtocolConformanceRef(result);
   }
 
@@ -6102,16 +6096,16 @@ Optional<ProtocolConformanceRef> SILParser::parseProtocolConformanceHelper(
     P.consumeToken();
 
     if (P.parseToken(tok::l_paren, diag::expected_sil_witness_lparen))
-      return None;
+      return ProtocolConformanceRef::forInvalid();
     auto baseConform = parseProtocolConformance(defaultForProto,
                                                 ConformanceContext::Ordinary);
-    if (!baseConform || !baseConform->isConcrete())
-      return None;
+    if (baseConform.isInvalid() || !baseConform.isConcrete())
+      return ProtocolConformanceRef::forInvalid();
     if (P.parseToken(tok::r_paren, diag::expected_sil_witness_rparen))
-      return None;
+      return ProtocolConformanceRef::forInvalid();
 
     auto result = P.Context.getInheritedConformance(ConformingTy,
-                                                    baseConform->getConcrete());
+                                                    baseConform.getConcrete());
     return ProtocolConformanceRef(result);
   }
 
@@ -6155,12 +6149,12 @@ static bool parseSILVTableEntry(
     auto conform =
       witnessState.parseProtocolConformance(defaultForProto,
                                             ConformanceContext::Ordinary);
-    if (!conform || !conform->isConcrete()) // Ignore this witness entry for now.
+    // Ignore invalid and abstract witness entries.
+    if (conform.isInvalid() || !conform.isConcrete())
       return false;
 
-    witnessEntries.push_back(SILWitnessTable::BaseProtocolWitness{
-      proto, conform->getConcrete()
-    });
+    witnessEntries.push_back(
+        SILWitnessTable::BaseProtocolWitness{proto, conform.getConcrete()});
     return false;
   }
 
@@ -6204,9 +6198,10 @@ static bool parseSILVTableEntry(
       auto concrete =
         witnessState.parseProtocolConformance(defaultForProto,
                                               ConformanceContext::Ordinary);
-      if (!concrete && !concrete->isConcrete()) // Ignore this for now.
+      // Ignore invalid and abstract witness entries.
+      if (concrete.isInvalid() || !concrete.isConcrete())
         return false;
-      conformance = *concrete;
+      conformance = concrete;
     } else {
       P.consumeToken();
     }
@@ -6330,10 +6325,9 @@ bool SILParserTUState::parseSILWitnessTable(Parser &P) {
   WitnessState.ContextGenericEnv = witnessEnv;
 
   // FIXME: should we really allow a specialized or inherited conformance here?
-  auto theConformance =
-    (conf && conf->isConcrete())
-      ? conf->getConcrete()->getRootConformance()
-      : nullptr;
+  RootProtocolConformance *theConformance = nullptr;
+  if (!conf.isInvalid() && conf.isConcrete())
+    theConformance = conf.getConcrete()->getRootConformance();
 
   SILWitnessTable *wt = nullptr;
   if (theConformance) {

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -96,7 +96,7 @@ classifyDynamicCastToProtocol(ModuleDecl *M, CanType source, CanType target,
 
   // If conformsToProtocol returns a valid conformance, then all requirements
   // were proven by the type checker.
-  if (!M->conformsToProtocol(source, TargetProtocol).isInvalid())
+  if (M->conformsToProtocol(source, TargetProtocol))
     return DynamicCastFeasibility::WillSucceed;
 
   auto *SourceNominalTy = source.getAnyNominal();
@@ -134,8 +134,7 @@ classifyDynamicCastToProtocol(ModuleDecl *M, CanType source, CanType target,
   // the conformsToProtocol interface needs to be reformulated as a query, and
   // the implementation, including checkGenericArguments, needs to be taught to
   // recognize that types with archetypes may potentially succeed.
-  auto conformance = M->lookupConformance(source, TargetProtocol);
-  if (!conformance.isInvalid()) {
+  if (auto conformance = M->lookupConformance(source, TargetProtocol)) {
     assert(!conformance.getConditionalRequirements().empty());
     return DynamicCastFeasibility::MaySucceed;
   }
@@ -218,7 +217,7 @@ bool swift::isObjectiveCBridgeable(ModuleDecl *M, CanType Ty) {
   if (bridgedProto) {
     // Find the conformance of the value type to _BridgedToObjectiveC.
     // Check whether the type conforms to _BridgedToObjectiveC.
-    return !M->lookupConformance(Ty, bridgedProto).isInvalid();
+    return (bool)M->lookupConformance(Ty, bridgedProto);
   }
   return false;
 }
@@ -232,7 +231,7 @@ bool swift::isError(ModuleDecl *M, CanType Ty) {
   if (errorTypeProto) {
     // Find the conformance of the value type to Error.
     // Check whether the type conforms to Error.
-    return !M->lookupConformance(Ty, errorTypeProto).isInvalid();
+    return (bool)M->lookupConformance(Ty, errorTypeProto);
   }
   return false;
 }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2423,8 +2423,7 @@ public:
     }
 
     auto witnessMethodConformance = ProtocolConformanceRef::forInvalid();
-    auto conformance = origType->getWitnessMethodConformanceOrInvalid();
-    if (!conformance.isInvalid()) {
+    if (auto conformance = origType->getWitnessMethodConformanceOrInvalid()) {
       assert(origType->getExtInfo().hasSelfParam());
       auto selfType = origType->getSelfParameter().getInterfaceType();
       // The Self type can be nested in a few layers of metatypes (etc.).

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -214,7 +214,7 @@ Lowering::adjustFunctionType(CanSILFunctionType type,
                              ParameterConvention callee,
                              ProtocolConformanceRef witnessMethodConformance) {
   if (type->getExtInfo() == extInfo && type->getCalleeConvention() == callee &&
-      type->getWitnessMethodConformanceOrNone() == witnessMethodConformance)
+      type->getWitnessMethodConformanceOrInvalid() == witnessMethodConformance)
     return type;
 
   return SILFunctionType::get(type->getSubstGenericSignature(),
@@ -246,11 +246,10 @@ CanSILFunctionType SILFunctionType::getWithExtInfo(ExtInfo newExt) {
        : ParameterConvention::Direct_Unowned);
 
   return get(getSubstGenericSignature(), newExt, getCoroutineKind(),
-             calleeConvention, getParameters(), getYields(),
-             getResults(), getOptionalErrorResult(),
-             getSubstitutions(), isGenericSignatureImplied(),
-             getASTContext(),
-             getWitnessMethodConformanceOrNone());
+             calleeConvention, getParameters(), getYields(), getResults(),
+             getOptionalErrorResult(), getSubstitutions(),
+             isGenericSignatureImplied(), getASTContext(),
+             getWitnessMethodConformanceOrInvalid());
 }
 
 namespace {
@@ -2424,7 +2423,7 @@ public:
     }
 
     auto witnessMethodConformance = ProtocolConformanceRef::forInvalid();
-    auto conformance = origType->getWitnessMethodConformanceOrNone();
+    auto conformance = origType->getWitnessMethodConformanceOrInvalid();
     if (!conformance.isInvalid()) {
       assert(origType->getExtInfo().hasSelfParam());
       auto selfType = origType->getSelfParameter().getInterfaceType();

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1713,7 +1713,7 @@ getSILFunctionTypeForClangDecl(TypeConverter &TC, const clang::Decl *clangDecl,
     return getSILFunctionType(TC, origPattern, substInterfaceType, extInfo,
                               ObjCMethodConventions(method), foreignInfo,
                               constant, constant, None,
-                              ProtocolConformanceRef::forInvalid());
+                              ProtocolConformanceRef());
   }
 
   if (auto method = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
@@ -1722,7 +1722,7 @@ getSILFunctionTypeForClangDecl(TypeConverter &TC, const clang::Decl *clangDecl,
     auto conventions = CXXMethodConventions(method);
     return getSILFunctionType(TC, origPattern, substInterfaceType, extInfo,
                               conventions, foreignInfo, constant, constant,
-                              None, ProtocolConformanceRef::forInvalid());
+                              None, ProtocolConformanceRef());
   }
 
   if (auto func = dyn_cast<clang::FunctionDecl>(clangDecl)) {
@@ -1734,8 +1734,7 @@ getSILFunctionTypeForClangDecl(TypeConverter &TC, const clang::Decl *clangDecl,
         : AbstractionPattern(origType, clangType);
     return getSILFunctionType(TC, origPattern, substInterfaceType, extInfo,
                               CFunctionConventions(func), foreignInfo, constant,
-                              constant, None,
-                              ProtocolConformanceRef::forInvalid());
+                              constant, None, ProtocolConformanceRef());
   }
 
   llvm_unreachable("call to unknown kind of C function");
@@ -1762,18 +1761,16 @@ getSILFunctionTypeForAbstractCFunction(TypeConverter &TC,
       llvm_unreachable("unexpected type imported as a function type");
     }
     if (fnType) {
-      return getSILFunctionType(TC, origType, substType, extInfo,
-                                CFunctionTypeConventions(fnType), ForeignInfo(),
-                                constant, constant, None,
-                                ProtocolConformanceRef::forInvalid());
+      return getSILFunctionType(
+          TC, origType, substType, extInfo, CFunctionTypeConventions(fnType),
+          ForeignInfo(), constant, constant, None, ProtocolConformanceRef());
     }
   }
 
   // TODO: Ought to support captures in block funcs.
   return getSILFunctionType(TC, origType, substType, extInfo,
                             DefaultBlockConventions(), ForeignInfo(), constant,
-                            constant, None,
-                            ProtocolConformanceRef::forInvalid());
+                            constant, None, ProtocolConformanceRef());
 }
 
 /// Try to find a clang method declaration for the given function.
@@ -1940,7 +1937,7 @@ getSILFunctionTypeForObjCSelectorFamily(TypeConverter &TC, ObjCSelectorFamily fa
   return getSILFunctionType(
       TC, AbstractionPattern(origType), substInterfaceType, extInfo,
       ObjCSelectorFamilyConventions(family), foreignInfo, constant, constant,
-      /*requirement subs*/ None, ProtocolConformanceRef::forInvalid());
+      /*requirement subs*/ None, ProtocolConformanceRef());
 }
 
 static bool isImporterGeneratedAccessor(const clang::Decl *clangDecl,
@@ -1973,7 +1970,7 @@ getUncachedSILFunctionTypeForConstant(TypeConverter &TC,
   auto extInfo = origLoweredInterfaceType->getExtInfo();
 
   if (!constant.isForeign) {
-    auto witnessMethodConformance = ProtocolConformanceRef::forInvalid();
+    ProtocolConformanceRef witnessMethodConformance;
 
     if (extInfo.getSILRepresentation() ==
         SILFunctionTypeRepresentation::WitnessMethod) {
@@ -2328,7 +2325,7 @@ TypeConverter::getConstantOverrideInfo(SILDeclRef derived, SILDeclRef base) {
   // Build the SILFunctionType for the vtable thunk.
   CanSILFunctionType fnTy = getNativeSILFunctionType(
       *this, basePattern, overrideLoweredInterfaceTy, base, derived,
-      /*reqt subs*/ None, ProtocolConformanceRef::forInvalid());
+      /*reqt subs*/ None, ProtocolConformanceRef());
 
   // Build the SILConstantInfo and cache it.
   auto resultBuf = Context.Allocate(sizeof(SILConstantInfo),
@@ -2422,7 +2419,7 @@ public:
       substYields.push_back(substInterface(origYield));
     }
 
-    auto witnessMethodConformance = ProtocolConformanceRef::forInvalid();
+    ProtocolConformanceRef witnessMethodConformance;
     if (auto conformance = origType->getWitnessMethodConformanceOrInvalid()) {
       assert(origType->getExtInfo().hasSelfParam());
       auto selfType = origType->getSelfParameter().getInterfaceType();

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -352,7 +352,7 @@ ProtocolConformance *SILGenModule::getNSErrorConformanceToError() {
     SwiftModule->lookupConformance(nsError->getDeclaredInterfaceType(),
                                    cast<ProtocolDecl>(error));
 
-  if (!conformance.isInvalid() && conformance.isConcrete())
+  if (conformance.isConcrete())
     NSErrorConformanceToError = conformance.getConcrete();
   else
     NSErrorConformanceToError = nullptr;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -284,8 +284,10 @@ SILGenModule::getConformanceToObjectiveCBridgeable(SILLocation loc, Type type) {
 
   // Find the conformance to _ObjectiveCBridgeable.
   auto result = SwiftModule->lookupConformance(type, proto);
-  if (result) return result->getConcrete();
-  return nullptr;
+  if (result.isInvalid())
+    return nullptr;
+
+  return result.getConcrete();
 }
 
 ProtocolDecl *SILGenModule::getBridgedStoredNSError(SILLocation loc) {
@@ -319,10 +321,11 @@ VarDecl *SILGenModule::getNSErrorRequirement(SILLocation loc) {
   return found;
 }
 
-Optional<ProtocolConformanceRef>
+ProtocolConformanceRef
 SILGenModule::getConformanceToBridgedStoredNSError(SILLocation loc, Type type) {
   auto proto = getBridgedStoredNSError(loc);
-  if (!proto) return None;
+  if (!proto)
+    return ProtocolConformanceRef::forInvalid();
 
   // Find the conformance to _BridgedStoredNSError.
   return SwiftModule->lookupConformance(type, proto);
@@ -349,8 +352,8 @@ ProtocolConformance *SILGenModule::getNSErrorConformanceToError() {
     SwiftModule->lookupConformance(nsError->getDeclaredInterfaceType(),
                                    cast<ProtocolDecl>(error));
 
-  if (conformance && conformance->isConcrete())
-    NSErrorConformanceToError = conformance->getConcrete();
+  if (!conformance.isInvalid() && conformance.isConcrete())
+    NSErrorConformanceToError = conformance.getConcrete();
   else
     NSErrorConformanceToError = nullptr;
   return *NSErrorConformanceToError;

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -393,8 +393,8 @@ public:
 
   /// Find the conformance of the given Swift type to the
   /// _BridgedStoredNSError protocol.
-  Optional<ProtocolConformanceRef>
-  getConformanceToBridgedStoredNSError(SILLocation loc, Type type);
+  ProtocolConformanceRef getConformanceToBridgedStoredNSError(SILLocation loc,
+                                                              Type type);
 
   /// Retrieve the conformance of NSError to the Error protocol.
   ProtocolConformance *getNSErrorConformanceToError();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -55,10 +55,8 @@ SubstitutionMap SILGenModule::mapSubstitutionsForWitnessOverride(
   Type origProtoSelfType = origProto->getSelfInterfaceType();
   auto baseProto = cast<ProtocolDecl>(overridden->getDeclContext());
   return SubstitutionMap::getProtocolSubstitutions(
-           baseProto,
-           origProtoSelfType.subst(subs),
-           *subs.lookupConformance(origProtoSelfType->getCanonicalType(),
-                                   baseProto));
+      baseProto, origProtoSelfType.subst(subs),
+      subs.lookupConformance(origProtoSelfType->getCanonicalType(), baseProto));
 }
 
 /// Return the abstraction pattern to use when calling a function value.
@@ -648,7 +646,7 @@ public:
       auto proto = cast<ProtocolDecl>(Constant.getDecl()->getDeclContext());
       auto selfType = proto->getSelfInterfaceType()->getCanonicalType();
       auto lookupType = selfType.subst(Substitutions)->getCanonicalType();
-      auto conformance = *Substitutions.lookupConformance(selfType, proto);
+      auto conformance = Substitutions.lookupConformance(selfType, proto);
 
       ArgumentScope S(SGF, Loc);
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -927,7 +927,7 @@ SILGenFunction::emitBlockToFunc(SILLocation loc,
 
   auto loweredFuncTyWithoutNoEscape = adjustFunctionType(
       loweredFuncTy, loweredFuncTy->getExtInfo().withNoEscape(false),
-      loweredFuncTy->getWitnessMethodConformanceOrNone());
+      loweredFuncTy->getWitnessMethodConformanceOrInvalid());
 
   CanType dynamicSelfType;
   auto thunkTy = buildThunkType(loweredBlockTy, loweredFuncTyWithoutNoEscape,

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -77,8 +77,7 @@ static bool shouldBridgeThroughError(SILGenModule &SGM, CanType type,
     }
   }
 
-  auto optConf = SGM.SwiftModule->lookupConformance(type, errorProtocol);
-  return optConf.hasValue();
+  return !SGM.SwiftModule->lookupConformance(type, errorProtocol).isInvalid();
 }
 
 /// Bridge the given Swift value to its corresponding Objective-C
@@ -1133,7 +1132,8 @@ ManagedValue SILGenFunction::emitBridgedToNativeError(SILLocation loc,
     auto nativeErrorTy = SILType::getExceptionType(getASTContext());
 
     auto conformance = SGM.getNSErrorConformanceToError();
-    if (!conformance) return emitUndef(nativeErrorTy);
+    if (!conformance)
+      return emitUndef(nativeErrorTy);
     ProtocolConformanceRef conformanceArray[] = {
       ProtocolConformanceRef(conformance)
     };

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -77,7 +77,7 @@ static bool shouldBridgeThroughError(SILGenModule &SGM, CanType type,
     }
   }
 
-  return !SGM.SwiftModule->lookupConformance(type, errorProtocol).isInvalid();
+  return (bool)SGM.SwiftModule->lookupConformance(type, errorProtocol);
 }
 
 /// Bridge the given Swift value to its corresponding Objective-C

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -643,7 +643,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     // then just erase the NSError.
     auto storedNSErrorConformance =
         SGM.getConformanceToBridgedStoredNSError(loc, concreteFormalType);
-    if (!storedNSErrorConformance.isInvalid()) {
+    if (storedNSErrorConformance) {
       auto nsErrorVar = SGM.getNSErrorRequirement(loc);
       if (!nsErrorVar) return emitUndef(existentialTL.getLoweredType());
 

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -641,8 +641,9 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     // If the concrete type is known to conform to _BridgedStoredNSError,
     // call the _nsError witness getter to extract the NSError directly,
     // then just erase the NSError.
-    if (auto storedNSErrorConformance =
-          SGM.getConformanceToBridgedStoredNSError(loc, concreteFormalType)) {
+    auto storedNSErrorConformance =
+        SGM.getConformanceToBridgedStoredNSError(loc, concreteFormalType);
+    if (!storedNSErrorConformance.isInvalid()) {
       auto nsErrorVar = SGM.getNSErrorRequirement(loc);
       if (!nsErrorVar) return emitUndef(existentialTL.getLoweredType());
 
@@ -650,9 +651,9 @@ ManagedValue SILGenFunction::emitExistentialErasure(
 
       // Devirtualize.  Maybe this should be done implicitly by
       // emitPropertyLValue?
-      if (storedNSErrorConformance->isConcrete()) {
+      if (storedNSErrorConformance.isConcrete()) {
         if (auto normal = dyn_cast<NormalProtocolConformance>(
-                                    storedNSErrorConformance->getConcrete())) {
+                storedNSErrorConformance.getConcrete())) {
           if (auto witnessVar = normal->getWitness(nsErrorVar)) {
             nsErrorVar = cast<VarDecl>(witnessVar.getDecl());
             nsErrorVarSubstitutions = witnessVar.getSubstitutions();

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3226,10 +3226,8 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
       SubstitutionMap hashableSubsMap = SubstitutionMap::get(
           hashGenericSig,
           [&](SubstitutableType *type) -> Type { return formalTy; },
-          [&](CanType dependentType, Type replacementType,
-              ProtocolDecl *proto)->Optional<ProtocolConformanceRef> {
-            return hashable;
-          });
+          [&](CanType dependentType, Type replacementType, ProtocolDecl *proto)
+              -> ProtocolConformanceRef { return hashable; });
 
       // Read the storage.
       ManagedValue base = ManagedValue::forBorrowedAddressRValue(indexAddr);

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -111,15 +111,15 @@ void SILGenModule::useConformancesFromObjectiveCType(CanType type) {
     if (objectiveCBridgeable) {
       auto subConformance = SwiftModule->lookupConformance(
           t, objectiveCBridgeable);
-      if (subConformance)
-        useConformance(*subConformance);
+      if (!subConformance.isInvalid())
+        useConformance(subConformance);
     }
 
     if (bridgedStoredNSError) {
       auto subConformance = SwiftModule->lookupConformance(
           t, bridgedStoredNSError);
-      if (subConformance)
-        useConformance(*subConformance);
+      if (!subConformance.isInvalid())
+        useConformance(subConformance);
     }
   });
 }

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -109,16 +109,14 @@ void SILGenModule::useConformancesFromObjectiveCType(CanType type) {
       return;
 
     if (objectiveCBridgeable) {
-      auto subConformance = SwiftModule->lookupConformance(
-          t, objectiveCBridgeable);
-      if (!subConformance.isInvalid())
+      if (auto subConformance =
+              SwiftModule->lookupConformance(t, objectiveCBridgeable))
         useConformance(subConformance);
     }
 
     if (bridgedStoredNSError) {
-      auto subConformance = SwiftModule->lookupConformance(
-          t, bridgedStoredNSError);
-      if (!subConformance.isInvalid())
+      if (auto subConformance =
+              SwiftModule->lookupConformance(t, bridgedStoredNSError))
         useConformance(subConformance);
     }
   });

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3385,7 +3385,7 @@ ManagedValue Transform::transformFunction(ManagedValue fn,
                                      : expectedFnType->isNoEscape());
   auto newFnType =
       adjustFunctionType(expectedFnType, newEI, fnType->getCalleeConvention(),
-                         fnType->getWitnessMethodConformanceOrNone());
+                         fnType->getWitnessMethodConformanceOrInvalid());
 
   // Apply any ABI-compatible conversions before doing thin-to-thick or
   // escaping->noescape conversion.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -177,7 +177,7 @@ collectExistentialConformances(ModuleDecl *M, CanType fromType, CanType toType) 
   for (auto proto : protocols) {
     auto conformance =
       M->lookupConformance(fromType, proto->getDecl());
-    assert(!conformance.isInvalid());
+    assert(conformance);
     conformances.push_back(conformance);
   }
   

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -177,7 +177,8 @@ collectExistentialConformances(ModuleDecl *M, CanType fromType, CanType toType) 
   for (auto proto : protocols) {
     auto conformance =
       M->lookupConformance(fromType, proto->getDecl());
-    conformances.push_back(*conformance);
+    assert(!conformance.isInvalid());
+    conformances.push_back(conformance);
   }
   
   return M->getASTContext().AllocateCopy(conformances);
@@ -596,9 +597,8 @@ ManagedValue Transform::transform(ManagedValue v,
     auto conformance = SGF.SGM.M.getSwiftModule()->lookupConformance(
         inputSubstType, protocol);
     auto addr = v.getType().isAddress() ? v : v.materialize(SGF, Loc);
-    auto result = SGF.emitAnyHashableErasure(Loc, addr,
-                                             inputSubstType, *conformance,
-                                             ctxt);
+    auto result = SGF.emitAnyHashableErasure(Loc, addr, inputSubstType,
+                                             conformance, ctxt);
     if (result.isInContext())
       return ManagedValue::forInContext();
     return std::move(result).getAsSingleValue(SGF, Loc);
@@ -3764,7 +3764,7 @@ getSelfTypeAndConformanceForWitness(SILDeclRef witness, SubstitutionMap subs) {
   auto protocol = cast<ProtocolDecl>(witness.getDecl()->getDeclContext());
   auto selfParam = protocol->getProtocolSelfType()->getCanonicalType();
   auto type = subs.getReplacementTypes()[0];
-  auto conf = *subs.lookupConformance(selfParam, protocol);
+  auto conf = subs.lookupConformance(selfParam, protocol);
   return {type->getCanonicalType(), conf};
 }
 

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -931,7 +931,7 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
   if (S->getConvertElementExpr()) {
     optTy = S->getConvertElementExpr()->getType()->getCanonicalType();
   } else {
-    optTy = OptionalType::get(S->getSequenceConformance()->getTypeWitnessByName(
+    optTy = OptionalType::get(S->getSequenceConformance().getTypeWitnessByName(
                                   S->getSequence()->getType(),
                                   SGF.getASTContext().Id_Element))
                 ->getCanonicalType();

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -133,7 +133,7 @@ getNextUncurryLevelRef(SILGenFunction &SGF, SILLocation loc, SILDeclRef thunk,
       auto origSelfType = protocol->getSelfInterfaceType()->getCanonicalType();
       auto substSelfType = origSelfType.subst(curriedSubs)->getCanonicalType();
       auto conformance = curriedSubs.lookupConformance(origSelfType, protocol);
-      auto result = SGF.B.createWitnessMethod(loc, substSelfType, *conformance,
+      auto result = SGF.B.createWitnessMethod(loc, substSelfType, conformance,
                                               next, constantInfo.getSILType());
       return {ManagedValue::forUnmanaged(result), next};
     }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -558,11 +558,11 @@ public:
           auto conformance =
               Conformance->getGenericSignature()->lookupConformance(type,
                                                                     protocol);
-          assert(conformance &&
+          assert(!conformance.isInvalid() &&
                  "unable to find conformance that should be known");
 
           ConditionalConformances.push_back(
-              SILWitnessTable::ConditionalConformance{type, *conformance});
+              SILWitnessTable::ConditionalConformance{type, conformance});
 
           return /*finished?*/ false;
         });
@@ -627,7 +627,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
     auto requirement = conformance.getRequirement();
     auto self = requirement->getSelfInterfaceType()->getCanonicalType();
 
-    conformance = *reqtSubMap.lookupConformance(self, requirement);
+    conformance = reqtSubMap.lookupConformance(self, requirement);
   }
 
   reqtSubstTy =
@@ -901,14 +901,11 @@ public:
         Proto->getDefaultAssociatedConformanceWitness(
           req.getAssociation(),
           req.getAssociatedRequirement());
-    if (!witness)
+    if (witness.isInvalid())
       return addMissingDefault();
 
-    auto entry =
-        SILWitnessTable::AssociatedTypeProtocolWitness{
-          req.getAssociation(),
-          req.getAssociatedRequirement(),
-          *witness};
+    auto entry = SILWitnessTable::AssociatedTypeProtocolWitness{
+        req.getAssociation(), req.getAssociatedRequirement(), witness};
     DefaultWitnesses.push_back(entry);
   }
 };

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -558,7 +558,7 @@ public:
           auto conformance =
               Conformance->getGenericSignature()->lookupConformance(type,
                                                                     protocol);
-          assert(!conformance.isInvalid() &&
+          assert(conformance &&
                  "unable to find conformance that should be known");
 
           ConditionalConformances.push_back(

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -362,7 +362,7 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
   /// Finally the ExtInfo.
   auto ExtInfo = FTy->getExtInfo();
   ExtInfo = ExtInfo.withRepresentation(SILFunctionTypeRepresentation::Thin);
-  auto witnessMethodConformance = FTy->getWitnessMethodConformanceOrNone();
+  auto witnessMethodConformance = FTy->getWitnessMethodConformanceOrInvalid();
 
   /// Return the new signature.
   return SILFunctionType::get(

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -381,7 +381,7 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
   auto witnessMethodConformance = FTy->getWitnessMethodConformanceOrNone();
   if (shouldModifySelfArgument) {
     ExtInfo = ExtInfo.withRepresentation(SILFunctionTypeRepresentation::Thin);
-    witnessMethodConformance = None;
+    witnessMethodConformance = ProtocolConformanceRef::forInvalid();
   }
 
   Optional<SILResultInfo> InterfaceErrorResult;

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -378,7 +378,7 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
 
   // Don't use a method representation if we modified self.
   auto ExtInfo = FTy->getExtInfo();
-  auto witnessMethodConformance = FTy->getWitnessMethodConformanceOrNone();
+  auto witnessMethodConformance = FTy->getWitnessMethodConformanceOrInvalid();
   if (shouldModifySelfArgument) {
     ExtInfo = ExtInfo.withRepresentation(SILFunctionTypeRepresentation::Thin);
     witnessMethodConformance = ProtocolConformanceRef::forInvalid();

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -427,10 +427,9 @@ ClosureCloner::initCloned(SILOptFunctionBuilder &FunctionBuilder,
   auto ClonedTy = SILFunctionType::get(
       OrigFTI->getInvocationGenericSignature(), OrigFTI->getExtInfo(),
       OrigFTI->getCoroutineKind(), OrigFTI->getCalleeConvention(),
-      ClonedInterfaceArgTys, OrigFTI->getYields(),
-      OrigFTI->getResults(), OrigFTI->getOptionalErrorResult(),
-      SubstitutionMap(), false,
-      M.getASTContext(), OrigFTI->getWitnessMethodConformanceOrNone());
+      ClonedInterfaceArgTys, OrigFTI->getYields(), OrigFTI->getResults(),
+      OrigFTI->getOptionalErrorResult(), SubstitutionMap(), false,
+      M.getASTContext(), OrigFTI->getWitnessMethodConformanceOrInvalid());
 
   assert((Orig->isTransparent() || Orig->isBare() || Orig->getLocation())
          && "SILFunction missing location");

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1258,7 +1258,7 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
           return type;
         },
         [&](CanType origTy, Type substTy,
-            ProtocolDecl *proto) -> Optional<ProtocolConformanceRef> {
+            ProtocolDecl *proto) -> ProtocolConformanceRef {
           if (origTy->isEqual(OAI.OpenedArchetype)) {
             assert(substTy->isEqual(CEI.ConcreteType));
             // Do a conformance lookup on this witness requirement using the
@@ -1376,7 +1376,7 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply,
   // Get the conformance of the init_existential type, which is passed as the
   // self argument, on the witness' protocol.
   ProtocolConformanceRef SelfConformance =
-      *SelfCEI.lookupExistentialConformance(WMI->getLookupProtocol());
+      SelfCEI.lookupExistentialConformance(WMI->getLookupProtocol());
 
   // Propagate the concrete type into a callee-operand, which is a
   // witness_method instruction. It's ok to rewrite the witness method in terms

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -601,10 +601,10 @@ SILFunction *PromotedParamCloner::initCloned(SILOptFunctionBuilder &FuncBuilder,
   auto ClonedTy = SILFunctionType::get(
       OrigFTI->getSubstGenericSignature(), OrigFTI->getExtInfo(),
       OrigFTI->getCoroutineKind(), OrigFTI->getCalleeConvention(),
-      ClonedInterfaceArgTys, OrigFTI->getYields(),
-      OrigFTI->getResults(), OrigFTI->getOptionalErrorResult(),
-      OrigFTI->getSubstitutions(), OrigFTI->isGenericSignatureImplied(),
-      M.getASTContext(), OrigFTI->getWitnessMethodConformanceOrNone());
+      ClonedInterfaceArgTys, OrigFTI->getYields(), OrigFTI->getResults(),
+      OrigFTI->getOptionalErrorResult(), OrigFTI->getSubstitutions(),
+      OrigFTI->isGenericSignatureImplied(), M.getASTContext(),
+      OrigFTI->getWitnessMethodConformanceOrInvalid());
 
   assert((Orig->isTransparent() || Orig->isBare() || Orig->getLocation())
          && "SILFunction missing location");

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -138,10 +138,10 @@ static SILDeclRef getBridgeToObjectiveC(CanType NativeType,
     return SILDeclRef();
   auto ConformanceRef =
       SwiftModule->lookupConformance(NativeType, Proto);
-  if (!ConformanceRef)
+  if (ConformanceRef.isInvalid())
     return SILDeclRef();
 
-  auto Conformance = ConformanceRef->getConcrete();
+  auto Conformance = ConformanceRef.getConcrete();
   // bridgeToObjectiveC
   DeclName Name(Ctx, Ctx.Id_bridgeToObjectiveC, llvm::ArrayRef<Identifier>());
   auto *Requirement = dyn_cast_or_null<FuncDecl>(
@@ -162,9 +162,9 @@ SILDeclRef getBridgeFromObjectiveC(CanType NativeType,
     return SILDeclRef();
   auto ConformanceRef =
       SwiftModule->lookupConformance(NativeType, Proto);
-  if (!ConformanceRef)
+  if (ConformanceRef.isInvalid())
     return SILDeclRef();
-  auto Conformance = ConformanceRef->getConcrete();
+  auto Conformance = ConformanceRef.getConcrete();
   // _unconditionallyBridgeFromObjectiveC
   DeclName Name(Ctx, Ctx.getIdentifier("_unconditionallyBridgeFromObjectiveC"),
                 llvm::makeArrayRef(Identifier()));

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -483,7 +483,7 @@ findBridgeToObjCFunc(SILOptFunctionBuilder &functionBuilder,
       mod.getASTContext().getProtocol(KnownProtocolKind::ObjectiveCBridgeable);
 
   auto conf = mod.getSwiftModule()->lookupConformance(sourceType, bridgedProto);
-  assert(!conf.isInvalid() && "_ObjectiveCBridgeable conformance should exist");
+  assert(conf && "_ObjectiveCBridgeable conformance should exist");
   (void)conf;
 
   // Generate code to invoke _bridgeToObjectiveC

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1133,7 +1133,7 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
     if (calleeFnType->getRepresentation() ==
         SILFunctionType::Representation::WitnessMethod) {
       auto protocol =
-          calleeFnType->getWitnessMethodConformanceOrNone().getRequirement();
+          calleeFnType->getWitnessMethodConformanceOrInvalid().getRequirement();
       // Compute a mapping that maps the Self type of the protocol given by
       // 'requirement' to the concrete type available in the substitutionMap.
       auto protoSelfToConcreteType =

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -380,12 +380,11 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
 
   // Try to resolve a witness method against our known conformances.
   if (auto *wmi = dyn_cast<WitnessMethodInst>(value)) {
-    auto confResult = substitutionMap.lookupConformance(
+    auto conf = substitutionMap.lookupConformance(
         wmi->getLookupType(), wmi->getConformance().getRequirement());
-    if (!confResult)
+    if (conf.isInvalid())
       return getUnknown(evaluator, value,
                         UnknownReason::UnknownWitnessMethodConformance);
-    auto conf = confResult.getValue();
     auto &module = wmi->getModule();
     SILFunction *fn =
         module.lookUpFunctionInWitnessTable(conf, wmi->getMember()).first;
@@ -1134,7 +1133,7 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
     if (calleeFnType->getRepresentation() ==
         SILFunctionType::Representation::WitnessMethod) {
       auto protocol =
-          calleeFnType->getWitnessMethodConformance().getRequirement();
+          calleeFnType->getWitnessMethodConformanceOrNone().getRequirement();
       // Compute a mapping that maps the Self type of the protocol given by
       // 'requirement' to the concrete type available in the substitutionMap.
       auto protoSelfToConcreteType =
@@ -1143,12 +1142,12 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
       // Self type of the requirement.
       auto conf = protoSelfToConcreteType.lookupConformance(
           protocol->getSelfInterfaceType()->getCanonicalType(), protocol);
-      if (!conf.hasValue())
+      if (conf.isInvalid())
         return getUnknown(evaluator, (SILInstruction *)apply,
                           UnknownReason::UnknownWitnessMethodConformance);
 
       callSubMap = getWitnessMethodSubstitutions(
-          apply->getModule(), ApplySite(apply), callee, conf.getValue());
+          apply->getModule(), ApplySite(apply), callee, conf);
 
       /// Remark: If we ever start to care about evaluating classes,
       /// getSubstitutionsForCallee() is the analogous mapping function we

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -362,11 +362,11 @@ ConcreteExistentialInfo::ConcreteExistentialInfo(SILValue existential,
   // We have the open_existential; we still need the conformance.
   auto ConformanceRef =
       M->getSwiftModule()->conformsToProtocol(ConcreteTypeCandidate, Protocol);
-  if (!ConformanceRef)
+  if (ConformanceRef.isInvalid())
     return;
 
   // Assert that the conformance is complete.
-  auto *ConcreteConformance = ConformanceRef.getValue().getConcrete();
+  auto *ConcreteConformance = ConformanceRef.getConcrete();
   assert(ConcreteConformance->isComplete());
 
   ConcreteType = ConcreteTypeCandidate;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -772,12 +772,10 @@ ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
 
   // Use the new specialized generic signature.
   auto NewFnTy = SILFunctionType::get(
-      CanSpecializedGenericSig, FnTy->getExtInfo(),
-      FnTy->getCoroutineKind(), FnTy->getCalleeConvention(),
-      FnTy->getParameters(), FnTy->getYields(),
-      FnTy->getResults(), FnTy->getOptionalErrorResult(),
-      SubstitutionMap(), false,
-      M.getASTContext(), FnTy->getWitnessMethodConformanceOrNone());
+      CanSpecializedGenericSig, FnTy->getExtInfo(), FnTy->getCoroutineKind(),
+      FnTy->getCalleeConvention(), FnTy->getParameters(), FnTy->getYields(),
+      FnTy->getResults(), FnTy->getOptionalErrorResult(), SubstitutionMap(),
+      false, M.getASTContext(), FnTy->getWitnessMethodConformanceOrInvalid());
 
   // This is an interface type. It should not have any archetypes.
   assert(!NewFnTy->hasArchetype());
@@ -846,13 +844,11 @@ createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
     SpecializedYields.push_back(YI);
   }
   return SILFunctionType::get(
-      SubstFTy->getInvocationGenericSignature(),
-      SubstFTy->getExtInfo(), SubstFTy->getCoroutineKind(),
-      SubstFTy->getCalleeConvention(),
+      SubstFTy->getInvocationGenericSignature(), SubstFTy->getExtInfo(),
+      SubstFTy->getCoroutineKind(), SubstFTy->getCalleeConvention(),
       SpecializedParams, SpecializedYields, SpecializedResults,
-      SubstFTy->getOptionalErrorResult(),
-      SubstitutionMap(), false, M.getASTContext(),
-      SubstFTy->getWitnessMethodConformanceOrNone());
+      SubstFTy->getOptionalErrorResult(), SubstitutionMap(), false,
+      M.getASTContext(), SubstFTy->getWitnessMethodConformanceOrInvalid());
 }
 
 /// Create a new generic signature from an existing one by adding

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -77,8 +77,8 @@ Solution::computeSubstitutions(GenericSignature sig,
     subs[opened.first] = getFixedType(opened.second);
 
   auto lookupConformanceFn =
-      [&](CanType original, Type replacement, ProtocolDecl *protoType)
-          -> Optional<ProtocolConformanceRef> {
+      [&](CanType original, Type replacement,
+          ProtocolDecl *protoType) -> ProtocolConformanceRef {
     if (replacement->hasError() ||
         isOpenedAnyObject(replacement) ||
         replacement->is<GenericTypeParamType>()) {
@@ -436,9 +436,9 @@ namespace {
               TypeChecker::conformsToProtocol(
                         baseTy, proto, cs.DC,
                         ConformanceCheckFlags::InExpression);
-            if (conformance && conformance->isConcrete()) {
+            if (!conformance.isInvalid() && conformance.isConcrete()) {
               if (auto witness =
-                      conformance->getConcrete()->getWitnessDecl(decl)) {
+                      conformance.getConcrete()->getWitnessDecl(decl)) {
                 // Hack up an AST that we can type-check (independently) to get
                 // it into the right form.
                 // FIXME: the hop through 'getDecl()' is because
@@ -1738,8 +1738,8 @@ namespace {
 
       FuncDecl *fn = nullptr;
 
-      if (bridgedToObjectiveCConformance) {
-        assert(bridgedToObjectiveCConformance->getConditionalRequirements()
+      if (!bridgedToObjectiveCConformance.isInvalid()) {
+        assert(bridgedToObjectiveCConformance.getConditionalRequirements()
                    .empty() &&
                "cannot conditionally conform to _BridgedToObjectiveC");
         // The conformance to _BridgedToObjectiveC is statically known.
@@ -1766,16 +1766,16 @@ namespace {
       auto genericSig = fn->getGenericSignature();
 
       auto subMap = SubstitutionMap::get(
-        genericSig,
-        [&](SubstitutableType *type) -> Type {
-          assert(type->isEqual(genericSig->getGenericParams()[0]));
-          return valueType;
-        },
-        [&](CanType origType, Type replacementType, ProtocolDecl *protoType)
-          -> ProtocolConformanceRef {
-          assert(bridgedToObjectiveCConformance);
-          return *bridgedToObjectiveCConformance;
-        });
+          genericSig,
+          [&](SubstitutableType *type) -> Type {
+            assert(type->isEqual(genericSig->getGenericParams()[0]));
+            return valueType;
+          },
+          [&](CanType origType, Type replacementType,
+              ProtocolDecl *protoType) -> ProtocolConformanceRef {
+            assert(!bridgedToObjectiveCConformance.isInvalid());
+            return bridgedToObjectiveCConformance;
+          });
 
       ConcreteDeclRef fnSpecRef(fn, subMap);
 
@@ -2004,8 +2004,9 @@ namespace {
       ProtocolDecl *protocol = tc.getProtocol(
           expr->getLoc(), KnownProtocolKind::ExpressibleByStringLiteral);
 
-      if (!TypeChecker::conformsToProtocol(type, protocol, cs.DC,
-                                           ConformanceCheckFlags::InExpression)) {
+      if (TypeChecker::conformsToProtocol(type, protocol, cs.DC,
+                                          ConformanceCheckFlags::InExpression)
+              .isInvalid()) {
         // If the type does not conform to ExpressibleByStringLiteral, it should
         // be ExpressibleByExtendedGraphemeClusterLiteral.
         protocol = tc.getProtocol(
@@ -2014,8 +2015,9 @@ namespace {
         isStringLiteral = false;
         isGraphemeClusterLiteral = true;
       }
-      if (!TypeChecker::conformsToProtocol(type, protocol, cs.DC,
-                                           ConformanceCheckFlags::InExpression)) {
+      if (TypeChecker::conformsToProtocol(type, protocol, cs.DC,
+                                          ConformanceCheckFlags::InExpression)
+              .isInvalid()) {
         // ... or it should be ExpressibleByUnicodeScalarLiteral.
         protocol = tc.getProtocol(
             expr->getLoc(),
@@ -2134,12 +2136,13 @@ namespace {
         auto conformance =
           TypeChecker::conformsToProtocol(type, proto, cs.DC,
                                           ConformanceCheckFlags::InExpression);
-        assert(conformance && "string interpolation type conforms to protocol");
+        assert(!conformance.isInvalid() &&
+               "string interpolation type conforms to protocol");
 
         DeclName constrName(tc.Context, DeclBaseName::createConstructor(), argLabels);
 
         ConcreteDeclRef witness =
-            conformance->getWitnessByName(type->getRValueType(), constrName);
+            conformance.getWitnessByName(type->getRValueType(), constrName);
         if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
           return nullptr;
         return witness;
@@ -2240,13 +2243,13 @@ namespace {
       auto conformance =
         TypeChecker::conformsToProtocol(conformingType, proto, cs.DC,
                                         ConformanceCheckFlags::InExpression);
-      assert(conformance && "object literal type conforms to protocol");
+      assert(!conformance.isInvalid() &&
+             "object literal type conforms to protocol");
 
       DeclName constrName(tc.getObjectLiteralConstructorName(expr));
 
-      ConcreteDeclRef witness =
-        conformance->getWitnessByName(conformingType->getRValueType(),
-                                      constrName);
+      ConcreteDeclRef witness = conformance.getWitnessByName(
+          conformingType->getRValueType(), constrName);
       if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
         return nullptr;
       expr->setInitializer(witness);
@@ -2901,12 +2904,12 @@ namespace {
       auto conformance =
         TypeChecker::conformsToProtocol(arrayTy, arrayProto, cs.DC,
                                         ConformanceCheckFlags::InExpression);
-      assert(conformance && "Type does not conform to protocol?");
+      assert(!conformance.isInvalid() && "Type does not conform to protocol?");
 
       DeclName name(tc.Context, DeclBaseName::createConstructor(),
                     { tc.Context.Id_arrayLiteral });
       ConcreteDeclRef witness =
-        conformance->getWitnessByName(arrayTy->getRValueType(), name);
+          conformance.getWitnessByName(arrayTy->getRValueType(), name);
       if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
         return nullptr;
       expr->setInitializer(witness);
@@ -2946,13 +2949,13 @@ namespace {
       auto conformance =
         TypeChecker::conformsToProtocol(dictionaryTy, dictionaryProto, cs.DC,
                                         ConformanceCheckFlags::InExpression);
-      if (!conformance)
+      if (conformance.isInvalid())
         return nullptr;
 
       DeclName name(tc.Context, DeclBaseName::createConstructor(),
                     { tc.Context.Id_dictionaryLiteral });
       ConcreteDeclRef witness =
-        conformance->getWitnessByName(dictionaryTy->getRValueType(), name);
+          conformance.getWitnessByName(dictionaryTy->getRValueType(), name);
       if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
         return nullptr;
       expr->setInitializer(witness);
@@ -4652,9 +4655,9 @@ namespace {
         auto hashableConformance =
           TypeChecker::conformsToProtocol(indexType, hashable, cs.DC,
                                           ConformanceCheckFlags::InExpression);
-        assert(hashableConformance.hasValue());
+        assert(!hashableConformance.isInvalid());
 
-        conformances.push_back(*hashableConformance);
+        conformances.push_back(hashableConformance);
       }
 
       component.setSubscriptIndexHashableConformances(conformances);
@@ -5022,9 +5025,8 @@ collectExistentialConformances(TypeChecker &tc, Type fromType, Type toType,
 
   SmallVector<ProtocolConformanceRef, 4> conformances;
   for (auto proto : layout.getProtocols()) {
-    conformances.push_back(
-      *tc.containsProtocol(fromType, proto->getDecl(), DC,
-                           ConformanceCheckFlags::InExpression));
+    conformances.push_back(tc.containsProtocol(
+        fromType, proto->getDecl(), DC, ConformanceCheckFlags::InExpression));
   }
 
   return tc.Context.AllocateCopy(conformances);
@@ -6117,10 +6119,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
         TypeChecker::conformsToProtocol(
                         cs.getType(expr), hashable, cs.DC,
                         ConformanceCheckFlags::InExpression);
-      assert(conformance && "must conform to Hashable");
+      assert(!conformance.isInvalid() && "must conform to Hashable");
 
       return cs.cacheType(
-          new (tc.Context) AnyHashableErasureExpr(expr, toType, *conformance));
+          new (tc.Context) AnyHashableErasureExpr(expr, toType, conformance));
     }
 
     case ConversionRestrictionKind::DictionaryUpcast: {
@@ -6600,50 +6602,49 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
 
   // Check whether this literal type conforms to the builtin protocol. If so,
   // initialize via the builtin protocol.
-  Optional<ProtocolConformanceRef> builtinConformance;
-  if (builtinProtocol &&
-      (builtinConformance =
-         TypeChecker::conformsToProtocol(type, builtinProtocol, cs.DC,
-                                         ConformanceCheckFlags::InExpression))) {
+  if (builtinProtocol) {
+    auto builtinConformance = TypeChecker::conformsToProtocol(
+        type, builtinProtocol, cs.DC, ConformanceCheckFlags::InExpression);
+    if (!builtinConformance.isInvalid()) {
+      // Find the witness that we'll use to initialize the type via a builtin
+      // literal.
+      auto witness = builtinConformance.getWitnessByName(
+          type->getRValueType(), builtinLiteralFuncName);
+      if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
+        return nullptr;
 
-    // Find the witness that we'll use to initialize the type via a builtin
-    // literal.
-    auto witness = builtinConformance->getWitnessByName(type->getRValueType(),
-                                                        builtinLiteralFuncName);
-    if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
-      return nullptr;
+      // Form a reference to the builtin conversion function.
 
-    // Form a reference to the builtin conversion function.
+      // Set the builtin initializer.
+      if (auto stringLiteral = dyn_cast<StringLiteralExpr>(literal))
+        stringLiteral->setBuiltinInitializer(witness);
+      else if (auto booleanLiteral = dyn_cast<BooleanLiteralExpr>(literal))
+        booleanLiteral->setBuiltinInitializer(witness);
+      else if (auto numberLiteral = dyn_cast<NumberLiteralExpr>(literal))
+        numberLiteral->setBuiltinInitializer(witness);
+      else {
+        cast<MagicIdentifierLiteralExpr>(literal)->setBuiltinInitializer(
+            witness);
+      }
 
-    // Set the builtin initializer.
-    if (auto stringLiteral = dyn_cast<StringLiteralExpr>(literal))
-      stringLiteral->setBuiltinInitializer(witness);
-    else if (auto booleanLiteral = dyn_cast<BooleanLiteralExpr>(literal))
-      booleanLiteral->setBuiltinInitializer(witness);
-    else if (auto numberLiteral = dyn_cast<NumberLiteralExpr>(literal))
-      numberLiteral->setBuiltinInitializer(witness);
-    else {
-      cast<MagicIdentifierLiteralExpr>(literal)
-        ->setBuiltinInitializer(witness);
+      // The literal expression has this type.
+      cs.setType(literal, type);
+
+      return literal;
     }
-
-    // The literal expression has this type.
-    cs.setType(literal, type);
-
-    return literal;
   }
 
   // This literal type must conform to the (non-builtin) protocol.
   assert(protocol && "requirements should have stopped recursion");
   auto conformance = TypeChecker::conformsToProtocol(type, protocol, cs.DC,
                                            ConformanceCheckFlags::InExpression);
-  assert(conformance && "must conform to literal protocol");
+  assert(!conformance.isInvalid() && "must conform to literal protocol");
 
   // Dig out the literal type and perform a builtin literal conversion to it.
   if (!literalType.empty()) {
     // Extract the literal type.
     Type builtinLiteralType =
-        conformance->getTypeWitnessByName(type, literalType);
+        conformance.getTypeWitnessByName(type, literalType);
     if (builtinLiteralType->hasError())
       return nullptr;
 
@@ -6656,8 +6657,8 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
   }
 
   // Find the witness that we'll use to initialize the literal value.
-  auto witness = conformance->getWitnessByName(type->getRValueType(),
-                                               literalFuncName);
+  auto witness =
+      conformance.getWitnessByName(type->getRValueType(), literalFuncName);
   if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
     return nullptr;
 
@@ -6778,9 +6779,9 @@ ExprRewriter::finishApplyDynamicCallable(ApplyExpr *apply,
     auto conformance =
         cs.TC.conformsToProtocol(argumentType, dictLitProto, cs.DC,
                                  ConformanceCheckFlags::InExpression);
-    auto keyType = conformance->getTypeWitnessByName(argumentType, ctx.Id_Key);
-    auto valueType = conformance->getTypeWitnessByName(argumentType,
-                                                       ctx.Id_Value);
+    auto keyType = conformance.getTypeWitnessByName(argumentType, ctx.Id_Key);
+    auto valueType =
+        conformance.getTypeWitnessByName(argumentType, ctx.Id_Value);
     SmallVector<Identifier, 4> names;
     SmallVector<Expr *, 4> dictElements;
     for (unsigned i = 0, n = arg->getNumElements(); i < n; i++) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1738,7 +1738,7 @@ namespace {
 
       FuncDecl *fn = nullptr;
 
-      if (!bridgedToObjectiveCConformance.isInvalid()) {
+      if (bridgedToObjectiveCConformance) {
         assert(bridgedToObjectiveCConformance.getConditionalRequirements()
                    .empty() &&
                "cannot conditionally conform to _BridgedToObjectiveC");
@@ -1773,7 +1773,7 @@ namespace {
           },
           [&](CanType origType, Type replacementType,
               ProtocolDecl *protoType) -> ProtocolConformanceRef {
-            assert(!bridgedToObjectiveCConformance.isInvalid());
+            assert(bridgedToObjectiveCConformance);
             return bridgedToObjectiveCConformance;
           });
 
@@ -2004,9 +2004,8 @@ namespace {
       ProtocolDecl *protocol = tc.getProtocol(
           expr->getLoc(), KnownProtocolKind::ExpressibleByStringLiteral);
 
-      if (TypeChecker::conformsToProtocol(type, protocol, cs.DC,
-                                          ConformanceCheckFlags::InExpression)
-              .isInvalid()) {
+      if (!TypeChecker::conformsToProtocol(
+              type, protocol, cs.DC, ConformanceCheckFlags::InExpression)) {
         // If the type does not conform to ExpressibleByStringLiteral, it should
         // be ExpressibleByExtendedGraphemeClusterLiteral.
         protocol = tc.getProtocol(
@@ -2015,9 +2014,8 @@ namespace {
         isStringLiteral = false;
         isGraphemeClusterLiteral = true;
       }
-      if (TypeChecker::conformsToProtocol(type, protocol, cs.DC,
-                                          ConformanceCheckFlags::InExpression)
-              .isInvalid()) {
+      if (!TypeChecker::conformsToProtocol(
+              type, protocol, cs.DC, ConformanceCheckFlags::InExpression)) {
         // ... or it should be ExpressibleByUnicodeScalarLiteral.
         protocol = tc.getProtocol(
             expr->getLoc(),
@@ -2136,8 +2134,7 @@ namespace {
         auto conformance =
           TypeChecker::conformsToProtocol(type, proto, cs.DC,
                                           ConformanceCheckFlags::InExpression);
-        assert(!conformance.isInvalid() &&
-               "string interpolation type conforms to protocol");
+        assert(conformance && "string interpolation type conforms to protocol");
 
         DeclName constrName(tc.Context, DeclBaseName::createConstructor(), argLabels);
 
@@ -2243,8 +2240,7 @@ namespace {
       auto conformance =
         TypeChecker::conformsToProtocol(conformingType, proto, cs.DC,
                                         ConformanceCheckFlags::InExpression);
-      assert(!conformance.isInvalid() &&
-             "object literal type conforms to protocol");
+      assert(conformance && "object literal type conforms to protocol");
 
       DeclName constrName(tc.getObjectLiteralConstructorName(expr));
 
@@ -2904,7 +2900,7 @@ namespace {
       auto conformance =
         TypeChecker::conformsToProtocol(arrayTy, arrayProto, cs.DC,
                                         ConformanceCheckFlags::InExpression);
-      assert(!conformance.isInvalid() && "Type does not conform to protocol?");
+      assert(conformance && "Type does not conform to protocol?");
 
       DeclName name(tc.Context, DeclBaseName::createConstructor(),
                     { tc.Context.Id_arrayLiteral });
@@ -4655,7 +4651,7 @@ namespace {
         auto hashableConformance =
           TypeChecker::conformsToProtocol(indexType, hashable, cs.DC,
                                           ConformanceCheckFlags::InExpression);
-        assert(!hashableConformance.isInvalid());
+        assert(hashableConformance);
 
         conformances.push_back(hashableConformance);
       }
@@ -6119,7 +6115,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
         TypeChecker::conformsToProtocol(
                         cs.getType(expr), hashable, cs.DC,
                         ConformanceCheckFlags::InExpression);
-      assert(!conformance.isInvalid() && "must conform to Hashable");
+      assert(conformance && "must conform to Hashable");
 
       return cs.cacheType(
           new (tc.Context) AnyHashableErasureExpr(expr, toType, conformance));
@@ -6605,7 +6601,7 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
   if (builtinProtocol) {
     auto builtinConformance = TypeChecker::conformsToProtocol(
         type, builtinProtocol, cs.DC, ConformanceCheckFlags::InExpression);
-    if (!builtinConformance.isInvalid()) {
+    if (builtinConformance) {
       // Find the witness that we'll use to initialize the type via a builtin
       // literal.
       auto witness = builtinConformance.getWitnessByName(
@@ -6638,7 +6634,7 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
   assert(protocol && "requirements should have stopped recursion");
   auto conformance = TypeChecker::conformsToProtocol(type, protocol, cs.DC,
                                            ConformanceCheckFlags::InExpression);
-  assert(!conformance.isInvalid() && "must conform to literal protocol");
+  assert(conformance && "must conform to literal protocol");
 
   // Dig out the literal type and perform a builtin literal conversion to it.
   if (!literalType.empty()) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -436,7 +436,7 @@ namespace {
               TypeChecker::conformsToProtocol(
                         baseTy, proto, cs.DC,
                         ConformanceCheckFlags::InExpression);
-            if (!conformance.isInvalid() && conformance.isConcrete()) {
+            if (conformance.isConcrete()) {
               if (auto witness =
                       conformance.getConcrete()->getWitnessDecl(decl)) {
                 // Hack up an AST that we can type-check (independently) to get

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -688,10 +688,11 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
 
         do {
           // If the type conforms to this protocol, we're covered.
-          if (TypeChecker::conformsToProtocol(
-                  testType, protocol, DC,
-                  (ConformanceCheckFlags::InExpression |
-                   ConformanceCheckFlags::SkipConditionalRequirements))) {
+          if (!TypeChecker::conformsToProtocol(
+                   testType, protocol, DC,
+                   (ConformanceCheckFlags::InExpression |
+                    ConformanceCheckFlags::SkipConditionalRequirements))
+                   .isInvalid()) {
             coveredLiteralProtocols.insert(protocol);
             break;
           }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -688,11 +688,10 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
 
         do {
           // If the type conforms to this protocol, we're covered.
-          if (!TypeChecker::conformsToProtocol(
-                   testType, protocol, DC,
-                   (ConformanceCheckFlags::InExpression |
-                    ConformanceCheckFlags::SkipConditionalRequirements))
-                   .isInvalid()) {
+          if (TypeChecker::conformsToProtocol(
+                  testType, protocol, DC,
+                  (ConformanceCheckFlags::InExpression |
+                   ConformanceCheckFlags::SkipConditionalRequirements))) {
             coveredLiteralProtocols.insert(protocol);
             break;
           }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -795,11 +795,11 @@ bool FailureDiagnosis::diagnoseGeneralConversionFailure(Constraint *constraint){
     }
 
     // Emit a conformance error through conformsToProtocol.
-    if (auto conformance = TypeChecker::conformsToProtocol(
-            fromType, PT->getDecl(), CS.DC, ConformanceCheckFlags::InExpression,
-            expr->getLoc())) {
-      if (conformance->isAbstract() ||
-          !conformance->getConcrete()->isInvalid())
+    auto conformance = TypeChecker::conformsToProtocol(
+        fromType, PT->getDecl(), CS.DC, ConformanceCheckFlags::InExpression,
+        expr->getLoc());
+    if (!conformance.isInvalid()) {
+      if (conformance.isAbstract() || !conformance.getConcrete()->isInvalid())
         return false;
     }
 
@@ -3668,12 +3668,13 @@ bool FailureDiagnosis::visitArrayExpr(ArrayExpr *E) {
     return visitExpr(E);
 
   // Check to see if the contextual type conforms.
-  if (auto Conformance
-        = TypeChecker::conformsToProtocol(contextualType, ALC, CS.DC,
-                                          ConformanceCheckFlags::InExpression)) {
+  auto Conformance = TypeChecker::conformsToProtocol(
+      contextualType, ALC, CS.DC, ConformanceCheckFlags::InExpression);
+  if (!Conformance.isInvalid()) {
     Type contextualElementType =
-        Conformance->getTypeWitnessByName(
-          contextualType, CS.getASTContext().Id_ArrayLiteralElement)
+        Conformance
+            .getTypeWitnessByName(contextualType,
+                                  CS.getASTContext().Id_ArrayLiteralElement)
             ->getDesugaredType();
 
     // Type check each of the subexpressions in place, passing down the contextual
@@ -3719,20 +3720,20 @@ bool FailureDiagnosis::visitDictionaryExpr(DictionaryExpr *E) {
     // and figure out what the contextual Key/Value types are in place.
     auto Conformance = TypeChecker::conformsToProtocol(
         contextualType, DLC, CS.DC, ConformanceCheckFlags::InExpression);
-    if (!Conformance) {
+    if (Conformance.isInvalid()) {
       diagnose(E->getStartLoc(), diag::type_is_not_dictionary, contextualType)
         .highlight(E->getSourceRange());
       return true;
     }
 
     contextualKeyType =
-        Conformance->getTypeWitnessByName(
-          contextualType, CS.getASTContext().Id_Key)
+        Conformance
+            .getTypeWitnessByName(contextualType, CS.getASTContext().Id_Key)
             ->getDesugaredType();
 
     contextualValueType =
-        Conformance->getTypeWitnessByName(
-          contextualType, CS.getASTContext().Id_Value)
+        Conformance
+            .getTypeWitnessByName(contextualType, CS.getASTContext().Id_Value)
             ->getDesugaredType();
 
     assert(contextualKeyType && contextualValueType &&

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -798,7 +798,7 @@ bool FailureDiagnosis::diagnoseGeneralConversionFailure(Constraint *constraint){
     auto conformance = TypeChecker::conformsToProtocol(
         fromType, PT->getDecl(), CS.DC, ConformanceCheckFlags::InExpression,
         expr->getLoc());
-    if (!conformance.isInvalid()) {
+    if (conformance) {
       if (conformance.isAbstract() || !conformance.getConcrete()->isInvalid())
         return false;
     }
@@ -3670,7 +3670,7 @@ bool FailureDiagnosis::visitArrayExpr(ArrayExpr *E) {
   // Check to see if the contextual type conforms.
   auto Conformance = TypeChecker::conformsToProtocol(
       contextualType, ALC, CS.DC, ConformanceCheckFlags::InExpression);
-  if (!Conformance.isInvalid()) {
+  if (Conformance) {
     Type contextualElementType =
         Conformance
             .getTypeWitnessByName(contextualType,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2294,7 +2294,7 @@ bool ContextualFailure::diagnoseThrowsTypeMismatch() const {
     auto conformance = TypeChecker::conformsToProtocol(
         errorCodeType, errorCodeProtocol, getDC(),
         ConformanceCheckFlags::InExpression);
-    if (!conformance.isInvalid()) {
+    if (conformance) {
       Type errorType =
           conformance
               .getTypeWitnessByName(errorCodeType, getASTContext().Id_ErrorType)

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2291,13 +2291,14 @@ bool ContextualFailure::diagnoseThrowsTypeMismatch() const {
   if (auto errorCodeProtocol =
           TC.Context.getProtocol(KnownProtocolKind::ErrorCodeProtocol)) {
     Type errorCodeType = getFromType();
-    if (auto conformance = TypeChecker::conformsToProtocol(
-            errorCodeType, errorCodeProtocol, getDC(),
-            ConformanceCheckFlags::InExpression)) {
-      Type errorType = conformance
-                           ->getTypeWitnessByName(errorCodeType,
-                                                  getASTContext().Id_ErrorType)
-                           ->getCanonicalType();
+    auto conformance = TypeChecker::conformsToProtocol(
+        errorCodeType, errorCodeProtocol, getDC(),
+        ConformanceCheckFlags::InExpression);
+    if (!conformance.isInvalid()) {
+      Type errorType =
+          conformance
+              .getTypeWitnessByName(errorCodeType, getASTContext().Id_ErrorType)
+              ->getCanonicalType();
       if (errorType) {
         auto diagnostic =
             emitDiagnostic(anchor->getLoc(), diag::cannot_throw_error_code,
@@ -2612,9 +2613,10 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
   // Let's build a list of protocols that the context does not conform to.
   SmallVector<std::string, 8> missingProtoTypeStrings;
   for (auto protocol : layout.getProtocols()) {
-    if (!getTypeChecker().conformsToProtocol(
-            FromType, protocol->getDecl(), getDC(),
-            ConformanceCheckFlags::InExpression)) {
+    if (getTypeChecker()
+            .conformsToProtocol(FromType, protocol->getDecl(), getDC(),
+                                ConformanceCheckFlags::InExpression)
+            .isInvalid()) {
       missingProtoTypeStrings.push_back(protocol->getString());
     }
   }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -558,10 +558,9 @@ namespace {
       // the literal.
       if (otherArgTy && otherArgTy->getAnyNominal()) {
         if (otherArgTy->isEqual(paramTy) &&
-            !TypeChecker::conformsToProtocol(
-                 otherArgTy, literalProto, CS.DC,
-                 ConformanceCheckFlags::InExpression)
-                 .isInvalid())
+            TypeChecker::conformsToProtocol(
+                otherArgTy, literalProto, CS.DC,
+                ConformanceCheckFlags::InExpression))
           return true;
       } else if (Type defaultType = tc.getDefaultType(literalProto, CS.DC)) {
         // If there is a default type for the literal protocol, check whether

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -558,8 +558,10 @@ namespace {
       // the literal.
       if (otherArgTy && otherArgTy->getAnyNominal()) {
         if (otherArgTy->isEqual(paramTy) &&
-            TypeChecker::conformsToProtocol(otherArgTy, literalProto, CS.DC,
-                                            ConformanceCheckFlags::InExpression))
+            !TypeChecker::conformsToProtocol(
+                 otherArgTy, literalProto, CS.DC,
+                 ConformanceCheckFlags::InExpression)
+                 .isInvalid())
           return true;
       } else if (Type defaultType = tc.getDefaultType(literalProto, CS.DC)) {
         // If there is a default type for the literal protocol, check whether

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -206,8 +206,7 @@ computeSelfTypeRelationship(TypeChecker &tc, DeclContext *dc, ValueDecl *decl1,
   // If both declarations are operators, even through they
   // might have Self such types are unrelated.
   if (decl1->isOperator() && decl2->isOperator())
-    return {SelfTypeRelationship::Unrelated,
-            ProtocolConformanceRef::forInvalid()};
+    return {SelfTypeRelationship::Unrelated, ProtocolConformanceRef()};
 
   auto *dc1 = decl1->getDeclContext();
   auto *dc2 = decl2->getDeclContext();
@@ -215,38 +214,32 @@ computeSelfTypeRelationship(TypeChecker &tc, DeclContext *dc, ValueDecl *decl1,
   // If at least one of the contexts is a non-type context, the two are
   // unrelated.
   if (!dc1->isTypeContext() || !dc2->isTypeContext())
-    return {SelfTypeRelationship::Unrelated,
-            ProtocolConformanceRef::forInvalid()};
+    return {SelfTypeRelationship::Unrelated, ProtocolConformanceRef()};
 
   Type type1 = dc1->getDeclaredInterfaceType();
   Type type2 = dc2->getDeclaredInterfaceType();
 
   // If the types are equal, the answer is simple.
   if (type1->isEqual(type2))
-    return {SelfTypeRelationship::Equivalent,
-            ProtocolConformanceRef::forInvalid()};
+    return {SelfTypeRelationship::Equivalent, ProtocolConformanceRef()};
 
   // If both types can have superclasses, which whether one is a superclass
   // of the other. The subclass is the common base type.
   if (type1->mayHaveSuperclass() && type2->mayHaveSuperclass()) {
     if (isNominallySuperclassOf(type1, type2))
-      return {SelfTypeRelationship::Superclass,
-              ProtocolConformanceRef::forInvalid()};
+      return {SelfTypeRelationship::Superclass, ProtocolConformanceRef()};
 
     if (isNominallySuperclassOf(type2, type1))
-      return {SelfTypeRelationship::Subclass,
-              ProtocolConformanceRef::forInvalid()};
+      return {SelfTypeRelationship::Subclass, ProtocolConformanceRef()};
 
-    return {SelfTypeRelationship::Unrelated,
-            ProtocolConformanceRef::forInvalid()};
+    return {SelfTypeRelationship::Unrelated, ProtocolConformanceRef()};
   }
 
   // If neither or both are protocol types, consider the bases unrelated.
   bool isProtocol1 = isa<ProtocolDecl>(dc1);
   bool isProtocol2 = isa<ProtocolDecl>(dc2);
   if (isProtocol1 == isProtocol2)
-    return {SelfTypeRelationship::Unrelated,
-            ProtocolConformanceRef::forInvalid()};
+    return {SelfTypeRelationship::Unrelated, ProtocolConformanceRef()};
 
   // Just one of the two is a protocol. Check whether the other conforms to
   // that protocol.

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -563,14 +563,14 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         break;
 
       case SelfTypeRelationship::ConformsTo:
-        assert(!conformance.isInvalid());
+        assert(conformance);
         cs.addConstraint(ConstraintKind::ConformsTo, selfTy1,
                          cast<ProtocolDecl>(outerDC2)->getDeclaredType(),
                          locator);
         break;
 
       case SelfTypeRelationship::ConformedToBy:
-        assert(!conformance.isInvalid());
+        assert(conformance);
         cs.addConstraint(ConstraintKind::ConformsTo, selfTy2,
                          cast<ProtocolDecl>(outerDC1)->getDeclaredType(),
                          locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4344,26 +4344,26 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   // conform -- they only need to contain the protocol, so check that
   // separately.
   switch (kind) {
-  case ConstraintKind::SelfObjectOfProtocol:
-    if (auto conformance =
-          TC.containsProtocol(type, protocol, DC,
-                              (ConformanceCheckFlags::InExpression|
-                               ConformanceCheckFlags::SkipConditionalRequirements))) {
-      return recordConformance(*conformance);
+  case ConstraintKind::SelfObjectOfProtocol: {
+    auto conformance = TC.containsProtocol(
+        type, protocol, DC,
+        (ConformanceCheckFlags::InExpression |
+         ConformanceCheckFlags::SkipConditionalRequirements));
+    if (!conformance.isInvalid()) {
+      return recordConformance(conformance);
     }
-    break;
+  } break;
   case ConstraintKind::ConformsTo:
   case ConstraintKind::LiteralConformsTo: {
     // Check whether this type conforms to the protocol.
-    if (auto conformance =
-          TypeChecker::conformsToProtocol(
-                      type, protocol, DC,
-                      (ConformanceCheckFlags::InExpression|
-                       ConformanceCheckFlags::SkipConditionalRequirements))) {
-      return recordConformance(*conformance);
+    auto conformance = TypeChecker::conformsToProtocol(
+        type, protocol, DC,
+        (ConformanceCheckFlags::InExpression |
+         ConformanceCheckFlags::SkipConditionalRequirements));
+    if (!conformance.isInvalid()) {
+      return recordConformance(conformance);
     }
-    break;
-  }
+  } break;
 
   default:
     llvm_unreachable("bad constraint kind");

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4349,7 +4349,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
         type, protocol, DC,
         (ConformanceCheckFlags::InExpression |
          ConformanceCheckFlags::SkipConditionalRequirements));
-    if (!conformance.isInvalid()) {
+    if (conformance) {
       return recordConformance(conformance);
     }
   } break;
@@ -4360,7 +4360,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
         type, protocol, DC,
         (ConformanceCheckFlags::InExpression |
          ConformanceCheckFlags::SkipConditionalRequirements));
-    if (!conformance.isInvalid()) {
+    if (conformance) {
       return recordConformance(conformance);
     }
   } break;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1909,9 +1909,8 @@ void ConstraintSystem::sortDesignatedTypes(
         ++nextType;
         break;
       } else if (auto *protoDecl = dyn_cast<ProtocolDecl>(nominalTypes[i])) {
-        if (!TypeChecker::conformsToProtocol(
-                 argType, protoDecl, DC, ConformanceCheckFlags::InExpression)
-                 .isInvalid()) {
+        if (TypeChecker::conformsToProtocol(
+                argType, protoDecl, DC, ConformanceCheckFlags::InExpression)) {
           std::swap(nominalTypes[nextType], nominalTypes[i]);
           ++nextType;
           break;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1709,10 +1709,10 @@ void ConstraintSystem::ArgumentInfoCollector::minimizeLiteralProtocols() {
     auto second =
         TypeChecker::conformsToProtocol(candidates[result].second, candidate.first,
                                         CS.DC, ConformanceCheckFlags::InExpression);
-    if ((first && second) || (!first && !second))
+    if (first.isInvalid() == second.isInvalid())
       return;
 
-    if (first)
+    if (!first.isInvalid())
       result = i;
   }
 
@@ -1909,8 +1909,9 @@ void ConstraintSystem::sortDesignatedTypes(
         ++nextType;
         break;
       } else if (auto *protoDecl = dyn_cast<ProtocolDecl>(nominalTypes[i])) {
-        if (TypeChecker::conformsToProtocol(argType, protoDecl, DC,
-                                            ConformanceCheckFlags::InExpression)) {
+        if (!TypeChecker::conformsToProtocol(
+                 argType, protoDecl, DC, ConformanceCheckFlags::InExpression)
+                 .isInvalid()) {
           std::swap(nominalTypes[nextType], nominalTypes[i]);
           ++nextType;
           break;

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -49,8 +49,7 @@ static bool isSubstitutableFor(Type type, ArchetypeType *archetype,
   }
 
   for (auto proto : archetype->getConformsTo()) {
-    if (!dc->getParentModule()->lookupConformance(
-          type, proto))
+    if (dc->getParentModule()->lookupConformance(type, proto).isInvalid())
       return false;
   }
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -429,8 +429,7 @@ configureGenericDesignatedInitOverride(ASTContext &ctx,
     auto lookupConformanceFn =
         [&](CanType depTy, Type substTy,
             ProtocolDecl *proto) -> ProtocolConformanceRef {
-      auto conf = subMap.lookupConformance(depTy, proto);
-      if (!conf.isInvalid())
+      if (auto conf = subMap.lookupConformance(depTy, proto))
         return conf;
 
       return ProtocolConformanceRef(proto);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2288,11 +2288,11 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
         auto *proto = assocType->getProtocol();
         auto conformance = cs.DC->getParentModule()->lookupConformance(
           lookupBaseType, proto);
-        if (!conformance)
+        if (conformance.isInvalid())
           return DependentMemberType::get(lookupBaseType, assocType);
 
         auto subs = SubstitutionMap::getProtocolSubstitutions(
-          proto, lookupBaseType, *conformance);
+            proto, lookupBaseType, conformance);
         auto result = assocType->getDeclaredInterfaceType().subst(subs);
         if (!result->hasError())
           return result;
@@ -3079,8 +3079,9 @@ bool constraints::hasAppliedSelf(ConstraintSystem &cs,
 bool constraints::conformsToKnownProtocol(ConstraintSystem &cs, Type type,
                                           KnownProtocolKind protocol) {
   if (auto *proto = cs.TC.getProtocol(SourceLoc(), protocol))
-    return bool(TypeChecker::conformsToProtocol(
-        type, proto, cs.DC, ConformanceCheckFlags::InExpression));
+    return !TypeChecker::conformsToProtocol(type, proto, cs.DC,
+                                            ConformanceCheckFlags::InExpression)
+                .isInvalid();
   return false;
 }
 
@@ -3097,10 +3098,10 @@ Type constraints::isRawRepresentable(ConstraintSystem &cs, Type type) {
 
   auto conformance = TypeChecker::conformsToProtocol(
       type, rawReprType, DC, ConformanceCheckFlags::InExpression);
-  if (!conformance)
+  if (conformance.isInvalid())
     return Type();
 
-  return conformance->getTypeWitnessByName(type, TC.Context.Id_RawValue);
+  return conformance.getTypeWitnessByName(type, TC.Context.Id_RawValue);
 }
 
 Type constraints::isRawRepresentable(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2288,7 +2288,7 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
         auto *proto = assocType->getProtocol();
         auto conformance = cs.DC->getParentModule()->lookupConformance(
           lookupBaseType, proto);
-        if (conformance.isInvalid())
+        if (!conformance)
           return DependentMemberType::get(lookupBaseType, assocType);
 
         auto subs = SubstitutionMap::getProtocolSubstitutions(
@@ -3079,9 +3079,8 @@ bool constraints::hasAppliedSelf(ConstraintSystem &cs,
 bool constraints::conformsToKnownProtocol(ConstraintSystem &cs, Type type,
                                           KnownProtocolKind protocol) {
   if (auto *proto = cs.TC.getProtocol(SourceLoc(), protocol))
-    return !TypeChecker::conformsToProtocol(type, proto, cs.DC,
-                                            ConformanceCheckFlags::InExpression)
-                .isInvalid();
+    return (bool)TypeChecker::conformsToProtocol(
+        type, proto, cs.DC, ConformanceCheckFlags::InExpression);
   return false;
 }
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -39,8 +39,8 @@ static bool inheritsConformanceTo(ClassDecl *target, ProtocolDecl *proto) {
 
   auto *superclassDecl = target->getSuperclassDecl();
   auto *superclassModule = superclassDecl->getModuleContext();
-  return !superclassModule->lookupConformance(target->getSuperclass(), proto)
-              .isInvalid();
+  return (bool)superclassModule->lookupConformance(target->getSuperclass(),
+                                                   proto);
 }
 
 /// Returns whether the superclass of the given class conforms to Encodable.
@@ -269,9 +269,8 @@ static CodingKeysValidity hasValidCodingKeysEnum(DerivedConformance &derived) {
 
   // Ensure that the type we found conforms to the CodingKey protocol.
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
-  if (TypeChecker::conformsToProtocol(codingKeysType, codingKeyProto,
-                                      derived.getConformanceContext(), None)
-          .isInvalid()) {
+  if (!TypeChecker::conformsToProtocol(codingKeysType, codingKeyProto,
+                                       derived.getConformanceContext(), None)) {
     // If CodingKeys is a typealias which doesn't point to a valid nominal type,
     // codingKeysTypeDecl will be nullptr here. In that case, we need to warn on
     // the location of the usage, since there isn't an underlying type to
@@ -1065,9 +1064,8 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
     if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
       DeclName memberName;
       auto superType = superclassDecl->getDeclaredInterfaceType();
-      if (!TypeChecker::conformsToProtocol(superType, proto, superclassDecl,
-                                           None)
-               .isInvalid()) {
+      if (TypeChecker::conformsToProtocol(superType, proto, superclassDecl,
+                                          None)) {
         // super.init(from:) must be accessible.
         memberName = cast<ConstructorDecl>(requirement)->getFullName();
       } else {

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -92,9 +92,8 @@ storedPropertiesNotConformingToProtocol(DeclContext *DC, StructDecl *theStruct,
     if (!type)
       nonconformingProperties.push_back(propertyDecl);
 
-    if (TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type), protocol,
-                                        DC, None)
-            .isInvalid()) {
+    if (!TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type), protocol,
+                                         DC, None)) {
       nonconformingProperties.push_back(propertyDecl);
     }
   }

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -53,8 +53,9 @@ associatedValuesNotConformingToProtocol(DeclContext *DC, EnumDecl *theEnum,
 
     for (auto param : *PL) {
       auto type = param->getInterfaceType();
-      if (!TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type),
-                                           protocol, DC, None)) {
+      if (TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type),
+                                          protocol, DC, None)
+              .isInvalid()) {
         nonconformingAssociatedValues.push_back(param);
       }
     }
@@ -91,8 +92,9 @@ storedPropertiesNotConformingToProtocol(DeclContext *DC, StructDecl *theStruct,
     if (!type)
       nonconformingProperties.push_back(propertyDecl);
 
-    if (!TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type), protocol,
-                                         DC, None)) {
+    if (TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type), protocol,
+                                        DC, None)
+            .isInvalid()) {
       nonconformingProperties.push_back(propertyDecl);
     }
   }
@@ -1205,17 +1207,17 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
 
   // We can't form a Hashable conformance if Int isn't Hashable or
   // ExpressibleByIntegerLiteral.
-  if (!TypeChecker::conformsToProtocol(intType,
-                                       C.getProtocol(KnownProtocolKind::Hashable),
-                                       parentDC, None)) {
+  if (TypeChecker::conformsToProtocol(
+          intType, C.getProtocol(KnownProtocolKind::Hashable), parentDC, None)
+          .isInvalid()) {
     derived.ConformanceDecl->diagnose(diag::broken_int_hashable_conformance);
     return nullptr;
   }
 
   ProtocolDecl *intLiteralProto =
       C.getProtocol(KnownProtocolKind::ExpressibleByIntegerLiteral);
-  if (!TypeChecker::conformsToProtocol(intType, intLiteralProto,
-                                       parentDC, None)) {
+  if (TypeChecker::conformsToProtocol(intType, intLiteralProto, parentDC, None)
+          .isInvalid()) {
     derived.ConformanceDecl->diagnose(
       diag::broken_int_integer_literal_convertible_conformance);
     return nullptr;

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -404,8 +404,9 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
   auto equatableProto = tc.getProtocol(enumDecl->getLoc(),
                                        KnownProtocolKind::Equatable);
   assert(equatableProto);
-  assert(TypeChecker::conformsToProtocol(rawType, equatableProto,
-                                         enumDecl, None));
+  assert(
+      !TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl, None)
+           .isInvalid());
   (void)equatableProto;
   (void)rawType;
 
@@ -466,8 +467,8 @@ static bool canSynthesizeRawRepresentable(DerivedConformance &derived) {
   if (!equatableProto)
     return false;
 
-  if (!TypeChecker::conformsToProtocol(rawType, equatableProto,
-                                       enumDecl, None))
+  if (TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl, None)
+          .isInvalid())
     return false;
   
   // There must be enum elements.

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -405,8 +405,7 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
                                        KnownProtocolKind::Equatable);
   assert(equatableProto);
   assert(
-      !TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl, None)
-           .isInvalid());
+      TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl, None));
   (void)equatableProto;
   (void)rawType;
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -167,10 +167,11 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     auto proto = ctx.getProtocol(kind);
     if (!proto) return nullptr;
 
-    if (auto conformance = TypeChecker::conformsToProtocol(
-            nominal->getDeclaredInterfaceType(), proto, nominal,
-            ConformanceCheckFlags::SkipConditionalRequirements)) {
-      auto DC = conformance->getConcrete()->getDeclContext();
+    auto conformance = TypeChecker::conformsToProtocol(
+        nominal->getDeclaredInterfaceType(), proto, nominal,
+        ConformanceCheckFlags::SkipConditionalRequirements);
+    if (!conformance.isInvalid()) {
+      auto DC = conformance.getConcrete()->getDeclContext();
       // Check whether this nominal type derives conformances to the protocol.
       if (!DerivedConformance::derivesProtocolConformance(DC, nominal, proto))
         return nullptr;

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -170,7 +170,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     auto conformance = TypeChecker::conformsToProtocol(
         nominal->getDeclaredInterfaceType(), proto, nominal,
         ConformanceCheckFlags::SkipConditionalRequirements);
-    if (!conformance.isInvalid()) {
+    if (conformance) {
       auto DC = conformance.getConcrete()->getDeclContext();
       // Check whether this nominal type derives conformances to the protocol.
       if (!DerivedConformance::derivesProtocolConformance(DC, nominal, proto))

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -405,8 +405,7 @@ static void lookupDeclsFromProtocolsBeingConformedTo(
     // couldn't be computed, so assume they conform in such cases.
     if (!BaseTy->hasUnboundGenericType()) {
       if (auto res = Conformance->getConditionalRequirementsIfAvailable()) {
-        if (!res->empty() &&
-            Module->conformsToProtocol(BaseTy, Proto).isInvalid())
+        if (!res->empty() && !Module->conformsToProtocol(BaseTy, Proto))
           continue;
       }
     }
@@ -697,8 +696,7 @@ template <> struct DenseMapInfo<FoundDeclTy> {
 static Type getBaseTypeForMember(ModuleDecl *M, ValueDecl *OtherVD, Type BaseTy) {
   if (auto *Proto = OtherVD->getDeclContext()->getSelfProtocolDecl()) {
     if (BaseTy->getClassOrBoundGenericClass()) {
-      auto Conformance = M->lookupConformance(BaseTy, Proto);
-      if (!Conformance.isInvalid()) {
+      if (auto Conformance = M->lookupConformance(BaseTy, Proto)) {
         auto *Superclass = Conformance.getConcrete()
                                ->getRootConformance()
                                ->getType()

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1082,9 +1082,8 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
   if (!hasKeywordArguments) {
     auto arrayLitProto =
       ctx.getProtocol(KnownProtocolKind::ExpressibleByArrayLiteral);
-    return !TypeChecker::conformsToProtocol(argType, arrayLitProto, DC,
-                                            ConformanceCheckOptions())
-                .isInvalid();
+    return (bool)TypeChecker::conformsToProtocol(argType, arrayLitProto, DC,
+                                                 ConformanceCheckOptions());
   }
   // If keyword arguments, check that argument type conforms to
   // `ExpressibleByDictionaryLiteral` and that the `Key` associated type
@@ -1098,9 +1097,8 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
   if (dictConf.isInvalid())
     return false;
   auto keyType = dictConf.getTypeWitnessByName(argType, ctx.Id_Key);
-  return !TypeChecker::conformsToProtocol(keyType, stringLitProtocol, DC,
-                                          ConformanceCheckOptions())
-              .isInvalid();
+  return (bool)TypeChecker::conformsToProtocol(keyType, stringLitProtocol, DC,
+                                               ConformanceCheckOptions());
 }
 
 /// Returns true if the given nominal type has a valid implementation of a
@@ -1194,9 +1192,8 @@ bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl,
     ctx.getProtocol(KnownProtocolKind::ExpressibleByStringLiteral);
 
   // If this is `subscript(dynamicMember: String*)`
-  return !TypeChecker::conformsToProtocol(paramType, stringLitProto, DC,
-                                          ConformanceCheckOptions())
-              .isInvalid();
+  return (bool)TypeChecker::conformsToProtocol(paramType, stringLitProto, DC,
+                                               ConformanceCheckOptions());
 }
 
 bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
@@ -1628,9 +1625,8 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
   }
 
   if (!ApplicationDelegateProto ||
-      TypeChecker::conformsToProtocol(CD->getDeclaredType(),
-                                      ApplicationDelegateProto, CD, None)
-          .isInvalid()) {
+      !TypeChecker::conformsToProtocol(CD->getDeclaredType(),
+                                       ApplicationDelegateProto, CD, None)) {
     TC.diagnose(attr->getLocation(),
                 diag::attr_ApplicationMain_not_ApplicationDelegate,
                 applicationMainKind);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1082,8 +1082,9 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
   if (!hasKeywordArguments) {
     auto arrayLitProto =
       ctx.getProtocol(KnownProtocolKind::ExpressibleByArrayLiteral);
-    return TypeChecker::conformsToProtocol(argType, arrayLitProto, DC,
-                                           ConformanceCheckOptions()).hasValue();
+    return !TypeChecker::conformsToProtocol(argType, arrayLitProto, DC,
+                                            ConformanceCheckOptions())
+                .isInvalid();
   }
   // If keyword arguments, check that argument type conforms to
   // `ExpressibleByDictionaryLiteral` and that the `Key` associated type
@@ -1094,10 +1095,12 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
     ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
   auto dictConf = TypeChecker::conformsToProtocol(argType, dictLitProto, DC,
                                                   ConformanceCheckOptions());
-  if (!dictConf) return false;
-  auto keyType = dictConf.getValue().getTypeWitnessByName(argType, ctx.Id_Key);
-  return TypeChecker::conformsToProtocol(keyType, stringLitProtocol, DC,
-                                         ConformanceCheckOptions()).hasValue();
+  if (dictConf.isInvalid())
+    return false;
+  auto keyType = dictConf.getTypeWitnessByName(argType, ctx.Id_Key);
+  return !TypeChecker::conformsToProtocol(keyType, stringLitProtocol, DC,
+                                          ConformanceCheckOptions())
+              .isInvalid();
 }
 
 /// Returns true if the given nominal type has a valid implementation of a
@@ -1191,8 +1194,9 @@ bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl,
     ctx.getProtocol(KnownProtocolKind::ExpressibleByStringLiteral);
 
   // If this is `subscript(dynamicMember: String*)`
-  return bool(TypeChecker::conformsToProtocol(paramType, stringLitProto, DC,
-                                              ConformanceCheckOptions()));
+  return !TypeChecker::conformsToProtocol(paramType, stringLitProto, DC,
+                                          ConformanceCheckOptions())
+              .isInvalid();
 }
 
 bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
@@ -1558,7 +1562,7 @@ void AttributeChecker::visitNSCopyingAttr(NSCopyingAttr *attr) {
   }
 
   if (VD->hasInterfaceType()) {
-    if (!TC.checkConformanceToNSCopying(VD)) {
+    if (TC.checkConformanceToNSCopying(VD).isInvalid()) {
       attr->setInvalid();
       return;
     }
@@ -1624,9 +1628,9 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
   }
 
   if (!ApplicationDelegateProto ||
-      !TypeChecker::conformsToProtocol(CD->getDeclaredType(),
-                                       ApplicationDelegateProto,
-                                       CD, None)) {
+      TypeChecker::conformsToProtocol(CD->getDeclaredType(),
+                                      ApplicationDelegateProto, CD, None)
+          .isInvalid()) {
     TC.diagnose(attr->getLocation(),
                 diag::attr_ApplicationMain_not_ApplicationDelegate,
                 applicationMainKind);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2644,12 +2644,10 @@ static bool isIntegerOrFloatingPointType(Type ty, DeclContext *DC,
     Context.getProtocol(KnownProtocolKind::ExpressibleByFloatLiteral);
   if (!integerType || !floatingType) return false;
 
-  return !TypeChecker::conformsToProtocol(ty, integerType, DC,
-                                          ConformanceCheckFlags::InExpression)
-              .isInvalid() ||
-         !TypeChecker::conformsToProtocol(ty, floatingType, DC,
-                                          ConformanceCheckFlags::InExpression)
-              .isInvalid();
+  return TypeChecker::conformsToProtocol(ty, integerType, DC,
+                                         ConformanceCheckFlags::InExpression) ||
+         TypeChecker::conformsToProtocol(ty, floatingType, DC,
+                                         ConformanceCheckFlags::InExpression);
 }
 
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2644,11 +2644,12 @@ static bool isIntegerOrFloatingPointType(Type ty, DeclContext *DC,
     Context.getProtocol(KnownProtocolKind::ExpressibleByFloatLiteral);
   if (!integerType || !floatingType) return false;
 
-  return
-    TypeChecker::conformsToProtocol(ty, integerType, DC,
-                                    ConformanceCheckFlags::InExpression) ||
-    TypeChecker::conformsToProtocol(ty, floatingType, DC,
-                                    ConformanceCheckFlags::InExpression);
+  return !TypeChecker::conformsToProtocol(ty, integerType, DC,
+                                          ConformanceCheckFlags::InExpression)
+              .isInvalid() ||
+         !TypeChecker::conformsToProtocol(ty, floatingType, DC,
+                                          ConformanceCheckFlags::InExpression)
+              .isInvalid();
 }
 
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -4325,9 +4325,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
           auto protocolDecl =
               dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal());
           if (protocolDecl &&
-              conformsToProtocol(toType, protocolDecl, dc,
-                                 ConformanceCheckFlags::InExpression)
-                  .isInvalid()) {
+              !conformsToProtocol(toType, protocolDecl, dc,
+                                  ConformanceCheckFlags::InExpression)) {
             return failed();
           }
         }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1541,12 +1541,13 @@ computeAutomaticEnumValueKind(EnumDecl *ED) {
   
   // Swift enums require that the raw type is convertible from one of the
   // primitive literal protocols.
-  auto conformsToProtocol = [&](KnownProtocolKind protoKind) {
+  auto conformsToProtocol = [&](KnownProtocolKind protoKind) -> bool {
     ProtocolDecl *proto = ED->getASTContext().getProtocol(protoKind);
-    return TypeChecker::conformsToProtocol(rawTy, proto,
-                                           ED->getDeclContext(), None);
+    return !TypeChecker::conformsToProtocol(rawTy, proto, ED->getDeclContext(),
+                                            None)
+                .isInvalid();
   };
-  
+
   static auto otherLiteralProtocolKinds = {
     KnownProtocolKind::ExpressibleByFloatLiteral,
     KnownProtocolKind::ExpressibleByUnicodeScalarLiteral,
@@ -4408,15 +4409,18 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
   TypeChecker::addImplicitConstructors(CD);
 
   auto forceConformance = [&](ProtocolDecl *protocol) {
-    if (auto ref = TypeChecker::conformsToProtocol(
-          CD->getDeclaredInterfaceType(), protocol, CD,
-          ConformanceCheckFlags::SkipConditionalRequirements,
-          SourceLoc())) {
-      auto conformance = ref->getConcrete();
-      if (conformance->getDeclContext() == CD &&
-          conformance->getState() == ProtocolConformanceState::Incomplete) {
-        TC.checkConformance(conformance->getRootNormalConformance());
-      }
+    auto ref = TypeChecker::conformsToProtocol(
+        CD->getDeclaredInterfaceType(), protocol, CD,
+        ConformanceCheckFlags::SkipConditionalRequirements, SourceLoc());
+
+    if (ref.isInvalid()) {
+      return;
+    }
+
+    auto conformance = ref.getConcrete();
+    if (conformance->getDeclContext() == CD &&
+        conformance->getState() == ProtocolConformanceState::Incomplete) {
+      TC.checkConformance(conformance->getRootNormalConformance());
     }
   };
 
@@ -4589,12 +4593,13 @@ static Optional<std::string> buildDefaultInitializerString(TypeChecker &tc,
     auto type = pattern->getType();
 
     // For literal-convertible types, form the corresponding literal.
-#define CHECK_LITERAL_PROTOCOL(Kind, String) \
-    if (auto proto = tc.getProtocol(SourceLoc(), KnownProtocolKind::Kind)) { \
-      if (tc.conformsToProtocol(type, proto, dc, \
-                                ConformanceCheckFlags::InExpression)) \
-        return std::string(String); \
-    }
+#define CHECK_LITERAL_PROTOCOL(Kind, String)                                   \
+  if (auto proto = tc.getProtocol(SourceLoc(), KnownProtocolKind::Kind)) {     \
+    auto conf = tc.conformsToProtocol(type, proto, dc,                         \
+                                      ConformanceCheckFlags::InExpression);    \
+    if (!conf.isInvalid())                                                     \
+      return std::string(String);                                              \
+  }
     CHECK_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "[]")
     CHECK_LITERAL_PROTOCOL(ExpressibleByDictionaryLiteral, "[:]")
     CHECK_LITERAL_PROTOCOL(ExpressibleByUnicodeScalarLiteral, "\"\"")
@@ -4675,10 +4680,10 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
     ASTContext &C = tc.Context;
     auto *decodableProto = C.getProtocol(KnownProtocolKind::Decodable);
     auto superclassType = superclassDecl->getDeclaredInterfaceType();
-    if (auto ref = TypeChecker::conformsToProtocol(superclassType, decodableProto,
-                                                   superclassDecl,
-                                                   ConformanceCheckOptions(),
-                                                   SourceLoc())) {
+    auto ref = TypeChecker::conformsToProtocol(
+        superclassType, decodableProto, superclassDecl,
+        ConformanceCheckOptions(), SourceLoc());
+    if (!ref.isInvalid()) {
       // super conforms to Decodable, so we've failed to inherit init(from:).
       // Let's suggest overriding it here.
       //
@@ -4702,10 +4707,10 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
       // likely that the user forgot to override its encode(to:). In this case,
       // we can produce a slightly different diagnostic to suggest doing so.
       auto *encodableProto = C.getProtocol(KnownProtocolKind::Encodable);
-      if ((ref = tc.conformsToProtocol(superclassType, encodableProto,
-                                       superclassDecl,
-                                       ConformanceCheckOptions(),
-                                       SourceLoc()))) {
+      auto ref =
+          tc.conformsToProtocol(superclassType, encodableProto, superclassDecl,
+                                ConformanceCheckOptions(), SourceLoc());
+      if (!ref.isInvalid()) {
         // We only want to produce this version of the diagnostic if the
         // subclass doesn't directly implement encode(to:).
         // The direct lookup here won't see an encode(to:) if it is inherited

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -803,12 +803,10 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
         // FIXME: Poor location information. How much better can we do here?
         // FIXME: This call should support listener to be able to properly
         //        diagnose problems with conformances.
-        auto result =
-            conformsToProtocol(firstType, proto->getDecl(), dc,
-                               conformanceOptions, loc);
+        auto conformance = conformsToProtocol(firstType, proto->getDecl(), dc,
+                                              conformanceOptions, loc);
 
-        if (result) {
-          auto conformance = *result;
+        if (!conformance.isInvalid()) {
           // Report the conformance.
           if (listener && valid && current.Parents.empty()) {
             listener->satisfiedConformance(rawFirstType, firstType,

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -806,7 +806,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
         auto conformance = conformsToProtocol(firstType, proto->getDecl(), dc,
                                               conformanceOptions, loc);
 
-        if (!conformance.isInvalid()) {
+        if (conformance) {
           // Report the conformance.
           if (listener && valid && current.Parents.empty()) {
             listener->satisfiedConformance(rawFirstType, firstType,

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -200,7 +200,7 @@ namespace {
       auto conformance = TypeChecker::conformsToProtocol(conformingType,
                                                          foundProto, DC,
                                                          conformanceOptions);
-      if (!conformance) {
+      if (conformance.isInvalid()) {
         // If there's no conformance, we have an existential
         // and we found a member from one of the protocols, and
         // not a class constraint if any.
@@ -210,7 +210,7 @@ namespace {
         return;
       }
 
-      if (conformance->isAbstract()) {
+      if (conformance.isAbstract()) {
         assert(foundInType->is<ArchetypeType>() ||
                foundInType->isExistentialType());
         addResult(found);
@@ -219,7 +219,7 @@ namespace {
 
       // Dig out the witness.
       ValueDecl *witness = nullptr;
-      auto concrete = conformance->getConcrete();
+      auto concrete = conformance.getConcrete();
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(found)) {
         witness = concrete->getTypeWitnessAndDecl(assocType)
           .second;
@@ -506,13 +506,13 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
       auto conformance = conformsToProtocol(type, protocol, dc,
                                             conformanceOptions);
-      if (!conformance) {
+      if (conformance.isInvalid()) {
         // FIXME: This is an error path. Should we try to recover?
         continue;
       }
 
       // Use the type witness.
-      auto concrete = conformance->getConcrete();
+      auto concrete = conformance.getConcrete();
 
       // This is the only case where NormalProtocolConformance::
       // getTypeWitnessAndDecl() returns a null type.

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -506,7 +506,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
       auto conformance = conformsToProtocol(type, protocol, dc,
                                             conformanceOptions);
-      if (conformance.isInvalid()) {
+      if (!conformance) {
         // FIXME: This is an error path. Should we try to recover?
         continue;
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3982,7 +3982,7 @@ static void diagnoseConformanceFailure(Type T,
   // If we're checking conformance of an existential type to a protocol,
   // do a little bit of extra work to produce a better diagnostic.
   if (T->isExistentialType() &&
-      !TypeChecker::containsProtocol(T, Proto, DC, None).isInvalid()) {
+      TypeChecker::containsProtocol(T, Proto, DC, None)) {
 
     if (!T->isObjCExistentialType()) {
       diags.diagnose(ComplainLoc, diag::type_cannot_conform, true,
@@ -4091,7 +4091,7 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
     if (auto superclass = layout.getSuperclass()) {
       auto result =
           TypeChecker::conformsToProtocol(superclass, Proto, DC, options);
-      if (!result.isInvalid()) {
+      if (result) {
         return result;
       }
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3043,7 +3043,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       auto derivableProto = cast<ProtocolDecl>(derivable->getDeclContext());
       auto conformance =
           TypeChecker::conformsToProtocol(Adoptee, derivableProto, DC, None);
-      if (!conformance.isInvalid() && conformance.isConcrete()) {
+      if (conformance.isConcrete()) {
         (void)conformance.getConcrete()->getWitnessDecl(derivable);
       }
     }

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -970,9 +970,9 @@ Type AssociatedTypeInference::substCurrentTypeWitnesses(Type type) {
         = TypeChecker::conformsToProtocol(
                           baseTy, assocType->getProtocol(), dc,
                           ConformanceCheckFlags::SkipConditionalRequirements);
-      if (!localConformance || localConformance->isAbstract() ||
-          (localConformance->getConcrete()->getRootConformance()
-             != conformance)) {
+      if (localConformance.isInvalid() || localConformance.isAbstract() ||
+          (localConformance.getConcrete()->getRootConformance() !=
+           conformance)) {
         return nullptr;
       }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -884,8 +884,7 @@ checkConformanceToNSCopying(ASTContext &ctx, VarDecl *var, Type type) {
   auto proto = ctx.getNSCopyingDecl();
 
   if (proto) {
-    auto result = TypeChecker::conformsToProtocol(type, proto, dc, None);
-    if (!result.isInvalid())
+    if (auto result = TypeChecker::conformsToProtocol(type, proto, dc, None))
       return result;
   }
 
@@ -923,7 +922,7 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
   // The element type must conform to NSCopying.  If not, emit an error and just
   // recovery by synthesizing without the copy call.
   auto conformance = checkConformanceToNSCopying(Ctx, VD, underlyingType);
-  if (conformance.isInvalid())
+  if (!conformance)
     return Val;
 
   //- (id)copyWithZone:(NSZone *)zone;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -878,19 +878,19 @@ createPropertyLoadOrCallSuperclassGetter(AccessorDecl *accessor,
                                ctx);
 }
 
-static Optional<ProtocolConformanceRef>
+static ProtocolConformanceRef
 checkConformanceToNSCopying(ASTContext &ctx, VarDecl *var, Type type) {
   auto dc = var->getDeclContext();
   auto proto = ctx.getNSCopyingDecl();
 
   if (proto) {
     auto result = TypeChecker::conformsToProtocol(type, proto, dc, None);
-    if (result)
+    if (!result.isInvalid())
       return result;
   }
 
   ctx.Diags.diagnose(var->getLoc(), diag::nscopying_doesnt_conform);
-  return None;
+  return ProtocolConformanceRef::forInvalid();
 }
 
 static std::pair<Type, bool> getUnderlyingTypeOfVariable(VarDecl *var) {
@@ -903,8 +903,7 @@ static std::pair<Type, bool> getUnderlyingTypeOfVariable(VarDecl *var) {
   }
 }
 
-Optional<ProtocolConformanceRef>
-TypeChecker::checkConformanceToNSCopying(VarDecl *var) {
+ProtocolConformanceRef TypeChecker::checkConformanceToNSCopying(VarDecl *var) {
   Type type = getUnderlyingTypeOfVariable(var).first;
   return ::checkConformanceToNSCopying(Context, var, type);
 }
@@ -924,13 +923,13 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
   // The element type must conform to NSCopying.  If not, emit an error and just
   // recovery by synthesizing without the copy call.
   auto conformance = checkConformanceToNSCopying(Ctx, VD, underlyingType);
-  if (!conformance)
+  if (conformance.isInvalid())
     return Val;
 
   //- (id)copyWithZone:(NSZone *)zone;
   DeclName copyWithZoneName(Ctx, Ctx.getIdentifier("copy"), { Ctx.Id_with });
   FuncDecl *copyMethod = nullptr;
-  for (auto member : conformance->getRequirement()->getMembers()) {
+  for (auto member : conformance.getRequirement()->getMembers()) {
     if (auto func = dyn_cast<FuncDecl>(member)) {
       if (func->getFullName() == copyWithZoneName) {
         copyMethod = func;
@@ -948,9 +947,8 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
   }
 
   SubstitutionMap subs =
-    SubstitutionMap::get(copyMethod->getGenericSignature(),
-                         {underlyingType},
-                         ArrayRef<ProtocolConformanceRef>(*conformance));
+      SubstitutionMap::get(copyMethod->getGenericSignature(), {underlyingType},
+                           ArrayRef<ProtocolConformanceRef>(conformance));
   ConcreteDeclRef copyMethodRef(copyMethod, subs);
   auto copyMethodType = copyMethod->getInterfaceType()
                            ->castTo<GenericFunctionType>()

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -892,15 +892,15 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
 
   // If we weren't given a conformance, go look it up.
   ProtocolConformance *conformance = nullptr;
-  if (protocol)
-    if (auto conformanceRef = TypeChecker::conformsToProtocol(
-            parentTy, protocol, dc,
-            (ConformanceCheckFlags::InExpression |
-             ConformanceCheckFlags::SuppressDependencyTracking |
-             ConformanceCheckFlags::SkipConditionalRequirements))) {
-      if (conformanceRef->isConcrete())
-        conformance = conformanceRef->getConcrete();
-    }
+  if (protocol) {
+    auto conformanceRef = TypeChecker::conformsToProtocol(
+        parentTy, protocol, dc,
+        (ConformanceCheckFlags::InExpression |
+         ConformanceCheckFlags::SuppressDependencyTracking |
+         ConformanceCheckFlags::SkipConditionalRequirements));
+    if (!conformanceRef.isInvalid() && conformanceRef.isConcrete())
+      conformance = conformanceRef.getConcrete();
+  }
 
   // If any errors have occurred, don't bother diagnosing this cross-file
   // issue.
@@ -2587,13 +2587,12 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
         auto result = TypeChecker::conformsToProtocol(
                                             replacement, proto, DC,
                                             ConformanceCheckOptions());
-        // TODO: getSubstitutions callback ought to return Optional.
-        if (!result) {
+        if (result.isInvalid()) {
           ok = false;
           return ProtocolConformanceRef(proto);
         }
-        
-        return *result;
+
+        return result;
       });
 
     if (!ok)
@@ -2712,7 +2711,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
     interfaceResults = results;
     interfaceErrorResult = errorResult;
   }
-  Optional<ProtocolConformanceRef> witnessMethodConformance;
+  auto witnessMethodConformance = ProtocolConformanceRef::forInvalid();
   if (witnessMethodProtocol) {
     auto resolved = resolveType(witnessMethodProtocol, options);
     if (resolved->hasError())
@@ -2733,7 +2732,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
 
     witnessMethodConformance = TypeChecker::conformsToProtocol(
         selfType, protocolType->getDecl(), DC, ConformanceCheckOptions());
-    assert(witnessMethodConformance &&
+    assert(!witnessMethodConformance.isInvalid() &&
            "found witness_method without matching conformance");
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2711,7 +2711,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
     interfaceResults = results;
     interfaceErrorResult = errorResult;
   }
-  auto witnessMethodConformance = ProtocolConformanceRef::forInvalid();
+  ProtocolConformanceRef witnessMethodConformance;
   if (witnessMethodProtocol) {
     auto resolved = resolveType(witnessMethodProtocol, options);
     if (resolved->hasError())

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -898,7 +898,7 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
         (ConformanceCheckFlags::InExpression |
          ConformanceCheckFlags::SuppressDependencyTracking |
          ConformanceCheckFlags::SkipConditionalRequirements));
-    if (!conformanceRef.isInvalid() && conformanceRef.isConcrete())
+    if (conformanceRef.isConcrete())
       conformance = conformanceRef.getConcrete();
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2732,7 +2732,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
 
     witnessMethodConformance = TypeChecker::conformsToProtocol(
         selfType, protocolType->getDecl(), DC, ConformanceCheckOptions());
-    assert(!witnessMethodConformance.isInvalid() &&
+    assert(witnessMethodConformance &&
            "found witness_method without matching conformance");
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1487,10 +1487,9 @@ public:
   ///
   /// \returns the conformance, if \c T conforms to the protocol \c Proto, or
   /// an empty optional.
-  static Optional<ProtocolConformanceRef> containsProtocol(
-                                             Type T, ProtocolDecl *Proto,
-                                             DeclContext *DC,
-                                             ConformanceCheckOptions options);
+  static ProtocolConformanceRef
+  containsProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
+                   ConformanceCheckOptions options);
 
   /// Determine whether the given type conforms to the given protocol.
   ///
@@ -1509,12 +1508,10 @@ public:
   ///
   /// \returns The protocol conformance, if \c T conforms to the
   /// protocol \c Proto, or \c None.
-  static Optional<ProtocolConformanceRef> conformsToProtocol(
-                                           Type T,
-                                           ProtocolDecl *Proto,
-                                           DeclContext *DC,
-                                           ConformanceCheckOptions options,
-                                           SourceLoc ComplainLoc = SourceLoc());
+  static ProtocolConformanceRef
+  conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
+                     ConformanceCheckOptions options,
+                     SourceLoc ComplainLoc = SourceLoc());
 
   /// Functor class suitable for use as a \c LookupConformanceFn to look up a
   /// conformance through a particular declaration context using the given
@@ -1525,10 +1522,9 @@ public:
   public:
     explicit LookUpConformance(DeclContext *dc) : dc(dc) { }
 
-    Optional<ProtocolConformanceRef>
-    operator()(CanType dependentType,
-               Type conformingReplacementType,
-               ProtocolDecl *conformedProtocol) const;
+    ProtocolConformanceRef operator()(CanType dependentType,
+                                      Type conformingReplacementType,
+                                      ProtocolDecl *conformedProtocol) const;
   };
 
   /// Completely check the given conformance.
@@ -1539,7 +1535,7 @@ public:
                                   IterableDeclContext *idc);
 
   /// Check that the type of the given property conforms to NSCopying.
-  Optional<ProtocolConformanceRef> checkConformanceToNSCopying(VarDecl *var);
+  ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);
 
   /// Derive an implicit declaration to satisfy a requirement of a derived
   /// protocol conformance.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5038,7 +5038,7 @@ public:
       errorResult = maybeErrorResult.get();
     }
 
-    Optional<ProtocolConformanceRef> witnessMethodConformance;
+    auto witnessMethodConformance = ProtocolConformanceRef::forInvalid();
     if (*representation == SILFunctionTypeRepresentation::WitnessMethod) {
       witnessMethodConformance = MF.readConformance(MF.DeclTypeCursor);
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5038,7 +5038,7 @@ public:
       errorResult = maybeErrorResult.get();
     }
 
-    auto witnessMethodConformance = ProtocolConformanceRef::forInvalid();
+    ProtocolConformanceRef witnessMethodConformance;
     if (*representation == SILFunctionTypeRepresentation::WitnessMethod) {
       witnessMethodConformance = MF.readConformance(MF.DeclTypeCursor);
     }
@@ -5388,9 +5388,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     // conformance requirements are on Self. This isn't actually a /safe/ change
     // even in Objective-C, but we mostly just don't want to crash.
 
-    // FIXME: DenseMap requires that its value type be default-constructible,
-    // which ProtocolConformanceRef is not, hence the extra Optional.
-    llvm::SmallDenseMap<ProtocolDecl *, Optional<ProtocolConformanceRef>, 16>
+    llvm::SmallDenseMap<ProtocolDecl *, ProtocolConformanceRef, 16>
         conformancesForProtocols;
     while (conformanceCount--) {
       ProtocolConformanceRef nextConformance = readConformance(DeclTypeCursor);
@@ -5405,7 +5403,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
           req.getSecondType()->castTo<ProtocolType>()->getDecl();
       auto iter = conformancesForProtocols.find(proto);
       if (iter != conformancesForProtocols.end()) {
-        reqConformances.push_back(iter->getSecond().getValue());
+        reqConformances.push_back(iter->getSecond());
       } else {
         // Put in an abstract conformance as a placeholder. This is a lie, but
         // there's not much better we can do. We're relying on the fact that

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3981,8 +3981,9 @@ public:
         fnTy->getNumYields(), fnTy->getNumResults(),
         S.addGenericSignatureRef(sig), variableData);
 
-    if (auto conformance = fnTy->getWitnessMethodConformanceOrNone())
-      S.writeConformance(*conformance, S.DeclTypeAbbrCodes);
+    auto conformance = fnTy->getWitnessMethodConformanceOrNone();
+    if (!conformance.isInvalid())
+      S.writeConformance(conformance, S.DeclTypeAbbrCodes);
   }
 
   void visitArraySliceType(const ArraySliceType *sliceTy) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3981,8 +3981,7 @@ public:
         fnTy->getNumYields(), fnTy->getNumResults(),
         S.addGenericSignatureRef(sig), variableData);
 
-    auto conformance = fnTy->getWitnessMethodConformanceOrInvalid();
-    if (!conformance.isInvalid())
+    if (auto conformance = fnTy->getWitnessMethodConformanceOrInvalid())
       S.writeConformance(conformance, S.DeclTypeAbbrCodes);
   }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3981,7 +3981,7 @@ public:
         fnTy->getNumYields(), fnTy->getNumResults(),
         S.addGenericSignatureRef(sig), variableData);
 
-    auto conformance = fnTy->getWitnessMethodConformanceOrNone();
+    auto conformance = fnTy->getWitnessMethodConformanceOrInvalid();
     if (!conformance.isInvalid())
       S.writeConformance(conformance, S.DeclTypeAbbrCodes);
   }


### PR DESCRIPTION
`ProtocolConformanceRef` already has an invalid state.  Use this instead of `None` to signal something has gone wrong or a witness is missing.  As this makes `ProtocolConformanceRef` behave like an Optional, give it an `operator bool` and a default constructor and clean up all the call sites.

The result has been `clang-format`'ed with some minor revisions to keep noise down. I apologize in advance for the size of this patch, but there should be no behavior changes so the diff should be read as a 1-1 mapping between APIs.