### PR TITLE
[Reflection] Fix length calculation in readTypeRef.

### DIFF
--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -44,8 +44,9 @@ RemoteRef<char> TypeRefBuilder::readTypeRef(uint64_t remoteAddr) {
     }
   }
   // TODO: Try using MetadataReader to read the string here?
-  fputs("invalid type ref pointer\n", stderr);
-  abort();
+  
+  // Invalid type ref pointer.
+  return nullptr;
 
 found_type_ref:
   // Make sure there's a valid mangled string within the bounds of the
@@ -57,16 +58,16 @@ found_type_ref:
       goto valid_type_ref;
       
     if (c >= '\1' && c <= '\x17')
-      i = i.atByteOffset(4);
+      i = i.atByteOffset(5);
     else if (c >= '\x18' && c <= '\x1F') {
-      i = i.atByteOffset(PointerSize);
+      i = i.atByteOffset(PointerSize + 1);
     } else {
       i = i.atByteOffset(1);
     }
   }
   
-  fputs("unterminated type ref\n", stderr);
-  abort();
+  // Unterminated string.
+  return nullptr;
   
 valid_type_ref:
   // Look past the $s prefix if the string has one.


### PR DESCRIPTION
The code was skipping 4/8 bytes to jump overn embedded reference, but it actually needs to skip 5/9 bytes in order to skip over the leading control character as well.

Also change the abort() calls to return nullptr so that we can fail more gracefully if this code is ever presented with bad data, since we want inspection tools to be robust in the face of garbage.

rdar://problem/56460096