### PR TITLE
Add a hidden option to disable debugger shadow copies.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -209,6 +209,10 @@ public:
   /// Disable round-trip verification of mangled debug types.
   unsigned DisableRoundTripDebugTypes : 1;
 
+  /// Whether to disable shadow copies for local variables on the stack. This is
+  /// only used for testing.
+  unsigned DisableDebuggerShadowCopies : 1;
+
   /// Path to the profdata file to be used for PGO, or the empty string.
   std::string UseProfile = "";
 
@@ -237,8 +241,7 @@ public:
         Sanitizers(OptionSet<SanitizerKind>()),
         DebugInfoLevel(IRGenDebugInfoLevel::None),
         DebugInfoFormat(IRGenDebugInfoFormat::None),
-        DisableClangModuleSkeletonCUs(false),
-        UseJIT(false),
+        DisableClangModuleSkeletonCUs(false), UseJIT(false),
         IntegratedREPL(false), DisableLLVMOptzns(false),
         DisableSwiftSpecificLLVMOptzns(false), DisableLLVMSLPVectorizer(false),
         DisableFPElim(true), Playground(false), EmitStackPromotionChecks(false),
@@ -250,8 +253,8 @@ public:
         LazyInitializeProtocolConformances(false), DisableLegacyTypeInfo(false),
         UseIncrementalLLVMCodeGen(true), UseSwiftCall(false),
         GenerateProfile(false), EnableDynamicReplacementChaining(false),
-        DisableRoundTripDebugTypes(false), CmdArgs(),
-        SanitizeCoverage(llvm::SanitizerCoverageOptions()),
+        DisableRoundTripDebugTypes(false), DisableDebuggerShadowCopies(false),
+        CmdArgs(), SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All) {}
 
   /// Appends to \p os an arbitrary string representing all options which

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -453,6 +453,11 @@ def debugger_testing_transform : Flag<["-"], "debugger-testing-transform">,
   HelpText<"Instrument the code with calls to an intrinsic that record the expected values of "
            "local variables so they can be compared against the results from the debugger.">;
 
+def disable_debugger_shadow_copies : Flag<["-"], "disable-debugger-shadow-copies">,
+  HelpText<"Disable debugger shadow copies of local variables."
+           "This option is only useful for testing the compiler.">,
+  Flags<[FrontendOption, HelpHidden]>;
+
 def playground : Flag<["-"], "playground">,
   HelpText<"Apply the playground semantics and transformation">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1078,6 +1078,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_no_clang_module_breadcrumbs))
     Opts.DisableClangModuleSkeletonCUs = true;
 
+  if (Args.hasArg(OPT_disable_debugger_shadow_copies))
+    Opts.DisableDebuggerShadowCopies = true;
+
   if (Args.hasArg(OPT_use_jit))
     Opts.UseJIT = true;
   

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -787,7 +787,8 @@ public:
                                       Alignment Align = Alignment(0)) {
     // Never emit shadow copies when optimizing, or if already on the stack.
     // No debug info is emitted for refcounts either.
-    if (IGM.IRGen.Opts.shouldOptimize() || IsAnonymous ||
+    if (IGM.IRGen.Opts.DisableDebuggerShadowCopies ||
+        IGM.IRGen.Opts.shouldOptimize() || IsAnonymous ||
         isa<llvm::AllocaInst>(Storage) || isa<llvm::UndefValue>(Storage) ||
         Storage->getType() == IGM.RefCountedPtrTy)
       return Storage;
@@ -830,7 +831,8 @@ public:
     Explosion e = getLoweredExplosion(SILVal);
 
     // Only do this at -O0.
-    if (IGM.IRGen.Opts.shouldOptimize() || IsAnonymous) {
+    if (IGM.IRGen.Opts.DisableDebuggerShadowCopies ||
+        IGM.IRGen.Opts.shouldOptimize() || IsAnonymous) {
       auto vals = e.claimAll();
       copy.append(vals.begin(), vals.end());
       return;
@@ -4009,7 +4011,8 @@ void IRGenSILFunction::emitDebugInfoForAllocStack(AllocStackInst *i,
          isa<llvm::IntrinsicInst>(addr));
 
   auto Indirection = DirectValue;
-  if (!IGM.IRGen.Opts.shouldOptimize())
+  if (!IGM.IRGen.Opts.DisableDebuggerShadowCopies &&
+      !IGM.IRGen.Opts.shouldOptimize())
     if (auto *Alloca = dyn_cast<llvm::AllocaInst>(addr))
       if (!Alloca->isStaticAlloca()) {
         // Store the address of the dynamic alloca on the stack.

--- a/test/DebugInfo/shadow_copies.swift
+++ b/test/DebugInfo/shadow_copies.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend %s -Onone -emit-ir -g -o - | %FileCheck %s
-
+// RUN: %target-swift-frontend %s -Onone -emit-ir -g -o - \
+// RUN:   -disable-debugger-shadow-copies | %FileCheck %s --check-prefix=NOCOPY
 class ClassA
 {
     var x : Int64
@@ -16,11 +17,17 @@ class ClassB : ClassA
 {
     override init (_ input : Int64)
     {
-    // CHECK: @"$s{{.*}}6ClassBCyACs5Int64Vcfc"
-    // CHECK:  alloca {{.*}}ClassBC*
-    // CHECK:  alloca i64
-    // CHECK-NOT: alloca
-    // CHECK: ret {{.*}}ClassBC
+    // CHECK:       @"$s{{.*}}6ClassBCyACs5Int64Vcfc"
+    // NOPCOPY:     @"$s{{.*}}6ClassBCyACs5Int64Vcfc"
+    // CHECK:       alloca {{.*}}ClassBC*
+    // NOPCOPY:     alloca {{.*}}ClassBC*
+
+    // CHECK:       alloca i64
+
+    // CHECK-NOT:   alloca
+    // NOPCOPY-NOT: alloca
+    // CHECK:       ret {{.*}}ClassBC
+    // NOCOPY:      ret {{.*}}ClassBC
         super.init (input)
     }
 }


### PR DESCRIPTION
This option is useful to debug the compiler itself, to simulate debug info as it
would be generated when producing optimized code, but without the unpredictable
output of an optimizing debugger.
