### PR TITLE
[TBDGen] Add the unmangled name to the IR-not-TBD diff list

### DIFF
--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -102,7 +102,9 @@ static bool validateSymbolSet(DiagnosticEngine &diags,
       if (!GV->isDeclaration() && externallyVisible) {
         // Is it listed?
         if (!symbols.erase(name))
-          irNotTBD.push_back(name);
+          // Note: Add the unmangled name to the irNotTBD list, which is owned
+          //       by the IRModule, instead of the mangled name.
+          irNotTBD.push_back(unmangledName);
       }
     } else {
       assert(symbols.find(name) == symbols.end() &&


### PR DESCRIPTION
In c94b952 I accidentally started adding StringRefs to an outer-scope
vector from a local SmallString instead of the ones that lived in the IR
module I was reading from. Instead, put the original symbol name from
the IR instead of the "mangled" (leading _ variant) into the diff list.