### PR TITLE
[CSGen] Add a tailored diagnostic for conditional casting from a nil literal.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -243,6 +243,8 @@ ERROR(cannot_subscript_ambiguous_base,none,
 
 ERROR(cannot_subscript_nil_literal,none,
       "cannot subscript a nil literal value", ())
+ERROR(conditional_cast_from_nil,none,
+      "nil literal cannot be the source of a conditional cast", ())
 
 ERROR(cannot_pass_rvalue_inout_subelement,none,
       "cannot pass immutable value as inout argument: %0",

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -220,3 +220,5 @@ func process(p: Any?) {
 
 func compare<T>(_: T, _: T) {} // expected-note {{'compare' declared here}}
 func compare<T>(_: T?, _: T?) {}
+
+_ = nil? as? Int?? // expected-error {{nil literal cannot be the source of a conditional cast}}


### PR DESCRIPTION
This is detected and diagnosed this in CSGen.

```swift
_ = nil? as? Int?? // error: nil literal cannot be the source of a conditional cast
    ^
```
