### PR TITLE
[DNM] Add explicit "[-warnings-as-errors]" to diagnostics as applicable.

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -21,7 +21,7 @@
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/DiagnosticConsumer.h"
-#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/VersionTuple.h"
 
@@ -655,7 +655,7 @@ namespace swift {
     /// A set of all strings involved in current transactional chain.
     /// This is required because diagnostics are not directly emitted
     /// but rather stored until all transactions complete.
-    llvm::StringMap<char, llvm::BumpPtrAllocator &> TransactionStrings;
+    llvm::StringSet<llvm::BumpPtrAllocator &> TransactionStrings;
 
     /// The number of open diagnostic transactions. Diagnostics are only
     /// emitted once all transactions have closed.

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -554,6 +554,7 @@ namespace swift {
       Remark,
       Warning,
       Error,
+      ErrorFromWarning,
       Fatal,
     };
 
@@ -944,8 +945,9 @@ namespace swift {
     void emitTentativeDiagnostics();
 
   public:
-    static const char *diagnosticStringFor(const DiagID id,
-                                           bool printDiagnosticName);
+    const char *diagnosticStringFor(const DiagID id,
+                                    bool printDiagnosticName,
+                                    bool fromWarningsAsErrors);
 
     /// If there is no clear .dia file for a diagnostic, put it in the one
     /// corresponding to the SourceLoc given here.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1026,7 +1026,7 @@ void DiagnosticEngine::onTentativeDiagnosticFlush(Diagnostic &diagnostic) {
     if (content.empty())
       continue;
 
-    auto I = TransactionStrings.insert(std::make_pair(content, char())).first;
+    auto I = TransactionStrings.insert(content).first;
     argument = DiagnosticArgument(StringRef(I->getKeyData()));
   }
 }

--- a/test/Driver/warnings-control.swift
+++ b/test/Driver/warnings-control.swift
@@ -9,7 +9,7 @@ func foo() -> Int {
 	let x = 1
 	var y = 2
 // DEFAULT:    warning: variable 'y' was never mutated; consider changing to 'let' constant
-// WERR:       error: variable 'y' was never mutated; consider changing to 'let' constant
+// WERR:       error: variable 'y' was never mutated; consider changing to 'let' constant [-warnings-as-errors]
 // NOWARN-NOT: variable 'y' was never mutated
 	return x + y
 }


### PR DESCRIPTION
Fixes rdar://problem/48911752.

Waiting for #27986 to be merged first.

Avoid storing duplicate prefixes of the format string in a table -- concatenate it at runtime instead. (cc @owenv)