### PR TITLE
[AutoDiff] NFC: fix warning in DeserializeSIL.cpp.

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1050,7 +1050,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   Builder.setCurrentDebugScope(Fn->getDebugScope());
   unsigned RawOpCode = 0, TyCategory = 0, TyCategory2 = 0, TyCategory3 = 0,
            // SWIFT_ENABLE_TENSORFLOW
-           Attr = 0, Attr2 = 0, Attr3 = 0, NumSubs = 0, NumConformances = 0,
+           Attr = 0, Attr2 = 0, NumSubs = 0, NumConformances = 0,
            IsNonThrowingApply = 0;
   ValueID ValID, ValID2, ValID3;
   TypeID TyID, TyID2, TyID3;


### PR DESCRIPTION
Remove unused variable `Attr3`. It is no longer necessary after
https://github.com/apple/swift/pull/27919:
`DifferentiabilityWitnessFunctionInst` has fewer fields to deserialize.