### PR TITLE
[NFC] Strip Witness Matching of its TypeChecker

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1627,6 +1627,26 @@ public:
   bool isCached() const { return true; }
 };
 
+class CompareDeclSpecializationRequest
+    : public SimpleRequest<CompareDeclSpecializationRequest,
+                           bool(DeclContext *, ValueDecl *, ValueDecl *, bool),
+                           CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<bool> evaluate(Evaluator &evaluator, DeclContext *DC,
+                                ValueDecl *VD1, ValueDecl *VD2,
+                                bool dynamic) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -29,6 +29,9 @@ SWIFT_REQUEST(TypeChecker, AttachedPropertyWrappersRequest,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ClassAncestryFlagsRequest,
               AncestryFlags(ClassDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, CompareDeclSpecializationRequest,
+              bool (DeclContext *, ValueDecl *, ValueDecl *, bool), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,
               Type(AssociatedTypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultTypeRequest,

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -16,8 +16,9 @@
 //===----------------------------------------------------------------------===//
 #include "ConstraintSystem.h"
 #include "swift/AST/GenericSignature.h"
-#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Compiler.h"
 
@@ -376,12 +377,24 @@ static bool paramIsIUO(const ValueDecl *decl, int paramNum) {
 /// the second declaration.
 ///
 /// "Specialized" is essentially a form of subtyping, defined below.
-static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
-                                  ValueDecl *decl1, ValueDecl *decl2,
+static bool isDeclAsSpecializedAs(DeclContext *dc, ValueDecl *decl1,
+                                  ValueDecl *decl2,
                                   bool isDynamicOverloadComparison = false) {
+  return evaluateOrDefault(decl1->getASTContext().evaluator,
+                           CompareDeclSpecializationRequest{
+                               dc, decl1, decl2, isDynamicOverloadComparison},
+                           false);
+}
 
-  if (tc.getLangOpts().DebugConstraintSolver) {
-    auto &log = tc.Context.TypeCheckerDebug->getStream();
+llvm::Expected<bool> CompareDeclSpecializationRequest::evaluate(
+    Evaluator &eval, DeclContext *dc, ValueDecl *decl1, ValueDecl *decl2,
+    bool isDynamicOverloadComparison) const {
+  auto &C = decl1->getASTContext();
+  // FIXME: Remove dependency on the lazy resolver.
+  auto *tc = static_cast<TypeChecker *>(C.getLazyResolver());
+
+  if (C.LangOpts.DebugConstraintSolver) {
+    auto &log = C.TypeCheckerDebug->getStream();
     log << "Comparing declarations\n";
     decl1->print(log); 
     log << "\nand\n";
@@ -391,313 +404,297 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
     log << ")\n";
   }
 
+  auto completeResult = [&C](bool result) {
+    if (C.LangOpts.DebugConstraintSolver) {
+      auto &log = C.TypeCheckerDebug->getStream();
+      log << "comparison result: " << (result ? "better" : "not better")
+          << "\n";
+    }
+    return result;
+  };
+
   auto *innerDC1 = decl1->getInnermostDeclContext();
   auto *innerDC2 = decl2->getInnermostDeclContext();
 
   auto *outerDC1 = decl1->getDeclContext();
   auto *outerDC2 = decl2->getDeclContext();
 
-  auto overloadComparisonKey =
-      std::make_tuple(decl1, decl2, isDynamicOverloadComparison);
-  if (!tc.specializedOverloadComparisonCache.count(overloadComparisonKey)) {
+  // If the kinds are different, there's nothing we can do.
+  // FIXME: This is wrong for type declarations, which we're skipping
+  // entirely.
+  if (decl1->getKind() != decl2->getKind() || isa<TypeDecl>(decl1))
+    return completeResult(false);
 
-    auto compareSpecializations = [&] () -> bool {
-      // If the kinds are different, there's nothing we can do.
-      // FIXME: This is wrong for type declarations, which we're skipping
-      // entirely.
-      if (decl1->getKind() != decl2->getKind() || isa<TypeDecl>(decl1))
-        return false;
+  // A non-generic declaration is more specialized than a generic declaration.
+  if (auto func1 = dyn_cast<AbstractFunctionDecl>(decl1)) {
+    auto func2 = cast<AbstractFunctionDecl>(decl2);
+    if (func1->isGeneric() != func2->isGeneric())
+      return completeResult(func2->isGeneric());
+  }
 
-      // A non-generic declaration is more specialized than a generic declaration.
-      if (auto func1 = dyn_cast<AbstractFunctionDecl>(decl1)) {
-        auto func2 = cast<AbstractFunctionDecl>(decl2);
-        if (func1->isGeneric() != func2->isGeneric())
-          return func2->isGeneric();
-      }
+  if (auto subscript1 = dyn_cast<SubscriptDecl>(decl1)) {
+    auto subscript2 = cast<SubscriptDecl>(decl2);
+    if (subscript1->isGeneric() != subscript2->isGeneric())
+      return completeResult(subscript2->isGeneric());
+  }
 
-      if (auto subscript1 = dyn_cast<SubscriptDecl>(decl1)) {
-        auto subscript2 = cast<SubscriptDecl>(decl2);
-        if (subscript1->isGeneric() != subscript2->isGeneric())
-          return subscript2->isGeneric();
-      }
+  // Members of protocol extensions have special overloading rules.
+  ProtocolDecl *inProtocolExtension1 = outerDC1->getExtendedProtocolDecl();
+  ProtocolDecl *inProtocolExtension2 = outerDC2->getExtendedProtocolDecl();
+  if (inProtocolExtension1 && inProtocolExtension2) {
+    // Both members are in protocol extensions.
+    // Determine whether the 'Self' type from the first protocol extension
+    // satisfies all of the requirements of the second protocol extension.
+    bool better1 = isProtocolExtensionAsSpecializedAs(*tc, outerDC1, outerDC2);
+    bool better2 = isProtocolExtensionAsSpecializedAs(*tc, outerDC2, outerDC1);
+    if (better1 != better2) {
+      return completeResult(better1);
+    }
+  } else if (inProtocolExtension1 || inProtocolExtension2) {
+    // One member is in a protocol extension, the other is in a concrete type.
+    // Prefer the member in the concrete type.
+    return completeResult(inProtocolExtension2);
+  }
 
-      // Members of protocol extensions have special overloading rules.
-      ProtocolDecl *inProtocolExtension1 = outerDC1->getExtendedProtocolDecl();
-      ProtocolDecl *inProtocolExtension2 = outerDC2->getExtendedProtocolDecl();
-      if (inProtocolExtension1 && inProtocolExtension2) {
-        // Both members are in protocol extensions.
-        // Determine whether the 'Self' type from the first protocol extension
-        // satisfies all of the requirements of the second protocol extension.
-        bool better1 = isProtocolExtensionAsSpecializedAs(tc, outerDC1, outerDC2);
-        bool better2 = isProtocolExtensionAsSpecializedAs(tc, outerDC2, outerDC1);
-        if (better1 != better2) {
-          return better1;
-        }
-      } else if (inProtocolExtension1 || inProtocolExtension2) {
-        // One member is in a protocol extension, the other is in a concrete type.
-        // Prefer the member in the concrete type.
-        return inProtocolExtension2;
-      }
+  // A concrete type member is always more specialised than a protocol
+  // member (bearing in mind that we have already handled the case where
+  // exactly one member is in a protocol extension). Only apply this rule in
+  // Swift 5 mode to better maintain source compatibility under Swift 4
+  // mode.
+  //
+  // Don't apply this rule when comparing two overloads found through
+  // dynamic lookup to ensure we keep cases like this ambiguous:
+  //
+  //    @objc protocol P {
+  //      var i: String { get }
+  //    }
+  //    class C {
+  //      @objc var i: Int { return 0 }
+  //    }
+  //    func foo(_ x: AnyObject) {
+  //      x.i // ensure ambiguous.
+  //    }
+  //
+  if (C.isSwiftVersionAtLeast(5) && !isDynamicOverloadComparison) {
+    auto inProto1 = isa<ProtocolDecl>(outerDC1);
+    auto inProto2 = isa<ProtocolDecl>(outerDC2);
+    if (inProto1 != inProto2)
+      return completeResult(inProto2);
+  }
 
-      // A concrete type member is always more specialised than a protocol
-      // member (bearing in mind that we have already handled the case where
-      // exactly one member is in a protocol extension). Only apply this rule in
-      // Swift 5 mode to better maintain source compatibility under Swift 4
-      // mode.
-      //
-      // Don't apply this rule when comparing two overloads found through
-      // dynamic lookup to ensure we keep cases like this ambiguous:
-      //
-      //    @objc protocol P {
-      //      var i: String { get }
-      //    }
-      //    class C {
-      //      @objc var i: Int { return 0 }
-      //    }
-      //    func foo(_ x: AnyObject) {
-      //      x.i // ensure ambiguous.
-      //    }
-      //
-      if (tc.Context.isSwiftVersionAtLeast(5) && !isDynamicOverloadComparison) {
-        auto inProto1 = isa<ProtocolDecl>(outerDC1);
-        auto inProto2 = isa<ProtocolDecl>(outerDC2);
-        if (inProto1 != inProto2)
-          return inProto2;
-      }
+  Type type1 = decl1->getInterfaceType();
+  Type type2 = decl2->getInterfaceType();
 
-      Type type1 = decl1->getInterfaceType();
-      Type type2 = decl2->getInterfaceType();
+  // Add curried 'self' types if necessary.
+  if (!decl1->hasCurriedSelf())
+    type1 = type1->addCurriedSelfType(outerDC1);
 
-      // Add curried 'self' types if necessary.
-      if (!decl1->hasCurriedSelf())
-        type1 = type1->addCurriedSelfType(outerDC1);
+  if (!decl2->hasCurriedSelf())
+    type2 = type2->addCurriedSelfType(outerDC2);
 
-      if (!decl2->hasCurriedSelf())
-        type2 = type2->addCurriedSelfType(outerDC2);
+  auto openType = [&](ConstraintSystem &cs, DeclContext *innerDC,
+                      DeclContext *outerDC, Type type,
+                      OpenedTypeMap &replacements,
+                      ConstraintLocator *locator) -> Type {
+    if (auto *funcType = type->getAs<AnyFunctionType>()) {
+      return cs.openFunctionType(funcType, locator, replacements, outerDC);
+    }
 
-      auto openType = [&](ConstraintSystem &cs, DeclContext *innerDC,
-                          DeclContext *outerDC, Type type,
-                          OpenedTypeMap &replacements,
-                          ConstraintLocator *locator) -> Type {
-        if (auto *funcType = type->getAs<AnyFunctionType>()) {
-          return cs.openFunctionType(funcType, locator, replacements, outerDC);
-        }
+    cs.openGeneric(outerDC, innerDC->getGenericSignatureOfContext(), locator,
+                   replacements);
 
-        cs.openGeneric(outerDC, innerDC->getGenericSignatureOfContext(),
-                       locator, replacements);
+    return cs.openType(type, replacements);
+  };
 
-        return cs.openType(type, replacements);
-      };
+  // Construct a constraint system to compare the two declarations.
+  ConstraintSystem cs(*tc, dc, ConstraintSystemOptions());
+  bool knownNonSubtype = false;
 
-      // Construct a constraint system to compare the two declarations.
-      ConstraintSystem cs(tc, dc, ConstraintSystemOptions());
-      bool knownNonSubtype = false;
+  auto *locator = cs.getConstraintLocator(nullptr);
+  // FIXME: Locator when anchored on a declaration.
+  // Get the type of a reference to the second declaration.
 
-      auto *locator = cs.getConstraintLocator(nullptr);
-      // FIXME: Locator when anchored on a declaration.
-      // Get the type of a reference to the second declaration.
+  OpenedTypeMap unused, replacements;
+  auto openedType2 = openType(cs, innerDC1, outerDC2, type2, unused, locator);
+  auto openedType1 =
+      openType(cs, innerDC2, outerDC1, type1, replacements, locator);
 
-      OpenedTypeMap unused, replacements;
-      auto openedType2 =
-          openType(cs, innerDC1, outerDC2, type2, unused, locator);
-      auto openedType1 =
-          openType(cs, innerDC2, outerDC1, type1, replacements, locator);
+  for (const auto &replacement : replacements) {
+    if (auto mapped = innerDC1->mapTypeIntoContext(replacement.first)) {
+      cs.addConstraint(ConstraintKind::Bind, replacement.second, mapped,
+                       locator);
+    }
+  }
 
-      for (const auto &replacement : replacements) {
-        if (auto mapped = innerDC1->mapTypeIntoContext(replacement.first)) {
-          cs.addConstraint(ConstraintKind::Bind, replacement.second, mapped,
-                           locator);
-        }
-      }
+  // Extract the self types from the declarations, if they have them.
+  auto getSelfType = [](AnyFunctionType *fnType) -> Type {
+    auto params = fnType->getParams();
+    assert(params.size() == 1);
+    return params.front().getPlainType()->getMetatypeInstanceType();
+  };
 
-      // Extract the self types from the declarations, if they have them.
-      auto getSelfType = [](AnyFunctionType *fnType) -> Type {
-        auto params = fnType->getParams();
-        assert(params.size() == 1);
-        return params.front().getPlainType()->getMetatypeInstanceType();
-      };
+  Type selfTy1;
+  Type selfTy2;
+  if (outerDC1->isTypeContext()) {
+    auto funcTy1 = openedType1->castTo<FunctionType>();
+    selfTy1 = getSelfType(funcTy1);
+    openedType1 = funcTy1->getResult();
+  }
+  if (outerDC2->isTypeContext()) {
+    auto funcTy2 = openedType2->castTo<FunctionType>();
+    selfTy2 = getSelfType(funcTy2);
+    openedType2 = funcTy2->getResult();
+  }
 
-      Type selfTy1;
-      Type selfTy2;
-      if (outerDC1->isTypeContext()) {
-        auto funcTy1 = openedType1->castTo<FunctionType>();
-        selfTy1 = getSelfType(funcTy1);
-        openedType1 = funcTy1->getResult();
-      }
-      if (outerDC2->isTypeContext()) {
-        auto funcTy2 = openedType2->castTo<FunctionType>();
-        selfTy2 = getSelfType(funcTy2);
-        openedType2 = funcTy2->getResult();
-      }
-      
-      // Determine the relationship between the 'self' types and add the
-      // appropriate constraints. The constraints themselves never fail, but
-      // they help deduce type variables that were opened.
-      auto selfTypeRelationship = computeSelfTypeRelationship(dc, decl1, decl2);
-      auto relationshipKind = selfTypeRelationship.first;
-      auto conformance = selfTypeRelationship.second;
-      (void)conformance;
-      switch (relationshipKind) {
-      case SelfTypeRelationship::Unrelated:
-        // Skip the self types parameter entirely.
-        break;
+  // Determine the relationship between the 'self' types and add the
+  // appropriate constraints. The constraints themselves never fail, but
+  // they help deduce type variables that were opened.
+  auto selfTypeRelationship = computeSelfTypeRelationship(dc, decl1, decl2);
+  auto relationshipKind = selfTypeRelationship.first;
+  auto conformance = selfTypeRelationship.second;
+  (void)conformance;
+  switch (relationshipKind) {
+  case SelfTypeRelationship::Unrelated:
+    // Skip the self types parameter entirely.
+    break;
 
-      case SelfTypeRelationship::Equivalent:
-        cs.addConstraint(ConstraintKind::Bind, selfTy1, selfTy2, locator);
-        break;
+  case SelfTypeRelationship::Equivalent:
+    cs.addConstraint(ConstraintKind::Bind, selfTy1, selfTy2, locator);
+    break;
 
-      case SelfTypeRelationship::Subclass:
-        cs.addConstraint(ConstraintKind::Subtype, selfTy1, selfTy2, locator);
-        break;
+  case SelfTypeRelationship::Subclass:
+    cs.addConstraint(ConstraintKind::Subtype, selfTy1, selfTy2, locator);
+    break;
 
-      case SelfTypeRelationship::Superclass:
-        cs.addConstraint(ConstraintKind::Subtype, selfTy2, selfTy1, locator);
-        break;
+  case SelfTypeRelationship::Superclass:
+    cs.addConstraint(ConstraintKind::Subtype, selfTy2, selfTy1, locator);
+    break;
 
-      case SelfTypeRelationship::ConformsTo:
-        assert(conformance);
-        cs.addConstraint(ConstraintKind::ConformsTo, selfTy1,
-                         cast<ProtocolDecl>(outerDC2)->getDeclaredType(),
-                         locator);
-        break;
+  case SelfTypeRelationship::ConformsTo:
+    assert(conformance);
+    cs.addConstraint(ConstraintKind::ConformsTo, selfTy1,
+                     cast<ProtocolDecl>(outerDC2)->getDeclaredType(), locator);
+    break;
 
-      case SelfTypeRelationship::ConformedToBy:
-        assert(conformance);
-        cs.addConstraint(ConstraintKind::ConformsTo, selfTy2,
-                         cast<ProtocolDecl>(outerDC1)->getDeclaredType(),
-                         locator);
-        break;
-      }
+  case SelfTypeRelationship::ConformedToBy:
+    assert(conformance);
+    cs.addConstraint(ConstraintKind::ConformsTo, selfTy2,
+                     cast<ProtocolDecl>(outerDC1)->getDeclaredType(), locator);
+    break;
+  }
 
-      bool fewerEffectiveParameters = false;
-      if (!decl1->hasParameterList() && !decl2->hasParameterList()) {
-        // If neither decl has a parameter list, simply check whether the first
-        // type is a subtype of the second.
-        cs.addConstraint(ConstraintKind::Subtype,
-                         openedType1,
-                         openedType2,
-                         locator);
-      } else if (decl1->hasParameterList() && decl2->hasParameterList()) {
-        // Otherwise, check whether the first function type's input is a subtype
-        // of the second type's inputs, i.e., can we forward the arguments?
-        auto funcTy1 = openedType1->castTo<FunctionType>();
-        auto funcTy2 = openedType2->castTo<FunctionType>();
-        auto params1 = funcTy1->getParams();
-        auto params2 = funcTy2->getParams();
+  bool fewerEffectiveParameters = false;
+  if (!decl1->hasParameterList() && !decl2->hasParameterList()) {
+    // If neither decl has a parameter list, simply check whether the first
+    // type is a subtype of the second.
+    cs.addConstraint(ConstraintKind::Subtype, openedType1, openedType2,
+                     locator);
+  } else if (decl1->hasParameterList() && decl2->hasParameterList()) {
+    // Otherwise, check whether the first function type's input is a subtype
+    // of the second type's inputs, i.e., can we forward the arguments?
+    auto funcTy1 = openedType1->castTo<FunctionType>();
+    auto funcTy2 = openedType2->castTo<FunctionType>();
+    auto params1 = funcTy1->getParams();
+    auto params2 = funcTy2->getParams();
 
-        unsigned numParams1 = params1.size();
-        unsigned numParams2 = params2.size();
-        if (numParams1 > numParams2) return false;
+    unsigned numParams1 = params1.size();
+    unsigned numParams2 = params2.size();
+    if (numParams1 > numParams2)
+      return completeResult(false);
 
-        // If they both have trailing closures, compare those separately.
-        bool compareTrailingClosureParamsSeparately = false;
-        if (numParams1 > 0 && numParams2 > 0 &&
-            params1.back().getOldType()->is<AnyFunctionType>() &&
-            params2.back().getOldType()->is<AnyFunctionType>()) {
-          compareTrailingClosureParamsSeparately = true;
-        }
+    // If they both have trailing closures, compare those separately.
+    bool compareTrailingClosureParamsSeparately = false;
+    if (numParams1 > 0 && numParams2 > 0 &&
+        params1.back().getOldType()->is<AnyFunctionType>() &&
+        params2.back().getOldType()->is<AnyFunctionType>()) {
+      compareTrailingClosureParamsSeparately = true;
+    }
 
-        auto maybeAddSubtypeConstraint =
-            [&](const AnyFunctionType::Param &param1,
-                const AnyFunctionType::Param &param2) -> bool {
-          // If one parameter is variadic and the other is not...
-          if (param1.isVariadic() != param2.isVariadic()) {
-            // If the first parameter is the variadic one, it's not
-            // more specialized.
-            if (param1.isVariadic()) return false;
-
-            fewerEffectiveParameters = true;
-          }
-
-          Type paramType1 = getAdjustedParamType(param1);
-          Type paramType2 = getAdjustedParamType(param2);
-
-          // Check whether the first parameter is a subtype of the second.
-          cs.addConstraint(ConstraintKind::Subtype,
-                           paramType1, paramType2, locator);
-          return true;
-        };
-
-        auto pairMatcher = [&](unsigned idx1, unsigned idx2) -> bool {
-          // Emulate behavior from when IUO was a type, where IUOs
-          // were considered subtypes of plain optionals, but not
-          // vice-versa.  This wouldn't normally happen, but there are
-          // cases where we can rename imported APIs so that we have a
-          // name collision, and where the parameter type(s) are the
-          // same except for details of the kind of optional declared.
-          auto param1IsIUO = paramIsIUO(decl1, idx1);
-          auto param2IsIUO = paramIsIUO(decl2, idx2);
-          if (param2IsIUO && !param1IsIUO)
-            return false;
-
-          if (!maybeAddSubtypeConstraint(params1[idx1], params2[idx2]))
-            return false;
-
-          return true;
-        };
-
-        ParameterListInfo paramInfo(
-            params2, decl2, decl2->hasCurriedSelf());
-        auto params2ForMatching = params2;
-        if (compareTrailingClosureParamsSeparately) {
-          --numParams1;
-          params2ForMatching = params2.drop_back();
-        }
-
-        InputMatcher IM(params2ForMatching, paramInfo);
-        if (IM.match(numParams1, pairMatcher) != InputMatcher::IM_Succeeded)
+    auto maybeAddSubtypeConstraint =
+        [&](const AnyFunctionType::Param &param1,
+            const AnyFunctionType::Param &param2) -> bool {
+      // If one parameter is variadic and the other is not...
+      if (param1.isVariadic() != param2.isVariadic()) {
+        // If the first parameter is the variadic one, it's not
+        // more specialized.
+        if (param1.isVariadic())
           return false;
 
-        fewerEffectiveParameters |= (IM.getNumSkippedParameters() != 0);
-
-        if (compareTrailingClosureParamsSeparately)
-          if (!maybeAddSubtypeConstraint(params1.back(), params2.back()))
-            knownNonSubtype = true;
+        fewerEffectiveParameters = true;
       }
 
-      if (!knownNonSubtype) {
-        // Solve the system.
-        auto solution = cs.solveSingle(FreeTypeVariableBinding::Allow);
+      Type paramType1 = getAdjustedParamType(param1);
+      Type paramType2 = getAdjustedParamType(param2);
 
-        // Ban value-to-optional conversions.
-        if (solution && solution->getFixedScore().Data[SK_ValueToOptional] == 0)
-          return true;
-      }
-
-      // If the first function has fewer effective parameters than the
-      // second, it is more specialized.
-      if (fewerEffectiveParameters) return true;
-
-      return false;
+      // Check whether the first parameter is a subtype of the second.
+      cs.addConstraint(ConstraintKind::Subtype, paramType1, paramType2,
+                       locator);
+      return true;
     };
 
-    tc.specializedOverloadComparisonCache[overloadComparisonKey] =
-        compareSpecializations();
-  } else if (tc.getLangOpts().DebugConstraintSolver) {
-    auto &log = tc.Context.TypeCheckerDebug->getStream();
-    log << "Found cached comparison: "
-        << tc.specializedOverloadComparisonCache[overloadComparisonKey] << "\n";
+    auto pairMatcher = [&](unsigned idx1, unsigned idx2) -> bool {
+      // Emulate behavior from when IUO was a type, where IUOs
+      // were considered subtypes of plain optionals, but not
+      // vice-versa.  This wouldn't normally happen, but there are
+      // cases where we can rename imported APIs so that we have a
+      // name collision, and where the parameter type(s) are the
+      // same except for details of the kind of optional declared.
+      auto param1IsIUO = paramIsIUO(decl1, idx1);
+      auto param2IsIUO = paramIsIUO(decl2, idx2);
+      if (param2IsIUO && !param1IsIUO)
+        return false;
+
+      if (!maybeAddSubtypeConstraint(params1[idx1], params2[idx2]))
+        return false;
+
+      return true;
+    };
+
+    ParameterListInfo paramInfo(params2, decl2, decl2->hasCurriedSelf());
+    auto params2ForMatching = params2;
+    if (compareTrailingClosureParamsSeparately) {
+      --numParams1;
+      params2ForMatching = params2.drop_back();
+    }
+
+    InputMatcher IM(params2ForMatching, paramInfo);
+    if (IM.match(numParams1, pairMatcher) != InputMatcher::IM_Succeeded)
+      return completeResult(false);
+
+    fewerEffectiveParameters |= (IM.getNumSkippedParameters() != 0);
+
+    if (compareTrailingClosureParamsSeparately)
+      if (!maybeAddSubtypeConstraint(params1.back(), params2.back()))
+        knownNonSubtype = true;
   }
 
-  if (tc.getLangOpts().DebugConstraintSolver) {
-    auto &log = tc.Context.TypeCheckerDebug->getStream();
-    auto result = tc.specializedOverloadComparisonCache[overloadComparisonKey];
-    log << "comparison result: " << (result ? "better" : "not better") << "\n";
+  if (!knownNonSubtype) {
+    // Solve the system.
+    auto solution = cs.solveSingle(FreeTypeVariableBinding::Allow);
+
+    // Ban value-to-optional conversions.
+    if (solution && solution->getFixedScore().Data[SK_ValueToOptional] == 0)
+      return completeResult(true);
   }
 
-  return tc.specializedOverloadComparisonCache[overloadComparisonKey];
+  // If the first function has fewer effective parameters than the
+  // second, it is more specialized.
+  if (fewerEffectiveParameters)
+    return completeResult(true);
+
+  return completeResult(false);
 }
 
 Comparison TypeChecker::compareDeclarations(DeclContext *dc,
                                             ValueDecl *decl1,
                                             ValueDecl *decl2){
-  bool decl1Better = isDeclAsSpecializedAs(*this, dc, decl1, decl2);
-  bool decl2Better = isDeclAsSpecializedAs(*this, dc, decl2, decl1);
+  bool decl1Better = isDeclAsSpecializedAs(dc, decl1, decl2);
+  bool decl2Better = isDeclAsSpecializedAs(dc, decl2, decl1);
 
   if (decl1Better == decl2Better)
     return Comparison::Unordered;
 
-  return decl1Better? Comparison::Better : Comparison::Worse;
+  return decl1Better ? Comparison::Better : Comparison::Worse;
 }
 
 static Type getUnlabeledType(Type type, ASTContext &ctx) {
@@ -876,12 +873,12 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // Determine whether one declaration is more specialized than the other.
     bool firstAsSpecializedAs = false;
     bool secondAsSpecializedAs = false;
-    if (isDeclAsSpecializedAs(tc, cs.DC, decl1, decl2,
+    if (isDeclAsSpecializedAs(cs.DC, decl1, decl2,
                               isDynamicOverloadComparison)) {
       score1 += weight;
       firstAsSpecializedAs = true;
     }
-    if (isDeclAsSpecializedAs(tc, cs.DC, decl2, decl1,
+    if (isDeclAsSpecializedAs(cs.DC, decl2, decl1,
                               isDynamicOverloadComparison)) {
       score2 += weight;
       secondAsSpecializedAs = true;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2010,7 +2010,6 @@ void ConstraintSystem::partitionForDesignatedTypes(
 // Performance hack: if there are two generic overloads, and one is
 // more specialized than the other, prefer the more-specialized one.
 static Constraint *tryOptimizeGenericDisjunction(
-                                          TypeChecker &tc,
                                           DeclContext *dc,
                                           ArrayRef<Constraint *> constraints) {
   llvm::SmallVector<Constraint *, 4> choices;
@@ -2067,7 +2066,7 @@ static Constraint *tryOptimizeGenericDisjunction(
   if (!isViable(declA) || !isViable(declB))
     return nullptr;
 
-  switch (tc.compareDeclarations(dc, declA, declB)) {
+  switch (TypeChecker::compareDeclarations(dc, declA, declB)) {
   case Comparison::Better:
     return choices[0];
 
@@ -2085,7 +2084,7 @@ void ConstraintSystem::partitionDisjunction(
     SmallVectorImpl<unsigned> &PartitionBeginning) {
   // Apply a special-case rule for favoring one generic function over
   // another.
-  if (auto favored = tryOptimizeGenericDisjunction(TC, DC, Choices)) {
+  if (auto favored = tryOptimizeGenericDisjunction(DC, Choices)) {
     favorConstraint(favored);
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -855,8 +855,7 @@ witnessHasImplementsAttrForExactRequirement(ValueDecl *witness,
 }
 
 /// Determine whether one requirement match is better than the other.
-static bool isBetterMatch(TypeChecker &tc, DeclContext *dc,
-                          ValueDecl *requirement,
+static bool isBetterMatch(DeclContext *dc, ValueDecl *requirement,
                           const RequirementMatch &match1,
                           const RequirementMatch &match2) {
 
@@ -875,7 +874,9 @@ static bool isBetterMatch(TypeChecker &tc, DeclContext *dc,
   }
 
   // Check whether one declaration is better than the other.
-  switch (tc.compareDeclarations(dc, match1.Witness, match2.Witness)) {
+  const auto comparisonResult =
+      TypeChecker::compareDeclarations(dc, match1.Witness, match2.Witness);
+  switch (comparisonResult) {
   case Comparison::Better:
     return true;
 
@@ -1085,7 +1086,7 @@ bool WitnessChecker::findBestWitness(
     // Find the best match.
     bestIdx = 0;
     for (unsigned i = 1, n = matches.size(); i != n; ++i) {
-      if (isBetterMatch(TC, DC, requirement, matches[i], matches[bestIdx]))
+      if (isBetterMatch(DC, requirement, matches[i], matches[bestIdx]))
         bestIdx = i;
     }
 
@@ -1094,7 +1095,7 @@ bool WitnessChecker::findBestWitness(
       if (i == bestIdx)
         continue;
 
-      if (!isBetterMatch(TC, DC, requirement, matches[bestIdx], matches[i])) {
+      if (!isBetterMatch(DC, requirement, matches[bestIdx], matches[i])) {
         isReallyBest = false;
         break;
       }

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -474,13 +474,13 @@ public:
       llvm::DenseMap<RequirementEnvironmentCacheKey, RequirementEnvironment>;
 
 protected:
-  TypeChecker &TC;
+  ASTContext &Context;
   ProtocolDecl *Proto;
   Type Adoptee;
   // The conforming context, either a nominal type or extension.
   DeclContext *DC;
 
-  ASTContext &getASTContext() const { return TC.Context; }
+  ASTContext &getASTContext() const { return Context; }
 
   // An auxiliary lookup table to be used for witnesses remapped via
   // @_implements(Protocol, DeclName)
@@ -490,8 +490,8 @@ protected:
 
   Optional<std::pair<AccessScope, bool>> RequiredAccessScopeAndUsableFromInline;
 
-  WitnessChecker(TypeChecker &tc, ProtocolDecl *proto,
-                 Type adoptee, DeclContext *dc);
+  WitnessChecker(ASTContext &ctx, ProtocolDecl *proto, Type adoptee,
+                 DeclContext *dc);
 
   bool isMemberOperator(FuncDecl *decl, Type type);
 
@@ -676,8 +676,8 @@ public:
   /// Emit any diagnostics that have been delayed.
   void emitDelayedDiags();
 
-  ConformanceChecker(TypeChecker &tc, NormalProtocolConformance *conformance,
-                     llvm::SetVector<ValueDecl*> &GlobalMissingWitnesses,
+  ConformanceChecker(ASTContext &ctx, NormalProtocolConformance *conformance,
+                     llvm::SetVector<ValueDecl *> &GlobalMissingWitnesses,
                      bool suppressDiagnostics = true);
 
   /// Resolve all of the type witnesses.
@@ -712,7 +712,7 @@ public:
 /// Captures the state needed to infer associated types.
 class AssociatedTypeInference {
   /// The type checker we'll need to validate declarations etc.
-  TypeChecker &tc;
+  ASTContext &ctx;
 
   /// The conformance for which we are inferring associated types.
   NormalProtocolConformance *conformance;
@@ -752,12 +752,12 @@ class AssociatedTypeInference {
   unsigned numTypeWitnessesBeforeConflict = 0;
 
 public:
-  AssociatedTypeInference(TypeChecker &tc,
+  AssociatedTypeInference(ASTContext &ctx,
                           NormalProtocolConformance *conformance);
 
 private:
   /// Retrieve the AST context.
-  ASTContext &getASTContext() const { return tc.Context; }
+  ASTContext &getASTContext() const { return ctx; }
 
   /// Infer associated type witnesses for the given tentative
   /// requirement/witness match.
@@ -883,7 +883,6 @@ public:
 
   /// Find an associated type declaration that provides a default definition.
   static AssociatedTypeDecl *findDefaultedAssociatedType(
-                                                 TypeChecker &tc,
                                                  AssociatedTypeDecl *assocType);
 };
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -554,12 +554,6 @@ public:
   /// Declarations that need their conformances checked.
   llvm::SmallVector<Decl *, 8> ConformanceContexts;
 
-  // Caches whether a given declaration is "as specialized" as another.
-  llvm::DenseMap<std::tuple<ValueDecl *, ValueDecl *,
-                            /*isDynamicOverloadComparison*/ unsigned>,
-                 bool>
-      specializedOverloadComparisonCache;
-
   /// A list of closures for the most recently type-checked function, which we
   /// will need to compute captures for.
   std::vector<AbstractClosureExpr *> ClosuresWithUncomputedCaptures;
@@ -1654,9 +1648,8 @@ public:
   /// A declaration is more specialized than another declaration if its type
   /// is a subtype of the other declaration's type (ignoring the 'self'
   /// parameter of function declarations) and if
-  Comparison compareDeclarations(DeclContext *dc,
-                                 ValueDecl *decl1,
-                                 ValueDecl *decl2);
+  static Comparison compareDeclarations(DeclContext *dc, ValueDecl *decl1,
+                                        ValueDecl *decl2);
 
   /// Build a type-checked reference to the given value.
   Expr *buildCheckedRefExpr(VarDecl *D, DeclContext *UseDC,


### PR DESCRIPTION
In order to do this, push the last remaining `TypeChecker` dependency on `swift::matchWitness` to the call sites and downgrade the `TypeChecker` in the matchers to an `ASTContext`.  This also removes a `TypeChecker` cache by defining `CompareDeclSpecializationRequest`, which now powers `isDeclAsSpecializedAs`.