### PR TITLE
[AutoDiff] Requestify `@differentiable` attribute parameter indices.

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1634,6 +1634,29 @@ public:
   bool isCached() const { return true; }
 };
 
+// SWIFT_ENABLE_TENSORFLOW
+class DifferentiableAttributeParameterIndicesRequest :
+    public SimpleRequest<DifferentiableAttributeParameterIndicesRequest,
+                         IndexSubset *(DifferentiableAttr *, Decl *),
+                         CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<IndexSubset *>
+  evaluate(Evaluator &evaluator, DifferentiableAttr *attr, Decl *decl) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<IndexSubset *> getCachedResult() const;
+  void cacheResult(IndexSubset *value) const;
+};
+// SWIFT_ENABLE_TENSORFLOW END
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -31,6 +31,11 @@ SWIFT_REQUEST(TypeChecker, ClassAncestryFlagsRequest,
               AncestryFlags(ClassDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,
               Type(AssociatedTypeDecl *), Cached, NoLocationInfo)
+// SWIFT_ENABLE_TENSORFLOW
+SWIFT_REQUEST(TypeChecker, DifferentiableAttributeParameterIndicesRequest,
+              IndexSubset *(DifferentiableAttr *, Decl *),
+              SeparatelyCached, NoLocationInfo)
+// SWIFT_ENABLE_TENSORFLOW END
 SWIFT_REQUEST(TypeChecker, DefaultTypeRequest,
               Type(KnownProtocolKind, const DeclContext *), SeparatelyCached,
               NoLocationInfo)

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1072,3 +1072,21 @@ void swift::simple_display(llvm::raw_ostream &out,
   out << "precedence group " << desc.ident << " at ";
   desc.nameLoc.print(out, desc.dc->getASTContext().SourceMgr);
 }
+
+//----------------------------------------------------------------------------//
+// DifferentiableAttributeParameterIndicesRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<IndexSubset *>
+DifferentiableAttributeParameterIndicesRequest::getCachedResult() const {
+  auto *attr = std::get<0>(getStorage());
+  if (attr->hasComputedParameterIndices())
+    return attr->ParameterIndicesAndBit.getPointer();
+  return None;
+}
+
+void DifferentiableAttributeParameterIndicesRequest::cacheResult(
+    IndexSubset *parameterIndices) const {
+  auto *attr = std::get<0>(getStorage());
+  attr->ParameterIndicesAndBit.setPointerAndInt(parameterIndices, true);
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3390,6 +3390,7 @@ static void setOriginalFunctionInDifferentiableAttributes(
   for (auto *attr : Attributes.getAttributes<DifferentiableAttr>())
     const_cast<DifferentiableAttr *>(attr)->setOriginalDeclaration(D);
 }
+// SWIFT_ENABLE_TENSORFLOW END
 
 /// Parse a single syntactic declaration and return a list of decl
 /// ASTs.  This can return multiple results for var decls that bind to multiple
@@ -3836,6 +3837,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
       // SWIFT_ENABLE_TENSORFLOW END
     }
     // SWIFT_ENABLE_TENSORFLOW
+    // Set original declaration in `@differentiable` attributes.
     setOriginalFunctionInDifferentiableAttributes(D->getAttrs(), D);
     // SWIFT_ENABLE_TENSORFLOW END
   }
@@ -5592,6 +5594,7 @@ Parser::parseDeclVarGetSet(Pattern *pattern, ParseDeclOptions Flags,
   accessors.record(*this, PrimaryVar, Invalid);
 
   // SWIFT_ENABLE_TENSORFLOW
+  // Set original declaration in `@differentiable` attributes.
   for (auto *accessor : accessors.Accessors)
     setOriginalFunctionInDifferentiableAttributes(accessor->getAttrs(),
                                                   accessor);
@@ -5852,6 +5855,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       VD->setStatic(StaticLoc.isValid());
       VD->getAttrs() = Attributes;
       // SWIFT_ENABLE_TENSORFLOW
+      // Set original declaration in `@differentiable` attributes.
       setOriginalFunctionInDifferentiableAttributes(Attributes, VD);
       // SWIFT_ENABLE_TENSORFLOW END
       setLocalDiscriminator(VD);
@@ -7109,6 +7113,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
   accessors.record(*this, Subscript, (Invalid || !Status.isSuccess()));
 
   // SWIFT_ENABLE_TENSORFLOW
+  // Set original declaration in `@differentiable` attributes.
   for (auto *accessor : accessors.Accessors)
     setOriginalFunctionInDifferentiableAttributes(accessor->getAttrs(),
                                                   accessor);

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -83,6 +83,14 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
       !constant.autoDiffDerivativeFunctionIdentifier &&
       !constant.isStoredPropertyInitializer() &&
       !constant.isThunk()) {
+    // NOTE: Validate `@differentiable` attributes on `AccessorDecl`s by calling
+    // `getParameterIndices`. This is significant to prevent duplicate SIL
+    // `[differentiable]` attribute generation: `getParameterIndices` deletes
+    // `@differentiable` attributes whose original declaration is an
+    // `AbstractStorageDecl`.
+    if (isa<AccessorDecl>(decl))
+      for (auto *A : Attrs.getAttributes<DifferentiableAttr>())
+        (void)A->getParameterIndices();
     for (auto *A : Attrs.getAttributes<DifferentiableAttr>()) {
       // Get lowered argument indices.
       auto *paramIndices = A->getParameterIndices();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1063,18 +1063,6 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
   }
 }
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-789): Figure out the proper way to typecheck these.
-void TypeChecker::checkDeclDifferentiableAttributes(Decl *D) {
-  AttributeChecker Checker(D);
-  for (auto attr : D->getAttrs()) {
-    if (!isa<DifferentiableAttr>(attr) || !attr->isValid() ||
-        !attr->canAppearOnDecl(D))
-      continue;
-    Checker.visit(attr);
-  }
-}
-
 /// Returns true if the given method is an valid implementation of a
 /// @dynamicCallable attribute requirement. The method is given to be defined
 /// as one of the following: `dynamicallyCall(withArguments:)` or
@@ -3205,6 +3193,19 @@ static bool checkTransposingParameters(
 
 // SWIFT_ENABLE_TENSORFLOW
 void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
+  // Call `getParameterIndices` to trigger a
+  // `DifferentiableAttributeParameterIndicesRequest`, which currently performs
+  // full `@differentiable` type-checking.
+  // TODO: Consider creating separate requests for the following functionality:
+  // - `DifferentiableAttr::getJVPFunction`
+  // - `DifferentiableAttr::getVJPFunction`
+  // - `DifferentiableAttr::getDerivativeGenericSignature`
+  (void)attr->getParameterIndices();
+}
+
+llvm::Expected<IndexSubset *>
+DifferentiableAttributeParameterIndicesRequest::evaluate(
+    Evaluator &evaluator, DifferentiableAttr *attr, Decl *D) const {
   // Skip checking implicit `@differentiable` attributes. We currently assume
   // that all implicit `@differentiable` attributes are valid.
   // Motivation: some implicit attributes do not contain a where clause, and
@@ -3212,26 +3213,31 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   // where clauses and requirements consistently is a larger problem, to be
   // revisited.
   if (attr->isImplicit())
-    return;
+    return nullptr;
 
+  auto &ctx = D->getASTContext();
+  auto &diags = ctx.Diags;
   auto lookupConformance =
       LookUpConformanceInModule(D->getDeclContext()->getParentModule());
 
   // If functions is marked as linear, you cannot have a custom VJP and/or
   // a JVP.
   if (attr->isLinear() && (attr->getVJP() || attr->getJVP())) {
-    diagnoseAndRemoveAttr(attr,
+    diagnoseAndRemoveAttr(diags, D, attr,
                           diag::attr_differentiable_no_vjp_or_jvp_when_linear);
-    return;
+    attr->setInvalid();
+    return nullptr;
   }
 
   AbstractFunctionDecl *original = dyn_cast<AbstractFunctionDecl>(D);
   if (auto *asd = dyn_cast<AbstractStorageDecl>(D)) {
     if (asd->getImplInfo().isSimpleStored() &&
         (attr->getJVP() || attr->getVJP())) {
-      diagnoseAndRemoveAttr(attr,
+      diagnoseAndRemoveAttr(
+          diags, D, attr,
           diag::differentiable_attr_stored_property_variable_unsupported);
-      return;
+      attr->setInvalid();
+      return nullptr;
     }
     // When used directly on a storage decl (stored/computed property or
     // subscript), the getter is currently inferred to be `@differentiable`.
@@ -3253,13 +3259,11 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   // Global immutable vars, for example, have no getter, and therefore trigger
   // this.
   if (!original) {
-    diagnoseAndRemoveAttr(attr, diag::invalid_decl_attribute, attr);
-    return;
+    diagnoseAndRemoveAttr(diags, D, attr, diag::invalid_decl_attribute, attr);
+    attr->setInvalid();
+    return nullptr;
   }
 
-  assert(attr->getOriginalDeclaration() &&
-         "`@differentiable` attribute should have original declaration set "
-         "during construction or parsing");
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
   bool isMethod = original->hasImplicitSelfDecl();
 
@@ -3268,12 +3272,12 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   auto originalResultTy = originalFnTy->getResult();
   if (isMethod)
     originalResultTy = originalResultTy->castTo<AnyFunctionType>()->getResult();
-  if (originalResultTy->isEqual(Ctx.TheEmptyTupleType)) {
-    diagnose(attr->getLocation(), diag::differentiable_attr_void_result,
-                   original->getFullName())
+  if (originalResultTy->isEqual(ctx.TheEmptyTupleType)) {
+    diags.diagnose(attr->getLocation(), diag::differentiable_attr_void_result,
+                original->getFullName())
         .highlight(original->getSourceRange());
     attr->setInvalid();
-    return;
+    return nullptr;
   }
 
   bool isOriginalProtocolRequirement =
@@ -3291,10 +3295,10 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     //  result - JVPs/VJPs would not type-check.
     if (auto *originalFn = dyn_cast<FuncDecl>(original)) {
       if (originalFn->hasDynamicSelfResult()) {
-        diagnose(attr->getLocation(),
-                 diag::differentiable_attr_class_member_no_dynamic_self);
+        diags.diagnose(attr->getLocation(),
+                       diag::differentiable_attr_class_member_no_dynamic_self);
         attr->setInvalid();
-        return;
+        return nullptr;
       }
     }
 
@@ -3302,10 +3306,10 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     // Extra JVP/VJP type calculation logic is necessary because classes have
     // both allocators and initializers.
     if (auto *initDecl = dyn_cast<ConstructorDecl>(original)) {
-      diagnose(attr->getLocation(),
-               diag::differentiable_attr_class_init_not_yet_supported);
+      diags.diagnose(attr->getLocation(),
+                     diag::differentiable_attr_class_init_not_yet_supported);
       attr->setInvalid();
-      return;
+      return nullptr;
     }
   }
 
@@ -3324,33 +3328,33 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     // `@differentiable` attributes on protocol requirements do not support
     // 'where' clauses.
     if (isOriginalProtocolRequirement) {
-      diagnose(attr->getLocation(),
-               diag::differentiable_attr_protocol_req_where_clause);
+      diags.diagnose(attr->getLocation(),
+                     diag::differentiable_attr_protocol_req_where_clause);
       attr->setInvalid();
-      return;
+      return nullptr;
     }
     if (whereClause->getRequirements().empty()) {
       // Where clause must not be empty.
-      diagnose(attr->getLocation(),
-               diag::differentiable_attr_empty_where_clause);
+      diags.diagnose(attr->getLocation(),
+                     diag::differentiable_attr_empty_where_clause);
       attr->setInvalid();
-      return;
+      return nullptr;
     }
 
     auto originalGenSig = original->getGenericSignature();
     if (!originalGenSig) {
       // Attributes with where clauses can only be declared on
       // generic functions.
-      diagnose(attr->getLocation(),
-               diag::differentiable_attr_nongeneric_trailing_where,
-               original->getFullName())
-        .highlight(whereClause->getSourceRange());
+      diags.diagnose(attr->getLocation(),
+                     diag::differentiable_attr_nongeneric_trailing_where,
+                     original->getFullName())
+          .highlight(whereClause->getSourceRange());
       attr->setInvalid();
-      return;
+      return nullptr;
     }
 
     // Build a new generic signature for autodiff derivative functions.
-    GenericSignatureBuilder builder(Ctx);
+    GenericSignatureBuilder builder(ctx);
     // Add the original function's generic signature.
     builder.addGenericSignature(originalGenSig);
 
@@ -3369,9 +3373,9 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
 
         // Layout requirements are not supported.
         case RequirementKind::Layout:
-          diagnose(attr->getLocation(),
-                   diag::differentiable_attr_layout_req_unsupported)
-            .highlight(reqRepr->getSourceRange());
+          diags.diagnose(attr->getLocation(),
+                         diag::differentiable_attr_layout_req_unsupported)
+              .highlight(reqRepr->getSourceRange());
           errorOccurred = true;
           return false;
         }
@@ -3385,7 +3389,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
 
     if (errorOccurred) {
       attr->setInvalid();
-      return;
+      return nullptr;
     }
 
     // Compute generic signature and environment for autodiff associated
@@ -3402,9 +3406,6 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   // Get the parsed wrt param indices, which have not yet been checked.
   // This is defined for parsed attributes.
   auto parsedWrtParams = attr->getParsedParameters();
-  // Get checked wrt param indices.
-  // This is defined only for compiler-synthesized attributes.
-  auto *checkedWrtParamIndices = attr->getParameterIndices();
 
   // Compute the derivative function type.
   auto derivativeFnTy = originalFnTy;
@@ -3412,15 +3413,13 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     derivativeFnTy = whereClauseGenEnv->mapTypeIntoContext(derivativeFnTy)
         ->castTo<AnyFunctionType>();
 
-  // If checked wrt param indices are not specified, compute them.
-  if (!checkedWrtParamIndices)
-    checkedWrtParamIndices =
-        computeDifferentiationParameters(parsedWrtParams, original,
-                                         whereClauseGenEnv, attr->getAttrName(),
-                                         attr->getLocation());
+  auto *checkedWrtParamIndices =
+      computeDifferentiationParameters(parsedWrtParams, original,
+                                       whereClauseGenEnv, attr->getAttrName(),
+                                       attr->getLocation());
   if (!checkedWrtParamIndices) {
     attr->setInvalid();
-    return;
+    return nullptr;
   }
 
   // Check if differentiation parameter indices are valid.
@@ -3428,11 +3427,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
           original, checkedWrtParamIndices, derivativeFnTy, whereClauseGenEnv,
           original->getModuleContext(), parsedWrtParams, attr->getLocation())) {
     attr->setInvalid();
-    return;
+    return nullptr;
   }
-
-  // Set the checked differentiation parameter indices in the attribute.
-  attr->setParameterIndices(checkedWrtParamIndices);
 
   if (whereClauseGenEnv)
     originalResultTy =
@@ -3441,20 +3437,20 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     originalResultTy = original->mapTypeIntoContext(originalResultTy);
   // Check that original function's result type conforms to `Differentiable`.
   if (!conformsToDifferentiable(originalResultTy, original)) {
-    diagnose(attr->getLocation(),
-             diag::differentiable_attr_result_not_differentiable,
-             originalResultTy);
+    diags.diagnose(attr->getLocation(),
+                   diag::differentiable_attr_result_not_differentiable,
+                   originalResultTy);
     attr->setInvalid();
-    return;
+    return nullptr;
   }
 
   // `@differentiable` attributes on protocol requirements do not support
   // JVP/VJP.
   if (isOriginalProtocolRequirement && (attr->getJVP() || attr->getVJP())) {
-    diagnose(attr->getLocation(),
-             diag::differentiable_attr_protocol_req_assoc_func);
+    diags.diagnose(attr->getLocation(),
+                   diag::differentiable_attr_protocol_req_assoc_func);
     attr->setInvalid();
-    return;
+    return nullptr;
   }
 
   // Resolve the JVP declaration, if it exists.
@@ -3476,7 +3472,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
 
     if (!jvp) {
       attr->setInvalid();
-      return;
+      return nullptr;
     }
     // Memorize the jvp reference in the attribute.
     attr->setJVPFunction(jvp);
@@ -3501,7 +3497,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
 
     if (!vjp) {
       attr->setInvalid();
-      return;
+      return nullptr;
     }
     // Memorize the vjp reference in the attribute.
     attr->setVJPFunction(vjp);
@@ -3516,34 +3512,36 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     auto *getterDecl = asd->getAccessor(AccessorKind::Get);
     auto *newAttr = DifferentiableAttr::create(
         getterDecl, /*implicit*/ true, attr->AtLoc, attr->getRange(),
-        attr->isLinear(), attr->getParameterIndices(), attr->getJVP(),
+        attr->isLinear(), checkedWrtParamIndices, attr->getJVP(),
         attr->getVJP(), attr->getDerivativeGenericSignature());
     newAttr->setJVPFunction(attr->getJVPFunction());
     newAttr->setVJPFunction(attr->getVJPFunction());
-    auto insertion = Ctx.DifferentiableAttrs.try_emplace(
-        {getterDecl, newAttr->getParameterIndices()}, newAttr);
+    auto insertion = ctx.DifferentiableAttrs.try_emplace(
+        {getterDecl, checkedWrtParamIndices}, newAttr);
     // Valid `@differentiable` attributes are uniqued by their parameter
     // indices. Reject duplicate attributes for the same decl and parameter
     // indices pair.
     if (!insertion.second) {
-      diagnoseAndRemoveAttr(attr, diag::differentiable_attr_duplicate);
-      diagnose(insertion.first->getSecond()->getLocation(),
-               diag::differentiable_attr_duplicate_note);
-      return;
+      diagnoseAndRemoveAttr(diags, D, attr,
+                            diag::differentiable_attr_duplicate);
+      diags.diagnose(insertion.first->getSecond()->getLocation(),
+                     diag::differentiable_attr_duplicate_note);
+      return nullptr;
     }
     getterDecl->getAttrs().add(newAttr);
-    return;
+    return checkedWrtParamIndices;
   }
-  auto insertion = Ctx.DifferentiableAttrs.try_emplace(
-      {D, attr->getParameterIndices()}, attr);
+  auto insertion = ctx.DifferentiableAttrs.try_emplace(
+      {D, checkedWrtParamIndices}, attr);
   // `@differentiable` attributes are uniqued by their parameter indices.
   // Reject duplicate attributes for the same decl and parameter indices pair.
   if (!insertion.second && insertion.first->getSecond() != attr) {
-    diagnoseAndRemoveAttr(attr, diag::differentiable_attr_duplicate);
-    diagnose(insertion.first->getSecond()->getLocation(),
-             diag::differentiable_attr_duplicate_note);
-    return;
+    diagnoseAndRemoveAttr(diags, D, attr, diag::differentiable_attr_duplicate);
+    diags.diagnose(insertion.first->getSecond()->getLocation(),
+                   diag::differentiable_attr_duplicate_note);
+    return nullptr;
   }
+  return checkedWrtParamIndices;
 }
 
 // SWIFT_ENABLE_TENSORFLOW

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4225,11 +4225,6 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
     if (interfaceType->hasArchetype())
       interfaceType = interfaceType->mapTypeOutOfContext();
 
-    // SWIFT_ENABLE_TENSORFLOW
-    // TODO(TF-789): Find proper way to type-check `@differentiable` attributes.
-    // TypeChecker::checkDeclDifferentiableAttributes(VD);
-    // SWIFT_ENABLE_TENSORFLOW END
-
     // In SIL mode, VarDecls are written as having reference storage types.
     if (!interfaceType->is<ReferenceStorageType>()) {
       if (auto *attr = VD->getAttrs().getAttribute<ReferenceOwnershipAttr>())
@@ -4292,11 +4287,6 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
         funcTy = FunctionType::get({selfParam}, funcTy);
     }
 
-    // SWIFT_ENABLE_TENSORFLOW
-    // TODO(TF-789): Find proper way to type-check `@differentiable` attributes.
-    // TypeChecker::checkDeclDifferentiableAttributes(AFD);
-    // SWIFT_ENABLE_TENSORFLOW END
-
     return funcTy;
   }
 
@@ -4313,11 +4303,6 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       funcTy = GenericFunctionType::get(sig, argTy, elementTy);
     else
       funcTy = FunctionType::get(argTy, elementTy);
-
-    // SWIFT_ENABLE_TENSORFLOW
-    // TODO(TF-789): Find proper way to type-check `@differentiable` attributes.
-    // TypeChecker::checkDeclDifferentiableAttributes(SD);
-    // SWIFT_ENABLE_TENSORFLOW END
 
     return funcTy;
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1018,10 +1018,6 @@ public:
   static void checkParameterAttributes(ParameterList *params);
   static ValueDecl *findReplacedDynamicFunction(const ValueDecl *d);
 
-  // SWIFT_ENABLE_TENSORFLOW
-  // TODO(TF-789): Figure out the proper way to typecheck these.
-  static void checkDeclDifferentiableAttributes(Decl *D);
-
   static Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
                                           ReferenceOwnershipAttr *attr);
 


### PR DESCRIPTION
Requestify `@differentiable` attribute parameter indices resolution:
`DifferentiableAttributeParameterIndicesRequest`.

This is necessary for type-checking `@differentiable` attributes in
non-primary files. The previous workaround
(`TypeChecker::checkDeclDifferentiableAttributes`) no longer works
because `TypeChecker::validateDecl` has been replaced with
`InterfaceTypeRequest::evaluate`.

Currently, all `@differentiable` attribute type-checking
(`AttributeChecker::visitDifferentiableAttr`) has been moved into
`DifferentiableAttributeParameterIndicesRequest::evaluate`.

In the future, consider splitting
`DifferentiableAttributeParameterIndicesRequest` into multiple requests
for the following functionality:
- `DifferentiableAttr::getJVPFunction`
- `DifferentiableAttr::getVJPFunction`
- `DifferentiableAttr::getDerivativeGenericSignature`

---

Notes:
* I studied `InterfaceTypeRequest` (https://github.com/apple/swift/pull/27764) to define `DifferentiableAttributeParameterIndicesRequest`.
* Landing this patch on current `tensorflow` (last merge `swift-DEVELOPMENT-SNAPSHOT-2019-10-13-a`) is not possible because https://github.com/apple/swift/commit/7676eb07d3bffb7465ef027f1676debc3492fbe2 (from `swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a`) is necessary for decoupling `AttributeChecker` from `TypeChecker`.