### PR TITLE
test: use `inferSwiftBinary` to find the reflection tool

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1594,8 +1594,7 @@ config.substitutions.append(('%target-swift-ide-test\(mock-sdk:([^)]+)\)',
 config.substitutions.append(('%target-swift-ide-test', "%s -swift-version %s" % (config.target_swift_ide_test, swift_version)))
 
 if not hasattr(config, 'target_swift_reflection_test'):
-    config.target_swift_reflection_test = lit.util.which(
-        swift_reflection_test_name, config.environment['PATH'])
+    config.target_swift_reflection_test = inferSwiftBinary(swift_reflection_test_name)
 
 config.substitutions.append(('%target-swift-reflection-test', config.target_swift_reflection_test))
 


### PR DESCRIPTION
We would previously search for it in the path rather than the build
tree.  This should identify where the tool is being used from, provide
the just built tool, and still allow the user to change the tool path by
an environment variable.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
