### PR TITLE
[Tests] Fix REQUIRES for two type checker perf tests

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/sr139.swift
+++ b/validation-test/Sema/type_checker_perf/fast/sr139.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck %s
+// REQUIRES: tools-release,no_asserts
 
 // SR-139:
 // Infinite recursion parsing bitwise operators

--- a/validation-test/Sema/type_checker_perf/slow/rdar46713933.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar46713933.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// REQUIRES: tools-release,no_asserts
 
 func wrap<T>(_ key: String, _ value: T) -> T { return value }
 func wrap<T: ExpressibleByIntegerLiteral>(_ key: String, _ value: T) -> T { return value }


### PR DESCRIPTION
The non-gyb type checker performance tests tend to require non-assert and release builds. This makes two tests consistent with the others.

This also fixes sr139.swift, which was needlessly running the type checker twice.