### PR TITLE
Basic: avoid an assertion on Windows

### DIFF
--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -124,12 +124,18 @@ protected:
   void appendIdentifier(StringRef ident);
 
   void addSubstitution(const void *ptr) {
-    if (UseSubstitutions)
-      Substitutions[ptr] = Substitutions.size() + StringSubstitutions.size();
+    if (!UseSubstitutions)
+      return;
+
+    auto value = Substitutions.size() + StringSubstitutions.size();
+    Substitutions[ptr] = value;
   }
   void addSubstitution(StringRef Str) {
-    if (UseSubstitutions)
-      StringSubstitutions[Str] = Substitutions.size() + StringSubstitutions.size();
+    if (!UseSubstitutions)
+      return;
+
+    auto value = Substitutions.size() + StringSubstitutions.size();
+    StringSubstitutions[Str] = value;
   }
 
   bool tryMangleSubstitution(const void *ptr);


### PR DESCRIPTION
The order of evaluation of the subscript operator would increase the
count of map, resulting in the decoration to be off by one.  This
enables building the swift standard library on Windows again.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
