### PR TITLE
[AutoDiff] NFC: remove unused parameter.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1632,8 +1632,7 @@ public:
   GenericSignature getDerivativeGenericSignature() const {
     return DerivativeGenericSignature;
   }
-  void setDerivativeGenericSignature(ASTContext &context,
-                                     GenericSignature derivativeGenSig) {
+  void setDerivativeGenericSignature(GenericSignature derivativeGenSig) {
     DerivativeGenericSignature = derivativeGenSig;
   }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1464,7 +1464,7 @@ DifferentiableAttr::DifferentiableAttr(ASTContext &context, bool implicit,
     : DeclAttribute(DAK_Differentiable, atLoc, baseRange, implicit),
       Linear(linear), JVP(std::move(jvp)), VJP(std::move(vjp)),
       ParameterIndices(indices) {
-  setDerivativeGenericSignature(context, derivativeGenSig);
+  setDerivativeGenericSignature(derivativeGenSig);
 }
 
 DifferentiableAttr *

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3409,7 +3409,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
         attr->getLocation(), /*allowConcreteGenericParams=*/true);
     whereClauseGenEnv = whereClauseGenSig->getGenericEnvironment();
     // Store the resolved derivative generic signature in the attribute.
-    attr->setDerivativeGenericSignature(ctx, whereClauseGenSig);
+    attr->setDerivativeGenericSignature(whereClauseGenSig);
   }
 
   // Validate the 'wrt:' parameters.


### PR DESCRIPTION
Remove unused `ASTContext &` parameter from `DifferentiableAttr::setDerivativeGenericSignature`.