### PR TITLE
[build-presets] Build the stress tester and SwiftEvolve for SwiftSyntax PR testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1571,6 +1571,8 @@ release
 assertions
 swiftsyntax
 swiftsyntax-verify-generated-files
+skstresstester
+swiftevolve
 
 #===------------------------------------------------------------------------===#
 # Test Swift Stress Tester


### PR DESCRIPTION
Test that we don’t break the stress tester or SwiftEvolve with changes to SwiftSyntax. At the moment this just adds the stress tester and SwiftEvolve as downstream dependencies of SwiftSyntax PR testing. I will add it to the main buildbot later once SwiftEvolve is also using the unified build.