### PR TITLE
[NFC] Standardize dump() methods in frontend

### DIFF
--- a/docs/DebuggingTheCompiler.rst
+++ b/docs/DebuggingTheCompiler.rst
@@ -214,6 +214,11 @@ debugging press <CTRL>-C on the LLDB prompt.
 Note that this only works in Xcode if the PATH variable in the scheme's
 environment setting contains the path to the dot tool.
 
+swift/Basic/Debug.h includes macros to help contributors declare these methods
+with the proper attributes to ensure they'll be available in the debugger. In
+particular, if you see ``SWIFT_DEBUG_DUMP`` in a class declaration, that class
+has a ``dump()`` method you can call.
+
 Debugging and Profiling on SIL level
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -18,6 +18,7 @@
 #define SWIFT_AST_AST_NODE_H
 
 #include "llvm/ADT/PointerUnion.h"
+#include "swift/Basic/Debug.h"
 #include "swift/AST/TypeAlignments.h"
 
 namespace llvm {
@@ -62,9 +63,7 @@ namespace swift {
     FUNC(Decl)
 #undef FUNC
     
-    LLVM_ATTRIBUTE_DEPRECATED(
-        void dump() const LLVM_ATTRIBUTE_USED,
-        "only for use within the debugger");
+    SWIFT_DEBUG_DUMP;
     void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
 
     /// Whether the AST node is implicit.

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -32,6 +32,7 @@
 #include "swift/AST/NameLookup.h" // for DeclVisibilityKind
 #include "swift/AST/SimpleRequest.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/NullablePtr.h"
 #include "swift/Basic/SourceManager.h"
@@ -330,8 +331,7 @@ protected:
   virtual NullablePtr<const void> addressForPrinting() const;
 
 public:
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   void dumpOneScopeMapLocation(std::pair<unsigned, unsigned> lineColumn);
 

--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/DeclContext.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/PointerIntPair.h"
 
 namespace swift {
@@ -87,7 +88,7 @@ public:
     return None;
   }
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
 };
 
 } // end namespace swift

--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -14,6 +14,7 @@
 #define SWIFT_AST_ANY_FUNCTION_REF_H
 
 #include "swift/Basic/Compiler.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
@@ -177,8 +178,7 @@ public:
 #pragma warning(push)
 #pragma warning(disable: 4996)
 #endif
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger") {
+  SWIFT_DEBUG_DUMP {
     if (auto afd = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
       return afd->dump();
     }

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_ATTR_H
 #define SWIFT_ATTR_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/InlineBitfield.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/UUID.h"
@@ -1583,7 +1584,7 @@ public:
   /// a declaration is deprecated on all deployment targets, or null otherwise.
   const AvailableAttr *getDeprecated(const ASTContext &ctx) const;
 
-  void dump(const Decl *D = nullptr) const;
+  SWIFT_DEBUG_DUMPER(dump(const Decl *D = nullptr));
   void print(ASTPrinter &Printer, const PrintOptions &Options,
              const Decl *D = nullptr) const;
   static void print(ASTPrinter &Printer, const PrintOptions &Options,

--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_CAPTURE_INFO_H
 #define SWIFT_AST_CAPTURE_INFO_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/SourceLoc.h"
@@ -219,7 +220,7 @@ public:
     return StorageAndFlags.getPointer()->getOpaqueValue();
   }
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void print(raw_ostream &OS) const;
 };
 

--- a/include/swift/AST/ConcreteDeclRef.h
+++ b/include/swift/AST/ConcreteDeclRef.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_CONCRETEDECLREF_H
 #define SWIFT_AST_CONCRETEDECLREF_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/TypeAlignments.h"
@@ -81,8 +82,8 @@ public:
   }
   
   /// Dump a debug representation of this reference.
-  void dump(raw_ostream &os);
-  void dump() LLVM_ATTRIBUTE_USED;
+  void dump(raw_ostream &os) const;
+  SWIFT_DEBUG_DUMP;
 };
 
 } // end namespace swift

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -35,6 +35,7 @@
 #include "swift/AST/Witness.h"
 #include "swift/Basic/ArrayRefView.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/InlineBitfield.h"
 #include "swift/Basic/NullablePtr.h"
 #include "swift/Basic/OptionalEnum.h"
@@ -776,12 +777,8 @@ public:
 
   SourceLoc TrailingSemiLoc;
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump(const char *filename) const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
+  SWIFT_DEBUG_DUMPER(dump(const char *filename));
   void dump(raw_ostream &OS, unsigned Indent = 0) const;
 
   /// Pretty-print the given declaration.
@@ -1202,9 +1199,7 @@ public:
     return repr->SecondType.getTypeRepr();
   }
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
   void print(raw_ostream &OS) const;
   void print(ASTPrinter &Printer) const;
 };
@@ -1374,7 +1369,7 @@ public:
   GenericParamList *clone(DeclContext *dc) const;
 
   void print(raw_ostream &OS) const;
-  void dump();
+  SWIFT_DEBUG_DUMP;
 };
   
 /// A trailing where clause.
@@ -2714,7 +2709,7 @@ public:
   void dumpRef(raw_ostream &os) const;
 
   /// Dump a reference to the given declaration.
-  void dumpRef() const;
+  SWIFT_DEBUG_DUMPER(dumpRef());
 
   /// Returns true if the declaration is a static member of a type.
   ///

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -23,6 +23,7 @@
 #include "swift/AST/LookupKinds.h"
 #include "swift/AST/ResilienceExpansion.h"
 #include "swift/AST/TypeAlignments.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/SourceLoc.h"
@@ -597,7 +598,7 @@ public:
   /// \returns true if traversal was aborted, false otherwise.
   bool walkContext(ASTWalker &Walker);
 
-  void dumpContext() const;
+  SWIFT_DEBUG_DUMPER(dumpContext());
   unsigned printContext(llvm::raw_ostream &OS, unsigned indent = 0,
                         bool onlyAPartialLine = false) const;
 

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -20,6 +20,7 @@
 
 #include "swift/AST/AnyRequest.h"
 #include "swift/Basic/AnyValue.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Statistic.h"
 #include "llvm/ADT/DenseMap.h"
@@ -452,17 +453,13 @@ public:
 
   /// Dump the dependencies of the given request to the debugging stream
   /// as a tree.
-  LLVM_ATTRIBUTE_DEPRECATED(
-    void dumpDependencies(const AnyRequest &request) const LLVM_ATTRIBUTE_USED,
-    "Only meant for use in the debugger");
+  SWIFT_DEBUG_DUMPER(dumpDependencies(const AnyRequest &request));
 
   /// Print all dependencies known to the evaluator as a single Graphviz
   /// directed graph.
   void printDependenciesGraphviz(llvm::raw_ostream &out) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-    void dumpDependenciesGraphviz() const LLVM_ATTRIBUTE_USED,
-    "Only meant for use in the debugger");
+  SWIFT_DEBUG_DUMPER(dumpDependenciesGraphviz());
 };
 
 template <typename Request>

--- a/include/swift/AST/ExperimentalDependencies.h
+++ b/include/swift/AST/ExperimentalDependencies.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_EXPERIMENTAL_DEPENDENCIES_H
 #define SWIFT_AST_EXPERIMENTAL_DEPENDENCIES_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Range.h"
 #include "llvm/ADT/Hashing.h"
@@ -498,7 +499,8 @@ public:
 
   std::string humanReadableName() const;
 
-  void dump() const { llvm::errs() << asString() << "\n"; }
+  void dump(llvm::raw_ostream &os) const { os << asString() << "\n"; }
+  SWIFT_DEBUG_DUMP { dump(llvm::errs()); }
 
   /// For debugging, needed for \ref TwoStageMap::verify
   std::string asString() const;
@@ -609,7 +611,8 @@ public:
   /// needs to set the fingerprint *after* the node has been created.
   void setFingerprint(Optional<std::string> fp) { fingerprint = fp; }
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
+  void dump(llvm::raw_ostream &os) const;
 
   std::string humanReadableName(StringRef where) const;
 
@@ -685,7 +688,6 @@ public:
     if (n != getSequenceNumber())
       defsIDependUpon.insert(n);
   }
-  void dump() const { DepGraphNode::dump(); }
 
   std::string humanReadableName() const {
     return DepGraphNode::humanReadableName("here");

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -27,6 +27,7 @@
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/Availability.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/InlineBitfield.h"
 #include "llvm/Support/TrailingObjects.h"
 #include <utility>
@@ -540,9 +541,7 @@ public:
   /// leaf node, etc.
   llvm::DenseMap<Expr *, unsigned> getPreorderIndexMap();
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &OS, unsigned Indent = 0) const;
   void dump(raw_ostream &OS, llvm::function_ref<Type(const Expr *)> getType,
             llvm::function_ref<Type(const TypeLoc &)> getTypeOfTypeLoc,

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -21,6 +21,7 @@
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/GenericParamKey.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -160,7 +161,7 @@ public:
 
   void dump(raw_ostream &os) const;
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
 };
   
 } // end namespace swift

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -21,6 +21,7 @@
 #include "swift/AST/Requirement.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/AnyValue.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -89,7 +90,7 @@ public:
 
   void print(raw_ostream &OS) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in a debugger");
+  SWIFT_DEBUG_DUMP;
 };
 
 class GenericSignatureImpl;
@@ -136,7 +137,7 @@ public:
 
   void print(raw_ostream &OS, PrintOptions Options = PrintOptions()) const;
   void print(ASTPrinter &Printer, PrintOptions Opts = PrintOptions()) const;
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   std::string getAsString() const;
 
   // Support for FoldingSet.
@@ -408,7 +409,7 @@ public:
   
   void print(raw_ostream &OS, PrintOptions Options = PrintOptions()) const;
   void print(ASTPrinter &Printer, PrintOptions Opts = PrintOptions()) const;
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   std::string getAsString() const;
 };
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -28,6 +28,7 @@
 #include "swift/AST/Types.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/TypeRepr.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
@@ -253,9 +254,7 @@ public:
     void dump(llvm::raw_ostream &out,
               GenericSignatureBuilder *builder = nullptr) const;
 
-    LLVM_ATTRIBUTE_DEPRECATED(
-                  void dump(GenericSignatureBuilder *builder = nullptr) const,
-                  "only for use in the debugger");
+    SWIFT_DEBUG_DUMPER(dump(GenericSignatureBuilder *builder = nullptr));
 
     /// Caches.
 
@@ -816,12 +815,12 @@ public:
   /// Verify all of the generic sigantures in the given module.
   static void verifyGenericSignaturesInModule(ModuleDecl *module);
 
-  /// Dump all of the requirements, both specified and inferred.
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump(),
-      "only for use within the debugger");
+  /// Dump all of the requirements, both specified and inferred. It cannot be
+  /// statically proven that this doesn't modify the GSB.
+  SWIFT_DEBUG_HELPER(void dump());
 
-  /// Dump all of the requirements to the given output stream.
+  /// Dump all of the requirements to the given output stream. It cannot be
+   /// statically proven that this doesn't modify the GSB.
   void dump(llvm::raw_ostream &out);
 };
 
@@ -1338,17 +1337,12 @@ public:
     ID.AddPointer(storage3);
   }
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
+  SWIFT_DEBUG_DUMPER(print());
 
   /// Dump the requirement source.
   void dump(llvm::raw_ostream &out, SourceManager *SrcMgr,
             unsigned indent) const;
-
-  LLVM_ATTRIBUTE_DEPRECATED(
-    void print() const,
-    "only for use within the debugger");
 
   /// Print the requirement source (shorter form)
   void print(llvm::raw_ostream &out, SourceManager *SrcMgr) const;
@@ -1691,9 +1685,7 @@ public:
   /// Retrieve the AST context in which this potential archetype resides.
   ASTContext &getASTContext() const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   void dump(llvm::raw_ostream &Out, SourceManager *SrcMgr,
             unsigned Indent) const;
@@ -1724,8 +1716,7 @@ public:
   /// Dump a debugging representation of this delayed requirement class.
   void dump(llvm::raw_ostream &out) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
-                            "only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 };
 
 /// Whether the given constraint result signals an error.

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -18,6 +18,7 @@
 #define SWIFT_AST_IDENTIFIER_H
 
 #include "swift/Basic/EditorPlaceholder.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -611,8 +612,7 @@ public:
   llvm::raw_ostream &printPretty(llvm::raw_ostream &os) const;
 
   /// Dump this name to standard error.
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 };
 
 enum class ObjCSelectorFamily : unsigned {
@@ -693,8 +693,7 @@ public:
   }
 
   /// Dump this selector to standard error.
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Compare two Objective-C selectors, producing -1 if \c *this comes before
   /// \c other,  1 if \c *this comes after \c other, and 0 if they are equal.

--- a/include/swift/AST/IndexSubset.h
+++ b/include/swift/AST/IndexSubset.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_INDEXSUBSET_H
 #define SWIFT_AST_INDEXSUBSET_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/STLExtras.h"
@@ -206,9 +207,7 @@ public:
   }
 
   void print(llvm::raw_ostream &s = llvm::outs()) const;
-  LLVM_ATTRIBUTE_DEPRECATED(void dump(llvm::raw_ostream &s = llvm::errs())
-                                const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMPER(dump(llvm::raw_ostream &s = llvm::errs()));
 
   int findNext(int startIndex) const;
   int findFirst() const { return findNext(-1); }

--- a/include/swift/AST/LayoutConstraint.h
+++ b/include/swift/AST/LayoutConstraint.h
@@ -18,6 +18,7 @@
 #define SWIFT_LAYOUT_CONSTRAINT_H
 
 #include "swift/AST/TypeAlignments.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
@@ -282,7 +283,7 @@ class LayoutConstraint {
 
   explicit operator bool() const { return Ptr != 0; }
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &os, unsigned indent = 0) const;
 
   void print(raw_ostream &OS, const PrintOptions &PO = PrintOptions()) const;

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -23,6 +23,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Module.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/NullablePtr.h"
 #include "swift/Basic/SourceLoc.h"
 
@@ -608,8 +609,7 @@ public:
   computeIsCascadingUse(ArrayRef<const ast_scope::ASTScopeImpl *> history,
                         Optional<bool> initialIsCascadingUse);
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
   void print(llvm::raw_ostream &) const;
   void dumpOneScopeMapLocation(std::pair<unsigned, unsigned>);
 

--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -18,6 +18,7 @@
 #define SWIFT_AST_PARAMETERLIST_H
 
 #include "swift/AST/Decl.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/OptionSet.h"
 #include "llvm/Support/TrailingObjects.h"
 
@@ -131,7 +132,7 @@ public:
   SourceLoc getStartLoc() const { return getSourceRange().Start; }
   SourceLoc getEndLoc() const { return getSourceRange().End; }
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &OS, unsigned Indent = 0) const;
   
   //  void print(raw_ostream &OS) const;

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -20,6 +20,7 @@
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/type_traits.h"
 #include "swift/AST/Decl.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
@@ -221,9 +222,7 @@ public:
   
   void print(llvm::raw_ostream &OS,
              const PrintOptions &Options = PrintOptions()) const;
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
   
   /// walk - This recursively walks the AST rooted at this pattern.
   Pattern *walk(ASTWalker &walker);

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -23,6 +23,7 @@
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/Witness.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
@@ -320,7 +321,7 @@ public:
                              LookupConformanceFn conformances,
                              SubstOptions options=None) const;
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void dump(llvm::raw_ostream &out, unsigned indent = 0) const;
 };
 

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -16,6 +16,7 @@
 #ifndef SWIFT_AST_PROTOCOLCONFORMANCEREF_H
 #define SWIFT_AST_PROTOCOLCONFORMANCEREF_H
 
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "swift/AST/Requirement.h"
@@ -124,7 +125,7 @@ public:
   getAssociatedConformance(Type origType, Type dependentType,
                            ProtocolDecl *requirement) const;
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void dump(llvm::raw_ostream &out, unsigned indent = 0) const;
 
   bool operator==(ProtocolConformanceRef other) const {

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -18,6 +18,7 @@
 #define SWIFT_AST_REQUIREMENT_H
 
 #include "swift/AST/Type.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -126,7 +127,7 @@ public:
   /// Get the canonical form of this requirement.
   Requirement getCanonical() const;
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &out) const;
   void print(raw_ostream &os, const PrintOptions &opts) const;
   void print(ASTPrinter &printer, const PrintOptions &opts) const;

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -14,6 +14,7 @@
 #define SWIFT_AST_SOURCEFILE_H
 
 #include "swift/AST/FileUnit.h"
+#include "swift/Basic/Debug.h"
 
 namespace swift {
 
@@ -323,7 +324,7 @@ public:
   /// Retrieve the scope that describes this source file.
   ASTScope &getScope();
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &os) const;
 
   /// Pretty-print the contents of this source file.

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -23,6 +23,7 @@
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/TypeAlignments.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/NullablePtr.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -134,9 +135,7 @@ public:
   Stmt *walk(ASTWalker &walker);
   Stmt *walk(ASTWalker &&walker) { return walk(walker); }
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &OS, const ASTContext *Ctx = nullptr, unsigned Indent = 0) const;
 
   // Only allow allocation of Exprs using the allocator in ASTContext

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -20,6 +20,7 @@
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/AST/Type.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/Optional.h"
@@ -234,7 +235,7 @@ public:
   void dump(llvm::raw_ostream &out, DumpStyle style = DumpStyle::Full,
             unsigned indent = 0) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Profile the substitution map, for use with LLVM's FoldingSet.
   void profile(llvm::FoldingSetNodeID &id) const;

--- a/include/swift/AST/SyntaxASTMap.h
+++ b/include/swift/AST/SyntaxASTMap.h
@@ -18,6 +18,7 @@
 #define SWIFT_AST_SYNTAXASTMAP_H
 
 #include "swift/AST/ASTNode.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Syntax/Syntax.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
@@ -49,7 +50,7 @@ public:
   void clearSyntaxMap();
 
   /// Dump the entire syntax node -> semantic node map for debugging purposes.
-  void dumpSyntaxMap() const;
+  SWIFT_DEBUG_DUMPER(dumpSyntaxMap());
 };
 
 } // end namespace swift

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLExtras.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/ArrayRefView.h"
 #include "swift/AST/LayoutConstraint.h"
@@ -317,7 +318,7 @@ public:
   
   bool isPrivateStdlibType(bool treatNonBuiltinProtocolsAsPublic = true) const;
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &os, unsigned indent = 0) const;
 
   void print(raw_ostream &OS, const PrintOptions &PO = PrintOptions()) const;

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -21,6 +21,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Availability.h"
 #include "swift/AST/Stmt.h" // for PoundAvailableInfo
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/STLExtras.h"
@@ -255,9 +256,7 @@ public:
   TypeRefinementContext *findMostRefinedSubContext(SourceLoc Loc,
                                                    SourceManager &SM);
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump(SourceManager &SrcMgr) const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMPER(dump(SourceManager &SrcMgr));
   void dump(raw_ostream &OS, SourceManager &SrcMgr) const;
   void print(raw_ostream &OS, SourceManager &SrcMgr, unsigned Indent = 0) const;
   

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -25,6 +25,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/STLExtras.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/InlineBitfield.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -160,9 +161,7 @@ public:
 
   void print(raw_ostream &OS, const PrintOptions &Opts = PrintOptions()) const;
   void print(ASTPrinter &Printer, const PrintOptions &Opts) const;
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Clone the given type representation.
   TypeRepr *clone(const ASTContext &ctx) const;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -28,6 +28,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/ArrayRefView.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/InlineBitfield.h"
 #include "swift/Basic/UUID.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -1088,10 +1089,10 @@ public:
   /// Error.
   bool isExistentialWithError();
 
-  void dump() const LLVM_ATTRIBUTE_USED;
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &os, unsigned indent = 0) const;
 
-  void dumpPrint() const LLVM_ATTRIBUTE_USED;
+  SWIFT_DEBUG_DUMPER(dumpPrint());
   void print(raw_ostream &OS,
              const PrintOptions &PO = PrintOptions()) const;
   void print(ASTPrinter &Printer, const PrintOptions &PO) const;
@@ -3493,7 +3494,7 @@ public:
     id.AddInteger((unsigned)getConvention());
   }
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void print(llvm::raw_ostream &out,
              const PrintOptions &options = PrintOptions()) const;
   void print(ASTPrinter &Printer, const PrintOptions &Options) const;
@@ -3612,7 +3613,7 @@ public:
     id.AddPointer(TypeAndConvention.getOpaqueValue());
   }
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void print(llvm::raw_ostream &out,
              const PrintOptions &options = PrintOptions()) const;
   void print(ASTPrinter &Printer, const PrintOptions &Options) const;

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -19,6 +19,7 @@
 #define SWIFT_AST_WITNESS_H
 
 #include "swift/AST/ConcreteDeclRef.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/Compiler.h"
 
@@ -182,9 +183,7 @@ public:
     return {};
   }
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-    void dump() const LLVM_ATTRIBUTE_USED,
-    "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   void dump(llvm::raw_ostream &out) const;
 };

--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -31,6 +31,7 @@
 
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/Optional.h"
+#include "swift/Basic/Debug.h"
 #include <cassert>
 
 namespace swift {
@@ -276,7 +277,7 @@ public:
 
   /// Pretty-print the vector.
   void print(llvm::raw_ostream &out) const;
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
 };
 
 } // end namespace swift

--- a/include/swift/Basic/Debug.h
+++ b/include/swift/Basic/Debug.h
@@ -1,0 +1,39 @@
+//===--- Debug.h - Compiler debugging helpers -------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_BASIC_DEBUG_H
+#define SWIFT_BASIC_DEBUG_H
+
+#include "llvm/Support/Compiler.h"
+
+
+/// Adds attributes to the provided method signature indicating that it is a
+/// debugging helper that should never be called directly from compiler code.
+/// This deprecates the method so it won't be called directly and marks it as
+/// used so it won't be eliminated as dead code.
+#define SWIFT_DEBUG_HELPER(method) \
+  LLVM_ATTRIBUTE_DEPRECATED(method LLVM_ATTRIBUTE_USED, \
+                            "only for use in the debugger")
+
+/// Declares a const void instance method with the name and parameters provided.
+/// Methods declared with this macro should never be called except in the
+/// debugger.
+#define SWIFT_DEBUG_DUMPER(nameAndParams) \
+  SWIFT_DEBUG_HELPER(void nameAndParams const)
+
+/// Declares an instance `void dump() const` method. Methods declared with this
+/// macro should never be called except in the debugger.
+#define SWIFT_DEBUG_DUMP \
+  SWIFT_DEBUG_DUMPER(dump())
+
+#endif
+
+

--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -14,6 +14,7 @@
 #define SWIFT_BASIC_MANGLER_H
 
 #include "swift/Demangling/ManglingUtils.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallString.h"
@@ -118,7 +119,7 @@ protected:
   /// Verify that demangling and remangling works.
   static void verify(StringRef mangledName);
 
-  void dump();
+  SWIFT_DEBUG_DUMP;
 
   /// Appends a mangled identifier string.
   void appendIdentifier(StringRef ident);

--- a/include/swift/Basic/PrefixMap.h
+++ b/include/swift/Basic/PrefixMap.h
@@ -35,6 +35,7 @@
 #define SWIFT_BASIC_PREFIXMAP_H
 
 #include "swift/Basic/Algorithm.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/type_traits.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -641,7 +642,7 @@ public:
                          [&]() -> const ValueType & { return value; });
   }
 
-  void dump() const { print(llvm::errs()); }
+  SWIFT_DEBUG_DUMP { print(llvm::errs()); }
   void print(raw_ostream &out) const {
     printOpaquePrefixMap(out, Root,
                          [](raw_ostream &out, void *_node) {

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_BASIC_SOURCELOC_H
 #define SWIFT_BASIC_SOURCELOC_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/StringRef.h"
@@ -77,7 +78,7 @@ public:
     print(OS, SM, Tmp);
   }
 
-  void dump(const SourceManager &SM) const;
+  SWIFT_DEBUG_DUMPER(dump(const SourceManager &SM));
 
 	friend size_t hash_value(SourceLoc loc) {
 		return reinterpret_cast<uintptr_t>(loc.getOpaquePointerValue());
@@ -128,7 +129,7 @@ public:
     print(OS, SM, Tmp, PrintText);
   }
 
-  void dump(const SourceManager &SM) const;
+  SWIFT_DEBUG_DUMPER(dump(const SourceManager &SM));
 };
 
 /// A half-open character-based source range.
@@ -219,7 +220,7 @@ public:
     print(OS, SM, Tmp, PrintText);
   }
   
-  void dump(const SourceManager &SM) const;
+  SWIFT_DEBUG_DUMPER(dump(const SourceManager &SM));
 };
 
 } // end namespace swift

--- a/include/swift/Basic/SuccessorMap.h
+++ b/include/swift/Basic/SuccessorMap.h
@@ -23,6 +23,7 @@
 #ifndef SWIFT_BASIC_SUCCESSORMAP_H
 #define SWIFT_BASIC_SUCCESSORMAP_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
@@ -59,7 +60,7 @@ class SuccessorMap {
     K Begin, End;
     V Value;
 
-    void dump() const {
+    SWIFT_DEBUG_DUMP {
       dumpNode(this);
     }
   };
@@ -159,11 +160,8 @@ public:
 #endif
   }
 
-  void dump() const {
-    // We call dump() on the object instead of using dumpNode here so
-    // that the former will be available in a debug build as long as
-    // something in the program calls dump on the collection.
-    if (Root) Root->dump();
+  SWIFT_DEBUG_DUMP {
+    if (Root) dumpNode(Root);
     else llvm::errs() << "(empty)\n";
   }
 

--- a/include/swift/Basic/TreeScopedHashTable.h
+++ b/include/swift/Basic/TreeScopedHashTable.h
@@ -18,6 +18,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Allocator.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/Malloc.h"
 #include <utility>
 
@@ -361,10 +362,9 @@ public:
   /// Visit each entry in the map without regard to order. Meant to be used with
   /// in the debugger in coordination with other dumpers that can dump whatever
   /// is stored in the map. No-op when asserts are disabled.
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void debugVisit(std::function<void(const DebugVisitValueTy &)> &&func)
-          const LLVM_ATTRIBUTE_USED,
-      "Only for use in the debugger");
+  SWIFT_DEBUG_HELPER(
+    void debugVisit(std::function<void(const DebugVisitValueTy &)> &&func) const
+  );
 
   /// This inserts the specified key/value at the specified
   /// (possibly not the current) scope.  While it is ok to insert into a scope

--- a/include/swift/Driver/ExperimentalDependencyDriverGraph.h
+++ b/include/swift/Driver/ExperimentalDependencyDriverGraph.h
@@ -14,6 +14,7 @@
 #define ExperimentalDependencyGraph_h
 
 #include "swift/AST/ExperimentalDependencies.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Driver/DependencyGraph.h"
@@ -89,7 +90,7 @@ public:
     return DepGraphNode::humanReadableName(where);
   }
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
 
   bool assertProvidedEntityMustBeInAFile() const {
     assert((getSwiftDeps().hasValue() || !getKey().isImplementation()) &&

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_DRIVER_JOB_H
 #define SWIFT_DRIVER_JOB_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OutputFileMap.h"
@@ -220,7 +221,7 @@ public:
   void writeOutputFileMap(llvm::raw_ostream &out) const;
 
   void print(raw_ostream &Stream) const;
-  void dump() const LLVM_ATTRIBUTE_USED;
+  SWIFT_DEBUG_DUMP;
 
   /// For use in assertions: check the CommandOutput's state is consistent with
   /// its invariants.
@@ -373,7 +374,7 @@ public:
     Callback(this, static_cast<Job::PID>(OSPid));
   }
 
-  void dump() const LLVM_ATTRIBUTE_USED;
+  SWIFT_DEBUG_DUMP;
 
   static void printArguments(raw_ostream &Stream,
                              const llvm::opt::ArgStringList &Args);

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -14,6 +14,7 @@
 #define SWIFT_IDE_CODECOMPLETION_H
 
 #include "swift/AST/Identifier.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
@@ -314,7 +315,7 @@ public:
 
   /// Print a debug representation of the code completion string to \p OS.
   void print(raw_ostream &OS) const;
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
 };
 
 /// Describes the origin of the code completion result.
@@ -763,7 +764,7 @@ public:
 
   /// Print a debug representation of the code completion result to \p OS.
   void print(raw_ostream &OS) const;
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
 
   static CodeCompletionDeclKind getCodeCompletionDeclKind(const Decl *D);
   static CodeCompletionOperatorKind

--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_PARSE_PARSEDRAWSYNTAXNODE_H
 #define SWIFT_PARSE_PARSEDRAWSYNTAXNODE_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Parse/ParsedTrivia.h"
 #include "swift/Parse/Token.h"
@@ -327,9 +328,7 @@ public:
   }
 
   /// Dump this piece of syntax recursively for debugging or testing.
-  LLVM_ATTRIBUTE_DEPRECATED(
-    void dump() const LLVM_ATTRIBUTE_USED,
-    "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Dump this piece of syntax recursively.
   void dump(raw_ostream &OS, unsigned Indent = 0) const;

--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -19,6 +19,7 @@
 #define SWIFT_SEMA_SCOPE_H
 
 #include "swift/AST/Identifier.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/TreeScopedHashTable.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -59,8 +60,7 @@ public:
   
   SavedScope saveCurrentScope();
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "Only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 };
 
 enum class ScopeKind {

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -14,6 +14,7 @@
 #define SWIFT_PARSE_SYNTAXPARSINGCONTEXT_H
 
 #include "llvm/ADT/PointerUnion.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Parse/ParsedRawSyntaxNode.h"
 #include "swift/Parse/ParsedRawSyntaxRecorder.h"
@@ -345,8 +346,7 @@ public:
   void synthesize(tok Kind, SourceLoc Loc);
 
   /// Dump the nodes that are in the storage stack of the SyntaxParsingContext
-  LLVM_ATTRIBUTE_DEPRECATED(void dumpStorage() const LLVM_ATTRIBUTE_USED,
-                            "Only meant for use in the debugger");
+  SWIFT_DEBUG_DUMPER(dumpStorage());
 };
 
 } // namespace swift

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SIL_OWNERSHIPUTILS_H
 #define SWIFT_SIL_OWNERSHIPUTILS_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/SIL/BranchPropagatedUser.h"
 #include "swift/SIL/SILArgument.h"
@@ -227,7 +228,7 @@ struct BorrowScopeOperandKind {
   }
 
   void print(llvm::raw_ostream &os) const;
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 };
 
 /// An operand whose user instruction introduces a new borrow scope for the
@@ -327,7 +328,7 @@ struct BorrowScopeIntroducingValueKind {
   }
 
   void print(llvm::raw_ostream &os) const;
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,

--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -65,10 +65,10 @@ public:
   SILFunction *getParentFunction() const;
 
 #ifndef NDEBUG
-  LLVM_ATTRIBUTE_DEPRECATED(void dump(SourceManager &SM, llvm::raw_ostream &OS = llvm::errs(),
-                            unsigned Indent = 0) const,
-                  "only for use in the debugger");
-  LLVM_ATTRIBUTE_DEPRECATED(void dump(SILModule &Mod) const, "only for use in the debugger");
+  SWIFT_DEBUG_DUMPER(dump(SourceManager &SM,
+                          llvm::raw_ostream &OS = llvm::errs(),
+                          unsigned Indent = 0));
+  SWIFT_DEBUG_DUMPER(dump(SILModule &Mod));
 #endif
 };
 

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -532,7 +532,7 @@ struct OperandOwnershipKindMap {
   UseLifetimeConstraint getLifetimeConstraint(ValueOwnershipKind kind) const;
 
   void print(llvm::raw_ostream &os) const;
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in a debugger");
+  SWIFT_DEBUG_DUMP;
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -255,7 +255,7 @@ public:
   void print(llvm::raw_ostream &os) const;
 
   /// Dump out the internal state of this type lowering to llvm::dbgs().
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "Only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Are r-values of this type passed as arguments indirectly by formal
   /// convention?

--- a/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
@@ -54,8 +54,7 @@ public:
       : CalleeFunctions(llvm::makeArrayRef(List.begin(), List.end())),
         IsIncomplete(IsIncomplete) {}
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "Only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 
   void print(llvm::raw_ostream &os) const;
 
@@ -167,8 +166,7 @@ public:
     Cache.reset();
   }
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "Only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 
   void print(llvm::raw_ostream &os) const;
 

--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -111,8 +111,7 @@ public:
   /// invalidating parts of the call graph.
   const FunctionInfo &getFunctionInfo(SILFunction *f) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "Only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Print the state of the caller analysis as a sequence of yaml documents for
   /// each callee we are tracking.
@@ -120,9 +119,7 @@ public:
 
   /// Print the state of the caller analysis as a sequence of yaml documents for
   /// each callee we are tracking to the passed in file path.
-  LLVM_ATTRIBUTE_DEPRECATED(void print(const char *filePath)
-                                const LLVM_ATTRIBUTE_USED,
-                            "Only for use in the debugger");
+  SWIFT_DEBUG_DUMPER(print(const char *filePath));
 
   void verify() const override;
   void verify(SILFunction *f) const override;
@@ -349,8 +346,7 @@ public:
     return llvm::make_range(callerStates.begin(), callerStates.end());
   }
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "Only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 
   void print(llvm::raw_ostream &os) const;
 };

--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -29,6 +29,7 @@
 #ifndef SWIFT_SYNTAX_RAWSYNTAX_H
 #define SWIFT_SYNTAX_RAWSYNTAX_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/InlineBitfield.h"
 #include "swift/Syntax/References.h"
 #include "swift/Syntax/SyntaxArena.h"
@@ -192,7 +193,9 @@ public:
 
   /// Dump a description of this position to the given output stream
   /// for debugging.
-  void dump(llvm::raw_ostream &OS = llvm::errs()) const;
+  void dump(llvm::raw_ostream &OS) const;
+
+  SWIFT_DEBUG_DUMP;
 };
 
 /// An indicator of whether a Syntax node was found or written in the source.
@@ -568,7 +571,7 @@ public:
   void print(llvm::raw_ostream &OS, SyntaxPrintOptions Opts) const;
 
   /// Dump this piece of syntax recursively for debugging or testing.
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
 
   /// Dump this piece of syntax recursively.
   void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -23,6 +23,7 @@
 #ifndef SWIFT_SYNTAX_SYNTAX_H
 #define SWIFT_SYNTAX_SYNTAX_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Syntax/SyntaxData.h"
 #include "swift/Syntax/References.h"
 #include "swift/Syntax/RawSyntax.h"
@@ -176,7 +177,7 @@ public:
   void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
 
   /// Print a debug representation of the syntax node to standard error.
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
 
   bool hasSameIdentityAs(const Syntax &Other) const {
     return Root == Other.Root && Data == Other.Data;

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -39,6 +39,7 @@
 #ifndef SWIFT_SYNTAX_SYNTAXDATA_H
 #define SWIFT_SYNTAX_SYNTAXDATA_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Syntax/AtomicCache.h"
 #include "swift/Syntax/RawSyntax.h"
 #include "swift/Syntax/References.h"
@@ -288,8 +289,7 @@ public:
   /// standard error.
   void dump(llvm::raw_ostream &OS) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "Only meant for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 };
 
 } // end namespace syntax

--- a/include/swift/Syntax/Trivia.h.gyb
+++ b/include/swift/Syntax/Trivia.h.gyb
@@ -87,6 +87,7 @@
 #ifndef SWIFT_SYNTAX_TRIVIA_H
 #define SWIFT_SYNTAX_TRIVIA_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/OwnedString.h"
 #include "swift/Basic/JSONSerialization.h"
 #include "swift/Basic/ByteTreeSerialization.h"
@@ -299,7 +300,7 @@ struct Trivia {
   void appendOrSquash(const TriviaPiece &Next);
 
   /// Dump a debug representation of this Trivia collection to standard error.
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
 
   /// Dump a debug representation of this Trivia collection to the provided
   /// stream and indentation level.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -185,7 +185,7 @@ void GenericParamList::print(llvm::raw_ostream &OS) const {
   OS << '>';
 }
 
-void GenericParamList::dump() {
+void GenericParamList::dump() const {
   print(llvm::errs());
   llvm::errs() << '\n';
 }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/TypeRepr.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/STLExtras.h"
 #include "llvm/Support/Compiler.h"
 #include <algorithm>
@@ -670,7 +671,7 @@ public:
 
     auto printDecl = [&](const Decl *d) {
       llvm::errs() << "\ngetAsDecl() -> " << d << " ";
-      d->getSourceRange().dump(ctx.SourceMgr);
+      d->getSourceRange().print(llvm::errs(), ctx.SourceMgr);
       llvm::errs() << " : ";
       d->dump(llvm::errs());
       llvm::errs() << "\n";
@@ -710,7 +711,7 @@ private:
   findLocalizableDeclContextsInAST() const;
 
 public:
-  void dump() const { print(llvm::errs()); }
+  SWIFT_DEBUG_DUMP { print(llvm::errs()); }
 
   void print(raw_ostream &out) const {
     out << "(swift::ASTSourceFileScope*) " << sourceFileScope << "\n";

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -94,9 +94,9 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
     name.print(llvm::errs());
     llvm::errs() << "' ";
     llvm::errs() << "loc: ";
-    loc.dump(sourceFile->getASTContext().SourceMgr);
+    loc.print(llvm::errs(), sourceFile->getASTContext().SourceMgr);
     llvm::errs() << "\nstarting context:\n ";
-    startingContext->dumpContext();
+    startingContext->printContext(llvm::errs());
     //    llvm::errs() << "\ninnermost: ";
     //    innermost->dump();
     //    llvm::errs() << "in: \n";

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -512,8 +512,8 @@ public:
       if (auto *DC = dyn_cast<DeclContext>(D)) {
         if (D->getDeclContext() != DC->getParent()) {
           Out << "Decl's DeclContext not in sync with DeclContext's parent\n";
-          D->getDeclContext()->dumpContext();
-          DC->getParent()->dumpContext();
+          D->getDeclContext()->printContext(Out);
+          DC->getParent()->printContext(Out);
           abort();
         }
       }
@@ -1652,7 +1652,7 @@ public:
 
       if (E->getConformance().getRequirement() != hashableDecl) {
         Out << "conformance on AnyHashableErasureExpr was not for Hashable\n";
-        E->getConformance().dump();
+        E->getConformance().dump(Out);
         abort();
       }
 

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -45,7 +45,7 @@ ConcreteDeclRef ConcreteDeclRef::getOverriddenDecl() const {
   return ConcreteDeclRef(baseDecl, subs);
 }
 
-void ConcreteDeclRef::dump(raw_ostream &os) {
+void ConcreteDeclRef::dump(raw_ostream &os) const {
   if (!getDecl()) {
     os << "**NULL**";
     return;
@@ -61,6 +61,6 @@ void ConcreteDeclRef::dump(raw_ostream &os) {
   }
 }
 
-void ConcreteDeclRef::dump() {
+void ConcreteDeclRef::dump() const {
   dump(llvm::errs());
 }

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -89,7 +89,7 @@ void ConformanceLookupTable::ConformanceEntry::dump(raw_ostream &os,
 
   if (Loc.isValid()) {
     os << " loc=";
-    Loc.dump(getProtocol()->getASTContext().SourceMgr);
+    Loc.print(os, getProtocol()->getASTContext().SourceMgr);
   }
 
   switch (getKind()) {

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -22,6 +22,7 @@
 
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/TypeLoc.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/MapVector.h"
@@ -289,9 +290,7 @@ class ConformanceLookupTable {
     void *operator new(size_t Bytes, ASTContext &C,
                        unsigned Alignment = alignof(ConformanceEntry));
 
-    LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const LLVM_ATTRIBUTE_USED,
-        "only for use within the debugger");
+    SWIFT_DEBUG_DUMP;
     void dump(raw_ostream &os, unsigned indent = 0) const;
   };
 
@@ -478,9 +477,7 @@ public:
     return Mem;
   }
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &os) const;
 
   /// Compare two protocol conformances to place them in some canonical order.

--- a/lib/AST/ExperimentalDependencies.cpp
+++ b/lib/AST/ExperimentalDependencies.cpp
@@ -133,9 +133,9 @@ bool SourceFileDepGraph::verify() const {
     auto iterInserted = nodesSeen.insert(std::make_pair(n->getKey(), n));
     if (!iterInserted.second) {
       llvm::errs() << "Duplicate frontend keys: ";
-      iterInserted.first->second->dump();
+      iterInserted.first->second->dump(llvm::errs());
       llvm::errs() << " and ";
-      n->dump();
+      n->dump(llvm::errs());
       llvm::errs() << "\n";
       llvm_unreachable("duplicate frontend keys");
     }
@@ -231,7 +231,11 @@ void DependencyKey::verifyDeclAspectNames() {
 }
 
 void DepGraphNode::dump() const {
-  key.dump();
+  dump(llvm::errs());
+}
+
+void DepGraphNode::dump(raw_ostream &os) const {
+  key.dump(os);
   if (fingerprint.hasValue())
     llvm::errs() << "fingerprint: " << fingerprint.getValue() << "";
   else

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -33,6 +33,7 @@
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/AST/TypeWalker.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Statistic.h"
 #include "llvm/ADT/GraphTraits.h"
@@ -198,8 +199,7 @@ public:
   /// Print this path.
   void print(llvm::raw_ostream &out) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger") {
+  SWIFT_DEBUG_DUMP {
     print(llvm::errs());
   }
 
@@ -401,8 +401,7 @@ public:
     return enumerateRulesRec(fn, temporarilyDisableVisitedRule, lhs);
   }
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Dump the tree.
   void dump(llvm::raw_ostream &out, bool lastChild = true) const;
@@ -6160,8 +6159,7 @@ namespace {
       return lhs.constraint < rhs.constraint;
     }
 
-    LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                              "only for use in the debugger");
+    SWIFT_DEBUG_DUMP;
   };
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ReferencedNameTracker.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/STLExtras.h"
@@ -851,8 +852,7 @@ public:
     os << "\n";
   }
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger") {
+  SWIFT_DEBUG_DUMP {
     dump(llvm::errs());
   }
 

--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -200,8 +200,10 @@ void Mangler::appendIdentifier(StringRef ident) {
   recordOpStat("<identifier>", OldPos);
 }
 
-void Mangler::dump() {
-  llvm::errs() << Buffer.str() << '\n';
+void Mangler::dump() const {
+  // FIXME: const_casting because llvm::raw_svector_ostream::str() is
+  // incorrectly not marked const.
+  llvm::errs() << const_cast<Mangler*>(this)->Buffer.str() << '\n';
 }
 
 bool Mangler::tryMangleSubstitution(const void *ptr) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3772,11 +3772,11 @@ void ClangImporter::Implementation::dumpSwiftLookupTables() {
   for (auto moduleName : moduleNames) {
     llvm::errs() << "<<" << moduleName << " lookup table>>\n";
     LookupTables[moduleName]->deserializeAll();
-    LookupTables[moduleName]->dump();
+    LookupTables[moduleName]->dump(llvm::errs());
   }
 
   llvm::errs() << "<<Bridging header lookup table>>\n";
-  BridgingHeaderLookupTable->dump();
+  BridgingHeaderLookupTable->dump(llvm::errs());
 }
 
 DeclName ClangImporter::

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -762,8 +762,8 @@ namespace {
         LLVM_FALLTHROUGH;
       default:
         if (!underlyingResult.AbstractType->isEqual(mappedType)) {
-          underlyingResult.AbstractType->dump();
-          mappedType->dump();
+          underlyingResult.AbstractType->dump(llvm::errs());
+          mappedType->dump(llvm::errs());
         }
         assert(underlyingResult.AbstractType->isEqual(mappedType) &&
                "typedef without special typedef kind was mapped "

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -838,89 +838,93 @@ static void printStoredEntry(const SwiftLookupTable *table, uint64_t entry,
 }
 
 void SwiftLookupTable::dump() const {
+  dump(llvm::errs());
+}
+
+void SwiftLookupTable::dump(raw_ostream &os) const {
   // Dump the base name -> full table entry mappings.
   SmallVector<SerializedSwiftName, 4> baseNames;
   for (const auto &entry : LookupTable) {
     baseNames.push_back(entry.first);
   }
   llvm::array_pod_sort(baseNames.begin(), baseNames.end());
-  llvm::errs() << "Base name -> entry mappings:\n";
+  os << "Base name -> entry mappings:\n";
   for (auto baseName : baseNames) {
     switch (baseName.Kind) {
     case DeclBaseName::Kind::Normal:
-      llvm::errs() << "  " << baseName.Name << ":\n";
+      os << "  " << baseName.Name << ":\n";
       break;
     case DeclBaseName::Kind::Subscript:
-      llvm::errs() << "  subscript:\n";
+      os << "  subscript:\n";
       break;
     case DeclBaseName::Kind::Constructor:
-      llvm::errs() << "  init:\n";
+      os << "  init:\n";
       break;
     case DeclBaseName::Kind::Destructor:
-      llvm::errs() << "  deinit:\n";
+      os << "  deinit:\n";
       break;
     }
     const auto &entries = LookupTable.find(baseName)->second;
     for (const auto &entry : entries) {
-      llvm::errs() << "    ";
-      printStoredContext(entry.Context, llvm::errs());
-      llvm::errs() << ": ";
+      os << "    ";
+      printStoredContext(entry.Context, os);
+      os << ": ";
 
       interleave(entry.DeclsOrMacros.begin(), entry.DeclsOrMacros.end(),
-                 [this](uint64_t entry) {
-                   printStoredEntry(this, entry, llvm::errs());
+                 [this, &os](uint64_t entry) {
+                   printStoredEntry(this, entry, os);
                  },
-                 [] {
-                   llvm::errs() << ", ";
+                 [&os] {
+                   os << ", ";
                  });
-      llvm::errs() << "\n";
+      os << "\n";
     }
   }
 
   if (!Categories.empty()) {
-    llvm::errs() << "Categories: ";
+    os << "Categories: ";
     interleave(Categories.begin(), Categories.end(),
-               [](clang::ObjCCategoryDecl *category) {
-                 llvm::errs() << category->getClassInterface()->getName()
-                              << "(" << category->getName() << ")";
+               [&os](clang::ObjCCategoryDecl *category) {
+                 os << category->getClassInterface()->getName()
+                    << "(" << category->getName() << ")";
                },
-               [] {
-                 llvm::errs() << ", ";
+               [&os] {
+                 os << ", ";
                });
-    llvm::errs() << "\n";
+    os << "\n";
   } else if (Reader && !Reader->categories().empty()) {
-    llvm::errs() << "Categories: ";
+    os << "Categories: ";
     interleave(Reader->categories().begin(), Reader->categories().end(),
-               [](clang::serialization::DeclID declID) {
-                 llvm::errs() << "decl ID #" << declID;
+               [&os](clang::serialization::DeclID declID) {
+                 os << "decl ID #" << declID;
                },
-               [] {
-                 llvm::errs() << ", ";
+               [&os] {
+                 os << ", ";
                });
-    llvm::errs() << "\n";
+    os << "\n";
   }
 
   if (!GlobalsAsMembers.empty()) {
-    llvm::errs() << "Globals-as-members mapping:\n";
+    os << "Globals-as-members mapping:\n";
     SmallVector<StoredContext, 4> contexts;
     for (const auto &entry : GlobalsAsMembers) {
       contexts.push_back(entry.first);
     }
     llvm::array_pod_sort(contexts.begin(), contexts.end());
     for (auto context : contexts) {
-      llvm::errs() << "  ";
-      printStoredContext(context, llvm::errs());
-      llvm::errs() << ": ";
+      os << "  ";
+      printStoredContext(context, os);
+      os << ": ";
 
       const auto &entries = GlobalsAsMembers.find(context)->second;
       interleave(entries.begin(), entries.end(),
-                 [this](uint64_t entry) {
-                   printStoredEntry(this, entry, llvm::errs());
+                 [this, &os](uint64_t entry) {
+                   printStoredEntry(this, entry, os);
                  },
-                 [] {
-                   llvm::errs() << ", ";
+                 [&os] {
+                   os << ", ";
                  });
-      llvm::errs() << "\n";
+      os << "\n";
     }
   }
 }

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_CLANGIMPORTER_SWIFTLOOKUPTABLE_H
 #define SWIFT_CLANGIMPORTER_SWIFTLOOKUPTABLE_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/Identifier.h"
 #include "clang/AST/Decl.h"
@@ -516,7 +517,9 @@ public:
   void deserializeAll();
 
   /// Dump the internal representation of this lookup table.
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
+
+  void dump(llvm::raw_ostream &os) const;
 };
 
 namespace importer {

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -154,7 +154,7 @@ LLVM_DUMP_METHOD void DebugTypeInfo::dump() const {
   llvm::errs() << "[Size " << size.getValue() << " Alignment "
                << align.getValue() << "] ";
 
-  getType()->dump();
+  getType()->dump(llvm::errs());
   if (StorageType) {
     llvm::errs() << "StorageType=";
     StorageType->dump();

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -515,7 +515,8 @@ private:
 
     auto FnTy = SILTy.getAs<SILFunctionType>();
     if (!FnTy) {
-      LLVM_DEBUG(llvm::dbgs() << "Unexpected function type: "; SILTy.dump();
+      LLVM_DEBUG(llvm::dbgs() << "Unexpected function type: ";
+                 SILTy.print(llvm::dbgs());
                  llvm::dbgs() << "\n");
       return CanSILFunctionType();
     }
@@ -803,14 +804,14 @@ private:
       if (!Reconstructed) {
         llvm::errs() << "Failed to reconstruct type for " << Result << "\n";
         llvm::errs() << "Original type:\n";
-        Ty->dump();
+        Ty->dump(llvm::errs());
         abort();
       } else if (!Reconstructed->isEqual(Ty)) {
         llvm::errs() << "Incorrect reconstructed type for " << Result << "\n";
         llvm::errs() << "Original type:\n";
-        Ty->dump();
+        Ty->dump(llvm::errs());
         llvm::errs() << "Reconstructed type:\n";
-        Reconstructed->dump();
+        Reconstructed->dump(llvm::errs());
         abort();
       }
 #endif
@@ -1172,7 +1173,7 @@ private:
 
     if (!BaseTy) {
       LLVM_DEBUG(llvm::dbgs() << "Type without TypeBase: ";
-                 DbgTy.getType()->dump();
+                 DbgTy.getType()->dump(llvm::dbgs());
                  llvm::dbgs() << "\n");
       if (!InternalType) {
         StringRef Name = "<internal>";
@@ -1499,8 +1500,9 @@ private:
     case TypeKind::SILToken:
     case TypeKind::BuiltinUnsafeValueBuffer:
 
-      LLVM_DEBUG(llvm::errs() << "Unhandled type: "; DbgTy.getType()->dump();
-                 llvm::errs() << "\n");
+      LLVM_DEBUG(llvm::dbgs() << "Unhandled type: ";
+                 DbgTy.getType()->dump(llvm::dbgs());
+                 llvm::dbgs() << "\n");
       MangledName = "<unknown>";
     }
     return DBuilder.createBasicType(MangledName, SizeInBits, Encoding);

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2356,7 +2356,8 @@ void LoadableByAddress::runOnFunction(SILFunction *F) {
     rewrittenReturn = rewriteFunctionReturn(pass);
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "\nREWRITING: " << F->getName(); F->dump());
+  LLVM_DEBUG(llvm::dbgs() << "\nREWRITING: " << F->getName();
+             F->print(llvm::dbgs()));
 
   // Rewrite instructions relating to the loadable struct.
   rewriteFunction(pass, allocator);

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -491,7 +491,7 @@ SILModule::lookUpFunctionInWitnessTable(ProtocolConformanceRef C,
   if (!Ret) {
     LLVM_DEBUG(llvm::dbgs() << "        Failed speculative lookup of "
                "witness for: ";
-               C.dump(); Requirement.dump());
+               C.dump(llvm::dbgs()); Requirement.dump());
     return std::make_pair(nullptr, nullptr);
   }
 

--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -210,7 +210,7 @@ void SILOpenedArchetypesTracker::dump() const {
     auto Archetype = KV.first;
     auto Def = KV.second;
     llvm::dbgs() << "open archetype:\n";
-    Type(Archetype)->dump();
+    Type(Archetype)->dump(llvm::dbgs());
     llvm::dbgs() << "defined at: " << *Def << "\n";
   }
   llvm::dbgs() << "}\n";

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -71,7 +71,7 @@ public:
   void dump(SILGenFunction &SGF) const override {
     llvm::errs() << "IndirectOpenedSelfCleanup\n";
     if (box)
-      box->dump();
+      box->print(llvm::errs());
   }
 };
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -366,12 +366,12 @@ FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
                               << F->getName() << "\n";
                  llvm::dbgs() << "Interface params:\n";
                  for (auto Param : InterfaceParams) {
-                   Param.getInterfaceType().dump();
+                   Param.getInterfaceType().dump(llvm::dbgs());
                  }
 
                  llvm::dbgs() << "Interface results:\n";
                  for (auto Result : InterfaceResults) {
-                   Result.getInterfaceType().dump();
+                   Result.getInterfaceType().dump(llvm::dbgs());
                  });
     }
   }

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -353,7 +353,7 @@ computeNewArgInterfaceTypes(SILFunction *F, IndicesSet &PromotableIndices,
 
     LLVM_DEBUG(llvm::dbgs() << "Index: " << Index << "; PromotableIndices: "
                << (PromotableIndices.count(ArgIndex)?"yes":"no")
-               << " Param: "; param.dump());
+               << " Param: "; param.print(llvm::dbgs()));
 
     if (!PromotableIndices.count(ArgIndex)) {
       OutTys.push_back(param);

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -130,8 +130,7 @@ public:
   BBEnumTagDataflowState(const BBEnumTagDataflowState &Other) = default;
   ~BBEnumTagDataflowState() = default;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   bool init(EnumCaseDataflowContext &Context, SILBasicBlock *NewBB);
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -207,7 +207,7 @@ bool ConstraintSystem::PotentialBindings::isViable(
 }
 
 static bool hasNilLiteralConstraint(TypeVariableType *typeVar,
-                                    ConstraintSystem &CS) {
+                                    const ConstraintSystem &CS) {
   // Look for a literal-conformance constraint on the type variable.
   auto constraints =
       CS.getConstraintGraph().gatherConstraints(
@@ -230,7 +230,7 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
     PotentialBindings &result, Constraint *constraint,
     bool &hasDependentMemberRelationalConstraints,
     bool &hasNonDependentMemberRelationalConstraints,
-    bool &addOptionalSupertypeBindings) {
+    bool &addOptionalSupertypeBindings) const {
   assert(constraint->getClassification() ==
              ConstraintClassification::Relational &&
          "only relational constraints handled here");
@@ -378,7 +378,7 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
 /// representative type variable, along with flags indicating whether
 /// those types should be opened.
 ConstraintSystem::PotentialBindings
-ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
+ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
   assert(typeVar->getImpl().getRepresentative(nullptr) == typeVar &&
          "not a representative");
   assert(!typeVar->getImpl().getFixedType(nullptr) && "has a fixed type");
@@ -796,7 +796,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
 ///
 /// \returns the type to bind to, if the binding is okay.
 Optional<Type> ConstraintSystem::checkTypeOfBinding(TypeVariableType *typeVar,
-                                                    Type type) {
+                                                    Type type) const {
   // Simplify the type.
   type = simplifyType(type);
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -22,6 +22,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -241,9 +242,7 @@ public:
 
   void print(llvm::raw_ostream &Out) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const
-                              LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Retrieve anchor expression associated with this fix.
   /// NOTE: such anchor comes directly from locator without

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -90,30 +90,36 @@ OverloadCandidate::OverloadCandidate(ValueDecl *decl, bool skipCurriedSelf)
   }
 }
 
-void OverloadCandidate::dump() const {
+void OverloadCandidate::dump(llvm::raw_ostream &os) const {
   if (auto decl = getDecl())
-    decl->dumpRef(llvm::errs());
+    decl->dumpRef(os);
   else
-    llvm::errs() << "<<EXPR>>";
-  llvm::errs() << " - ignore curried self = " << (skipCurriedSelf ? "yes"
-                                                                  : "no");
+    os << "<<EXPR>>";
+  os << " - ignore curried self = " << (skipCurriedSelf ? "yes" : "no");
 
   if (auto FT = getFunctionType())
-    llvm::errs() << " - type: " << Type(FT) << "\n";
+    os << " - type: " << Type(FT) << "\n";
   else
-    llvm::errs() << " - type <<NONFUNCTION>>: " << entityType << "\n";
+    os << " - type <<NONFUNCTION>>: " << entityType << "\n";
 }
 
-void CalleeCandidateInfo::dump() const {
-  llvm::errs() << "CalleeCandidateInfo for '" << declName << "': closeness="
+void CalleeCandidateInfo::dump(llvm::raw_ostream &os) const {
+  os << "CalleeCandidateInfo for '" << declName << "': closeness="
   << unsigned(closeness) << "\n";
-  llvm::errs() << candidates.size() << " candidates:\n";
+  os << candidates.size() << " candidates:\n";
   for (auto c : candidates) {
-    llvm::errs() << "  ";
-    c.dump();
+    os << "  ";
+    c.dump(os);
   }
 }
 
+void OverloadCandidate::dump() const {
+  dump(llvm::errs());
+}
+
+void CalleeCandidateInfo::dump() const {
+  dump(llvm::errs());
+}
 
 /// Given a candidate list, this computes the narrowest closeness to the match
 /// we're looking for and filters out any worse matches.  The predicate

--- a/lib/Sema/CalleeCandidateInfo.h
+++ b/lib/Sema/CalleeCandidateInfo.h
@@ -20,6 +20,8 @@
 #ifndef SWIFT_SEMA_CALLEECANDIDATEINFO_H
 #define SWIFT_SEMA_CALLEECANDIDATEINFO_H
 
+#include "swift/Basic/Debug.h"
+
 namespace swift {
   
   using namespace constraints;
@@ -140,7 +142,8 @@ namespace swift {
       return Type();
     }
 
-    void dump() const LLVM_ATTRIBUTE_USED;
+    void dump(llvm::raw_ostream &os) const;
+    SWIFT_DEBUG_DUMP;
   };
 
   class CalleeCandidateInfo {
@@ -229,7 +232,8 @@ namespace swift {
     /// list.
     bool diagnoseSimpleErrors(const Expr *E);
     
-    void dump() const LLVM_ATTRIBUTE_USED;
+    void dump(llvm::raw_ostream &os) const;
+    SWIFT_DEBUG_DUMP;
     
   private:
     void collectCalleeCandidates(Expr *fnExpr, bool implicitDotSyntax);

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -23,6 +23,7 @@
 #include "swift/AST/FunctionRefKind.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/ADT/ilist_node.h"
@@ -642,13 +643,9 @@ public:
 
   void print(llvm::raw_ostream &Out, SourceManager *sm) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump(SourceManager *SM) const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMPER(dump(SourceManager *SM));
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump(ConstraintSystem *CS) const LLVM_ATTRIBUTE_USED,
-    "only for use within the debugger");
+  SWIFT_DEBUG_DUMPER(dump(ConstraintSystem *CS));
 
   void *operator new(size_t bytes, ConstraintSystem& cs,
                      size_t alignment = alignof(Constraint));

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1394,10 +1394,10 @@ void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent) {
   }
 }
 
-void ConstraintGraphNode::dump() {
+void ConstraintGraphNode::dump() const {
   llvm::SaveAndRestore<bool>
     debug(TypeVar->getASTContext().LangOpts.DebugConstraintSolver, true);
-  print(llvm::dbgs(), 0);
+  const_cast<ConstraintGraphNode*>(this)->print(llvm::dbgs(), 0);
 }
 
 void ConstraintGraph::print(ArrayRef<TypeVariableType *> typeVars,

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1319,7 +1319,7 @@ void ConstraintGraph::incrementConstraintsPerContractionCounter() {
 
 #pragma mark Debugging output
 
-void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent) {
+void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent) const {
   out.indent(indent);
   TypeVar->print(out);
   out << ":\n";
@@ -1351,7 +1351,7 @@ void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent) {
      out << ' ';
      adj->print(out);
 
-     auto &info = AdjacencyInfo[adj];
+     const auto info = AdjacencyInfo.lookup(adj);
      auto degree = info.NumConstraints;
      if (degree > 1) {
        out << " (" << degree << ")";
@@ -1397,7 +1397,7 @@ void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent) {
 void ConstraintGraphNode::dump() const {
   llvm::SaveAndRestore<bool>
     debug(TypeVar->getASTContext().LangOpts.DebugConstraintSolver, true);
-  const_cast<ConstraintGraphNode*>(this)->print(llvm::dbgs(), 0);
+  print(llvm::dbgs(), 0);
 }
 
 void ConstraintGraph::print(ArrayRef<TypeVariableType *> typeVars,

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -160,7 +160,7 @@ private:
   mutable SmallVector<TypeVariableType *, 2> EquivalenceClass;
 
   /// Print this graph node.
-  void print(llvm::raw_ostream &out, unsigned indent);
+  void print(llvm::raw_ostream &out, unsigned indent) const;
 
   SWIFT_DEBUG_DUMP;
 

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SEMA_CONSTRAINT_GRAPH_H
 #define SWIFT_SEMA_CONSTRAINT_GRAPH_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
@@ -161,8 +162,7 @@ private:
   /// Print this graph node.
   void print(llvm::raw_ostream &out, unsigned indent);
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Verify the invariants of this node within the given constraint graph.
   void verify(ConstraintGraph &cg);
@@ -333,15 +333,15 @@ public:
   void print(ArrayRef<TypeVariableType *> typeVars, llvm::raw_ostream &out);
   void dump(llvm::raw_ostream &out);
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  // FIXME: Potentially side-effectful.
+  SWIFT_DEBUG_HELPER(void dump());
 
   /// Print the connected components of the graph.
   void printConnectedComponents(ArrayRef<TypeVariableType *> typeVars,
                                 llvm::raw_ostream &out);
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dumpConnectedComponents() LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  // FIXME: Potentially side-effectful.
+  SWIFT_DEBUG_HELPER(void dumpConnectedComponents());
 
   /// Verify the invariants of the graph.
   void verify();

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -243,18 +243,18 @@ GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
   return castLastElementTo<LocatorPathElt::GenericParameter>().getType();
 }
 
-void ConstraintLocator::dump(SourceManager *sm) {
+void ConstraintLocator::dump(SourceManager *sm) const {
   dump(sm, llvm::errs());
   llvm::errs() << "\n";
 }
 
-void ConstraintLocator::dump(ConstraintSystem *CS) {
+void ConstraintLocator::dump(ConstraintSystem *CS) const {
   dump(&CS->TC.Context.SourceMgr, llvm::errs());
   llvm::errs() << "\n";
 }
 
 
-void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
+void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
   out << "locator@" << (void*) this << " [";
 
   if (anchor) {

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_SEMA_CONSTRAINTLOCATOR_H
 #define SWIFT_SEMA_CONSTRAINTLOCATOR_H
 
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
@@ -491,14 +492,10 @@ public:
   }
   
   /// Produce a debugging dump of this locator.
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump(SourceManager *SM) LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump(ConstraintSystem *CS) LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMPER(dump(SourceManager *SM));
+  SWIFT_DEBUG_DUMPER(dump(ConstraintSystem *CS));
 
-  void dump(SourceManager *SM, raw_ostream &OS) LLVM_ATTRIBUTE_USED;
+  void dump(SourceManager *SM, raw_ostream &OS) const LLVM_ATTRIBUTE_USED;
 
 private:
   /// Initialize a constraint locator with an anchor and a path.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -746,7 +746,7 @@ bool ConstraintSystem::isAnyHashableType(Type type) {
 
 Type ConstraintSystem::getFixedTypeRecursive(Type type,
                                              TypeMatchOptions &flags,
-                                             bool wantRValue) {
+                                             bool wantRValue) const {
 
   if (wantRValue)
     type = type->getRValueType();
@@ -2259,7 +2259,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
 }
 
 template <typename Fn>
-Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
+Type simplifyTypeImpl(const ConstraintSystem &cs, Type type,
+                      Fn getFixedTypeFn) {
   return type.transform([&](Type type) -> Type {
     if (auto tvt = dyn_cast<TypeVariableType>(type.getPointer()))
       return getFixedTypeFn(tvt);
@@ -2305,7 +2306,7 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
   });
 }
 
-Type ConstraintSystem::simplifyType(Type type) {
+Type ConstraintSystem::simplifyType(Type type) const {
   if (!type->hasTypeVariable())
     return type;
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -31,6 +31,7 @@
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/TypeCheckerDebugConsumer.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptionSet.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -740,9 +741,7 @@ public:
     return None;
   }
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() const LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
 
   /// Dump this solution.
   void dump(raw_ostream &OS) const LLVM_ATTRIBUTE_USED;
@@ -2456,7 +2455,7 @@ public:
 
   /// Retrieve the fixed type corresponding to the given type variable,
   /// or a null type if there is no fixed type.
-  Type getFixedType(TypeVariableType *typeVar) {
+  Type getFixedType(TypeVariableType *typeVar) const {
     return typeVar->getImpl().getFixedType(getSavedBindings());
   }
 
@@ -3803,8 +3802,7 @@ public:
       return LiteralProtocols;
     }
 
-    LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
-                              "only for use within the debugger");
+    SWIFT_DEBUG_DUMP;
   };
 
   bool haveTypeInformationForAllArguments(FunctionType *fnType);
@@ -3835,11 +3833,8 @@ public:
                             SmallVectorImpl<unsigned> &Ordering,
                             SmallVectorImpl<unsigned> &PartitionBeginning);
 
-  LLVM_ATTRIBUTE_DEPRECATED(
-      void dump() LLVM_ATTRIBUTE_USED,
-      "only for use within the debugger");
-  LLVM_ATTRIBUTE_DEPRECATED(void dump(Expr *) LLVM_ATTRIBUTE_USED,
-                            "only for use within the debugger");
+  SWIFT_DEBUG_DUMP;
+  SWIFT_DEBUG_DUMPER(dump(Expr *));
 
   void print(raw_ostream &out);
   void print(raw_ostream &out, Expr *);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2360,7 +2360,7 @@ public:
 
   /// Retrieve the representative of the equivalence class containing
   /// this type variable.
-  TypeVariableType *getRepresentative(TypeVariableType *typeVar) {
+  TypeVariableType *getRepresentative(TypeVariableType *typeVar) const {
     return typeVar->getImpl().getRepresentative(getSavedBindings());
   }
 
@@ -2467,7 +2467,7 @@ public:
   ///
   /// \param wantRValue Whether this routine should look through
   /// lvalues at each step.
-  Type getFixedTypeRecursive(Type type, bool wantRValue) {
+  Type getFixedTypeRecursive(Type type, bool wantRValue) const {
     TypeMatchOptions flags = None;
     return getFixedTypeRecursive(type, flags, wantRValue);
   }
@@ -2485,7 +2485,7 @@ public:
   /// \param wantRValue Whether this routine should look through
   /// lvalues at each step.
   Type getFixedTypeRecursive(Type type, TypeMatchOptions &flags,
-                             bool wantRValue);
+                             bool wantRValue) const;
 
   /// Determine whether the given type variable occurs within the given type.
   ///
@@ -3027,7 +3027,7 @@ public:
   ///
   /// The resulting types can be compared canonically, so long as additional
   /// type equivalence requirements aren't introduced between comparisons.
-  Type simplifyType(Type type);
+  Type simplifyType(Type type) const;
 
   /// Simplify a type, by replacing type variables with either their
   /// fixed types (if available) or their representatives.
@@ -3478,15 +3478,15 @@ private:
     }
   };
 
-  Optional<Type> checkTypeOfBinding(TypeVariableType *typeVar, Type type);
+  Optional<Type> checkTypeOfBinding(TypeVariableType *typeVar, Type type) const;
   Optional<PotentialBindings> determineBestBindings();
   Optional<ConstraintSystem::PotentialBinding>
   getPotentialBindingForRelationalConstraint(
       PotentialBindings &result, Constraint *constraint,
       bool &hasDependentMemberRelationalConstraints,
       bool &hasNonDependentMemberRelationalConstraints,
-      bool &addOptionalSupertypeBindings);
-  PotentialBindings getPotentialBindings(TypeVariableType *typeVar);
+      bool &addOptionalSupertypeBindings) const;
+  PotentialBindings getPotentialBindings(TypeVariableType *typeVar) const;
 
 private:
   /// Add a constraint to the constraint system.
@@ -3836,8 +3836,8 @@ public:
   SWIFT_DEBUG_DUMP;
   SWIFT_DEBUG_DUMPER(dump(Expr *));
 
-  void print(raw_ostream &out);
-  void print(raw_ostream &out, Expr *);
+  void print(raw_ostream &out) const;
+  void print(raw_ostream &out, Expr *) const;
 };
 
 /// Compute the shuffle required to map from a given tuple type to

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeChecker.h"
+#include "swift/Basic/Debug.h"
 
 using namespace swift;
 
@@ -72,7 +73,7 @@ struct PathElement {
   size_t TupleIndex;
   Type Ty;
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void print(llvm::raw_ostream &out) const;
 };
 
@@ -87,7 +88,7 @@ public:
   const PathElement &operator[](size_t index) const { return Elements[index]; }
   const PathElement &back() const { return Elements.back(); }
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void printCycle(llvm::raw_ostream &out, size_t cycleIndex) const;
   void printInfinite(llvm::raw_ostream &out) const;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3618,14 +3618,14 @@ void Solution::dump(raw_ostream &out) const {
 }
 
 void ConstraintSystem::dump() const {
-  const_cast<ConstraintSystem*>(this)->print(llvm::errs());
+  print(llvm::errs());
 }
 
 void ConstraintSystem::dump(Expr *E) const {
-  const_cast<ConstraintSystem*>(this)->print(llvm::errs(), E);
+  print(llvm::errs(), E);
 }
 
-void ConstraintSystem::print(raw_ostream &out, Expr *E) {
+void ConstraintSystem::print(raw_ostream &out, Expr *E) const {
   auto getTypeOfExpr = [&](const Expr *E) -> Type {
     if (hasType(E))
       return getType(E);
@@ -3646,7 +3646,7 @@ void ConstraintSystem::print(raw_ostream &out, Expr *E) {
   E->dump(out, getTypeOfExpr, getTypeOfTypeLoc, getTypeOfKeyPathComponent);
 }
 
-void ConstraintSystem::print(raw_ostream &out) {
+void ConstraintSystem::print(raw_ostream &out) const {
   // Print all type variables as $T0 instead of _ here.
   llvm::SaveAndRestore<bool> X(getASTContext().LangOpts.DebugConstraintSolver,
                                true);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3617,12 +3617,12 @@ void Solution::dump(raw_ostream &out) const {
   }
 }
 
-void ConstraintSystem::dump() {
-  print(llvm::errs());
+void ConstraintSystem::dump() const {
+  const_cast<ConstraintSystem*>(this)->print(llvm::errs());
 }
 
-void ConstraintSystem::dump(Expr *E) {
-  print(llvm::errs(), E);
+void ConstraintSystem::dump(Expr *E) const {
+  const_cast<ConstraintSystem*>(this)->print(llvm::errs(), E);
 }
 
 void ConstraintSystem::print(raw_ostream &out, Expr *E) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4865,8 +4865,8 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     // Now that they're filled out, print out information about the conformances
     // here, when requested.
     for (auto conformance : conformances) {
-      dc->dumpContext();
-      conformance->dump();
+      dc->printContext(llvm::errs());
+      conformance->dump(llvm::errs());
     }
   }
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -24,6 +24,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/Witness.h"
+#include "swift/Basic/Debug.h"
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -115,8 +116,7 @@ struct InferredAssociatedTypesByWitness {
 
   void dump(llvm::raw_ostream &out, unsigned indent) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
-                            "only for use in the debugger");
+  SWIFT_DEBUG_DUMP;
 };
 
 /// The set of witnesses that were considered when attempting to

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -86,10 +86,10 @@ void InferredTypeWitnessesSolution::dump() const {
     auto &valueWitness = ValueWitnesses[i];
     llvm::errs() << i << ":  " << (Decl*)valueWitness.first
     << ' ' << valueWitness.first->getBaseName() << '\n';
-    valueWitness.first->getDeclContext()->dumpContext();
+    valueWitness.first->getDeclContext()->printContext(llvm::errs());
     llvm::errs() << "    for " << (Decl*)valueWitness.second
     << ' ' << valueWitness.second->getBaseName() << '\n';
-    valueWitness.second->getDeclContext()->dumpContext();
+    valueWitness.second->getDeclContext()->printContext(llvm::errs());
   }
 }
 

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Pattern.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/STLExtras.h"
 
 #include "swift/Basic/APIntMap.h"
@@ -242,7 +243,7 @@ namespace {
 
       SpaceKind getKind() const { return Kind; }
 
-      void dump() const LLVM_ATTRIBUTE_USED;
+      SWIFT_DEBUG_DUMP;
 
       size_t getSize(TypeChecker &TC, const DeclContext *DC) const {
         SmallPtrSet<TypeBase *, 4> cache;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2786,8 +2786,8 @@ public:
     if (paramTy->hasError()) {
       // FIXME: This should never happen, because we don't serialize
       // error types.
-      DC->dumpContext();
-      paramTy->dump();
+      DC->printContext(llvm::errs());
+      paramTy->dump(llvm::errs());
       MF.fatal();
     }
 
@@ -5132,7 +5132,7 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
 #ifndef NDEBUG
   PrettyStackTraceType trace(getContext(), "deserializing", typeOrOffset.get());
   if (typeOrOffset.get()->hasError()) {
-    typeOrOffset.get()->dump();
+    typeOrOffset.get()->dump(llvm::errs());
     llvm_unreachable("deserialization produced an invalid type "
                      "(rdar://problem/30382791)");
   }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3188,8 +3188,8 @@ public:
         defaultArgumentText);
 
     if (interfaceType->hasError()) {
-      param->getDeclContext()->dumpContext();
-      interfaceType->dump();
+      param->getDeclContext()->printContext(llvm::errs());
+      interfaceType->dump(llvm::errs());
       llvm_unreachable("error in interface type of parameter");
     }
   }

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -325,6 +325,10 @@ void AbsolutePosition::dump(llvm::raw_ostream &OS) const {
   OS << ')';
 }
 
+void AbsolutePosition::dump() const {
+  dump(llvm::errs());
+}
+
 void RawSyntax::Profile(llvm::FoldingSetNodeID &ID, tok TokKind,
                         OwnedString Text, ArrayRef<TriviaPiece> LeadingTrivia,
                         ArrayRef<TriviaPiece> TrailingTrivia) {


### PR DESCRIPTION
By convention, most structs and classes in the Swift compiler include a `dump()` method which prints debugging information. This method is meant to be called only from the debugger, but this means they’re often unused and may be eliminated from optimized binaries. On the other hand, some parts of the compiler call `dump()` methods directly despite them being intended as a pure debugging aid. clang supports attributes which can be used to avoid these problems, but they’re used very inconsistently across the compiler.

This commit adds `SWIFT_DEBUG_DUMP` and `SWIFT_DEBUG_DUMPER(<name>(<params>))` macros to declare `dump()` methods with the appropriate set of attributes and adopts this macro throughout the frontend. It does not pervasively adopt this macro in SILGen, SILOptimizer, or IRGen; these components use `dump()` methods in a different way where they’re frequently called from debugging code. Nor does it adopt it in runtime components like swiftRuntime and swiftReflection, because I’m a bit worried about size.

Despite the large number of files and lines affected, this change is NFC.