### PR TITLE
Fix crash when optimizing protocol composition

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -904,7 +904,7 @@ SILCombiner::buildConcreteOpenedExistentialInfoFromSoleConformingType(
         (archetypeTy->getConformsTo().size() == 1)) {
       PD = archetypeTy->getConformsTo()[0];
     } else if (ArgType.isExistentialType() && !ArgType.isAnyObject() &&
-               !SwiftArgType->isAny()) {
+               !SwiftArgType->isAny() && SwiftArgType->getAnyNominal()) {
       PD = dyn_cast<ProtocolDecl>(SwiftArgType->getAnyNominal());
     }
   }

--- a/validation-test/compiler_crashers_2_fixed/sr11624.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11624.swift
@@ -1,0 +1,20 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not %target-swift-frontend %s -O -whole-module-optimization
+
+class ClassA<T> { }
+protocol ProtocolA { }
+
+class MainClass<H> {
+    init(x: ClassA<H> & ProtocolA) { }
+}
+
+final class ClassB: ClassA<String> { }
+extension ClassB: ProtocolA { }
+
+_ = MainClass(x: ClassB())


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch fixes a compiler crash when trying to optimize a protocol composition between a class and protocol. This is a super simple fix where I simply add a condition to check if the nominal arg type is null. Here's an example program:
```swift
class ClassA<T> { }
protocol ProtocolA { }

class MainClass<H> {
    init(x: ClassA<H> & ProtocolA) { }
}

final class ClassB: ClassA<String> { }
extension ClassB: ProtocolA { }

_ = MainClass(x: ClassB())
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #54035

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Once this has been reviewed, can someone with commit access trigger swift-ci, please?