### PR TITLE
Don't unnecessarily force InterfaceTypeRequest

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -923,13 +923,8 @@ static FuncDecl *findLibraryIntrinsic(const ASTContext &ctx,
                                       StringRef name) {
   SmallVector<ValueDecl *, 1> results;
   ctx.lookupInSwiftModule(name, results);
-  if (results.size() == 1) {
-    if (auto FD = dyn_cast<FuncDecl>(results.front())) {
-      // FIXME(InterfaceTypeRequest): Remove this.
-      (void)FD->getInterfaceType();
-      return FD;
-    }
-  }
+  if (results.size() == 1)
+    return dyn_cast_or_null<FuncDecl>(results.front());
   return nullptr;
 }
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2969,15 +2969,8 @@ public:
     void verifyChecked(AbstractFunctionDecl *AFD) {
       PrettyStackTraceDecl debugStack("verifying AbstractFunctionDecl", AFD);
 
-      if (!AFD->hasInterfaceType()) {
-        if (isa<AccessorDecl>(AFD) && AFD->isImplicit())
-          return;
-
-        Out << "All functions except implicit accessors should be "
-               "validated by now\n";
-        AFD->dump(Out);
-        abort();
-      }
+      if (!AFD->hasInterfaceType())
+        return;
 
       // If this function is generic or is within a generic context, it should
       // have an interface type.

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -17,10 +17,8 @@
 #include "swift/AST/Builtins.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/FileUnit.h"
-#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
-#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/LLVMContext.h"
 #include "swift/Strings.h"
 #include "llvm/ADT/SmallString.h"
@@ -176,7 +174,6 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType) {
                              /*GenericParams=*/nullptr,
                              paramList,
                              TypeLoc::withoutLoc(ResType), DC);
-  (void)FD->getInterfaceType();
   FD->setImplicit();
   FD->setAccess(AccessLevel::Public);
   return FD;
@@ -187,8 +184,7 @@ static FuncDecl *
 getBuiltinGenericFunction(Identifier Id,
                           ArrayRef<AnyFunctionType::Param> ArgParamTypes,
                           Type ResType,
-                          GenericParamList *GenericParams,
-                          GenericSignature Sig) {
+                          GenericParamList *GenericParams) {
   assert(GenericParams && "Missing generic parameters");
   auto &Context = ResType->getASTContext();
 
@@ -222,8 +218,6 @@ getBuiltinGenericFunction(Identifier Id,
                                paramList,
                                TypeLoc::withoutLoc(ResType), DC);
 
-  func->setGenericSignature(Sig);
-  (void)func->getInterfaceType();
   func->setImplicit();
   func->setAccess(AccessLevel::Public);
 
@@ -431,11 +425,10 @@ createGenericParam(ASTContext &ctx, const char *name, unsigned index) {
 
 /// Create a generic parameter list with multiple generic parameters.
 static GenericParamList *getGenericParams(ASTContext &ctx,
-                                          unsigned numParameters,
-                       SmallVectorImpl<GenericTypeParamDecl*> &genericParams) {
+                                          unsigned numParameters) {
   assert(numParameters <= llvm::array_lengthof(GenericParamNames));
-  assert(genericParams.empty());
 
+  SmallVector<GenericTypeParamDecl*, 2> genericParams;
   for (unsigned i = 0; i != numParameters; ++i)
     genericParams.push_back(createGenericParam(ctx, GenericParamNames[i], i));
 
@@ -445,34 +438,19 @@ static GenericParamList *getGenericParams(ASTContext &ctx,
 }
 
 namespace {
-  class BuiltinGenericSignatureBuilder {
+  class BuiltinFunctionBuilder {
   public:
     ASTContext &Context;
 
   private:
     GenericParamList *TheGenericParamList;
-    SmallVector<GenericTypeParamDecl*, 2> GenericTypeParams;
-    GenericSignature GenericSig = GenericSignature();
     SmallVector<AnyFunctionType::Param, 4> InterfaceParams;
     Type InterfaceResult;
 
   public:
-    BuiltinGenericSignatureBuilder(ASTContext &ctx, unsigned numGenericParams = 1)
+    BuiltinFunctionBuilder(ASTContext &ctx, unsigned numGenericParams = 1)
         : Context(ctx) {
-      TheGenericParamList = getGenericParams(ctx, numGenericParams,
-                                             GenericTypeParams);
-
-      SmallVector<GenericTypeParamType *, 2> genericParamTypes;
-      for (auto gp : GenericTypeParams) {
-        genericParamTypes.push_back(
-            gp->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
-      }
-
-      GenericSig = evaluateOrDefault(
-          ctx.evaluator,
-          AbstractGenericSignatureRequest{
-            nullptr, std::move(genericParamTypes), { }},
-          GenericSignature());
+      TheGenericParamList = getGenericParams(ctx, numGenericParams);
     }
 
     template <class G>
@@ -488,11 +466,10 @@ namespace {
       InterfaceResult = generator.build(*this);
     }
 
-    ValueDecl *build(Identifier name) {
+    FuncDecl *build(Identifier name) {
       return getBuiltinGenericFunction(name, InterfaceParams,
                                        InterfaceResult,
-                                       TheGenericParamList,
-                                       GenericSig);
+                                       TheGenericParamList);
     }
 
     // Don't use these generator classes directly; call the make{...}
@@ -500,19 +477,20 @@ namespace {
 
     struct ConcreteGenerator {
       Type TheType;
-      Type build(BuiltinGenericSignatureBuilder &builder) const {
+      Type build(BuiltinFunctionBuilder &builder) const {
         return TheType;
       }
     };
     struct ParameterGenerator {
       unsigned Index;
-      Type build(BuiltinGenericSignatureBuilder &builder) const {
-        return builder.GenericTypeParams[Index]->getDeclaredInterfaceType();
+      Type build(BuiltinFunctionBuilder &builder) const {
+        return builder.TheGenericParamList->getParams()[Index]
+            ->getDeclaredInterfaceType();
       }
     };
     struct LambdaGenerator {
-      std::function<Type(BuiltinGenericSignatureBuilder &)> TheFunction;
-      Type build(BuiltinGenericSignatureBuilder &builder) const {
+      std::function<Type(BuiltinFunctionBuilder &)> TheFunction;
+      Type build(BuiltinFunctionBuilder &builder) const {
         return TheFunction(builder);
       }
     };
@@ -520,28 +498,28 @@ namespace {
     struct MetatypeGenerator {
       T Object;
       Optional<MetatypeRepresentation> Repr;
-      Type build(BuiltinGenericSignatureBuilder &builder) const {
+      Type build(BuiltinFunctionBuilder &builder) const {
         return MetatypeType::get(Object.build(builder), Repr);
       }
     };
   };
 } // end anonymous namespace
 
-static BuiltinGenericSignatureBuilder::ConcreteGenerator
+static BuiltinFunctionBuilder::ConcreteGenerator
 makeConcrete(Type type) {
   return { type };
 }
 
-static BuiltinGenericSignatureBuilder::ParameterGenerator
+static BuiltinFunctionBuilder::ParameterGenerator
 makeGenericParam(unsigned index = 0) {
   return { index };
 }
 
 template <class... Gs>
-static BuiltinGenericSignatureBuilder::LambdaGenerator
+static BuiltinFunctionBuilder::LambdaGenerator
 makeTuple(const Gs & ...elementGenerators) {
   return {
-    [=](BuiltinGenericSignatureBuilder &builder) -> Type {
+    [=](BuiltinFunctionBuilder &builder) -> Type {
       TupleTypeElt elts[] = {
         elementGenerators.build(builder)...
       };
@@ -551,11 +529,11 @@ makeTuple(const Gs & ...elementGenerators) {
 }
 
 template <class... Gs>
-static BuiltinGenericSignatureBuilder::LambdaGenerator
+static BuiltinFunctionBuilder::LambdaGenerator
 makeBoundGenericType(NominalTypeDecl *decl,
                      const Gs & ...argumentGenerators) {
   return {
-    [=](BuiltinGenericSignatureBuilder &builder) -> Type {
+    [=](BuiltinFunctionBuilder &builder) -> Type {
       Type args[] = {
         argumentGenerators.build(builder)...
       };
@@ -565,28 +543,28 @@ makeBoundGenericType(NominalTypeDecl *decl,
 }
 
 template <class T>
-static BuiltinGenericSignatureBuilder::MetatypeGenerator<T>
+static BuiltinFunctionBuilder::MetatypeGenerator<T>
 makeMetatype(const T &object, Optional<MetatypeRepresentation> repr = None) {
   return { object, repr };
 }
 
 /// Create a function with type <T> T -> ().
 static ValueDecl *getRefCountingOperation(ASTContext &Context, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeGenericParam());
   builder.setResult(makeConcrete(TupleType::getEmpty(Context)));
   return builder.build(Id);
 }
 
 static ValueDecl *getLoadOperation(ASTContext &Context, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.setResult(makeGenericParam());
   return builder.build(Id);
 }
 
 static ValueDecl *getStoreOperation(ASTContext &Context, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeGenericParam(), ValueOwnership::Owned);
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.setResult(makeConcrete(TupleType::getEmpty(Context)));
@@ -594,7 +572,7 @@ static ValueDecl *getStoreOperation(ASTContext &Context, Identifier Id) {
 }
 
 static ValueDecl *getDestroyOperation(ASTContext &Context, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.setResult(makeConcrete(TupleType::getEmpty(Context)));
@@ -604,7 +582,7 @@ static ValueDecl *getDestroyOperation(ASTContext &Context, Identifier Id) {
 static ValueDecl *getDestroyArrayOperation(ASTContext &Context, Identifier Id) {
   auto wordType = BuiltinIntegerType::get(BuiltinIntegerWidth::pointer(),
                                           Context);
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.addParameter(makeConcrete(wordType));
@@ -615,7 +593,7 @@ static ValueDecl *getDestroyArrayOperation(ASTContext &Context, Identifier Id) {
 static ValueDecl *getTransferArrayOperation(ASTContext &Context, Identifier Id){
   auto wordType = BuiltinIntegerType::get(BuiltinIntegerWidth::pointer(),
                                           Context);
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
@@ -628,14 +606,14 @@ static ValueDecl *getIsUniqueOperation(ASTContext &Context, Identifier Id) {
   // <T> (@inout T) -> Int1
   Type Int1Ty = BuiltinIntegerType::get(1, Context);
 
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeGenericParam(), ValueOwnership::InOut);
   builder.setResult(makeConcrete(Int1Ty));
   return builder.build(Id);
 }
 
 static ValueDecl *getBindMemoryOperation(ASTContext &Context, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.addParameter(makeConcrete(BuiltinIntegerType::getWordType(Context)));
   builder.addParameter(makeMetatype(makeGenericParam()));
@@ -649,7 +627,7 @@ static ValueDecl *getAllocWithTailElemsOperation(ASTContext &Context,
   if (NumTailTypes < 1 ||
       1 + NumTailTypes > (int)llvm::array_lengthof(GenericParamNames))
     return nullptr;
-  BuiltinGenericSignatureBuilder builder(Context, 1 + NumTailTypes);
+  BuiltinFunctionBuilder builder(Context, 1 + NumTailTypes);
   builder.addParameter(makeMetatype(makeGenericParam(0)));
   for (int Idx = 0; Idx < NumTailTypes; ++Idx) {
     builder.addParameter(makeConcrete(BuiltinIntegerType::getWordType(Context)));
@@ -661,7 +639,7 @@ static ValueDecl *getAllocWithTailElemsOperation(ASTContext &Context,
 
 static ValueDecl *getProjectTailElemsOperation(ASTContext &Context,
                                                Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context, 2);
+  BuiltinFunctionBuilder builder(Context, 2);
   builder.addParameter(makeGenericParam(0));
   builder.addParameter(makeMetatype(makeGenericParam(1)));
   builder.setResult(makeConcrete(Context.TheRawPointerType));
@@ -671,7 +649,7 @@ static ValueDecl *getProjectTailElemsOperation(ASTContext &Context,
 /// Build a getelementptr operation declaration.
 static ValueDecl *getGepOperation(ASTContext &Context, Identifier Id,
                                   Type ArgType) {
-  BuiltinGenericSignatureBuilder builder(Context, 1);
+  BuiltinFunctionBuilder builder(Context, 1);
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.addParameter(makeConcrete(ArgType));
   builder.addParameter(makeMetatype(makeGenericParam(0)));
@@ -681,7 +659,7 @@ static ValueDecl *getGepOperation(ASTContext &Context, Identifier Id,
 
 static ValueDecl *getGetTailAddrOperation(ASTContext &Context, Identifier Id,
                                           Type ArgType) {
-  BuiltinGenericSignatureBuilder builder(Context, 2);
+  BuiltinFunctionBuilder builder(Context, 2);
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.addParameter(makeConcrete(ArgType));
   builder.addParameter(makeMetatype(makeGenericParam(0)));
@@ -692,7 +670,7 @@ static ValueDecl *getGetTailAddrOperation(ASTContext &Context, Identifier Id,
 
 static ValueDecl *getBeginUnpairedAccessOperation(ASTContext &Context,
                                                   Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.addParameter(makeMetatype(makeGenericParam(0)));
@@ -703,7 +681,7 @@ static ValueDecl *getBeginUnpairedAccessOperation(ASTContext &Context,
 static ValueDecl *
 getPerformInstantaneousReadAccessOperation(ASTContext &Context,
                                            Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeConcrete(Context.TheRawPointerType));
   builder.addParameter(makeMetatype(makeGenericParam(0)));
   builder.setResult(makeConcrete(Context.TheEmptyTupleType));
@@ -717,35 +695,35 @@ static ValueDecl *getEndUnpairedAccessOperation(ASTContext &Context,
 }
 static ValueDecl *getSizeOrAlignOfOperation(ASTContext &Context,
                                             Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.setResult(makeConcrete(BuiltinIntegerType::getWordType(Context)));
   return builder.build(Id);
 }
 
 static ValueDecl *getIsPODOperation(ASTContext &Context, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.setResult(makeConcrete(BuiltinIntegerType::get(1,Context)));
   return builder.build(Id);
 }
 
 static ValueDecl *getIsConcrete(ASTContext &Context, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.setResult(makeConcrete(BuiltinIntegerType::get(1,Context)));
   return builder.build(Id);
 }
 
 static ValueDecl *getIsBitwiseTakable(ASTContext &Context, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.setResult(makeConcrete(BuiltinIntegerType::get(1,Context)));
   return builder.build(Id);
 }
 
 static ValueDecl *getIsOptionalOperation(ASTContext &Context, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.setResult(makeConcrete(BuiltinIntegerType::get(1,Context)));
   return builder.build(Id);
@@ -832,7 +810,7 @@ static ValueDecl *getNativeObjectCast(ASTContext &Context, Identifier Id,
     llvm_unreachable("unexpected kind");
   }
 
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   if (BV == BuiltinValueKind::CastToNativeObject ||
       BV == BuiltinValueKind::UnsafeCastToNativeObject ||
       BV == BuiltinValueKind::BridgeToRawPointer) {
@@ -849,7 +827,7 @@ static ValueDecl *getCastToBridgeObjectOperation(ASTContext &C,
                                                  Identifier Id) {
   auto wordType = BuiltinIntegerType::get(BuiltinIntegerWidth::pointer(),
                                           C);
-  BuiltinGenericSignatureBuilder builder(C);
+  BuiltinFunctionBuilder builder(C);
   builder.addParameter(makeGenericParam(), ValueOwnership::Owned);
   builder.addParameter(makeConcrete(wordType));
   builder.setResult(makeConcrete(C.TheBridgeObjectType));
@@ -862,7 +840,7 @@ static ValueDecl *getCastFromBridgeObjectOperation(ASTContext &C,
   Type BridgeTy = C.TheBridgeObjectType;
   switch (BV) {
   case BuiltinValueKind::CastReferenceFromBridgeObject: {
-    BuiltinGenericSignatureBuilder builder(C);
+    BuiltinFunctionBuilder builder(C);
     builder.addParameter(makeConcrete(BridgeTy), ValueOwnership::Owned);
     builder.setResult(makeGenericParam());
     return builder.build(Id);
@@ -891,7 +869,7 @@ static ValueDecl *getClassifyBridgeObject(ASTContext &C, Identifier Id) {
 }
 
 static ValueDecl *getValueToBridgeObject(ASTContext &C, Identifier Id) {
-  BuiltinGenericSignatureBuilder builder(C);
+  BuiltinFunctionBuilder builder(C);
   builder.addParameter(makeGenericParam(0));
   builder.setResult(makeConcrete(C.TheBridgeObjectType));
   return builder.build(Id);
@@ -900,7 +878,7 @@ static ValueDecl *getValueToBridgeObject(ASTContext &C, Identifier Id) {
 static ValueDecl *getUnsafeGuaranteed(ASTContext &C, Identifier Id) {
   // <T : AnyObject> T -> (T, Int8Ty)
   //
-  BuiltinGenericSignatureBuilder builder(C);
+  BuiltinFunctionBuilder builder(C);
   auto T = makeGenericParam();
   builder.addParameter(T);
   Type Int8Ty = BuiltinIntegerType::get(8, C);
@@ -922,7 +900,7 @@ static ValueDecl *getCastReferenceOperation(ASTContext &ctx,
                                             Identifier name) {
   // <T, U> T -> U
   // SILGen and IRGen check additional constraints during lowering.
-  BuiltinGenericSignatureBuilder builder(ctx, 2);
+  BuiltinFunctionBuilder builder(ctx, 2);
   builder.addParameter(makeGenericParam(0), ValueOwnership::Owned);
   builder.setResult(makeGenericParam(1));
   return builder.build(name);
@@ -932,7 +910,7 @@ static ValueDecl *getReinterpretCastOperation(ASTContext &ctx,
                                               Identifier name) {
   // <T, U> T -> U
   // SILGen and IRGen check additional constraints during lowering.
-  BuiltinGenericSignatureBuilder builder(ctx, 2);
+  BuiltinFunctionBuilder builder(ctx, 2);
   builder.addParameter(makeGenericParam(0), ValueOwnership::Owned);
   builder.setResult(makeGenericParam(1));
   return builder.build(name);
@@ -941,7 +919,7 @@ static ValueDecl *getReinterpretCastOperation(ASTContext &ctx,
 static ValueDecl *getZeroInitializerOperation(ASTContext &Context,
                                              Identifier Id) {
   // <T> () -> T
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.setResult(makeGenericParam());
   return builder.build(Id);
 }
@@ -949,7 +927,7 @@ static ValueDecl *getZeroInitializerOperation(ASTContext &Context,
 static ValueDecl *getGetObjCTypeEncodingOperation(ASTContext &Context,
                                                   Identifier Id) {
   // <T> T.Type -> RawPointer
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.setResult(makeConcrete(Context.TheRawPointerType));
   return builder.build(Id);
@@ -972,7 +950,7 @@ static ValueDecl *getPoundAssert(ASTContext &Context, Identifier Id) {
 
 static ValueDecl *getTSanInoutAccess(ASTContext &Context, Identifier Id) {
   // <T> T -> ()
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeGenericParam());
   builder.setResult(makeConcrete(Context.TheEmptyTupleType));
   return builder.build(Id);
@@ -980,7 +958,7 @@ static ValueDecl *getTSanInoutAccess(ASTContext &Context, Identifier Id) {
 
 static ValueDecl *getAddressOfOperation(ASTContext &Context, Identifier Id) {
   // <T> (@inout T) -> RawPointer
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeGenericParam(), ValueOwnership::InOut);
   builder.setResult(makeConcrete(Context.TheRawPointerType));
   return builder.build(Id);
@@ -989,7 +967,7 @@ static ValueDecl *getAddressOfOperation(ASTContext &Context, Identifier Id) {
 static ValueDecl *getAddressOfBorrowOperation(ASTContext &Context,
                                               Identifier Id) {
   // <T> (T) -> RawPointer
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeGenericParam());
   builder.setResult(makeConcrete(Context.TheRawPointerType));
   return builder.build(Id);
@@ -997,7 +975,7 @@ static ValueDecl *getAddressOfBorrowOperation(ASTContext &Context,
 
 static ValueDecl *getTypeJoinOperation(ASTContext &Context, Identifier Id) {
   // <T,U,V> (T.Type, U.Type) -> V.Type
-  BuiltinGenericSignatureBuilder builder(Context, 3);
+  BuiltinFunctionBuilder builder(Context, 3);
   builder.addParameter(makeMetatype(makeGenericParam(0)));
   builder.addParameter(makeMetatype(makeGenericParam(1)));
   builder.setResult(makeMetatype(makeGenericParam(2)));
@@ -1007,7 +985,7 @@ static ValueDecl *getTypeJoinOperation(ASTContext &Context, Identifier Id) {
 static ValueDecl *getTypeJoinInoutOperation(ASTContext &Context,
                                             Identifier Id) {
   // <T,U,V> (inout T, U.Type) -> V.Type
-  BuiltinGenericSignatureBuilder builder(Context, 3);
+  BuiltinFunctionBuilder builder(Context, 3);
   builder.addParameter(makeGenericParam(0), ValueOwnership::InOut);
   builder.addParameter(makeMetatype(makeGenericParam(1)));
   builder.setResult(makeMetatype(makeGenericParam(2)));
@@ -1016,7 +994,7 @@ static ValueDecl *getTypeJoinInoutOperation(ASTContext &Context,
 
 static ValueDecl *getTypeJoinMetaOperation(ASTContext &Context, Identifier Id) {
   // <T,U,V> (T.Type, U.Type) -> V.Type
-  BuiltinGenericSignatureBuilder builder(Context, 3);
+  BuiltinFunctionBuilder builder(Context, 3);
   builder.addParameter(makeMetatype(makeGenericParam(0)));
   builder.addParameter(makeMetatype(makeGenericParam(1)));
   builder.setResult(makeMetatype(makeGenericParam(2)));
@@ -1032,7 +1010,7 @@ static ValueDecl *getTriggerFallbackDiagnosticOperation(ASTContext &Context,
 static ValueDecl *getCanBeObjCClassOperation(ASTContext &Context,
                                              Identifier Id) {
   // <T> T.Type -> Builtin.Int8
-  BuiltinGenericSignatureBuilder builder(Context);
+  BuiltinFunctionBuilder builder(Context);
   builder.addParameter(makeMetatype(makeGenericParam()));
   builder.setResult(makeConcrete(BuiltinIntegerType::get(8, Context)));
   return builder.build(Id);
@@ -1061,7 +1039,7 @@ static ValueDecl *getAssertConfOperation(ASTContext &C, Identifier Id) {
 
 static ValueDecl *getFixLifetimeOperation(ASTContext &C, Identifier Id) {
   // <T> T -> ()
-  BuiltinGenericSignatureBuilder builder(C);
+  BuiltinFunctionBuilder builder(C);
   builder.addParameter(makeGenericParam());
   builder.setResult(makeConcrete(TupleType::getEmpty(C)));
   return builder.build(Id);
@@ -1176,7 +1154,7 @@ static ValueDecl *getOnceOperation(ASTContext &Context,
 
 static ValueDecl *getPolymorphicBinaryOperation(ASTContext &ctx,
                                                 Identifier id) {
-  BuiltinGenericSignatureBuilder builder(ctx);
+  BuiltinFunctionBuilder builder(ctx);
   builder.addParameter(makeGenericParam());
   builder.addParameter(makeGenericParam());
   builder.setResult(makeGenericParam());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4043,9 +4043,6 @@ GetDestructorRequest::evaluate(Evaluator &evaluator, ClassDecl *CD) const {
   if (ctx.LangOpts.EnableObjCInterop)
     CD->recordObjCMethod(DD, DD->getObjCSelector());
 
-  // Assign DD the interface type (Self) -> () -> ()
-  (void)DD->getInterfaceType();
-
   return DD;
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -540,8 +540,6 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
                             /*GenericParams=*/nullptr, enumDecl);
   ctorDecl->setImplicit();
   ctorDecl->setAccess(AccessLevel::Public);
-
-  (void)ctorDecl->getInterfaceType();
   ctorDecl->setBodySynthesizer(synthesizeEnumRawValueConstructorBody, enumDecl);
   return ctorDecl;
 }
@@ -616,8 +614,6 @@ static void makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
   getterDecl->setIsTransparent(false);
-
-  (void)getterDecl->getInterfaceType();
 
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setBodySynthesizer(synthesizeEnumRawValueGetterBody, enumDecl);
@@ -698,8 +694,6 @@ static AccessorDecl *makeStructRawValueGetter(
   getterDecl->setIsDynamic(false);
   getterDecl->setIsTransparent(false);
 
-  (void)getterDecl->getInterfaceType();
-
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setBodySynthesizer(synthesizeStructRawValueGetterBody, storedVar);
   return getterDecl;
@@ -728,8 +722,6 @@ static AccessorDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
-
-  (void)getterDecl->getInterfaceType();
 
   return getterDecl;
 }
@@ -764,8 +756,6 @@ static AccessorDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
   setterDecl->setIsDynamic(false);
   setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
   setterDecl->setAccess(AccessLevel::Public);
-
-  (void)setterDecl->getInterfaceType();
 
   return setterDecl;
 }
@@ -1308,9 +1298,6 @@ createDefaultConstructor(ClangImporter::Implementation &Impl,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), emptyPL,
       /*GenericParams=*/nullptr, structDecl);
 
-  // Set the constructor's type.
-  (void)constructor->getInterfaceType();
-
   constructor->setAccess(AccessLevel::Public);
 
   // Mark the constructor transparent so that we inline it away completely.
@@ -1436,9 +1423,6 @@ createValueConstructor(ClangImporter::Implementation &Impl,
       /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), paramList,
       /*GenericParams=*/nullptr, structDecl);
-
-  // Set the constructor's type.
-  (void)constructor->getInterfaceType();
 
   constructor->setAccess(AccessLevel::Public);
 
@@ -1714,8 +1698,6 @@ buildSubscriptGetterDecl(ClangImporter::Implementation &Impl,
                      TypeLoc::withoutLoc(elementTy), dc,
                      getter->getClangNode());
 
-  (void)thunk->getInterfaceType();
-
   thunk->setAccess(getOverridableAccessLevel(dc));
 
   if (auto objcAttr = getter->getAttrs().getAttribute<ObjCAttr>())
@@ -1767,7 +1749,6 @@ buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
                      valueIndicesPL,
                      TypeLoc::withoutLoc(TupleType::getEmpty(C)), dc,
                      setter->getClangNode());
-  (void)thunk->getInterfaceType();
 
   thunk->setAccess(getOverridableAccessLevel(dc));
 
@@ -1952,7 +1933,6 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
                      /*GenericParams=*/nullptr,
                      params,
                      TypeLoc::withoutLoc(stringTy), swiftDecl);
-  (void)getterDecl->getInterfaceType();
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
   getterDecl->setIsTransparent(false);
@@ -3733,7 +3713,6 @@ namespace {
 
       result->setIsObjC(false);
       result->setIsDynamic(false);
-      (void)result->getInterfaceType();
 
       Impl.recordImplicitUnwrapForDecl(result,
                                        importedType.isImplicitlyUnwrapped());
@@ -4315,9 +4294,6 @@ namespace {
         result->setStatic();
       if (forceClassMethod)
         result->setImplicit();
-
-      // Compute the interface type.
-      (void)result->getInterfaceType();
 
       Impl.recordImplicitUnwrapForDecl(result, isIUO);
 
@@ -5855,8 +5831,6 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
                                                 std::move(initKind));
   result->setImportAsStaticMember();
 
-  // Set the constructor's type.
-  (void)result->getInterfaceType();
   Impl.recordImplicitUnwrapForDecl(result,
                                    importedType.isImplicitlyUnwrapped());
   result->setOverriddenDecls({ });
@@ -6334,9 +6308,6 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
       /*GenericParams=*/nullptr, dc);
 
   addObjCAttribute(result, selector);
-
-  // Calculate the function type of the result.
-  (void)result->getInterfaceType();
 
   Impl.recordImplicitUnwrapForDecl(result,
                                    importedType.isImplicitlyUnwrapped());
@@ -8378,7 +8349,6 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
                      params,
                      TypeLoc::withoutLoc(type), dc);
   func->setStatic(isStatic);
-  (void)func->getInterfaceType();
   func->setAccess(getOverridableAccessLevel(dc));
   func->setIsObjC(false);
   func->setIsDynamic(false);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -685,7 +685,6 @@ createDesignatedInitOverride(ClassDecl *classDecl,
 
   // Set the interface type of the initializer.
   ctor->setGenericSignature(genericSig);
-  (void)ctor->getInterfaceType();
 
   ctor->setImplicitlyUnwrappedOptional(
     superclassCtor->isImplicitlyUnwrappedOptional());

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -738,8 +738,6 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
     encodeDecl->getAttrs().add(attr);
   }
 
-  (void)encodeDecl->getInterfaceType();
-
   encodeDecl->copyFormalAccessFrom(derived.Nominal,
                                    /*sourceIsParentContext*/ true);
 
@@ -1017,8 +1015,6 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
     auto *reqAttr = new (C) RequiredAttr(/*IsImplicit=*/true);
     initDecl->getAttrs().add(reqAttr);
   }
-
-  (void)initDecl->getInterfaceType();
 
   initDecl->copyFormalAccessFrom(derived.Nominal,
                                  /*sourceIsParentContext*/ true);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -143,9 +143,6 @@ static ValueDecl *deriveInitDecl(DerivedConformance &derived, Type paramType,
   // Synthesize the body.
   synthesizer(initDecl);
 
-  // Compute the interface type of the initializer.
-  (void)initDecl->getInterfaceType();
-
   initDecl->setAccess(derived.Nominal->getFormalAccess());
 
   C.addSynthesizedDecl(initDecl);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -767,9 +767,6 @@ deriveEquatable_eq(
 
   eqDecl->setBodySynthesizer(bodySynthesizer);
 
-  // Compute the interface type.
-  (void)eqDecl->getInterfaceType();
-
   eqDecl->copyFormalAccessFrom(derived.Nominal, /*sourceIsParentContext*/ true);
 
   C.addSynthesizedDecl(eqDecl);
@@ -891,7 +888,6 @@ deriveHashable_hashInto(
   hashDecl->setImplicit();
   hashDecl->setBodySynthesizer(bodySynthesizer);
 
-  (void)hashDecl->getInterfaceType();
   hashDecl->copyFormalAccessFrom(derived.Nominal);
 
   C.addSynthesizedDecl(hashDecl);
@@ -1237,9 +1233,6 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   getterDecl->setImplicit();
   getterDecl->setBodySynthesizer(&deriveBodyHashable_hashValue);
   getterDecl->setIsTransparent(false);
-
-  // Compute the interface type of hashValue().
-  (void)getterDecl->getInterfaceType();
 
   getterDecl->copyFormalAccessFrom(derived.Nominal,
                                    /*sourceIsParentContext*/ true);

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -428,9 +428,6 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
   initDecl->setImplicit();
   initDecl->setBodySynthesizer(&deriveBodyRawRepresentable_init);
 
-  // Compute the interface type of the initializer.
-  (void)initDecl->getInterfaceType();
-
   initDecl->copyFormalAccessFrom(enumDecl, /*sourceIsParentContext*/true);
 
   // If the containing module is not resilient, make sure clients can construct

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -309,9 +309,6 @@ DerivedConformance::declareDerivedPropertyGetter(VarDecl *property,
   getterDecl->setImplicit();
   getterDecl->setIsTransparent(false);
 
-  // Compute the interface type of the getter.
-  (void)getterDecl->getInterfaceType();
-
   getterDecl->copyFormalAccessFrom(property);
 
   C.addSynthesizedDecl(getterDecl);

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -282,9 +282,6 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
       if (D->isRecursiveValidation())
         return;
 
-      // FIXME: This is used to compute isInvalid() below.
-      (void) D->getInterfaceType();
-
       switch (D->getKind()) {
 #define DECL(ID, SUPER) \
       case DeclKind::ID:
@@ -430,8 +427,6 @@ static void lookupDeclsFromProtocolsBeingConformedTo(
           continue;
         }
         if (auto *VD = dyn_cast<ValueDecl>(Member)) {
-          // FIXME(InterfaceTypeRequest): Remove this.
-          (void)VD->getInterfaceType();
           if (auto *TypeResolver = VD->getASTContext().getLazyResolver()) {
             if (!NormalConformance->hasWitness(VD) &&
                 (Conformance->getDeclContext()->getParentSourceFile() !=

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1071,8 +1071,6 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
   //    `ExpressibleByStringLiteral`.
   //    `D.Value` and the return type can be arbitrary.
 
-  // FIXME(InterfaceTypeRequest): Remove this.
-  (void)decl->getInterfaceType();
   auto paramList = decl->getParameters();
   if (paramList->size() != 1 || paramList->get(0)->isVariadic()) return false;
   auto argType = paramList->get(0)->getType();
@@ -1242,8 +1240,6 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
     auto oneCandidate = candidates.front().getValueDecl();
     candidates.filter([&](LookupResultEntry entry, bool isOuter) -> bool {
       auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-      // FIXME(InterfaceTypeRequest): Remove this.
-      (void)cand->getInterfaceType();
       return isValidDynamicMemberLookupSubscript(cand, decl);
     });
 
@@ -1266,8 +1262,6 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   // Validate the candidates while ignoring the label.
   newCandidates.filter([&](const LookupResultEntry entry, bool isOuter) {
     auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-    // FIXME(InterfaceTypeRequest): Remove this.
-    (void)cand->getInterfaceType();
     return isValidDynamicMemberLookupSubscript(cand, decl,
                                                /*ignoreLabel*/ true);
   });
@@ -2111,9 +2105,6 @@ static Type getDynamicComparisonType(ValueDecl *value) {
   }
 
   auto interfaceType = value->getInterfaceType();
-  if (!interfaceType)
-    return ErrorType::get(value->getASTContext());
-
   return interfaceType->removeArgumentLabels(numArgumentLabels);
 }
 
@@ -2177,8 +2168,6 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
 
   assert(!isa<FuncDecl>(results[0]));
   
-  // FIXME(InterfaceTypeRequest): Remove this.
-  (void)results[0]->getInterfaceType();
   auto *origStorage = cast<AbstractStorageDecl>(results[0]);
   if (!origStorage->isDynamic()) {
     Diags.diagnose(attr->getLocation(),
@@ -2194,8 +2183,6 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
   if (!origAccessor)
     return nullptr;
 
-  // FIXME(InterfaceTypeRequest): Remove this.
-  (void)origAccessor->getInterfaceType();
   if (origAccessor->isImplicit() &&
       !(origStorage->getReadImpl() == ReadImplKind::Stored &&
         origStorage->getWriteImpl() == WriteImplKind::Stored)) {
@@ -2348,8 +2335,6 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
       if (attr->isInvalid())
         return;
 
-      // FIXME(InterfaceTypeRequest): Remove this.
-      (void)accessor->getInterfaceType();
        auto *orig = findReplacedAccessor(attr->getReplacedFunctionName(),
                                          accessor, attr, Ctx);
        if (!orig)

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -229,7 +229,7 @@ static bool containsDeclRefKind(LookupResult &lookupResult,
                                 DeclRefKind refKind) {
   for (auto candidate : lookupResult) {
     ValueDecl *D = candidate.getValueDecl();
-    if (!D || !D->hasInterfaceType())
+    if (!D)
       continue;
     if (matchesDeclRefKind(D, refKind))
       return true;

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -487,8 +487,7 @@ bool swift::isRepresentableInObjC(
 
   // If you change this function, you must add or modify a test in PrintAsObjC.
   ASTContext &ctx = AFD->getASTContext();
-  // FIXME(InterfaceTypeRequest): Remove this.
-  (void)AFD->getInterfaceType();
+
   bool Diagnose = shouldDiagnoseObjCReason(Reason, ctx);
 
   if (checkObjCInForeignClassContext(AFD, Reason))
@@ -980,50 +979,6 @@ Type TypeChecker::getObjCSelectorType(DeclContext *dc) {
                                   Context.Id_ObjectiveC,
                                   Context.Id_Selector,
                                   dc);
-}
-
-#pragma mark Bridging support
-
-/// Check runtime functions responsible for implicit bridging of Objective-C
-/// types.
-static void checkObjCBridgingFunctions(ModuleDecl *mod,
-                                       StringRef bridgedTypeName,
-                                       StringRef forwardConversion,
-                                       StringRef reverseConversion) {
-  assert(mod);
-  SmallVector<ValueDecl *, 4> results;
-
-  auto &ctx = mod->getASTContext();
-  mod->lookupValue(ctx.getIdentifier(bridgedTypeName),
-                   NLKind::QualifiedLookup, results);
-  mod->lookupValue(ctx.getIdentifier(forwardConversion),
-                   NLKind::QualifiedLookup, results);
-  mod->lookupValue(ctx.getIdentifier(reverseConversion),
-                   NLKind::QualifiedLookup, results);
-
-  for (auto D : results) {
-    // FIXME(InterfaceTypeRequest): Remove this.
-    (void)D->getInterfaceType();
-  }
-}
-
-void swift::checkBridgedFunctions(ASTContext &ctx) {
-  #define BRIDGE_TYPE(BRIDGED_MOD, BRIDGED_TYPE, _, NATIVE_TYPE, OPT) \
-  Identifier ID_##BRIDGED_MOD = ctx.getIdentifier(#BRIDGED_MOD);\
-  if (ModuleDecl *module = ctx.getLoadedModule(ID_##BRIDGED_MOD)) {\
-    checkObjCBridgingFunctions(module, #BRIDGED_TYPE, \
-    "_convert" #BRIDGED_TYPE "To" #NATIVE_TYPE, \
-    "_convert" #NATIVE_TYPE "To" #BRIDGED_TYPE); \
-  }
-  #include "swift/SIL/BridgedTypes.def"
-
-  if (ModuleDecl *module = ctx.getLoadedModule(ctx.Id_Foundation)) {
-    checkObjCBridgingFunctions(module,
-                               ctx.getSwiftName(
-                                 KnownFoundationEntity::NSError),
-                               "_convertNSErrorToError",
-                               "_convertErrorToNSError");
-  }
 }
 
 #pragma mark "@objc declaration handling"

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -135,11 +135,6 @@ bool isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason);
 /// Check whether the given declaration can be represented in Objective-C.
 bool canBeRepresentedInObjC(const ValueDecl *decl);
 
-/// Check that specific, known bridging functions are fully type-checked.
-///
-/// NOTE: This is only here to support the --enable-source-import hack.
-void checkBridgedFunctions(ASTContext &ctx);
-
 /// Attach Fix-Its to the given diagnostic that updates the name of the
 /// given declaration to the desired target name.
 ///

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -546,8 +546,6 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   }
 
   // Compute the type of the property to plug in to the wrapper type.
-  // FIXME(InterfaceTypeRequest): Remove this.
-  (void)var->getInterfaceType();
   Type propertyType = var->getType();
   if (!propertyType || propertyType->hasError())
     return Type();

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2065,9 +2065,6 @@ TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
   if (tc.DebugTimeFunctionBodies || tc.WarnLongFunctionBodies)
     timer.emplace(AFD, tc.DebugTimeFunctionBodies, tc.WarnLongFunctionBodies);
 
-  // FIXME(InterfaceTypeRequest): Remove this.
-  (void)AFD->getInterfaceType();
-
   BraceStmt *body = AFD->getBody();
   if (!body || AFD->isBodyTypeChecked())
     return false;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -424,10 +424,6 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
     // to work.
     bindExtensions(SF);
 
-    // Look for bridging functions. This only matters when
-    // -enable-source-import is provided.
-    checkBridgedFunctions(TC.Context);
-
     // Type check the top-level elements of the source file.
     for (auto D : llvm::makeArrayRef(SF.Decls).slice(StartElem)) {
       if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2564,7 +2564,6 @@ public:
     }
 
     ctor->setImplicitlyUnwrappedOptional(isIUO);
-    (void)ctor->getInterfaceType();
 
     return ctor;
   }
@@ -3040,9 +3039,6 @@ public:
           OpaqueResultTypeRequest{fn},
           cast<OpaqueTypeDecl>(MF.getDecl(opaqueReturnTypeID)));
     }
-
-    // Compute the interface type.
-    (void)fn->getInterfaceType();
 
     return fn;
   }
@@ -3825,7 +3821,6 @@ public:
 
     dtor->setAccess(std::max(cast<ClassDecl>(DC)->getFormalAccess(),
                              AccessLevel::Internal));
-    (void)dtor->getInterfaceType();
 
     if (isImplicit)
       dtor->setImplicit();


### PR DESCRIPTION
In various places, we were still calling `(void) foo->getInterfaceType()` to force the interface type to be computed. This was a transitional step to migrate code off `validateDecl()`. We've now refactored enough code that this should no longer be necessary.