### PR TITLE
Fix spurious test failure during back deployment tests

### DIFF
--- a/test/Interpreter/bridged_casts_folding.swift
+++ b/test/Interpreter/bridged_casts_folding.swift
@@ -5,6 +5,9 @@
 // the correct reason in the test. We want to separate a memory management error
 // from a cast error which prints a nice error message.
 
+// FIXME: we should run this test if the OS-provided stdlib is recent enough.
+// UNSUPPORTED: use_os_stdlib
+
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1461,6 +1461,7 @@ if not kIsWindows:
 			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
 			.format(target_stdlib_path, libdispatch_path)) + config.target_run
 	else:
+		config.available_features.add('use_os_stdlib')
 		os_stdlib_path = ''
 		if run_vendor == 'apple':
 			#If we get swift-in-the-OS for non-Apple platforms, add a condition here


### PR DESCRIPTION
Also, fix a lit configuration issue where we're not marking back deployment tests as such.

rdar://55727406