### PR TITLE
SILCombine cleanup; replace null check with dyn_cast_or_null.

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -907,8 +907,8 @@ SILCombiner::buildConcreteOpenedExistentialInfoFromSoleConformingType(
         (archetypeTy->getConformsTo().size() == 1)) {
       PD = archetypeTy->getConformsTo()[0];
     } else if (ArgType.isExistentialType() && !ArgType.isAnyObject() &&
-               !SwiftArgType->isAny() && SwiftArgType->getAnyNominal()) {
-      PD = dyn_cast<ProtocolDecl>(SwiftArgType->getAnyNominal());
+               !SwiftArgType->isAny()) {
+      PD = dyn_cast_or_null<ProtocolDecl>(SwiftArgType->getAnyNominal());
     }
   }
 

--- a/validation-test/compiler_crashers_2_fixed/sr11624.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11624.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -O -whole-module-optimization
+// RUN: %target-swift-frontend %s -O -whole-module-optimization -emit-sil
 
 class ClassA<T> { }
 protocol ProtocolA { }


### PR DESCRIPTION
Remove 'not' and add '-emit-sil' to the corresponding lit test's run line.