### PR TITLE
Build SwiftSyntax and the stress tester using a unified build

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -808,12 +808,17 @@ class BuildScriptInvocation(object):
                     continue
                 product_source = product_class.product_source_name()
                 product_name = product_class.product_name()
+                if product_class.is_swiftpm_unified_build_product():
+                    build_dir = self.workspace.swiftpm_unified_build_dir(
+                        host_target)
+                else:
+                    build_dir = self.workspace.build_dir(
+                        host_target, product_name)
                 product = product_class(
                     args=self.args,
                     toolchain=self.toolchain,
                     source_dir=self.workspace.source_dir(product_source),
-                    build_dir=self.workspace.build_dir(
-                        host_target, product_name))
+                    build_dir=build_dir)
                 if product.should_build(host_target):
                     print("--- Building %s ---" % product_name)
                     product.build(host_target)

--- a/utils/swift_build_support/SwiftPM-Unified-Build.xcworkspace/.gitignore
+++ b/utils/swift_build_support/SwiftPM-Unified-Build.xcworkspace/.gitignore
@@ -1,0 +1,1 @@
+/xcuserdata

--- a/utils/swift_build_support/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
+++ b/utils/swift_build_support/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:../../../swift-syntax">
+   </FileRef>
+   <FileRef
+      location = "group:../../../swift-stress-tester/SourceKitStressTester">
+   </FileRef>
+</Workspace>

--- a/utils/swift_build_support/SwiftPM-Unified-Build.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/utils/swift_build_support/SwiftPM-Unified-Build.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/utils/swift_build_support/swift_build_support/multiroot_data_file.py
+++ b/utils/swift_build_support/swift_build_support/multiroot_data_file.py
@@ -1,0 +1,23 @@
+# swift_build_support/multiroot_data_file.py - Unified build -----*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+import os
+
+
+def path():
+    """product_source_name() -> str
+
+    The path to the Xcode workspace to use for a unified build of multiple
+    SwiftPM projects.
+    """
+    return os.path.join(os.path.dirname(__file__), '..',
+                        'SwiftPM-Unified-Build.xcworkspace')

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -47,6 +47,15 @@ class Product(object):
         """
         return True
 
+    @classmethod
+    def is_swiftpm_unified_build_product(cls):
+        """is_swiftpm_unified_build_product -> bool
+
+        Whether this product should be build in the unified build of SwiftPM
+        products.
+        """
+        return False
+
     def should_build(self, host_target):
         """should_build() -> Bool
 

--- a/utils/swift_build_support/swift_build_support/products/skstresstester.py
+++ b/utils/swift_build_support/swift_build_support/products/skstresstester.py
@@ -1,3 +1,4 @@
+
 # swift_build_support/products/skstresstester.py -----------------*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -14,6 +15,7 @@ import os
 import platform
 
 from . import product
+from .. import multiroot_data_file
 from .. import shell
 
 
@@ -25,6 +27,14 @@ class SKStressTester(product.Product):
         The name of the source code directory of this product.
         """
         return "swift-stress-tester"
+
+    @classmethod
+    def is_build_script_impl_product(cls):
+        return False
+
+    @classmethod
+    def is_swiftpm_unified_build_product(cls):
+        return True
 
     def package_name(self):
         return 'SourceKitStressTester'
@@ -42,16 +52,17 @@ class SKStressTester(product.Product):
             '--toolchain', self.install_toolchain_path(),
             '--config', configuration,
             '--build-dir', self.build_dir,
+            '--multiroot-data-file', multiroot_data_file.path(),
+            # There might have been a Package.resolved created by other builds
+            # or by the package being opened using Xcode. Discard that and
+            # reset the dependencies to be local.
+            '--update'
         ]
         if self.args.verbose_build:
             helper_cmd.append('--verbose')
         helper_cmd.extend(additional_params)
 
         shell.call(helper_cmd)
-
-    @classmethod
-    def is_build_script_impl_product(cls):
-        return False
 
     def should_build(self, host_target):
         return True

--- a/utils/swift_build_support/swift_build_support/products/swiftevolve.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftevolve.py
@@ -10,7 +10,10 @@
 #
 # ----------------------------------------------------------------------------
 
+import os
+
 from . import skstresstester
+from .. import shell
 
 
 class SwiftEvolve(skstresstester.SKStressTester):
@@ -22,8 +25,38 @@ class SwiftEvolve(skstresstester.SKStressTester):
         """
         return "swift-stress-tester"
 
+    @classmethod
+    def is_swiftpm_unified_build_product(cls):
+        return False
+
     def package_name(self):
         return 'SwiftEvolve'
+
+    # Copy of the build-script-helper invocation without the multiroot data 
+    # file. Remove again once SwiftEvolve also builds in the unified build.
+    def run_build_script_helper(self, action, additional_params=[]):
+        script_path = os.path.join(
+            self.source_dir, 'build-script-helper.py')
+
+        configuration = 'release' if self.is_release() else 'debug'
+
+        helper_cmd = [
+            script_path,
+            action,
+            '--package-dir', self.package_name(),
+            '--toolchain', self.install_toolchain_path(),
+            '--config', configuration,
+            '--build-dir', self.build_dir,
+            # There might have been a Package.resolved created by other builds
+            # or by the package being opened using Xcode. Discard that and
+            # reset the dependencies to be local.
+            '--update'
+        ]
+        if self.args.verbose_build:
+            helper_cmd.append('--verbose')
+        helper_cmd.extend(additional_params)
+
+        shell.call(helper_cmd)
 
     # Inherit the entire build configuration from the SourceKit stress tester
 

--- a/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
@@ -13,6 +13,7 @@
 import os
 
 from . import product
+from .. import multiroot_data_file
 from .. import shell
 from .. import targets
 
@@ -26,6 +27,14 @@ class SwiftSyntax(product.Product):
         """
         return "swift-syntax"
 
+    @classmethod
+    def is_build_script_impl_product(cls):
+        return False
+
+    @classmethod
+    def is_swiftpm_unified_build_product(cls):
+        return True
+
     def run_swiftsyntax_build_script(self, target, additional_params=[]):
         llvm_build_dir = os.path.join(self.build_dir, '..', 'llvm-' + target)
         llvm_build_dir = os.path.realpath(llvm_build_dir)
@@ -35,6 +44,7 @@ class SwiftSyntax(product.Product):
         build_cmd = [
             script_path,
             '--build-dir', self.build_dir,
+            '--multiroot-data-file', multiroot_data_file.path(),
             '--toolchain', self.install_toolchain_path(),
             '--filecheck-exec', os.path.join(llvm_build_dir, 'bin',
                                              'FileCheck'),
@@ -52,10 +62,6 @@ class SwiftSyntax(product.Product):
             build_cmd.append('--verbose')
 
         shell.call(build_cmd)
-
-    @classmethod
-    def is_build_script_impl_product(cls):
-        return False
 
     def should_build(self, host_target):
         return True

--- a/utils/swift_build_support/swift_build_support/workspace.py
+++ b/utils/swift_build_support/swift_build_support/workspace.py
@@ -29,6 +29,15 @@ class Workspace(object):
         return os.path.join(self.build_root,
                             '%s-%s' % (product, deployment_target))
 
+    def swiftpm_unified_build_dir(self, deployment_target):
+        """ swiftpm_unified_build_dir() -> str
+
+        Build directory that all SwiftPM unified build products share.
+        """
+        return os.path.join(self.build_root,
+                            'unified-swiftpm-build-%s' %
+                            deployment_target)
+
 
 def compute_build_subdir(args):
     # Create a name for the build directory.


### PR DESCRIPTION
Avoid recompiling SwiftSyntax for every project that depends on it by building all of these projects in a unified build. 

This PR add SwiftSyntax and the stress tester to the new unified build. I will add SwiftEvolve later on.