### PR TITLE
Fix TensorFlow module compilation.

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -73,8 +73,8 @@ endif()
 # dependency for `numpy.ndarray` bridging to `ShapedArray`/`Tensor`.
 if(SWIFT_BUILD_STDLIB AND SWIFT_ENABLE_TENSORFLOW)
   # TODO: Add TensorFlow support for iOS/Raspberry Pi.
-  #  add_subdirectory(CTensorFlow)
-  #  add_subdirectory(TensorFlow)
+  add_subdirectory(CTensorFlow)
+  add_subdirectory(TensorFlow)
 endif()
 
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)

--- a/test/Sema/struct_key_path_iterable.swift
+++ b/test/Sema/struct_key_path_iterable.swift
@@ -114,6 +114,26 @@ struct DummyOptimizer<P : KeyPathIterable, Scalar : BinaryFloatingPoint>
   }
 }
 
+// TF-575: Test overloaded key path component name.
+protocol NameLookupConflictProtocol {}
+extension NameLookupConflictProtocol {
+  func member() {}
+}
+struct NameLookupConflict: NameLookupConflictProtocol & KeyPathIterable {
+  // Note: `NameLookupConflict.member` is overloaded with
+  // `MemberNameConflictProtocol.member`.
+  // This makes the following generated code fail:
+  //
+  //   var allKeyPaths: [PartialKeyPath<Self>] {
+  //     [\Self.member]
+  //   }
+  //
+  // error: cannot convert value of type
+  // 'WritableKeyPath<NameLookupConflict, Float>' to expected element type
+  // 'PartialKeyPath<NameLookupConflict>'
+  var member: Float
+}
+
 // Test derived conformances in disallowed contexts.
 
 // expected-error @+3 {{type 'OtherFileNonconforming' does not conform to protocol 'KeyPathIterable'}}


### PR DESCRIPTION
Fix `KeyPathIterable` derived conformances: `KeyPathIterable.allKeyPaths`
synthesis logic now requires different key-path expression coercion logic
to accommodate upstream type-checker changes.

---

Summary:

```swift
// Generated code for `KeyPathIterable.allKeyPaths`.
var allKeyPaths: [PartialKeyPath<Self>] {
  // Ideal code: TF-575.
  // error: cannot convert parent type 'main.TF575_LayerNorm<Scalar>' to expected type 'main.TF575_LayerNorm<Scalar>'
  [\Self.offset, \Self.scale]

  // Previously working code before swift-DEVELOPMENT-SNAPSHOT-2019-10-24-a.
  // error: cannot convert value of type '[WritableKeyPath<TF575_LayerNorm<Scalar>.TangentVector, Tensor<Scalar>>]' to type 'Array<Element>' in coercion
  // [\Self.offset, \Self.scale] as [PartialKeyPath<Self>]

  // Newly generated code.
  // [\Self.offset as PartialKeyPath<Self>, \Self.scale as PartialKeyPath<Self>]
}

```

---

See TF-575 for more information.
I'll minimize the type-checker issues and file upstream bugs.