### PR TITLE
[AutoDiff] Store original declaration in `DifferentiableAttr`.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1542,7 +1542,7 @@ class DifferentiableAttr final
   friend TrailingObjects;
 
   /// The declaration on which the `@differentiable` attribute is declared.
-  AbstractFunctionDecl *OriginalFunction = nullptr;
+  Decl *OriginalDeclaration = nullptr;
   /// Whether this function is linear.
   bool Linear;
   /// The number of parsed parameters specified in 'wrt:'.
@@ -1575,7 +1575,7 @@ class DifferentiableAttr final
                               Optional<DeclNameWithLoc> vjp,
                               TrailingWhereClause *clause);
 
-  explicit DifferentiableAttr(AbstractFunctionDecl *original, bool implicit,
+  explicit DifferentiableAttr(Decl *original, bool implicit,
                               SourceLoc atLoc, SourceRange baseRange,
                               bool linear, IndexSubset *indices,
                               Optional<DeclNameWithLoc> jvp,
@@ -1591,18 +1591,15 @@ public:
                                     Optional<DeclNameWithLoc> vjp,
                                     TrailingWhereClause *clause);
 
-  static DifferentiableAttr *create(AbstractFunctionDecl *original,
-                                    bool implicit, SourceLoc atLoc,
-                                    SourceRange baseRange, bool linear,
-                                    IndexSubset *indices,
+  static DifferentiableAttr *create(Decl *original, bool implicit,
+                                    SourceLoc atLoc, SourceRange baseRange,
+                                    bool linear, IndexSubset *indices,
                                     Optional<DeclNameWithLoc> jvp,
                                     Optional<DeclNameWithLoc> vjp,
                                     GenericSignature derivativeGenSig);
 
-  AbstractFunctionDecl *getOriginalFunction() const {
-    return OriginalFunction;
-  }
-  void setOriginalFunction(AbstractFunctionDecl *decl);
+  Decl *getOriginalDeclaration() const { return OriginalDeclaration; }
+  void setOriginalDeclaration(Decl *decl);
 
   /// Get the optional 'jvp:' function name and location.
   /// Use this instead of `getJVPFunction` to check whether the attribute has a

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1541,6 +1541,8 @@ class DifferentiableAttr final
                                     ParsedAutoDiffParameter> {
   friend TrailingObjects;
 
+  /// The declaration on which the `@differentiable` attribute is declared.
+  AbstractFunctionDecl *OriginalFunction = nullptr;
   /// Whether this function is linear.
   bool Linear;
   /// The number of parsed parameters specified in 'wrt:'.
@@ -1573,7 +1575,7 @@ class DifferentiableAttr final
                               Optional<DeclNameWithLoc> vjp,
                               TrailingWhereClause *clause);
 
-  explicit DifferentiableAttr(ASTContext &context, bool implicit,
+  explicit DifferentiableAttr(AbstractFunctionDecl *original, bool implicit,
                               SourceLoc atLoc, SourceRange baseRange,
                               bool linear, IndexSubset *indices,
                               Optional<DeclNameWithLoc> jvp,
@@ -1589,12 +1591,18 @@ public:
                                     Optional<DeclNameWithLoc> vjp,
                                     TrailingWhereClause *clause);
 
-  static DifferentiableAttr *create(ASTContext &context, bool implicit,
-                                    SourceLoc atLoc, SourceRange baseRange,
-                                    bool linear, IndexSubset *indices,
+  static DifferentiableAttr *create(AbstractFunctionDecl *original,
+                                    bool implicit, SourceLoc atLoc,
+                                    SourceRange baseRange, bool linear,
+                                    IndexSubset *indices,
                                     Optional<DeclNameWithLoc> jvp,
                                     Optional<DeclNameWithLoc> vjp,
                                     GenericSignature derivativeGenSig);
+
+  AbstractFunctionDecl *getOriginalFunction() const {
+    return OriginalFunction;
+  }
+  void setOriginalFunction(AbstractFunctionDecl *decl);
 
   /// Get the optional 'jvp:' function name and location.
   /// Use this instead of `getJVPFunction` to check whether the attribute has a

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1454,17 +1454,16 @@ DifferentiableAttr::DifferentiableAttr(ASTContext &context, bool implicit,
             getTrailingObjects<ParsedAutoDiffParameter>());
 }
 
-DifferentiableAttr::DifferentiableAttr(AbstractFunctionDecl *original,
-                                       bool implicit, SourceLoc atLoc,
-                                       SourceRange baseRange, bool linear,
-                                       IndexSubset *indices,
+DifferentiableAttr::DifferentiableAttr(Decl *original, bool implicit,
+                                       SourceLoc atLoc, SourceRange baseRange,
+                                       bool linear, IndexSubset *indices,
                                        Optional<DeclNameWithLoc> jvp,
                                        Optional<DeclNameWithLoc> vjp,
                                        GenericSignature derivativeGenSig)
     : DeclAttribute(DAK_Differentiable, atLoc, baseRange, implicit),
       Linear(linear), JVP(std::move(jvp)), VJP(std::move(vjp)),
       ParameterIndices(indices) {
-  setOriginalFunction(original);
+  setOriginalDeclaration(original);
   setDerivativeGenericSignature(derivativeGenSig);
 }
 
@@ -1484,10 +1483,9 @@ DifferentiableAttr::create(ASTContext &context, bool implicit,
 }
 
 DifferentiableAttr *
-DifferentiableAttr::create(AbstractFunctionDecl *original, bool implicit,
-                           SourceLoc atLoc, SourceRange baseRange,
-                           bool linear, IndexSubset *indices,
-                           Optional<DeclNameWithLoc> jvp,
+DifferentiableAttr::create(Decl *original, bool implicit, SourceLoc atLoc,
+                           SourceRange baseRange, bool linear,
+                           IndexSubset *indices, Optional<DeclNameWithLoc> jvp,
                            Optional<DeclNameWithLoc> vjp,
                            GenericSignature derivativeGenSig) {
   auto &ctx = original->getASTContext();
@@ -1498,10 +1496,11 @@ DifferentiableAttr::create(AbstractFunctionDecl *original, bool implicit,
                                       std::move(vjp), derivativeGenSig);
 }
 
-void DifferentiableAttr::setOriginalFunction(AbstractFunctionDecl *decl) {
-  assert(!OriginalFunction && "Original function cannot have already been set");
-  assert(decl && "Original function must be non-null");
-  OriginalFunction = decl;
+void DifferentiableAttr::setOriginalDeclaration(Decl *decl) {
+  assert(decl && "Original declaration must be non-null");
+  assert(!OriginalDeclaration &&
+         "Original declaration cannot have already been set");
+  OriginalDeclaration = decl;
 }
 
 void DifferentiableAttr::setJVPFunction(FuncDecl *decl) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3724,9 +3724,11 @@ Parser::parseDecl(ParseDeclOptions Flags,
           Handler(quoteDecl);
         }
       }
-      setOriginalFunctionInDifferentiableAttributes(D->getAttrs(), D);
       // SWIFT_ENABLE_TENSORFLOW END
     }
+    // SWIFT_ENABLE_TENSORFLOW
+    setOriginalFunctionInDifferentiableAttributes(D->getAttrs(), D);
+    // SWIFT_ENABLE_TENSORFLOW END
   }
 
   if (!DeclResult.isParseError()) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3718,11 +3718,11 @@ Parser::parseDecl(ParseDeclOptions Flags,
         }
       }
 
-      if (D->getAttrs().hasAttribute<DifferentiableAttr>()) {
-        auto *AFD = dyn_cast<AbstractFunctionDecl>(D);
-        if (auto *ASD = dyn_cast<AbstractStorageDecl>(D))
-          AFD = ASD->getAccessor(AccessorKind::Get);
-        assert(AFD && "Must resolve '@differentiable' attribute declaration");
+      // Set original declaration in `@differentiable` attributes.
+      auto *AFD = dyn_cast<AbstractFunctionDecl>(D);
+      if (auto *ASD = dyn_cast<AbstractStorageDecl>(D))
+        AFD = ASD->getAccessor(AccessorKind::Get);
+      if (AFD) {
         for (auto *attr : D->getAttrs().getAttributes<DifferentiableAttr>()) {
           auto *diffAttr = const_cast<DifferentiableAttr *>(attr);
           diffAttr->setOriginalFunction(AFD);

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -641,8 +641,9 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
       if (auto *extDecl = dyn_cast<ExtensionDecl>(parentDC->getAsDecl()))
         derivativeGenSig = extDecl->getGenericSignature();
       auto *diffableAttr = DifferentiableAttr::create(
-          C, /*implicit*/ true, SourceLoc(), SourceLoc(),
-          /*linear*/ false, {}, None, None, derivativeGenSig);
+          member->getAccessor(AccessorKind::Get), /*implicit*/ true,
+          SourceLoc(), SourceLoc(), /*linear*/ false, {}, None, None,
+          derivativeGenSig);
       member->getAttrs().add(diffableAttr);
       // Set getter `@differentiable` attribute parameter indices.
       diffableAttr->setParameterIndices(IndexSubset::get(C, 1, {0}));

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3274,8 +3274,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
-  if (!attr->getOriginalFunction())
-    attr->setOriginalFunction(original);
+  if (!attr->getOriginalDeclaration())
+    attr->setOriginalDeclaration(original);
   TC.resolveDeclSignature(original);
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
   bool isMethod = original->hasImplicitSelfDecl();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3274,8 +3274,9 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
-  if (!attr->getOriginalDeclaration())
-    attr->setOriginalDeclaration(original);
+  assert(attr->getOriginalDeclaration() &&
+         "`@differentiable` attribute should have original declaration set "
+         "during construction or parsing");
   TC.resolveDeclSignature(original);
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
   bool isMethod = original->hasImplicitSelfDecl();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3274,6 +3274,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
+  if (!attr->getOriginalFunction())
+    attr->setOriginalFunction(original);
   TC.resolveDeclSignature(original);
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
   bool isMethod = original->hasImplicitSelfDecl();
@@ -3530,15 +3532,15 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     D->getAttrs().removeAttribute(attr);
     // Transfer `@differentiable` attribute from storage declaration to
     // getter accessor.
+    auto *getterDecl = asd->getAccessor(AccessorKind::Get);
     auto *newAttr = DifferentiableAttr::create(
-        ctx, /*implicit*/ true, attr->AtLoc, attr->getRange(), attr->isLinear(),
-        attr->getParameterIndices(), attr->getJVP(), attr->getVJP(),
-        attr->getDerivativeGenericSignature());
+        getterDecl, /*implicit*/ true, attr->AtLoc, attr->getRange(),
+        attr->isLinear(), attr->getParameterIndices(), attr->getJVP(),
+        attr->getVJP(), attr->getDerivativeGenericSignature());
     newAttr->setJVPFunction(attr->getJVPFunction());
     newAttr->setVJPFunction(attr->getVJPFunction());
     auto insertion = ctx.DifferentiableAttrs.try_emplace(
-        {asd->getAccessor(AccessorKind::Get), newAttr->getParameterIndices()},
-        newAttr);
+        {getterDecl, newAttr->getParameterIndices()}, newAttr);
     // Valid `@differentiable` attributes are uniqued by their parameter
     // indices. Reject duplicate attributes for the same decl and parameter
     // indices pair.
@@ -3548,7 +3550,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
                   diag::differentiable_attr_duplicate_note);
       return;
     }
-    asd->getAccessor(AccessorKind::Get)->getAttrs().add(newAttr);
+    getterDecl->getAttrs().add(newAttr);
     return;
   }
   auto insertion = ctx.DifferentiableAttrs.try_emplace(
@@ -3826,7 +3828,7 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
   // If the original function does not have a `@differentiable` attribute with
   // the same differentiation parameters, create one.
   if (!da) {
-    da = DifferentiableAttr::create(ctx, /*implicit*/ true, attr->AtLoc,
+    da = DifferentiableAttr::create(originalFn, /*implicit*/ true, attr->AtLoc,
                                     attr->getRange(), attr->isLinear(),
                                     checkedWrtParamIndices, /*jvp*/ None,
                                     /*vjp*/ None,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -567,8 +567,9 @@ swift::matchWitness(
       if (!reqDiffAttrMatch) {
         auto implicitDiffAttr = false;
         if (reqDiffAttrSupersetMatch) {
+          auto *witnessAFD = cast<AbstractFunctionDecl>(witness);
           auto *newAttr = DifferentiableAttr::create(
-              ctx, /*implicit*/ true, reqDiffAttr->AtLoc,
+              witnessAFD, /*implicit*/ true, reqDiffAttr->AtLoc,
               reqDiffAttr->getRange(), reqDiffAttr->isLinear(),
               reqDiffAttr->getParameterIndices(), /*jvp*/ None,
               /*vjp*/ None, reqDiffAttr->getDerivativeGenericSignature());

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2180,7 +2180,7 @@ static void setOriginalDeclarationInDifferentiableAttributes(
   DeclAttributes tempAttrs;
   tempAttrs.setRawAttributeChain(attrs);
   for (auto *attr : tempAttrs.getAttributes<DifferentiableAttr>())
-    const_cast<DifferentiableAttr *>(attr)->setOriginalFunction(decl);
+    const_cast<DifferentiableAttr *>(attr)->setOriginalDeclaration(decl);
 }
 // SWIFT_ENABLE_TENSORFLOW END
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2166,6 +2166,24 @@ static bool attributeChainContains(DeclAttribute *attr) {
   return tempAttrs.hasAttribute<DERIVED>();
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+// Set original declaration in `@differentiable` attributes.
+//
+// Serializing/deserializing the original declaration DeclID in
+// `@differentiable` attributes does not work because it causes
+// `@differentiable` attribute deserialization to enter an infinite loop.
+//
+// Instead, call this ad-hoc function after deserializing a declaration to set
+// it as the original declaration in its `@differentiable` attributes.
+static void setOriginalDeclarationInDifferentiableAttributes(
+    AbstractFunctionDecl *decl, DeclAttribute *attrs) {
+  DeclAttributes tempAttrs;
+  tempAttrs.setRawAttributeChain(attrs);
+  for (auto *attr : tempAttrs.getAttributes<DifferentiableAttr>())
+    const_cast<DifferentiableAttr *>(attr)->setOriginalFunction(decl);
+}
+// SWIFT_ENABLE_TENSORFLOW END
+
 Decl *ModuleFile::getDecl(DeclID DID) {
   Expected<Decl *> deserialized = getDeclChecked(DID);
   if (!deserialized) {
@@ -2565,6 +2583,11 @@ public:
 
     ctor->setImplicitlyUnwrappedOptional(isIUO);
     ctor->computeType();
+
+    // SWIFT_ENABLE_TENSORFLOW
+    // Set original declaration in `@differentiable` attributes.
+    setOriginalDeclarationInDifferentiableAttributes(ctor, DAttrs);
+    // SWIFT_ENABLE_TENSORFLOW END
 
     return ctor;
   }
@@ -3038,6 +3061,11 @@ public:
 
     // Set the interface type.
     fn->computeType();
+
+    // SWIFT_ENABLE_TENSORFLOW
+    // Set original declaration in `@differentiable` attributes.
+    setOriginalDeclarationInDifferentiableAttributes(fn, DAttrs);
+    // SWIFT_ENABLE_TENSORFLOW END
 
     return fn;
   }
@@ -4051,7 +4079,6 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
       // SWIFT_ENABLE_TENSORFLOW
       case decls_block::Differentiable_DECL_ATTR: {
         bool isImplicit;
-        DeclID originalDeclId;
         bool linear;
         uint64_t jvpNameId;
         DeclID jvpDeclId;
@@ -4061,10 +4088,9 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         ArrayRef<uint64_t> parameters;
 
         serialization::decls_block::DifferentiableDeclAttrLayout::readRecord(
-            scratch, isImplicit, originalDeclId, linear, jvpNameId, jvpDeclId,
-            vjpNameId, vjpDeclId, derivativeGenSigId, parameters);
+            scratch, isImplicit, linear, jvpNameId, jvpDeclId, vjpNameId,
+            vjpDeclId, derivativeGenSigId, parameters);
 
-        FuncDecl *originalDecl = cast<FuncDecl>(MF.getDecl(originalDeclId));
         Optional<DeclNameWithLoc> jvp;
         FuncDecl *jvpDecl = nullptr;
         if (jvpNameId != 0)
@@ -4086,10 +4112,11 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
           parametersBitVector[i] = parameters[i];
         auto *indices = IndexSubset::get(ctx, parametersBitVector);
 
-        auto diffAttr =
-            DifferentiableAttr::create(originalDecl, isImplicit, SourceLoc(),
-                                       SourceRange(), linear, indices, jvp, vjp,
-                                       derivativeGenSig);
+        auto *diffAttr = DifferentiableAttr::create(
+            ctx, isImplicit, SourceLoc(), SourceRange(), linear,
+            /*parsedParameters*/ {}, jvp, vjp, /*trailingWhereClause*/ nullptr);
+        diffAttr->setParameterIndices(indices);
+        diffAttr->setDerivativeGenericSignature(derivativeGenSig);
         diffAttr->setJVPFunction(jvpDecl);
         diffAttr->setVJPFunction(vjpDecl);
         Attr = diffAttr;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 525; // @differentiable attribute original declaration
+const uint16_t SWIFTMODULE_VERSION_MINOR = 524; // differentiable_function_extract explicit extractee type
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1759,7 +1759,6 @@ namespace decls_block {
   using DifferentiableDeclAttrLayout = BCRecordLayout<
     Differentiable_DECL_ATTR,
     BCFixed<1>, // Implicit flag.
-    DeclIDField, // Original function declaration.
     BCFixed<1>, // Linear flag.
     IdentifierIDField, // JVP name.
     DeclIDField, // JVP function declaration.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 524; // differentiable_function_extract explicit extractee type
+const uint16_t SWIFTMODULE_VERSION_MINOR = 525; // @differentiable attribute original declaration
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1759,6 +1759,7 @@ namespace decls_block {
   using DifferentiableDeclAttrLayout = BCRecordLayout<
     Differentiable_DECL_ATTR,
     BCFixed<1>, // Implicit flag.
+    DeclIDField, // Original function declaration.
     BCFixed<1>, // Linear flag.
     IdentifierIDField, // JVP name.
     DeclIDField, // JVP function declaration.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2309,8 +2309,9 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DAK_Differentiable: {
       auto abbrCode = S.DeclTypeAbbrCodes[DifferentiableDeclAttrLayout::Code];
       auto *attr = cast<DifferentiableAttr>(DA);
-      assert(attr->getOriginalFunction() &&
-             "@differentiable attribute must have original function resolved");
+      assert(attr->getOriginalDeclaration() &&
+             "@differentiable attribute must have original declaration "
+             "resolved");
 
       IdentifierID jvpName = 0;
       DeclID jvpRef = 0;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2310,8 +2310,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       auto abbrCode = S.DeclTypeAbbrCodes[DifferentiableDeclAttrLayout::Code];
       auto *attr = cast<DifferentiableAttr>(DA);
       assert(attr->getOriginalDeclaration() &&
-             "@differentiable attribute must have original declaration "
-             "resolved");
+             "`@differentiable` attribute should have original declaration set "
+             "during construction or parsing");
 
       IdentifierID jvpName = 0;
       DeclID jvpRef = 0;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2309,10 +2309,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DAK_Differentiable: {
       auto abbrCode = S.DeclTypeAbbrCodes[DifferentiableDeclAttrLayout::Code];
       auto *attr = cast<DifferentiableAttr>(DA);
-
       assert(attr->getOriginalFunction() &&
              "@differentiable attribute must have original function resolved");
-      DeclID originalRef = S.addDeclRef(attr->getOriginalFunction());
 
       IdentifierID jvpName = 0;
       DeclID jvpRef = 0;
@@ -2335,7 +2333,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
         indices.push_back(paramIndices->contains(i));
 
       DifferentiableDeclAttrLayout::emitRecord(
-          S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(), originalRef,
+          S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(),
           attr->isLinear(), jvpName, jvpRef, vjpName, vjpRef,
           S.addGenericSignatureRef(attr->getDerivativeGenericSignature()),
           indices);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2310,6 +2310,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       auto abbrCode = S.DeclTypeAbbrCodes[DifferentiableDeclAttrLayout::Code];
       auto *attr = cast<DifferentiableAttr>(DA);
 
+      assert(attr->getOriginalFunction() &&
+             "@differentiable attribute must have original function resolved");
+      DeclID originalRef = S.addDeclRef(attr->getOriginalFunction());
+
       IdentifierID jvpName = 0;
       DeclID jvpRef = 0;
       if (auto jvp = attr->getJVP())
@@ -2331,7 +2335,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
         indices.push_back(paramIndices->contains(i));
 
       DifferentiableDeclAttrLayout::emitRecord(
-          S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(),
+          S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(), originalRef,
           attr->isLinear(), jvpName, jvpRef, vjpName, vjpRef,
           S.addGenericSignatureRef(attr->getDerivativeGenericSignature()),
           indices);

--- a/test/AutoDiff/differentiable_attr_serialization.swift
+++ b/test/AutoDiff/differentiable_attr_serialization.swift
@@ -17,6 +17,16 @@ struct Foo: Differentiable {
   @differentiable
   var computedProperty: Float { 1 }
 
+  var computedPropertyGetter: Float {
+    @differentiable
+    get { 1 }
+  }
+
   @differentiable
   subscript() -> Float { 1 }
+
+  subscript(_ x: Float) -> Float {
+    @differentiable
+    get { 1 }
+  }
 }

--- a/test/AutoDiff/differentiable_attr_serialization.swift
+++ b/test/AutoDiff/differentiable_attr_serialization.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %s -o %t/differentiable_attr_serialization.swiftmodule
+// RUN: %target-swift-frontend -merge-modules -sil-merge-partial-modules -emit-module %t/differentiable_attr_serialization.swiftmodule
+
+// Test round-trip `@differentiable` attribute AST serialization.
+
+// Motivation: check that `@differentiable` attributes always have original
+// declaration set.
+
+struct Foo: Differentiable {
+  @differentiable
+  func method() -> Self { self }
+
+  @differentiable
+  init(_ x: Float) {}
+
+  @differentiable
+  var computedProperty: Float { 1 }
+
+  @differentiable
+  subscript() -> Float { 1 }
+}


### PR DESCRIPTION
Store original declaration `Decl *` in `DifferentiableAttr`.

This is important for requestifying
`DifferentiableAttr->getParameterIndices()`: we want the ability to
resolve parameter indices without needing to pass the original
`AbstractFunctionDecl` to `getParameterIndices`.

Add round-trip `@differentiable` attribute AST serialization test.
`@differentiable` attribute type-checking and serialization assert
that the original declaration is set.

---

A step towards unblocking the `swift-DEVELOPMENT-SNAPSHOT-2019-10-24-a` merge.