### PR TITLE
[Diagnostics] Resolve SR-11677: Offer a better diagnostic when && is …

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1524,6 +1524,8 @@ ERROR(expected_generics_type_restriction,none,
       (Identifier))
 ERROR(requires_single_equal,none,
       "use '==' for same-type requirements rather than '='", ())
+ERROR(requires_comma,none,
+      "expected ',' to separate the requirements of this 'where' clause", ())
 ERROR(expected_requirement_delim,none,
       "expected ':' or '==' to indicate a conformance or same-type requirement",
       ())

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -368,6 +368,13 @@ ParserStatus Parser::parseGenericWhereClause(
     BodyContext.reset();
     HasNextReq = consumeIf(tok::comma);
     // If there's a comma, keep parsing the list.
+    // If there's a "&&", diagnose replace with a comma and keep parsing
+    if (Tok.isBinaryOperator() && Tok.getText() == "&&" && !HasNextReq) {
+      diagnose(Tok, diag::requires_comma)
+        .fixItReplace(SourceRange(Tok.getLoc()), ",");
+      consumeToken();
+      HasNextReq = true;
+    }
   } while (HasNextReq);
 
   if (Requirements.empty())

--- a/test/Parse/rdar38225184.swift
+++ b/test/Parse/rdar38225184.swift
@@ -1,0 +1,4 @@
+// RUN: %target-typecheck-verify-swift
+
+extension Collection where Element == Int && Index == Int {}
+// expected-error@-1 {{expected ',' to separate the requirements of this 'where' clause}} {{43-45=,}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add a `&&` checker and improve the diagnostic to remind developer replacing `&&` with comma instead of garbage diagnostics.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-11677](https://bugs.swift.org/browse/SR-11677)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
