### PR TITLE
[AutoDiff upstream] set EnableExperimentalDifferentiableProgramming bool

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -355,6 +355,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_experimental_dependency_include_intrafile))
     Opts.ExperimentalDependenciesIncludeIntrafileOnes = true;
 
+  if (Args.hasArg(OPT_enable_experimental_differentiable_programming))
+    Opts.EnableExperimentalDifferentiableProgramming = true;
+
   Opts.DebuggerSupport |= Args.hasArg(OPT_debugger_support);
   if (Opts.DebuggerSupport)
     Opts.EnableDollarIdentifiers = true;


### PR DESCRIPTION
I noticed that the PR introducing `EnableExperimentalDifferentiableProgramming` (https://github.com/apple/swift/pull/27446) does not actually set it. This PR sets it.

cc @dan-zheng @bgogul @rxwei 