### PR TITLE
[NFC] Plot The Demise of LazyResolver

### DIFF
--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -53,9 +53,6 @@ public:
   virtual void resolveWitness(const NormalProtocolConformance *conformance,
                               ValueDecl *requirement) = 0;
 
-  /// Resolve any implicitly-declared constructors within the given nominal.
-  virtual void resolveImplicitConstructors(NominalTypeDecl *nominal) = 0;
-
   /// Resolve an implicitly-generated member with the given name.
   virtual void resolveImplicitMember(NominalTypeDecl *nominal, DeclName member) = 0;
 };

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1572,9 +1572,6 @@ bool DeclContext::lookupQualified(ArrayRef<NominalTypeDecl *> typeDecls,
 
     // Make sure we've resolved implicit members, if we need them.
     if (typeResolver) {
-      if (member.getBaseName() == DeclBaseName::createConstructor())
-        typeResolver->resolveImplicitConstructors(current);
-
       typeResolver->resolveImplicitMember(current, member);
     }
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1097,7 +1097,7 @@ void TypeChecker::synthesizeMemberForLookup(NominalTypeDecl *target,
     if (auto *conformance = dyn_cast<NormalProtocolConformance>(
             ref.getConcrete()->getRootConformance())) {
       if (conformance->getState() == ProtocolConformanceState::Incomplete) {
-        checkConformance(conformance);
+        TypeChecker::checkConformance(conformance);
       }
     }
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1077,6 +1077,9 @@ void TypeChecker::synthesizeMemberForLookup(NominalTypeDecl *target,
                                             DeclName member) {
   auto baseName = member.getBaseName();
 
+  if (baseName == DeclBaseName::createConstructor())
+    addImplicitConstructors(target);
+
   // Checks whether the target conforms to the given protocol. If the
   // conformance is incomplete, force the conformance.
   //

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -370,10 +370,7 @@ static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
     return nullptr;
 
   // Forcibly derive conformance to CodingKey.
-  //
-  // FIXME: Drop the dependency on the type checker.
-  auto *tc = static_cast<TypeChecker *>(C.getLazyResolver());
-  tc->checkConformancesInContext(enumDecl, enumDecl);
+  TypeChecker::checkConformancesInContext(enumDecl, enumDecl);
 
   // Add to the type.
   target->addMember(enumDecl);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4450,9 +4450,6 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
 
   auto &Context = CD->getASTContext();
 
-  // FIXME: Remove TypeChecker dependencies below
-  auto &TC = *(TypeChecker *) Context.getLazyResolver();
-
   // We need to add implicit initializers because they
   // affect vtable layout.
   TypeChecker::addImplicitConstructors(CD);
@@ -4469,7 +4466,7 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
     auto conformance = ref.getConcrete();
     if (conformance->getDeclContext() == CD &&
         conformance->getState() == ProtocolConformanceState::Incomplete) {
-      TC.checkConformance(conformance->getRootNormalConformance());
+      TypeChecker::checkConformance(conformance->getRootNormalConformance());
     }
   };
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -981,7 +981,7 @@ bool WitnessChecker::findBestWitness(
   bool anyFromUnconstrainedExtension;
   numViable = 0;
 
-  // FIXME: Remove dependnecy on the lazy resolver.
+  // FIXME: Remove dependency on the lazy resolver.
   auto *TC = static_cast<TypeChecker *>(
       requirement->getASTContext().getLazyResolver());
   for (Attempt attempt = Regular; numViable == 0 && attempt != Done;
@@ -4537,7 +4537,7 @@ static void diagnosePotentialWitness(NormalProtocolConformance *conformance,
   // Describe why the witness didn't satisfy the requirement.
   WitnessChecker::RequirementEnvironmentCache oneUseCache;
   auto dc = conformance->getDeclContext();
-  // FIXME: Remove dependnecy on the lazy resolver.
+  // FIXME: Remove dependency on the lazy resolver.
   auto *TC = static_cast<TypeChecker *>(req->getASTContext().getLazyResolver());
   auto match = matchWitness(*TC, oneUseCache, conformance->getProtocol(),
                             conformance, dc, req, witness);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -293,10 +293,10 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
     for (unsigned i = 0; i != TC.ConformanceContexts.size(); ++i) {
       auto decl = TC.ConformanceContexts[i];
       if (auto *ext = dyn_cast<ExtensionDecl>(decl))
-        TC.checkConformancesInContext(ext, ext);
+        TypeChecker::checkConformancesInContext(ext, ext);
       else {
         auto *ntd = cast<NominalTypeDecl>(decl);
-        TC.checkConformancesInContext(ntd, ntd);
+        TypeChecker::checkConformancesInContext(ntd, ntd);
 
         // Finally, we can check classes for missing initializers.
         if (auto *classDecl = dyn_cast<ClassDecl>(ntd))

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1015,10 +1015,6 @@ public:
   static Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
                                           ReferenceOwnershipAttr *attr);
 
-  virtual void resolveImplicitConstructors(NominalTypeDecl *nominal) override {
-    addImplicitConstructors(nominal);
-  }
-
   virtual void resolveImplicitMember(NominalTypeDecl *nominal, DeclName member) override {
     synthesizeMemberForLookup(nominal, member);
   }
@@ -1524,11 +1520,11 @@ public:
   };
 
   /// Completely check the given conformance.
-  void checkConformance(NormalProtocolConformance *conformance);
+  static void checkConformance(NormalProtocolConformance *conformance);
 
   /// Check all of the conformances in the given context.
-  void checkConformancesInContext(DeclContext *dc,
-                                  IterableDeclContext *idc);
+  static void checkConformancesInContext(DeclContext *dc,
+                                         IterableDeclContext *idc);
 
   /// Check that the type of the given property conforms to NSCopying.
   static ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var);


### PR DESCRIPTION
Between this and #28009, only `LazyResolver::resolveImplicitMember` exists and will soon be requestified away.

To facilitate its speedy demise, drop the TypeChecker dependency out of the multi-conformance checker and fold `resolveImplicitConstructors` into `resolveImplicitMember`.