### PR TITLE
[NFC] Squash Out Some More TypeChecker Dependencies

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6827,7 +6827,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, ConcreteDeclRef callee,
     = [&](ApplyExpr *apply,
           ConcreteDeclRef declRef,
           Type openedType) -> Expr* {
-      switch (cs.TC.getDeclTypeCheckingSemantics(declRef.getDecl())) {
+      switch (TypeChecker::getDeclTypeCheckingSemantics(declRef.getDecl())) {
       case DeclTypeCheckingSemantics::TypeOf: {
         // Resolve into a DynamicTypeExpr.
         auto arg = apply->getArg();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -272,7 +272,7 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
 static Expr *buildDynamicMemberLookupIndexExpr(StringRef name, SourceLoc loc,
                                                DeclContext *dc,
                                                ConstraintSystem &cs) {
-  auto &ctx = cs.TC.Context;
+  auto &ctx = cs.getASTContext();
 
   auto *stringDecl = ctx.getStringDecl();
   auto stringType = stringDecl->getDeclaredType();
@@ -4584,7 +4584,7 @@ namespace {
       auto dc = subscript->getInnermostDeclContext();
 
       auto indexType = AnyFunctionType::composeInput(
-          cs.TC.Context,
+          cs.getASTContext(),
           subscript->getInterfaceType()->castTo<AnyFunctionType>()->getParams(),
           /*canonicalVararg=*/false);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2494,10 +2494,9 @@ namespace {
           auto baseTyNominalDecl = baseTyUnwrapped
                                    ->getNominalOrBoundGenericNominal();
           auto &tc = cs.getTypeChecker();
-          auto results = tc.lookupMember(baseTyNominalDecl->getModuleContext(),
-                                         baseTyUnwrapped,
-                                         memberName,
-                                         defaultMemberLookupOptions);
+          auto results = TypeChecker::lookupMember(
+              baseTyNominalDecl->getModuleContext(), baseTyUnwrapped,
+              memberName, defaultMemberLookupOptions);
 
           // Filter out any functions, instance members, enum cases with
           // associated values or variables whose type does not match the

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1837,12 +1837,12 @@ namespace {
         return expr;
 
       auto &tc = cs.getTypeChecker();
-      ProtocolDecl *protocol
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByIntegerLiteral);
-      ProtocolDecl *builtinProtocol
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByBuiltinIntegerLiteral);
+      ProtocolDecl *protocol = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByIntegerLiteral);
+      ProtocolDecl *builtinProtocol = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByBuiltinIntegerLiteral);
 
       // For type-sugar reasons, prefer the spelling of the default literal
       // type.
@@ -1851,9 +1851,9 @@ namespace {
         if (defaultType->isEqual(type))
           type = defaultType;
       }
-      if (auto floatProtocol
-            = tc.getProtocol(expr->getLoc(),
-                             KnownProtocolKind::ExpressibleByFloatLiteral)) {
+      if (auto floatProtocol = TypeChecker::getProtocol(
+              cs.getASTContext(), expr->getLoc(),
+              KnownProtocolKind::ExpressibleByFloatLiteral)) {
         if (auto defaultFloatType = tc.getDefaultType(floatProtocol, dc)) {
           if (defaultFloatType->isEqual(type))
             type = defaultFloatType;
@@ -1888,8 +1888,9 @@ namespace {
       }
 
       auto &tc = cs.getTypeChecker();
-      auto *protocol = tc.getProtocol(expr->getLoc(),
-                                      KnownProtocolKind::ExpressibleByNilLiteral);
+      auto *protocol =
+          TypeChecker::getProtocol(cs.getASTContext(), expr->getLoc(),
+                                   KnownProtocolKind::ExpressibleByNilLiteral);
 
       // For type-sugar reasons, prefer the spelling of the default literal
       // type.
@@ -1920,12 +1921,12 @@ namespace {
         return expr;
 
       auto &tc = cs.getTypeChecker();
-      ProtocolDecl *protocol
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByFloatLiteral);
-      ProtocolDecl *builtinProtocol
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByBuiltinFloatLiteral);
+      ProtocolDecl *protocol = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByFloatLiteral);
+      ProtocolDecl *builtinProtocol = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByBuiltinFloatLiteral);
 
       // For type-sugar reasons, prefer the spelling of the default literal
       // type.
@@ -1964,12 +1965,12 @@ namespace {
         return expr;
 
       auto &tc = cs.getTypeChecker();
-      ProtocolDecl *protocol
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByBooleanLiteral);
-      ProtocolDecl *builtinProtocol
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByBuiltinBooleanLiteral);
+      ProtocolDecl *protocol = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByBooleanLiteral);
+      ProtocolDecl *builtinProtocol = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByBuiltinBooleanLiteral);
       if (!protocol || !builtinProtocol)
         return nullptr;
 
@@ -2001,15 +2002,16 @@ namespace {
 
       bool isStringLiteral = true;
       bool isGraphemeClusterLiteral = false;
-      ProtocolDecl *protocol = tc.getProtocol(
-          expr->getLoc(), KnownProtocolKind::ExpressibleByStringLiteral);
+      ProtocolDecl *protocol = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByStringLiteral);
 
       if (!TypeChecker::conformsToProtocol(
               type, protocol, cs.DC, ConformanceCheckFlags::InExpression)) {
         // If the type does not conform to ExpressibleByStringLiteral, it should
         // be ExpressibleByExtendedGraphemeClusterLiteral.
-        protocol = tc.getProtocol(
-            expr->getLoc(),
+        protocol = TypeChecker::getProtocol(
+            cs.getASTContext(), expr->getLoc(),
             KnownProtocolKind::ExpressibleByExtendedGraphemeClusterLiteral);
         isStringLiteral = false;
         isGraphemeClusterLiteral = true;
@@ -2017,8 +2019,8 @@ namespace {
       if (!TypeChecker::conformsToProtocol(
               type, protocol, cs.DC, ConformanceCheckFlags::InExpression)) {
         // ... or it should be ExpressibleByUnicodeScalarLiteral.
-        protocol = tc.getProtocol(
-            expr->getLoc(),
+        protocol = TypeChecker::getProtocol(
+            cs.getASTContext(), expr->getLoc(),
             KnownProtocolKind::ExpressibleByUnicodeScalarLiteral);
         isStringLiteral = false;
         isGraphemeClusterLiteral = false;
@@ -2044,8 +2046,8 @@ namespace {
         literalFuncName = DeclName(tc.Context, DeclBaseName::createConstructor(),
                                    { tc.Context.Id_stringLiteral });
 
-        builtinProtocol = tc.getProtocol(
-            expr->getLoc(),
+        builtinProtocol = TypeChecker::getProtocol(
+            cs.getASTContext(), expr->getLoc(),
             KnownProtocolKind::ExpressibleByBuiltinStringLiteral);
         builtinLiteralFuncName
           = DeclName(tc.Context, DeclBaseName::createConstructor(),
@@ -2070,9 +2072,10 @@ namespace {
                        tc.Context.getIdentifier("utf8CodeUnitCount"),
                        tc.Context.getIdentifier("isASCII") });
 
-        builtinProtocol = tc.getProtocol(
-            expr->getLoc(),
-            KnownProtocolKind::ExpressibleByBuiltinExtendedGraphemeClusterLiteral);
+        builtinProtocol = TypeChecker::getProtocol(
+            cs.getASTContext(), expr->getLoc(),
+            KnownProtocolKind::
+                ExpressibleByBuiltinExtendedGraphemeClusterLiteral);
         brokenProtocolDiag =
             diag::extended_grapheme_cluster_literal_broken_proto;
         brokenBuiltinProtocolDiag =
@@ -2088,8 +2091,8 @@ namespace {
           = DeclName(tc.Context, DeclBaseName::createConstructor(),
                      {tc.Context.Id_builtinUnicodeScalarLiteral});
 
-        builtinProtocol = tc.getProtocol(
-            expr->getLoc(),
+        builtinProtocol = TypeChecker::getProtocol(
+            cs.getASTContext(), expr->getLoc(),
             KnownProtocolKind::ExpressibleByBuiltinUnicodeScalarLiteral);
 
         brokenProtocolDiag = diag::unicode_scalar_literal_broken_proto;
@@ -2125,10 +2128,10 @@ namespace {
       auto loc = expr->getStartLoc();
 
       auto fetchProtocolInitWitness =
-        [&](KnownProtocolKind protocolKind, Type type,
-            ArrayRef<Identifier> argLabels) -> ConcreteDeclRef {
-
-        auto proto = tc.getProtocol(loc, protocolKind);
+          [&](KnownProtocolKind protocolKind, Type type,
+              ArrayRef<Identifier> argLabels) -> ConcreteDeclRef {
+        auto proto =
+            TypeChecker::getProtocol(cs.getASTContext(), loc, protocolKind);
         assert(proto && "Missing string interpolation protocol?");
 
         auto conformance =
@@ -2145,9 +2148,9 @@ namespace {
         return witness;
       };
 
-      auto *interpolationProto = 
-        tc.getProtocol(expr->getLoc(),
-             KnownProtocolKind::ExpressibleByStringInterpolation);
+      auto *interpolationProto = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByStringInterpolation);
       auto associatedTypeDecl = interpolationProto->getAssociatedType(
           tc.Context.Id_StringInterpolation);
       if (associatedTypeDecl == nullptr) {
@@ -2235,7 +2238,7 @@ namespace {
       }
 
       // Find the appropriate object literal protocol.
-      auto proto = tc.getLiteralProtocol(expr);
+      auto proto = TypeChecker::getLiteralProtocol(cs.getASTContext(), expr);
       assert(proto && "Missing object literal protocol?");
       auto conformance =
         TypeChecker::conformsToProtocol(conformingType, proto, cs.DC,
@@ -2891,9 +2894,9 @@ namespace {
       Type arrayTy = cs.getType(expr);
       auto &tc = cs.getTypeChecker();
 
-      ProtocolDecl *arrayProto
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByArrayLiteral);
+      ProtocolDecl *arrayProto = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByArrayLiteral);
       assert(arrayProto && "type-checked array literal w/o protocol?!");
 
       auto conformance =
@@ -2937,9 +2940,9 @@ namespace {
       Type dictionaryTy = cs.getType(expr);
 
       auto &tc = cs.getTypeChecker();
-      ProtocolDecl *dictionaryProto
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByDictionaryLiteral);
+      ProtocolDecl *dictionaryProto = TypeChecker::getProtocol(
+          cs.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByDictionaryLiteral);
 
       auto conformance =
         TypeChecker::conformsToProtocol(dictionaryTy, dictionaryProto, cs.DC,
@@ -6772,8 +6775,8 @@ ExprRewriter::finishApplyDynamicCallable(ApplyExpr *apply,
     auto dictLitProto =
         ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
     auto conformance =
-        cs.TC.conformsToProtocol(argumentType, dictLitProto, cs.DC,
-                                 ConformanceCheckFlags::InExpression);
+        TypeChecker::conformsToProtocol(argumentType, dictLitProto, cs.DC,
+                                        ConformanceCheckFlags::InExpression);
     auto keyType = conformance.getTypeWitnessByName(argumentType, ctx.Id_Key);
     auto valueType =
         conformance.getTypeWitnessByName(argumentType, ctx.Id_Value);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -85,7 +85,7 @@ ConstraintSystem::determineBestBindings() {
       }
     }
 
-    if (TC.getLangOpts().DebugConstraintSolver) {
+    if (getASTContext().LangOpts.DebugConstraintSolver) {
       auto &log = getASTContext().TypeCheckerDebug->getStream();
       bindings.dump(typeVar, log, solverState->depth * 2);
     }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -811,7 +811,7 @@ bool FailureDiagnosis::diagnoseGeneralConversionFailure(Constraint *constraint){
   // tries to add a specific diagnosis/fixit to explicitly invoke 'boolValue'.
   if (toType->isBool() &&
       fromType->mayHaveMembers()) {
-    auto LookupResult = CS.TC.lookupMember(
+    auto LookupResult = TypeChecker::lookupMember(
         CS.DC, fromType, DeclName(CS.TC.Context.getIdentifier("boolValue")));
     if (!LookupResult.empty()) {
       if (isa<VarDecl>(LookupResult.begin()->getValueDecl())) {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1741,7 +1741,8 @@ static void emitFixItForExplicitlyQualifiedReference(
 
 void ConstraintSystem::diagnoseDeprecatedConditionalConformanceOuterAccess(
     UnresolvedDotExpr *UDE, ValueDecl *choice) {
-  auto result = TC.lookupUnqualified(DC, UDE->getName(), UDE->getLoc());
+  auto result =
+      TypeChecker::lookupUnqualified(DC, UDE->getName(), UDE->getLoc());
   assert(result && "names can't just disappear");
   // These should all come from the same place.
   auto exampleInner = result.front();
@@ -1940,7 +1941,8 @@ bool FailureDiagnosis::diagnoseImplicitSelfErrors(
   // For each of the parent contexts, let's try to find any candidates
   // which have the same name and the same number of arguments as callee.
   while (context->getParent()) {
-    auto result = TC.lookupUnqualified(context, UDE->getName(), UDE->getLoc());
+    auto result =
+        TypeChecker::lookupUnqualified(context, UDE->getName(), UDE->getLoc());
     context = context->getParent();
 
     if (!result || result.empty())

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -812,7 +812,8 @@ bool FailureDiagnosis::diagnoseGeneralConversionFailure(Constraint *constraint){
   if (toType->isBool() &&
       fromType->mayHaveMembers()) {
     auto LookupResult = TypeChecker::lookupMember(
-        CS.DC, fromType, DeclName(CS.TC.Context.getIdentifier("boolValue")));
+        CS.DC, fromType,
+        DeclName(CS.getASTContext().getIdentifier("boolValue")));
     if (!LookupResult.empty()) {
       if (isa<VarDecl>(LookupResult.begin()->getValueDecl())) {
         if (anchor->canAppendPostfixExpression())
@@ -4151,7 +4152,8 @@ bool FailureDiagnosis::diagnoseMemberFailures(
 
   // Since the lookup was allowing inaccessible members, let's check
   // if it found anything of that sort, which is easy to diagnose.
-  bool allUnavailable = !CS.TC.getLangOpts().DisableAvailabilityChecking;
+  bool allUnavailable =
+      !CS.getASTContext().LangOpts.DisableAvailabilityChecking;
   bool allInaccessible = true;
   for (auto &member : viableCandidatesToReport) {
     if (!member.isDecl()) {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3663,7 +3663,8 @@ bool FailureDiagnosis::visitArrayExpr(ArrayExpr *E) {
 
   // Validate that the contextual type conforms to ExpressibleByArrayLiteral and
   // figure out what the contextual element type is in place.
-  auto ALC = CS.TC.getProtocol(E->getLoc(),
+  auto ALC =
+      TypeChecker::getProtocol(CS.getASTContext(), E->getLoc(),
                                KnownProtocolKind::ExpressibleByArrayLiteral);
   if (!ALC)
     return visitExpr(E);
@@ -3713,8 +3714,9 @@ bool FailureDiagnosis::visitDictionaryExpr(DictionaryExpr *E) {
     // surely initializing whatever is inside.
     contextualType = contextualType->lookThroughAllOptionalTypes();
 
-    auto DLC = CS.TC.getProtocol(
-        E->getLoc(), KnownProtocolKind::ExpressibleByDictionaryLiteral);
+    auto DLC = TypeChecker::getProtocol(
+        CS.getASTContext(), E->getLoc(),
+        KnownProtocolKind::ExpressibleByDictionaryLiteral);
     if (!DLC) return visitExpr(E);
 
     // Validate the contextual type conforms to ExpressibleByDictionaryLiteral
@@ -3774,7 +3776,7 @@ bool FailureDiagnosis::visitObjectLiteralExpr(ObjectLiteralExpr *E) {
   auto &TC = CS.getTypeChecker();
 
   // Type check the argument first.
-  auto protocol = TC.getLiteralProtocol(E);
+  auto protocol = TypeChecker::getLiteralProtocol(CS.getASTContext(), E);
   if (!protocol)
     return false;
   DeclName constrName = TC.getObjectLiteralConstructorName(E);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2613,8 +2613,7 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
   // Let's build a list of protocols that the context does not conform to.
   SmallVector<std::string, 8> missingProtoTypeStrings;
   for (auto protocol : layout.getProtocols()) {
-    if (getTypeChecker()
-            .conformsToProtocol(FromType, protocol->getDecl(), getDC(),
+    if (TypeChecker::conformsToProtocol(FromType, protocol->getDecl(), getDC(),
                                 ConformanceCheckFlags::InExpression)
             .isInvalid()) {
       missingProtoTypeStrings.push_back(protocol->getString());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2613,9 +2613,8 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
   // Let's build a list of protocols that the context does not conform to.
   SmallVector<std::string, 8> missingProtoTypeStrings;
   for (auto protocol : layout.getProtocols()) {
-    if (TypeChecker::conformsToProtocol(FromType, protocol->getDecl(), getDC(),
-                                ConformanceCheckFlags::InExpression)
-            .isInvalid()) {
+    if (!TypeChecker::conformsToProtocol(FromType, protocol->getDecl(), getDC(),
+                                         ConformanceCheckFlags::InExpression)) {
       missingProtoTypeStrings.push_back(protocol->getString());
     }
   }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1708,8 +1708,7 @@ namespace {
         CS.addConstraint(ConstraintKind::Conversion,
                          CS.getType(expr->getSubExpr()), optTy,
                          CS.getConstraintLocator(expr));
-      }
-      else {
+      } else {
         CS.addConstraint(ConstraintKind::OptionalObject,
                          optTy, CS.getType(expr->getSubExpr()),
                          CS.getConstraintLocator(expr));

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -478,9 +478,8 @@ namespace {
     }    
     
     if (lti.haveFloatLiteral) {
-      if (auto floatProto =
-            CS.TC.Context.getProtocol(
-                                  KnownProtocolKind::ExpressibleByFloatLiteral)) {
+      if (auto floatProto = CS.getASTContext().getProtocol(
+              KnownProtocolKind::ExpressibleByFloatLiteral)) {
         if (auto defaultType = CS.TC.getDefaultType(floatProto, CS.DC)) {
           if (!CS.getFavoredType(expr)) {
             CS.setFavoredType(expr, defaultType.getPointer());
@@ -491,9 +490,8 @@ namespace {
     }
     
     if (lti.haveIntLiteral) {
-      if (auto intProto =
-            CS.TC.Context.getProtocol(
-                                KnownProtocolKind::ExpressibleByIntegerLiteral)) {
+      if (auto intProto = CS.getASTContext().getProtocol(
+              KnownProtocolKind::ExpressibleByIntegerLiteral)) {
         if (auto defaultType = CS.TC.getDefaultType(intProto, CS.DC)) {
           if (!CS.getFavoredType(expr)) {
             CS.setFavoredType(expr, defaultType.getPointer());
@@ -504,9 +502,8 @@ namespace {
     }
     
     if (lti.haveStringLiteral) {
-      if (auto stringProto =
-          CS.TC.Context.getProtocol(
-                                KnownProtocolKind::ExpressibleByStringLiteral)) {
+      if (auto stringProto = CS.getASTContext().getProtocol(
+              KnownProtocolKind::ExpressibleByStringLiteral)) {
         if (auto defaultType = CS.TC.getDefaultType(stringProto, CS.DC)) {
           if (!CS.getFavoredType(expr)) {
             CS.setFavoredType(expr, defaultType.getPointer());
@@ -1387,7 +1384,8 @@ namespace {
       TypeResolutionOptions options(TypeResolverContext::InExpression);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
       bool hadError = TypeChecker::validateType(
-          CS.TC.Context, loc, TypeResolution::forContextual(CS.DC), options);
+          CS.getASTContext(), loc, TypeResolution::forContextual(CS.DC),
+          options);
       return hadError ? Type() : loc.getType();
     }
 
@@ -1706,7 +1704,7 @@ namespace {
 
       // Prior to Swift 5, 'try?' always adds an additional layer of optionality,
       // even if the sub-expression was already optional.
-      if (CS.getTypeChecker().getLangOpts().isSwiftVersionAtLeast(5)) {
+      if (CS.getASTContext().LangOpts.isSwiftVersionAtLeast(5)) {
         CS.addConstraint(ConstraintKind::Conversion,
                          CS.getType(expr->getSubExpr()), optTy,
                          CS.getConstraintLocator(expr));
@@ -2286,7 +2284,7 @@ namespace {
           // of is-patterns applied to an irrefutable pattern.
           pattern = pattern->getSemanticsProvidingPattern();
           while (auto isp = dyn_cast<IsPattern>(pattern)) {
-            if (TypeChecker::validateType(CS.TC.Context,
+            if (TypeChecker::validateType(CS.getASTContext(),
                                           isp->getCastTypeLoc(),
                                           TypeResolution::forContextual(CS.DC),
                                           TypeResolverContext::InExpression)) {
@@ -3734,7 +3732,7 @@ Type ConstraintSystem::generateConstraints(Pattern *pattern,
 }
 
 void ConstraintSystem::optimizeConstraints(Expr *e) {
-  if (TC.getLangOpts().DisableConstraintSolverPerformanceHacks)
+  if (getASTContext().LangOpts.DisableConstraintSolverPerformanceHacks)
     return;
   
   SmallVector<Expr *, 16> linkedExprs;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1150,7 +1150,7 @@ namespace {
       if (expr->getType())
         return expr->getType();
 
-      auto protocol = CS.getTypeChecker().getLiteralProtocol(expr);
+      auto protocol = TypeChecker::getLiteralProtocol(CS.getASTContext(), expr);
       if (!protocol)
         return nullptr;
 
@@ -1167,9 +1167,9 @@ namespace {
     visitInterpolatedStringLiteralExpr(InterpolatedStringLiteralExpr *expr) {
       // Dig out the ExpressibleByStringInterpolation protocol.
       auto &tc = CS.getTypeChecker();
-      auto interpolationProto
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByStringInterpolation);
+      auto interpolationProto = TypeChecker::getProtocol(
+          CS.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByStringInterpolation);
       if (!interpolationProto) {
         tc.diagnose(expr->getStartLoc(), diag::interpolation_missing_proto);
         return nullptr;
@@ -1240,7 +1240,7 @@ namespace {
         return expr->getType();
 
       auto &tc = CS.getTypeChecker();
-      auto protocol = tc.getLiteralProtocol(expr);
+      auto protocol = TypeChecker::getLiteralProtocol(CS.getASTContext(), expr);
       if (!protocol) {
         tc.diagnose(expr->getLoc(), diag::use_unknown_object_literal_protocol,
                     expr->getLiteralKindPlainName());
@@ -1763,9 +1763,9 @@ namespace {
       // An array expression can be of a type T that conforms to the
       // ExpressibleByArrayLiteral protocol.
       auto &tc = CS.getTypeChecker();
-      ProtocolDecl *arrayProto
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByArrayLiteral);
+      ProtocolDecl *arrayProto = TypeChecker::getProtocol(
+          CS.getASTContext(), expr->getLoc(),
+          KnownProtocolKind::ExpressibleByArrayLiteral);
       if (!arrayProto) {
         return Type();
       }
@@ -1846,9 +1846,8 @@ namespace {
       // ExpressibleByDictionaryLiteral protocol.
       // FIXME: This isn't actually used for anything at the moment.
       auto &tc = CS.getTypeChecker();
-      ProtocolDecl *dictionaryProto
-        = tc.getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByDictionaryLiteral);
+      ProtocolDecl *dictionaryProto = TypeChecker::getProtocol(
+          C, expr->getLoc(), KnownProtocolKind::ExpressibleByDictionaryLiteral);
       if (!dictionaryProto) {
         return Type();
       }

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -201,7 +201,7 @@ static bool isNominallySuperclassOf(Type type1, Type type2) {
 /// Determine the relationship between the self types of the given declaration
 /// contexts..
 static std::pair<SelfTypeRelationship, ProtocolConformanceRef>
-computeSelfTypeRelationship(TypeChecker &tc, DeclContext *dc, ValueDecl *decl1,
+computeSelfTypeRelationship(DeclContext *dc, ValueDecl *decl1,
                             ValueDecl *decl2) {
   // If both declarations are operators, even through they
   // might have Self such types are unrelated.
@@ -533,8 +533,7 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       // Determine the relationship between the 'self' types and add the
       // appropriate constraints. The constraints themselves never fail, but
       // they help deduce type variables that were opened.
-      auto selfTypeRelationship =
-          computeSelfTypeRelationship(tc, dc, decl1, decl2);
+      auto selfTypeRelationship = computeSelfTypeRelationship(dc, decl1, decl2);
       auto relationshipKind = selfTypeRelationship.first;
       auto conformance = selfTypeRelationship.second;
       (void)conformance;

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -34,7 +34,7 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
   unsigned index = static_cast<unsigned>(kind);
   CurrentScore.Data[index] += value;
 
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     if (solverState)
       log.indent(solverState->depth * 2);
@@ -90,7 +90,7 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
 }
 
 bool ConstraintSystem::worseThanBestSolution() const {
-  if (TC.getLangOpts().DisableConstraintSolverPerformanceHacks)
+  if (getASTContext().LangOpts.DisableConstraintSolverPerformanceHacks)
     return false;
 
   if (retainAllSolutions())
@@ -100,7 +100,7 @@ bool ConstraintSystem::worseThanBestSolution() const {
       CurrentScore <= *solverState->BestScore)
     return false;
 
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log.indent(solverState->depth * 2)
       << "(solution is worse than the best solution)\n";
@@ -720,7 +720,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     ConstraintSystem &cs, ArrayRef<Solution> solutions,
     const SolutionDiff &diff, unsigned idx1, unsigned idx2,
     llvm::DenseMap<Expr *, std::pair<unsigned, Expr *>> &weights) {
-  if (cs.TC.getLangOpts().DebugConstraintSolver) {
+  if (cs.getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = cs.getASTContext().TypeCheckerDebug->getStream();
     log.indent(cs.solverState->depth * 2)
       << "comparing solutions " << idx1 << " and " << idx2 <<"\n";
@@ -1126,14 +1126,14 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     if (!(score1 || score2)) {
       if (auto nominalType2 = type2->getNominalOrBoundGenericNominal()) {
         if ((nominalType2->getName() ==
-             cs.TC.Context.Id_OptionalNilComparisonType)) {
+             cs.getASTContext().Id_OptionalNilComparisonType)) {
           ++score2;
         }
       }
 
       if (auto nominalType1 = type1->getNominalOrBoundGenericNominal()) {
         if ((nominalType1->getName() ==
-             cs.TC.Context.Id_OptionalNilComparisonType)) {
+             cs.getASTContext().Id_OptionalNilComparisonType)) {
           ++score1;
         }
       }
@@ -1190,7 +1190,7 @@ ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
   if (viable.size() == 1)
     return 0;
 
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log.indent(solverState->depth * 2)
         << "Comparing " << viable.size() << " viable solutions\n";

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3742,7 +3742,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     //
     // Class and protocol metatypes are interoperable with certain Objective-C
     // runtime classes, but only when ObjC interop is enabled.
-    
+
     if (getASTContext().LangOpts.EnableObjCInterop) {
       // These conversions are between concrete types that don't need further
       // resolution, so we can consider them immediately solved.
@@ -3790,7 +3790,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         }
       }
     }
-    
+
     // Special implicit nominal conversions.
     if (!type1->is<LValueType>() && kind >= ConstraintKind::Subtype) {
       // Array -> Array.
@@ -4020,7 +4020,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (auto optTryExpr =
           dyn_cast_or_null<OptionalTryExpr>(locator.trySimplifyToExpr())) {
         auto subExprType = getType(optTryExpr->getSubExpr());
-        const bool isSwift5OrGreater = getASTContext().LangOpts.isSwiftVersionAtLeast(5);
+        const bool isSwift5OrGreater =
+            getASTContext().LangOpts.isSwiftVersionAtLeast(5);
         if (isSwift5OrGreater && (bool)subExprType->getOptionalObjectType()) {
           // For 'try?' expressions, a ForceOptional fix converts 'try?'
           // to 'try!'. If the sub-expression is optional, then a force-unwrap

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5378,9 +5378,9 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     lookupOptions |= NameLookupFlags::IgnoreAccessControl;
     // This is only used for diagnostics, so always use KnownPrivate.
     lookupOptions |= NameLookupFlags::KnownPrivate;
-    
-    auto lookup = TC.lookupMember(DC, instanceTy,
-                                  memberName, lookupOptions);
+
+    auto lookup =
+        TypeChecker::lookupMember(DC, instanceTy, memberName, lookupOptions);
     for (auto entry : lookup) {
       auto *cand = entry.getValueDecl();
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3743,7 +3743,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     // Class and protocol metatypes are interoperable with certain Objective-C
     // runtime classes, but only when ObjC interop is enabled.
     
-    if (TC.getLangOpts().EnableObjCInterop) {
+    if (getASTContext().LangOpts.EnableObjCInterop) {
       // These conversions are between concrete types that don't need further
       // resolution, so we can consider them immediately solved.
       auto addSolvedRestrictedConstraint
@@ -4020,7 +4020,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (auto optTryExpr =
           dyn_cast_or_null<OptionalTryExpr>(locator.trySimplifyToExpr())) {
         auto subExprType = getType(optTryExpr->getSubExpr());
-        bool isSwift5OrGreater = TC.getLangOpts().isSwiftVersionAtLeast(5);
+        const bool isSwift5OrGreater = getASTContext().LangOpts.isSwiftVersionAtLeast(5);
         if (isSwift5OrGreater && (bool)subExprType->getOptionalObjectType()) {
           // For 'try?' expressions, a ForceOptional fix converts 'try?'
           // to 'try!'. If the sub-expression is optional, then a force-unwrap

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1098,9 +1098,9 @@ bool ConstraintSystem::solve(Expr *&expr,
                              ExprTypeCheckListener *listener,
                              SmallVectorImpl<Solution> &solutions,
                              FreeTypeVariableBinding allowFreeTypeVariables) {
-  llvm::SaveAndRestore<bool>
-    debugForExpr(getASTContext().LangOpts.DebugConstraintSolver,
-                 debugConstraintSolverForExpr(TC.Context, expr));
+  llvm::SaveAndRestore<bool> debugForExpr(
+      getASTContext().LangOpts.DebugConstraintSolver,
+      debugConstraintSolverForExpr(TC.Context, expr));
 
   // Attempt to solve the constraint system.
   auto solution = solveImpl(expr,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -69,7 +69,7 @@ Solution ConstraintSystem::finalize() {
 
   // Update the best score we've seen so far.
   if (!retainAllSolutions()) {
-    assert(TC.getLangOpts().DisableConstraintSolverPerformanceHacks ||
+    assert(getASTContext().LangOpts.DisableConstraintSolverPerformanceHacks ||
            !solverState->BestScore || CurrentScore <= *solverState->BestScore);
 
     if (!solverState->BestScore || CurrentScore <= *solverState->BestScore) {
@@ -283,7 +283,7 @@ bool ConstraintSystem::simplify(bool ContinueAfterFailures) {
         failedConstraint = constraint;
       }
 
-      if (TC.getLangOpts().DebugConstraintSolver) {
+      if (getASTContext().LangOpts.DebugConstraintSolver) {
         auto &log = getASTContext().TypeCheckerDebug->getStream();
         log.indent(solverState ? solverState->depth * 2 : 0)
             << "(failed constraint ";
@@ -594,7 +594,7 @@ bool ConstraintSystem::Candidate::solve(
   if (isTooComplexGiven(&cs, shrunkExprs))
     return false;
 
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (cs.getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = cs.getASTContext().TypeCheckerDebug->getStream();
     log << "--- Solving candidate for shrinking at ";
     auto R = E->getSourceRange();
@@ -715,7 +715,7 @@ void ConstraintSystem::Candidate::applySolutions(
 }
 
 void ConstraintSystem::shrink(Expr *expr) {
-  if (TC.getLangOpts().SolverDisableShrink)
+  if (getASTContext().LangOpts.SolverDisableShrink)
     return;
 
   using DomainMap = llvm::SmallDenseMap<Expr *, ArrayRef<ValueDecl *>>;
@@ -1099,7 +1099,7 @@ bool ConstraintSystem::solve(Expr *&expr,
                              SmallVectorImpl<Solution> &solutions,
                              FreeTypeVariableBinding allowFreeTypeVariables) {
   llvm::SaveAndRestore<bool>
-    debugForExpr(TC.getLangOpts().DebugConstraintSolver,
+    debugForExpr(getASTContext().LangOpts.DebugConstraintSolver,
                  debugConstraintSolverForExpr(TC.Context, expr));
 
   // Attempt to solve the constraint system.
@@ -1138,7 +1138,7 @@ bool ConstraintSystem::solve(Expr *&expr,
     return true;
   }
 
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     if (solutions.size() == 1) {
       log << "---Solution---\n";
@@ -1160,7 +1160,7 @@ ConstraintSystem::solveImpl(Expr *&expr,
                             ExprTypeCheckListener *listener,
                             SmallVectorImpl<Solution> &solutions,
                             FreeTypeVariableBinding allowFreeTypeVariables) {
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log << "---Constraint solving for the expression at ";
     auto R = expr->getSourceRange();
@@ -1232,7 +1232,7 @@ ConstraintSystem::solveImpl(Expr *&expr,
     return SolutionKind::Error;
   }
 
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log << "---Initial constraints for the given expression---\n";
     print(log, expr);
@@ -1257,7 +1257,7 @@ bool ConstraintSystem::solve(Expr *const expr,
   // Solve the system.
   solve(solutions);
 
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log << "---Solver statistics---\n";
     log << "Total number of scopes explored: " << solverState->NumStatesExplored << "\n";
@@ -2150,7 +2150,7 @@ void ConstraintSystem::partitionDisjunction(
   }
 
   // Partition SIMD operators.
-  if (!TC.getLangOpts().SolverEnableOperatorDesignatedTypes &&
+  if (!getASTContext().LangOpts.SolverEnableOperatorDesignatedTypes &&
       isOperatorBindOverload(Choices[0])) {
     forEachChoice(Choices, [&](unsigned index, Constraint *constraint) -> bool {
       if (!isOperatorBindOverload(constraint))
@@ -2175,7 +2175,7 @@ void ConstraintSystem::partitionDisjunction(
         }
       };
 
-  if (TC.getLangOpts().SolverEnableOperatorDesignatedTypes &&
+  if (getASTContext().LangOpts.SolverEnableOperatorDesignatedTypes &&
       isOperatorBindOverload(Choices[0])) {
     partitionForDesignatedTypes(Choices, forEachChoice, appendPartition);
   }
@@ -2210,7 +2210,7 @@ Constraint *ConstraintSystem::selectDisjunction() {
   // disjunctions that we may not be able to short-circuit, allowing
   // us to eliminate behavior that is exponential in the number of
   // operators in the expression.
-  if (TC.getLangOpts().SolverEnableOperatorDesignatedTypes) {
+  if (getASTContext().LangOpts.SolverEnableOperatorDesignatedTypes) {
     if (auto *disjunction = selectApplyDisjunction())
       return disjunction;
   }

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -233,7 +233,9 @@ protected:
 
   /// Check whether constraint solver is running in "debug" mode,
   /// which should output diagnostic information.
-  bool isDebugMode() const { return CS.TC.getLangOpts().DebugConstraintSolver; }
+  bool isDebugMode() const {
+    return CS.getASTContext().LangOpts.DebugConstraintSolver;
+  }
 
   llvm::raw_ostream &getDebugLogger(bool indent = true) const {
     auto &log = CS.getASTContext().TypeCheckerDebug->getStream();

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -137,7 +137,7 @@ void CalleeCandidateInfo::filterList(ClosenessPredicate predicate) {
       // treat it as unavailable, which is a very close failure.
       if (declCloseness.first == CC_ExactMatch &&
           VD->getAttrs().isUnavailable(CS.getASTContext()) &&
-          !CS.TC.getLangOpts().DisableAvailabilityChecking)
+          !CS.getASTContext().LangOpts.DisableAvailabilityChecking)
         declCloseness.first = CC_Unavailable;
       
       // Likewise, if the candidate is inaccessible from the scope it is being

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1255,7 +1255,7 @@ bool ConstraintGraph::contractEdges() {
           rep2->getImpl().canBindToLValue()) ||
          // Allow l-value contractions when binding parameter types.
          isParamBindingConstraint)) {
-      if (CS.TC.getLangOpts().DebugConstraintSolver) {
+      if (CS.getASTContext().LangOpts.DebugConstraintSolver) {
         auto &log = CS.getASTContext().TypeCheckerDebug->getStream();
         if (CS.solverState)
           log.indent(CS.solverState->depth * 2);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1603,7 +1603,7 @@ resolveOverloadForDeclWithSpecialTypeCheckingSemantics(ConstraintSystem &CS,
                                                      Type &openedFullType) {
   assert(choice.getKind() == OverloadChoiceKind::Decl);
 
-  switch (CS.TC.getDeclTypeCheckingSemantics(choice.getDecl())) {
+  switch (TypeChecker::getDeclTypeCheckingSemantics(choice.getDecl())) {
   case DeclTypeCheckingSemantics::Normal:
     return false;
     

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -244,7 +244,7 @@ LookupResult &ConstraintSystem::lookupMember(Type base, DeclName name) {
   if (isa<AbstractFunctionDecl>(DC))
     lookupOptions |= NameLookupFlags::KnownPrivate;
 
-  result = TC.lookupMember(DC, base, name, lookupOptions);
+  result = TypeChecker::lookupMember(DC, base, name, lookupOptions);
 
   // If we aren't performing dynamic lookup, we're done.
   if (!*result || !base->isAnyObject())

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -182,7 +182,8 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
       if (!anchor)
         continue;
 
-      literalProtocol = TC.getLiteralProtocol(anchor);
+      literalProtocol =
+          TypeChecker::getLiteralProtocol(getASTContext(), anchor);
       if (literalProtocol)
         break;
     }
@@ -1781,8 +1782,9 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
   // components.
   auto verifyThatArgumentIsHashable = [&](unsigned index, Type argType,
                                           ConstraintLocator *locator) {
-    if (auto *hashable = TC.getProtocol(choice.getDecl()->getLoc(),
-                                        KnownProtocolKind::Hashable)) {
+    if (auto *hashable = TypeChecker::getProtocol(
+            argType->getASTContext(), choice.getDecl()->getLoc(),
+            KnownProtocolKind::Hashable)) {
       addConstraint(ConstraintKind::ConformsTo, argType,
                     hashable->getDeclaredType(),
                     getConstraintLocator(
@@ -1966,11 +1968,9 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
              "subscript always has one arg");
       auto argType = refFnType->getParams()[0].getPlainType();
 
-      auto &TC = getTypeChecker();
-
-      auto stringLiteral =
-          TC.getProtocol(choice.getDecl()->getLoc(),
-                         KnownProtocolKind::ExpressibleByStringLiteral);
+      auto stringLiteral = TypeChecker::getProtocol(
+          getASTContext(), choice.getDecl()->getLoc(),
+          KnownProtocolKind::ExpressibleByStringLiteral);
       if (!stringLiteral)
         break;
 
@@ -3078,7 +3078,8 @@ bool constraints::hasAppliedSelf(ConstraintSystem &cs,
 
 bool constraints::conformsToKnownProtocol(ConstraintSystem &cs, Type type,
                                           KnownProtocolKind protocol) {
-  if (auto *proto = cs.TC.getProtocol(SourceLoc(), protocol))
+  if (auto *proto =
+          TypeChecker::getProtocol(cs.getASTContext(), SourceLoc(), protocol))
     return (bool)TypeChecker::conformsToProtocol(
         type, proto, cs.DC, ConformanceCheckFlags::InExpression);
   return false;
@@ -3090,8 +3091,8 @@ Type constraints::isRawRepresentable(ConstraintSystem &cs, Type type) {
   auto &TC = cs.TC;
   auto *DC = cs.DC;
 
-  auto rawReprType =
-      TC.getProtocol(SourceLoc(), KnownProtocolKind::RawRepresentable);
+  auto rawReprType = TypeChecker::getProtocol(
+      cs.getASTContext(), SourceLoc(), KnownProtocolKind::RawRepresentable);
   if (!rawReprType)
     return Type();
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1079,7 +1079,7 @@ static void bindArchetypesFromContext(
     if (parentDC->isTypeContext()) {
       if (parentDC != outerDC && parentDC->getSelfProtocolDecl()) {
         auto selfTy = parentDC->getSelfInterfaceType();
-        auto contextTy = cs.TC.Context.TheUnresolvedType;
+        auto contextTy = cs.getASTContext().TheUnresolvedType;
         bindPrimaryArchetype(selfTy, contextTy);
       }
       continue;
@@ -2243,7 +2243,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     }
   }
 
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log.indent(solverState ? solverState->depth * 2 : 2)
       << "(overload set choice binding "
@@ -2395,7 +2395,7 @@ bool OverloadChoice::isImplicitlyUnwrappedValueOrReturnValue() const {
 }
 
 bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
-  if (TC.getLangOpts().DebugConstraintSolver) {
+  if (getASTContext().LangOpts.DebugConstraintSolver) {
     auto &log = TC.Context.TypeCheckerDebug->getStream();
     log << "---Attempting to salvage and emit diagnostics---\n";
   }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1247,7 +1247,8 @@ private:
         }
       }
 
-      unsigned threshold = cs->getASTContext().LangOpts.SolverShrinkUnsolvedThreshold;
+      unsigned threshold =
+          cs->getASTContext().LangOpts.SolverShrinkUnsolvedThreshold;
       return unsolvedDisjunctions >= threshold;
     }
   };

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1247,7 +1247,7 @@ private:
         }
       }
 
-      unsigned threshold = cs->TC.getLangOpts().SolverShrinkUnsolvedThreshold;
+      unsigned threshold = cs->getASTContext().LangOpts.SolverShrinkUnsolvedThreshold;
       return unsolvedDisjunctions >= threshold;
     }
   };

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -87,14 +87,11 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
   if (!canDeriveConformance(Nominal))
     return nullptr;
 
-  ASTContext &C = TC.Context;
-
   // Build the necessary decl.
-  if (requirement->getBaseName() != C.Id_allCases) {
+  if (requirement->getBaseName() != Context.Id_allCases) {
     requirement->diagnose(diag::broken_case_iterable_requirement);
     return nullptr;
   }
-
 
   // Define the property.
   auto *returnTy = computeAllCasesType(Nominal);
@@ -102,7 +99,7 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
   std::tie(propDecl, pbDecl) =
-      declareDerivedProperty(C.Id_allCases, returnTy, returnTy,
+      declareDerivedProperty(Context.Id_allCases, returnTy, returnTy,
                              /*isStatic=*/true, /*isFinal=*/true);
 
   // Define the getter.
@@ -123,11 +120,12 @@ Type DerivedConformance::deriveCaseIterable(AssociatedTypeDecl *assocType) {
   if (!canDeriveConformance(Nominal))
     return nullptr;
 
-  if (assocType->getName() == TC.Context.Id_AllCases) {
+  if (assocType->getName() == Context.Id_AllCases) {
     return deriveCaseIterable_AllCases(*this);
   }
 
-  TC.diagnose(assocType->getLoc(), diag::broken_case_iterable_requirement);
+  Context.Diags.diagnose(assocType->getLoc(),
+                         diag::broken_case_iterable_requirement);
   return nullptr;
 }
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1076,7 +1076,8 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
                               ArrayRef<Identifier>());
       }
 
-      auto result = tc.lookupMember(superclassDecl, superType, memberName);
+      auto result =
+          TypeChecker::lookupMember(superclassDecl, superType, memberName);
 
       if (result.empty()) {
         // No super initializer for us to call.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -93,17 +93,13 @@ static CodableConformanceType typeConformsToCodable(DeclContext *context,
 /// Returns whether the given variable conforms to the given {En,De}codable
 /// protocol.
 ///
-/// \param tc The typechecker to use in validating {En,De}codable conformance.
-///
-/// \param context The \c DeclContext in which to check conformance.
+/// \param DC The \c DeclContext in which to check conformance.
 ///
 /// \param varDecl The \c VarDecl to validate.
 ///
 /// \param proto The \c ProtocolDecl to check conformance to.
-static CodableConformanceType varConformsToCodable(TypeChecker &tc,
-                                                   DeclContext *context,
-                                                   VarDecl *varDecl,
-                                                   ProtocolDecl *proto) {
+static CodableConformanceType
+varConformsToCodable(DeclContext *DC, VarDecl *varDecl, ProtocolDecl *proto) {
   // If the decl doesn't yet have a type, we may be seeing it before the type
   // checker has gotten around to evaluating its type. For example:
   //
@@ -117,8 +113,8 @@ static CodableConformanceType varConformsToCodable(TypeChecker &tc,
   //              //    hasn't yet been evaluated
   // }
   bool isIUO = varDecl->isImplicitlyUnwrappedOptional();
-  return typeConformsToCodable(context, varDecl->getValueInterfaceType(),
-                               isIUO, proto);
+  return typeConformsToCodable(DC, varDecl->getValueInterfaceType(), isIUO,
+                               proto);
 }
 
 /// Retrieve the variable name for the purposes of encoding/decoding.
@@ -135,7 +131,6 @@ static Identifier getVarNameForCoding(VarDecl *var) {
 /// \param codingKeysDecl The \c CodingKeys enum decl to validate.
 static bool validateCodingKeysEnum(DerivedConformance &derived,
                                    EnumDecl *codingKeysDecl) {
-  auto &tc = derived.TC;
   auto conformanceDC = derived.getConformanceContext();
 
   // Look through all var decls in the given type.
@@ -161,8 +156,8 @@ static bool validateCodingKeysEnum(DerivedConformance &derived,
   for (auto elt : codingKeysDecl->getAllElements()) {
     auto it = properties.find(elt->getName());
     if (it == properties.end()) {
-      tc.diagnose(elt->getLoc(), diag::codable_extraneous_codingkey_case_here,
-                  elt->getName());
+      elt->diagnose(diag::codable_extraneous_codingkey_case_here,
+                    elt->getName());
       // TODO: Investigate typo-correction here; perhaps the case name was
       //       misspelled and we can provide a fix-it.
       propertiesAreValid = false;
@@ -171,7 +166,7 @@ static bool validateCodingKeysEnum(DerivedConformance &derived,
 
     // We have a property to map to. Ensure it's {En,De}codable.
     auto conformance =
-        varConformsToCodable(tc, conformanceDC, it->second, derived.Protocol);
+        varConformsToCodable(conformanceDC, it->second, derived.Protocol);
     switch (conformance) {
       case Conforms:
         // The property was valid. Remove it from the list.
@@ -179,9 +174,8 @@ static bool validateCodingKeysEnum(DerivedConformance &derived,
         break;
 
       case DoesNotConform:
-        tc.diagnose(it->second->getLoc(),
-                    diag::codable_non_conforming_property_here,
-                    derived.getProtocolType(), it->second->getType());
+        it->second->diagnose(diag::codable_non_conforming_property_here,
+                             derived.getProtocolType(), it->second->getType());
         LLVM_FALLTHROUGH;
 
       case TypeNotValidated:
@@ -215,8 +209,8 @@ static bool validateCodingKeysEnum(DerivedConformance &derived,
       // The var was not default initializable, and did not have an explicit
       // initial value.
       propertiesAreValid = false;
-      tc.diagnose(it->second->getLoc(), diag::codable_non_decoded_property_here,
-                  derived.getProtocolType(), it->first);
+      it->second->diagnose(diag::codable_non_decoded_property_here,
+                           derived.getProtocolType(), it->first);
     }
   }
 
@@ -241,8 +235,7 @@ struct CodingKeysValidity {
 ///
 /// \returns A \c CodingKeysValidity value representing the result of the check.
 static CodingKeysValidity hasValidCodingKeysEnum(DerivedConformance &derived) {
-  auto &tc = derived.TC;
-  auto &C = tc.Context;
+  auto &C = derived.Context;
   auto codingKeysDecls =
       derived.Nominal->lookupDirect(DeclName(C.Id_CodingKeys));
   if (codingKeysDecls.empty())
@@ -255,9 +248,8 @@ static CodingKeysValidity hasValidCodingKeysEnum(DerivedConformance &derived) {
 
   auto *codingKeysTypeDecl = dyn_cast<TypeDecl>(result);
   if (!codingKeysTypeDecl) {
-    tc.diagnose(result->getLoc(),
-                diag::codable_codingkeys_type_is_not_an_enum_here,
-                derived.getProtocolType());
+    result->diagnose(diag::codable_codingkeys_type_is_not_an_enum_here,
+                     derived.getProtocolType());
     return CodingKeysValidity(/*hasType=*/true, /*isValid=*/false);
   }
 
@@ -279,8 +271,8 @@ static CodingKeysValidity hasValidCodingKeysEnum(DerivedConformance &derived) {
                     codingKeysTypeDecl->getLoc() :
                     cast<TypeDecl>(result)->getLoc();
 
-    tc.diagnose(loc, diag::codable_codingkeys_type_does_not_conform_here,
-                derived.getProtocolType());
+    C.Diags.diagnose(loc, diag::codable_codingkeys_type_does_not_conform_here,
+                     derived.getProtocolType());
 
     return CodingKeysValidity(/*hasType=*/true, /*isValid=*/false);
   }
@@ -288,9 +280,9 @@ static CodingKeysValidity hasValidCodingKeysEnum(DerivedConformance &derived) {
   // CodingKeys must be an enum for synthesized conformance.
   auto *codingKeysEnum = dyn_cast<EnumDecl>(codingKeysTypeDecl);
   if (!codingKeysEnum) {
-    tc.diagnose(codingKeysTypeDecl->getLoc(),
-                diag::codable_codingkeys_type_is_not_an_enum_here,
-                derived.getProtocolType());
+    codingKeysTypeDecl->diagnose(
+        diag::codable_codingkeys_type_is_not_an_enum_here,
+        derived.getProtocolType());
     return CodingKeysValidity(/*hasType=*/true, /*isValid=*/false);
   }
 
@@ -303,8 +295,7 @@ static CodingKeysValidity hasValidCodingKeysEnum(DerivedConformance &derived) {
 ///
 /// If able to synthesize the enum, adds it directly to \c derived.Nominal.
 static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
-  auto &tc = derived.TC;
-  auto &C = tc.Context;
+  auto &C = derived.Context;
   // Create CodingKeys in the parent type always, because both
   // Encodable and Decodable might want to use it, and they may have
   // different conditional bounds. CodingKeys is simple and can't
@@ -348,7 +339,7 @@ static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
     // concurrently checking the variables for the current protocol
     // conformance being synthesized, for which we use the conformance
     // context, not the type.
-    auto conformance = varConformsToCodable(tc, derived.getConformanceContext(),
+    auto conformance = varConformsToCodable(derived.getConformanceContext(),
                                             varDecl, derived.Protocol);
     switch (conformance) {
       case Conforms:
@@ -363,9 +354,8 @@ static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
       }
 
       case DoesNotConform:
-        tc.diagnose(varDecl->getLoc(),
-                    diag::codable_non_conforming_property_here,
-                    derived.getProtocolType(), varDecl->getType());
+        varDecl->diagnose(diag::codable_non_conforming_property_here,
+                          derived.getProtocolType(), varDecl->getType());
         LLVM_FALLTHROUGH;
 
       case TypeNotValidated:
@@ -380,7 +370,10 @@ static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
     return nullptr;
 
   // Forcibly derive conformance to CodingKey.
-  tc.checkConformancesInContext(enumDecl, enumDecl);
+  //
+  // FIXME: Drop the dependency on the type checker.
+  auto *tc = static_cast<TypeChecker *>(C.getLazyResolver());
+  tc->checkConformancesInContext(enumDecl, enumDecl);
 
   // Add to the type.
   target->addMember(enumDecl);
@@ -706,7 +699,7 @@ deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *) {
 ///
 /// Adds the function declaration to the given type before returning it.
 static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
-  auto &C = derived.TC.Context;
+  auto &C = derived.Context;
   auto conformanceDC = derived.getConformanceContext();
 
   // Expected type: (Self) -> (Encoder) throws -> ()
@@ -985,7 +978,7 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
 ///
 /// Adds the function declaration to the given type before returning it.
 static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
-  auto &C = derived.TC.Context;
+  auto &C = derived.Context;
 
   auto classDecl = dyn_cast<ClassDecl>(derived.Nominal);
   auto conformanceDC = derived.getConformanceContext();
@@ -1056,8 +1049,6 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
   //
   // If the required initializer is not available, we shouldn't attempt to
   // synthesize CodingKeys.
-  auto &tc = derived.TC;
-  ASTContext &C = tc.Context;
   auto proto = derived.Protocol;
   auto *classDecl = dyn_cast<ClassDecl>(derived.Nominal);
   if (proto->isSpecificProtocol(KnownProtocolKind::Decodable) && classDecl) {
@@ -1072,8 +1063,9 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
         // super.init() must be accessible.
         // Passing an empty params array constructs a compound name with no
         // arguments (as opposed to a simple name when omitted).
-        memberName = DeclName(C, DeclBaseName::createConstructor(),
-                              ArrayRef<Identifier>());
+        memberName =
+            DeclName(derived.Context, DeclBaseName::createConstructor(),
+                     ArrayRef<Identifier>());
       }
 
       auto result =
@@ -1139,9 +1131,9 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
   if (!isa<StructDecl>(Nominal) && !isa<ClassDecl>(Nominal))
     return nullptr;
 
-  if (requirement->getBaseName() != TC.Context.Id_encode) {
+  if (requirement->getBaseName() != Context.Id_encode) {
     // Unknown requirement.
-    TC.diagnose(requirement->getLoc(), diag::broken_encodable_requirement);
+    requirement->diagnose(diag::broken_encodable_requirement);
     return nullptr;
   }
 
@@ -1163,12 +1155,12 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
   // diagnostics, then potentially collect notes. If we succeed in
   // synthesizing Encodable, we can cancel the transaction and get rid of the
   // fake failures.
-  DiagnosticTransaction diagnosticTransaction(TC.Context.Diags);
-  TC.diagnose(ConformanceDecl, diag::type_does_not_conform,
-              Nominal->getDeclaredType(), getProtocolType());
-  TC.diagnose(requirement, diag::no_witnesses, diag::RequirementKind::Func,
-              requirement->getFullName(), getProtocolType(),
-              /*AddFixIt=*/false);
+  DiagnosticTransaction diagnosticTransaction(Context.Diags);
+  ConformanceDecl->diagnose(diag::type_does_not_conform,
+                            Nominal->getDeclaredType(), getProtocolType());
+  requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Func,
+                        requirement->getFullName(), getProtocolType(),
+                        /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.
@@ -1187,7 +1179,7 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
 
   if (requirement->getBaseName() != DeclBaseName::createConstructor()) {
     // Unknown requirement.
-    TC.diagnose(requirement->getLoc(), diag::broken_decodable_requirement);
+    requirement->diagnose(diag::broken_decodable_requirement);
     return nullptr;
   }
 
@@ -1199,12 +1191,12 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
   // diagnostics produced by canSynthesize and deriveDecodable_init to produce
   // them in the right order -- see the comment in deriveEncodable for
   // background on this transaction.
-  DiagnosticTransaction diagnosticTransaction(TC.Context.Diags);
-  TC.diagnose(ConformanceDecl->getLoc(), diag::type_does_not_conform,
-              Nominal->getDeclaredType(), getProtocolType());
-  TC.diagnose(requirement, diag::no_witnesses,
-              diag::RequirementKind::Constructor, requirement->getFullName(),
-              getProtocolType(), /*AddFixIt=*/false);
+  DiagnosticTransaction diagnosticTransaction(Context.Diags);
+  ConformanceDecl->diagnose(diag::type_does_not_conform,
+                            Nominal->getDeclaredType(), getProtocolType());
+  requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Constructor,
+                        requirement->getFullName(), getProtocolType(),
+                        /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -115,7 +115,7 @@ template <typename Synthesizer>
 static ValueDecl *deriveInitDecl(DerivedConformance &derived, Type paramType,
                                  Identifier paramName,
                                  const Synthesizer &synthesizer) {
-  auto &C = derived.TC.Context;
+  auto &C = derived.Context;
   auto *parentDC = derived.getConformanceContext();
 
   // rawValue
@@ -340,7 +340,7 @@ static bool canSynthesizeCodingKey(DerivedConformance &derived) {
     auto *parentDC = derived.getConformanceContext();
     rawType = parentDC->mapTypeIntoContext(rawType);
 
-    auto &C = derived.TC.Context;
+    auto &C = derived.Context;
     auto *nominal = rawType->getCanonicalType()->getAnyNominal();
     if (nominal != C.getStringDecl() && nominal != C.getIntDecl())
       return false;
@@ -367,12 +367,11 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
   if (!canSynthesizeCodingKey(*this))
     return nullptr;
 
-  auto &C = TC.Context;
   auto rawType = enumDecl->getRawType();
   auto name = requirement->getBaseName();
-  if (name == C.Id_stringValue) {
+  if (name == Context.Id_stringValue) {
     // Synthesize `var stringValue: String { get }`
-    auto stringType = C.getStringDecl()->getDeclaredType();
+    auto stringType = Context.getStringDecl()->getDeclaredType();
     auto synth = [rawType, stringType](AbstractFunctionDecl *getterDecl) {
       if (rawType && rawType->isEqual(stringType)) {
         // enum SomeStringEnum : String {
@@ -399,11 +398,11 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
       }
     };
 
-    return deriveProperty(*this, stringType, C.Id_stringValue, synth);
+    return deriveProperty(*this, stringType, Context.Id_stringValue, synth);
 
-  } else if (name == C.Id_intValue) {
+  } else if (name == Context.Id_intValue) {
     // Synthesize `var intValue: Int? { get }`
-    auto intType = C.getIntDecl()->getDeclaredType();
+    auto intType = Context.getIntDecl()->getDeclaredType();
     auto optionalIntType = OptionalType::get(intType);
 
     auto synth = [rawType, intType](AbstractFunctionDecl *getterDecl) {
@@ -426,13 +425,13 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
       }
     };
 
-    return deriveProperty(*this, optionalIntType, C.Id_intValue, synth);
+    return deriveProperty(*this, optionalIntType, Context.Id_intValue, synth);
   } else if (name == DeclBaseName::createConstructor()) {
     auto argumentNames = requirement->getFullName().getArgumentNames();
     if (argumentNames.size() == 1) {
-      if (argumentNames[0] == C.Id_stringValue) {
+      if (argumentNames[0] == Context.Id_stringValue) {
         // Derive `init?(stringValue:)`
-        auto stringType = C.getStringDecl()->getDeclaredType();
+        auto stringType = Context.getStringDecl()->getDeclaredType();
         auto synth = [rawType, stringType](AbstractFunctionDecl *initDecl) {
           if (rawType && rawType->isEqual(stringType)) {
             // enum SomeStringEnum : String {
@@ -462,10 +461,10 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
           }
         };
 
-        return deriveInitDecl(*this, stringType, C.Id_stringValue, synth);
-      } else if (argumentNames[0] == C.Id_intValue) {
+        return deriveInitDecl(*this, stringType, Context.Id_stringValue, synth);
+      } else if (argumentNames[0] == Context.Id_intValue) {
         // Synthesize `init?(intValue:)`
-        auto intType = C.getIntDecl()->getDeclaredType();
+        auto intType = Context.getIntDecl()->getDeclaredType();
         auto synthesizer = [rawType, intType](AbstractFunctionDecl *initDecl) {
           if (rawType && rawType->isEqual(intType)) {
             // enum SomeIntEnum : Int {
@@ -486,11 +485,12 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
           }
         };
 
-        return deriveInitDecl(*this, intType, C.Id_intValue, synthesizer);
+        return deriveInitDecl(*this, intType, Context.Id_intValue, synthesizer);
       }
     }
   }
 
-  TC.diagnose(requirement->getLoc(), diag::broken_coding_key_requirement);
+  Context.Diags.diagnose(requirement->getLoc(),
+                         diag::broken_coding_key_requirement);
   return nullptr;
 }

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -701,7 +701,7 @@ deriveEquatable_eq(
   //   }
   // }
 
-  ASTContext &C = derived.TC.Context;
+  ASTContext &C = derived.Context;
 
   auto parentDC = derived.getConformanceContext();
   auto selfIfaceTy = parentDC->getDeclaredInterfaceType();
@@ -761,8 +761,7 @@ deriveEquatable_eq(
   }
 
   if (!C.getEqualIntDecl()) {
-    derived.TC.diagnose(derived.ConformanceDecl->getLoc(),
-                        diag::no_equal_overload_for_int);
+    derived.ConformanceDecl->diagnose(diag::no_equal_overload_for_int);
     return nullptr;
   }
 
@@ -808,7 +807,7 @@ ValueDecl *DerivedConformance::deriveEquatable(ValueDecl *requirement) {
     else
       llvm_unreachable("todo");
   }
-  TC.diagnose(requirement->getLoc(), diag::broken_equatable_requirement);
+  requirement->diagnose(diag::broken_equatable_requirement);
   return nullptr;
 }
 
@@ -850,7 +849,7 @@ deriveHashable_hashInto(
                                                     void *)) {
   // @derived func hash(into hasher: inout Hasher)
 
-  ASTContext &C = derived.TC.Context;
+  ASTContext &C = derived.Context;
   auto parentDC = derived.getConformanceContext();
 
   // Expected type: (Self) -> (into: inout Hasher) -> ()
@@ -863,8 +862,7 @@ deriveHashable_hashInto(
   auto hasherDecl = C.getHasherDecl();
   if (!hasherDecl) {
     auto hashableProto = C.getProtocol(KnownProtocolKind::Hashable);
-    derived.TC.diagnose(hashableProto->getLoc(),
-                        diag::broken_hashable_no_hasher);
+    hashableProto->diagnose(diag::broken_hashable_no_hasher);
     return nullptr;
   }
   Type hasherType = hasherDecl->getDeclaredType();
@@ -1198,8 +1196,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   // @derived var hashValue: Int {
   //   return _hashValue(for: self)
   // }
-  auto &tc = derived.TC;
-  ASTContext &C = tc.Context;
+  ASTContext &C = derived.Context;
 
   auto parentDC = derived.getConformanceContext();
   Type intType = C.getIntDecl()->getDeclaredType();

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -90,15 +90,13 @@ deriveBridgedNSError_enum_nsErrorDomain(
   //   }
   // }
 
-  ASTContext &C = derived.TC.Context;
-
-  auto stringTy = C.getStringDecl()->getDeclaredType();
+  auto stringTy = derived.Context.getStringDecl()->getDeclaredType();
 
   // Define the property.
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
   std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
-      C.Id_nsErrorDomain, stringTy, stringTy, /*isStatic=*/true,
+      derived.Context.Id_nsErrorDomain, stringTy, stringTy, /*isStatic=*/true,
       /*isFinal=*/true);
 
   // Define the getter.
@@ -115,7 +113,7 @@ ValueDecl *DerivedConformance::deriveBridgedNSError(ValueDecl *requirement) {
   if (!isa<EnumDecl>(Nominal))
     return nullptr;
 
-  if (requirement->getBaseName() == TC.Context.Id_nsErrorDomain) {
+  if (requirement->getBaseName() == Context.Id_nsErrorDomain) {
     auto synthesizer = deriveBodyBridgedNSError_enum_nsErrorDomain;
 
     auto scope = Nominal->getFormalAccessScope(Nominal->getModuleScopeContext());
@@ -127,6 +125,7 @@ ValueDecl *DerivedConformance::deriveBridgedNSError(ValueDecl *requirement) {
     return deriveBridgedNSError_enum_nsErrorDomain(*this, synthesizer);
   }
 
-  TC.diagnose(requirement->getLoc(), diag::broken_errortype_requirement);
+  Context.Diags.diagnose(requirement->getLoc(),
+                         diag::broken_errortype_requirement);
   return nullptr;
 }

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -136,7 +136,7 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
 
 static void maybeMarkAsInlinable(DerivedConformance &derived,
                                  AbstractFunctionDecl *afd) {
-  ASTContext &C = derived.TC.Context;
+  ASTContext &C = derived.Context;
   auto parentDC = derived.getConformanceContext();
   if (!parentDC->getParentModule()->isResilient()) {
     AccessScope access =
@@ -150,7 +150,7 @@ static void maybeMarkAsInlinable(DerivedConformance &derived,
 }
 
 static VarDecl *deriveRawRepresentable_raw(DerivedConformance &derived) {
-  ASTContext &C = derived.TC.Context;
+  ASTContext &C = derived.Context;
 
   auto enumDecl = cast<EnumDecl>(derived.Nominal);
   auto parentDC = derived.getConformanceContext();
@@ -393,16 +393,15 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
 
 static ConstructorDecl *
 deriveRawRepresentable_init(DerivedConformance &derived) {
-  auto &tc = derived.TC;
-  ASTContext &C = tc.Context;
+  ASTContext &C = derived.Context;
 
   auto enumDecl = cast<EnumDecl>(derived.Nominal);
   auto parentDC = derived.getConformanceContext();
   auto rawInterfaceType = enumDecl->getRawType();
   auto rawType = parentDC->mapTypeIntoContext(rawInterfaceType);
 
-  auto equatableProto = tc.getProtocol(enumDecl->getLoc(),
-                                       KnownProtocolKind::Equatable);
+  auto equatableProto = TypeChecker::getProtocol(C, enumDecl->getLoc(),
+                                                 KnownProtocolKind::Equatable);
   assert(equatableProto);
   assert(
       TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl, None));
@@ -446,7 +445,6 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
 
 static bool canSynthesizeRawRepresentable(DerivedConformance &derived) {
   auto enumDecl = cast<EnumDecl>(derived.Nominal);
-  auto &tc = derived.TC;
 
   Type rawType = enumDecl->getRawType();
   if (!rawType)
@@ -462,7 +460,8 @@ static bool canSynthesizeRawRepresentable(DerivedConformance &derived) {
   // The raw type must be Equatable, so that we have a suitable ~= for
   // synthesized switch statements.
   auto equatableProto =
-      tc.getProtocol(enumDecl->getLoc(), KnownProtocolKind::Equatable);
+      TypeChecker::getProtocol(enumDecl->getASTContext(), enumDecl->getLoc(),
+                               KnownProtocolKind::Equatable);
   if (!equatableProto)
     return false;
 
@@ -504,14 +503,14 @@ ValueDecl *DerivedConformance::deriveRawRepresentable(ValueDecl *requirement) {
   if (!canSynthesizeRawRepresentable(*this))
     return nullptr;
 
-  if (requirement->getBaseName() == TC.Context.Id_rawValue)
+  if (requirement->getBaseName() == Context.Id_rawValue)
     return deriveRawRepresentable_raw(*this);
 
   if (requirement->getBaseName() == DeclBaseName::createConstructor())
     return deriveRawRepresentable_init(*this);
 
-  TC.diagnose(requirement->getLoc(),
-              diag::broken_raw_representable_requirement);
+  Context.Diags.diagnose(requirement->getLoc(),
+                         diag::broken_raw_representable_requirement);
   return nullptr;
 }
 
@@ -525,10 +524,11 @@ Type DerivedConformance::deriveRawRepresentable(AssociatedTypeDecl *assocType) {
   if (!canSynthesizeRawRepresentable(*this))
     return nullptr;
 
-  if (assocType->getName() == TC.Context.Id_RawValue) {
+  if (assocType->getName() == Context.Id_RawValue) {
     return deriveRawRepresentable_Raw(*this);
   }
 
-  TC.diagnose(assocType->getLoc(), diag::broken_raw_representable_requirement);
+  Context.Diags.diagnose(assocType->getLoc(),
+                         diag::broken_raw_representable_requirement);
   return nullptr;
 }

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -23,10 +23,10 @@
 
 using namespace swift;
 
-DerivedConformance::DerivedConformance(TypeChecker &tc, Decl *conformanceDecl,
+DerivedConformance::DerivedConformance(ASTContext &ctx, Decl *conformanceDecl,
                                        NominalTypeDecl *nominal,
                                        ProtocolDecl *protocol)
-    : TC(tc), ConformanceDecl(conformanceDecl), Nominal(nominal),
+    : Context(ctx), ConformanceDecl(conformanceDecl), Nominal(nominal),
       Protocol(protocol) {
   assert(getConformanceContext()->getSelfNominalTypeDecl() == nominal);
 }
@@ -324,24 +324,24 @@ DerivedConformance::declareDerivedProperty(Identifier name,
                                            Type propertyInterfaceType,
                                            Type propertyContextType,
                                            bool isStatic, bool isFinal) {
-  auto &C = TC.Context;
   auto parentDC = getConformanceContext();
 
-  VarDecl *propDecl = new (C) VarDecl(/*IsStatic*/isStatic, VarDecl::Introducer::Var,
-                                      /*IsCaptureList*/false, SourceLoc(), name,
-                                      parentDC);
+  VarDecl *propDecl = new (Context)
+      VarDecl(/*IsStatic*/ isStatic, VarDecl::Introducer::Var,
+              /*IsCaptureList*/ false, SourceLoc(), name, parentDC);
   propDecl->setImplicit();
   propDecl->copyFormalAccessFrom(Nominal, /*sourceIsParentContext*/ true);
   propDecl->setInterfaceType(propertyInterfaceType);
 
-  Pattern *propPat = new (C) NamedPattern(propDecl, /*implicit*/ true);
+  Pattern *propPat = new (Context) NamedPattern(propDecl, /*implicit*/ true);
   propPat->setType(propertyContextType);
 
-  propPat = TypedPattern::createImplicit(C, propPat, propertyContextType);
+  propPat = TypedPattern::createImplicit(Context, propPat, propertyContextType);
   propPat->setType(propertyContextType);
 
   auto *pbDecl = PatternBindingDecl::createImplicit(
-      C, StaticSpellingKind::None, propPat, /*InitExpr*/ nullptr, parentDC);
+      Context, StaticSpellingKind::None, propPat, /*InitExpr*/ nullptr,
+      parentDC);
   return {propDecl, pbDecl};
 }
 
@@ -360,11 +360,9 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
   if (!allowCrossfileExtensions &&
       Nominal->getModuleScopeContext() !=
           getConformanceContext()->getModuleScopeContext()) {
-    TC.diagnose(ConformanceDecl->getLoc(),
-                diag::cannot_synthesize_in_crossfile_extension,
-                getProtocolType());
-    TC.diagnose(Nominal->getLoc(), diag::kind_declared_here,
-                DescriptiveDeclKind::Type);
+    ConformanceDecl->diagnose(diag::cannot_synthesize_in_crossfile_extension,
+                              getProtocolType());
+    Nominal->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
     return true;
   }
 
@@ -373,9 +371,9 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
   if (auto CD = dyn_cast<ClassDecl>(Nominal)) {
     if (!CD->isFinal() && isa<ConstructorDecl>(synthesizing) &&
         isa<ExtensionDecl>(ConformanceDecl)) {
-      TC.diagnose(ConformanceDecl->getLoc(),
-                  diag::cannot_synthesize_init_in_extension_of_nonfinal,
-                  getProtocolType(), synthesizing->getFullName());
+      ConformanceDecl->diagnose(
+          diag::cannot_synthesize_init_in_extension_of_nonfinal,
+          getProtocolType(), synthesizing->getFullName());
       return true;
     }
   }

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -33,12 +33,12 @@ class VarDecl;
 
 class DerivedConformance {
 public:
-  TypeChecker &TC;
+  ASTContext &Context;
   Decl *ConformanceDecl;
   NominalTypeDecl *Nominal;
   ProtocolDecl *Protocol;
 
-  DerivedConformance(TypeChecker &tc, Decl *conformanceDecl,
+  DerivedConformance(ASTContext &ctx, Decl *conformanceDecl,
                      NominalTypeDecl *nominal, ProtocolDecl *protocol);
 
   /// Retrieve the context in which the conformance is declared (either the

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3152,11 +3152,10 @@ class ObjCSelectorWalker : public ASTWalker {
 
     // Look for members with the given name.
     auto nominal = method->getDeclContext()->getSelfNominalTypeDecl();
-    auto result = TC.lookupMember(const_cast<DeclContext *>(DC),
-                                  nominal->getDeclaredInterfaceType(),
-                                  lookupName,
-                                  (defaultMemberLookupOptions |
-                                   NameLookupFlags::KnownPrivate));
+    auto result = TypeChecker::lookupMember(
+        const_cast<DeclContext *>(DC), nominal->getDeclaredInterfaceType(),
+        lookupName,
+        (defaultMemberLookupOptions | NameLookupFlags::KnownPrivate));
 
     // If we didn't find multiple methods, there is no ambiguity.
     if (result.size() < 2) return false;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -570,7 +570,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       // Referencing type(of:) and other decls with special type-checking
       // behavior as functions is not implemented. Maybe we could wrap up the
       // special-case behavior in a closure someday...
-      if (TC.getDeclTypeCheckingSemantics(DRE->getDecl())
+      if (TypeChecker::getDeclTypeCheckingSemantics(DRE->getDecl())
             != DeclTypeCheckingSemantics::Normal) {
         TC.diagnose(DRE->getLoc(), diag::unsupported_special_decl_ref,
                     DRE->getDecl()->getBaseName().getIdentifier());

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -315,11 +315,11 @@ static bool diagnoseOperatorJuxtaposition(UnresolvedDeclRefExpr *UDRE,
     NameLookupOptions LookupOptions = defaultUnqualifiedLookupOptions;
     // This is only used for diagnostics, so always use KnownPrivate.
     LookupOptions |= NameLookupFlags::KnownPrivate;
-    auto startLookup = TC.lookupUnqualified(DC, startName, UDRE->getLoc(),
-                                       LookupOptions);
+    auto startLookup = TypeChecker::lookupUnqualified(
+        DC, startName, UDRE->getLoc(), LookupOptions);
     if (!startLookup) continue;
-    auto endLookup = TC.lookupUnqualified(DC, endName, UDRE->getLoc(),
-                                          LookupOptions);
+    auto endLookup = TypeChecker::lookupUnqualified(DC, endName, UDRE->getLoc(),
+                                                    LookupOptions);
     if (!endLookup) continue;
 
     // If the overall operator is a binary one, then we're looking at
@@ -1404,10 +1404,8 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
         lookupOptions |= NameLookupFlags::KnownPrivate;
 
       // See if the type has a member type with this name.
-      auto Result = TC.lookupMemberType(DC,
-                                        TD->getDeclaredInterfaceType(),
-                                        Name,
-                                        lookupOptions);
+      auto Result = TypeChecker::lookupMemberType(
+          DC, TD->getDeclaredInterfaceType(), Name, lookupOptions);
 
       // If there is no nested type with this name, we have a lookup of
       // a non-type member, so leave the expression as-is.
@@ -1462,10 +1460,8 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
         lookupOptions |= NameLookupFlags::KnownPrivate;
 
       // See if there is a member type with this name.
-      auto Result = TC.lookupMemberType(DC,
-                                        BaseTy,
-                                        Name,
-                                        lookupOptions);
+      auto Result =
+          TypeChecker::lookupMemberType(DC, BaseTy, Name, lookupOptions);
 
       // If there is no nested type with this name, we have a lookup of
       // a non-type member, so leave the expression as-is.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1963,7 +1963,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
   if (!literal)
     return nullptr;
 
-  auto *protocol = TC.getLiteralProtocol(literal);
+  auto *protocol = TypeChecker::getLiteralProtocol(TC.Context, literal);
   if (!protocol)
     return nullptr;
 
@@ -2914,8 +2914,8 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
 
       // The expression type must conform to the Sequence.
       auto &tc = cs.getTypeChecker();
-      ProtocolDecl *sequenceProto
-        = tc.getProtocol(Stmt->getForLoc(), KnownProtocolKind::Sequence);
+      ProtocolDecl *sequenceProto = TypeChecker::getProtocol(
+          cs.getASTContext(), Stmt->getForLoc(), KnownProtocolKind::Sequence);
       if (!sequenceProto) {
         return true;
       }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3571,6 +3571,7 @@ bool TypeChecker::isAvailabilitySafeForConformance(
   if (!dc->getParentSourceFile())
     return true;
 
+  auto &Context = proto->getASTContext();
   NominalTypeDecl *conformingDecl = dc->getSelfNominalTypeDecl();
   assert(conformingDecl && "Must have conforming declaration");
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4594,9 +4594,10 @@ static Optional<std::string> buildDefaultInitializerString(TypeChecker &tc,
 
     // For literal-convertible types, form the corresponding literal.
 #define CHECK_LITERAL_PROTOCOL(Kind, String)                                   \
-  if (auto proto = tc.getProtocol(SourceLoc(), KnownProtocolKind::Kind)) {     \
-    if (tc.conformsToProtocol(type, proto, dc,                                 \
-                              ConformanceCheckFlags::InExpression))            \
+  if (auto proto = TypeChecker::getProtocol(                                   \
+          type->getASTContext(), SourceLoc(), KnownProtocolKind::Kind)) {      \
+    if (TypeChecker::conformsToProtocol(type, proto, dc,                       \
+                                        ConformanceCheckFlags::InExpression))  \
       return std::string(String);                                              \
   }
     CHECK_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "[]")

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4689,9 +4689,10 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
       // and isn't implicit; otherwise, on the subclass itself.
       ValueDecl *diagDest = classDecl;
       auto initFrom = DeclName(C, DeclBaseName::createConstructor(), C.Id_from);
-      auto result = tc.lookupMember(superclassDecl, superclassType, initFrom,
+      auto result =
+          TypeChecker::lookupMember(superclassDecl, superclassType, initFrom,
                                     NameLookupFlags::ProtocolMembers |
-                                    NameLookupFlags::IgnoreAccessControl);
+                                        NameLookupFlags::IgnoreAccessControl);
 
       if (!result.empty() && !result.front().getValueDecl()->isImplicit())
         diagDest = result.front().getValueDecl();

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -665,10 +665,10 @@ static Type lookupDefaultLiteralType(const DeclContext *dc,
 
 static Optional<KnownProtocolKind>
 getKnownProtocolKindIfAny(const ProtocolDecl *protocol) {
-  TypeChecker &tc = TypeChecker::createForContext(protocol->getASTContext());
-
 #define EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME(Id, _, __, ___)              \
-  if (protocol == tc.getProtocol(SourceLoc(), KnownProtocolKind::Id))          \
+  if (protocol == TypeChecker::getProtocol(protocol->getASTContext(),          \
+                                           SourceLoc(),                        \
+                                           KnownProtocolKind::Id))             \
     return KnownProtocolKind::Id;
 #include "swift/AST/KnownProtocols.def"
 #undef EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -117,7 +117,8 @@ lookupUnqualifiedEnumMemberElement(TypeChecker &TC, DeclContext *DC,
                                    Identifier name, SourceLoc UseLoc) {
   auto lookupOptions = defaultUnqualifiedLookupOptions;
   lookupOptions |= NameLookupFlags::KnownPrivate;
-  auto lookup = TC.lookupUnqualified(DC, name, SourceLoc(), lookupOptions);
+  auto lookup =
+      TypeChecker::lookupUnqualified(DC, name, SourceLoc(), lookupOptions);
   return filterForEnumElement(TC, DC, UseLoc,
                               /*unqualifiedLookup=*/true, lookup);
 }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -132,7 +132,8 @@ lookupEnumMemberElement(TypeChecker &TC, DeclContext *DC, Type ty,
   // Look up the case inside the enum.
   // FIXME: We should be able to tell if this is a private lookup.
   NameLookupOptions lookupOptions = defaultMemberLookupOptions;
-  LookupResult foundElements = TC.lookupMember(DC, ty, name, lookupOptions);
+  LookupResult foundElements =
+      TypeChecker::lookupMember(DC, ty, name, lookupOptions);
   return filterForEnumElement(TC, DC, UseLoc,
                               /*unqualifiedLookup=*/false, foundElements);
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1196,7 +1196,7 @@ bool WitnessChecker::
 checkWitnessAvailability(ValueDecl *requirement,
                          ValueDecl *witness,
                          AvailabilityContext *requiredAvailability) {
-  return (!TC.getLangOpts().DisableAvailabilityChecking &&
+  return (!TC.Context.LangOpts.DisableAvailabilityChecking &&
           !TC.isAvailabilitySafeForConformance(Proto, requirement, witness,
                                                DC, *requiredAvailability));
 }
@@ -1635,12 +1635,12 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     bool hasDiagnosed = false;
     auto *protoFile = Proto->getModuleScopeContext();
     if (auto *serialized = dyn_cast<SerializedASTFile>(protoFile)) {
-      if (serialized->getLanguageVersionBuiltWith() !=
-          TC.getLangOpts().EffectiveLanguageVersion) {
+      const auto effectiveVers = TC.Context.LangOpts.EffectiveLanguageVersion;
+      if (serialized->getLanguageVersionBuiltWith() != effectiveVers) {
         TC.diagnose(ComplainLoc,
                     diag::protocol_has_missing_requirements_versioned, T,
                     ProtoType, serialized->getLanguageVersionBuiltWith(),
-                    TC.getLangOpts().EffectiveLanguageVersion);
+                    effectiveVers);
         hasDiagnosed = true;
       }
     }
@@ -2697,7 +2697,7 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
   if (LocalMissing.empty())
     return;
   SourceLoc ComplainLoc = Loc;
-  bool EditorMode = TC.getLangOpts().DiagnosticsEditorMode;
+  bool EditorMode = TC.Context.LangOpts.DiagnosticsEditorMode;
   llvm::SetVector<ValueDecl*> MissingWitnesses(GlobalMissingWitnesses.begin(),
                                                GlobalMissingWitnesses.end());
   auto InsertFixitCallback = [ComplainLoc, EditorMode, MissingWitnesses]

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1197,8 +1197,8 @@ checkWitnessAvailability(ValueDecl *requirement,
                          ValueDecl *witness,
                          AvailabilityContext *requiredAvailability) {
   return (!TC.Context.LangOpts.DisableAvailabilityChecking &&
-          !TC.isAvailabilitySafeForConformance(Proto, requirement, witness,
-                                               DC, *requiredAvailability));
+          !TypeChecker::isAvailabilitySafeForConformance(
+              Proto, requirement, witness, DC, *requiredAvailability));
 }
 
 RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -907,8 +907,8 @@ WitnessChecker::lookupValueWitnessesViaImplementsAttr(
   auto lookupOptions = defaultMemberTypeLookupOptions;
   lookupOptions -= NameLookupFlags::PerformConformanceCheck;
   lookupOptions |= NameLookupFlags::IncludeAttributeImplements;
-  auto candidates = TC.lookupMember(DC, Adoptee, req->getFullName(),
-                                    lookupOptions);
+  auto candidates =
+      TypeChecker::lookupMember(DC, Adoptee, req->getFullName(), lookupOptions);
   for (auto candidate : candidates) {
     if (witnessHasImplementsAttrForExactRequirement(candidate.getValueDecl(), req)) {
       witnesses.push_back(candidate.getValueDecl());
@@ -947,14 +947,14 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
     auto lookupOptions = defaultMemberTypeLookupOptions;
     lookupOptions -= NameLookupFlags::PerformConformanceCheck;
 
-    auto candidates = TC.lookupMember(DC, Adoptee, req->getFullName(),
-                                      lookupOptions);
+    auto candidates = TypeChecker::lookupMember(DC, Adoptee, req->getFullName(),
+                                                lookupOptions);
 
     // If we didn't find anything with the appropriate name, look
     // again using only the base name.
     if (candidates.empty() && ignoringNames) {
-      candidates = TC.lookupMember(DC, Adoptee, req->getBaseName(),
-                                   lookupOptions);
+      candidates = TypeChecker::lookupMember(DC, Adoptee, req->getBaseName(),
+                                             lookupOptions);
       *ignoringNames = true;
     }
 
@@ -4732,9 +4732,9 @@ diagnoseMissingAppendInterpolationMethod(TypeChecker &tc,
       auto baseName = DeclName(tc.Context.Id_appendInterpolation);
       auto lookupOptions = defaultMemberTypeLookupOptions;
       lookupOptions -= NameLookupFlags::PerformConformanceCheck;
-      
-      for (auto resultEntry : tc.lookupMember(typeDecl, type, baseName,
-                                              lookupOptions)) {
+
+      for (auto resultEntry :
+           TypeChecker::lookupMember(typeDecl, type, baseName, lookupOptions)) {
         auto method = dyn_cast<FuncDecl>(resultEntry.getValueDecl()); 
         if (!method) continue;
         
@@ -4756,7 +4756,7 @@ diagnoseMissingAppendInterpolationMethod(TypeChecker &tc,
         
         return true;
       }
-      
+
       return false;
     }
   };

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3693,7 +3693,7 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
     }
   } listener(Conformance, fileForCheckingExportability);
 
-  auto result = TC.checkGenericArguments(
+  auto result = TypeChecker::checkGenericArguments(
       DC, Loc, Loc,
       // FIXME: maybe this should be the conformance's type
       proto->getDeclaredInterfaceType(),

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5269,7 +5269,8 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
   if (Decl->isInvalid())
     return nullptr;
 
-  DerivedConformance derived(*this, Decl, TypeDecl, protocol);
+  DerivedConformance derived(TypeDecl->getASTContext(), Decl, TypeDecl,
+                             protocol);
 
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:
@@ -5313,7 +5314,8 @@ Type TypeChecker::deriveTypeWitness(DeclContext *DC,
 
   auto Decl = DC->getInnermostDeclarationDeclContext();
 
-  DerivedConformance derived(*this, Decl, TypeDecl, protocol);
+  DerivedConformance derived(TypeDecl->getASTContext(), Decl, TypeDecl,
+                             protocol);
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:
     return derived.deriveRawRepresentable(AssocType);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3358,7 +3358,8 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDerivation(
   }
 
   // Attempt to derive the witness.
-  auto derived = TC.deriveProtocolRequirement(DC, derivingTypeDecl, requirement);
+  auto derived =
+      TypeChecker::deriveProtocolRequirement(DC, derivingTypeDecl, requirement);
   if (!derived)
     return ResolveWitnessResult::ExplicitFailed;
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1193,7 +1193,7 @@ bool WitnessChecker::
 checkWitnessAvailability(ValueDecl *requirement,
                          ValueDecl *witness,
                          AvailabilityContext *requiredAvailability) {
-  return (!TC.Context.LangOpts.DisableAvailabilityChecking &&
+  return (!getASTContext().LangOpts.DisableAvailabilityChecking &&
           !TypeChecker::isAvailabilitySafeForConformance(
               Proto, requirement, witness, DC, *requiredAvailability));
 }
@@ -1224,7 +1224,7 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
     return RequirementCheck(CheckKind::Availability, requiredAvailability);
   }
 
-  if (requirement->getAttrs().isUnavailable(TC.Context) &&
+  if (requirement->getAttrs().isUnavailable(getASTContext()) &&
       match.Witness->getDeclContext() == DC) {
     return RequirementCheck(CheckKind::Unavailable);
   }
@@ -1247,8 +1247,8 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
     }
   }
 
-  if (match.Witness->getAttrs().isUnavailable(TC.Context) &&
-      !requirement->getAttrs().isUnavailable(TC.Context)) {
+  if (match.Witness->getAttrs().isUnavailable(getASTContext()) &&
+      !requirement->getAttrs().isUnavailable(getASTContext())) {
     return CheckKind::WitnessUnavailable;
   }
 
@@ -1278,7 +1278,7 @@ class swift::MultiConformanceChecker {
 public:
   MultiConformanceChecker(TypeChecker &TC): TC(TC){}
 
-  TypeChecker &getTypeChecker() const { return TC; }
+  ASTContext &getASTContext() const { return TC.Context; }
 
   /// Add a conformance into the batched checker.
   void addConformance(NormalProtocolConformance *conformance) {
@@ -1493,15 +1493,16 @@ static void diagnoseConformanceImpliedByConditionalConformance(
 ProtocolConformance *MultiConformanceChecker::
 checkIndividualConformance(NormalProtocolConformance *conformance,
                            bool issueFixit) {
-  PrettyStackTraceConformance trace(TC.Context, "type-checking", conformance);
+  PrettyStackTraceConformance trace(getASTContext(), "type-checking",
+                                    conformance);
 
   std::vector<ValueDecl*> revivedMissingWitnesses;
   switch (conformance->getState()) {
     case ProtocolConformanceState::Incomplete:
       if (conformance->isInvalid()) {
         // Revive registered missing witnesses to handle it below.
-        revivedMissingWitnesses = TC.Context.
-          takeDelayedMissingWitnesses(conformance);
+        revivedMissingWitnesses =
+            getASTContext().takeDelayedMissingWitnesses(conformance);
 
         // If we have no missing witnesses for this invalid conformance, the
         // conformance is invalid for other reasons, so emit diagnosis now.
@@ -1529,6 +1530,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
   auto Proto = conformance->getProtocol();
   auto ProtoType = Proto->getDeclaredType();
   SourceLoc ComplainLoc = conformance->getLoc();
+  auto &C = ProtoType->getASTContext();
 
   // Note that we are checking this conformance now.
   conformance->setState(ProtocolConformanceState::Checking);
@@ -1546,8 +1548,9 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
 
   // If the protocol requires a class, non-classes are a non-starter.
   if (Proto->requiresClass() && !canT->getClassOrBoundGenericClass()) {
-    TC.diagnose(ComplainLoc, diag::non_class_cannot_conform_to_class_protocol,
-                T, ProtoType);
+    C.Diags.diagnose(ComplainLoc,
+                     diag::non_class_cannot_conform_to_class_protocol, T,
+                     ProtoType);
     conformance->setInvalid();
     return conformance;
   }
@@ -1568,7 +1571,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
           break;
       }
       if (diagKind) {
-        TC.diagnose(ComplainLoc, diagKind.getValue(), T, ProtoType);
+        C.Diags.diagnose(ComplainLoc, diagKind.getValue(), T, ProtoType);
         conformance->setInvalid();
         return conformance;
       }
@@ -1580,9 +1583,9 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     // with the Obj-C runtime when they're satisfied, but we'd still have solve
     // the problem with extensions that we check for below.
     if (!conformance->getConditionalRequirements().empty()) {
-      TC.diagnose(ComplainLoc,
-                  diag::objc_protocol_cannot_have_conditional_conformance,
-                  T, ProtoType);
+      C.Diags.diagnose(ComplainLoc,
+                       diag::objc_protocol_cannot_have_conditional_conformance,
+                       T, ProtoType);
       conformance->setInvalid();
       return conformance;
     }
@@ -1594,8 +1597,9 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
       if (auto classDecl = ext->getSelfClassDecl()) {
         if (classDecl->isGenericContext()) {
           if (!classDecl->usesObjCGenericsModel()) {
-            TC.diagnose(ComplainLoc, diag::objc_protocol_in_generic_extension,
-                        classDecl->isGeneric(), T, ProtoType);
+            C.Diags.diagnose(ComplainLoc,
+                             diag::objc_protocol_in_generic_extension,
+                             classDecl->isGeneric(), T, ProtoType);
             conformance->setInvalid();
             return conformance;
           }
@@ -1614,9 +1618,9 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     while (nestedType) {
       if (auto clas = nestedType->getClassOrBoundGenericClass()) {
         if (clas->usesObjCGenericsModel()) {
-          TC.diagnose(ComplainLoc,
-                      diag::objc_generics_cannot_conditionally_conform, T,
-                      ProtoType);
+          C.Diags.diagnose(ComplainLoc,
+                           diag::objc_generics_cannot_conditionally_conform, T,
+                           ProtoType);
           conformance->setInvalid();
           return conformance;
         }
@@ -1632,18 +1636,19 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     bool hasDiagnosed = false;
     auto *protoFile = Proto->getModuleScopeContext();
     if (auto *serialized = dyn_cast<SerializedASTFile>(protoFile)) {
-      const auto effectiveVers = TC.Context.LangOpts.EffectiveLanguageVersion;
+      const auto effectiveVers =
+          getASTContext().LangOpts.EffectiveLanguageVersion;
       if (serialized->getLanguageVersionBuiltWith() != effectiveVers) {
-        TC.diagnose(ComplainLoc,
-                    diag::protocol_has_missing_requirements_versioned, T,
-                    ProtoType, serialized->getLanguageVersionBuiltWith(),
-                    effectiveVers);
+        C.Diags.diagnose(ComplainLoc,
+                         diag::protocol_has_missing_requirements_versioned, T,
+                         ProtoType, serialized->getLanguageVersionBuiltWith(),
+                         effectiveVers);
         hasDiagnosed = true;
       }
     }
     if (!hasDiagnosed) {
-      TC.diagnose(ComplainLoc, diag::protocol_has_missing_requirements, T,
-                  ProtoType);
+      C.Diags.diagnose(ComplainLoc, diag::protocol_has_missing_requirements, T,
+                       ProtoType);
     }
     conformance->setInvalid();
     return conformance;
@@ -1675,7 +1680,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
       impliedDisablesMissingWitnessFixits = true;
 
       diagnoseConformanceImpliedByConditionalConformance(
-          TC.Diags, conformance, implyingConf, issueFixit);
+          C.Diags, conformance, implyingConf, issueFixit);
 
       conformance->setInvalid();
     }
@@ -1693,9 +1698,8 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
       // Recursive call already diagnosed this problem, but tack on a note
       // to establish the relationship.
       if (ComplainLoc.isValid()) {
-        TC.diagnose(Proto,
-                    diag::inherited_protocol_does_not_conform, T,
-                    InheritedProto->getDeclaredType());
+        C.Diags.diagnose(Proto, diag::inherited_protocol_does_not_conform, T,
+                         InheritedProto->getDeclaredType());
       }
 
       conformance->setInvalid();
@@ -2239,7 +2243,7 @@ void ConformanceChecker::recordWitness(ValueDecl *requirement,
   }
 
   // Record this witness in the conformance.
-  auto witness = match.getWitness(TC.Context);
+  auto witness = match.getWitness(getASTContext());
   Conformance->setWitness(requirement, witness);
 }
 
@@ -2468,12 +2472,9 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
     }
   } else {
     // If there was no type declaration, synthesize one.
-    auto aliasDecl = new (TC.Context) TypeAliasDecl(SourceLoc(),
-                                                    SourceLoc(),
-                                                    assocType->getName(),
-                                                    SourceLoc(),
-                                                    /*genericparams*/nullptr, 
-                                                    DC);
+    auto aliasDecl = new (getASTContext()) TypeAliasDecl(
+        SourceLoc(), SourceLoc(), assocType->getName(), SourceLoc(),
+        /*genericparams*/ nullptr, DC);
     aliasDecl->setUnderlyingType(type);
     
     aliasDecl->setImplicit();
@@ -2484,7 +2485,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
     if (auto nominal = DC->getSelfNominalTypeDecl()) {
       AccessScope requiredAccessScope = getRequiredAccessScope();
 
-      if (!TC.Context.isSwiftVersionAtLeast(5) &&
+      if (!getASTContext().isSwiftVersionAtLeast(5) &&
           !DC->getParentModule()->isResilient()) {
         // HACK: In pre-Swift-5, these typealiases were synthesized with the
         // same access level as the conforming type, which might be more
@@ -2513,7 +2514,8 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
 
       aliasDecl->setAccess(requiredAccess);
       if (isUsableFromInlineRequired()) {
-        auto *attr = new (TC.Context) UsableFromInlineAttr(/*implicit=*/true);
+        auto *attr =
+            new (getASTContext()) UsableFromInlineAttr(/*implicit=*/true);
         aliasDecl->getAttrs().add(attr);
       }
 
@@ -2694,7 +2696,7 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
   if (LocalMissing.empty())
     return;
   SourceLoc ComplainLoc = Loc;
-  bool EditorMode = TC.Context.LangOpts.DiagnosticsEditorMode;
+  bool EditorMode = getASTContext().LangOpts.DiagnosticsEditorMode;
   llvm::SetVector<ValueDecl*> MissingWitnesses(GlobalMissingWitnesses.begin(),
                                                GlobalMissingWitnesses.end());
   auto InsertFixitCallback = [ComplainLoc, EditorMode, MissingWitnesses]
@@ -2789,8 +2791,8 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
       // If the diagnostics are suppressed, we register these missing witnesses
       // for later revisiting.
       Conformance->setInvalid();
-      TC.Context.addDelayedMissingWitnesses(Conformance,
-                                            MissingWitnesses.getArrayRef());
+      getASTContext().addDelayedMissingWitnesses(
+          Conformance, MissingWitnesses.getArrayRef());
     } else {
       diagnoseOrDefer(LocalMissing[0], true, InsertFixitCallback);
     }
@@ -3053,8 +3055,8 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   bool doNotDiagnoseMatches = false;
   bool ignoringNames = false;
   bool considerRenames =
-    !canDerive && !requirement->getAttrs().hasAttribute<OptionalAttr>() &&
-    !requirement->getAttrs().isUnavailable(TC.Context);
+      !canDerive && !requirement->getAttrs().hasAttribute<OptionalAttr>() &&
+      !requirement->getAttrs().isUnavailable(getASTContext());
   if (findBestWitness(requirement,
                       considerRenames ? &ignoringNames : nullptr,
                       Conformance,
@@ -3114,7 +3116,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       //
       // Work around this by discarding the witness if its not sufficiently
       // visible.
-      if (!TC.Context.isSwiftVersionAtLeast(5))
+      if (!getASTContext().isSwiftVersionAtLeast(5))
         if (requirement->getAttrs().hasAttribute<OptionalAttr>())
           return ResolveWitnessResult::Missing;
 
@@ -3184,7 +3186,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     }
 
     case CheckKind::Unavailable: {
-      auto *attr = requirement->getAttrs().getUnavailable(TC.Context);
+      auto *attr = requirement->getAttrs().getUnavailable(getASTContext());
       diagnoseUnavailableOverride(witness, requirement, attr);
       break;
     }
@@ -3287,7 +3289,8 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   // Treat 'unavailable' implicitly as if it were 'optional'.
   // The compiler will reject actual uses.
   auto Attrs = requirement->getAttrs();
-  if (Attrs.hasAttribute<OptionalAttr>() || Attrs.isUnavailable(TC.Context)) {
+  if (Attrs.hasAttribute<OptionalAttr>() ||
+      Attrs.isUnavailable(getASTContext())) {
     return ResolveWitnessResult::Missing;
   }
 
@@ -3391,7 +3394,8 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDefault(
   // An optional requirement is trivially satisfied with an empty requirement.
   // An 'unavailable' requirement is treated like an optional requirement.
   auto Attrs = requirement->getAttrs();
-  if (Attrs.hasAttribute<OptionalAttr>() || Attrs.isUnavailable(TC.Context)) {
+  if (Attrs.hasAttribute<OptionalAttr>() ||
+      Attrs.isUnavailable(getASTContext())) {
     recordOptionalWitness(requirement);
     return ResolveWitnessResult::Success;
   }
@@ -3402,16 +3406,16 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDefault(
 
 # pragma mark Type witness resolution
 
-CheckTypeWitnessResult swift::checkTypeWitness(TypeChecker &tc, DeclContext *dc,
+CheckTypeWitnessResult swift::checkTypeWitness(DeclContext *dc,
                                                ProtocolDecl *proto,
-                                               AssociatedTypeDecl *assocType, 
+                                               AssociatedTypeDecl *assocType,
                                                Type type) {
   auto genericSig = proto->getGenericSignature();
   auto *depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
                                          assocType);
 
   if (type->hasError())
-    return ErrorType::get(tc.Context);
+    return ErrorType::get(proto->getASTContext());
 
   Type contextType = type->hasTypeParameter() ? dc->mapTypeIntoContext(type)
                                               : type;
@@ -3449,7 +3453,7 @@ CheckTypeWitnessResult swift::checkTypeWitness(TypeChecker &tc, DeclContext *dc,
 
   if (genericSig->requiresClass(depTy) &&
       !contextType->satisfiesClassConstraint())
-    return CheckTypeWitnessResult(tc.Context.getAnyObjectType());
+    return CheckTypeWitnessResult(proto->getASTContext().getAnyObjectType());
 
   // Success!
   return CheckTypeWitnessResult();
@@ -3514,7 +3518,7 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
 
     // Check this type against the protocol requirements.
     if (auto checkResult =
-            checkTypeWitness(TC, DC, Proto, assocType, candidate.MemberType)) {
+            checkTypeWitness(DC, Proto, assocType, candidate.MemberType)) {
       nonViable.push_back({candidate.Member, checkResult});
     } else {
       viable.push_back(candidate);
@@ -3541,7 +3545,7 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
   }
 
   // Record an error.
-  recordTypeWitness(assocType, ErrorType::get(TC.Context), nullptr);
+  recordTypeWitness(assocType, ErrorType::get(getASTContext()), nullptr);
 
   // If we had multiple viable types, diagnose the ambiguity.
   if (!viable.empty()) {
@@ -3715,8 +3719,8 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
     // Diagnose the failure generically.
     // FIXME: Would be nice to give some more context here!
     if (!Conformance->isInvalid()) {
-      TC.diagnose(Loc, diag::type_does_not_conform,
-                  Adoptee, Proto->getDeclaredType());
+      proto->getASTContext().Diags.diagnose(Loc, diag::type_does_not_conform,
+                                            Adoptee, Proto->getDeclaredType());
       Conformance->setInvalid();
     }
     return;
@@ -3746,9 +3750,10 @@ void ConformanceChecker::resolveValueWitnesses() {
       if (!witness) return;
 
       // Objective-C checking for @objc requirements.
+      auto &C = witness->getASTContext();
       if (requirement->isObjC() &&
           requirement->getFullName() == witness->getFullName() &&
-          !requirement->getAttrs().isUnavailable(TC.Context)) {
+          !requirement->getAttrs().isUnavailable(getASTContext())) {
         // The witness must also be @objc.
         if (!witness->isObjC()) {
           bool isOptional =
@@ -3756,19 +3761,18 @@ void ConformanceChecker::resolveValueWitnesses() {
           SourceLoc diagLoc = getLocForDiagnosingWitness(Conformance, witness);
           if (auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness)) {
             auto diagInfo = getObjCMethodDiagInfo(witnessFunc);
-            Optional<InFlightDiagnostic> fixItDiag =
-                TC.diagnose(diagLoc,
-                            isOptional ? diag::witness_non_objc_optional
-                                       : diag::witness_non_objc,
-                            diagInfo.first, diagInfo.second,
-                            Proto->getFullName());
+            Optional<InFlightDiagnostic> fixItDiag = C.Diags.diagnose(
+                diagLoc,
+                isOptional ? diag::witness_non_objc_optional
+                           : diag::witness_non_objc,
+                diagInfo.first, diagInfo.second, Proto->getFullName());
             if (diagLoc != witness->getLoc()) {
               // If the main diagnostic is emitted on the conformance, we want
               // to attach the fix-it to the note that shows where the
               // witness is defined.
               fixItDiag.getValue().flush();
-              fixItDiag.emplace(TC.diagnose(witness, diag::make_decl_objc,
-                                            witness->getDescriptiveKind()));
+              fixItDiag.emplace(witness->diagnose(
+                  diag::make_decl_objc, witness->getDescriptiveKind()));
             }
             if (!witness->canInferObjCFromRequirement(requirement)) {
               fixDeclarationObjCName(
@@ -3777,20 +3781,19 @@ void ConformanceChecker::resolveValueWitnesses() {
                   requirement->getObjCRuntimeName());
             }
           } else if (isa<VarDecl>(witness)) {
-            Optional<InFlightDiagnostic> fixItDiag =
-                TC.diagnose(diagLoc,
-                            isOptional ? diag::witness_non_objc_storage_optional
-                                       : diag::witness_non_objc_storage,
-                            /*isSubscript=*/false,
-                            witness->getFullName(),
-                            Proto->getFullName());
+            Optional<InFlightDiagnostic> fixItDiag = C.Diags.diagnose(
+                diagLoc,
+                isOptional ? diag::witness_non_objc_storage_optional
+                           : diag::witness_non_objc_storage,
+                /*isSubscript=*/false, witness->getFullName(),
+                Proto->getFullName());
             if (diagLoc != witness->getLoc()) {
               // If the main diagnostic is emitted on the conformance, we want
               // to attach the fix-it to the note that shows where the
               // witness is defined.
               fixItDiag.getValue().flush();
-              fixItDiag.emplace(TC.diagnose(witness, diag::make_decl_objc,
-                                            witness->getDescriptiveKind()));
+              fixItDiag.emplace(witness->diagnose(
+                  diag::make_decl_objc, witness->getDescriptiveKind()));
             }
             if (!witness->canInferObjCFromRequirement(requirement)) {
               fixDeclarationObjCName(
@@ -3799,21 +3802,19 @@ void ConformanceChecker::resolveValueWitnesses() {
                   requirement->getObjCRuntimeName());
             }
           } else if (isa<SubscriptDecl>(witness)) {
-            Optional<InFlightDiagnostic> fixItDiag =
-                TC.diagnose(diagLoc,
-                            isOptional
-                              ? diag::witness_non_objc_storage_optional
-                              : diag::witness_non_objc_storage,
-                            /*isSubscript=*/true,
-                            witness->getFullName(),
-                            Proto->getFullName());
+            Optional<InFlightDiagnostic> fixItDiag = C.Diags.diagnose(
+                diagLoc,
+                isOptional ? diag::witness_non_objc_storage_optional
+                           : diag::witness_non_objc_storage,
+                /*isSubscript=*/true, witness->getFullName(),
+                Proto->getFullName());
             if (diagLoc != witness->getLoc()) {
               // If the main diagnostic is emitted on the conformance, we want
               // to attach the fix-it to the note that shows where the
               // witness is defined.
               fixItDiag.getValue().flush();
-              fixItDiag.emplace(TC.diagnose(witness, diag::make_decl_objc,
-                                            witness->getDescriptiveKind()));
+              fixItDiag.emplace(witness->diagnose(
+                  diag::make_decl_objc, witness->getDescriptiveKind()));
             }
             fixItDiag->fixItInsert(witness->getAttributeInsertionLoc(false),
                                    "@objc ");
@@ -3822,14 +3823,14 @@ void ConformanceChecker::resolveValueWitnesses() {
           // If the requirement is optional, @nonobjc suppresses the
           // diagnostic.
           if (isOptional) {
-            TC.diagnose(witness, diag::req_near_match_nonobjc, false)
-              .fixItInsert(witness->getAttributeInsertionLoc(false),
-                           "@nonobjc ");
+            witness->diagnose(diag::req_near_match_nonobjc, false)
+                .fixItInsert(witness->getAttributeInsertionLoc(false),
+                             "@nonobjc ");
           }
 
-          TC.diagnose(requirement, diag::kind_declname_declared_here,
-                      DescriptiveDeclKind::Requirement,
-                      requirement->getFullName());
+          requirement->diagnose(diag::kind_declname_declared_here,
+                                DescriptiveDeclKind::Requirement,
+                                requirement->getFullName());
 
           Conformance->setInvalid();
           return;
@@ -3845,16 +3846,16 @@ void ConformanceChecker::resolveValueWitnesses() {
         // Swift 3 rules, warn if asked.
         if (auto attr = witness->getAttrs().getAttribute<ObjCAttr>()) {
           if (attr->isSwift3Inferred() &&
-              TC.Context.LangOpts.WarnSwift3ObjCInference
-                == Swift3ObjCInferenceWarnings::Minimal) {
-            TC.diagnose(Conformance->getLoc(),
-                        diag::witness_swift3_objc_inference,
-                        witness->getDescriptiveKind(), witness->getFullName(),
-                        Conformance->getProtocol()->getDeclaredInterfaceType());
-            TC.diagnose(witness, diag::make_decl_objc,
-                        witness->getDescriptiveKind())
-              .fixItInsert(witness->getAttributeInsertionLoc(false),
-                           "@objc ");
+              getASTContext().LangOpts.WarnSwift3ObjCInference ==
+                  Swift3ObjCInferenceWarnings::Minimal) {
+            C.Diags.diagnose(
+                Conformance->getLoc(), diag::witness_swift3_objc_inference,
+                witness->getDescriptiveKind(), witness->getFullName(),
+                Conformance->getProtocol()->getDeclaredInterfaceType());
+            witness
+                ->diagnose(diag::make_decl_objc, witness->getDescriptiveKind())
+                .fixItInsert(witness->getAttributeInsertionLoc(false),
+                             "@objc ");
           }
         }
       }
@@ -3896,7 +3897,7 @@ void ConformanceChecker::resolveValueWitnesses() {
 void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
   assert(!Conformance->isComplete() && "Conformance is already complete");
 
-  FrontendStatsTracer statsTracer(TC.Context.Stats, "check-conformance",
+  FrontendStatsTracer statsTracer(getASTContext().Stats, "check-conformance",
                                   Conformance);
 
   llvm::SaveAndRestore<bool> restoreSuppressDiagnostics(SuppressDiagnostics);
@@ -3954,14 +3955,16 @@ void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
   // between an imported Objective-C module and its overlay.
   if (Proto->isSpecificProtocol(KnownProtocolKind::ObjectiveCBridgeable)) {
     auto nominal = Adoptee->getAnyNominal();
-    if (!TC.Context.isTypeBridgedInExternalModule(nominal)) {
-      auto clangLoader = TC.Context.getClangModuleLoader();
+    if (!getASTContext().isTypeBridgedInExternalModule(nominal)) {
+      auto clangLoader = getASTContext().getClangModuleLoader();
       if (nominal->getParentModule() != DC->getParentModule() &&
           !(clangLoader &&
             clangLoader->isInOverlayModuleForImportedModule(DC, nominal))) {
         auto nominalModule = nominal->getParentModule();
-        TC.diagnose(Loc, diag::nonlocal_bridged_to_objc, nominal->getName(),
-                    Proto->getName(), nominalModule->getName());
+        auto &C = nominal->getASTContext();
+        C.Diags.diagnose(Loc, diag::nonlocal_bridged_to_objc,
+                         nominal->getName(), Proto->getName(),
+                         nominalModule->getName());
       }
     }
   }
@@ -4046,12 +4049,9 @@ void ConformanceChecker::diagnoseOrDefer(
   if (SuppressDiagnostics) {
     // Stash this in the ASTContext for later emission.
     auto conformance = Conformance;
-    TC.Context.addDelayedConformanceDiag(conformance,
-                                         { requirement,
-                                           [conformance, fn] {
-                                              fn(conformance);
-                                            },
-                                           isError });
+    getASTContext().addDelayedConformanceDiag(
+        conformance,
+        {requirement, [conformance, fn] { fn(conformance); }, isError});
     return;
   }
 
@@ -4065,7 +4065,7 @@ void ConformanceChecker::diagnoseOrDefer(
 }
 
 void ConformanceChecker::emitDelayedDiags() {
-  auto diags = TC.Context.takeDelayedConformanceDiags(Conformance);
+  auto diags = getASTContext().takeDelayedConformanceDiags(Conformance);
 
   assert(!SuppressDiagnostics && "Should not be suppressing diagnostics now");
   for (const auto &diag: diags) {
@@ -4315,32 +4315,30 @@ static Optional<unsigned> scorePotentiallyMatchingNames(DeclName lhs,
   return score;
 }
 
-/// Apply omit-needless-words to the given declaration, if possible.
-static Optional<DeclName> omitNeedlessWords(TypeChecker &tc, ValueDecl *value) {
-  if (auto func = dyn_cast<AbstractFunctionDecl>(value))
-    return tc.omitNeedlessWords(func);
-  if (auto var = dyn_cast<VarDecl>(value)) {
-    if (auto newName = tc.omitNeedlessWords(var))
-      return DeclName(*newName);
-    return None;
-  }
-  return None;
-}
-
 /// Determine the score between two potentially-matching declarations.
-static Optional<unsigned> scorePotentiallyMatching(TypeChecker &tc,
-                                                   ValueDecl *req,
-                                                   ValueDecl *witness,
-                                                   unsigned limit) {
+static Optional<unsigned>
+scorePotentiallyMatching(ValueDecl *req, ValueDecl *witness, unsigned limit) {
+  /// Apply omit-needless-words to the given declaration, if possible.
+  auto omitNeedlessWordsIfPossible = [](ValueDecl *VD) -> Optional<DeclName> {
+    if (auto func = dyn_cast<AbstractFunctionDecl>(VD))
+      return TypeChecker::omitNeedlessWords(func);
+    if (auto var = dyn_cast<VarDecl>(VD)) {
+      if (auto newName = TypeChecker::omitNeedlessWords(var))
+        return DeclName(*newName);
+      return None;
+    }
+    return None;
+  };
+
   DeclName reqName = req->getFullName();
   DeclName witnessName = witness->getFullName();
 
   // For @objc protocols, apply the omit-needless-words heuristics to
   // both names.
   if (cast<ProtocolDecl>(req->getDeclContext())->isObjC()) {
-    if (auto adjustedReqName = ::omitNeedlessWords(tc, req))
+    if (auto adjustedReqName = omitNeedlessWordsIfPossible(req))
       reqName = *adjustedReqName;
-    if (auto adjustedWitnessName = ::omitNeedlessWords(tc, witness))
+    if (auto adjustedWitnessName = omitNeedlessWordsIfPossible(witness))
       witnessName = *adjustedWitnessName;
   }
 
@@ -4531,12 +4529,10 @@ static void diagnosePotentialWitness(TypeChecker &tc,
   auto proto = cast<ProtocolDecl>(req->getDeclContext());
 
   // Primary warning.
-  tc.diagnose(witness, diag::req_near_match,
-              witness->getDescriptiveKind(),
-              witness->getFullName(),
-              req->getAttrs().hasAttribute<OptionalAttr>(),
-              req->getFullName(),
-              proto->getFullName());
+  witness->diagnose(diag::req_near_match, witness->getDescriptiveKind(),
+                    witness->getFullName(),
+                    req->getAttrs().hasAttribute<OptionalAttr>(),
+                    req->getFullName(), proto->getFullName());
 
   // Describe why the witness didn't satisfy the requirement.
   WitnessChecker::RequirementEnvironmentCache oneUseCache;
@@ -4546,8 +4542,8 @@ static void diagnosePotentialWitness(TypeChecker &tc,
   if (match.Kind == MatchKind::ExactMatch &&
       req->isObjC() && !witness->isObjC()) {
     // Special case: note to add @objc.
-    auto diag = tc.diagnose(witness,
-                            diag::optional_req_nonobjc_near_match_add_objc);
+    auto diag =
+        witness->diagnose(diag::optional_req_nonobjc_near_match_add_objc);
     if (!witness->canInferObjCFromRequirement(req))
       fixDeclarationObjCName(diag, witness,
                              witness->getObjCRuntimeName(),
@@ -4560,26 +4556,26 @@ static void diagnosePotentialWitness(TypeChecker &tc,
   // If moving the declaration can help, suggest that.
   if (auto move
         = canSuppressPotentialWitnessWarningWithMovement(req, witness)) {
-    tc.diagnose(witness, diag::req_near_match_move,
-                witness->getFullName(), static_cast<unsigned>(*move));
+    witness->diagnose(diag::req_near_match_move, witness->getFullName(),
+                      static_cast<unsigned>(*move));
   }
 
   // If adding 'private', 'fileprivate', or 'internal' can help, suggest that.
   if (access > AccessLevel::FilePrivate &&
       !witness->getAttrs().hasAttribute<AccessControlAttr>()) {
-    tc.diagnose(witness, diag::req_near_match_access,
-                witness->getFullName(), access)
-      .fixItInsert(witness->getAttributeInsertionLoc(true), "private ");
+    witness
+        ->diagnose(diag::req_near_match_access, witness->getFullName(), access)
+        .fixItInsert(witness->getAttributeInsertionLoc(true), "private ");
   }
 
   // If adding @nonobjc can help, suggest that.
   if (canSuppressPotentialWitnessWarningWithNonObjC(req, witness)) {
-    tc.diagnose(witness, diag::req_near_match_nonobjc, false)
-      .fixItInsert(witness->getAttributeInsertionLoc(false), "@nonobjc ");
+    witness->diagnose(diag::req_near_match_nonobjc, false)
+        .fixItInsert(witness->getAttributeInsertionLoc(false), "@nonobjc ");
   }
 
-  tc.diagnose(req, diag::kind_declname_declared_here,
-              DescriptiveDeclKind::Requirement, req->getFullName());
+  req->diagnose(diag::kind_declname_declared_here,
+                DescriptiveDeclKind::Requirement, req->getFullName());
 }
 
 /// Whether the given protocol is "NSCoding".
@@ -4607,9 +4603,8 @@ static bool hasExplicitObjCName(ClassDecl *classDecl) {
 
 /// Check if the name of a class might be unstable, and if so, emit a
 /// diag::nscoding_unstable_mangled_name diagnostic.
-static void
-diagnoseUnstableName(TypeChecker &tc, ProtocolConformance *conformance,
-                     ClassDecl *classDecl) {
+static void diagnoseUnstableName(ProtocolConformance *conformance,
+                                 ClassDecl *classDecl) {
   // Note: these 'kind' values are synchronized with
   // diag::nscoding_unstable_mangled_name.
   enum class UnstableNameKind : unsigned {
@@ -4641,13 +4636,14 @@ diagnoseUnstableName(TypeChecker &tc, ProtocolConformance *conformance,
     }
   }
 
-  if (kind && tc.getLangOpts().EnableNSKeyedArchiverDiagnostics &&
+  auto &C = classDecl->getASTContext();
+  if (kind && C.LangOpts.EnableNSKeyedArchiverDiagnostics &&
       isa<NormalProtocolConformance>(conformance) &&
       !hasExplicitObjCName(classDecl)) {
-    tc.diagnose(cast<NormalProtocolConformance>(conformance)->getLoc(),
-             diag::nscoding_unstable_mangled_name,
-             static_cast<unsigned>(kind.getValue()),
-             classDecl->getDeclaredInterfaceType());
+    C.Diags.diagnose(cast<NormalProtocolConformance>(conformance)->getLoc(),
+                     diag::nscoding_unstable_mangled_name,
+                     static_cast<unsigned>(kind.getValue()),
+                     classDecl->getDeclaredInterfaceType());
     auto insertionLoc =
       classDecl->getAttributeInsertionLoc(/*forModifier=*/false);
     // Note: this is intentionally using the Swift 3 mangling,
@@ -4657,26 +4653,25 @@ diagnoseUnstableName(TypeChecker &tc, ProtocolConformance *conformance,
     std::string mangledName = mangler.mangleObjCRuntimeName(classDecl);
     assert(Lexer::isIdentifier(mangledName) &&
            "mangled name is not an identifier; can't use @objc");
-    tc.diagnose(classDecl, diag::unstable_mangled_name_add_objc)
-      .fixItInsert(insertionLoc,
-                   "@objc(" + mangledName + ")");
-    tc.diagnose(classDecl, diag::unstable_mangled_name_add_objc_new)
-      .fixItInsert(insertionLoc,
-                   "@objc(<#prefixed Objective-C class name#>)");
+    classDecl->diagnose(diag::unstable_mangled_name_add_objc)
+        .fixItInsert(insertionLoc, "@objc(" + mangledName + ")");
+    classDecl->diagnose(diag::unstable_mangled_name_add_objc_new)
+        .fixItInsert(insertionLoc,
+                     "@objc(<#prefixed Objective-C class name#>)");
   }
 }
 
 /// Infer the attribute tostatic-initialize the Objective-C metadata for the
 /// given class, if needed.
-static void inferStaticInitializeObjCMetadata(TypeChecker &tc,
-                                              ClassDecl *classDecl) {
+static void inferStaticInitializeObjCMetadata(ClassDecl *classDecl) {
   // If we already have the attribute, there's nothing to do.
   if (classDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
     return;
 
   // If the class does not have a custom @objc name and the deployment target
   // supports the objc_getClass() hook, the workaround is unnecessary.
-  if (tc.Context.LangOpts.doesTargetSupportObjCGetClassHook() &&
+  ASTContext &ctx = classDecl->getASTContext();
+  if (ctx.LangOpts.doesTargetSupportObjCGetClassHook() &&
       !hasExplicitObjCName(classDecl))
     return;
 
@@ -4696,21 +4691,19 @@ static void inferStaticInitializeObjCMetadata(TypeChecker &tc,
     for (Decl *enclosingDecl = classDecl; enclosingDecl;
          enclosingDecl = enclosingDecl->getDeclContext()
                            ->getInnermostDeclarationDeclContext()) {
-      if (!tc.isDeclAvailable(enclosingDecl, SourceLoc(), sourceFile,
-                              availableInfo))
+      if (!TypeChecker::isDeclAvailable(enclosingDecl, SourceLoc(), sourceFile,
+                                        availableInfo))
         return;
     }
   }
 
   // Infer @_staticInitializeObjCMetadata.
-  ASTContext &ctx = classDecl->getASTContext();
   classDecl->getAttrs().add(
             new (ctx) StaticInitializeObjCMetadataAttr(/*implicit=*/true));
 }
 
 static void
-diagnoseMissingAppendInterpolationMethod(TypeChecker &tc,
-                                         NominalTypeDecl *typeDecl) {
+diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
   struct InvalidMethod {
     enum class Reason : unsigned {
       ReturnType,
@@ -4723,11 +4716,12 @@ diagnoseMissingAppendInterpolationMethod(TypeChecker &tc,
     
     InvalidMethod(FuncDecl *method, Reason reason)
       : method(method), reason(reason) {}
-    
-    static bool hasValidMethod(TypeChecker &tc, NominalTypeDecl *typeDecl,
-                                SmallVectorImpl<InvalidMethod> &invalid) {
+
+    static bool hasValidMethod(NominalTypeDecl *typeDecl,
+                               SmallVectorImpl<InvalidMethod> &invalid) {
       auto type = typeDecl->getDeclaredType();
-      auto baseName = DeclName(tc.Context.Id_appendInterpolation);
+      auto baseName =
+          DeclName(typeDecl->getASTContext().Id_appendInterpolation);
       auto lookupOptions = defaultMemberTypeLookupOptions;
       lookupOptions -= NameLookupFlags::PerformConformanceCheck;
 
@@ -4737,18 +4731,18 @@ diagnoseMissingAppendInterpolationMethod(TypeChecker &tc,
         if (!method) continue;
         
         if (method->isStatic()) {
-          invalid.push_back(InvalidMethod(method, Reason::Static));
+          invalid.emplace_back(method, Reason::Static);
           continue;
         }
         
         if (!method->getResultInterfaceType()->isVoid() &&
             !method->getAttrs().hasAttribute<DiscardableResultAttr>()) {
-          invalid.push_back(InvalidMethod(method, Reason::ReturnType));
+          invalid.emplace_back(method, Reason::ReturnType);
           continue;
         }
         
         if (method->getFormalAccess() < typeDecl->getFormalAccess()) {
-          invalid.push_back(InvalidMethod(method, Reason::AccessControl));
+          invalid.emplace_back(method, Reason::AccessControl);
           continue;
         }
         
@@ -4760,32 +4754,35 @@ diagnoseMissingAppendInterpolationMethod(TypeChecker &tc,
   };
   
   SmallVector<InvalidMethod, 4> invalidMethods;
-  
-  if (InvalidMethod::hasValidMethod(tc, typeDecl, invalidMethods))
+
+  if (InvalidMethod::hasValidMethod(typeDecl, invalidMethods))
     return;
-  
-  tc.diagnose(typeDecl, diag::missing_append_interpolation);
-  
+
+  typeDecl->diagnose(diag::missing_append_interpolation);
+
+  auto &C = typeDecl->getASTContext();
   for (auto invalidMethod : invalidMethods) {
     switch (invalidMethod.reason) {
       case InvalidMethod::Reason::Static:
-        tc.diagnose(invalidMethod.method->getStaticLoc(),
-                    diag::append_interpolation_static)
+        C.Diags
+            .diagnose(invalidMethod.method->getStaticLoc(),
+                      diag::append_interpolation_static)
             .fixItRemove(invalidMethod.method->getStaticLoc());
         break;
         
       case InvalidMethod::Reason::ReturnType:
-        tc.diagnose(invalidMethod.method->getBodyResultTypeLoc().getLoc(),
-                    diag::append_interpolation_void_or_discardable)
+        C.Diags
+            .diagnose(invalidMethod.method->getBodyResultTypeLoc().getLoc(),
+                      diag::append_interpolation_void_or_discardable)
             .fixItInsert(invalidMethod.method->getStartLoc(),
                          "@discardableResult ");
         break;
         
       case InvalidMethod::Reason::AccessControl:
-        tc.diagnose(invalidMethod.method,
-                    diag::append_interpolation_access_control,
-                    invalidMethod.method->getFormalAccess(),
-                    typeDecl->getName(), typeDecl->getFormalAccess());
+        C.Diags.diagnose(invalidMethod.method,
+                         diag::append_interpolation_access_control,
+                         invalidMethod.method->getFormalAccess(),
+                         typeDecl->getName(), typeDecl->getFormalAccess());
     }
   }
 }
@@ -4841,16 +4838,16 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
           isNSCoding(conformance->getProtocol()) &&
           !classDecl->isGenericContext() &&
           !classDecl->hasClangNode()) {
-        diagnoseUnstableName(*this, conformance, classDecl);
+        diagnoseUnstableName(conformance, classDecl);
         // Infer @_staticInitializeObjCMetadata if needed.
-        inferStaticInitializeObjCMetadata(*this, classDecl);
+        inferStaticInitializeObjCMetadata(classDecl);
       }
     }
 
     if (conformance->getProtocol()->
           isSpecificProtocol(KnownProtocolKind::StringInterpolationProtocol)) {
       if (auto typeDecl = dc->getSelfNominalTypeDecl()) {
-        diagnoseMissingAppendInterpolationMethod(*this, typeDecl);
+        diagnoseMissingAppendInterpolationMethod(typeDecl);
       }
     }
   }
@@ -5000,7 +4997,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
           if (req->getAttrs().isUnavailable(Context)) continue;
 
           // Score this particular optional requirement.
-          auto score = scorePotentiallyMatching(*this, req, value, bestScore);
+          auto score = scorePotentiallyMatching(req, value, bestScore);
           if (!score) continue;
 
           // If the score is better than the best we've seen, update the best
@@ -5372,8 +5369,7 @@ DefaultWitnessChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
 void DefaultWitnessChecker::recordWitness(
                                   ValueDecl *requirement,
                                   const RequirementMatch &match) {
-  Proto->setDefaultWitness(requirement,
-                           match.getWitness(TC.Context));
+  Proto->setDefaultWitness(requirement, match.getWitness(getASTContext()));
 }
 
 void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -94,8 +94,7 @@ public:
 /// associated type.
 ///
 /// \returns an empty result on success, or a description of the error.
-CheckTypeWitnessResult checkTypeWitness(TypeChecker &tc, DeclContext *dc,
-                                        ProtocolDecl *proto,
+CheckTypeWitnessResult checkTypeWitness(DeclContext *dc, ProtocolDecl *proto,
                                         AssociatedTypeDecl *assocType,
                                         Type type);
 
@@ -481,6 +480,8 @@ protected:
   // The conforming context, either a nominal type or extension.
   DeclContext *DC;
 
+  ASTContext &getASTContext() const { return TC.Context; }
+
   // An auxiliary lookup table to be used for witnesses remapped via
   // @_implements(Protocol, DeclName)
   llvm::DenseMap<DeclName, llvm::TinyPtrVector<ValueDecl *>> ImplementsTable;
@@ -755,6 +756,9 @@ public:
                           NormalProtocolConformance *conformance);
 
 private:
+  /// Retrieve the AST context.
+  ASTContext &getASTContext() const { return tc.Context; }
+
   /// Infer associated type witnesses for the given tentative
   /// requirement/witness match.
   InferredAssociatedTypesByWitness inferTypeWitnessesViaValueWitness(

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -378,8 +378,8 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
       if (!canInferFromOtherAssociatedType) {
         // Check that the type witness meets the
         // requirements on the associated type.
-        if (auto failed = checkTypeWitness(tc, dc, proto, result.first,
-                                           result.second)) {
+        if (auto failed =
+                checkTypeWitness(dc, proto, result.first, result.second)) {
           witnessResult.NonViable.push_back(
                           std::make_tuple(result.first,result.second,failed));
           LLVM_DEBUG(llvm::dbgs() << "-- doesn't fulfill requirements\n");
@@ -582,7 +582,7 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
       out << assocType->getName().str();
     }
 
-    defaultName = tc.Context.getIdentifier(defaultNameStr);
+    defaultName = getASTContext().getIdentifier(defaultNameStr);
   }
 
   // Look for types with the given default name that have appropriate
@@ -868,7 +868,7 @@ Type AssociatedTypeInference::computeDefaultTypeWitness(
   if (defaultType->hasError())
     return Type();
 
-  if (auto failed = checkTypeWitness(tc, dc, proto, assocType, defaultType)) {
+  if (auto failed = checkTypeWitness(dc, proto, assocType, defaultType)) {
     // Record the failure, if we haven't seen one already.
     if (!failedDefaultedAssocType && !failed.isError()) {
       failedDefaultedAssocType = defaultedAssocType;
@@ -894,12 +894,13 @@ Type AssociatedTypeInference::computeDerivedTypeWitness(
     return Type();
 
   // Try to derive the type witness.
-  Type derivedType = tc.deriveTypeWitness(dc, derivingTypeDecl, assocType);
+  Type derivedType =
+      TypeChecker::deriveTypeWitness(dc, derivingTypeDecl, assocType);
   if (!derivedType)
     return Type();
 
   // Make sure that the derived type is sane.
-  if (checkTypeWitness(tc, dc, proto, assocType, derivedType)) {
+  if (checkTypeWitness(dc, proto, assocType, derivedType)) {
     /// FIXME: Diagnose based on this.
     failedDerivedAssocType = assocType;
     failedDerivedWitness = derivedType;
@@ -2004,7 +2005,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
     if (Conformance->hasTypeWitness(assocType))
       continue;
 
-    recordTypeWitness(assocType, ErrorType::get(TC.Context), nullptr);
+    recordTypeWitness(assocType, ErrorType::get(getASTContext()), nullptr);
   }
 }
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1102,13 +1102,13 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
   sanitizeProtocolRequirements(proto, proto->getRequirementSignature(),
                                sanitizedRequirements);
   auto result =
-    tc.checkGenericArguments(dc, SourceLoc(), SourceLoc(),
-                             typeInContext,
-                             { proto->getSelfInterfaceType() },
-                             sanitizedRequirements,
-                             QuerySubstitutionMap{substitutions},
-                             TypeChecker::LookUpConformance(dc),
-                             None, nullptr, options);
+    TypeChecker::checkGenericArguments(dc, SourceLoc(), SourceLoc(),
+                                       typeInContext,
+                                       { proto->getSelfInterfaceType() },
+                                       sanitizedRequirements,
+                                       QuerySubstitutionMap{substitutions},
+                                       TypeChecker::LookUpConformance(dc),
+                                       None, nullptr, options);
   switch (result) {
   case RequirementCheckResult::Failure:
     ++NumSolutionStatesFailedCheck;
@@ -1150,7 +1150,7 @@ bool AssociatedTypeInference::checkConstrainedExtension(ExtensionDecl *ext) {
   auto subs = typeInContext->getContextSubstitutions(ext);
 
   SubstOptions options = getSubstOptionsWithCurrentTypeWitnesses();
-  switch (tc.checkGenericArguments(
+  switch (TypeChecker::checkGenericArguments(
                        dc, SourceLoc(), SourceLoc(), adoptee,
                        ext->getGenericSignature()->getGenericParams(),
                        ext->getGenericSignature()->getRequirements(),

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -590,8 +590,8 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
   InferredAssociatedTypesByWitnesses result;
   auto lookupOptions = defaultMemberTypeLookupOptions;
   lookupOptions -= NameLookupFlags::PerformConformanceCheck;
-  for (auto candidate : tc.lookupMember(dc, adoptee, defaultName,
-                                        lookupOptions)) {
+  for (auto candidate :
+       TypeChecker::lookupMember(dc, adoptee, defaultName, lookupOptions)) {
     // We want type declarations.
     auto typeDecl = dyn_cast<TypeDecl>(candidate.getValueDecl());
     if (!typeDecl || isa<AssociatedTypeDecl>(typeDecl))

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -46,8 +46,8 @@ struct REPLContext {
 
     {
       Identifier Id(Context.getIdentifier("_replPrintLiteralString"));
-      auto lookup = TC.lookupUnqualified(TC.getStdlibModule(&SF),
-                                         Id, SourceLoc());
+      auto lookup = TypeChecker::lookupUnqualified(TC.getStdlibModule(&SF), Id,
+                                                   SourceLoc());
       if (!lookup)
         return true;
       for (auto result : lookup)
@@ -55,8 +55,8 @@ struct REPLContext {
     }
     {
       Identifier Id(Context.getIdentifier("_replDebugPrintln"));
-      auto lookup = TC.lookupUnqualified(TC.getStdlibModule(&SF),
-                                         Id, SourceLoc());
+      auto lookup = TypeChecker::lookupUnqualified(TC.getStdlibModule(&SF), Id,
+                                                   SourceLoc());
       if (!lookup)
         return true;
       for (auto result : lookup)

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -743,15 +743,15 @@ public:
 
 
     // Retrieve the 'Sequence' protocol.
-    ProtocolDecl *sequenceProto
-      = TC.getProtocol(S->getForLoc(), KnownProtocolKind::Sequence);
+    ProtocolDecl *sequenceProto = TypeChecker::getProtocol(
+        TC.Context, S->getForLoc(), KnownProtocolKind::Sequence);
     if (!sequenceProto) {
       return nullptr;
     }
 
     // Retrieve the 'Iterator' protocol.
-    ProtocolDecl *iteratorProto =
-        TC.getProtocol(S->getForLoc(), KnownProtocolKind::IteratorProtocol);
+    ProtocolDecl *iteratorProto = TypeChecker::getProtocol(
+        TC.Context, S->getForLoc(), KnownProtocolKind::IteratorProtocol);
     if (!iteratorProto) {
       return nullptr;
     }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -61,11 +61,12 @@ TypeChecker::TypeChecker(ASTContext &Ctx)
 
 TypeChecker::~TypeChecker() {}
 
-ProtocolDecl *TypeChecker::getProtocol(SourceLoc loc, KnownProtocolKind kind) {
+ProtocolDecl *TypeChecker::getProtocol(ASTContext &Context, SourceLoc loc,
+                                       KnownProtocolKind kind) {
   auto protocol = Context.getProtocol(kind);
   if (!protocol && loc.isValid()) {
-    diagnose(loc, diag::missing_protocol,
-             Context.getIdentifier(getProtocolName(kind)));
+    Context.Diags.diagnose(loc, diag::missing_protocol,
+                           Context.getIdentifier(getProtocolName(kind)));
   }
 
   if (protocol && !protocol->getInterfaceType()) {
@@ -76,64 +77,70 @@ ProtocolDecl *TypeChecker::getProtocol(SourceLoc loc, KnownProtocolKind kind) {
   return protocol;
 }
 
-ProtocolDecl *TypeChecker::getLiteralProtocol(Expr *expr) {
+ProtocolDecl *TypeChecker::getLiteralProtocol(ASTContext &Context, Expr *expr) {
   if (isa<ArrayExpr>(expr))
-    return getProtocol(expr->getLoc(),
-                       KnownProtocolKind::ExpressibleByArrayLiteral);
+    return TypeChecker::getProtocol(
+        Context, expr->getLoc(), KnownProtocolKind::ExpressibleByArrayLiteral);
 
   if (isa<DictionaryExpr>(expr))
-    return getProtocol(expr->getLoc(),
-                       KnownProtocolKind::ExpressibleByDictionaryLiteral);
+    return TypeChecker::getProtocol(
+        Context, expr->getLoc(),
+        KnownProtocolKind::ExpressibleByDictionaryLiteral);
 
   if (!isa<LiteralExpr>(expr))
     return nullptr;
   
   if (isa<NilLiteralExpr>(expr))
-    return getProtocol(expr->getLoc(),
-                       KnownProtocolKind::ExpressibleByNilLiteral);
-  
+    return TypeChecker::getProtocol(Context, expr->getLoc(),
+                                    KnownProtocolKind::ExpressibleByNilLiteral);
+
   if (isa<IntegerLiteralExpr>(expr))
-    return getProtocol(expr->getLoc(),
-                       KnownProtocolKind::ExpressibleByIntegerLiteral);
+    return TypeChecker::getProtocol(
+        Context, expr->getLoc(),
+        KnownProtocolKind::ExpressibleByIntegerLiteral);
 
   if (isa<FloatLiteralExpr>(expr))
-    return getProtocol(expr->getLoc(),
-                       KnownProtocolKind::ExpressibleByFloatLiteral);
+    return TypeChecker::getProtocol(
+        Context, expr->getLoc(), KnownProtocolKind::ExpressibleByFloatLiteral);
 
   if (isa<BooleanLiteralExpr>(expr))
-    return getProtocol(expr->getLoc(),
-                       KnownProtocolKind::ExpressibleByBooleanLiteral);
+    return TypeChecker::getProtocol(
+        Context, expr->getLoc(),
+        KnownProtocolKind::ExpressibleByBooleanLiteral);
 
   if (const auto *SLE = dyn_cast<StringLiteralExpr>(expr)) {
     if (SLE->isSingleUnicodeScalar())
-      return getProtocol(
-          expr->getLoc(),
+      return TypeChecker::getProtocol(
+          Context, expr->getLoc(),
           KnownProtocolKind::ExpressibleByUnicodeScalarLiteral);
 
     if (SLE->isSingleExtendedGraphemeCluster())
       return getProtocol(
-          expr->getLoc(),
+          Context, expr->getLoc(),
           KnownProtocolKind::ExpressibleByExtendedGraphemeClusterLiteral);
 
-    return getProtocol(expr->getLoc(),
-                       KnownProtocolKind::ExpressibleByStringLiteral);
+    return TypeChecker::getProtocol(
+        Context, expr->getLoc(), KnownProtocolKind::ExpressibleByStringLiteral);
   }
 
   if (isa<InterpolatedStringLiteralExpr>(expr))
-    return getProtocol(expr->getLoc(),
-                       KnownProtocolKind::ExpressibleByStringInterpolation);
+    return TypeChecker::getProtocol(
+        Context, expr->getLoc(),
+        KnownProtocolKind::ExpressibleByStringInterpolation);
 
   if (auto E = dyn_cast<MagicIdentifierLiteralExpr>(expr)) {
     switch (E->getKind()) {
     case MagicIdentifierLiteralExpr::File:
     case MagicIdentifierLiteralExpr::Function:
-      return getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByStringLiteral);
+      return TypeChecker::getProtocol(
+          Context, expr->getLoc(),
+          KnownProtocolKind::ExpressibleByStringLiteral);
 
     case MagicIdentifierLiteralExpr::Line:
     case MagicIdentifierLiteralExpr::Column:
-      return getProtocol(expr->getLoc(),
-                         KnownProtocolKind::ExpressibleByIntegerLiteral);
+      return TypeChecker::getProtocol(
+          Context, expr->getLoc(),
+          KnownProtocolKind::ExpressibleByIntegerLiteral);
 
     case MagicIdentifierLiteralExpr::DSOHandle:
       return nullptr;
@@ -142,9 +149,10 @@ ProtocolDecl *TypeChecker::getLiteralProtocol(Expr *expr) {
 
   if (auto E = dyn_cast<ObjectLiteralExpr>(expr)) {
     switch (E->getLiteralKind()) {
-#define POUND_OBJECT_LITERAL(Name, Desc, Protocol)\
-    case ObjectLiteralExpr::Name:\
-      return getProtocol(expr->getLoc(), KnownProtocolKind::Protocol);
+#define POUND_OBJECT_LITERAL(Name, Desc, Protocol)                             \
+  case ObjectLiteralExpr::Name:                                                \
+    return TypeChecker::getProtocol(Context, expr->getLoc(),                   \
+                                    KnownProtocolKind::Protocol);
 #include "swift/Syntax/TokenKinds.def"
     }
   }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -301,7 +301,7 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
 
         // Finally, we can check classes for missing initializers.
         if (auto *classDecl = dyn_cast<ClassDecl>(ntd))
-          TC.maybeDiagnoseClassWithoutInitializers(classDecl);
+          TypeChecker::maybeDiagnoseClassWithoutInitializers(classDecl);
       }
     }
     TC.ConformanceContexts.clear();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1949,7 +1949,8 @@ public:
 
   /// Check if the given decl has a @_semantics attribute that gives it
   /// special case type-checking behavior.
-  DeclTypeCheckingSemantics getDeclTypeCheckingSemantics(ValueDecl *decl);
+  static DeclTypeCheckingSemantics
+  getDeclTypeCheckingSemantics(ValueDecl *decl);
 };
 
 /// Temporary on-stack storage and unescaping for encoded diagnostic

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1774,7 +1774,7 @@ public:
   /// is sufficient to safely conform to the requirement in the context
   /// the provided conformance. On return, requiredAvailability holds th
   /// availability levels required for conformance.
-  bool
+  static bool
   isAvailabilitySafeForConformance(ProtocolDecl *proto, ValueDecl *requirement,
                                    ValueDecl *witness, DeclContext *dc,
                                    AvailabilityContext &requiredAvailability);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1557,9 +1557,8 @@ public:
   /// Derive an implicit type witness for the given associated type in
   /// the conformance of the given nominal type to some known
   /// protocol.
-  Type deriveTypeWitness(DeclContext *DC,
-                         NominalTypeDecl *nominal,
-                         AssociatedTypeDecl *assocType);
+  static Type deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
+                                AssociatedTypeDecl *assocType);
 
   /// Perform unqualified name lookup at the given source location
   /// within a particular declaration context.
@@ -1920,10 +1919,10 @@ public:
           [](const GenericTypeParamDecl *) { return Type(); });
 
   /// Attempt to omit needless words from the name of the given declaration.
-  Optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
+  static Optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
 
   /// Attempt to omit needless words from the name of the given declaration.
-  Optional<Identifier> omitNeedlessWords(VarDecl *var);
+  static Optional<Identifier> omitNeedlessWords(VarDecl *var);
 
   /// Calculate edit distance between declaration names.
   static unsigned getCallEditDistance(DeclName writtenName,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1682,13 +1682,14 @@ public:
   ///
   /// \returns null if the protocol is not available. This represents a
   /// problem with the Standard Library.
-  ProtocolDecl *getProtocol(SourceLoc loc, KnownProtocolKind kind);
+  static ProtocolDecl *getProtocol(ASTContext &ctx, SourceLoc loc,
+                                   KnownProtocolKind kind);
 
   /// Retrieve the literal protocol for the given expression.
   ///
   /// \returns the literal protocol, if known and available, or null if the
   /// expression does not have an associated literal protocol.
-  ProtocolDecl *getLiteralProtocol(Expr *expr);
+  static ProtocolDecl *getLiteralProtocol(ASTContext &ctx, Expr *expr);
 
   DeclName getObjectLiteralConstructorName(ObjectLiteralExpr *expr);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1550,9 +1550,9 @@ public:
   /// \returns nullptr if the derivation failed, or the derived declaration
   ///          if it succeeded. If successful, the derived declaration is added
   ///          to TypeDecl's body.
-  ValueDecl *deriveProtocolRequirement(DeclContext *DC,
-                                       NominalTypeDecl *TypeDecl,
-                                       ValueDecl *Requirement);
+  static ValueDecl *deriveProtocolRequirement(DeclContext *DC,
+                                              NominalTypeDecl *TypeDecl,
+                                              ValueDecl *Requirement);
 
   /// Derive an implicit type witness for the given associated type in
   /// the conformance of the given nominal type to some known

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1111,7 +1111,7 @@ public:
       SubstOptions options = None);
 
   /// Diagnose if the class has no designated initializers.
-  void maybeDiagnoseClassWithoutInitializers(ClassDecl *classDecl);
+  static void maybeDiagnoseClassWithoutInitializers(ClassDecl *classDecl);
 
   ///
   /// Add any implicitly-defined constructors required for the given


### PR DESCRIPTION
Downgrade a bunch of parts of the Sema that thought they needed a TypeChecker, but really just needed an ASTContext.  The great success here is `DerivedConformance`, which now only requires the type checker in one place, and that place is conformance checking.  The end goal is to completely decouple conformance checking from a type checker instance anyways, so there should be a follow-up here that squashes out even more from `TypeCheckProtocol[Inference]`.

