### PR TITLE
[stdlib] [gardening] Refactor bridging from StringStorage.swift

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -152,6 +152,7 @@ set(SWIFTLIB_ESSENTIAL
   StringNormalization.swift
   StringRangeReplaceableCollection.swift
   StringStorage.swift
+  StringStorageBridge.swift
   StringSwitch.swift
   StringTesting.swift
   StringUnicodeScalarView.swift

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -23,27 +23,27 @@ internal typealias _CocoaString = AnyObject
 // Foundation.
 
 @objc private protocol _StringSelectorHolder : _NSCopying {
-    
+
   @objc var length: Int { get }
-  
+
   @objc var hash: UInt { get }
-  
+
   @objc(characterAtIndex:)
   func character(at offset: Int) -> UInt16
-  
+
   @objc(getCharacters:range:)
   func getCharacters(
    _ buffer: UnsafeMutablePointer<UInt16>, range aRange: _SwiftNSRange
   )
- 
+
   @objc(_fastCStringContents:)
   func _fastCStringContents(
     _ requiresNulTermination: Int8
   ) -> UnsafePointer<CChar>?
-  
+
   @objc(_fastCharacterContents)
   func _fastCharacterContents() -> UnsafePointer<UInt16>?
-  
+
   @objc(getBytes:maxLength:usedLength:encoding:options:range:remainingRange:)
   func getBytes(_ buffer: UnsafeMutableRawPointer?,
    maxLength maxBufferCount: Int,
@@ -52,7 +52,7 @@ internal typealias _CocoaString = AnyObject
      options: UInt,
        range: _SwiftNSRange,
        remaining leftover: UnsafeMutablePointer<_SwiftNSRange>?) -> Int8
-  
+
   @objc(compare:options:range:locale:)
   func compare(_ string: _CocoaString,
                options: UInt,
@@ -60,7 +60,7 @@ internal typealias _CocoaString = AnyObject
                locale: AnyObject?) -> Int
 
   @objc(newTaggedNSStringWithASCIIBytes_:length_:)
-  func createTaggedString(bytes: UnsafePointer<UInt8>, 
+  func createTaggedString(bytes: UnsafePointer<UInt8>,
                           count: Int) -> AnyObject?
 }
 
@@ -68,9 +68,9 @@ internal typealias _CocoaString = AnyObject
  Passing a _CocoaString through _objc() lets you call ObjC methods that the
  compiler doesn't know about, via the protocol above. In order to get good
  performance, you need a double indirection like this:
- 
+
   func a -> _objc -> func a'
- 
+
  because any refcounting @_effects on 'a' will be lost when _objc breaks ARC's
  knowledge that the _CocoaString and _StringSelectorHolder are the same object.
  */
@@ -442,9 +442,9 @@ extension String {
   @_effects(releasenone)
   public // SPI(Foundation)
   func _bridgeToObjectiveCImpl() -> AnyObject {
-    
+
     _connectOrphanedFoundationSubclassesIfNeeded()
-    
+
     // Smol ASCII a) may bridge to tagged pointers, b) can't contain a BOM
     if _guts.isSmallASCII {
       let maybeTagged = _guts.asSmall.withUTF8 { bufPtr in
@@ -456,7 +456,7 @@ extension String {
       }
       if let tagged = maybeTagged { return tagged }
     }
-    
+
     if _guts.isSmall {
         // We can't form a tagged pointer String, so grow to a non-small String,
         // and bridge that instead. Also avoids CF deleting any BOM that may be

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftShims
-
 // Having @objc stuff in an extension creates an ObjC category, which we don't
 // want.
 #if _runtime(_ObjC)
@@ -24,14 +22,6 @@ internal protocol _AbstractStringStorage: _NSCopying {
   var UTF16Length: Int { get }
 }
 
-internal let _cocoaASCIIEncoding:UInt = 1 /* NSASCIIStringEncoding */
-internal let _cocoaUTF8Encoding:UInt = 4 /* NSUTF8StringEncoding */
-
-@_effects(readonly)
-private func _isNSString(_ str:AnyObject) -> UInt8 {
-  return _swift_stdlib_isNSString(str)
-}
-
 #else
 
 internal protocol _AbstractStringStorage {
@@ -42,134 +32,6 @@ internal protocol _AbstractStringStorage {
 }
 
 #endif
-
-extension _AbstractStringStorage {
-
-// ObjC interfaces.
-#if _runtime(_ObjC)
-
-  @inline(__always)
-  @_effects(releasenone)
-  internal func _getCharacters(
-    _ buffer: UnsafeMutablePointer<UInt16>, _ aRange: _SwiftNSRange
-  ) {
-    _precondition(aRange.location >= 0 && aRange.length >= 0,
-                  "Range out of bounds")
-    _precondition(aRange.location + aRange.length <= Int(count),
-                  "Range out of bounds")
-
-    let range = Range(
-      uncheckedBounds: (aRange.location, aRange.location+aRange.length))
-    let str = asString
-    str._copyUTF16CodeUnits(
-      into: UnsafeMutableBufferPointer(start: buffer, count: range.count),
-      range: range)
-  }
-
-  @inline(__always)
-  @_effects(releasenone)
-  internal func _getCString(
-    _ outputPtr: UnsafeMutablePointer<UInt8>, _ maxLength: Int, _ encoding: UInt
-  ) -> Int8 {
-    switch (encoding, isASCII) {
-    case (_cocoaASCIIEncoding, true),
-         (_cocoaUTF8Encoding, _):
-      guard maxLength >= count + 1 else { return 0 }
-      outputPtr.initialize(from: start, count: count)
-      outputPtr[count] = 0
-      return 1
-    default:
-      return  _cocoaGetCStringTrampoline(self, outputPtr, maxLength, encoding)
-    }
-  }
-
-  @inline(__always)
-  @_effects(readonly)
-  internal func _cString(encoding: UInt) -> UnsafePointer<UInt8>? {
-    switch (encoding, isASCII) {
-    case (_cocoaASCIIEncoding, true),
-         (_cocoaUTF8Encoding, _):
-      return start
-    default:
-      return _cocoaCStringUsingEncodingTrampoline(self, encoding)
-    }
-  }
-
-  @_effects(readonly)
-  internal func _nativeIsEqual<T:_AbstractStringStorage>(
-    _ nativeOther: T
-  ) -> Int8 {
-    if count != nativeOther.count {
-      return 0
-    }
-    return (start == nativeOther.start ||
-      (memcmp(start, nativeOther.start, count) == 0)) ? 1 : 0
-  }
-
-  @inline(__always)
-  @_effects(readonly)
-  internal func _isEqual(_ other: AnyObject?) -> Int8 {
-    guard let other = other else {
-      return 0
-    }
-
-    if self === other {
-      return 1
-    }
-
-    // Handle the case where both strings were bridged from Swift.
-    // We can't use String.== because it doesn't match NSString semantics.
-    let knownOther = _KnownCocoaString(other)
-    switch knownOther {
-    case .storage:
-      return _nativeIsEqual(
-        _unsafeUncheckedDowncast(other, to: __StringStorage.self))
-    case .shared:
-      return _nativeIsEqual(
-        _unsafeUncheckedDowncast(other, to: __SharedStringStorage.self))
-#if !(arch(i386) || arch(arm))
-    case .tagged:
-      fallthrough
-#endif
-    case .cocoa:
-      // We're allowed to crash, but for compatibility reasons NSCFString allows
-      // non-strings here.
-      if _isNSString(other) != 1 {
-        return 0
-      }
-      // At this point we've proven that it is an NSString of some sort, but not
-      // one of ours.
-
-      defer { _fixLifetime(other) }
-
-      let otherUTF16Length = _stdlib_binary_CFStringGetLength(other)
-
-      // CFString will only give us ASCII bytes here, but that's fine.
-      // We already handled non-ASCII UTF8 strings earlier since they're Swift.
-      if let otherStart = _cocoaASCIIPointer(other) {
-        //We know that otherUTF16Length is also its byte count at this point
-        if count != otherUTF16Length {
-          return 0
-        }
-        return (start == otherStart ||
-          (memcmp(start, otherStart, count) == 0)) ? 1 : 0
-      }
-
-      if UTF16Length != otherUTF16Length {
-        return 0
-      }
-
-      /*
-       The abstract implementation of -isEqualToString: falls back to -compare:
-       immediately, so when we run out of fast options to try, do the same.
-       We can likely be more clever here if need be
-      */
-      return _cocoaStringCompare(self, other) == 0 ? 1 : 0
-    }
-  }
-
-#endif //_runtime(_ObjC)
-}
 
 private typealias CountAndFlags = _StringObject.CountAndFlags
 
@@ -221,108 +83,10 @@ final internal class __StringStorage
   final internal var isASCII: Bool { return _countAndFlags.isASCII }
 
   final internal var asString: String {
-    @_effects(readonly) @inline(__always) get {
-      return String(_StringGuts(self))
-    }
+    @_effects(readonly) @inline(__always)
+    get { return String(_StringGuts(self)) }
   }
 
-#if _runtime(_ObjC)
-
-  @objc(length)
-  final internal var UTF16Length: Int {
-    @_effects(readonly) @inline(__always) get {
-      return asString.utf16.count // UTF16View special-cases ASCII for us.
-    }
-  }
-
-  @objc
-  final internal var hash: UInt {
-    @_effects(readonly) get {
-      if isASCII {
-        return _cocoaHashASCIIBytes(start, length: count)
-      }
-      return _cocoaHashString(self)
-    }
-  }
-
-  @objc(characterAtIndex:)
-  @_effects(readonly)
-  final internal func character(at offset: Int) -> UInt16 {
-    let str = asString
-    return str.utf16[str._toUTF16Index(offset)]
-  }
-
-  @objc(getCharacters:range:)
-  @_effects(releasenone)
-  final internal func getCharacters(
-   _ buffer: UnsafeMutablePointer<UInt16>, range aRange: _SwiftNSRange
-  ) {
-    _getCharacters(buffer, aRange)
-  }
-
-  @objc(_fastCStringContents:)
-  @_effects(readonly)
-  final internal func _fastCStringContents(
-    _ requiresNulTermination: Int8
-  ) -> UnsafePointer<CChar>? {
-    if isASCII {
-      return start._asCChar
-    }
-    return nil
-  }
-
-  @objc(UTF8String)
-  @_effects(readonly)
-  final internal func _utf8String() -> UnsafePointer<UInt8>? {
-    return start
-  }
-
-  @objc(cStringUsingEncoding:)
-  @_effects(readonly)
-  final internal func cString(encoding: UInt) -> UnsafePointer<UInt8>? {
-    return _cString(encoding: encoding)
-  }
-
-  @objc(getCString:maxLength:encoding:)
-  @_effects(releasenone)
-  final internal func getCString(
-    _ outputPtr: UnsafeMutablePointer<UInt8>, maxLength: Int, encoding: UInt
-  ) -> Int8 {
-    return _getCString(outputPtr, maxLength, encoding)
-  }
-
-  @objc
-  final internal var fastestEncoding: UInt {
-    @_effects(readonly) get {
-      if isASCII {
-        return _cocoaASCIIEncoding
-      }
-      return _cocoaUTF8Encoding
-    }
-  }
-
-  @objc(isEqualToString:)
-  @_effects(readonly)
-  final internal func isEqualToString(to other: AnyObject?) -> Int8 {
-    return _isEqual(other)
-  }
-  
-  @objc(isEqual:)
-  @_effects(readonly)
-  final internal func isEqual(to other: AnyObject?) -> Int8 {
-    return _isEqual(other)
-  }
-
-  @objc(copyWithZone:)
-  final internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
-    // While __StringStorage instances aren't immutable in general,
-    // mutations may only occur when instances are uniquely referenced.
-    // Therefore, it is safe to return self here; any outstanding Objective-C
-    // reference will make the instance non-unique.
-    return self
-  }
-
-#endif // _runtime(_ObjC)
 
   private init(_doNotCallMe: ()) {
     _internalInvariantFailure("Use the create method")
@@ -404,7 +168,7 @@ extension __StringStorage {
     return __StringStorage.create(
       realCodeUnitCapacity: realCapacity, countAndFlags: countAndFlags)
   }
-  
+
   // The caller is expected to check UTF8 validity and ASCII-ness and update
   // the resulting StringStorage accordingly
   internal static func create(
@@ -420,7 +184,7 @@ extension __StringStorage {
     let buffer = UnsafeMutableBufferPointer(start: storage.mutableStart,
                                             count: capacity)
     let count = try initializer(buffer)
-    
+
     let countAndFlags = CountAndFlags(mortalCount: count, isASCII: false)
     #if arch(i386) || arch(arm)
     storage._count = countAndFlags.count
@@ -428,7 +192,7 @@ extension __StringStorage {
     #else
     storage._countAndFlags = countAndFlags
     #endif
-    
+
     storage.terminator.pointee = 0 // nul-terminated
     return storage
   }
@@ -739,105 +503,6 @@ final internal class __SharedStringStorage
       return String(_StringGuts(self))
     }
   }
-
-#if _runtime(_ObjC)
-
-  @objc(length)
-  final internal var UTF16Length: Int {
-    @_effects(readonly) get {
-      return asString.utf16.count // UTF16View special-cases ASCII for us.
-    }
-  }
-
-  @objc
-  final internal var hash: UInt {
-    @_effects(readonly) get {
-      if isASCII {
-        return _cocoaHashASCIIBytes(start, length: count)
-      }
-      return _cocoaHashString(self)
-    }
-  }
-
-  @objc(characterAtIndex:)
-  @_effects(readonly)
-  final internal func character(at offset: Int) -> UInt16 {
-    let str = asString
-    return str.utf16[str._toUTF16Index(offset)]
-  }
-
-  @objc(getCharacters:range:)
-  @_effects(releasenone)
-  final internal func getCharacters(
-    _ buffer: UnsafeMutablePointer<UInt16>, range aRange: _SwiftNSRange
-  ) {
-    _getCharacters(buffer, aRange)
-  }
-
-  @objc
-  final internal var fastestEncoding: UInt {
-    @_effects(readonly) get {
-      if isASCII {
-        return _cocoaASCIIEncoding
-      }
-      return _cocoaUTF8Encoding
-    }
-  }
-
-  @objc(_fastCStringContents:)
-  @_effects(readonly)
-  final internal func _fastCStringContents(
-    _ requiresNulTermination: Int8
-  ) -> UnsafePointer<CChar>? {
-    if isASCII {
-      return start._asCChar
-    }
-    return nil
-  }
-
-  @objc(UTF8String)
-  @_effects(readonly)
-  final internal func _utf8String() -> UnsafePointer<UInt8>? {
-    return start
-  }
-
-  @objc(cStringUsingEncoding:)
-  @_effects(readonly)
-  final internal func cString(encoding: UInt) -> UnsafePointer<UInt8>? {
-    return _cString(encoding: encoding)
-  }
-
-  @objc(getCString:maxLength:encoding:)
-  @_effects(releasenone)
-  final internal func getCString(
-    _ outputPtr: UnsafeMutablePointer<UInt8>, maxLength: Int, encoding: UInt
-  ) -> Int8 {
-    return _getCString(outputPtr, maxLength, encoding)
-  }
-
-  @objc(isEqualToString:)
-  @_effects(readonly)
-  final internal func isEqualToString(to other: AnyObject?) -> Int8 {
-    return _isEqual(other)
-  }
-  
-  @objc(isEqual:)
-  @_effects(readonly)
-  final internal func isEqual(to other: AnyObject?) -> Int8 {
-    return _isEqual(other)
-  }
-
-  @objc(copyWithZone:)
-  final internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
-    // While __StringStorage instances aren't immutable in general,
-    // mutations may only occur when instances are uniquely referenced.
-    // Therefore, it is safe to return self here; any outstanding Objective-C
-    // reference will make the instance non-unique.
-    return self
-  }
-
-#endif // _runtime(_ObjC)
-
 }
 
 extension __SharedStringStorage {

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -1,0 +1,340 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftShims
+
+#if _runtime(_ObjC)
+
+@_effects(readonly)
+private func _isNSString(_ str:AnyObject) -> UInt8 {
+  return _swift_stdlib_isNSString(str)
+}
+
+internal let _cocoaASCIIEncoding:UInt = 1 /* NSASCIIStringEncoding */
+internal let _cocoaUTF8Encoding:UInt = 4 /* NSUTF8StringEncoding */
+
+// ObjC interfaces.
+extension _AbstractStringStorage {
+  @inline(__always)
+  @_effects(releasenone)
+  internal func _getCharacters(
+    _ buffer: UnsafeMutablePointer<UInt16>, _ aRange: _SwiftNSRange
+  ) {
+    _precondition(aRange.location >= 0 && aRange.length >= 0,
+                  "Range out of bounds")
+    _precondition(aRange.location + aRange.length <= Int(count),
+                  "Range out of bounds")
+
+    let range = Range(
+      uncheckedBounds: (aRange.location, aRange.location+aRange.length))
+    let str = asString
+    str._copyUTF16CodeUnits(
+      into: UnsafeMutableBufferPointer(start: buffer, count: range.count),
+      range: range)
+  }
+
+  @inline(__always)
+  @_effects(releasenone)
+  internal func _getCString(
+    _ outputPtr: UnsafeMutablePointer<UInt8>, _ maxLength: Int, _ encoding: UInt
+  ) -> Int8 {
+    switch (encoding, isASCII) {
+    case (_cocoaASCIIEncoding, true),
+         (_cocoaUTF8Encoding, _):
+      guard maxLength >= count + 1 else { return 0 }
+      outputPtr.initialize(from: start, count: count)
+      outputPtr[count] = 0
+      return 1
+    default:
+      return  _cocoaGetCStringTrampoline(self, outputPtr, maxLength, encoding)
+    }
+  }
+
+  @inline(__always)
+  @_effects(readonly)
+  internal func _cString(encoding: UInt) -> UnsafePointer<UInt8>? {
+    switch (encoding, isASCII) {
+    case (_cocoaASCIIEncoding, true),
+         (_cocoaUTF8Encoding, _):
+      return start
+    default:
+      return _cocoaCStringUsingEncodingTrampoline(self, encoding)
+    }
+  }
+
+  @_effects(readonly)
+  internal func _nativeIsEqual<T:_AbstractStringStorage>(
+    _ nativeOther: T
+  ) -> Int8 {
+    if count != nativeOther.count {
+      return 0
+    }
+    return (start == nativeOther.start ||
+      (memcmp(start, nativeOther.start, count) == 0)) ? 1 : 0
+  }
+
+  @inline(__always)
+  @_effects(readonly)
+  internal func _isEqual(_ other: AnyObject?) -> Int8 {
+    guard let other = other else {
+      return 0
+    }
+
+    if self === other {
+      return 1
+    }
+
+    // Handle the case where both strings were bridged from Swift.
+    // We can't use String.== because it doesn't match NSString semantics.
+    let knownOther = _KnownCocoaString(other)
+    switch knownOther {
+    case .storage:
+      return _nativeIsEqual(
+        _unsafeUncheckedDowncast(other, to: __StringStorage.self))
+    case .shared:
+      return _nativeIsEqual(
+        _unsafeUncheckedDowncast(other, to: __SharedStringStorage.self))
+#if !(arch(i386) || arch(arm))
+    case .tagged:
+      fallthrough
+#endif
+    case .cocoa:
+      // We're allowed to crash, but for compatibility reasons NSCFString allows
+      // non-strings here.
+      if _isNSString(other) != 1 {
+        return 0
+      }
+      // At this point we've proven that it is an NSString of some sort, but not
+      // one of ours.
+
+      defer { _fixLifetime(other) }
+
+      let otherUTF16Length = _stdlib_binary_CFStringGetLength(other)
+
+      // CFString will only give us ASCII bytes here, but that's fine.
+      // We already handled non-ASCII UTF8 strings earlier since they're Swift.
+      if let otherStart = _cocoaASCIIPointer(other) {
+        //We know that otherUTF16Length is also its byte count at this point
+        if count != otherUTF16Length {
+          return 0
+        }
+        return (start == otherStart ||
+          (memcmp(start, otherStart, count) == 0)) ? 1 : 0
+      }
+
+      if UTF16Length != otherUTF16Length {
+        return 0
+      }
+
+      /*
+       The abstract implementation of -isEqualToString: falls back to -compare:
+       immediately, so when we run out of fast options to try, do the same.
+       We can likely be more clever here if need be
+      */
+      return _cocoaStringCompare(self, other) == 0 ? 1 : 0
+    }
+  }
+}
+
+extension __StringStorage {
+  @objc(length)
+  final internal var UTF16Length: Int {
+    @_effects(readonly) @inline(__always) get {
+      return asString.utf16.count // UTF16View special-cases ASCII for us.
+    }
+  }
+
+  @objc
+  final internal var hash: UInt {
+    @_effects(readonly) get {
+      if isASCII {
+        return _cocoaHashASCIIBytes(start, length: count)
+      }
+      return _cocoaHashString(self)
+    }
+  }
+
+  @objc(characterAtIndex:)
+  @_effects(readonly)
+  final internal func character(at offset: Int) -> UInt16 {
+    let str = asString
+    return str.utf16[str._toUTF16Index(offset)]
+  }
+
+  @objc(getCharacters:range:)
+  @_effects(releasenone)
+  final internal func getCharacters(
+   _ buffer: UnsafeMutablePointer<UInt16>, range aRange: _SwiftNSRange
+  ) {
+    _getCharacters(buffer, aRange)
+  }
+
+  @objc(_fastCStringContents:)
+  @_effects(readonly)
+  final internal func _fastCStringContents(
+    _ requiresNulTermination: Int8
+  ) -> UnsafePointer<CChar>? {
+    if isASCII {
+      return start._asCChar
+    }
+    return nil
+  }
+
+  @objc(UTF8String)
+  @_effects(readonly)
+  final internal func _utf8String() -> UnsafePointer<UInt8>? {
+    return start
+  }
+
+  @objc(cStringUsingEncoding:)
+  @_effects(readonly)
+  final internal func cString(encoding: UInt) -> UnsafePointer<UInt8>? {
+    return _cString(encoding: encoding)
+  }
+
+  @objc(getCString:maxLength:encoding:)
+  @_effects(releasenone)
+  final internal func getCString(
+    _ outputPtr: UnsafeMutablePointer<UInt8>, maxLength: Int, encoding: UInt
+  ) -> Int8 {
+    return _getCString(outputPtr, maxLength, encoding)
+  }
+
+  @objc
+  final internal var fastestEncoding: UInt {
+    @_effects(readonly) get {
+      if isASCII {
+        return _cocoaASCIIEncoding
+      }
+      return _cocoaUTF8Encoding
+    }
+  }
+
+  @objc(isEqualToString:)
+  @_effects(readonly)
+  final internal func isEqualToString(to other: AnyObject?) -> Int8 {
+    return _isEqual(other)
+  }
+
+  @objc(isEqual:)
+  @_effects(readonly)
+  final internal func isEqual(to other: AnyObject?) -> Int8 {
+    return _isEqual(other)
+  }
+
+  @objc(copyWithZone:)
+  final internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
+    // While __StringStorage instances aren't immutable in general,
+    // mutations may only occur when instances are uniquely referenced.
+    // Therefore, it is safe to return self here; any outstanding Objective-C
+    // reference will make the instance non-unique.
+    return self
+  }
+}
+
+extension __SharedStringStorage {
+  @objc(length)
+  final internal var UTF16Length: Int {
+    @_effects(readonly) get {
+      return asString.utf16.count // UTF16View special-cases ASCII for us.
+    }
+  }
+
+  @objc
+  final internal var hash: UInt {
+    @_effects(readonly) get {
+      if isASCII {
+        return _cocoaHashASCIIBytes(start, length: count)
+      }
+      return _cocoaHashString(self)
+    }
+  }
+
+  @objc(characterAtIndex:)
+  @_effects(readonly)
+  final internal func character(at offset: Int) -> UInt16 {
+    let str = asString
+    return str.utf16[str._toUTF16Index(offset)]
+  }
+
+  @objc(getCharacters:range:)
+  @_effects(releasenone)
+  final internal func getCharacters(
+    _ buffer: UnsafeMutablePointer<UInt16>, range aRange: _SwiftNSRange
+  ) {
+    _getCharacters(buffer, aRange)
+  }
+
+  @objc
+  final internal var fastestEncoding: UInt {
+    @_effects(readonly) get {
+      if isASCII {
+        return _cocoaASCIIEncoding
+      }
+      return _cocoaUTF8Encoding
+    }
+  }
+
+  @objc(_fastCStringContents:)
+  @_effects(readonly)
+  final internal func _fastCStringContents(
+    _ requiresNulTermination: Int8
+  ) -> UnsafePointer<CChar>? {
+    if isASCII {
+      return start._asCChar
+    }
+    return nil
+  }
+
+  @objc(UTF8String)
+  @_effects(readonly)
+  final internal func _utf8String() -> UnsafePointer<UInt8>? {
+    return start
+  }
+
+  @objc(cStringUsingEncoding:)
+  @_effects(readonly)
+  final internal func cString(encoding: UInt) -> UnsafePointer<UInt8>? {
+    return _cString(encoding: encoding)
+  }
+
+  @objc(getCString:maxLength:encoding:)
+  @_effects(releasenone)
+  final internal func getCString(
+    _ outputPtr: UnsafeMutablePointer<UInt8>, maxLength: Int, encoding: UInt
+  ) -> Int8 {
+    return _getCString(outputPtr, maxLength, encoding)
+  }
+
+  @objc(isEqualToString:)
+  @_effects(readonly)
+  final internal func isEqualToString(to other: AnyObject?) -> Int8 {
+    return _isEqual(other)
+  }
+
+  @objc(isEqual:)
+  @_effects(readonly)
+  final internal func isEqual(to other: AnyObject?) -> Int8 {
+    return _isEqual(other)
+  }
+
+  @objc(copyWithZone:)
+  final internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
+    // While __StringStorage instances aren't immutable in general,
+    // mutations may only occur when instances are uniquely referenced.
+    // Therefore, it is safe to return self here; any outstanding Objective-C
+    // reference will make the instance non-unique.
+    return self
+  }
+}
+
+#endif // _runtime(_ObjC)


### PR DESCRIPTION
Add StringStorageBridge.swift to separate out ObjC interop
functionality.

NFC

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
