### PR TITLE
Fix tensorflow_osx_base build preset.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2152,7 +2152,7 @@ test-installable-package
 reconfigure
 
 swift-install-components=compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd
 install-libcxx
 
 # Path to the .tar.gz package.


### PR DESCRIPTION
Rename `clang-headers` to `clang-resources-headers`.
Upstream patch: https://github.com/apple/swift/pull/27161

This fixes macOS toolchain builds via `build-toolchain-tensorflow`.