### PR TITLE
ClangImporter: Fix init kind computation with overridden constructors

### DIFF
--- a/test/ClangImporter/Inputs/objc_init_override_kind.h
+++ b/test/ClangImporter/Inputs/objc_init_override_kind.h
@@ -1,0 +1,8 @@
+#import <Foundation.h>
+
+@interface Base : NSObject
+
+- (instancetype) init;
+
+- (instancetype) initWithFoo: (int) x NS_DESIGNATED_INITIALIZER;
+@end

--- a/test/ClangImporter/objc_init_override_kind.swift
+++ b/test/ClangImporter/objc_init_override_kind.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -import-objc-header %S/Inputs/objc_init_override_kind.h %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// rdar://problem/56674158
+class Derived : Base {
+  // This is not flagged as an error, because Base.init() is a
+  // convenience init.
+  init() { super.init(foo: 123) }
+
+  required init?(coder: NSCoder) {}
+}
+


### PR DESCRIPTION
We used to compute the init kind from the overridden declaration;
this was switched to use the base declaration in 42f72cb0d.

Refactor the init kind computation a little to get the old behavior
back. Otherwise, if a class defines an initializer named -init, we
always import it as designated by virtue of overridding NSObject's
-init.

Fixes <rdar://problem/56674158>.