### PR TITLE
[Frontend] Avoid crashing in trace emission due to "duplicate" swiftinterfaces

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -359,15 +359,15 @@ static void computeSwiftModuleTraceInfo(
     // FIXME: The behavior of fs::exists for relative paths is undocumented.
     // Use something else instead?
     if (fs::exists(moduleAdjacentInterfacePath)) {
-      err << "Found swiftinterface at\n" << moduleAdjacentInterfacePath
-          << "\nbut it was not recorded\n";
-      errorUnexpectedPath(err);
+      // This should be an error but it is not because of funkiness around
+      // compatible modules such as us having both armv7s.swiftinterface
+      // and armv7.swiftinterface in the dependency tracker.
+      continue;
     }
     buffer.clear();
 
-    err << "Don't know how to handle the dependency at:\n" << depPath
-        << "\nfor module trace emission.\n";
-    errorUnexpectedPath(err);
+    // We might land here when we have a arm.swiftmodule in the cache path
+    // which added a dependency on a arm.swiftinterface (which was not loaded).
   }
 
   // Almost a re-implementation of reversePathSortedFilenames :(.

--- a/test/Driver/loaded_module_trace_nocrash.swift
+++ b/test/Driver/loaded_module_trace_nocrash.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/Mods/Foo.swiftmodule
+// RUN: mkdir -p %t/Mods/Bar.swiftmodule
+
+// RUN: %target-swift-frontend %s -DFoo -emit-module -o %t/Mods/Foo.swiftmodule/armv7s-apple-ios.swiftmodule -emit-module-interface-path %t/Mods/Foo.swiftmodule/armv7s-apple-ios.swiftinterface -target armv7s-apple-ios10 -module-name Foo -enable-library-evolution -parse-stdlib
+// RUN: %target-swift-frontend %s -DFoo -emit-module -o %t/Mods/Foo.swiftmodule/arm.swiftmodule -emit-module-interface-path %t/Mods/Foo.swiftmodule/arm.swiftinterface -target arm-apple-ios10 -module-name Foo -enable-library-evolution -parse-stdlib
+// RUN: %target-swift-frontend %s -DBar -typecheck -emit-module-interface-path %t/Mods/Bar.swiftmodule/arm.swiftinterface -I %t/Mods -target arm-apple-ios10 -module-name Bar -enable-library-evolution -parse-stdlib
+// RUN: %target-swift-frontend %s -DFooBar -typecheck -emit-loaded-module-trace-path - -I %t/Mods -target armv7s-apple-ios10 -parse-stdlib
+
+#if Foo
+#endif
+
+#if Bar
+import Foo
+#endif
+
+#if FooBar
+import Foo
+import Bar
+#endif

--- a/test/Driver/loaded_module_trace_nocrash.swift
+++ b/test/Driver/loaded_module_trace_nocrash.swift
@@ -1,3 +1,5 @@
+// UNSUPPORTED: -windows-msvc
+
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/Mods/Foo.swiftmodule
 // RUN: mkdir -p %t/Mods/Bar.swiftmodule


### PR DESCRIPTION
If the build system ends up using the standard library with an `arm.swiftinterface` and an `armv7s.swiftinterface`, we will only load the latter but that should be fine (due to ABI compatibility) and we shouldn't crash in trace emission on seeing a swiftinterface in the depTracker that was not loaded.