### PR TITLE
Fix typealias used in associatedtype constraint

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -48,6 +48,8 @@
 #include "llvm/Support/SaveAndRestore.h"
 #include <algorithm>
 
+#include <iostream>
+
 using namespace swift;
 using llvm::DenseMap;
 
@@ -3625,6 +3627,8 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
                                     Type type,
                                     ArchetypeResolutionKind resolutionKind,
                                     bool wantExactPotentialArchetype) {
+  type->dump();
+  
   // An error type is best modeled as an unresolved potential archetype, since
   // there's no way to be sure what it is actually meant to be.
   if (type->is<ErrorType>()) {
@@ -3633,12 +3637,16 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
 
   // The equivalence class of a generic type is known directly.
   if (auto genericParam = type->getAs<GenericTypeParamType>()) {
+    std::cout << "0" << std::endl;
     unsigned index = GenericParamKey(genericParam).findIndexIn(
                                                             getGenericParams());
+    std::cout << "1" << std::endl;
     if (index < Impl->GenericParams.size()) {
+      std::cout << "2" << std::endl;
       return ResolvedType(Impl->PotentialArchetypes[index]);
     }
 
+    std::cout << "3" << std::endl;
     return ResolvedType::forUnresolved(nullptr);
   }
 
@@ -3646,6 +3654,7 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
   // base equivalence class, if there is one.
   if (auto depMemTy = type->getAs<DependentMemberType>()) {
     // Find the equivalence class of the base.
+    std::cout << "4" << std::endl;
     auto resolvedBase =
       maybeResolveEquivalenceClass(depMemTy->getBase(),
                                    resolutionKind,
@@ -4850,6 +4859,16 @@ ConstraintResult GenericSignatureBuilder::addSameTypeRequirement(
     FloatingRequirementSource source,
     UnresolvedHandlingKind unresolvedHandling,
     llvm::function_ref<void(Type, Type)> diagnoseMismatch) {
+  
+  if (paOrT1.is<Type>())
+    paOrT1.get<Type>()->dump();
+  if (paOrT1.is<PotentialArchetype*>())
+    paOrT1.get<PotentialArchetype*>()->dump();
+  
+  if (paOrT2.is<Type>())
+    paOrT2.get<Type>()->dump();
+  if (paOrT2.is<PotentialArchetype*>())
+    paOrT2.get<PotentialArchetype*>()->dump();
 
   auto resolved1 = resolve(paOrT1, source);
   if (!resolved1) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -47,6 +47,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include <iostream>
 
 using namespace swift;
 
@@ -565,7 +566,8 @@ Type TypeChecker::resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
 
     if (selfType->is<GenericTypeParamType>()) {
       if (typeDecl->getDeclContext()->getSelfProtocolDecl()) {
-        if (isa<AssociatedTypeDecl>(typeDecl)) {
+        if (isa<AssociatedTypeDecl>(typeDecl) ||
+            typeDecl->getAsGenericContext()) {
           // FIXME: We should use this lookup method for the Interface
           // stage too, but right now that causes problems with
           // Sequence.SubSequence vs Collection.SubSequence; the former
@@ -574,10 +576,16 @@ Type TypeChecker::resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
           // because we use the Sequence.SubSequence default instead of
           // the Collection.SubSequence default, even when the conforming
           // type wants to conform to Collection.
+//          selfType->dump();
+//          typeDecl->dump();
+//          std::cout << typeDecl->getName().get() << std::endl;
+          
           if (resolution.getStage() == TypeResolutionStage::Structural) {
             return resolution.resolveSelfAssociatedType(selfType, foundDC,
                                                         typeDecl->getName());
-          } else if (auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl)) {
+          }
+          
+          if (auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl)) {
             typeDecl = assocType->getAssociatedTypeAnchor();
           }
         }

--- a/validation-test/compiler_crashers_2_fixed/sr11639.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11639.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift
 
 protocol ProtocolA {
     associatedtype T1

--- a/validation-test/compiler_crashers_2_fixed/sr11639.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11639.swift
@@ -1,0 +1,16 @@
+// RUN: not %target-typecheck-verify-swift
+
+protocol ProtocolA {
+    associatedtype T1
+}
+
+struct S<T> : ProtocolA {
+  typealias T1 = T
+}
+
+protocol ProtocolB: ProtocolA {
+    associatedtype T2: ProtocolB where T2.T1 == T3.T1
+    associatedtype X
+    typealias T3 = S<X>
+}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch fixes the compiler crash when type typealias are used in associatedtype constraints. For example:
```swift
protocol ProtocolA {
    associatedtype T1
}

struct S : ProtocolA {
  typealias T1 = Int
}

protocol ProtocolB: ProtocolA {
    associatedtype T2: ProtocolB where T2.T1 == T3.T1
    associatedtype X
    typealias T3 = S
}
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-11639](https://bugs.swift.org/browse/SR-11639).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Let me know if I put my tests in the right place. 