### PR TITLE
Replace #import with #include to please VC++.

### DIFF
--- a/lib/ClangImporter/ClangSourceBufferImporter.cpp
+++ b/lib/ClangImporter/ClangSourceBufferImporter.cpp
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#import "ClangSourceBufferImporter.h"
-#import "swift/Basic/SourceManager.h"
-#import "clang/Basic/SourceManager.h"
-#import "llvm/Support/MemoryBuffer.h"
+#include "ClangSourceBufferImporter.h"
+#include "swift/Basic/SourceManager.h"
+#include "clang/Basic/SourceManager.h"
+#include "llvm/Support/MemoryBuffer.h"
 
 using namespace swift;
 using namespace swift::importer;


### PR DESCRIPTION
VC++ chokes on the #import, and thinks we are trying to import
libraries. Replace by #include, which should be more portable.

Introduced in #27924, and making the Windows CI fail since https://ci-external.swift.org/job/oss-swift-windows-x86_64/1783/.