### PR TITLE
[IRGen] NFC: Add operator<< for MetadataResponse

### DIFF
--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -372,6 +372,18 @@ public:
   static llvm::Constant *getCompletedState(IRGenModule &IGM);
 };
 
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                                     const MetadataResponse &MR) {
+  if (!MR.isValid())
+    return OS;
+  OS << MR.getMetadata();
+  if (MR.hasDynamicState())
+    OS << MR.getDynamicState();
+  // FIXME
+  // OS << MR.getStaticLowerBoundOnState();
+  return OS;
+}
+
 inline bool
 DynamicMetadataRequest::isSatisfiedBy(MetadataResponse response) const {
   return isSatisfiedBy(response.getStaticLowerBoundOnState());


### PR DESCRIPTION
Newer versions of clang are more reliable about emitting "used" functions, but that means that newer versions of clang can break the build if the dependencies of a "used" function aren't satisfied.