### PR TITLE
StdlibUnittest: port to android x86, x86_64

### DIFF
--- a/stdlib/private/StdlibUnittest/SymbolLookup.swift
+++ b/stdlib/private/StdlibUnittest/SymbolLookup.swift
@@ -26,9 +26,9 @@
 #elseif os(Linux)
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0)
 #elseif os(Android)
-  #if arch(arm)
+  #if arch(arm) || arch(i386)
     let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0xffffffff as UInt)
-  #elseif arch(arm64)
+  #elseif arch(arm64) || arch(x86_64)
     let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0)
   #else
     #error("Unsupported platform")


### PR DESCRIPTION
Account for the x86 and x86_64 architectures when defining
`RTLD_DEFAULT`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
