### PR TITLE
Remove a double-checked invariant

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3639,17 +3639,7 @@ public:
     void checkErrors(Stmt *S) {}
     void checkErrors(Pattern *P) {}
     void checkErrors(Decl *D) {}
-    void checkErrors(ValueDecl *D) {
-      PrettyStackTraceDecl debugStack("verifying errors", D);
-
-      if (!D->hasInterfaceType())
-        return;
-      if (D->getInterfaceType()->hasError() && !D->isInvalid()) {
-        Out << "Valid decl has error type!\n";
-        D->dump(Out);
-        abort();
-      }
-    }
+    void checkErrors(ValueDecl *D) {}
   };
 } // end anonymous namespace
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2885,12 +2885,10 @@ bool ValueDecl::isRecursiveValidation() const {
 Type ValueDecl::getInterfaceType() const {
   auto &ctx = getASTContext();
 
-  // Our clients that don't register the lazy resolver are relying on the
-  // fact that they can't pull an interface type out to avoid doing work.
-  // This is a necessary evil until we can wean them off.
-  if (!ctx.getLazyResolver()) {
-    return TypeAndAccess.getPointer();
-  }
+  // N.B. This assertion exists to catch new broken callers. It can be removed
+  // with the LazyResolver when the time comes.
+  assert(ctx.getLazyResolver()
+         && "The lazy resolver must be registered to make semantic queries!");
 
   if (auto type =
           evaluateOrDefault(ctx.evaluator,


### PR DESCRIPTION
Now that isInvalid() is a semantic property, drop the assertion for this
invariant in the ASTVerifier.  This should also remove the last client
that wasn't registering the lazy resolver and expecting to pull any old
interface type out, so change a hack to an assertion to hopefully catch
future callers before we remove the LazyResolver entirely.