### PR TITLE
[preset] Build toolchain-benchmarks in swiftpm PR tests

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1509,6 +1509,9 @@ assertions
 # Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
 
+toolchain-benchmarks
+skip-test-toolchain-benchmarks
+
 skip-test-llbuild
 
 #===------------------------------------------------------------------------===#
@@ -1524,6 +1527,9 @@ assertions
 
 # Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
+
+toolchain-benchmarks
+skip-test-toolchain-benchmarks
 
 skip-test-llbuild
 

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -208,6 +208,7 @@ def _apply_default_arguments(args):
         args.test_sourcekitlsp = False
         args.test_skstresstester = False
         args.test_swiftevolve = False
+        args.test_toolchainbenchmarks = False
 
     # --skip-test-ios is merely a shorthand for host and simulator tests.
     if not args.test_ios:
@@ -977,6 +978,8 @@ def create_argument_parser():
            help='skip testing the SourceKit Stress tester')
     option('--skip-test-swiftevolve', toggle_false('test_swiftevolve'),
            help='skip testing SwiftEvolve')
+    option('--skip-test-toolchain-benchmarks', toggle_false('test_toolchainbenchmarks'),
+           help='skip testing toolchain benchmarks')
 
     # -------------------------------------------------------------------------
     in_group('Build settings specific for LLVM')

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -213,6 +213,7 @@ EXPECTED_DEFAULTS = {
     'test_sourcekitlsp': False,
     'test_skstresstester': False,
     'test_swiftevolve': False,
+    'test_toolchainbenchmarks': False,
     'tvos': False,
     'tvos_all': False,
     'validation_test': None,
@@ -546,6 +547,7 @@ EXPECTED_OPTIONS = [
     DisableOption('--skip-test-sourcekit-lsp', dest='test_sourcekitlsp'),
     DisableOption('--skip-test-skstresstester', dest='test_skstresstester'),
     DisableOption('--skip-test-swiftevolve', dest='test_swiftevolve'),
+    DisableOption('--skip-test-toolchain-benchmarks', dest='test_toolchainbenchmarks'),
 
     ChoicesOption('--android-ndk-gcc-version',
                   choices=['4.8', '4.9']),

--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -35,7 +35,7 @@ class Benchmarks(product.Product):
         run_build_script_helper(host_target, self, self.args)
 
     def should_test(self, host_target):
-        return True
+        return self.args.test_toolchainbenchmarks
 
     def test(self, host_target):
         """Just run a single instance of the command for both .debug and


### PR DESCRIPTION
The build recently broke because we were not building the toolchain benchmarks (package built using the just-built toolchain).  Add that so we don't do it again.

rdar://56781583