### PR TITLE
fix TF-489: stdlib ParseableInterface tests

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3487,8 +3487,6 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
   if (auto *ownerClass = dyn_cast<ClassDecl>(ownerNominal))
     baseTy = baseTy->getSuperclassForDecl(ownerClass);
 
-  assert(ownerNominal == baseTy->getAnyNominal());
-
   // Gather all of the substitutions for all levels of generic arguments.
   auto genericSig = dc->getGenericSignatureOfContext();
   if (!genericSig)
@@ -3498,6 +3496,9 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
   unsigned n = params.size();
 
   while (baseTy && n > 0) {
+    if (baseTy->is<ErrorType>())
+      break;
+
     // For a bound generic type, gather the generic parameter -> generic
     // argument substitutions.
     if (auto boundGeneric = baseTy->getAs<BoundGenericType>()) {

--- a/stdlib/public/core/KeyPathIterable.swift
+++ b/stdlib/public/core/KeyPathIterable.swift
@@ -104,12 +104,19 @@ extension Array : KeyPathIterable {
   }
 }
 
-extension Array.DifferentiableView : KeyPathIterable {
+// TODO(TF-938): Remove 'Element : Differentiable' constraint.
+extension Array.DifferentiableView : KeyPathIterable where Element : Differentiable {
   public typealias AllKeyPaths = [PartialKeyPath<Array.DifferentiableView>]
   public var allKeyPaths: [PartialKeyPath<Array.DifferentiableView>] {
     return [\Array.DifferentiableView.base]
   }
 }
+
+// TODO(TF-938): Remove this.
+// This is neccessary now because otherwise the compiler complains:
+//   error: conditional conformance of type 'Array<Element>.DifferentiableView' to protocol
+//   'KeyPathIterable' does not imply conformance to inherited protocol '_KeyPathIterableBase'
+extension Array.DifferentiableView : _KeyPathIterableBase where Element : Differentiable {}
 
 extension Dictionary : KeyPathIterable {
   public typealias AllKeyPaths = [PartialKeyPath<Dictionary>]

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -489,7 +489,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-10-13-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-10-13-a",
                 "tensorflow": "7c7d924821a8b1b20433c2f3f484bbd409873a84",
-                "tensorflow-swift-apis": "668d4ca530bf451fc543c4093216caf99b93842f",
+                "tensorflow-swift-apis": "e70b979b7a3c2ebd38457b8d4058a0b310b4e4b0",
                 "tensorflow-swift-quote": "62c0a88dc64a201497a66cbbc087c0c7771edabc",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-10-13-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-10-13-a"

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -489,7 +489,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-10-13-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-10-13-a",
                 "tensorflow": "7c7d924821a8b1b20433c2f3f484bbd409873a84",
-                "tensorflow-swift-apis": "f4f88d924d71eedb0709e26d0d5e4b7cfe94d830",
+                "tensorflow-swift-apis": "668d4ca530bf451fc543c4093216caf99b93842f",
                 "tensorflow-swift-quote": "62c0a88dc64a201497a66cbbc087c0c7771edabc",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-10-13-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-10-13-a"

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -50,8 +50,9 @@ for filename in os.listdir(sdk_overlay_dir):
         continue
 
     # SWIFT_ENABLE_TENSORFLOW
-    # TODO(TF-939): Enable this on DifferentiationUnittest and Python.
-    if module_name in ["Swift", "SwiftLang", "DifferentiationUnittest", "Python"]:
+    # TODO(TF-939): Enable this on DifferentiationUnittest, Python, and
+    # TensorFlow.
+    if module_name in ["Swift", "SwiftLang", "DifferentiationUnittest", "Python", "TensorFlow"]:
         continue
 
     # swift -build-module-from-parseable-interface

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -49,6 +49,8 @@ for filename in os.listdir(sdk_overlay_dir):
     else:
         continue
 
+    # SWIFT_ENABLE_TENSORFLOW
+    # TODO(TF-939): Enable this on DifferentiationUnittest and Python.
     if module_name in ["Swift", "SwiftLang", "DifferentiationUnittest", "Python"]:
         continue
 

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -49,9 +49,7 @@ for filename in os.listdir(sdk_overlay_dir):
     else:
         continue
 
-    # SWIFT_ENABLE_TENSORFLOW
-    # FIXME(TF-489): Re-enable this test after fixing `.swiftinterface` errors.
-    if module_name in ["Swift", "SwiftLang", "DifferentiationUnittest", "Python", "TensorFlow"]:
+    if module_name in ["Swift", "SwiftLang", "DifferentiationUnittest", "Python"]:
         continue
 
     # swift -build-module-from-parseable-interface

--- a/validation-test/ParseableInterface/verify_stdlib.swift
+++ b/validation-test/ParseableInterface/verify_stdlib.swift
@@ -1,10 +1,6 @@
 // Note that this test should still "pass" when Swift.swiftinterface has not
 // been generated.
 
-// SWIFT_ENABLE_TENSORFLOW
-// FIXME(TF-489): Re-enable this test after fixing `.swiftinterface` errors.
-// UNSUPPORTED: nonexecutable_test
-
 // RUN: %empty-directory(%t)
 // RUN: not ls %platform-module-dir/Swift.swiftmodule/%target-cpu.swiftinterface || %target-swift-frontend -build-module-from-parseable-interface %platform-module-dir/Swift.swiftmodule/%target-cpu.swiftinterface -parse-stdlib -o %t/Swift.swiftmodule
 


### PR DESCRIPTION
Having `Array.DifferentiableView` only defined when `Element : Differentiable` makes the compiler quite confused, leading to issues like TF-489, TF-934.

This PR works around the issue by making `Array.DifferentiableView` unconstrained.

I reduced the problem to something that reproduces on master, and filed an issue for that: SR-11685. Once that issue is resolved, we can try reconstraining it.