### PR TITLE
[build-script] Build SwiftEvolve as part of the unified build

### DIFF
--- a/utils/swift_build_support/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
+++ b/utils/swift_build_support/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:../../../swift-stress-tester/SourceKitStressTester">
    </FileRef>
+   <FileRef
+      location = "group:../../../swift-stress-tester/SwiftEvolve">
+   </FileRef>
 </Workspace>

--- a/utils/swift_build_support/swift_build_support/products/swiftevolve.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftevolve.py
@@ -10,10 +10,7 @@
 #
 # ----------------------------------------------------------------------------
 
-import os
-
 from . import skstresstester
-from .. import shell
 
 
 class SwiftEvolve(skstresstester.SKStressTester):
@@ -25,38 +22,8 @@ class SwiftEvolve(skstresstester.SKStressTester):
         """
         return "swift-stress-tester"
 
-    @classmethod
-    def is_swiftpm_unified_build_product(cls):
-        return False
-
     def package_name(self):
         return 'SwiftEvolve'
-
-    # Copy of the build-script-helper invocation without the multiroot data 
-    # file. Remove again once SwiftEvolve also builds in the unified build.
-    def run_build_script_helper(self, action, additional_params=[]):
-        script_path = os.path.join(
-            self.source_dir, 'build-script-helper.py')
-
-        configuration = 'release' if self.is_release() else 'debug'
-
-        helper_cmd = [
-            script_path,
-            action,
-            '--package-dir', self.package_name(),
-            '--toolchain', self.install_toolchain_path(),
-            '--config', configuration,
-            '--build-dir', self.build_dir,
-            # There might have been a Package.resolved created by other builds
-            # or by the package being opened using Xcode. Discard that and
-            # reset the dependencies to be local.
-            '--update'
-        ]
-        if self.args.verbose_build:
-            helper_cmd.append('--verbose')
-        helper_cmd.extend(additional_params)
-
-        shell.call(helper_cmd)
 
     # Inherit the entire build configuration from the SourceKit stress tester
 


### PR DESCRIPTION
Now that the unified build seems to be working fine for SwiftSyntax and the stress tester, let’s add SwiftEvolve to it.