### PR TITLE
[android] Disable SwiftPM in CI build.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -847,10 +847,12 @@ skip-build-foundation
 skip-build-xctest
 skip-build-playgroundsupport
 skip-build-benchmarks
+swiftpm=0
 indexstore-db=0
 sourcekit-lsp=0
 toolchain-benchmarks=0
 test-installable-package=
+install-swiftpm=0
 
 [preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build,aarch64]
 mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -555,7 +555,7 @@ def create_argument_parser():
     option(['--libcxx'], store_true('build_libcxx'),
            help='build libcxx')
 
-    option(['-p', '--swiftpm'], store_true('build_swiftpm'),
+    option(['-p', '--swiftpm'], toggle_true('build_swiftpm'),
            help='build swiftpm')
 
     option(['--install-swiftpm'], toggle_true('install_swiftpm'),


### PR DESCRIPTION
The Android CI build only builds the stdlib because the rest of the
components are build for the host, which is not very useful, since they
are already tested in other CI configurations.

The problem was introduced in #28035 and started showing in https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/4328/ and https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/2599/

@aciidb0mb3r, @ahoppen: In my opinion, removing the three `skip-build-swiftpm` in `build-presets.ini` in the original PR should be reviewed. ~The removed switch haven't disappered from the `build_script(.py)` script, and it is still honored.~ [edit: not true, it didn't fail in my system, but it is not longer supported] I only removed the Android one, because it is the one that actually breaks things.