### PR TITLE
Pre-Request Cleanup For Implicit Constructors

### DIFF
--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2024,13 +2024,13 @@ OverrideRequiresKeyword overrideRequiresKeyword(ValueDecl *overridden);
 
 /// Compute the type of a member that will be used for comparison when
 /// performing override checking.
-Type getMemberTypeForComparison(ASTContext &ctx, ValueDecl *member,
-                                ValueDecl *derivedDecl = nullptr);
+Type getMemberTypeForComparison(const ValueDecl *member,
+                                const ValueDecl *derivedDecl = nullptr);
 
 /// Determine whether the given declaration is an override by comparing type
 /// information.
-bool isOverrideBasedOnType(ValueDecl *decl, Type declTy,
-                           ValueDecl *parentDecl, Type parentDeclTy);
+bool isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
+                           const ValueDecl *parentDecl, Type parentDeclTy);
 
 /// Determine whether the given declaration is an operator defined in a
 /// protocol. If \p type is not null, check specifically whether \p decl

--- a/validation-test/compiler_crashers_2_fixed/0124-sr5825.swift
+++ b/validation-test/compiler_crashers_2_fixed/0124-sr5825.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir
+// RUN: %target-typecheck-verify-swift
 
 struct DefaultAssociatedType {
 }
@@ -10,7 +10,7 @@ protocol Protocol {
 
 final class Conformance: Protocol {
     private let object: AssociatedType
-    init(object: AssociatedType) {
+    init(object: AssociatedType) { // expected-error {{reference to invalid associated type 'AssociatedType' of type 'Conformance'}}
         self.object = object
     }
 }


### PR DESCRIPTION
Push through an easy refactoring to the way we validate and install
implicit constructors.  This patch would be NFC but for a regression
test that now must diagnose.  #26159 changed validation order in such
a way that the code in validation-test-macosx-x86_64/compiler_crashers_2_fixed/0124-sr5825.swift
used to be accepted.  This patch once again changes validation order, so
we now reject this code, restoring the behavior seen on all prior
versions of Swift.

On its face, this test should work.  In order for it to do so, witness
matching has to be smarter about the declarations it asks for their
interface type, or it will risk these circular constructions
accidentally being accepted or rejected on a whim.