### PR TITLE
[NameLookup, ASTScope] Fix boundary condition test in scope search.

### DIFF
--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -157,8 +157,8 @@ ASTScopeImpl::findChildContaining(SourceLoc loc,
     }
     bool operator()(SourceLoc loc, const ASTScopeImpl *scope) {
       ASTScopeAssert(scope->checkSourceRangeOfThisASTNode(), "Bad range.");
-      return sourceMgr.isBeforeInBuffer(loc,
-                                        scope->getSourceRangeOfScope().End);
+      return !sourceMgr.isBeforeInBuffer(scope->getSourceRangeOfScope().End,
+                                         loc);
     }
   };
   auto *const *child = std::lower_bound(


### PR DESCRIPTION
The comparator used for the binary search at each node in the scope lookup tree had an incorrect boundary condition.
