### PR TITLE
[Runtime] Fix guards around _swift_isBackDeploying call in SwiftObject.mm.

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -160,6 +160,7 @@
 # else
 #  define SWIFT_CLASS_IS_SWIFT_MASK _swift_classIsSwiftMask
 #  define SWIFT_CLASS_IS_SWIFT_MASK_GLOBAL_VARIABLE 1
+#  define SWIFT_BUILD_HAS_BACK_DEPLOYMENT 1
 #  include "BackDeployment.h"
 
 # endif

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -201,7 +201,10 @@ static id _getClassDescription(Class cls) {
   // runs on older OSes in certain testing scenarios, so that doesn't matter.
   // Only perform the check on newer OSes where the value should definitely
   // match.
-  if (!_swift_isBackDeploying()) {
+#  if SWIFT_BUILD_HAS_BACK_DEPLOYMENT
+  if (!_swift_isBackDeploying())
+#  endif
+  {
     assert(&objc_debug_isa_class_mask);
     assert(objc_debug_isa_class_mask == SWIFT_ISA_MASK);
   }


### PR DESCRIPTION
This could fail to build due to BackDeployment.h not always being included in Config.h. Check an additional condition to ensure that this code is only active when BackDeployment.h is included.

rdar://problem/56735154