### PR TITLE
SIL: remove unused variable (NFC)

### DIFF
--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -133,7 +133,7 @@ static bool canCreateProfilerForAST(ASTNode N, SILDeclRef forDecl) {
 
     if (isa<TopLevelCodeDecl>(D))
       return true;
-  } else if (auto *E = N.get<Expr *>()) {
+  } else if (N.get<Expr *>()) {
     if (forDecl.isStoredPropertyInitializer() ||
         forDecl.isPropertyWrapperBackingInitializer() ||
         forDecl.getAbstractClosureExpr())


### PR DESCRIPTION
Silence a `-Wunused-variable` warning.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
