### PR TITLE
lit: use `gyb.py` instead of `gyb`

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -294,7 +294,7 @@ config.benchmark_driver = inferSwiftBinary('Benchmark_Driver')
 
 config.swift_utils = make_path(config.swift_src_root, 'utils')
 config.line_directive = make_path(config.swift_utils, 'line-directive')
-config.gyb = make_path(config.swift_utils, 'gyb')
+config.gyb = make_path(config.swift_utils, 'gyb.py')
 config.rth = make_path(config.swift_utils, 'rth') # Resilience test helper
 config.scale_test = make_path(config.swift_utils, 'scale-test')
 config.PathSanitizingFileCheck = make_path(config.swift_utils, 'PathSanitizingFileCheck')


### PR DESCRIPTION
On Windows, when `gyb` is used, the import would fail.  This ensures
that we use the tool directly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
