### PR TITLE
[CodeCompletion] Avoid type checking all top-level decls in the primary file

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -46,8 +46,6 @@ namespace swift {
   class ValueDecl;
   struct PrintOptions;
 
-  void bindExtensions(SourceFile &SF);
-
   /// Typecheck binding initializer at \p bindingIndex.
   void typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned bindingIndex);
 

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -46,6 +46,8 @@ namespace swift {
   class ValueDecl;
   struct PrintOptions;
 
+  void bindExtensions(SourceFile &SF);
+
   /// Typecheck binding initializer at \p bindingIndex.
   void typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned bindingIndex);
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -199,6 +199,9 @@ namespace swift {
   /// \returns a reference to the type checker instance.
   TypeChecker &createTypeChecker(ASTContext &Ctx);
 
+  /// Bind all 'extension' visible from \p SF to the extended nominal.
+  void bindExtensions(SourceFile &SF);
+
   /// Once parsing and name-binding are complete, this walks the AST to resolve
   /// types and diagnose problems therein.
   ///

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -845,8 +845,13 @@ void CompilerInstance::parseAndCheckTypesUpTo(
 
   // If the limiting AST stage is name binding, we're done.
   if (limitStage <= SourceFile::NameBound) {
+    if (Invocation.isCodeCompletion()) {
+      performCodeCompletionSecondPass(*PersistentState.get(),
+                                      *Invocation.getCodeCompletionFactory());
+    }
     return;
   }
+  assert(!Invocation.isCodeCompletion());
 
   const auto &options = Invocation.getFrontendOptions();
   forEachFileToTypeCheck([&](SourceFile &SF) {
@@ -870,10 +875,6 @@ void CompilerInstance::parseAndCheckTypesUpTo(
     }
   });
 
-  if (Invocation.isCodeCompletion()) {
-    performCodeCompletionSecondPass(*PersistentState.get(),
-                                    *Invocation.getCodeCompletionFactory());
-  }
   finishTypeChecking(TypeCheckOptions);
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4399,10 +4399,6 @@ public:
     if (D->isFinal())
       return;
 
-    // A 'class' member with an initial value cannot be overriden either.
-    if (D->isStatic() && isa<VarDecl>(D) && cast<VarDecl>(D)->hasInitialValue())
-      return;
-
     bool hasIntroducer = hasFuncIntroducer ||
                          hasVarIntroducer ||
                          hasTypealiasIntroducer;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4164,17 +4164,12 @@ public:
     if (Access < AccessLevel::Public &&
         !isa<ProtocolDecl>(VD->getDeclContext())) {
       for (auto Conformance : CurrentNominal->getAllConformances()) {
-        auto Proto = Conformance->getProtocol();
-        for (auto Member : Proto->getMembers()) {
-          auto Requirement = dyn_cast<ValueDecl>(Member);
-          if (!Requirement || !Requirement->isProtocolRequirement() ||
-              isa<AssociatedTypeDecl>(Requirement))
-            continue;
-
-          auto Witness = Conformance->getWitnessDecl(Requirement);
-          if (Witness == VD)
-            Access = std::max(Access, Requirement->getFormalAccess());
-        }
+        Conformance->getRootConformance()->forEachValueWitness(
+            [&](ValueDecl *req, Witness witness) {
+              if (witness.getDecl() == VD)
+                Access = std::max(
+                    Access, Conformance->getProtocol()->getFormalAccess());
+            });
       }
     }
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -91,12 +91,6 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
 } // anonymous namespace
 
 void swift::ide::typeCheckContextUntil(DeclContext *DC, SourceLoc Loc) {
-  // Lookup the swift module.  This ensures that we record all known
-  // protocols in the AST.
-  (void) DC->getASTContext().getStdlibModule();
-
-  bindExtensions(*DC->getParentSourceFile());
-
   while (isa<AbstractClosureExpr>(DC))
     DC = DC->getParent();
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
@@ -61,10 +62,9 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
     if (auto *patternInit = dyn_cast<PatternBindingInitializer>(DC)) {
       if (auto *PBD = patternInit->getBinding()) {
         auto i = patternInit->getBindingIndex();
+        PBD->getPattern(i)->forEachVariable(
+            [](VarDecl *VD) { (void)VD->getInterfaceType(); });
         if (PBD->getInit(i)) {
-          PBD->getPattern(i)->forEachVariable([](VarDecl *VD) {
-            (void) VD->getInterfaceType();
-          });
           if (!PBD->isInitializerChecked(i))
             typeCheckPatternBinding(PBD, i);
         }
@@ -91,15 +91,35 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
 } // anonymous namespace
 
 void swift::ide::typeCheckContextUntil(DeclContext *DC, SourceLoc Loc) {
-  // The only time we have to explicitly check a TopLevelCodeDecl
-  // is when we're directly inside of one. In this case,
-  // performTypeChecking() did not type check it for us.
+  // Lookup the swift module.  This ensures that we record all known
+  // protocols in the AST.
+  (void) DC->getASTContext().getStdlibModule();
+
+  bindExtensions(*DC->getParentSourceFile());
+
   while (isa<AbstractClosureExpr>(DC))
     DC = DC->getParent();
-  if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(DC))
-    typeCheckTopLevelCodeDecl(TLCD);
-  else
+
+  if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(DC)) {
+    // Typecheck all 'TopLevelCodeDecl's up to the target one.
+    // In theory, this is not needed, but it fails to resolve the type of
+    // 'guard'ed variable. e.g.
+    //
+    //   guard value = something() else { fatalError() }
+    //   <complete>
+    // Here, 'value' is '<error type>' unless we explicitly typecheck the
+    // 'guard' statement.
+    SourceFile *SF = DC->getParentSourceFile();
+    for (auto *D : SF->Decls) {
+      if (auto Code = dyn_cast<TopLevelCodeDecl>(D)) {
+        typeCheckTopLevelCodeDecl(Code);
+        if (Code == TLCD)
+          break;
+      }
+    }
+  } else {
     typeCheckContextImpl(DC, Loc);
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -500,7 +500,8 @@ static void synthesizeMemberDeclsForLookup(NominalTypeDecl *NTD,
                                            const DeclContext *DC) {
   // Synthesize the memberwise initializer for structs or default initializer
   // for classes.
-  if (!NTD->hasInterfaceType())
+  if (!NTD->getASTContext().evaluator.hasActiveRequest(
+          SynthesizeMemberwiseInitRequest{NTD}))
     TypeChecker::addImplicitConstructors(NTD);
 
   // Check all conformances to trigger the synthesized decl generation.

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -513,15 +513,11 @@ static void synthesizeMemberDeclsForLookup(NominalTypeDecl *NTD,
         Conformance->getRootConformance());
     if (!NormalConformance)
       continue;
-    for (auto Member : Proto->getMembers()) {
-      auto *VD = dyn_cast<ValueDecl>(Member);
-      if (!VD || !VD->isProtocolRequirement())
-        continue;
-      if (auto *ATD = dyn_cast<AssociatedTypeDecl>(Member))
-        (void)NormalConformance->getTypeWitnessAndDecl(ATD);
-      else
-        (void)NormalConformance->getWitness(VD);
-    }
+    NormalConformance->forEachTypeWitness(
+        [](AssociatedTypeDecl *, Type, TypeDecl *) { return false; },
+        /*useResolver=*/true);
+    NormalConformance->forEachValueWitness([](ValueDecl *, Witness) {},
+                                           /*useResolver=*/true);
   }
 
   synthesizePropertyWrapperStorageWrapperProperties(NTD);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -385,10 +385,6 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
       if (!SF.getParentModule()->isOnoneSupportModule())
         TC.setSkipNonInlinableBodies(true);
 
-    // Lookup the swift module.  This ensures that we record all known
-    // protocols in the AST.
-    (void) TC.getStdlibModule(&SF);
-
     if (!Ctx.LangOpts.DisableAvailabilityChecking) {
       // Build the type refinement hierarchy for the primary
       // file before type checking.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -398,7 +398,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
     // Resolve extensions. This has to occur first during type checking,
     // because the extensions need to be wired into the AST for name lookup
     // to work.
-    bindExtensions(SF);
+    ::bindExtensions(SF);
 
     // Type check the top-level elements of the source file.
     for (auto D : llvm::makeArrayRef(SF.Decls).slice(StartElem)) {
@@ -738,4 +738,8 @@ TypeChecker::getDeclTypeCheckingSemantics(ValueDecl *decl) {
       return DeclTypeCheckingSemantics::OpenExistential;
   }
   return DeclTypeCheckingSemantics::Normal;
+}
+
+void swift::bindExtensions(SourceFile &SF) {
+  ::bindExtensions(SF);
 }

--- a/test/IDE/complete_after_super.swift
+++ b/test/IDE/complete_after_super.swift
@@ -491,7 +491,7 @@ class SemanticContextDerived1 : SemanticContextBase1 {
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2-NEXT: End completions
   }
-  func instanceFunc1() {
+  override func instanceFunc1() {
     #^SEMANTIC_CONTEXT_OVERRIDDEN_DECL_3^#
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_3: Begin completions
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_3-DAG: Decl[InstanceMethod]/CurrNominal: instanceFunc1()[#Void#]{{; name=.+$}}
@@ -504,7 +504,7 @@ class SemanticContextDerived1 : SemanticContextBase1 {
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_4-NEXT: Decl[InstanceMethod]/CurrNominal:  instanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_4-NEXT: End completions
   }
-  func instanceFunc1(_ a: Int) {
+  override func instanceFunc1(_ a: Int) {
     super.#^SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5^#
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5: Begin completions
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5-NEXT: Decl[InstanceMethod]/CurrNominal:  instanceFunc1()[#Void#]{{; name=.+$}}

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -75,8 +75,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_1 | %FileCheck %s -check-prefix=IN_TUPLE_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_TUPLE_2 | %FileCheck %s -check-prefix=IN_TUPLE_2
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_1 | %FileCheck %s -check-prefix=OWN_INIT_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_2 | %FileCheck %s -check-prefix=OWN_INIT_2
+// RUN-FIXME(rdar56755598): %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_1 | %FileCheck %s -check-prefix=OWN_INIT_1
+// RUN-FIXME(rdar56755598): %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_2 | %FileCheck %s -check-prefix=OWN_INIT_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_3 | %FileCheck %s -check-prefix=OWN_INIT_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_4 | %FileCheck %s -check-prefix=OWN_INIT_4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OWN_INIT_5 | %FileCheck %s -check-prefix=OWN_INIT_5

--- a/test/IDE/complete_multifile.swift
+++ b/test/IDE/complete_multifile.swift
@@ -1,0 +1,93 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/Main.swift %t/Library.swift -code-completion-token=POINT_PAREN | %FileCheck --check-prefix=POINT_PAREN %s
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/Main.swift %t/Library.swift -code-completion-token=POINT_DOT | %FileCheck --check-prefix=POINT_DOT %s
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/Main.swift %t/Library.swift -code-completion-token=LENS_DOT | %FileCheck --check-prefix=LENS_DOT %s
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/Main.swift %t/Library.swift -code-completion-token=MYENUM_DOT | %FileCheck --check-prefix=MYENUM_DOT %s
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/Main.swift %t/Library.swift -code-completion-token=HASWRAPPED_DOT| %FileCheck --check-prefix=HASWRAPPED_DOT %s
+
+// BEGIN Library.swift
+
+public struct Point {
+  var x: Int
+  var y: Int
+}
+
+@dynamicMemberLookup
+struct Lens<T> {
+  var obj: T
+  init(_ obj: T) { self.obj = obj }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+    set { obj[keyPath: member] = newValue.obj }
+  }
+}
+
+enum MyEnum: String {
+  case foo = "foo"
+  case bar = "bar"
+}
+
+@propertyWrapper
+struct Wrap<T> {
+  var wrappedValue: T
+
+  public var projectedValue: Self {
+    get { self }
+    set { self = newValue }
+  }
+}
+
+struct HasWrapped {
+  @Wrap
+  var wrapped: Int = 1
+}
+
+// BEGIN Main.swift
+
+func testStructDefaultInit() {
+  Point(#^POINT_PAREN^#
+// POINT_PAREN: Begin completions, 1 items
+// POINT_PAREN-DAG: Decl[Constructor]/CurrNominal:      ['(']{#x: Int#}, {#y: Int#}[')'][#Point#];
+// POINT_PAREN: End completions
+  func sync() {}
+  Point.#^POINT_DOT^#
+// POINT_DOT: Begin completions, 3 items
+// POINT_DOT-DAG: Keyword[self]/CurrNominal:          self[#Point.Type#];
+// POINT_DOT-DAG: Keyword/CurrNominal:                Type[#Point.Type#];
+// POINT_DOT-DAG: Decl[Constructor]/CurrNominal:      init({#x: Int#}, {#y: Int#})[#Point#];
+// POINT_DOT: End completions
+}
+
+func testDynamicMemberLookup(lens: Lens<Point>) {
+  _ = lens.#^LENS_DOT^#
+// LENS_DOT: Begin completions, 4 items
+// LENS_DOT-DAG: Keyword[self]/CurrNominal:          self[#Lens<Point>#];
+// LENS_DOT-DAG: Decl[InstanceVar]/CurrNominal:      x[#Lens<Int>#];
+// LENS_DOT-DAG: Decl[InstanceVar]/CurrNominal:      y[#Lens<Int>#];
+// LENS_DOT-DAG: Decl[InstanceVar]/CurrNominal:      obj[#Point#];
+// LENS_DOT: End completions
+}
+func testRawRepresentable() {
+  MyEnum.#^MYENUM_DOT^#
+// MYENUM_DOT: Begin completions, 7 items
+// MYENUM_DOT-DAG: Keyword[self]/CurrNominal:          self[#MyEnum.Type#];
+// MYENUM_DOT-DAG: Keyword/CurrNominal:                Type[#MyEnum.Type#];
+// MYENUM_DOT-DAG: Decl[EnumElement]/CurrNominal:      foo[#MyEnum#];
+// MYENUM_DOT-DAG: Decl[EnumElement]/CurrNominal:      bar[#MyEnum#];
+// MYENUM_DOT-DAG: Decl[TypeAlias]/CurrNominal:        RawValue[#String#];
+// MYENUM_DOT-DAG: Decl[Constructor]/CurrNominal:      init({#rawValue: String#})[#MyEnum?#];
+// MYENUM_DOT-DAG: Decl[InstanceMethod]/Super:         hash({#(self): MyEnum#})[#(into: inout Hasher) -> Void#];
+// MYENUM_DOT: End completions
+}
+
+func testHasWrappedValue(value: HasWrapped) {
+  value.#^HASWRAPPED_DOT^#
+// HASWRAPPED_DOT: Begin completions, 3 items
+// HASWRAPPED_DOT: Keyword[self]/CurrNominal:          self[#HasWrapped#];
+// HASWRAPPED_DOT: Decl[InstanceVar]/CurrNominal:      wrapped[#Int#];
+// HASWRAPPED_DOT: Decl[InstanceVar]/CurrNominal:      $wrapped[#Wrap<Int>#];
+// HASWRAPPED_DOT: End completions
+}

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -724,9 +724,10 @@ class Override26 : OverrideBase, OverrideP {
   // Same as MODIFIER24
 }
 
-// MODIFIER1: Begin completions, 9 items
+// MODIFIER1: Begin completions, 10 items
 // MODIFIER1-DAG: Decl[Constructor]/Super:            required init(p: Int) {|}; name=required init(p: Int)
 // MODIFIER1-DAG: Decl[StaticMethod]/Super:           override class func classMethod() {|}; name=classMethod()
+// MODIFIER1-DAG: Decl[StaticVar]/Super:              override class var classVar: Int; name=classVar: Int
 // MODIFIER1-DAG: Decl[StaticVar]/Super:              override class var classGetOnlyVar: Int; name=classGetOnlyVar: Int
 // MODIFIER1-DAG: Decl[InstanceMethod]/Super:         override func defaultMethod() {|}; name=defaultMethod()
 // MODIFIER1-DAG: Decl[InstanceMethod]/Super:         override func openMethod() {|}; name=openMethod()
@@ -736,7 +737,8 @@ class Override26 : OverrideBase, OverrideP {
 // MODIFIER1-DAG: Decl[AssociatedType]/Super:         typealias Assoc = {#(Type)#}; name=Assoc = Type
 // MODIFIER1: End completions
 
-// MODIFIER2: Begin completions, 5 items
+// MODIFIER2: Begin completions, 6 items
+// MODIFIER2-DAG: Decl[StaticVar]/Super:              override class var classVar: Int; name=classVar: Int
 // MODIFIER2-DAG: Decl[StaticVar]/Super:              override class var classGetOnlyVar: Int; name=classGetOnlyVar: Int
 // MODIFIER2-DAG: Decl[StaticMethod]/Super:           override class func classMethod() {|}; name=classMethod()
 // MODIFIER2-DAG: Decl[InstanceMethod]/Super:         override func defaultMethod() {|}; name=defaultMethod()
@@ -760,7 +762,8 @@ class Override26 : OverrideBase, OverrideP {
 // MODIFIER6-DAG: Decl[AssociatedType]/Super:         Assoc = {#(Type)#}; name=Assoc = Type
 // MODIFIER6: End completions
 
-// MODIFIER7: Begin completions, 7 items
+// MODIFIER7: Begin completions, 8 items
+// MODIFIER7-DAG: Decl[StaticVar]/Super:              class var classVar: Int; name=classVar: Int
 // MODIFIER7-DAG: Decl[StaticVar]/Super:              class var classGetOnlyVar: Int; name=classGetOnlyVar: Int
 // MODIFIER7-DAG: Decl[StaticMethod]/Super:           class func classMethod() {|}; name=classMethod()
 // MODIFIER7-DAG: Decl[InstanceMethod]/Super:         func defaultMethod() {|}; name=defaultMethod()
@@ -785,11 +788,13 @@ class Override26 : OverrideBase, OverrideP {
 
 // MODIFIER13-NOT: Begin completions
 
-// MODIFIER15: Begin completions, 1 items
+// MODIFIER15: Begin completions, 2 items
+// MODIFIER15-DAG: Decl[StaticVar]/Super/Erase[4]:    override var classVar: Int; name=classVar: Int
 // MODIFIER15-DAG: Decl[StaticVar]/Super/Erase[4]:    override var classGetOnlyVar: Int; name=classGetOnlyVar: Int
 // MODIFIER15: End completions
 
-// MODIFIER17: Begin completions, 1 items
+// MODIFIER17: Begin completions, 2 items
+// MODIFIER17-DAG: Decl[StaticVar]/Super:             classVar: Int; name=classVar: Int
 // MODIFIER17-DAG: Decl[StaticVar]/Super:             classGetOnlyVar: Int; name=classGetOnlyVar: Int
 // MODIFIER17: End completions
 
@@ -801,13 +806,15 @@ class Override26 : OverrideBase, OverrideP {
 // MODIFIER22: Decl[StaticMethod]/Super/Erase[5]:     override func classMethod() {|}; name=classMethod()
 // MODIFIER22: End completions
 
-// MODIFIER23: Begin completions, 2 items
+// MODIFIER23: Begin completions, 3 items
 // MODIFIER23-DAG: Decl[StaticMethod]/Super:          override func classMethod() {|}; name=classMethod()
+// MODIFIER23-DAG: Decl[StaticVar]/Super:             override var classVar: Int; name=classVar: Int
 // MODIFIER23-DAG: Decl[StaticVar]/Super:             override var classGetOnlyVar: Int; name=classGetOnlyVar: Int
 // MODIFIER23: End completions
 
-// MODIFIER24: Begin completions, 2 items
+// MODIFIER24: Begin completions, 3 items
 // MODIFIER24-DAG: Decl[StaticMethod]/Super:          func classMethod() {|}; name=classMethod()
+// MODIFIER24-DAG: Decl[StaticVar]/Super:             var classVar: Int; name=classVar: Int
 // MODIFIER24-DAG: Decl[StaticVar]/Super:             var classGetOnlyVar: Int; name=classGetOnlyVar: Int
 // MODIFIER24: End completions
 

--- a/test/SourceKit/CodeComplete/complete_member.swift
+++ b/test/SourceKit/CodeComplete/complete_member.swift
@@ -32,7 +32,7 @@ class Base {
 }
 
 class Derived: Base {
-    func foo() {}
+    override func foo() {}
 }
 
 func testOverrideUSR() {

--- a/test/SourceKit/CompileNotifications/diagnostics.swift
+++ b/test/SourceKit/CompileNotifications/diagnostics.swift
@@ -63,7 +63,7 @@
 // Note: we're missing the "compiler is in code completion mode" diagnostic,
 // which is probably just as well.
 // RUN: %sourcekitd-test -req=track-compiles == -req=complete -offset=0 %s -- %s | %FileCheck %s -check-prefix=NODIAGS
-// RUN: %sourcekitd-test -req=track-compiles == -req=complete -pos=2:1 %S/Inputs/sema-error.swift -- %S/Inputs/sema-error.swift | %FileCheck %s -check-prefix=SEMA
+// RUN: %sourcekitd-test -req=track-compiles == -req=complete -pos=2:1 %S/Inputs/sema-error.swift -- %S/Inputs/sema-error.swift | %FileCheck %s -check-prefix=NODIAGS
 
 // FIXME: invalid arguments cause us to early-exit and not send the notifications
 // RUN_DISABLED: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s -invalid-arg | %FileCheck %s -check-prefix=INVALID_ARG

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -212,7 +212,7 @@ static bool swiftCodeCompleteImpl(
   SwiftConsumer.setContext(&CI.getASTContext(), &Invocation,
                            &CompletionContext);
   registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);
-  CI.performSema();
+  CI.performParseAndResolveImportsOnly();
   SwiftConsumer.clearContext();
 
   return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -82,7 +82,7 @@ static bool swiftConformingMethodListImpl(
     return true;
   }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performSema();
+  CI.performParseAndResolveImportsOnly();
 
   return true;
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -81,7 +81,7 @@ static bool swiftTypeContextInfoImpl(SwiftLangSupport &Lang,
     return true;
   }
   registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);
-  CI.performSema();
+  CI.performParseAndResolveImportsOnly();
 
   return true;
 }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -766,7 +766,7 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performSema();
+  CI.performParseAndResolveImportsOnly();
   return 0;
 }
 
@@ -831,7 +831,7 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performSema();
+  CI.performParseAndResolveImportsOnly();
   return 0;
 }
 
@@ -908,7 +908,7 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performSema();
+  CI.performParseAndResolveImportsOnly();
   return 0;
 }
 


### PR DESCRIPTION
The first commit is purely bug fixes. They are revealed if the second commit is enabled. However they can be reproduced if the declaration is in the other files in the current module. (Added `test/IDE/complete_multifile.swift` regression test case).

- Default memberwise initializer for struct was not suggested
- Dynamic member lookup didn't work
- `init(rawValue:)` was not suggested for `RawRepresentable` types (rdar://problem/56391233)
- '$name' was not suggested for `@propertyWrapper`ed value

The second commit actually stops eager typechecking decls in the primary file.

- Use `performParseAndResolveImportsOnly()` to invoke the frontend
- Do `bindExtensions()` in `ide::typeCheckContextUntil()`
- Typecheck preceding `TopLevelCodeDecl`s only if the compleiton is in
  a `TopLevelCodeDecl`
- Other related tweaks

rdar://problem/56636747