### PR TITLE
Drop ConformanceContexts out of the TypeChecker

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2817,7 +2817,8 @@ public:
     checkExplicitAvailability(ED);
 
     TypeChecker::checkDeclCircularity(ED);
-    TC.ConformanceContexts.push_back(ED);
+
+    TypeChecker::checkConformancesInContext(ED, ED);
   }
 
   void visitStructDecl(StructDecl *SD) {
@@ -2844,7 +2845,8 @@ public:
     checkExplicitAvailability(SD);
 
     TypeChecker::checkDeclCircularity(SD);
-    TC.ConformanceContexts.push_back(SD);
+
+    TypeChecker::checkConformancesInContext(SD, SD);
   }
 
   /// Check whether the given properties can be @NSManaged in this class.
@@ -3090,7 +3092,10 @@ public:
     checkExplicitAvailability(CD);
 
     TypeChecker::checkDeclCircularity(CD);
-    TC.ConformanceContexts.push_back(CD);
+
+    TypeChecker::checkConformancesInContext(CD, CD);
+
+    TypeChecker::maybeDiagnoseClassWithoutInitializers(CD);
   }
 
   void visitProtocolDecl(ProtocolDecl *PD) {
@@ -3436,7 +3441,7 @@ public:
     for (Decl *Member : ED->getMembers())
       visit(Member);
 
-    TC.ConformanceContexts.push_back(ED);
+    TypeChecker::checkConformancesInContext(ED, ED);
 
     TypeChecker::checkDeclAttributes(ED);
     checkAccessControl(ED);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -291,22 +291,6 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
   unsigned currentFunctionIdx = 0;
   unsigned currentSynthesizedDecl = SF.LastCheckedSynthesizedDecl;
   do {
-    // Type check conformance contexts.
-    for (unsigned i = 0; i != TC.ConformanceContexts.size(); ++i) {
-      auto decl = TC.ConformanceContexts[i];
-      if (auto *ext = dyn_cast<ExtensionDecl>(decl))
-        TypeChecker::checkConformancesInContext(ext, ext);
-      else {
-        auto *ntd = cast<NominalTypeDecl>(decl);
-        TypeChecker::checkConformancesInContext(ntd, ntd);
-
-        // Finally, we can check classes for missing initializers.
-        if (auto *classDecl = dyn_cast<ClassDecl>(ntd))
-          TypeChecker::maybeDiagnoseClassWithoutInitializers(classDecl);
-      }
-    }
-    TC.ConformanceContexts.clear();
-
     // Type check the body of each of the function in turn.  Note that outside
     // functions must be visited before nested functions for type-checking to
     // work correctly.
@@ -327,8 +311,7 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
     }
 
   } while (currentFunctionIdx < TC.definedFunctions.size() ||
-           currentSynthesizedDecl < SF.SynthesizedDecls.size() ||
-           !TC.ConformanceContexts.empty());
+           currentSynthesizedDecl < SF.SynthesizedDecls.size());
 
   // FIXME: Horrible hack. Store this somewhere more appropriate.
   SF.LastCheckedSynthesizedDecl = currentSynthesizedDecl;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -551,9 +551,6 @@ public:
   /// The list of function definitions we've encountered.
   std::vector<AbstractFunctionDecl *> definedFunctions;
 
-  /// Declarations that need their conformances checked.
-  llvm::SmallVector<Decl *, 8> ConformanceContexts;
-
   /// A list of closures for the most recently type-checked function, which we
   /// will need to compute captures for.
   std::vector<AbstractClosureExpr *> ClosuresWithUncomputedCaptures;

--- a/test/Frontend/debug-generic-signatures.swift
+++ b/test/Frontend/debug-generic-signatures.swift
@@ -72,6 +72,9 @@ struct NonRecur: P2 {
 
 // Conditional conformance.
 
+// CHECK: Generic signature: <T>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0>
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Generic
 struct Generic<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Generic
 // CHECK-NEXT: (normal_conformance type=Generic<T> protocol=P1
@@ -85,6 +88,10 @@ extension Generic: P1 where T: P1 {
 
 
 // Satisfying associated types with requirements with generic params
+
+// CHECK: Generic signature: <T, U>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0, τ_0_1>
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Super
 class Super<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Super
 // CHECK-NEXT: (normal_conformance type=Super<T, U> protocol=P2

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -33,6 +33,7 @@ func free_bad<U>(_: U) {
 
 struct Constrained<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained
 // CHECK-NEXT: (normal_conformance type=Constrained<T> protocol=P2
 // CHECK-NEXT:   conforms_to: T P3)
 extension Constrained: P2 where T: P3 {} // expected-note {{requirement from conditional conformance of 'Constrained<U>' to 'P2'}}
@@ -45,15 +46,18 @@ func constrained_bad<U: P1>(_: U) {
 
 struct RedundantSame<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame
 // CHECK-NEXT: (normal_conformance type=RedundantSame<T> protocol=P2)
 extension RedundantSame: P2 where T: P1 {}
 
 struct RedundantSuper<T: P4> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
 // CHECK-NEXT: (normal_conformance type=RedundantSuper<T> protocol=P2)
 extension RedundantSuper: P2 where T: P1 {}
 
 struct OverlappingSub<T: P1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
 // CHECK-NEXT: (normal_conformance type=OverlappingSub<T> protocol=P2
 // CHECK-NEXT:   conforms_to: T P4)
@@ -67,6 +71,7 @@ func overlapping_sub_bad<U: P1>(_: U) {
 
 
 struct SameType<T> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType
 // CHECK-NEXT: (normal_conformance type=SameType<T> protocol=P2
 // CHECK-NEXT:   same_type: T Int)
@@ -83,6 +88,7 @@ func same_type_bad<U>(_: U) {
 
 
 struct SameTypeGeneric<T, U> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric
 // CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, U> protocol=P2
 // CHECK-NEXT:   same_type: T U)
@@ -109,6 +115,7 @@ func same_type_bad<U, V>(_: U, _: V) {
 
 struct Infer<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer
 // CHECK-NEXT: (normal_conformance type=Infer<T, U> protocol=P2
 // CHECK-NEXT:   same_type: T Constrained<U>
 // CHECK-NEXT:   conforms_to:  U P1)
@@ -126,6 +133,7 @@ func infer_bad<U: P1, V>(_: U, _: V) {
 }
 
 struct InferRedundant<T, U: P1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant
 // CHECK-NEXT: (normal_conformance type=InferRedundant<T, U> protocol=P2
 // CHECK-NEXT:   same_type: T Constrained<U>)
@@ -147,6 +155,7 @@ class C3: C2 {}
 
 struct ClassFree<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree
 // CHECK-NEXT: (normal_conformance type=ClassFree<T> protocol=P2
 // CHECK-NEXT:   superclass: T C1)
 extension ClassFree: P2 where T: C1 {} // expected-note {{requirement from conditional conformance of 'ClassFree<U>' to 'P2'}}
@@ -159,6 +168,7 @@ func class_free_bad<U>(_: U) {
 }
 
 struct ClassMoreSpecific<T: C1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific
 // CHECK-NEXT: (normal_conformance type=ClassMoreSpecific<T> protocol=P2
 // CHECK-NEXT:   superclass: T C3)
@@ -173,6 +183,7 @@ func class_more_specific_bad<U: C1>(_: U) {
 
 
 struct ClassLessSpecific<T: C3> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific
 // CHECK-NEXT: (normal_conformance type=ClassLessSpecific<T> protocol=P2)
 extension ClassLessSpecific: P2 where T: C1 {}
@@ -196,9 +207,11 @@ func subclass_bad() {
 
 struct InheritEqual<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P2
 // CHECK-NEXT:    conforms_to: T P1)
 extension InheritEqual: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P2'}}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P5
 // CHECK-NEXT:    (normal_conformance type=InheritEqual<T> protocol=P2
@@ -224,9 +237,11 @@ extension InheritLess: P5 {} // expected-error{{type 'T' does not conform to pro
 
 struct InheritMore<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P2
 // CHECK-NEXT:    conforms_to: T P1)
 extension InheritMore: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritMore<U>' to 'P2'}}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P5
 // CHECK-NEXT:    (normal_conformance type=InheritMore<T> protocol=P2
@@ -311,10 +326,12 @@ extension TwoDisjointConformances: P2 where T == String {}
 // true in the original type's generic signature.
 struct RedundancyOrderDependenceGood<T: P1, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood
 // CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceGood<T, U> protocol=P2
 // CHECK-NEXT:   same_type: T U)
 extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
 struct RedundancyOrderDependenceBad<T, U: P1> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
 // CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceBad<T, U> protocol=P2
 // CHECK-NEXT:   conforms_to: T P1

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -103,10 +103,10 @@ protocol P3 {
   func foo() -> Assoc
 }
 
-struct X3 : P3 { // expected-note{{'X3' declared here}}
+struct X3 : P3 {
 }
 
-extension X3.Assoc { // expected-error{{'Assoc' is not a member type of 'X3'}}
+extension X3.Assoc {
 }
 
 extension X3 {

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -150,7 +150,6 @@ struct XSubP0b : SubscriptP0 {
 struct XSubP0c : SubscriptP0 {
 // expected-error@-1 {{type 'XSubP0c' does not conform to protocol 'SubscriptP0'}}
   subscript (i: Index) -> Element { get { } }
-  // expected-error@-1 {{reference to invalid associated type 'Element' of type 'XSubP0c'}}
 }
 
 struct XSubP0d : SubscriptP0 {

--- a/test/refactoring/FillStubs/Outputs/basic/P59-12.swift.expected
+++ b/test/refactoring/FillStubs/Outputs/basic/P59-12.swift.expected
@@ -61,6 +61,10 @@ extension C12 : P1 {
         <#code#>
     }
 
+    func foo1() {
+        <#code#>
+    }
+
   func foo1() {}
 }
 extension C12 : P2 {

--- a/test/refactoring/RefactoringKind/basic.swift
+++ b/test/refactoring/RefactoringKind/basic.swift
@@ -309,7 +309,7 @@ func testConvertToIfLetExpr(idxOpt: Int?) {
 // RUN: %refactor -source-filename %s -pos=68:12 | %FileCheck %s -check-prefix=CHECK-RENAME-STUB
 
 // RUN: %refactor -source-filename %s -pos=69:8 | %FileCheck %s -check-prefix=CHECK-RENAME-ONLY
-// RUN: %refactor -source-filename %s -pos=70:12 | %FileCheck %s -check-prefix=CHECK-RENAME-ONLY
+// RUN: %refactor -source-filename %s -pos=70:12 | %FileCheck %s -check-prefix=CHECK-RENAME-STUB
 // RUN: %refactor -source-filename %s -pos=74:12 | %FileCheck %s -check-prefix=CHECK-RENAME-ONLY
 
 // RUN: %refactor -source-filename %s -pos=79:8 | %FileCheck %s -check-prefix=CHECK-RENAME-ONLY
@@ -321,7 +321,7 @@ func testConvertToIfLetExpr(idxOpt: Int?) {
 // RUN: %refactor -source-filename %s -pos=91:12 | %FileCheck %s -check-prefix=CHECK-RENAME-STUB
 
 // RUN: %refactor -source-filename %s -pos=95:8 | %FileCheck %s -check-prefix=CHECK-RENAME-ONLY
-// RUN: %refactor -source-filename %s -pos=96:12 | %FileCheck %s -check-prefix=CHECK-RENAME-ONLY
+// RUN: %refactor -source-filename %s -pos=96:12 | %FileCheck %s -check-prefix=CHECK-RENAME-STUB
 // RUN: %refactor -source-filename %s -pos=100:12 | %FileCheck %s -check-prefix=CHECK-RENAME-STUB
 
 // RUN: %refactor -source-filename %s -pos=104:8 | %FileCheck %s -check-prefix=CHECK-RENAME-ONLY

--- a/validation-test/compiler_crashers_2_fixed/0126-sr5905.swift
+++ b/validation-test/compiler_crashers_2_fixed/0126-sr5905.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend %s -emit-ir -o /dev/null
+// RUN: %target-typecheck-verify-swift
+
 protocol VectorIndex {
     associatedtype Vector8 : Vector where Vector8.Index == Self, Vector8.Element == UInt8
 }
@@ -18,7 +19,7 @@ struct Vector1<Element> : Vector {
     init(elementForIndex: (VectorIndex1) -> Element) {
         e0 = elementForIndex(.i0)
     }
-    subscript(index: Index) -> Element {
+    subscript(index: Index) -> Element { // expected-error {{reference to invalid associated type 'Index' of type 'Vector1<Element>'}}
         get { return e0 }
         set { e0 = newValue }
     }


### PR DESCRIPTION
This patch appears to both regress an SR and accept a class of programs that were previously rejected.

On the regression, it appears this code was materializing a type witness purely by coincidence.  Validation order has changed, and this no longer works.

On the other hand, matching now appears to take into account type witnesses in more kinds of extensions.  i.e. this compiles now

```
protocol P3 {
  associatedtype Assoc
  func foo() -> Assoc
}

struct X3 : P3 {
}

extension X3.Assoc {
}

extension X3 {
  func foo() -> Int { return 0 }
}
```