### PR TITLE
Debug Info: Avoid type uniquing clashes for bound generic enums.

### DIFF
--- a/test/DebugInfo/BoundGenericEnum.swift
+++ b/test/DebugInfo/BoundGenericEnum.swift
@@ -1,0 +1,87 @@
+// RUN: %target-swift-frontend %s -Onone -emit-ir -g -o - -module-name a \
+// RUN:   -disable-debugger-shadow-copies | %FileCheck %s
+public enum Result<Value> {
+  case success(Value)
+  case failure(Error)
+}
+
+extension Result {
+  public func map<U>(_ transform: (Value) -> U) -> Result<U> {
+    switch self {
+    case .success(let value):
+      return .success(transform(value))
+    case .failure(let error):
+      return .failure(error)
+    }
+  }
+}
+
+func use<T>(_ t : T) {
+}
+
+public class SomeClass {
+  public let s = "hello"
+}
+
+extension Result where Value : SomeClass {
+  public func f() -> Self {
+    use(self)
+    return map({ $0 })
+  }  
+}
+
+extension Result {
+  public func g() {
+    use(self)
+  }  
+}
+
+let x : Result<SomeClass> = .success(SomeClass())
+let y : Result<(Int64, Int64, Int64, Int64)> = .success((1, 2, 3, 4))
+x.f()
+y.g()
+
+// Here we have three types, all named $s1a6ResultOyxGD (---> a.Result<A>),
+// but with different storage sizes:
+//
+//   0. Unsized from the subroutine tupe of map<U>.
+//   1. Enum wrapping a pointer-sized object [map() and f()].
+//   2. Enum wrapping a 4x64-bit tuple.
+//
+// Test that bound generic enums are *not* using their mangled name as a unique
+// identifier.
+
+// (0) unsized.
+// CHECK: !DISubprogram(name: "map", {{.*}}line: 9, type: ![[SBTY:[0-9]+]]
+// CHECK: ![[SBTY]] = !DISubroutineType(types: ![[SBTYS:[0-9]+]])
+// CHECK: ![[SBTYS]] = !{!{{[0-9]+}}, !{{[0-9]+}}, ![[SELFTY:[0-9]+]]}
+// CHECK: ![[SELFTY]] =
+// CHECK-SAME:  !DICompositeType(tag: DW_TAG_structure_type, {{.*}}line: 3,
+// CHECK-SAME:                   elements: ![[UNSIZED_ELTS:[0-9]+]]
+// CHECK: ![[UNSIZED_ELTS]] = !{![[UNSIZED_MEM:[0-9]+]]}
+// CHECK: ![[UNSIZED_MEM]] = !DIDerivedType(tag: DW_TAG_member,
+// CHECK-SAME:                              baseType: ![[UNIQ:[0-9]+]]
+
+// The unique unsized type.
+// CHECK: ![[UNIQ]] = !DICompositeType(
+// CHECK-SAME:            tag: DW_TAG_structure_type, name: "Result",
+// CHECK-SAME:            line: 3,
+// CHECK-NOT:             size:
+// CHECK-SAME:            runtimeLang: DW_LANG_Swift,
+// CHECK-SAME:            identifier: "$s1a6ResultOyxGD")
+
+// (2)
+// CHECK: !DILocalVariable(name: "self", arg: 2, {{.*}}line: 9,
+// CHECK-SAME:             type: ![[C_TUP:[0-9]+]]
+// CHECK: ![[C_TUP]] = !DIDerivedType(tag: DW_TAG_const_type,
+// CHECK-SAME:                        baseType: ![[TUP:[0-9]+]])
+// CHECK: ![[TUP]] = !DICompositeType(tag: DW_TAG_structure_type,
+// CHECK-SAME:                        line: 3, size: {{256|512}},
+
+// (1)
+// CHECK: !DILocalVariable(name: "self", arg: 1, {{.*}}line: 27,
+// CHECK-SAME:             type: ![[C_CLASS:[0-9]+]]
+// CHECK: ![[C_CLASS]] = !DIDerivedType(tag: DW_TAG_const_type,
+// CHECK-SAME:                          baseType: ![[CLASS:[0-9]+]])
+// CHECK: ![[CLASS]] = !DICompositeType(tag: DW_TAG_structure_type,
+// CHECK-SAME:                          line: 3, size:

--- a/test/DebugInfo/bound-namealiastype.swift
+++ b/test/DebugInfo/bound-namealiastype.swift
@@ -9,7 +9,10 @@ func dispatch_queue_create() -> dispatch_queue_t! {
 }
 
 // CHECK: !DIGlobalVariable(name: "queue",
-// CHECK-SAME:              line: [[@LINE+3]], type: ![[T:[0-9]+]]
-// CHECK: ![[T]] = !DICompositeType(
+// CHECK-SAME:              line: [[@LINE+6]], type: ![[TY_CONTAINER:[0-9]+]]
+// CHECK: ![[TY_CONTAINER]] = !DICompositeType({{.*}}elements: ![[TY_ELTS:[0-9]+]]
+// CHECK: ![[TY_ELTS]] = !{![[TY_MEMBER:[0-9]+]]}
+// CHECK: ![[TY_MEMBER]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}baseType: ![[TY:[0-9]+]]
+// CHECK: ![[TY]] = !DICompositeType(
 // CHECK-SAME:             identifier: "$s4main16dispatch_queue_taSgD"
 public var queue = dispatch_queue_create()

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -52,7 +52,6 @@ let r = Color.Red
 let c = MaybeIntPair.just(74, 75)
 // CHECK: !DICompositeType({{.*}}name: "Maybe",
 // CHECK-SAME:             line: [[@LINE-8]],
-// CHECK-SAME:             size: 8{{[,)]}}
 // CHECK-SAME:             identifier: "$s4enum5MaybeOyAA5ColorOGD"
 let movie : Maybe<Color> = .none
 
@@ -79,8 +78,12 @@ public enum Tuple<P> {
 
 func bar<T>(_ x : Tuple<T>) -> Tuple<T> { return x }
 
-// CHECK: ![[LIST:.*]] = !DICompositeType({{.*}}identifier: "$s4enum4ListOyxGD"
-// CHECK-DAG: ![[LET_LIST:.*]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[LIST]])
+// CHECK-DAG: ![[LIST:.*]] = !DICompositeType({{.*}}identifier: "$s4enum4ListOyxGD"
+// CHECK-DAG: ![[LIST_MEMBER:.*]] = !DIDerivedType(tag: DW_TAG_member, {{.*}} baseType: ![[LIST]]
+// CHECK-DAG: ![[LIST_ELTS:.*]] = !{![[LIST_MEMBER]]}
+// CHECK-DAG: ![[LIST_CONTAINER:.*]] = !DICompositeType({{.*}}elements: ![[LIST_ELTS]]
+
+// CHECK-DAG: ![[LET_LIST:.*]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[LIST_CONTAINER]])
 // CHECK-DAG: !DILocalVariable(name: "self", arg: 1, {{.*}} line: [[@LINE+4]], type: ![[LET_LIST]], flags: DIFlagArtificial)
 public enum List<T> {
        indirect case Tail(List, T)

--- a/test/DebugInfo/generic_enum.swift
+++ b/test/DebugInfo/generic_enum.swift
@@ -17,7 +17,10 @@ func wrapTrivialGeneric<T, U>(_ t: T, u: U) -> TrivialGeneric<T, U> {
   return .x(t, u)
 }
 // CHECK-DAG: ![[T1:.*]] = !DICompositeType({{.*}}identifier: "$s12generic_enum14TrivialGenericOys5Int64VSSGD"
-// CHECK-DAG: !DIGlobalVariable(name: "tg",{{.*}} line: [[@LINE+2]],{{.*}} type: ![[T1]],{{.*}} isLocal: false, isDefinition: true
+// CHECK-DAG: ![[T1_MEMBER:.*]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}baseType: ![[T1]]
+// CHECK-DAG: ![[T1_ELTS:.*]] = !{![[T1_MEMBER]]}
+// CHECK-DAG: ![[T1_CONTAINER:.*]] = !DICompositeType({{.*}}elements: ![[T1_ELTS]]
+// CHECK-DAG: !DIGlobalVariable(name: "tg",{{.*}} line: [[@LINE+2]],{{.*}} type: ![[T1_CONTAINER]],{{.*}} isLocal: false, isDefinition: true
 // CHECK-DAG: !DICompositeType({{.*}}, name: "TrivialGeneric", {{.*}}identifier: "$s12generic_enum14TrivialGenericOys5Int64VSSGD"
 var tg : TrivialGeneric<Int64, String> = .x(23, "skidoo")
 switch tg {

--- a/test/DebugInfo/protocol-sugar.swift
+++ b/test/DebugInfo/protocol-sugar.swift
@@ -4,5 +4,8 @@ protocol B {}
 typealias C = B & A
 protocol D {}
 var p: (C & D)?
-// CHECK-DAG: !DIGlobalVariable(name: "p", {{.*}}type: ![[TY:[0-9]+]]
+// CHECK-DAG: !DIGlobalVariable(name: "p", {{.*}}type: ![[TY_CONTAINER:[0-9]+]]
+// CHECK-DAG: ![[TY_CONTAINER]] = !DICompositeType({{.*}}elements: ![[TY_ELTS:[0-9]+]]
+// CHECK-DAG: ![[TY_ELTS]] = !{![[TY_MEMBER:[0-9]+]]}
+// CHECK-DAG: ![[TY_MEMBER]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}baseType: ![[TY:[0-9]+]]
 // CHECK-DAG: ![[TY]] = {{.*}}identifier: "$s4main1A_AA1BAA1DpXSpSgD"


### PR DESCRIPTION
This patch changes the DWARF representation of bound generic enums to a nested
struct where the (sized) outer struct is anonymous and thus distinct and the
inner struct in uniqued and sizeless.

BoundGenericEnums may have different sizes depending on what they are bound to,
but still share a mangled name.

rdar://problem/56521648
