### PR TITLE
Replace uses of some string semantics with constant string literals

### DIFF
--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -121,6 +121,12 @@ constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_SILTOKEN = {
 constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_WORD = {
     "Builtin.Word"};
 
+/// The name of the semantics of make utf8 string
+constexpr static StringLiteral STRING_MAKE_UTF8 = "string.makeUTF8";
+
+/// The name of the semantics of string equal
+constexpr static StringLiteral STRING_EQUALS = "string.equals";
+
 } // end namespace swift
 
 #endif // SWIFT_STRINGS_H

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -121,10 +121,10 @@ constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_SILTOKEN = {
 constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_WORD = {
     "Builtin.Word"};
 
-/// The name of the semantics of make utf8 string
+/// The string passed as a semantics attribute to signal to the optimizer that a function is a call functionally to string.makeUTF8
 constexpr static StringLiteral STRING_MAKE_UTF8 = "string.makeUTF8";
 
-/// The name of the semantics of string equal
+/// The string passed as a semantics attribute to signal to the optimizer that a function is a call functionally to string.equals
 constexpr static StringLiteral STRING_EQUALS = "string.equals";
 
 } // end namespace swift

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -119,7 +119,7 @@ static SILFunction *getStringMakeUTF8Init(SILInstruction *inst) {
     return nullptr;
 
   SILFunction *callee = apply->getCalleeFunction();
-  if (!callee || !callee->hasSemanticsAttr("string.makeUTF8"))
+  if (!callee || !callee->hasSemanticsAttr(STRING_MAKE_UTF8))
     return nullptr;
   return callee;
 }

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -73,11 +73,11 @@ static llvm::Optional<WellKnownFunction> classifyFunction(SILFunction *fn) {
   // There are two string initializers in the standard library with the
   // semantics "string.makeUTF8". They are identical from the perspective of
   // the interpreter. One of those functions is probably redundant and not used.
-  if (fn->hasSemanticsAttr("string.makeUTF8"))
+  if (fn->hasSemanticsAttr(STRING_MAKE_UTF8))
     return WellKnownFunction::StringMakeUTF8;
   if (fn->hasSemanticsAttr("string.append"))
     return WellKnownFunction::StringAppend;
-  if (fn->hasSemanticsAttr("string.equals"))
+  if (fn->hasSemanticsAttr(STRING_EQUALS))
     return WellKnownFunction::StringEquals;
   if (fn->hasSemanticsAttr("string.escapePercent.get"))
     return WellKnownFunction::StringEscapePercent;

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1535,7 +1535,7 @@ constantFoldGlobalStringTablePointerBuiltin(BuiltinInst *bi,
   FullApplySite stringInitSite = FullApplySite::isa(builtinOperand);
   if (!stringInitSite || !stringInitSite.getReferencedFunctionOrNull() ||
       !stringInitSite.getReferencedFunctionOrNull()->hasSemanticsAttr(
-          "string.makeUTF8")) {
+          STRING_MAKE_UTF8)) {
     // Emit diagnostics only on non-transparent functions.
     if (enableDiagnostics && !caller->isTransparent()) {
       diagnose(caller->getASTContext(), bi->getLoc().getSourceLoc(),

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -756,9 +756,9 @@ bool StringConcatenationOptimizer::extractStringConcatOperands() {
 
   // makeUTF8 should have following parameters:
   // (start: RawPointer, utf8CodeUnitCount: Word, isASCII: Int1)
-  if (!((friLeftFun->hasSemanticsAttr("string.makeUTF8")
+  if (!((friLeftFun->hasSemanticsAttr(STRING_MAKE_UTF8)
          && aiLeftOperandsNum == 5)
-        || (friRightFun->hasSemanticsAttr("string.makeUTF8")
+        || (friRightFun->hasSemanticsAttr(STRING_MAKE_UTF8)
             && aiRightOperandsNum == 5)))
     return false;
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch updates all uses of `string.equals` and `string.makeUTF8` to use a constant string literal. I have another patch to do this on a more broad scale (coming soon).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
