### PR TITLE
[Diagnostics] Use constant strings to avoid use after free.

### DIFF
--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -50,7 +50,7 @@ namespace {
     }
   };
 
-  DiagnosticInfo testDiagnosticInfo(SourceLoc Loc, std::string Message,
+  DiagnosticInfo testDiagnosticInfo(SourceLoc Loc, const char *Message,
                                     DiagnosticKind Kind) {
     return DiagnosticInfo(DiagID(0), Loc, Kind, Message, /*args*/ {},
                           /*indirectBuffer*/ SourceLoc(), /*childInfo*/ {},


### PR DESCRIPTION
Using std::string in the function signature copies the constant string
into a stack allocated copy, which is the one referenced by the
StringRef that DiagnosticInfo stores. when the stack is abandoned, the
string seems to be modificed in VC++, which makes the test fail in
Windows.

Using const char * in the signature avoids the std::string creation, and
StringRef will refer to the static data instead.

Intreoduced in #27868 and started to fail in https://ci-external.swift.org/job/oss-swift-windows-x86_64/1790

/cc @owenv 