### PR TITLE
[PropertyWrappers] Mark the property as invalid when there is a mismatch with wrappedValue type

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2980,6 +2980,16 @@ bool ConstraintSystem::repairFailures(
                        locator);
     }
 
+    // Let's not complain about argument type mismatch if we have a synthesized
+    // wrappedValue initializer, because we already emit a diagnostic for a
+    // type mismatch between the property's type and the wrappedValue type.
+    if (auto CE = dyn_cast<CallExpr>(loc->getAnchor())) {
+      if (CE->isImplicit() && !CE->getArgumentLabels().empty() &&
+          CE->getArgumentLabels().front() == getASTContext().Id_wrappedValue) {
+        break;
+      }
+    }
+
     conversionsOrFixes.push_back(
         AllowArgumentMismatch::create(*this, lhs, rhs, loc));
     break;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -596,6 +596,8 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   if (cs.solve(nullptr, solutions) || solutions.size() != 1) {
     var->diagnose(diag::property_wrapper_incompatible_property,
                   propertyType, rawType);
+    var->setInvalid();
+    var->setInterfaceType(ErrorType::get(propertyType));
     if (auto nominalWrapper = rawType->getAnyNominal()) {
       nominalWrapper->diagnose(diag::property_wrapper_declared_here,
                                nominalWrapper->getFullName());

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -597,7 +597,6 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
     var->diagnose(diag::property_wrapper_incompatible_property,
                   propertyType, rawType);
     var->setInvalid();
-    var->setInterfaceType(ErrorType::get(propertyType));
     if (auto nominalWrapper = rawType->getAnyNominal()) {
       nominalWrapper->diagnose(diag::property_wrapper_declared_here,
                                nominalWrapper->getFullName());

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2344,6 +2344,8 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
         !propertyType->isEqual(expectedPropertyType)) {
       var->diagnose(diag::property_wrapper_incompatible_property,
                     propertyType, wrapperType);
+      var->setInvalid();
+      var->setInterfaceType(ErrorType::get(propertyType));
       if (auto nominalWrapper = wrapperType->getAnyNominal()) {
         nominalWrapper->diagnose(diag::property_wrapper_declared_here,
                                  nominalWrapper->getFullName());

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2345,7 +2345,6 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
       var->diagnose(diag::property_wrapper_incompatible_property,
                     propertyType, wrapperType);
       var->setInvalid();
-      var->setInterfaceType(ErrorType::get(propertyType));
       if (auto nominalWrapper = wrapperType->getAnyNominal()) {
         nominalWrapper->diagnose(diag::property_wrapper_declared_here,
                                  nominalWrapper->getFullName());

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -244,10 +244,8 @@ struct Initialization {
   @WrapperWithInitialValue
   var y = true
 
-  // FIXME: For some reason this is type-checked twice, second time around solver complains about <<error type>> argument
   @WrapperWithInitialValue<Int>
-  var y2 = true // expected-error{{cannot convert value of type 'Bool' to expected argument type 'Int'}}
-  // expected-error@-1 {{cannot convert value of type '<<error type>>' to expected argument type 'Int'}}
+  var y2 = true // expected-error{{Bool' is not convertible to 'Int}}
 
   mutating func checkTypes(s: String) {
     x2 = s // expected-error{{cannot assign value of type 'String' to type 'Double'}}
@@ -1584,9 +1582,7 @@ extension SR_11288_P4 where Self: AnyObject { // expected-note 2 {{where 'Self' 
 }
 
 struct SR_11288_S4: SR_11288_P4 {
-  // FIXME: We shouldn't diagnose the arg-to-param mismatch (rdar://problem/56345248)
   @SR_11288_Wrapper4 var answer = 42 // expected-error 2 {{referencing type alias 'SR_11288_Wrapper4' on 'SR_11288_P4' requires that 'SR_11288_S4' be a class type}}
-  // expected-error @-1 {{cannot convert value of type '<<error type>>' to expected argument type 'Int'}}
 }
 
 class SR_11288_C0: SR_11288_P4 {

--- a/validation-test/compiler_crashers_2_fixed/sr11600.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11600.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+@propertyWrapper struct A {
+  var wrappedValue: Int
+}
+
+@propertyWrapper struct B {
+  var wrappedValue: Int
+}
+
+struct C {
+  @A @B var foo: Int?
+}

--- a/validation-test/compiler_crashers_2_fixed/sr11684.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11684.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend %s -typecheck -verify
+
+@propertyWrapper 
+struct Wrapper1 { // expected-note {{property wrapper type 'Wrapper1' declared here}}
+  var wrappedValue: Int?
+}
+
+class Test1 {
+  @Wrapper1 var user: Int 
+  // expected-error@-1 {{property type 'Int' does not match that of the 'wrappedValue' property of its wrapper type 'Wrapper1'}}
+  // expected-error@-2 {{cannot convert value of type 'Int' to expected argument type 'Int?'}}
+  // FIXME: The 2nd error shouldn't appear because it comes from the synthesized wrappedValue init
+}
+
+@propertyWrapper 
+struct Wrapper2 { // expected-note {{property wrapper type 'Wrapper2' declared here}}
+  var wrappedValue: Int??
+}
+
+class Test2 {
+  @Wrapper2 var user: Int? 
+  // expected-error@-1 {{property type 'Int?' does not match that of the 'wrappedValue' property of its wrapper type 'Wrapper2'}}
+  // expected-error@-2 {{cannot convert value of type 'Int?' to expected argument type 'Int??'}}
+  // FIXME: The 2nd error shouldn't appear because it comes from the synthesized wrappedValue init
+}

--- a/validation-test/compiler_crashers_2_fixed/sr11684.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11684.swift
@@ -8,8 +8,6 @@ struct Wrapper1 { // expected-note {{property wrapper type 'Wrapper1' declared h
 class Test1 {
   @Wrapper1 var user: Int 
   // expected-error@-1 {{property type 'Int' does not match that of the 'wrappedValue' property of its wrapper type 'Wrapper1'}}
-  // expected-error@-2 {{cannot convert value of type 'Int' to expected argument type 'Int?'}}
-  // FIXME: The 2nd error shouldn't appear because it comes from the synthesized wrappedValue init
 }
 
 @propertyWrapper 
@@ -20,6 +18,4 @@ struct Wrapper2 { // expected-note {{property wrapper type 'Wrapper2' declared h
 class Test2 {
   @Wrapper2 var user: Int? 
   // expected-error@-1 {{property type 'Int?' does not match that of the 'wrappedValue' property of its wrapper type 'Wrapper2'}}
-  // expected-error@-2 {{cannot convert value of type 'Int?' to expected argument type 'Int??'}}
-  // FIXME: The 2nd error shouldn't appear because it comes from the synthesized wrappedValue init
 }


### PR DESCRIPTION
When the property's type does not match the `wrappedValue` property's type, mark the property as invalid. Otherwise, we will end up producing a bunch of incorrect diagnostics later on as well as crashing in certain cases.

For example, this little snippet crashes the compiler:

```swift
@propertyWrapper 
struct Wrapper {
  var wrappedValue: Int
}

class Test {
  @Wrapper var user: Int?
}
```

because we're trying to synthesise a setter that assigns a value of type `Int?` into a storage of type `Int`. We also end up emitting a bunch of incorrect diagnostics, such as suggesting the user to force unwrap the property declaration or provide a default value (which isn't possible/make sense).

In addition, we emit another diagnostic about failing to convert the argument type, for the synthesised `wrappedValue` initializer. This diagnostic isn't valuable because (1) we already inform the user about the type mismatch between the property's type and the `wrappedValue` type and (2) the diagnostic is attached to the synthesised init, but appears on the property and can be confusing to the user. This diagnostic is now disabled for a synthesised `wrappedValue` init.

Resolves SR-11684
Resolves SR-11600
Resolves rdar://problem/56785162
Resolves rdar://problem/56345248
Resolves rdar://problem/56190606
