### PR TITLE
add interface printing test

### DIFF
--- a/test/IDE/print_type_interface.swift
+++ b/test/IDE/print_type_interface.swift
@@ -83,3 +83,22 @@ extension D {
 // TYPE5-DAG: public func formIndex(_ i: inout Int, offsetBy distance: Int)
 // TYPE5-DAG: public func distance(from start: Int, to end: Int) -> Int
 // TYPE5-DAG: public func joined(separator: String = "") -> String
+
+extension Array {
+  public struct Inner {}
+}
+
+public protocol P2 {}
+
+extension Array.Inner where Element: P2 {
+  public func innerFoo() {}
+}
+
+extension Int: P2 {}
+
+// Print interface for Array<Int>.Inner
+// RUN: %target-swift-ide-test -print-type-interface -usr=\$sSa20print_type_interfaceE5InnerVySi_GD -module-name print_type_interface -source-filename %s | %FileCheck %s -check-prefix=TYPE6
+
+// TYPE6-LABEL: public struct Inner {
+// TYPE6:   public func innerFoo()
+// TYPE6: }


### PR DESCRIPTION
Before https://github.com/apple/swift/pull/27857, this test case fails with an assertion failure [1].

It looks like https://github.com/apple/swift/pull/27857 may have "accidentally" fixed this test case, because the description and test cases on that PR are about something completely different.

So I thought it would be good to add this test case to make sure that this doesn't regress.

[1] the assertion failure:
```
swift-ide-test: /usr/local/google/home/marcrasi/swift-base/swift/lib/AST/Type.cpp:3490: swift::TypeSubstitutionMap swift::TypeBase::getContextSubstitutions(const swift::DeclContext *, swift::GenericEnvironment *): Assertion `ownerNominal == baseTy->getAnyNominal()' failed.
Stack dump:
0.	Program arguments: /usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test -target x86_64-unknown-linux-gnu -module-cache-path /usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/swift-test-results/x86_64-unknown-linux-gnu/clang-module-cache -completion-cache-path /usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/swift-test-results/x86_64-unknown-linux-gnu/completion-cache -swift-version 4 -print-type-interface -usr=_TtGSaSi_ -module-name print_type_interface -source-filename /usr/local/google/home/marcrasi/swift-base/swift/test/IDE/print_type_interface.swift 
1.	While evaluating request IsDeclApplicableRequest(Checking if extension of Array.Inner is applicable for Array<Int>)
 #0 0x000000000488dd74 PrintStackTraceSignalHandler(void*) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x488dd74)
 #1 0x000000000488b98e llvm::sys::RunSignalHandlers() (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x488b98e)
 #2 0x000000000488e188 SignalHandler(int) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x488e188)
 #3 0x00007f28200323a0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x123a0)
 #4 0x00007f281f11fcfb raise (/lib/x86_64-linux-gnu/libc.so.6+0x36cfb)
 #5 0x00007f281f10a8ad abort (/lib/x86_64-linux-gnu/libc.so.6+0x218ad)
 #6 0x00007f281f10a77f (/lib/x86_64-linux-gnu/libc.so.6+0x2177f)
 #7 0x00007f281f118542 (/lib/x86_64-linux-gnu/libc.so.6+0x2f542)
 #8 0x0000000001544b92 swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x1544b92)
 #9 0x000000000153e270 swift::TypeBase::getContextSubstitutionMap(swift::ModuleDecl*, swift::DeclContext const*, swift::GenericEnvironment*) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x153e270)
#10 0x0000000000ef8938 swift::IsDeclApplicableRequest::evaluate(swift::Evaluator&, swift::DeclApplicabilityOwner) const (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0xef8938)
#11 0x0000000000ef8c8d swift::SimpleRequest<swift::IsDeclApplicableRequest, bool (swift::DeclApplicabilityOwner), (swift::CacheKind)1>::evaluateRequest(swift::IsDeclApplicableRequest const&, swift::Evaluator&) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0xef8c8d)
#12 0x00000000005d76e3 llvm::Expected<swift::IsDeclApplicableRequest::OutputType> swift::Evaluator::getResultUncached<swift::IsDeclApplicableRequest>(swift::IsDeclApplicableRequest const&) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x5d76e3)
#13 0x00000000005d716e llvm::Expected<swift::IsDeclApplicableRequest::OutputType> swift::Evaluator::getResultCached<swift::IsDeclApplicableRequest, (void*)0>(swift::IsDeclApplicableRequest const&) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x5d716e)
#14 0x00000000005d6326 llvm::Expected<swift::IsDeclApplicableRequest::OutputType> swift::Evaluator::operator()<swift::IsDeclApplicableRequest>(swift::IsDeclApplicableRequest const&) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x5d6326)
#15 0x00000000005c7d87 swift::IsDeclApplicableRequest::OutputType swift::evaluateOrDefault<swift::IsDeclApplicableRequest>(swift::Evaluator&, swift::IsDeclApplicableRequest, swift::IsDeclApplicableRequest::OutputType) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x5c7d87)
#16 0x00000000005d109e std::_Function_handler<bool (swift::ExtensionDecl const*), swift::PrintOptions::printTypeInterface(swift::Type)::$_0>::_M_invoke(std::_Any_data const&, swift::ExtensionDecl const*&&) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x5d109e)
#17 0x00000000013c5b94 (anonymous namespace)::PrintAST::printMembersOfDecl(swift::Decl*, bool, bool, bool) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x13c5b94)
#18 0x00000000013bfbe9 swift::ASTVisitor<(anonymous namespace)::PrintAST, void, void, void, void, void, void>::visit(swift::Decl*) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x13bfbe9)
#19 0x00000000013b6a6e (anonymous namespace)::PrintAST::visit(swift::Decl*) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x13b6a6e)
#20 0x00000000013c5e43 (anonymous namespace)::PrintAST::printMembersOfDecl(swift::Decl*, bool, bool, bool) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x13c5e43)
#21 0x00000000013bfbe9 swift::ASTVisitor<(anonymous namespace)::PrintAST, void, void, void, void, void, void>::visit(swift::Decl*) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x13bfbe9)
#22 0x00000000013b6a6e (anonymous namespace)::PrintAST::visit(swift::Decl*) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x13b6a6e)
#23 0x00000000013b668c swift::Decl::print(swift::ASTPrinter&, swift::PrintOptions const&) const (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x13b668c)
#24 0x000000000058c9db swift::ide::printTypeInterface(swift::ModuleDecl*, swift::Type, swift::ASTPrinter&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x58c9db)
#25 0x0000000000492e56 main (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x492e56)
#26 0x00007f281f10c52b __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2352b)
#27 0x000000000048dd0a _start (/usr/local/google/home/marcrasi/swift-base/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test+0x48dd0a)
```