### PR TITLE
Remove explicit `-enable-large-loadable-types` flag.

### DIFF
--- a/test/DebugInfo/LoadableByAddress.swift
+++ b/test/DebugInfo/LoadableByAddress.swift
@@ -1,6 +1,5 @@
 // SWIFT_ENABLE_TENSORFLOW
-// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
-// RUN: %target-swift-frontend %s -module-name A -emit-ir -enable-large-loadable-types -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -module-name A -emit-ir -g -o - | %FileCheck %s
 // REQUIRES: CPU=x86_64
 public struct Continuation<A> {
    private let magicToken = "Hello World"

--- a/test/IRGen/copy_value_destroy_value.sil
+++ b/test/IRGen/copy_value_destroy_value.sil
@@ -1,6 +1,4 @@
-// SWIFT_ENABLE_TENSORFLOW
-// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
-// RUN: %target-swift-frontend -parse-sil -emit-ir -enable-large-loadable-types %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-sil -emit-ir %s | %FileCheck %s
 // REQUIRES: OS=macosx
 
 // Make sure that we are using type lowering and that we are handling the return

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -1,6 +1,4 @@
-// SWIFT_ENABLE_TENSORFLOW
-// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
-// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine %s -emit-ir -enable-large-loadable-types | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=MandatoryCombine %s -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s
 import Swift
 import Builtin
 

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -1,6 +1,4 @@
-// SWIFT_ENABLE_TENSORFLOW
-// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
-// RUN: %target-swift-frontend %s -emit-ir -enable-large-loadable-types | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/value_buffers.sil
+++ b/test/IRGen/value_buffers.sil
@@ -1,6 +1,4 @@
-// SWIFT_ENABLE_TENSORFLOW
-// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
-// RUN: %target-swift-frontend %s -emit-ir -enable-large-loadable-types | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -1,6 +1,4 @@
-// SWIFT_ENABLE_TENSORFLOW
-// NOTE(TF-11): Added explicit `-enable-large-loadable-types` flag.
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns %s -enable-large-loadable-types | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 import Builtin
 import Swift


### PR DESCRIPTION
LoadableByAddress was re-enabled by default on tensorflow branch in https://github.com/apple/swift/pull/27923.
IRGen tests no longer require an explicit `-enable-large-loadable-types` flag.