### PR TITLE
[build-presets] Add preset for testing SwiftSyntax on Linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1574,6 +1574,14 @@ swiftsyntax-verify-generated-files
 skstresstester
 swiftevolve
 
+[preset: buildbot_swiftsyntax_linux]
+mixin-preset=mixin_swiftpm_package_linux_platform
+release
+assertions
+swiftsyntax
+swiftsyntax-verify-generated-files
+
+
 #===------------------------------------------------------------------------===#
 # Test Swift Stress Tester
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
Since SwiftSyntax builds and runs on Linux with https://github.com/apple/swift-syntax/pull/171 we should have a preset we can use for testing SwiftSyntax in PR testing.