### PR TITLE
[AutoDiff] IRGen differentiability witness tables

### DIFF
--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -192,21 +192,19 @@ public:
 /// specific differentiability witness.
 class PrettyStackTraceDifferentiabilityWitness
     : public llvm::PrettyStackTraceEntry {
-  ASTContext &Context;
   const SILDifferentiabilityWitnessKey Key;
   const char *Action;
 
 public:
   PrettyStackTraceDifferentiabilityWitness(
-      ASTContext &C, const char *action,
-      const SILDifferentiabilityWitnessKey key)
-      : Context(C), Key(key), Action(action) {}
+      const char *action, const SILDifferentiabilityWitnessKey key)
+      : Key(key), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
 
 void printDifferentiabilityWitnessDescription(
     llvm::raw_ostream &out, const SILDifferentiabilityWitnessKey key,
-    ASTContext &Context, bool addNewline = true);
+    bool addNewline = true);
 // SWIFT_ENABLE_TENSORFLOW END
 
 } // end namespace swift

--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -187,6 +187,28 @@ public:
   void print(llvm::raw_ostream &OS) const override;
 };
 
+// SWIFT_ENABLE_TENSORFLOW
+/// PrettyStackTraceDifferentiabilityWitness - Observe that we are processing a
+/// specific differentiability witness.
+class PrettyStackTraceDifferentiabilityWitness
+    : public llvm::PrettyStackTraceEntry {
+  ASTContext &Context;
+  const SILDifferentiabilityWitnessKey Key;
+  const char *Action;
+
+public:
+  PrettyStackTraceDifferentiabilityWitness(
+      ASTContext &C, const char *action,
+      const SILDifferentiabilityWitnessKey key)
+      : Context(C), Key(key), Action(action) {}
+  virtual void print(llvm::raw_ostream &OS) const;
+};
+
+void printDifferentiabilityWitnessDescription(
+    llvm::raw_ostream &out, const SILDifferentiabilityWitnessKey key,
+    ASTContext &Context, bool addNewline = true);
+// SWIFT_ENABLE_TENSORFLOW END
+
 } // end namespace swift
 
 #endif

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -346,6 +346,11 @@ class LinkEntity {
     /// ProtocolConformance*.
     ProtocolWitnessTableLazyCacheVariable,
 
+    // SWIFT_ENABLE_TENSORFLOW
+    /// A SIL differentiability witness.
+    DifferentiabilityWitness,
+    // SWIFT_ENABLE_TENSORFLOW_END
+
     // Everything following this is a type kind.
 
     /// A value witness for a type.
@@ -467,6 +472,15 @@ class LinkEntity {
                                 getAssociatedConformanceIndex(c, associatedType,
                                                           associatedProtocol));
   }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  void
+  setForDifferentiabilityWitness(Kind kind,
+                                 const SILDifferentiabilityWitness *witness) {
+    Pointer = const_cast<void *>(static_cast<const void *>(witness));
+    Data = LINKENTITY_SET_FIELD(Kind, unsigned(kind));
+  }
+  // SWIFT_ENABLE_TENSORFLOW_END
 
   // We store associated types using their index in their parent protocol
   // in order to avoid bloating LinkEntity out to three key pointers.
@@ -848,6 +862,16 @@ public:
     return entity;
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  static LinkEntity
+  forDifferentiabilityWitness(const SILDifferentiabilityWitness *witness) {
+    LinkEntity entity;
+    entity.setForDifferentiabilityWitness(Kind::DifferentiabilityWitness,
+                                          witness);
+    return entity;
+  }
+  // SWIFT_ENABLE_TENSORFLOW_END
+
   static LinkEntity
   forGenericProtocolWitnessTableInstantiationFunction(
                                       const ProtocolConformance *C) {
@@ -1041,6 +1065,11 @@ public:
   SILGlobalVariable *getSILGlobalVariable() const {
     assert(getKind() == Kind::SILGlobalVariable);
     return reinterpret_cast<SILGlobalVariable*>(Pointer);
+  }
+
+  SILDifferentiabilityWitness *getSILDifferentiabilityWitness() const {
+    assert(getKind() == Kind::DifferentiabilityWitness);
+    return reinterpret_cast<SILDifferentiabilityWitness *>(Pointer);
   }
 
   const RootProtocolConformance *getRootProtocolConformance() const {

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -267,12 +267,12 @@ void PrettyStackTraceSelector::print(llvm::raw_ostream &out) const {
 void PrettyStackTraceDifferentiabilityWitness::print(
     llvm::raw_ostream &out) const {
   out << "While " << Action << ' ';
-  printDifferentiabilityWitnessDescription(out, Key, Context);
+  printDifferentiabilityWitnessDescription(out, Key);
 }
 
 void swift::printDifferentiabilityWitnessDescription(
     llvm::raw_ostream &out, const SILDifferentiabilityWitnessKey key,
-    ASTContext &Context, bool addNewline) {
+    bool addNewline) {
   out << key.first << " ";
   key.second.print(out);
   if (addNewline)

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -263,3 +263,18 @@ void PrettyStackTraceGenericSignature::print(llvm::raw_ostream &out) const {
 void PrettyStackTraceSelector::print(llvm::raw_ostream &out) const {
   out << "While " << Action << " '" << Selector << "'";
 }
+
+void PrettyStackTraceDifferentiabilityWitness::print(
+    llvm::raw_ostream &out) const {
+  out << "While " << Action << ' ';
+  printDifferentiabilityWitnessDescription(out, Key, Context);
+}
+
+void swift::printDifferentiabilityWitnessDescription(
+    llvm::raw_ostream &out, const SILDifferentiabilityWitnessKey key,
+    ASTContext &Context, bool addNewline) {
+  out << key.first << " ";
+  key.second.print(out);
+  if (addNewline)
+    out << '\n';
+}

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2166,6 +2166,40 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
                                        RequireMetadata);
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+void IRGenModule::emitSILDifferentiabilityWitness(
+    SILDifferentiabilityWitness *dw) {
+  PrettyStackTraceDifferentiabilityWitness _st(
+      Context, "emitting differentiability witness for", dw->getKey());
+
+  // Don't emit declarations.
+  if (dw->isDeclaration())
+    return;
+
+  ConstantInitBuilder builder(*this);
+  auto diffWitnessContents = builder.beginStruct();
+
+  // TODO(marcrasi): When the differentiation pass generates JVP/VJP for
+  // witnesses, remove the nullptr case and add assertions that the JVP/VJP
+  // exist.
+  if (dw->getJVP()) {
+    diffWitnessContents.addBitCast(
+        getAddrOfSILFunction(dw->getJVP(), NotForDefinition), Int8PtrTy);
+  } else {
+    diffWitnessContents.addNullPointer(Int8PtrTy);
+  }
+  if (dw->getVJP()) {
+    diffWitnessContents.addBitCast(
+        getAddrOfSILFunction(dw->getVJP(), NotForDefinition), Int8PtrTy);
+  } else {
+    diffWitnessContents.addNullPointer(Int8PtrTy);
+  }
+
+  getAddrOfDifferentiabilityWitness(
+      dw, diffWitnessContents.finishAndCreateFuture());
+}
+// SWIFT_ENABLE_TENSORFLOW_END
+
 /// True if a function's signature in LLVM carries polymorphic parameters.
 /// Generic functions and protocol witnesses carry polymorphic parameters.
 bool irgen::hasPolymorphicParameters(CanSILFunctionType ty) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2170,7 +2170,7 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
 void IRGenModule::emitSILDifferentiabilityWitness(
     SILDifferentiabilityWitness *dw) {
   PrettyStackTraceDifferentiabilityWitness _st(
-      Context, "emitting differentiability witness for", dw->getKey());
+      "emitting differentiability witness for", dw->getKey());
 
   // Don't emit declarations.
   if (dw->isDeclaration())

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -524,6 +524,11 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
   DynamicReplacementKeyTy = createStructType(*this, "swift.dyn_repl_key",
                                              {RelativeAddressTy, Int32Ty});
+
+  // SWIFT_ENABLE_TENSORFLOW
+  DifferentiabilityWitnessTy = createStructType(
+      *this, "swift.differentiability_witness", {Int8PtrTy, Int8PtrTy});
+  // SWIFT_ENABLE_TENSORFLOW_END
 }
 
 IRGenModule::~IRGenModule() {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -639,6 +639,10 @@ public:
       *DynamicReplacementLinkEntryPtrTy; // %link_entry*
   llvm::StructType *DynamicReplacementKeyTy; // { i32, i32}
 
+  // SWIFT_ENABLE_TENSORFLOW
+  llvm::StructType *DifferentiabilityWitnessTy; // { i8*, i8* }
+  // SWIFT_ENABLE_TENSORFLOW_END
+
   llvm::GlobalVariable *TheTrivialPropertyDescriptor = nullptr;
 
   /// Used to create unique names for class layout types with tail allocated
@@ -1233,6 +1237,9 @@ public:
   void emitSILFunction(SILFunction *f);
   void emitSILWitnessTable(SILWitnessTable *wt);
   void emitSILProperty(SILProperty *prop);
+  // SWIFT_ENABLE_TENSORFLOW
+  void emitSILDifferentiabilityWitness(SILDifferentiabilityWitness *dw);
+  // SWIFT_ENABLE_TENSORFLOW END
   void emitSILStaticInitializers();
   llvm::Constant *emitFixedTypeLayout(CanType t, const FixedTypeInfo &ti);
   void emitProtocolConformance(const ConformanceDescription &record);
@@ -1410,6 +1417,12 @@ public:
   llvm::Constant *getAddrOfWitnessTablePattern(
                                       const NormalProtocolConformance *C,
                                       ConstantInit definition = ConstantInit());
+
+  // SWIFT_ENABLE_TENSORFLOW
+  llvm::Constant *
+  getAddrOfDifferentiabilityWitness(const SILDifferentiabilityWitness *witness,
+                                    ConstantInit definition = ConstantInit());
+  // SWIFT_ENABLE_TENSORFLOW_END
 
   llvm::Function *
   getAddrOfGenericWitnessTableInstantiationFunction(

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -414,6 +414,12 @@ std::string LinkEntity::mangleAsString() const {
   case Kind::ReflectionAssociatedTypeDescriptor:
     return mangler.mangleReflectionAssociatedTypeDescriptor(
                                                     getProtocolConformance());
+  // SWIFT_ENABLE_TENSORFLOW
+  case Kind::DifferentiabilityWitness:
+    return mangler.mangleSILDifferentiabilityWitnessKey(
+        {getSILDifferentiabilityWitness()->getOriginalFunction()->getName(),
+         getSILDifferentiabilityWitness()->getConfig()});
+    // SWIFT_ENABLE_TENSORFLOW_END
   }
   llvm_unreachable("bad entity kind!");
 }
@@ -659,6 +665,10 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::ExtensionDescriptor:
   case Kind::AnonymousDescriptor:
     return SILLinkage::Shared;
+  // SWIFT_ENABLE_TENSORFLOW
+  case Kind::DifferentiabilityWitness:
+    return getSILDifferentiabilityWitness()->getLinkage();
+  // SWIFT_ENABLE_TENSORFLOW_END
   }
   llvm_unreachable("bad link entity kind");
 }
@@ -803,6 +813,10 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
   case Kind::DynamicallyReplaceableFunctionImpl:
   case Kind::DynamicallyReplaceableFunctionKeyAST:
     llvm_unreachable("Relative reference to unsupported link entity");
+  // SWIFT_ENABLE_TENSORFLOW
+  case Kind::DifferentiabilityWitness:
+    return true;
+  // SWIFT_ENABLE_TENSORFLOW_END
   }
   llvm_unreachable("bad link entity kind");
 }
@@ -904,6 +918,10 @@ llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
       return IGM.ObjCResilientClassStubTy;
     }
     llvm_unreachable("invalid metadata address");
+  // SWIFT_ENABLE_TENSORFLOW
+  case Kind::DifferentiabilityWitness:
+    return IGM.DifferentiabilityWitnessTy;
+  // SWIFT_ENABLE_TENSORFLOW_END
   default:
     llvm_unreachable("declaration LLVM type not specified");
   }
@@ -956,6 +974,10 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
     return Alignment(8);
   case Kind::SILFunction:
     return Alignment(1);
+  // SWIFT_ENABLE_TENSORFLOW
+  case Kind::DifferentiabilityWitness:
+    return IGM.getPointerAlignment();
+  // SWIFT_ENABLE_TENSORFLOW_END
   default:
     llvm_unreachable("alignment not specified");
   }
@@ -1053,6 +1075,11 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   case Kind::ReflectionFieldDescriptor:
   case Kind::CoroutineContinuationPrototype:
     return false;
+
+  // SWIFT_ENABLE_TENSORFLOW
+  case Kind::DifferentiabilityWitness:
+    return false;
+  // SWIFT_ENABLE_TENSORFLOW_END
   }
 
   llvm_unreachable("Bad link entity kind");
@@ -1182,6 +1209,11 @@ const SourceFile *LinkEntity::getSourceFileForEmission() const {
   case Kind::ValueWitness:
   case Kind::ValueWitnessTable:
     return nullptr;
+
+  // SWIFT_ENABLE_TENSORFLOW
+  case Kind::DifferentiabilityWitness:
+    return nullptr;
+  // SWIFT_ENABLE_TENSORFLOW_END
   }
   
   return sf;

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -606,6 +606,14 @@ class DeadFunctionElimination : FunctionLivenessComputation {
       }
     }
 
+    // SWIFT_ENABLE_TENSORFLOW
+    // Check differentiable function witness entries.
+    for (auto &dw : Module->getDifferentiabilityWitnessList()) {
+      if (dw.getJVP())
+        ensureAlive(dw.getJVP());
+      if (dw.getVJP())
+        ensureAlive(dw.getVJP());
+    }
   }
 
   /// Removes all dead methods from vtables and witness tables.

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -74,6 +74,23 @@ private:
   void addAssociatedConformanceDescriptor(AssociatedConformance conformance);
   void addBaseConformanceDescriptor(BaseConformance conformance);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Adds the symbol for the autodiff function of the given kind associated
+  /// with the given original function and `@differentiable` attr.
+  void addAutoDiffDerivativeFunction(AbstractFunctionDecl *original,
+                                     const DifferentiableAttr *attr,
+                                     AutoDiffDerivativeFunctionKind kind);
+
+  /// Adds the symbol for the differentiability witness associated with the
+  /// given original function and `@differentiable` attr.
+  void addDifferentiabilityWitness(AbstractFunctionDecl *original,
+                                   const DifferentiableAttr *attr);
+
+  /// Adds symbols associated with the given original function and
+  /// `@differentiable` attr.
+  void addDifferentiableAttr(AbstractFunctionDecl *original,
+                             const DifferentiableAttr *attr);
+
 public:
   TBDGenVisitor(llvm::MachO::InterfaceFile &symbols,
                 llvm::MachO::ArchitectureSet archs, StringSet *stringSymbols,

--- a/test/AutoDiff/sil_differentiability_witness.sil
+++ b/test/AutoDiff/sil_differentiability_witness.sil
@@ -1,11 +1,17 @@
-// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
+// Round-trip parsing/printing test.
+
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck --check-prefix=ROUNDTRIP %s
+
+// Round-trip serialization-deserialization test.
 
 // RUN: %empty-directory(%t)
 // RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name main
 // RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name main
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name main | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name main | %FileCheck --check-prefix=ROUNDTRIP %s
 
-// Round-trip parsing/printing and serialization/deserialization test.
+// IRGen test.
+
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck --check-prefix=IRGEN %s
 
 sil_stage raw
 
@@ -38,11 +44,16 @@ sil_differentiability_witness [parameters 0] [results 0] @foo : $@convention(thi
   vjp: @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 }
 
-// CHECK-LABEL: // differentiability witness for foo
-// CHECK: sil_differentiability_witness [parameters 0] [results 0] @foo : $@convention(thin) (Float) -> Float {
-// CHECK:   jvp: @AD__foo__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
-// CHECK:   vjp: @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
-// CHECK: }
+// ROUNDTRIP-LABEL: // differentiability witness for foo
+// ROUNDTRIP: sil_differentiability_witness [parameters 0] [results 0] @foo : $@convention(thin) (Float) -> Float {
+// ROUNDTRIP:   jvp: @AD__foo__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP:   vjp: @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP: }
+
+// IRGEN-LABEL: @AD__foo_PSRS = protected global { i8*, i8* } {
+// IRGEN-SAME: @AD__foo__jvp_src_0_wrt_0
+// IRGEN-SAME: @AD__foo__vjp_src_0_wrt_0
+// IRGEN-SAME: }
 
 // Test internal generic function.
 // SIL differentiability witness:
@@ -71,11 +82,16 @@ sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where 
   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
 }
 
-// CHECK-LABEL: // differentiability witness for generic
-// CHECK: sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where τ_0_0 : Differentiable> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
-// CHECK:   jvp: @AD__generic__jvp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector)
-// CHECK:   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
-// CHECK: }
+// ROUNDTRIP-LABEL: // differentiability witness for generic
+// ROUNDTRIP: sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where τ_0_0 : Differentiable> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
+// ROUNDTRIP:   jvp: @AD__generic__jvp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector)
+// ROUNDTRIP:   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
+// ROUNDTRIP: }
+
+// IRGEN-LABEL: @AD__generic_PSSRSs15_DifferentiableRzl = hidden global { i8*, i8* } {
+// IRGEN-SAME: @AD__generic__jvp_src_0_wrt_0_1
+// IRGEN-SAME: @AD__generic__vjp_src_0_wrt_0_1
+// IRGEN-SAME: }
 
 // Test SIL differentiability witness for bodiless original function, with defined jvp/vjp.
 
@@ -96,11 +112,16 @@ sil_differentiability_witness [parameters 0] [results 0] @externalFn1 : $@conven
   vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 }
 
-// CHECK-LABEL: // differentiability witness for externalFn1
-// CHECK: sil_differentiability_witness [parameters 0] [results 0] @externalFn1 : $@convention(thin) (Float) -> Float {
-// CHECK:   jvp: @AD__externalFn1__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
-// CHECK:   vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
-// CHECK: }
+// ROUNDTRIP-LABEL: // differentiability witness for externalFn1
+// ROUNDTRIP: sil_differentiability_witness [parameters 0] [results 0] @externalFn1 : $@convention(thin) (Float) -> Float {
+// ROUNDTRIP:   jvp: @AD__externalFn1__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP:   vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP: }
+
+// IRGEN-LABEL: @AD__externalFn1_PSRS = protected global { i8*, i8* } {
+// IRGEN-SAME: @AD__externalFn1__jvp_src_0_wrt_0
+// IRGEN-SAME: @AD__externalFn1__vjp_src_0_wrt_0
+// IRGEN-SAME: }
 
 // Test SIL differentiability witness for bodiless original function, with bodiless jvp/vjp.
 
@@ -115,11 +136,24 @@ sil_differentiability_witness [parameters 0] [results 0] @externalFn2 : $@conven
   vjp: @AD__externalFn2__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 }
 
+// ROUNDTRIP-LABEL: // differentiability witness for externalFn2
+// ROUNDTRIP: sil_differentiability_witness [parameters 0] [results 0] @externalFn2 : $@convention(thin) (Float) -> Float {
+// ROUNDTRIP:   jvp: @AD__externalFn2__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP:   vjp: @AD__externalFn2__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP: }
+
+// IRGEN-LABEL: @AD__externalFn2_PSRS = protected global { i8*, i8* } {
+// IRGEN-SAME: @AD__externalFn2__jvp_src_0_wrt_0
+// IRGEN-SAME: @AD__externalFn2__vjp_src_0_wrt_0
+// IRGEN-SAME: }
+
 // Test SIL differentiability witness declaration.
 
 sil @externalFn3 : $@convention(thin) (Float) -> Float
 
 sil_differentiability_witness [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float
 
-// CHECK-LABEL: // differentiability witness for externalFn3
-// CHECK: sil_differentiability_witness [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float{{[^{]*$}}
+// ROUNDTRIP-LABEL: // differentiability witness for externalFn3
+// ROUNDTRIP: sil_differentiability_witness [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float{{[^{]*$}}
+
+// IRGEN-NOT: @AD__externalFn3{{.*}}={{.*}}{ i8*, i8* }

--- a/test/AutoDiff/sil_differentiability_witness.sil
+++ b/test/AutoDiff/sil_differentiability_witness.sil
@@ -88,7 +88,7 @@ sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where 
 // ROUNDTRIP:   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
 // ROUNDTRIP: }
 
-// IRGEN-LABEL: @AD__generic_PSSRSs15_DifferentiableRzl = hidden global { i8*, i8* } {
+// IRGEN-LABEL: @AD__generic_PSSRSs14DifferentiableRzl = hidden global { i8*, i8* } {
 // IRGEN-SAME: @AD__generic__jvp_src_0_wrt_0_1
 // IRGEN-SAME: @AD__generic__vjp_src_0_wrt_0_1
 // IRGEN-SAME: }

--- a/test/AutoDiff/sil_differentiability_witness.sil
+++ b/test/AutoDiff/sil_differentiability_witness.sil
@@ -50,7 +50,7 @@ sil_differentiability_witness [parameters 0] [results 0] @foo : $@convention(thi
 // ROUNDTRIP:   vjp: @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // ROUNDTRIP: }
 
-// IRGEN-LABEL: @AD__foo_PSRS = protected global { i8*, i8* } {
+// IRGEN-LABEL: @AD__foo_PSRS ={{( protected)?}} global { i8*, i8* } {
 // IRGEN-SAME: @AD__foo__jvp_src_0_wrt_0
 // IRGEN-SAME: @AD__foo__vjp_src_0_wrt_0
 // IRGEN-SAME: }
@@ -118,7 +118,7 @@ sil_differentiability_witness [parameters 0] [results 0] @externalFn1 : $@conven
 // ROUNDTRIP:   vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // ROUNDTRIP: }
 
-// IRGEN-LABEL: @AD__externalFn1_PSRS = protected global { i8*, i8* } {
+// IRGEN-LABEL: @AD__externalFn1_PSRS ={{( protected)?}} global { i8*, i8* } {
 // IRGEN-SAME: @AD__externalFn1__jvp_src_0_wrt_0
 // IRGEN-SAME: @AD__externalFn1__vjp_src_0_wrt_0
 // IRGEN-SAME: }
@@ -142,7 +142,7 @@ sil_differentiability_witness [parameters 0] [results 0] @externalFn2 : $@conven
 // ROUNDTRIP:   vjp: @AD__externalFn2__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
 // ROUNDTRIP: }
 
-// IRGEN-LABEL: @AD__externalFn2_PSRS = protected global { i8*, i8* } {
+// IRGEN-LABEL: @AD__externalFn2_PSRS ={{( protected)?}} global { i8*, i8* } {
 // IRGEN-SAME: @AD__externalFn2__jvp_src_0_wrt_0
 // IRGEN-SAME: @AD__externalFn2__vjp_src_0_wrt_0
 // IRGEN-SAME: }


### PR DESCRIPTION
Summary of changes:
* Add `LinkEntity` for `SILDifferentiabilityWitnessTable`.
* Add `IRGenModule::emitSILDifferentiabilityWitness` & `IRGenModule::getAddrOfDifferentiabilityWitness`, which do the actual work of emitting the IR.
* Add TBDGen for the differentiability witnesses. Also some factoring duplicated code out into a common function.

I think this resolves TF-930, by making TBDGen incorporate the VJP/JVP generic signatures in its calculation.