### PR TITLE
Update checkout for swift-syntax.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -255,7 +255,7 @@
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",
-                "swift-syntax": "adc26e4473d53e6b3e1b7945aca495595f07cc41",
+                "swift-syntax": "ed002604feb028333e9fe3612cadc8ace8c4e3ec",
                 "swift-stress-tester": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",
                 "swift-corelibs-xctest": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",
                 "swift-corelibs-foundation": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",


### PR DESCRIPTION
Related to `swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a -> tensorflow` merge: https://github.com/apple/swift/pull/28080

---

Fixes the following error from `./swift/utils/build-toolchain-tensorflow --pkg` on macOS:
```
$ ./swift/utils/build-toolchain-tensorflow --pkg
...
+ /Users/danielzheng/swift-merge/swift-syntax/build-script.py --build-dir /Users/danielzheng/swift-merge/build/buildbot_osx/swiftsyntax-macosx-x86_64 --toolchain /Users/danielzheng/swift-merge/swift/swift-nightly-install/Library/Developer/Toolchains/swift-tensorflow-LOCAL-2019-11-05-a.xctoolchain --filecheck-exec /Users/danielzheng/swift-merge/build/buildbot_osx/llvm-macosx-x86_64/bin/FileCheck --release --verbose
usage: build-script.py [-h] [--build-dir BUILD_DIR] [-v] [-r]
                       [--add-source-locations] [--install]
                       [--generate-xcodeproj] [--xcconfig-path XCCONFIG_PATH]
                       [--dylib-dir DYLIB_DIR]
                       [--swiftmodule-dir SWIFTMODULE_DIR] [--disable-sandbox]
                       [--degyb-only] [--degyb-tar-path DEGYB_TAR_PATH] [-t]
                       [--swift-build-exec SWIFT_BUILD_EXEC]
                       [--swift-test-exec SWIFT_TEST_EXEC]
                       [--swiftc-exec SWIFTC_EXEC]
                       [--syntax-parser-header-dir SYNTAX_PARSER_HEADER_DIR]
                       [--syntax-parser-lib-dir SYNTAX_PARSER_LIB_DIR]
                       [--swift-syntax-test-exec SWIFT_SYNTAX_TEST_EXEC]
                       [--filecheck-exec FILECHECK_EXEC]
build-script.py: error: unrecognized arguments: --toolchain /Users/danielzheng/swift-merge/swift/swift-nightly-install/Library/Developer/Toolchains/swift-tensorflow-LOCAL-2019-11-05-a.xctoolchain
```

Related upstream patches:
- https://github.com/apple/swift/pull/27871
- https://github.com/apple/swift-syntax/pull/160

[`build-script.py`](https://github.com/apple/swift-syntax/blame/master/build-script.py) now accepts a [`--toolchain` argument](https://github.com/apple/swift-syntax/blame/master/build-script.py#L435).

---

However, this led to another error while building `SourceKitStressTester`:

```
$ ./swift/utils/build-toolchain-tensorflow --pkg
** Building SwiftSyntax **
/Users/danielzheng/swift-merge/swift/swift-nightly-install/Library/Developer/Toolchains/swift-tensorflow-LOCAL-2019-11-05-a.xctoolchain/usr/bin/swift build --package-path /Users/danielzheng/swift-merge/swift-syntax --configuration release --build-path /Users/danielzheng/swift-merge/build/buildbot_osx/swiftsyntax-macosx-x86_64 --verbose --product SwiftSyntax
+ /Users/danielzheng/swift-merge/swift-syntax/build-script.py --build-dir /Users/danielzheng/swift-merge/build/buildbot_osx/swiftsyntax-macosx-x86_64 --toolchain /Users/danielzheng/swift-merge/swift/swift-nightly-install/Library/Developer/Toolchains/swift-tensorflow-LOCAL-2019-11-05-a.xctoolchain --filecheck-exec /Users/danielzheng/swift-merge/build/buildbot_osx/llvm-macosx-x86_64/bin/FileCheck --release --dylib-dir /Users/danielzheng/swift-merge/swift/swift-nightly-install/Library/Developer/Toolchains/swift-tensorflow-LOCAL-2019-11-05-a.xctoolchain/usr/lib/swift/macosx --install --verbose
--- build-script.py: note: changing id in /Users/danielzheng/swift-merge/build/buildbot_osx/swiftsyntax-macosx-x86_64/release/libSwiftSyntax.dylib: install_name_tool -id @rpath/libSwiftSyntax.dylib /Users/danielzheng/swift-merge/build/buildbot_osx/swiftsyntax-macosx-x86_64/release/libSwiftSyntax.dylib
--- build-script.py: note: removing RPATH from /Users/danielzheng/swift-merge/build/buildbot_osx/swiftsyntax-macosx-x86_64/release/libSwiftSyntax.dylib: install_name_tool -delete_rpath /Users/danielzheng/swift-merge/swift/swift-nightly-install/Library/Developer/Toolchains/swift-tensorflow-LOCAL-2019-11-05-a.xctoolchain/usr/lib/swift/macosx /Users/danielzheng/swift-merge/build/buildbot_osx/swiftsyntax-macosx-x86_64/release/libSwiftSyntax.dylib
--- build-script.py: note: installing libSwiftSyntax.dylib: rsync -a /Users/danielzheng/swift-merge/build/buildbot_osx/swiftsyntax-macosx-x86_64/release/libSwiftSyntax.dylib /Users/danielzheng/swift-merge/swift/swift-nightly-install/Library/Developer/Toolchains/swift-tensorflow-LOCAL-2019-11-05-a.xctoolchain/usr/lib/swift/macosx/libSwiftSyntax.dylib
+ /Users/danielzheng/swift-merge/swift-stress-tester/build-script-helper.py build --package-dir SourceKitStressTester --toolchain /Users/danielzheng/swift-merge/swift/swift-nightly-install/Library/Developer/Toolchains/swift-tensorflow-LOCAL-2019-11-05-a.xctoolchain --config release --build-dir /Users/danielzheng/swift-merge/build/buildbot_osx/skstresstester-macosx-x86_64 --verbose
Fetching https://github.com/apple/swift-package-manager.git
Fetching https://github.com/apple/swift-syntax.git
https://github.com/apple/swift-syntax.git @ master-gen: error: terminated(128): git -C /Users/danielzheng/swift-merge/build/buildbot_osx/skstresstester-macosx-x86_64/repositories/swift-syntax-cb9339b1 rev-parse --verify 'master-gen^{commit}' output:
    fatal: Needed a single revision

FAIL: Building SourceKitStressTester failed
```

I'm not sure what's the cause - not investigating further but happy to continue testing macOS toolchain builds!