### PR TITLE
SILOptimizer: Don't optimize initializers for dynamically-sized globals [5.1]

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5580,6 +5580,15 @@ void IRGenModule::emitSILStaticInitializers() {
     if (!InitValue)
       continue;
 
+#ifndef NDEBUG
+    SILType loweredTy = Global.getLoweredType();
+    auto &ti = getTypeInfo(loweredTy);
+
+    auto expansion = getResilienceExpansionForLayout(&Global);
+    assert(ti.isFixedSize(expansion) &&
+           "cannot emit a static initializer for dynamically-sized global");
+#endif
+
     auto *IRGlobal =
         Module.getGlobalVariable(Global.getName(), true /* = AllowLocal */);
 

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -739,6 +739,14 @@ void SILGlobalOpt::optimizeInitializer(SILFunction *AddrF,
   if (!SILG)
     return;
 
+  auto expansion = ResilienceExpansion::Maximal;
+  if (hasPublicVisibility(SILG->getLinkage()))
+    expansion = ResilienceExpansion::Minimal;
+
+  auto &tl = Module->Types.getTypeLowering(SILG->getLoweredType(), expansion);
+  if (!tl.isLoadable())
+    return;
+
   LLVM_DEBUG(llvm::dbgs() << "GlobalOpt: use static initializer for "
                           << SILG->getName() << '\n');
 

--- a/test/SILOptimizer/globalopt_resilience_testing.swift
+++ b/test/SILOptimizer/globalopt_resilience_testing.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-sil -O -enable-library-evolution -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -O -enable-library-evolution -enable-testing -primary-file %s | %FileCheck %s --check-prefix=CHECK-TESTING
+
+// If a global variable with a resilient type has public linkage, we have to
+// allocate a buffer for it even if the type has a fixed size in its
+// defining module.
+//
+// There are two cases where this can occur:
+//
+// - An internal property is defined in a resilient module built with
+//   -enable-testing
+//
+// - A public property is defined to have the @_fixed_layout attribute
+
+public struct Wrapper {
+  var x: Int32
+
+  static let usefulConstant = Wrapper(x: 321)
+}
+
+// CHECK-LABEL: sil_global hidden [let] @$s28globalopt_resilience_testing7WrapperV14usefulConstantACvpZ : $Wrapper = {
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int32, 321
+// CHECK-NEXT:   %1 = struct $Int32 (%0 : $Builtin.Int32)
+// CHECK-NEXT:   %initval = struct $Wrapper (%1 : $Int32)
+// CHECK-NEXT: }
+
+// CHECK-TESTING-LABEL: sil_global [let] @$s28globalopt_resilience_testing7WrapperV14usefulConstantACvpZ : $Wrapper{{$}}


### PR DESCRIPTION
If the size of a global variable is not known at compile time, we emit
a fixed size buffer together with initialization code when the global
variable is initialized.

Make sure the SIL optimizer does not convert this into a static
initialization, even if the size of the type is known inside the
module where the global is declared, because we don't have a way to
statically initialize something that looks like a fixed-size buffer
to client code.

Fixes <https://bugs.swift.org/browse/SR-11709> / <rdar://problem/56892401>.