### PR TITLE
Basic: add a comment about the "complex" code

### DIFF
--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -123,6 +123,11 @@ protected:
   /// Appends a mangled identifier string.
   void appendIdentifier(StringRef ident);
 
+  // NOTE: the addSubsitution functions perform the value computation before
+  // the assignment because there is no sequence point synchronising the
+  // computation of the value before the insertion of the new key, resulting in
+  // the computed value being off-by-one causing an undecoration failure during
+  // round-tripping.
   void addSubstitution(const void *ptr) {
     if (!UseSubstitutions)
       return;


### PR DESCRIPTION
This addresses comments from Joe to document the special behaviour that
we do in the `addSubsitution` functions which cause a subtle failure on
Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
