### PR TITLE
SR-11679: Incorrect FixIt suggestion for CFTypes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2884,6 +2884,9 @@ ERROR(delegating_designated_init,none,
       "designated initializer for %0 cannot delegate (with 'self.init'); "
       "did you mean this to be a convenience initializer?",
       (Type))
+ERROR(delegating_designated_init_in_extension,none,
+      "designated initializer for %0 cannot delegate (with 'self.init')",
+      (Type))
 NOTE(delegation_here,none, "delegation occurs here", ())
 ERROR(chain_convenience_init,none,
       "must call a designated initializer of the superclass %0",
@@ -2911,6 +2914,9 @@ ERROR(designated_init_in_extension,none,
       "designated initializer cannot be declared in an extension of %0; "
       "did you mean this to be a convenience initializer?",
       (DeclName))
+ERROR(cfclass_designated_init_in_extension,none,
+      "designated initializer cannot be declared in an extension of %0",
+      (DeclName))
 ERROR(enumstruct_convenience_init,none,
       "delegating initializers in %0 are not marked with 'convenience'",
       (StringRef))
@@ -2920,7 +2926,6 @@ ERROR(nonclass_convenience_init,none,
 ERROR(cfclass_convenience_init,none,
       "convenience initializers are not supported in extensions of CF types",
       ())
-
 ERROR(dynamic_construct_class,none,
       "constructing an object of class type %0 with a metatype value must use "
       "a 'required' initializer", (Type))

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1990,9 +1990,15 @@ static void checkClassConstructorBody(ClassDecl *classDecl,
 
   // A class designated initializer must never be delegating.
   if (ctor->isDesignatedInit() && isDelegating) {
-    ctor->diagnose(diag::delegating_designated_init,
-                   ctor->getDeclContext()->getDeclaredInterfaceType())
-      .fixItInsert(ctor->getLoc(), "convenience ");
+    if (classDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
+      ctor->diagnose(diag::delegating_designated_init_in_extension,
+                     ctor->getDeclContext()->getDeclaredInterfaceType());
+    } else {
+      ctor->diagnose(diag::delegating_designated_init,
+                     ctor->getDeclContext()->getDeclaredInterfaceType())
+          .fixItInsert(ctor->getLoc(), "convenience ");
+    }
+
     ctx.Diags.diagnose(initExpr->getLoc(), diag::delegation_here);
   }
 

--- a/test/decl/init/cf-types.swift
+++ b/test/decl/init/cf-types.swift
@@ -14,10 +14,27 @@ extension CGMutablePath {
   public convenience init(toss: Bool) throws { // expected-error{{convenience initializers are not supported in extensions of CF types}}
     self.init()
   }
+
+  public init(simple: Bool) { // expected-error{{designated initializer cannot be declared in an extension of 'CGMutablePath'}}{{none}}
+                              // expected-error @-1 {{designated initializer for 'CGMutablePath' cannot delegate (with 'self.init')}}{{none}}
+    self.init() // expected-note {{delegation occurs here}}
+  }
+
+  public init?(value: Bool) { // expected-error{{designated initializer cannot be declared in an extension of 'CGMutablePath'}}{{none}}
+                              // expected-error @-1 {{designated initializer for 'CGMutablePath' cannot delegate (with 'self.init')}}{{none}}
+    self.init() // expected-note {{delegation occurs here}}
+  }
+
+  public init?(string: String) { // expected-error{{designated initializer cannot be declared in an extension of 'CGMutablePath'}}{{none}}
+    let _ = string
+  }
 }
 
 public func useInit() {
   let _ = CGMutablePath(p: true)
   let _ = CGMutablePath(maybe: true)
   let _ = try! CGMutablePath(toss: true)
+  let _ = CGMutablePath(simple: true)
+  let _ = CGMutablePath(value: true)
+  let _ = CGMutablePath(string: "value")
 }


### PR DESCRIPTION
## Summary

Convenience inits are only allowed on classes and in extensions thereof. And in CFTypes we are not allowed to put convenince inits since swift does not support this feature yet.

This PR solve the bad fix suggestion when a user declare a init method in an extension of CF Type. The simple solution was removing the fix suggestion when the ClassDecl type is CF.

Another bug (similar to this one) that i found and became visible when i was doing the test cases for [SR-11679](https://bugs.swift.org/browse/SR-11679). Was the fact that if you declare a convenience init that delegates the init function in self, a fix suggestion will appear. The same suggestion that is causing troubles in [SR-11679](https://bugs.swift.org/browse/SR-11679). The fix for this was removing the fix suggestion when the class kind type was CFType since if we leave it as is, it will be the same problem as [SR-11679](https://bugs.swift.org/browse/SR-11679).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
