### PR TITLE
[build-presets] Install the stress tester in its PR test preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1576,6 +1576,8 @@ release
 assertions
 skstresstester
 swiftevolve
+install-skstresstester
+install-swiftevolve
 
 #===------------------------------------------------------------------------===#
 # Test SourceKit-LSP


### PR DESCRIPTION
We should check that the install phase still works when running PR testing for the stress tester.

The preset isn’t currently used yet.