### PR TITLE
[NFC] Drop More Type Checkers

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -271,6 +271,9 @@ public:
   /// Cache of remapped types (useful for diagnostics).
   llvm::StringMap<Type> RemappedTypes;
 
+  /// The # of times we have performed typo correction.
+  unsigned NumTypoCorrections = 0;
+
 private:
   /// The current generation number, which reflects the number of
   /// times that external modules have been loaded.
@@ -840,6 +843,11 @@ public:
   /// This guarantees that resulted \p names doesn't have duplicated names.
   void getVisibleTopLevelModuleNames(SmallVectorImpl<Identifier> &names) const;
 
+  /// Whether to perform typo correction given the pre-configured correction limit.
+  /// Increments \c NumTypoCorrections then checks this against the limit in
+  /// the language options.
+  bool shouldPerformTypoCorrection();
+  
 private:
   /// Register the given generic signature builder to be used as the canonical
   /// generic signature builder for the given signature, if we don't already

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1737,6 +1737,11 @@ void ASTContext::getVisibleTopLevelModuleNames(
   names.erase(std::unique(names.begin(), names.end()), names.end());
 }
 
+bool ASTContext::shouldPerformTypoCorrection() {
+  NumTypoCorrections += 1;
+  return NumTypoCorrections <= LangOpts.TypoCorrectionLimit;
+}
+
 bool ASTContext::canImportModule(std::pair<Identifier, SourceLoc> ModulePath) {
   // If this module has already been successfully imported, it is importable.
   if (getLoadedModule(ModulePath) != nullptr)

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -657,8 +657,6 @@ namespace {
                                    ValueDecl *member) {
       assert(archetype && "archetype not already opened?");
 
-      auto &tc = cs.getTypeChecker();
-
       // Dig out the base type.
       Type baseTy = cs.getType(base);
 
@@ -702,7 +700,7 @@ namespace {
       if (isLValue)
         opaqueType = LValueType::get(opaqueType);
 
-      ASTContext &ctx = tc.Context;
+      ASTContext &ctx = cs.getASTContext();
       auto archetypeVal =
           new (ctx) OpaqueValueExpr(base->getSourceRange(), opaqueType);
       cs.cacheType(archetypeVal);
@@ -726,8 +724,6 @@ namespace {
         return false;
 
       // If we had a return type of 'Self', erase it.
-      ConstraintSystem &innerCS = solution.getConstraintSystem();
-      auto &tc = innerCS.getTypeChecker();
       Type resultTy;
       resultTy = cs.getType(result);
       if (resultTy->hasOpenedExistential(record.Archetype)) {
@@ -736,7 +732,7 @@ namespace {
         result = coerceToType(result, erasedTy, locator);
         // FIXME: Implement missing tuple-to-tuple conversion
         if (result == nullptr) {
-          result = new (tc.Context) ErrorExpr(range);
+          result = new (cs.getASTContext()) ErrorExpr(range);
           cs.setType(result, erasedTy);
           // The opaque value is no longer reachable in an AST walk as
           // a result of the result above being replaced with an
@@ -748,7 +744,7 @@ namespace {
       }
 
       // Form the open-existential expression.
-      result = new (tc.Context) OpenExistentialExpr(
+      result = new (cs.getASTContext()) OpenExistentialExpr(
                                   record.ExistentialValue,
                                   record.OpaqueValue,
                                   result, cs.getType(result));
@@ -1847,7 +1843,7 @@ namespace {
       // For type-sugar reasons, prefer the spelling of the default literal
       // type.
       auto type = simplifyType(cs.getType(expr));
-      if (auto defaultType = tc.getDefaultType(protocol, dc)) {
+      if (auto defaultType = TypeChecker::getDefaultType(protocol, dc)) {
         if (defaultType->isEqual(type))
           type = defaultType;
       }
@@ -1894,7 +1890,7 @@ namespace {
 
       // For type-sugar reasons, prefer the spelling of the default literal
       // type.
-      if (auto defaultType = tc.getDefaultType(protocol, dc)) {
+      if (auto defaultType = TypeChecker::getDefaultType(protocol, dc)) {
         if (defaultType->isEqual(type))
           type = defaultType;
       }
@@ -1931,7 +1927,7 @@ namespace {
       // For type-sugar reasons, prefer the spelling of the default literal
       // type.
       auto type = simplifyType(cs.getType(expr));
-      if (auto defaultType = tc.getDefaultType(protocol, dc)) {
+      if (auto defaultType = TypeChecker::getDefaultType(protocol, dc)) {
         if (defaultType->isEqual(type))
           type = defaultType;
       }
@@ -2027,7 +2023,7 @@ namespace {
 
       // For type-sugar reasons, prefer the spelling of the default literal
       // type.
-      if (auto defaultType = tc.getDefaultType(protocol, dc)) {
+      if (auto defaultType = TypeChecker::getDefaultType(protocol, dc)) {
         if (defaultType->isEqual(type))
           type = defaultType;
       }
@@ -7284,6 +7280,7 @@ namespace {
         Rewriter.simplifyExprType(expr);
         auto &cs = Rewriter.getConstraintSystem();
         auto &tc = cs.getTypeChecker();
+        auto &ctx = cs.getASTContext();
 
         // Coerce the pattern, in case we resolved something.
         auto fnType = cs.getType(closure)->castTo<FunctionType>();
@@ -7297,10 +7294,10 @@ namespace {
             Rewriter.solution.builderTransformedClosures.find(closure);
         if (builder != Rewriter.solution.builderTransformedClosures.end()) {
           auto singleExpr = builder->second.singleExpr;
-          auto returnStmt = new (tc.Context) ReturnStmt(
+          auto returnStmt = new (ctx) ReturnStmt(
              singleExpr->getStartLoc(), singleExpr, /*implicit=*/true);
           auto braceStmt = BraceStmt::create(
-              tc.Context, returnStmt->getStartLoc(), ASTNode(returnStmt),
+              ctx, returnStmt->getStartLoc(), ASTNode(returnStmt),
               returnStmt->getEndLoc(), /*implicit=*/true);
           closure->setBody(braceStmt, /*isSingleExpression=*/true);
         }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4939,23 +4939,21 @@ Expr *ExprRewriter::coerceTupleToTuple(Expr *expr,
                                               toTuple));
 }
 
-static Type getMetatypeSuperclass(Type t, TypeChecker &tc) {
+static Type getMetatypeSuperclass(Type t) {
   if (auto *metaTy = t->getAs<MetatypeType>())
     return MetatypeType::get(getMetatypeSuperclass(
-                               metaTy->getInstanceType(),
-                               tc));
+                               metaTy->getInstanceType()));
 
   if (auto *metaTy = t->getAs<ExistentialMetatypeType>())
     return ExistentialMetatypeType::get(getMetatypeSuperclass(
-                                          metaTy->getInstanceType(),
-                                          tc));
+                                          metaTy->getInstanceType()));
 
   return t->getSuperclass();
 }
 
 Expr *ExprRewriter::coerceSuperclass(Expr *expr, Type toType,
                                      ConstraintLocatorBuilder locator) {
-  auto &tc = cs.getTypeChecker();
+  auto &ctx = cs.getASTContext();
 
   auto fromType = cs.getType(expr);
 
@@ -4972,11 +4970,11 @@ Expr *ExprRewriter::coerceSuperclass(Expr *expr, Type toType,
 
   if (fromInstanceType->is<ArchetypeType>()) {
     // Coercion from archetype to its (concrete) superclass.
-    auto superclass = getMetatypeSuperclass(fromType, tc);
+    auto superclass = getMetatypeSuperclass(fromType);
 
     expr =
       cs.cacheType(
-        new (tc.Context) ArchetypeToSuperExpr(expr, superclass));
+        new (ctx) ArchetypeToSuperExpr(expr, superclass));
 
     if (!superclass->isEqual(toType))
       return coerceSuperclass(expr, toType, locator);
@@ -4990,24 +4988,24 @@ Expr *ExprRewriter::coerceSuperclass(Expr *expr, Type toType,
     // concrete superclass.
     auto fromArchetype = OpenedArchetypeType::getAny(fromType);
 
-    auto *archetypeVal = cs.cacheType(new (tc.Context) OpaqueValueExpr(
+    auto *archetypeVal = cs.cacheType(new (ctx) OpaqueValueExpr(
         expr->getSourceRange(), fromArchetype));
 
     auto *result = coerceSuperclass(archetypeVal, toType, locator);
 
     return cs.cacheType(
-      new (tc.Context) OpenExistentialExpr(expr, archetypeVal, result,
+      new (ctx) OpenExistentialExpr(expr, archetypeVal, result,
                                            toType));
   }
 
   // Coercion from subclass to superclass.
   if (toType->is<MetatypeType>()) {
     return cs.cacheType(
-      new (tc.Context) MetatypeConversionExpr(expr, toType));
+      new (ctx) MetatypeConversionExpr(expr, toType));
   }
 
   return cs.cacheType(
-    new (tc.Context) DerivedToBaseExpr(expr, toType));
+    new (ctx) DerivedToBaseExpr(expr, toType));
 }
 
 /// Collect the conformances for all the protocols of an existential type.
@@ -5016,22 +5014,21 @@ Expr *ExprRewriter::coerceSuperclass(Expr *expr, Type toType,
 /// allow the conversion here, except the ErasureExpr ends up with trivial
 /// conformances.
 static ArrayRef<ProtocolConformanceRef>
-collectExistentialConformances(TypeChecker &tc, Type fromType, Type toType,
+collectExistentialConformances(Type fromType, Type toType,
                                DeclContext *DC) {
   auto layout = toType->getExistentialLayout();
 
   SmallVector<ProtocolConformanceRef, 4> conformances;
   for (auto proto : layout.getProtocols()) {
-    conformances.push_back(tc.containsProtocol(
+    conformances.push_back(TypeChecker::containsProtocol(
         fromType, proto->getDecl(), DC, ConformanceCheckFlags::InExpression));
   }
 
-  return tc.Context.AllocateCopy(conformances);
+  return toType->getASTContext().AllocateCopy(conformances);
 }
 
 Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
                                       ConstraintLocatorBuilder locator) {
-  auto &tc = solution.getConstraintSystem().getTypeChecker();
   Type fromType = cs.getType(expr);
   Type fromInstanceType = fromType;
   Type toInstanceType = toType;
@@ -5045,10 +5042,10 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
     toInstanceType = toInstanceType->castTo<ExistentialMetatypeType>()->getInstanceType();
   }
 
-  ASTContext &ctx = tc.Context;
+  ASTContext &ctx = cs.getASTContext();
 
   auto conformances =
-    collectExistentialConformances(tc, fromInstanceType, toInstanceType, cs.DC);
+    collectExistentialConformances(fromInstanceType, toInstanceType, cs.DC);
 
   // For existential-to-existential coercions, open the source existential.
   if (fromType->isAnyExistentialType()) {
@@ -6817,7 +6814,7 @@ ExprRewriter::finishApplyDynamicCallable(ApplyExpr *apply,
 Expr *ExprRewriter::finishApply(ApplyExpr *apply, ConcreteDeclRef callee,
                                 Type openedType,
                                 ConstraintLocatorBuilder locator) {
-  TypeChecker &tc = cs.getTypeChecker();
+  auto &ctx = cs.getASTContext();
   
   auto fn = apply->getFn();
 
@@ -6849,7 +6846,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, ConcreteDeclRef callee,
         if (auto tuple = dyn_cast<TupleExpr>(arg))
           arg = tuple->getElements()[0];
 
-        auto replacement = new (tc.Context)
+        auto replacement = new (ctx)
           DynamicTypeExpr(apply->getFn()->getLoc(),
                           apply->getArg()->getStartLoc(),
                           arg,
@@ -6876,7 +6873,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, ConcreteDeclRef callee,
         body = coerceToType(body, bodyFnTy, locator);
         assert(body && "can't make nonescaping?!");
 
-        auto escapable = new (tc.Context)
+        auto escapable = new (ctx)
             OpaqueValueExpr(apply->getFn()->getSourceRange(), Type());
         cs.setType(escapable, escapableParams[0].getOldType());
 
@@ -6884,15 +6881,15 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, ConcreteDeclRef callee,
           return cs.getType(E);
         };
 
-        auto callSubExpr = CallExpr::createImplicit(tc.Context, body,
+        auto callSubExpr = CallExpr::createImplicit(ctx, body,
                                                     {escapable}, {}, getType);
         cs.cacheSubExprTypes(callSubExpr);
         cs.setType(callSubExpr->getArg(),
-                   AnyFunctionType::composeInput(tc.Context,
+                   AnyFunctionType::composeInput(ctx,
                                                  escapableParams, false));
         cs.setType(callSubExpr, resultType);
         
-        auto replacement = new (tc.Context)
+        auto replacement = new (ctx)
           MakeTemporarilyEscapableExpr(apply->getFn()->getLoc(),
                                        apply->getArg()->getStartLoc(),
                                        nonescaping,
@@ -6935,18 +6932,18 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, ConcreteDeclRef callee,
                    ->isEqual(existentialInstanceTy));
 
         auto opaqueValue =
-            new (tc.Context) OpaqueValueExpr(apply->getSourceRange(), openedTy);
+            new (ctx) OpaqueValueExpr(apply->getSourceRange(), openedTy);
         cs.setType(opaqueValue, openedTy);
         
         auto getType = [&](const Expr *E) -> Type {
           return cs.getType(E);
         };
 
-        auto callSubExpr = CallExpr::createImplicit(tc.Context, body, {opaqueValue}, {}, getType);
+        auto callSubExpr = CallExpr::createImplicit(ctx, body, {opaqueValue}, {}, getType);
         cs.cacheSubExprTypes(callSubExpr);
         cs.setType(callSubExpr, resultTy);
         
-        auto replacement = new (tc.Context)
+        auto replacement = new (ctx)
           OpenExistentialExpr(existential, opaqueValue, callSubExpr,
                               resultTy);
         cs.setType(replacement, resultTy);
@@ -7052,10 +7049,10 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, ConcreteDeclRef callee,
     // If we have a covariant result type, perform the conversion now.
     if (covariantResultType) {
       if (covariantResultType->is<FunctionType>())
-        result = cs.cacheType(new (tc.Context) CovariantFunctionConversionExpr(
+        result = cs.cacheType(new (ctx) CovariantFunctionConversionExpr(
             result, covariantResultType));
       else
-        result = cs.cacheType(new (tc.Context) CovariantReturnConversionExpr(
+        result = cs.cacheType(new (ctx) CovariantReturnConversionExpr(
             result, covariantResultType));
     }
 
@@ -7191,13 +7188,13 @@ static std::pair<Expr *, unsigned> getPrecedenceParentAndIndex(Expr *expr,
 /// parentheses must be added around "<expr>" to allow the new operator
 /// to bind correctly.
 bool swift::exprNeedsParensInsideFollowingOperator(
-    TypeChecker &TC, DeclContext *DC, Expr *expr,
+    DeclContext *DC, Expr *expr,
     PrecedenceGroupDecl *followingPG) {
   if (expr->isInfixOperator()) {
     auto exprPG = TypeChecker::lookupPrecedenceGroupForInfixOperator(DC, expr);
     if (!exprPG) return true;
 
-    return TC.Context.associateInfixOperators(exprPG, followingPG)
+    return DC->getASTContext().associateInfixOperators(exprPG, followingPG)
              != Associativity::Left;
   }
 
@@ -7214,7 +7211,7 @@ bool swift::exprNeedsParensInsideFollowingOperator(
 /// the new operator to prevent it from binding incorrectly in the
 /// surrounding context.
 bool swift::exprNeedsParensOutsideFollowingOperator(
-    TypeChecker &TC, DeclContext *DC, Expr *expr, Expr *rootExpr,
+    DeclContext *DC, Expr *expr, Expr *rootExpr,
     PrecedenceGroupDecl *followingPG) {
   Expr *parent;
   unsigned index;
@@ -7233,11 +7230,12 @@ bool swift::exprNeedsParensOutsideFollowingOperator(
     if (!parentPG) return true;
 
     // If the index is 0, this is on the LHS of the parent.
+    auto &Context = DC->getASTContext();
     if (index == 0) {
-      return TC.Context.associateInfixOperators(followingPG, parentPG)
+      return Context.associateInfixOperators(followingPG, parentPG)
                != Associativity::Left;
     } else {
-      return TC.Context.associateInfixOperators(parentPG, followingPG)
+      return Context.associateInfixOperators(parentPG, followingPG)
                != Associativity::Right;
     }
   }
@@ -7245,24 +7243,22 @@ bool swift::exprNeedsParensOutsideFollowingOperator(
   return true;
 }
 
-bool swift::exprNeedsParensBeforeAddingNilCoalescing(TypeChecker &TC,
-                                                     DeclContext *DC,
+bool swift::exprNeedsParensBeforeAddingNilCoalescing(DeclContext *DC,
                                                      Expr *expr) {
   auto asPG = TypeChecker::lookupPrecedenceGroup(
       DC, DC->getASTContext().Id_NilCoalescingPrecedence, SourceLoc());
   if (!asPG)
     return true;
-  return exprNeedsParensInsideFollowingOperator(TC, DC, expr, asPG);
+  return exprNeedsParensInsideFollowingOperator(DC, expr, asPG);
 }
 
-bool swift::exprNeedsParensAfterAddingNilCoalescing(TypeChecker &TC,
-                                                    DeclContext *DC,
+bool swift::exprNeedsParensAfterAddingNilCoalescing(DeclContext *DC,
                                                     Expr *expr,
                                                     Expr *rootExpr) {
   auto asPG = TypeChecker::lookupPrecedenceGroup(
       DC, DC->getASTContext().Id_NilCoalescingPrecedence, SourceLoc());
   if (!asPG) return true;
-  return exprNeedsParensOutsideFollowingOperator(TC, DC, expr, rootExpr, asPG);
+  return exprNeedsParensOutsideFollowingOperator(DC, expr, rootExpr, asPG);
 }
 
 namespace {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -403,7 +403,6 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
   SmallVector<Constraint *, 2> defaultableConstraints;
   SmallVector<PotentialBinding, 4> literalBindings;
   bool addOptionalSupertypeBindings = false;
-  auto &tc = getTypeChecker();
   bool hasNonDependentMemberRelationalConstraints = false;
   bool hasDependentMemberRelationalConstraints = false;
   for (auto constraint : constraints) {
@@ -523,7 +522,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
     case ConstraintKind::SelfObjectOfProtocol:
       // Swift 3 allowed the use of default types for normal conformances
       // to expressible-by-literal protocols.
-      if (tc.Context.LangOpts.EffectiveLanguageVersion[0] >= 4)
+      if (getASTContext().LangOpts.EffectiveLanguageVersion[0] >= 4)
         continue;
 
       if (!constraint->getSecondType()->is<ProtocolType>())
@@ -541,7 +540,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
 
       // If there is a default literal type for this protocol, it's a
       // potential binding.
-      auto defaultType = tc.getDefaultType(constraint->getProtocol(), DC);
+      auto defaultType = TypeChecker::getDefaultType(constraint->getProtocol(), DC);
       if (!defaultType)
         continue;
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3702,7 +3702,7 @@ bool FailureDiagnosis::visitObjectLiteralExpr(ObjectLiteralExpr *E) {
 
   // Conditions for showing this diagnostic:
   // * The object literal protocol's default type is unimplemented
-  if (TC.getDefaultType(protocol, CS.DC))
+  if (TypeChecker::getDefaultType(protocol, CS.DC))
     return false;
   // * The object literal has no contextual type
   if (CS.getContextualType())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1130,12 +1130,11 @@ void MissingOptionalUnwrapFailure::offerDefaultValueUnwrapFixIt(
 
   auto diag = emitDiagnostic(expr->getLoc(), diag::unwrap_with_default_value);
 
-  auto &TC = getTypeChecker();
   // Figure out what we need to parenthesize.
   bool needsParensInside =
-      exprNeedsParensBeforeAddingNilCoalescing(TC, DC, expr);
+      exprNeedsParensBeforeAddingNilCoalescing(DC, expr);
   bool needsParensOutside =
-      exprNeedsParensAfterAddingNilCoalescing(TC, DC, expr, getParentExpr());
+      exprNeedsParensAfterAddingNilCoalescing(DC, expr, getParentExpr());
 
   llvm::SmallString<2> insertBefore;
   llvm::SmallString<32> insertAfter;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3013,7 +3013,6 @@ DeclName MissingMemberFailure::findCorrectEnumCaseName(
 }
 
 bool MissingMemberFailure::diagnoseAsError() {
-  auto &TC = getTypeChecker();
   auto *anchor = getRawAnchor();
   auto *baseExpr = getAnchor();
 
@@ -3045,10 +3044,10 @@ bool MissingMemberFailure::diagnoseAsError() {
         .highlight(nameLoc.getSourceRange());
   };
 
-  TypoCorrectionResults corrections(TC, getName(), nameLoc);
+  TypoCorrectionResults corrections(getName(), nameLoc);
   auto tryTypoCorrection = [&] (Type type) {
-    TC.performTypoCorrection(getDC(), DeclRefKind::Ordinary, type,
-                             defaultMemberLookupOptions, corrections);
+    TypeChecker::performTypoCorrection(getDC(), DeclRefKind::Ordinary, type,
+                                       defaultMemberLookupOptions, corrections);
   };
 
   if (getName().getBaseName().getKind() == DeclBaseName::Kind::Subscript) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -938,26 +938,21 @@ public:
 private:
   bool exprNeedsParensBeforeAddingAs(Expr *expr) {
     auto *DC = getDC();
-    auto &TC = getTypeChecker();
-
     auto asPG = TypeChecker::lookupPrecedenceGroup(
         DC, DC->getASTContext().Id_CastingPrecedence, SourceLoc());
     if (!asPG)
       return true;
-    return exprNeedsParensInsideFollowingOperator(TC, DC, expr, asPG);
+    return exprNeedsParensInsideFollowingOperator(DC, expr, asPG);
   }
 
   bool exprNeedsParensAfterAddingAs(Expr *expr, Expr *rootExpr) {
     auto *DC = getDC();
-    auto &TC = getTypeChecker();
-
     auto asPG = TypeChecker::lookupPrecedenceGroup(
         DC, DC->getASTContext().Id_CastingPrecedence, SourceLoc());
     if (!asPG)
       return true;
 
-    return exprNeedsParensOutsideFollowingOperator(TC, DC, expr, rootExpr,
-                                                   asPG);
+    return exprNeedsParensOutsideFollowingOperator(DC, expr, rootExpr, asPG);
   }
 };
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2267,8 +2267,8 @@ namespace {
 
           // Okay, resolve the pattern.
           Pattern *pattern = clause->getErrorPattern();
-          pattern = CS.TC.resolvePattern(pattern, CS.DC,
-                                         /*isStmtCondition*/false);
+          pattern = TypeChecker::resolvePattern(pattern, CS.DC,
+                                                /*isStmtCondition*/false);
           if (!pattern) return false;
 
           // Save that aside while we explore the type.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3792,7 +3792,6 @@ bool swift::areGenericRequirementsSatisfied(
 
 bool swift::canSatisfy(Type type1, Type type2, bool openArchetypes,
                        ConstraintKind kind, DeclContext *dc) {
-  std::unique_ptr<TypeChecker> CreatedTC;
   auto *TC = dc->getASTContext().getLegacyGlobalTypeChecker();
   assert(TC && "Must have type checker to make semantic query!");
   return TC->typesSatisfyConstraint(type1, type2, openArchetypes, kind, dc,
@@ -3840,7 +3839,6 @@ getMemberDecls(InterestedMemberKind Kind) {
 ResolvedMemberResult
 swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
   ResolvedMemberResult Result;
-  std::unique_ptr<TypeChecker> CreatedTC;
   // If the current ast context has no type checker, create one for it.
   auto *TC = DC.getASTContext().getLegacyGlobalTypeChecker();
   assert(TC && "Must have type checker to make global query!");

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -480,7 +480,7 @@ namespace {
     if (lti.haveFloatLiteral) {
       if (auto floatProto = CS.getASTContext().getProtocol(
               KnownProtocolKind::ExpressibleByFloatLiteral)) {
-        if (auto defaultType = CS.TC.getDefaultType(floatProto, CS.DC)) {
+        if (auto defaultType = TypeChecker::getDefaultType(floatProto, CS.DC)) {
           if (!CS.getFavoredType(expr)) {
             CS.setFavoredType(expr, defaultType.getPointer());
           }
@@ -547,7 +547,6 @@ namespace {
     if (otherArgTy)
       otherArgTy = otherArgTy->getWithoutSpecifierType();
 
-    auto &tc = CS.getTypeChecker();
     for (auto literalProto : literalProtos) {
       // If there is another, concrete argument, check whether it's type
       // conforms to the literal protocol and test against it directly.
@@ -559,7 +558,7 @@ namespace {
                 otherArgTy, literalProto, CS.DC,
                 ConformanceCheckFlags::InExpression))
           return true;
-      } else if (Type defaultType = tc.getDefaultType(literalProto, CS.DC)) {
+      } else if (Type defaultType = TypeChecker::getDefaultType(literalProto, CS.DC)) {
         // If there is a default type for the literal protocol, check whether
         // it is the same as the parameter type.
         // Check whether there is a default type to compare against.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1685,7 +1685,7 @@ void ConstraintSystem::ArgumentInfoCollector::minimizeLiteralProtocols() {
   llvm::SmallVector<ProtocolDecl *, 2> skippedProtocols;
 
   for (auto *protocol : LiteralProtocols) {
-    if (auto defaultType = CS.TC.getDefaultType(protocol, CS.DC)) {
+    if (auto defaultType = TypeChecker::getDefaultType(protocol, CS.DC)) {
       candidates.push_back({protocol, defaultType});
       continue;
     }
@@ -1923,7 +1923,7 @@ void ConstraintSystem::sortDesignatedTypes(
     return;
 
   for (auto *protocol : argInfo.getLiteralProtocols()) {
-    auto defaultType = TC.getDefaultType(protocol, DC);
+    auto defaultType = TypeChecker::getDefaultType(protocol, DC);
     // ExpressibleByNilLiteral does not have a default type.
     if (!defaultType)
       continue;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -815,7 +815,7 @@ Type ConstraintSystem::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
                                                   DeclContext *UseDC,
                                                   const DeclRefExpr *base,
                                                   bool wantInterfaceType) {
-  return TC.getUnopenedTypeOfReference(
+  return TypeChecker::getUnopenedTypeOfReference(
       value, baseType, UseDC,
       [&](VarDecl *var) -> Type {
         if (auto *param = dyn_cast<ParamDecl>(var))
@@ -1289,8 +1289,9 @@ ConstraintSystem::getTypeOfMemberReference(
                               ->castTo<AnyFunctionType>()->getParams();
       refType = FunctionType::get(indices, elementTy);
     } else {
-      refType = getUnopenedTypeOfReference(cast<VarDecl>(value), baseTy, useDC,
-                                           base, /*wantInterfaceType=*/true);
+      refType = TypeChecker::getUnopenedTypeOfReference(
+          cast<VarDecl>(value), baseTy, useDC, base,
+          /*wantInterfaceType=*/true);
     }
 
     auto selfTy = outerDC->getSelfInterfaceType();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -895,7 +895,7 @@ void ConstraintSystem::recordOpenedTypes(
 
 /// Determine how many levels of argument labels should be removed from the
 /// function type when referencing the given declaration.
-static unsigned getNumRemovedArgumentLabels(TypeChecker &TC, ValueDecl *decl,
+static unsigned getNumRemovedArgumentLabels(ValueDecl *decl,
                                             bool isCurriedInstanceReference,
                                             FunctionRefKind functionRefKind) {
   unsigned numParameterLists = decl->getNumCurryLevels();
@@ -964,8 +964,7 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
 
     auto funcType = funcDecl->getInterfaceType()->castTo<AnyFunctionType>();
     auto numLabelsToRemove = getNumRemovedArgumentLabels(
-        TC, funcDecl,
-        /*isCurriedInstanceReference=*/false, functionRefKind);
+        funcDecl, /*isCurriedInstanceReference=*/false, functionRefKind);
 
     auto openedType = openFunctionType(funcType, locator, replacements,
                                        funcDecl->getDeclContext())
@@ -1257,8 +1256,7 @@ ConstraintSystem::getTypeOfMemberReference(
   OpenedTypeMap localReplacements;
   auto &replacements = replacementsPtr ? *replacementsPtr : localReplacements;
   unsigned numRemovedArgumentLabels = getNumRemovedArgumentLabels(
-      TC, value, /*isCurriedInstanceReference*/ !hasAppliedSelf,
-      functionRefKind);
+      value, /*isCurriedInstanceReference*/ !hasAppliedSelf, functionRefKind);
 
   AnyFunctionType *funcType;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -190,7 +190,7 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
 
     // If the protocol has a default type, check it.
     if (literalProtocol) {
-      if (auto defaultType = TC.getDefaultType(literalProtocol, DC)) {
+      if (auto defaultType = TypeChecker::getDefaultType(literalProtocol, DC)) {
         // Check whether the nominal types match. This makes sure that we
         // properly handle Array vs. Array<T>.
         if (defaultType->getAnyNominal() != type->getAnyNominal())
@@ -350,7 +350,7 @@ getAlternativeLiteralTypes(KnownProtocolKind kind) {
     // Integer literals can be treated as floating point literals.
     if (auto floatProto = TC.Context.getProtocol(
                             KnownProtocolKind::ExpressibleByFloatLiteral)) {
-      if (auto defaultType = TC.getDefaultType(floatProto, DC)) {
+      if (auto defaultType = TypeChecker::getDefaultType(floatProto, DC)) {
         types.push_back(defaultType);
       }
     }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4429,22 +4429,20 @@ public:
 
 // Return true if, when replacing "<expr>" with "<expr> ?? T", parentheses need
 // to be added around <expr> first in order to maintain the correct precedence.
-bool exprNeedsParensBeforeAddingNilCoalescing(TypeChecker &TC,
-                                              DeclContext *DC,
+bool exprNeedsParensBeforeAddingNilCoalescing(DeclContext *DC,
                                               Expr *expr);
 
 // Return true if, when replacing "<expr>" with "<expr> as T", parentheses need
 // to be added around the new expression in order to maintain the correct
 // precedence.
-bool exprNeedsParensAfterAddingNilCoalescing(TypeChecker &TC,
-                                             DeclContext *DC,
+bool exprNeedsParensAfterAddingNilCoalescing(DeclContext *DC,
                                              Expr *expr,
                                              Expr *rootExpr);
 
 /// Return true if, when replacing "<expr>" with "<expr> op <something>",
 /// parentheses must be added around "<expr>" to allow the new operator
 /// to bind correctly.
-bool exprNeedsParensInsideFollowingOperator(TypeChecker &TC, DeclContext *DC,
+bool exprNeedsParensInsideFollowingOperator(DeclContext *DC,
                                             Expr *expr,
                                             PrecedenceGroupDecl *followingPG);
 
@@ -4453,7 +4451,7 @@ bool exprNeedsParensInsideFollowingOperator(TypeChecker &TC, DeclContext *DC,
 /// the new operator to prevent it from binding incorrectly in the
 /// surrounding context.
 bool exprNeedsParensOutsideFollowingOperator(
-    TypeChecker &TC, DeclContext *DC, Expr *expr, Expr *rootExpr,
+    DeclContext *DC, Expr *expr, Expr *rootExpr,
     PrecedenceGroupDecl *followingPG);
 
 /// Determine whether this is a SIMD operator.

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -14,11 +14,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "TypeChecker.h"
 #include "TypeCheckAccess.h"
 #include "TypeAccessScopeChecker.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
@@ -73,7 +73,6 @@ using CheckTypeAccessCallback =
 
 class AccessControlCheckerBase {
 protected:
-  TypeChecker &TC;
   bool checkUsableFromInline;
 
   void checkTypeAccessImpl(
@@ -104,8 +103,8 @@ protected:
     });
   }
 
-  AccessControlCheckerBase(TypeChecker &TC, bool checkUsableFromInline)
-    : TC(TC), checkUsableFromInline(checkUsableFromInline) {}
+  AccessControlCheckerBase(bool checkUsableFromInline)
+      : checkUsableFromInline(checkUsableFromInline) {}
 
 public:
   void checkGenericParamAccess(
@@ -193,7 +192,8 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     Type type, TypeRepr *typeRepr, AccessScope contextAccessScope,
     const DeclContext *useDC, bool mayBeInferred,
     llvm::function_ref<CheckTypeAccessCallback> diagnose) {
-  if (TC.Context.isAccessControlDisabled())
+  auto &Context = useDC->getASTContext();
+  if (Context.isAccessControlDisabled())
     return;
   // Don't spend time checking local declarations; this is always valid by the
   // time we get to this point.
@@ -244,7 +244,7 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     // TypeRepr into account).
 
     if (typeRepr && mayBeInferred &&
-        !TC.getLangOpts().isSwiftVersionAtLeast(5) &&
+        !Context.LangOpts.isSwiftVersionAtLeast(5) &&
         !useDC->getParentModule()->isResilient()) {
       // Swift 4.2 and earlier didn't check the Type when a TypeRepr was
       // present. However, this is a major hole when generic parameters are
@@ -298,7 +298,7 @@ void AccessControlCheckerBase::checkTypeAccess(
 /// declaration if possible.
 ///
 /// Just flushes \p diag as is if \p complainRepr is null.
-static void highlightOffendingType(TypeChecker &TC, InFlightDiagnostic &diag,
+static void highlightOffendingType(InFlightDiagnostic &diag,
                                    const TypeRepr *complainRepr) {
   if (!complainRepr) {
     diag.flush();
@@ -310,7 +310,7 @@ static void highlightOffendingType(TypeChecker &TC, InFlightDiagnostic &diag,
 
   if (auto CITR = dyn_cast<ComponentIdentTypeRepr>(complainRepr)) {
     const ValueDecl *VD = CITR->getBoundDecl();
-    TC.diagnose(VD, diag::kind_declared_here, DescriptiveDeclKind::Type);
+    VD->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
   }
 }
 
@@ -372,18 +372,18 @@ void AccessControlCheckerBase::checkGenericParamAccess(
   if (isa<SubscriptDecl>(owner) || isa<TypeAliasDecl>(owner))
     downgradeToWarning = DowngradeToWarning::Yes;
 
+  auto &Context = owner->getASTContext();
   if (checkUsableFromInline) {
-    if (!TC.Context.isSwiftVersionAtLeast(5))
+    if (!Context.isSwiftVersionAtLeast(5))
       downgradeToWarning = DowngradeToWarning::Yes;
 
     auto diagID = diag::generic_param_usable_from_inline;
     if (downgradeToWarning == DowngradeToWarning::Yes)
       diagID = diag::generic_param_usable_from_inline_warn;
-    auto diag = TC.diagnose(owner,
-                            diagID,
-                            owner->getDescriptiveKind(),
-                            accessControlErrorKind == ACEK::Requirement);
-    highlightOffendingType(TC, diag, complainRepr);
+    auto diag =
+        Context.Diags.diagnose(owner, diagID, owner->getDescriptiveKind(),
+                               accessControlErrorKind == ACEK::Requirement);
+    highlightOffendingType(diag, complainRepr);
     return;
   }
 
@@ -395,12 +395,11 @@ void AccessControlCheckerBase::checkGenericParamAccess(
   auto diagID = diag::generic_param_access;
   if (downgradeToWarning == DowngradeToWarning::Yes)
     diagID = diag::generic_param_access_warn;
-  auto diag = TC.diagnose(owner, diagID,
-                          owner->getDescriptiveKind(), isExplicit,
-                          contextAccess, minAccess,
-                          isa<FileUnit>(owner->getDeclContext()),
-                          accessControlErrorKind == ACEK::Requirement);
-  highlightOffendingType(TC, diag, complainRepr);
+  auto diag = Context.Diags.diagnose(
+      owner, diagID, owner->getDescriptiveKind(), isExplicit, contextAccess,
+      minAccess, isa<FileUnit>(owner->getDeclContext()),
+      accessControlErrorKind == ACEK::Requirement);
+  highlightOffendingType(diag, complainRepr);
 }
 
 void AccessControlCheckerBase::checkGenericParamAccess(
@@ -416,8 +415,8 @@ namespace {
 class AccessControlChecker : public AccessControlCheckerBase,
                              public DeclVisitor<AccessControlChecker> {
 public:
-  explicit AccessControlChecker(TypeChecker &TC)
-    : AccessControlCheckerBase(TC, /*checkUsableFromInline=*/false) {}
+  AccessControlChecker()
+      : AccessControlCheckerBase(/*checkUsableFromInline=*/false) {}
 
   void visit(Decl *D) {
     if (D->isInvalid() || D->isImplicit())
@@ -477,14 +476,11 @@ public:
       auto diagID = diag::pattern_type_access_inferred;
       if (downgradeToWarning == DowngradeToWarning::Yes)
         diagID = diag::pattern_type_access_inferred_warn;
-      auto diag = TC.diagnose(NP->getLoc(), diagID,
-                              theVar->isLet(),
-                              isTypeContext,
-                              isExplicit,
-                              theVarAccess,
+      auto &DE = theVar->getASTContext().Diags;
+      auto diag = DE.diagnose(NP->getLoc(), diagID, theVar->isLet(),
+                              isTypeContext, isExplicit, theVarAccess,
                               isa<FileUnit>(theVar->getDeclContext()),
-                              typeAccess,
-                              theVar->getInterfaceType());
+                              typeAccess, theVar->getInterfaceType());
     });
   }
 
@@ -511,14 +507,11 @@ public:
       auto anyVarAccess =
           isExplicit ? anyVar->getFormalAccess()
                      : typeAccessScope.requiredAccessForDiagnostics();
-      auto diag = TC.diagnose(TP->getLoc(), diagID,
-                              anyVar->isLet(),
-                              isTypeContext,
-                              isExplicit,
-                              anyVarAccess,
-                              isa<FileUnit>(anyVar->getDeclContext()),
-                              typeAccess);
-      highlightOffendingType(TC, diag, complainRepr);
+      auto &DE = anyVar->getASTContext().Diags;
+      auto diag = DE.diagnose(
+          TP->getLoc(), diagID, anyVar->isLet(), isTypeContext, isExplicit,
+          anyVarAccess, isa<FileUnit>(anyVar->getDeclContext()), typeAccess);
+      highlightOffendingType(diag, complainRepr);
     });
 
     // Check the property wrapper types.
@@ -542,7 +535,7 @@ public:
                                      anyVarAccess,
                                      isa<FileUnit>(anyVar->getDeclContext()),
                                      typeAccess);
-        highlightOffendingType(TC, diag, complainRepr);
+        highlightOffendingType(diag, complainRepr);
       });
     }
   }
@@ -587,10 +580,9 @@ public:
       auto aliasAccess = isExplicit
         ? TAD->getFormalAccess()
         : typeAccessScope.requiredAccessForDiagnostics();
-      auto diag = TC.diagnose(TAD, diagID,
-                              isExplicit, aliasAccess,
-                              typeAccess, isa<FileUnit>(TAD->getDeclContext()));
-      highlightOffendingType(TC, diag, complainRepr);
+      auto diag = TAD->diagnose(diagID, isExplicit, aliasAccess, typeAccess,
+                                isa<FileUnit>(TAD->getDeclContext()));
+      highlightOffendingType(diag, complainRepr);
     });
   }
 
@@ -658,7 +650,7 @@ public:
 
         // Swift versions before 5.0 did not check requirements on the
         // protocol's where clause, so emit a warning.
-        if (!TC.Context.isSwiftVersionAtLeast(5))
+        if (!assocType->getASTContext().isSwiftVersionAtLeast(5))
           downgradeToWarning = DowngradeToWarning::Yes;
       }
     });
@@ -668,10 +660,9 @@ public:
       auto diagID = diag::associated_type_access;
       if (downgradeToWarning == DowngradeToWarning::Yes)
         diagID = diag::associated_type_access_warn;
-      auto diag = TC.diagnose(assocType, diagID,
-                              assocType->getFormalAccess(),
-                              minAccess, accessControlErrorKind);
-      highlightOffendingType(TC, diag, complainRepr);
+      auto diag = assocType->diagnose(diagID, assocType->getFormalAccess(),
+                                      minAccess, accessControlErrorKind);
+      highlightOffendingType(diag, complainRepr);
     }
   }
 
@@ -702,10 +693,9 @@ public:
         auto enumDeclAccess = isExplicit
           ? ED->getFormalAccess()
           : typeAccessScope.requiredAccessForDiagnostics();
-        auto diag = TC.diagnose(ED, diagID, isExplicit,
-                                enumDeclAccess, typeAccess,
-                                isa<FileUnit>(ED->getDeclContext()));
-        highlightOffendingType(TC, diag, complainRepr);
+        auto diag = ED->diagnose(diagID, isExplicit, enumDeclAccess, typeAccess,
+                                 isa<FileUnit>(ED->getDeclContext()));
+        highlightOffendingType(diag, complainRepr);
       });
     }
   }
@@ -739,7 +729,7 @@ public:
 
       auto outerDowngradeToWarning = DowngradeToWarning::No;
       if (superclassDecl->isGenericContext() &&
-          !TC.getLangOpts().isSwiftVersionAtLeast(5)) {
+          !CD->getASTContext().isSwiftVersionAtLeast(5)) {
         // Swift 4 failed to properly check this if the superclass was generic,
         // because the above loop was too strict.
         outerDowngradeToWarning = DowngradeToWarning::Yes;
@@ -760,11 +750,11 @@ public:
           ? CD->getFormalAccess()
           : typeAccessScope.requiredAccessForDiagnostics();
 
-        auto diag = TC.diagnose(CD, diagID, isExplicit, classDeclAccess,
-                                typeAccess,
-                                isa<FileUnit>(CD->getDeclContext()),
-                                superclassLocIter->getTypeRepr() != complainRepr);
-        highlightOffendingType(TC, diag, complainRepr);
+        auto diag =
+            CD->diagnose(diagID, isExplicit, classDeclAccess, typeAccess,
+                         isa<FileUnit>(CD->getDeclContext()),
+                         superclassLocIter->getTypeRepr() != complainRepr);
+        highlightOffendingType(diag, complainRepr);
       });
     }
   }
@@ -834,7 +824,7 @@ public:
               declKind = declKindForType(type);
               // Swift versions before 5.0 did not check requirements on the
               // protocol's where clause, so emit a warning.
-              if (!TC.Context.isSwiftVersionAtLeast(5))
+              if (!proto->getASTContext().isSwiftVersionAtLeast(5))
                 downgradeToWarning = DowngradeToWarning::Yes;
             }
           });
@@ -849,10 +839,10 @@ public:
       auto diagID = diag::protocol_access;
       if (downgradeToWarning == DowngradeToWarning::Yes)
         diagID = diag::protocol_access_warn;
-      auto diag = TC.diagnose(proto, diagID, isExplicit, protoAccess,
-                              protocolControlErrorKind, minAccess,
-                              isa<FileUnit>(proto->getDeclContext()), declKind);
-      highlightOffendingType(TC, diag, complainRepr);
+      auto diag = proto->diagnose(
+          diagID, isExplicit, protoAccess, protocolControlErrorKind, minAccess,
+          isa<FileUnit>(proto->getDeclContext()), declKind);
+      highlightOffendingType(diag, complainRepr);
     }
   }
 
@@ -904,12 +894,9 @@ public:
       auto subscriptDeclAccess = isExplicit
         ? SD->getFormalAccess()
         : minAccessScope.requiredAccessForDiagnostics();
-      auto diag = TC.diagnose(SD, diagID,
-                              isExplicit,
-                              subscriptDeclAccess,
-                              minAccess,
-                              problemIsElement);
-      highlightOffendingType(TC, diag, complainRepr);
+      auto diag = SD->diagnose(diagID, isExplicit, subscriptDeclAccess,
+                               minAccess, problemIsElement);
+      highlightOffendingType(diag, complainRepr);
     }
   }
 
@@ -975,14 +962,10 @@ public:
       auto fnAccess = isExplicit
         ? fn->getFormalAccess()
         : minAccessScope.requiredAccessForDiagnostics();
-      auto diag = TC.diagnose(fn, diagID,
-                              isExplicit,
-                              fnAccess,
-                              isa<FileUnit>(fn->getDeclContext()),
-                              minAccess,
-                              functionKind,
-                              problemIsResult);
-      highlightOffendingType(TC, diag, complainRepr);
+      auto diag = fn->diagnose(diagID, isExplicit, fnAccess,
+                               isa<FileUnit>(fn->getDeclContext()), minAccess,
+                               functionKind, problemIsResult);
+      highlightOffendingType(diag, complainRepr);
     }
   }
 
@@ -999,8 +982,8 @@ public:
             if (downgradeToWarning == DowngradeToWarning::Yes)
               diagID = diag::enum_case_access_warn;
             auto diag =
-                TC.diagnose(EED, diagID, EED->getFormalAccess(), typeAccess);
-            highlightOffendingType(TC, diag, complainRepr);
+                EED->diagnose(diagID, EED->getFormalAccess(), typeAccess);
+            highlightOffendingType(diag, complainRepr);
           });
     }
   }
@@ -1009,8 +992,8 @@ public:
 class UsableFromInlineChecker : public AccessControlCheckerBase,
                                 public DeclVisitor<UsableFromInlineChecker> {
 public:
-  explicit UsableFromInlineChecker(TypeChecker &TC)
-    : AccessControlCheckerBase(TC, /*checkUsableFromInline=*/true) {}
+  UsableFromInlineChecker()
+      : AccessControlCheckerBase(/*checkUsableFromInline=*/true) {}
 
   static bool shouldSkipChecking(const ValueDecl *VD) {
     if (VD->getFormalAccess() != AccessLevel::Internal)
@@ -1019,7 +1002,7 @@ public:
   };
 
   void visit(Decl *D) {
-    if (!TC.Context.isSwiftVersionAtLeast(4, 2))
+    if (!D->getASTContext().isSwiftVersionAtLeast(4, 2))
       return;
 
     if (D->isInvalid() || D->isImplicit())
@@ -1093,23 +1076,22 @@ public:
     if (seenVars.count(theVar) || theVar->isInvalid())
       return;
 
-    checkTypeAccess(theVar->getInterfaceType(), nullptr,
-                    fixedLayoutStructContext ? fixedLayoutStructContext
-                                             : theVar,
-                    /*mayBeInferred*/false,
-                    [&](AccessScope typeAccessScope,
-                        const TypeRepr *complainRepr,
-                        DowngradeToWarning downgradeToWarning) {
-      auto diagID = diag::pattern_type_not_usable_from_inline_inferred;
-      if (fixedLayoutStructContext) {
-        diagID =
-            diag::pattern_type_not_usable_from_inline_inferred_frozen;
-      } else if (!TC.Context.isSwiftVersionAtLeast(5)) {
-        diagID = diag::pattern_type_not_usable_from_inline_inferred_warn;
-      }
-      TC.diagnose(NP->getLoc(), diagID, theVar->isLet(), isTypeContext,
-                  theVar->getInterfaceType());
-    });
+    checkTypeAccess(
+        theVar->getInterfaceType(), nullptr,
+        fixedLayoutStructContext ? fixedLayoutStructContext : theVar,
+        /*mayBeInferred*/ false,
+        [&](AccessScope typeAccessScope, const TypeRepr *complainRepr,
+            DowngradeToWarning downgradeToWarning) {
+          auto &Ctx = theVar->getASTContext();
+          auto diagID = diag::pattern_type_not_usable_from_inline_inferred;
+          if (fixedLayoutStructContext) {
+            diagID = diag::pattern_type_not_usable_from_inline_inferred_frozen;
+          } else if (!Ctx.isSwiftVersionAtLeast(5)) {
+            diagID = diag::pattern_type_not_usable_from_inline_inferred_warn;
+          }
+          Ctx.Diags.diagnose(NP->getLoc(), diagID, theVar->isLet(),
+                             isTypeContext, theVar->getInterfaceType());
+        });
   }
 
   /// \see visitPatternBindingDecl
@@ -1130,22 +1112,22 @@ public:
     if (!fixedLayoutStructContext && shouldSkipChecking(anyVar))
       return;
 
-    checkTypeAccess(TP->getTypeLoc(),
-                    fixedLayoutStructContext ? fixedLayoutStructContext
-                                             : anyVar,
-                    /*mayBeInferred*/true,
-                    [&](AccessScope typeAccessScope,
-                        const TypeRepr *complainRepr,
-                        DowngradeToWarning downgradeToWarning) {
-      auto diagID = diag::pattern_type_not_usable_from_inline;
-      if (fixedLayoutStructContext)
-        diagID = diag::pattern_type_not_usable_from_inline_frozen;
-      else if (!TC.Context.isSwiftVersionAtLeast(5))
-        diagID = diag::pattern_type_not_usable_from_inline_warn;
-      auto diag = TC.diagnose(TP->getLoc(), diagID, anyVar->isLet(),
-                              isTypeContext);
-      highlightOffendingType(TC, diag, complainRepr);
-    });
+    checkTypeAccess(
+        TP->getTypeLoc(),
+        fixedLayoutStructContext ? fixedLayoutStructContext : anyVar,
+        /*mayBeInferred*/ true,
+        [&](AccessScope typeAccessScope, const TypeRepr *complainRepr,
+            DowngradeToWarning downgradeToWarning) {
+          auto &Ctx = anyVar->getASTContext();
+          auto diagID = diag::pattern_type_not_usable_from_inline;
+          if (fixedLayoutStructContext)
+            diagID = diag::pattern_type_not_usable_from_inline_frozen;
+          else if (!Ctx.isSwiftVersionAtLeast(5))
+            diagID = diag::pattern_type_not_usable_from_inline_warn;
+          auto diag = Ctx.Diags.diagnose(TP->getLoc(), diagID, anyVar->isLet(),
+                                         isTypeContext);
+          highlightOffendingType(diag, complainRepr);
+        });
 
     for (auto attr : anyVar->getAttachedPropertyWrappers()) {
       checkTypeAccess(attr->getTypeLoc(),
@@ -1158,7 +1140,7 @@ public:
         auto diag = anyVar->diagnose(
             diag::property_wrapper_type_not_usable_from_inline,
             anyVar->isLet(), isTypeContext);
-        highlightOffendingType(TC, diag, complainRepr);
+        highlightOffendingType(diag, complainRepr);
       });
     }
   }
@@ -1201,10 +1183,10 @@ public:
                         const TypeRepr *complainRepr,
                         DowngradeToWarning downgradeToWarning) {
       auto diagID = diag::type_alias_underlying_type_not_usable_from_inline;
-      if (!TC.Context.isSwiftVersionAtLeast(5))
+      if (!TAD->getASTContext().isSwiftVersionAtLeast(5))
         diagID = diag::type_alias_underlying_type_not_usable_from_inline_warn;
-      auto diag = TC.diagnose(TAD, diagID);
-      highlightOffendingType(TC, diag, complainRepr);
+      auto diag = TAD->diagnose(diagID);
+      highlightOffendingType(diag, complainRepr);
     });
   }
 
@@ -1223,10 +1205,10 @@ public:
             const TypeRepr *complainRepr,
             DowngradeToWarning downgradeDiag) {
         auto diagID = diag::associated_type_not_usable_from_inline;
-        if (!TC.Context.isSwiftVersionAtLeast(5))
+        if (!assocType->getASTContext().isSwiftVersionAtLeast(5))
           diagID = diag::associated_type_not_usable_from_inline_warn;
-        auto diag = TC.diagnose(assocType, diagID, ACEK_Requirement);
-        highlightOffendingType(TC, diag, complainRepr);
+        auto diag = assocType->diagnose(diagID, ACEK_Requirement);
+        highlightOffendingType(diag, complainRepr);
       });
     });
     checkTypeAccess(assocType->getDefaultDefinitionType(),
@@ -1236,10 +1218,10 @@ public:
                         const TypeRepr *complainRepr,
                         DowngradeToWarning downgradeDiag) {
       auto diagID = diag::associated_type_not_usable_from_inline;
-      if (!TC.Context.isSwiftVersionAtLeast(5))
+      if (!assocType->getASTContext().isSwiftVersionAtLeast(5))
         diagID = diag::associated_type_not_usable_from_inline_warn;
-      auto diag = TC.diagnose(assocType, diagID, ACEK_DefaultDefinition);
-      highlightOffendingType(TC, diag, complainRepr);
+      auto diag = assocType->diagnose(diagID, ACEK_DefaultDefinition);
+      highlightOffendingType(diag, complainRepr);
     });
 
     if (assocType->getTrailingWhereClause()) {
@@ -1252,10 +1234,10 @@ public:
                                  const TypeRepr *complainRepr,
                                  DowngradeToWarning downgradeDiag) {
         auto diagID = diag::associated_type_not_usable_from_inline;
-        if (!TC.Context.isSwiftVersionAtLeast(5))
+        if (!assocType->getASTContext().isSwiftVersionAtLeast(5))
           diagID = diag::associated_type_not_usable_from_inline_warn;
-        auto diag = TC.diagnose(assocType, diagID, ACEK_Requirement);
-        highlightOffendingType(TC, diag, complainRepr);
+        auto diag = assocType->diagnose(diagID, ACEK_Requirement);
+        highlightOffendingType(diag, complainRepr);
       });
     }
   }
@@ -1280,10 +1262,10 @@ public:
                           const TypeRepr *complainRepr,
                           DowngradeToWarning downgradeToWarning) {
         auto diagID = diag::enum_raw_type_not_usable_from_inline;
-        if (!TC.Context.isSwiftVersionAtLeast(5))
+        if (!ED->getASTContext().isSwiftVersionAtLeast(5))
           diagID = diag::enum_raw_type_not_usable_from_inline_warn;
-        auto diag = TC.diagnose(ED, diagID);
-        highlightOffendingType(TC, diag, complainRepr);
+        auto diag = ED->diagnose(diagID);
+        highlightOffendingType(diag, complainRepr);
       });
     }
   }
@@ -1322,11 +1304,11 @@ public:
                           const TypeRepr *complainRepr,
                           DowngradeToWarning downgradeToWarning) {
         auto diagID = diag::class_super_not_usable_from_inline;
-        if (!TC.Context.isSwiftVersionAtLeast(5))
+        if (!CD->getASTContext().isSwiftVersionAtLeast(5))
           diagID = diag::class_super_not_usable_from_inline_warn;
-        auto diag = TC.diagnose(CD, diagID,
-                                superclassLocIter->getTypeRepr() != complainRepr);
-        highlightOffendingType(TC, diag, complainRepr);
+        auto diag = CD->diagnose(diagID, superclassLocIter->getTypeRepr() !=
+                                             complainRepr);
+        highlightOffendingType(diag, complainRepr);
       });
     }
   }
@@ -1346,10 +1328,10 @@ public:
                           const TypeRepr *complainRepr,
                           DowngradeToWarning downgradeDiag) {
         auto diagID = diag::protocol_usable_from_inline;
-        if (!TC.Context.isSwiftVersionAtLeast(5))
+        if (!proto->getASTContext().isSwiftVersionAtLeast(5))
           diagID = diag::protocol_usable_from_inline_warn;
-        auto diag = TC.diagnose(proto, diagID, PCEK_Refine);
-        highlightOffendingType(TC, diag, complainRepr);
+        auto diag = proto->diagnose(diagID, PCEK_Refine);
+        highlightOffendingType(diag, complainRepr);
       });
     });
 
@@ -1363,10 +1345,10 @@ public:
                                  const TypeRepr *complainRepr,
                                  DowngradeToWarning downgradeDiag) {
         auto diagID = diag::protocol_usable_from_inline;
-        if (!TC.Context.isSwiftVersionAtLeast(5))
+        if (!proto->getASTContext().isSwiftVersionAtLeast(5))
           diagID = diag::protocol_usable_from_inline_warn;
-        auto diag = TC.diagnose(proto, diagID, PCEK_Requirement);
-        highlightOffendingType(TC, diag, complainRepr);
+        auto diag = proto->diagnose(diagID, PCEK_Requirement);
+        highlightOffendingType(diag, complainRepr);
       });
     }
   }
@@ -1380,11 +1362,10 @@ public:
           [&](AccessScope typeAccessScope, const TypeRepr *complainRepr,
               DowngradeToWarning downgradeDiag) {
             auto diagID = diag::subscript_type_usable_from_inline;
-            if (!TC.Context.isSwiftVersionAtLeast(5))
+            if (!SD->getASTContext().isSwiftVersionAtLeast(5))
               diagID = diag::subscript_type_usable_from_inline_warn;
-            auto diag = TC.diagnose(SD, diagID,
-                                    /*problemIsElement=*/false);
-            highlightOffendingType(TC, diag, complainRepr);
+            auto diag = SD->diagnose(diagID, /*problemIsElement=*/false);
+            highlightOffendingType(diag, complainRepr);
           });
     }
 
@@ -1393,11 +1374,10 @@ public:
                         const TypeRepr *complainRepr,
                         DowngradeToWarning downgradeDiag) {
       auto diagID = diag::subscript_type_usable_from_inline;
-      if (!TC.Context.isSwiftVersionAtLeast(5))
+      if (!SD->getASTContext().isSwiftVersionAtLeast(5))
         diagID = diag::subscript_type_usable_from_inline_warn;
-      auto diag = TC.diagnose(SD, diagID,
-                              /*problemIsElement=*/true);
-      highlightOffendingType(TC, diag, complainRepr);
+      auto diag = SD->diagnose(diagID, /*problemIsElement=*/true);
+      highlightOffendingType(diag, complainRepr);
     });
   }
 
@@ -1423,11 +1403,11 @@ public:
           [&](AccessScope typeAccessScope, const TypeRepr *complainRepr,
               DowngradeToWarning downgradeDiag) {
             auto diagID = diag::function_type_usable_from_inline;
-            if (!TC.Context.isSwiftVersionAtLeast(5))
+            if (!fn->getASTContext().isSwiftVersionAtLeast(5))
               diagID = diag::function_type_usable_from_inline_warn;
-            auto diag = TC.diagnose(fn, diagID, functionKind,
-                                    /*problemIsResult=*/false);
-            highlightOffendingType(TC, diag, complainRepr);
+            auto diag = fn->diagnose(diagID, functionKind,
+                                     /*problemIsResult=*/false);
+            highlightOffendingType(diag, complainRepr);
           });
     }
 
@@ -1437,11 +1417,11 @@ public:
                           const TypeRepr *complainRepr,
                           DowngradeToWarning downgradeDiag) {
         auto diagID = diag::function_type_usable_from_inline;
-        if (!TC.Context.isSwiftVersionAtLeast(5))
+        if (!fn->getASTContext().isSwiftVersionAtLeast(5))
           diagID = diag::function_type_usable_from_inline_warn;
-        auto diag = TC.diagnose(fn, diagID, functionKind,
-                                /*problemIsResult=*/true);
-        highlightOffendingType(TC, diag, complainRepr);
+        auto diag = fn->diagnose(diagID, functionKind,
+                                 /*problemIsResult=*/true);
+        highlightOffendingType(diag, complainRepr);
       });
     }
   }
@@ -1455,10 +1435,10 @@ public:
           [&](AccessScope typeAccessScope, const TypeRepr *complainRepr,
               DowngradeToWarning downgradeToWarning) {
             auto diagID = diag::enum_case_usable_from_inline;
-            if (!TC.Context.isSwiftVersionAtLeast(5))
+            if (!EED->getASTContext().isSwiftVersionAtLeast(5))
               diagID = diag::enum_case_usable_from_inline_warn;
-            auto diag = TC.diagnose(EED, diagID);
-            highlightOffendingType(TC, diag, complainRepr);
+            auto diag = EED->diagnose(diagID);
+            highlightOffendingType(diag, complainRepr);
           });
     }
   }
@@ -1469,8 +1449,6 @@ class ExportabilityChecker : public DeclVisitor<ExportabilityChecker> {
       llvm::function_ref<void(const TypeDecl *, const TypeRepr *)>;
   using CheckExportabilityConformanceCallback =
       llvm::function_ref<void(const ProtocolConformance *)>;
-
-  TypeChecker &TC;
 
   void checkTypeImpl(
       Type type, const TypeRepr *typeRepr, const SourceFile &SF,
@@ -1620,26 +1598,24 @@ class ExportabilityChecker : public DeclVisitor<ExportabilityChecker> {
   };
 
   class DiagnoseGenerically {
-    TypeChecker &TC;
     const Decl *D;
     Reason reason;
   public:
-    DiagnoseGenerically(TypeChecker &TC, const Decl *D, Reason reason)
-        : TC(TC), D(D), reason(reason) {}
+    DiagnoseGenerically(const Decl *D, Reason reason) : D(D), reason(reason) {}
 
     void operator()(const TypeDecl *offendingType,
                     const TypeRepr *complainRepr) {
       ModuleDecl *M = offendingType->getModuleContext();
-      auto diag = TC.diagnose(D, diag::decl_from_implementation_only_module,
+      auto diag = D->diagnose(diag::decl_from_implementation_only_module,
                               offendingType->getDescriptiveKind(),
                               offendingType->getFullName(),
                               static_cast<unsigned>(reason), M->getName());
-      highlightOffendingType(TC, diag, complainRepr);
+      highlightOffendingType(diag, complainRepr);
     }
 
     void operator()(const ProtocolConformance *offendingConformance) {
       ModuleDecl *M = offendingConformance->getDeclContext()->getParentModule();
-      TC.diagnose(D, diag::conformance_from_implementation_only_module,
+      D->diagnose(diag::conformance_from_implementation_only_module,
                   offendingConformance->getType(),
                   offendingConformance->getProtocol()->getFullName(),
                   static_cast<unsigned>(reason), M->getName());
@@ -1657,11 +1633,11 @@ class ExportabilityChecker : public DeclVisitor<ExportabilityChecker> {
 
   DiagnoseGenerically getDiagnoseCallback(const Decl *D,
                                           Reason reason = Reason::General) {
-    return DiagnoseGenerically(TC, D, reason);
+    return DiagnoseGenerically(D, reason);
   }
 
 public:
-  explicit ExportabilityChecker(TypeChecker &TC) : TC(TC) {}
+  ExportabilityChecker() {}
 
   static bool shouldSkipChecking(const ValueDecl *VD) {
     if (VD->getAttrs().hasAttribute<ImplementationOnlyAttr>())
@@ -1706,20 +1682,20 @@ public:
 
     ModuleDecl *M = overridden->getModuleContext();
     if (SF->isImportedImplementationOnly(M)) {
-      TC.diagnose(VD, diag::implementation_only_override_import_without_attr,
-                  overridden->getDescriptiveKind())
-        .fixItInsert(VD->getAttributeInsertionLoc(false),
-                     "@_implementationOnly ");
-      TC.diagnose(overridden, diag::overridden_here);
+      VD->diagnose(diag::implementation_only_override_import_without_attr,
+                   overridden->getDescriptiveKind())
+          .fixItInsert(VD->getAttributeInsertionLoc(false),
+                       "@_implementationOnly ");
+      overridden->diagnose(diag::overridden_here);
       return;
     }
 
     if (overridden->getAttrs().hasAttribute<ImplementationOnlyAttr>()) {
-      TC.diagnose(VD, diag::implementation_only_override_without_attr,
-                  overridden->getDescriptiveKind())
-        .fixItInsert(VD->getAttributeInsertionLoc(false),
-                     "@_implementationOnly ");
-      TC.diagnose(overridden, diag::overridden_here);
+      VD->diagnose(diag::implementation_only_override_without_attr,
+                   overridden->getDescriptiveKind())
+          .fixItInsert(VD->getAttributeInsertionLoc(false),
+                       "@_implementationOnly ");
+      overridden->diagnose(diag::overridden_here);
       return;
     }
 
@@ -1970,14 +1946,15 @@ public:
     if (!SF->isImportedImplementationOnly(M))
       return;
 
-    auto diag = TC.diagnose(diagLoc, diag::decl_from_implementation_only_module,
-                            PGD->getDescriptiveKind(), PGD->getName(),
-                            static_cast<unsigned>(Reason::General),
-                            M->getName());
+    auto &DE = PGD->getASTContext().Diags;
+    auto diag =
+        DE.diagnose(diagLoc, diag::decl_from_implementation_only_module,
+                    PGD->getDescriptiveKind(), PGD->getName(),
+                    static_cast<unsigned>(Reason::General), M->getName());
     if (refRange.isValid())
       diag.highlight(refRange);
     diag.flush();
-    TC.diagnose(PGD, diag::decl_declared_here, PGD->getName());
+    PGD->diagnose(diag::decl_declared_here, PGD->getName());
   }
 
   void visitInfixOperatorDecl(InfixOperatorDecl *IOD) {
@@ -2006,8 +1983,7 @@ public:
 };
 } // end anonymous namespace
 
-static void checkExtensionGenericParamAccess(TypeChecker &TC,
-                                             const ExtensionDecl *ED) {
+static void checkExtensionGenericParamAccess(const ExtensionDecl *ED) {
   auto *AA = ED->getAttrs().getAttribute<AccessControlAttr>();
   if (!AA)
     return;
@@ -2034,18 +2010,17 @@ static void checkExtensionGenericParamAccess(TypeChecker &TC,
     break;
   }
 
-  AccessControlChecker(TC).checkGenericParamAccess(ED->getGenericParams(), ED,
-                                                   desiredAccessScope,
-                                                   userSpecifiedAccess);
+  AccessControlChecker().checkGenericParamAccess(
+      ED->getGenericParams(), ED, desiredAccessScope, userSpecifiedAccess);
 }
 
-void swift::checkAccessControl(TypeChecker &TC, Decl *D) {
+void swift::checkAccessControl(Decl *D) {
   if (isa<ValueDecl>(D) || isa<PatternBindingDecl>(D)) {
-    AccessControlChecker(TC).visit(D);
-    UsableFromInlineChecker(TC).visit(D);
+    AccessControlChecker().visit(D);
+    UsableFromInlineChecker().visit(D);
   } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
-    checkExtensionGenericParamAccess(TC, ED);
+    checkExtensionGenericParamAccess(ED);
   }
 
-  ExportabilityChecker(TC).visit(D);
+  ExportabilityChecker().visit(D);
 }

--- a/lib/Sema/TypeCheckAccess.h
+++ b/lib/Sema/TypeCheckAccess.h
@@ -27,7 +27,7 @@ class TypeChecker;
 /// At a high level, this checks the given declaration's signature does not
 /// reference any other declarations that are less visible than the declaration
 /// itself. Related checks may also be performed.
-void checkAccessControl(TypeChecker &TC, Decl *D);
+void checkAccessControl(Decl *D);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -235,10 +235,9 @@ static bool containsDeclRefKind(LookupResult &lookupResult,
 
 /// Emit a diagnostic with a fixit hint for an invalid binary operator, showing
 /// how to split it according to splitCandidate.
-static void diagnoseBinOpSplit(UnresolvedDeclRefExpr *UDRE,
+static void diagnoseBinOpSplit(ASTContext &Context, UnresolvedDeclRefExpr *UDRE,
                                std::pair<unsigned, bool> splitCandidate,
-                               Diag<Identifier, Identifier, bool> diagID,
-                               TypeChecker &TC) {
+                               Diag<Identifier, Identifier, bool> diagID) {
 
   unsigned splitLoc = splitCandidate.first;
   bool isBinOpFirst = splitCandidate.second;
@@ -247,9 +246,9 @@ static void diagnoseBinOpSplit(UnresolvedDeclRefExpr *UDRE,
   auto endStr = nameStr.drop_front(splitLoc);
 
   // One valid split found, it is almost certainly the right answer.
-  auto diag = TC.diagnose(UDRE->getLoc(), diagID,
-                          TC.Context.getIdentifier(startStr),
-                          TC.Context.getIdentifier(endStr), isBinOpFirst);
+  auto diag = Context.Diags.diagnose(
+      UDRE->getLoc(), diagID, Context.getIdentifier(startStr),
+      Context.getIdentifier(endStr), isBinOpFirst);
   // Highlight the whole operator.
   diag.highlight(UDRE->getLoc());
   // Insert whitespace on the left if the binop is at the start, or to the
@@ -268,8 +267,7 @@ static void diagnoseBinOpSplit(UnresolvedDeclRefExpr *UDRE,
 /// needs whitespace.  If so, emit specific diagnostics for it and return true,
 /// otherwise return false.
 static bool diagnoseOperatorJuxtaposition(UnresolvedDeclRefExpr *UDRE,
-                                          DeclContext *DC,
-                                          TypeChecker &TC) {
+                                          DeclContext *DC) {
   Identifier name = UDRE->getName().getBaseIdentifier();
   StringRef nameStr = name.str();
   if (!name.isOperator() || nameStr.size() < 2)
@@ -280,8 +278,9 @@ static bool diagnoseOperatorJuxtaposition(UnresolvedDeclRefExpr *UDRE,
   // If this is a binary operator, relex the token, to decide whether it has
   // whitespace around it or not.  If it does "x +++ y", then it isn't likely to
   // be a case where a space was forgotten.
+  auto &Context = DC->getASTContext();
   if (isBinOp) {
-    auto tok = Lexer::getTokenAtLocation(TC.Context.SourceMgr, UDRE->getLoc());
+    auto tok = Lexer::getTokenAtLocation(Context.SourceMgr, UDRE->getLoc());
     if (tok.getKind() != tok::oper_binary_unspaced)
       return false;
   }
@@ -303,8 +302,8 @@ static bool diagnoseOperatorJuxtaposition(UnresolvedDeclRefExpr *UDRE,
     if (!Lexer::isOperator(startStr) || !Lexer::isOperator(endStr))
       continue;
 
-    auto startName = TC.Context.getIdentifier(startStr);
-    auto endName = TC.Context.getIdentifier(endStr);
+    auto startName = Context.getIdentifier(startStr);
+    auto endName = Context.getIdentifier(endStr);
 
     // Perform name lookup for the first and second pieces.  If either fail to
     // be found, then it isn't a valid split.
@@ -344,29 +343,30 @@ static bool diagnoseOperatorJuxtaposition(UnresolvedDeclRefExpr *UDRE,
   case 1:
     // One candidate: produce an error with a fixit on it.
     if (isBinOp)
-      diagnoseBinOpSplit(UDRE, WorkableSplits[0],
-                         diag::unspaced_binary_operator_fixit, TC);
+      diagnoseBinOpSplit(Context, UDRE, WorkableSplits[0],
+                         diag::unspaced_binary_operator_fixit);
     else
-      TC.diagnose(UDRE->getLoc().getAdvancedLoc(WorkableSplits[0].first),
-                  diag::unspaced_unary_operator);
+      Context.Diags.diagnose(
+          UDRE->getLoc().getAdvancedLoc(WorkableSplits[0].first),
+          diag::unspaced_unary_operator);
     return true;
 
   default:
     // Otherwise, we have to produce a series of notes listing the various
     // options.
-    TC.diagnose(UDRE->getLoc(), isBinOp ? diag::unspaced_binary_operator :
-                diag::unspaced_unary_operator)
-      .highlight(UDRE->getLoc());
+    Context.Diags
+        .diagnose(UDRE->getLoc(), isBinOp ? diag::unspaced_binary_operator
+                                          : diag::unspaced_unary_operator)
+        .highlight(UDRE->getLoc());
 
     if (isBinOp) {
       for (auto candidateSplit : WorkableSplits)
-        diagnoseBinOpSplit(UDRE, candidateSplit,
-                           diag::unspaced_binary_operators_candidate, TC);
+        diagnoseBinOpSplit(Context, UDRE, candidateSplit,
+                           diag::unspaced_binary_operators_candidate);
     }
     return true;
   }
 }
-
 
 static bool diagnoseRangeOperatorMisspell(UnresolvedDeclRefExpr *UDRE,
                                           TypeChecker &TC) {
@@ -481,7 +481,7 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
     // e.g. (x*-4) that needs whitespace.
     if (diagnoseRangeOperatorMisspell(UDRE, *this) ||
         diagnoseIncDecOperator(UDRE, *this) ||
-        diagnoseOperatorJuxtaposition(UDRE, DC, *this)) {
+        diagnoseOperatorJuxtaposition(UDRE, DC)) {
       return new (Context) ErrorExpr(UDRE->getSourceRange());
     }
 
@@ -942,16 +942,16 @@ namespace {
     /// argument-labeled interpolations.
     void correctInterpolationIfStrange(InterpolatedStringLiteralExpr *ISLE) {
       // These expressions are valid in Swift 5+.
-      if (TC.Context.isSwiftVersionAtLeast(5))
+      if (getASTContext().isSwiftVersionAtLeast(5))
         return;
 
       /// Diagnoses appendInterpolation(...) calls with multiple
       /// arguments or argument labels and corrects them.
       class StrangeInterpolationRewriter : public ASTWalker {
-        TypeChecker &TC;
+        ASTContext &Context;
 
       public:
-        StrangeInterpolationRewriter(TypeChecker &TC) : TC(TC) { }
+        StrangeInterpolationRewriter(ASTContext &Ctx) : Context(Ctx) {}
 
         virtual bool walkToDeclPre(Decl *D) {
           // We don't want to look inside decls.
@@ -972,7 +972,7 @@ namespace {
           auto call = cast<CallExpr>(E);
           if (auto callee = dyn_cast<UnresolvedDotExpr>(call->getFn())) {
             if (callee->getName().getBaseName() ==
-                    TC.Context.Id_appendInterpolation) {
+                Context.Id_appendInterpolation) {
               Expr *newArg = nullptr;
               SourceLoc lParen, rParen;
 
@@ -983,13 +983,15 @@ namespace {
                 rParen = args->getRParenLoc();
                 Expr *secondArg = args->getElement(1);
 
-                TC.diagnose(secondArg->getLoc(),
-                            diag::string_interpolation_list_changing)
-                  .highlightChars(secondArg->getLoc(), rParen);
-                TC.diagnose(secondArg->getLoc(),
-                            diag::string_interpolation_list_insert_parens)
-                  .fixItInsertAfter(lParen, "(")
-                  .fixItInsert(rParen, ")");
+                Context.Diags
+                    .diagnose(secondArg->getLoc(),
+                              diag::string_interpolation_list_changing)
+                    .highlightChars(secondArg->getLoc(), rParen);
+                Context.Diags
+                    .diagnose(secondArg->getLoc(),
+                              diag::string_interpolation_list_insert_parens)
+                    .fixItInsertAfter(lParen, "(")
+                    .fixItInsert(rParen, ")");
 
                 newArg = args;
               }
@@ -1004,27 +1006,30 @@ namespace {
                 SourceLoc argLabelLoc = call->getArgumentLabelLoc(0),
                           argLoc = newArg->getStartLoc();
 
-                TC.diagnose(argLabelLoc,
-                            diag::string_interpolation_label_changing)
-                  .highlightChars(argLabelLoc, argLoc);
-                TC.diagnose(argLabelLoc,
-                            diag::string_interpolation_remove_label,
-                            call->getArgumentLabels().front())
-                  .fixItRemoveChars(argLabelLoc, argLoc);
+                Context.Diags
+                    .diagnose(argLabelLoc,
+                              diag::string_interpolation_label_changing)
+                    .highlightChars(argLabelLoc, argLoc);
+                Context.Diags
+                    .diagnose(argLabelLoc,
+                              diag::string_interpolation_remove_label,
+                              call->getArgumentLabels().front())
+                    .fixItRemoveChars(argLabelLoc, argLoc);
               }
 
               // If newArg is no longer null, we need to build a new
               // appendInterpolation(_:) call that takes it to replace the bad
               // appendInterpolation(...) call.
               if (newArg) {
-                auto newCallee = new (TC.Context) UnresolvedDotExpr(
+                auto newCallee = new (Context) UnresolvedDotExpr(
                     callee->getBase(), /*dotloc=*/SourceLoc(),
-                    DeclName(TC.Context.Id_appendInterpolation),
+                    DeclName(Context.Id_appendInterpolation),
                     /*nameloc=*/DeclNameLoc(), /*Implicit=*/true);
 
-                E = CallExpr::create(TC.Context, newCallee, lParen,
-                    { newArg }, { Identifier() }, { SourceLoc() },
-                    rParen, /*trailingClosure=*/nullptr, /*implicit=*/false);
+                E = CallExpr::create(Context, newCallee, lParen, {newArg},
+                                     {Identifier()}, {SourceLoc()}, rParen,
+                                     /*trailingClosure=*/nullptr,
+                                     /*implicit=*/false);
               }
             }
           }
@@ -1035,13 +1040,16 @@ namespace {
           return { false, E };
         }
       };
-      
-      ISLE->getAppendingExpr()->walk(StrangeInterpolationRewriter(TC));
+
+      ISLE->getAppendingExpr()->walk(
+          StrangeInterpolationRewriter(getASTContext()));
     }
 
   public:
     PreCheckExpression(TypeChecker &tc, DeclContext *dc, Expr *parent)
         : TC(tc), DC(dc), ParentExpr(parent) {}
+
+    ASTContext &getASTContext() const { return TC.Context; }
 
     bool walkToClosureExprPre(ClosureExpr *expr);
 
@@ -1117,15 +1125,15 @@ namespace {
 
       if (auto unresolved = dyn_cast<UnresolvedDeclRefExpr>(expr)) {
         TypeChecker::checkForForbiddenPrefix(
-            TC.Context, unresolved->getName().getBaseName());
+            getASTContext(), unresolved->getName().getBaseName());
         return finish(true, TC.resolveDeclRefExpr(unresolved, DC));
       }
 
       if (auto PlaceholderE = dyn_cast<EditorPlaceholderExpr>(expr)) {
         if (!PlaceholderE->getTypeLoc().isNull()) {
-          if (!TypeChecker::validateType(TC.Context, PlaceholderE->getTypeLoc(),
-                                         TypeResolution::forContextual(DC),
-                                         None))
+          if (!TypeChecker::validateType(
+                  getASTContext(), PlaceholderE->getTypeLoc(),
+                  TypeResolution::forContextual(DC), None))
             expr->setType(PlaceholderE->getTypeLoc().getType());
         }
         return finish(true, expr);
@@ -1280,8 +1288,8 @@ namespace {
       // RebindSelfInConstructorExpr, wrap it in the
       // RebindSelfInConstructorExpr.
       if (expr == UnresolvedCtorRebindTarget) {
-        expr = new (TC.Context) RebindSelfInConstructorExpr(expr,
-                                                            UnresolvedCtorSelf);
+        expr = new (getASTContext())
+            RebindSelfInConstructorExpr(expr, UnresolvedCtorSelf);
         UnresolvedCtorRebindTarget = nullptr;
         return expr;
       }
@@ -1355,7 +1363,7 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
 
   // Validate the result type, if present.
   if (closure->hasExplicitResultType() &&
-      TypeChecker::validateType(TC.Context,
+      TypeChecker::validateType(getASTContext(),
                                 closure->getExplicitResultTypeLoc(),
                                 TypeResolution::forContextual(closure),
                                 TypeResolverContext::InExpression)) {
@@ -1421,18 +1429,18 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
     return nullptr;
 
   // Fold 'T.Protocol' into a protocol metatype.
-  if (Name == TC.Context.Id_Protocol) {
+  if (Name == getASTContext().Id_Protocol) {
     auto *NewTypeRepr =
-      new (TC.Context) ProtocolTypeRepr(InnerTypeRepr, NameLoc);
-    return new (TC.Context) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+        new (getASTContext()) ProtocolTypeRepr(InnerTypeRepr, NameLoc);
+    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
   }
 
   // Fold 'T.Type' into an existential metatype if 'T' is a protocol,
   // or an ordinary metatype otherwise.
-  if (Name == TC.Context.Id_Type) {
+  if (Name == getASTContext().Id_Type) {
     auto *NewTypeRepr =
-      new (TC.Context) MetatypeTypeRepr(InnerTypeRepr, NameLoc);
-    return new (TC.Context) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+        new (getASTContext()) MetatypeTypeRepr(InnerTypeRepr, NameLoc);
+    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
   }
 
   // Fold 'T.U' into a nested type.
@@ -1483,7 +1491,7 @@ TypeExpr *PreCheckExpression::simplifyUnresolvedSpecializeExpr(
   if (auto *te = dyn_cast<TypeExpr>(us->getSubExpr())) {
     if (auto *ITR = dyn_cast_or_null<IdentTypeRepr>(te->getTypeRepr())) {
       return TypeExpr::createForSpecializedDecl(ITR, genericArgs, angleRange,
-                                                TC.Context);
+                                                getASTContext());
     }
   }
 
@@ -1526,8 +1534,8 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       return TyExpr;
 
     auto *NewTypeRepr =
-      new (TC.Context) OptionalTypeRepr(InnerTypeRepr, QuestionLoc);
-    return new (TC.Context) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+        new (getASTContext()) OptionalTypeRepr(InnerTypeRepr, QuestionLoc);
+    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
   }
 
   // Fold T! into an IUO type when T is a TypeExpr.
@@ -1540,10 +1548,10 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
            "This doesn't work on implicit TypeExpr's, "
            "the TypeExpr should have been built correctly in the first place");
 
-    auto *NewTypeRepr =
-      new (TC.Context) ImplicitlyUnwrappedOptionalTypeRepr(InnerTypeRepr,
-                                                          FVE->getExclaimLoc());
-    return new (TC.Context) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    auto *NewTypeRepr = new (getASTContext())
+        ImplicitlyUnwrappedOptionalTypeRepr(InnerTypeRepr,
+                                            FVE->getExclaimLoc());
+    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
   }
 
   // Fold (T) into a type T with parens around it.
@@ -1555,11 +1563,10 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     assert(!TyExpr->isImplicit() && InnerTypeRepr[0].Type &&
            "SubscriptExpr doesn't work on implicit TypeExpr's, "
            "the TypeExpr should have been built correctly in the first place");
-    
-    auto *NewTypeRepr = TupleTypeRepr::create(TC.Context,
-                                              InnerTypeRepr,
+
+    auto *NewTypeRepr = TupleTypeRepr::create(getASTContext(), InnerTypeRepr,
                                               PE->getSourceRange());
-    return new (TC.Context) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
   }
   
   // Fold a tuple expr like (T1,T2) into a tuple type (T1,T2).
@@ -1590,10 +1597,9 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       Elts.push_back(elt);
       ++EltNo;
     }
-    auto *NewTypeRepr = TupleTypeRepr::create(TC.Context, Elts,
-                                              TE->getSourceRange(),
-                                              SourceLoc(), Elts.size());
-    return new (TC.Context) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    auto *NewTypeRepr = TupleTypeRepr::create(
+        getASTContext(), Elts, TE->getSourceRange(), SourceLoc(), Elts.size());
+    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
   }
   
 
@@ -1606,12 +1612,10 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     if (!TyExpr)
       return nullptr;
 
-    auto *NewTypeRepr =
-      new (TC.Context) ArrayTypeRepr(TyExpr->getTypeRepr(), 
-                                     SourceRange(AE->getLBracketLoc(),
-                                                 AE->getRBracketLoc()));
-    return new (TC.Context) TypeExpr(TypeLoc(NewTypeRepr, Type()));
-
+    auto *NewTypeRepr = new (getASTContext())
+        ArrayTypeRepr(TyExpr->getTypeRepr(),
+                      SourceRange(AE->getLBracketLoc(), AE->getRBracketLoc()));
+    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
   }
 
   // Fold [K : V] into a dictionary type.
@@ -1648,12 +1652,11 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       valueTypeRepr = TRE->getElementType(1);
     }
 
-    auto *NewTypeRepr =
-      new (TC.Context) DictionaryTypeRepr(keyTypeRepr, valueTypeRepr,
-                                          /*FIXME:colonLoc=*/SourceLoc(),
-                                          SourceRange(DE->getLBracketLoc(),
-                                                      DE->getRBracketLoc()));
-    return new (TC.Context) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    auto *NewTypeRepr = new (getASTContext()) DictionaryTypeRepr(
+        keyTypeRepr, valueTypeRepr,
+        /*FIXME:colonLoc=*/SourceLoc(),
+        SourceRange(DE->getLBracketLoc(), DE->getRBracketLoc()));
+    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
   }
 
   // Reinterpret arrow expr T1 -> T2 as function type.
@@ -1688,12 +1691,13 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
         if (auto *TTyRepr = dyn_cast<TupleTypeRepr>(ArgRepr))
           return TTyRepr;
         diagnoseMissingParens(TC, ArgRepr);
-        return TupleTypeRepr::create(TC.Context, {ArgRepr},
+        return TupleTypeRepr::create(getASTContext(), {ArgRepr},
                                      ArgRepr->getSourceRange());
       }
       if (auto *TE = dyn_cast<TupleExpr>(E))
         if (TE->getNumElements() == 0)
-          return TupleTypeRepr::createEmpty(TC.Context, TE->getSourceRange());
+          return TupleTypeRepr::createEmpty(getASTContext(),
+                                            TE->getSourceRange());
 
       // When simplifying a type expr like "(P1 & P2) -> (P3 & P4) -> Int",
       // it may have been folded at the same time; recursively simplify it.
@@ -1702,7 +1706,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
         if (auto *TTyRepr = dyn_cast<TupleTypeRepr>(ArgRepr))
           return TTyRepr;
         diagnoseMissingParens(TC, ArgRepr);
-        return TupleTypeRepr::create(TC.Context, {ArgRepr},
+        return TupleTypeRepr::create(getASTContext(), {ArgRepr},
                                      ArgRepr->getSourceRange());
       }
       return nullptr;
@@ -1715,7 +1719,8 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
         return TyE->getTypeRepr();
       if (auto *TE = dyn_cast<TupleExpr>(E))
         if (TE->getNumElements() == 0)
-          return TupleTypeRepr::createEmpty(TC.Context, TE->getSourceRange());
+          return TupleTypeRepr::createEmpty(getASTContext(),
+                                            TE->getSourceRange());
 
       // When simplifying a type expr like "P1 & P2 -> P3 & P4 -> Int",
       // it may have been folded at the same time; recursively simplify it.
@@ -1729,24 +1734,23 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       TC.diagnose(AE->getArgsExpr()->getLoc(),
                   diag::expected_type_before_arrow);
       auto ArgRange = AE->getArgsExpr()->getSourceRange();
-      auto ErrRepr =
-          new (TC.Context) ErrorTypeRepr(ArgRange);
-      ArgsTypeRepr = TupleTypeRepr::create(TC.Context, {ErrRepr}, ArgRange);
+      auto ErrRepr = new (getASTContext()) ErrorTypeRepr(ArgRange);
+      ArgsTypeRepr =
+          TupleTypeRepr::create(getASTContext(), {ErrRepr}, ArgRange);
     }
 
     TypeRepr *ResultTypeRepr = extractTypeRepr(AE->getResultExpr());
     if (!ResultTypeRepr) {
       TC.diagnose(AE->getResultExpr()->getLoc(),
                   diag::expected_type_after_arrow);
-      ResultTypeRepr =
-        new (TC.Context) ErrorTypeRepr(AE->getResultExpr()->getSourceRange());
+      ResultTypeRepr = new (getASTContext())
+          ErrorTypeRepr(AE->getResultExpr()->getSourceRange());
     }
 
-    auto NewTypeRepr =
-      new (TC.Context) FunctionTypeRepr(nullptr, ArgsTypeRepr,
-                                        AE->getThrowsLoc(), AE->getArrowLoc(),
-                                        ResultTypeRepr);
-    return new (TC.Context) TypeExpr(TypeLoc(NewTypeRepr, Type()));
+    auto NewTypeRepr = new (getASTContext())
+        FunctionTypeRepr(nullptr, ArgsTypeRepr, AE->getThrowsLoc(),
+                         AE->getArrowLoc(), ResultTypeRepr);
+    return new (getASTContext()) TypeExpr(TypeLoc(NewTypeRepr, Type()));
   }
   
   // Fold 'P & Q' into a composition type
@@ -1795,9 +1799,10 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       if (!rhs) return nullptr;
       Types.push_back(rhs->getTypeRepr());
 
-      auto CompRepr = CompositionTypeRepr::create(TC.Context, Types,
-          lhsExpr->getStartLoc(), binaryExpr->getSourceRange());
-      return new (TC.Context) TypeExpr(TypeLoc(CompRepr, Type()));
+      auto CompRepr = CompositionTypeRepr::create(getASTContext(), Types,
+                                                  lhsExpr->getStartLoc(),
+                                                  binaryExpr->getSourceRange());
+      return new (getASTContext()) TypeExpr(TypeLoc(CompRepr, Type()));
     }
   }
 
@@ -1847,8 +1852,8 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
         // .[0] or just plain [0]
         components.push_back(
             KeyPathExpr::Component::forUnresolvedSubscriptWithPrebuiltIndexExpr(
-                TC.Context,
-                SE->getIndex(), SE->getArgumentLabels(), SE->getLoc()));
+                getASTContext(), SE->getIndex(), SE->getArgumentLabels(),
+                SE->getLoc()));
 
         expr = SE->getBase();
       } else if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {
@@ -1925,7 +1930,7 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
   std::reverse(components.begin(), components.end());
 
   KPE->setRootType(rootType);
-  KPE->resolveComponents(TC.Context, components);
+  KPE->resolveComponents(getASTContext(), components);
 }
 
 Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
@@ -1952,7 +1957,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
   if (!literal)
     return nullptr;
 
-  auto *protocol = TypeChecker::getLiteralProtocol(TC.Context, literal);
+  auto *protocol = TypeChecker::getLiteralProtocol(getASTContext(), literal);
   if (!protocol)
     return nullptr;
 
@@ -1964,9 +1969,8 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
     options |= TypeResolutionFlags::AllowUnboundGenerics;
 
     auto &typeLoc = typeExpr->getTypeLoc();
-    bool hadError =
-        TypeChecker::validateType(TC.Context, typeLoc,
-                                  TypeResolution::forContextual(DC), options);
+    bool hadError = TypeChecker::validateType(
+        getASTContext(), typeLoc, TypeResolution::forContextual(DC), options);
 
     if (hadError)
       return nullptr;
@@ -1986,7 +1990,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
   auto *NTD = type->getAnyNominal();
   SmallVector<ProtocolConformance *, 2> conformances;
   return NTD->lookupConformance(DC->getParentModule(), protocol, conformances)
-             ? CoerceExpr::forLiteralInit(TC.Context, argExpr,
+             ? CoerceExpr::forLiteralInit(getASTContext(), argExpr,
                                           call->getSourceRange(),
                                           typeExpr->getTypeLoc())
              : nullptr;
@@ -2060,14 +2064,14 @@ bool GenericRequirementsCheckListener::diagnoseUnsatisfiedRequirement(
 /// error diagnostic, and there were no errors emitted or scheduled to be
 /// emitted previously.
 class FallbackDiagnosticListener : public ExprTypeCheckListener {
-  TypeChecker &TC;
+  ASTContext &Context;
   TypeCheckExprOptions Options;
   ExprTypeCheckListener *BaseListener;
 
 public:
-  FallbackDiagnosticListener(TypeChecker &TC, TypeCheckExprOptions options,
+  FallbackDiagnosticListener(ASTContext &ctx, TypeCheckExprOptions options,
                              ExprTypeCheckListener *base)
-      : TC(TC), Options(options), BaseListener(base) {}
+      : Context(ctx), Options(options), BaseListener(base) {}
 
   bool builtConstraints(ConstraintSystem &cs, Expr *expr) override {
     return BaseListener ? BaseListener->builtConstraints(cs, expr) : false;
@@ -2117,18 +2121,19 @@ public:
   }
 
 private:
-  bool hadAnyErrors() const { return TC.Context.Diags.hadAnyError(); }
+  bool hadAnyErrors() const { return Context.Diags.hadAnyError(); }
 
   void maybeProduceFallbackDiagnostic(Expr *expr) const {
     if (Options.contains(TypeCheckExprFlags::SubExpressionDiagnostics) ||
-        DiagnosticSuppression::isEnabled(TC.Diags))
+        DiagnosticSuppression::isEnabled(Context.Diags))
       return;
 
     // Before producing fatal error here, let's check if there are any "error"
     // diagnostics already emitted or waiting to be emitted. Because they are
     // a better indication of the problem.
-    if (!(hadAnyErrors() || TC.Context.hasDelayedConformanceErrors()))
-      TC.diagnose(expr->getLoc(), diag::failed_to_produce_diagnostic);
+    if (!(hadAnyErrors() || Context.hasDelayedConformanceErrors()))
+      Context.Diags.diagnose(expr->getLoc(),
+                             diag::failed_to_produce_diagnostic);
   }
 };
 
@@ -2139,7 +2144,7 @@ Type TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
                                       TypeCheckExprOptions options,
                                       ExprTypeCheckListener *listener,
                                       ConstraintSystem *baseCS) {
-  FallbackDiagnosticListener diagListener(*this, options, listener);
+  FallbackDiagnosticListener diagListener(Context, options, listener);
   return typeCheckExpressionImpl(expr, dc, convertType, convertTypePurpose,
                                  options, diagListener, baseCS);
 }
@@ -2555,7 +2560,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
   /// Type checking listener for pattern binding initializers.
   class BindingListener : public ExprTypeCheckListener {
-    TypeChecker &tc;
+    ASTContext &context;
     Pattern *&pattern;
     Expr *&initializer;
 
@@ -2569,10 +2574,10 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
     VarDecl *wrappedVar = nullptr;
 
   public:
-    explicit BindingListener(TypeChecker &tc, Pattern *&pattern,
+    explicit BindingListener(ASTContext &ctx, Pattern *&pattern,
                              Expr *&initializer)
-      : tc(tc), pattern(pattern), initializer(initializer),
-        Locator(nullptr) {
+        : context(ctx), pattern(pattern), initializer(initializer),
+          Locator(nullptr) {
       maybeApplyPropertyWrapper();
     }
 
@@ -2672,7 +2677,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       // been subsumed by the backing property.
       if (wrappedVar) {
         wrappedVar->getParentPatternBinding()->setInitializerSubsumed(0);
-        tc.Context.setSideCachedPropertyWrapperBackingPropertyType(
+        context.setSideCachedPropertyWrapperBackingPropertyType(
             wrappedVar, initType->mapTypeOutOfContext());
 
         // Record the semantic initializer on the outermost property wrapper.
@@ -2736,7 +2741,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
     }
   };
 
-  BindingListener listener(*this, pattern, initializer);
+  BindingListener listener(Context, pattern, initializer);
   if (!initializer)
     return true;
 
@@ -2909,8 +2914,8 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
         return true;
       }
 
-      auto elementAssocType = sequenceProto->getAssociatedType(
-        tc.Context.Id_Element);
+      auto elementAssocType =
+          sequenceProto->getAssociatedType(cs.getASTContext().Id_Element);
 
       SequenceType = cs.createTypeVariable(Locator, TVO_CanBindToNoEscape);
       cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
@@ -3285,13 +3290,13 @@ Expr *TypeChecker::addImplicitLoadExpr(
     using GetTypeFn = std::function<Type(Expr *)>;
     using SetTypeFn = std::function<void(Expr *, Type)>;
 
-    TypeChecker &TC;
+    ASTContext &Ctx;
     GetTypeFn getType;
     SetTypeFn setType;
 
   public:
-    LoadAdder(TypeChecker &TC, GetTypeFn getType, SetTypeFn setType)
-      : TC(TC), getType(getType), setType(setType) {}
+    LoadAdder(ASTContext &ctx, GetTypeFn getType, SetTypeFn setType)
+        : Ctx(ctx), getType(getType), setType(setType) {}
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
       if (isa<ParenExpr>(E) || isa<ForceValueExpr>(E))
@@ -3311,7 +3316,7 @@ Expr *TypeChecker::addImplicitLoadExpr(
         setType(E, getType(FVE->getSubExpr())->getOptionalObjectType());
 
       if (auto *PE = dyn_cast<ParenExpr>(E))
-        setType(E, ParenType::get(TC.Context, getType(PE->getSubExpr())));
+        setType(E, ParenType::get(Ctx, getType(PE->getSubExpr())));
 
       return E;
     }
@@ -3319,13 +3324,13 @@ Expr *TypeChecker::addImplicitLoadExpr(
   private:
     LoadExpr *createLoadExpr(Expr *E) {
       auto objectType = getType(E)->getRValueType();
-      auto *LE = new (TC.Context) LoadExpr(E, objectType);
+      auto *LE = new (Ctx) LoadExpr(E, objectType);
       setType(LE, objectType);
       return LE;
     }
   };
 
-  return expr->walk(LoadAdder(*this, getType, setType));
+  return expr->walk(LoadAdder(Context, getType, setType));
 }
 
 Expr *TypeChecker::coerceToRValue(Expr *expr,
@@ -3677,7 +3682,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
 
     if (auto *locator = tv->getImpl().getLocator()) {
       out << " @ ";
-      locator->dump(&TC.Context.SourceMgr, out);
+      locator->dump(&getASTContext().SourceMgr, out);
     }
 
     out << "\n";

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1192,7 +1192,7 @@ namespace {
 
       // Fold sequence expressions.
       if (auto *seqExpr = dyn_cast<SequenceExpr>(expr)) {
-        auto result = TC.foldSequence(seqExpr, DC);
+        auto result = TypeChecker::foldSequence(seqExpr, DC);
         return result->walk(*this);
       }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -553,9 +553,9 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
         }
       }
 
-      TypoCorrectionResults corrections(*this, Name, nameLoc);
-      performTypoCorrection(DC, UDRE->getRefKind(), Type(),
-                            lookupOptions, corrections);
+      TypoCorrectionResults corrections(Name, nameLoc);
+      TypeChecker::performTypoCorrection(DC, UDRE->getRefKind(), Type(),
+                                         lookupOptions, corrections);
 
       if (auto typo = corrections.claimUniqueCorrection()) {
         auto diag = diagnose(Loc, diag::use_unresolved_identifier_corrected,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3046,8 +3046,8 @@ bool TypeChecker::typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
     };
 
     // Resolve the pattern.
-    auto *pattern = resolvePattern(elt.getPattern(), dc,
-                                   /*isStmtCondition*/true);
+    auto *pattern = TypeChecker::resolvePattern(elt.getPattern(), dc,
+                                                /*isStmtCondition*/true);
     if (!pattern) {
       typeCheckPatternFailed();
       continue;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2361,13 +2361,13 @@ public:
       }
       return;
     }
-    checkAccessControl(TC, OD);
+    checkAccessControl(OD);
   }
 
   void visitPrecedenceGroupDecl(PrecedenceGroupDecl *PGD) {
     TypeChecker::checkDeclAttributes(PGD);
     validatePrecedenceGroup(PGD);
-    checkAccessControl(TC, PGD);
+    checkAccessControl(PGD);
   }
 
   void visitMissingMemberDecl(MissingMemberDecl *MMD) {
@@ -2586,7 +2586,7 @@ public:
 
     TypeChecker::checkDeclAttributes(PBD);
 
-    checkAccessControl(TC, PBD);
+    checkAccessControl(PBD);
 
     // If the initializers in the PBD aren't checked yet, do so now.
     for (auto i : range(PBD->getNumPatternEntries())) {
@@ -2640,7 +2640,7 @@ public:
 
     TypeChecker::checkDeclAttributes(SD);
 
-    checkAccessControl(TC, SD);
+    checkAccessControl(SD);
 
     if (!checkOverrides(SD)) {
       // If a subscript has an override attribute but does not override
@@ -2683,8 +2683,7 @@ public:
     (void) TAD->getUnderlyingType();
 
     TypeChecker::checkDeclAttributes(TAD);
-    checkAccessControl(TC, TAD);
-
+    checkAccessControl(TAD);
   }
   
   void visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {
@@ -2692,7 +2691,7 @@ public:
     (void) OTD->getGenericSignature();
 
     TypeChecker::checkDeclAttributes(OTD);
-    checkAccessControl(TC, OTD);
+    checkAccessControl(OTD);
   }
   
   void visitAssociatedTypeDecl(AssociatedTypeDecl *AT) {
@@ -2710,7 +2709,7 @@ public:
                   proto->getName());
     }
 
-    checkAccessControl(TC, AT);
+    checkAccessControl(AT);
 
     // Trigger the checking for overridden declarations.
     (void) AT->getOverriddenDecls();
@@ -2804,7 +2803,7 @@ public:
 
     checkInheritanceClause(ED);
 
-    checkAccessControl(TC, ED);
+    checkAccessControl(ED);
 
     TC.checkPatternBindingCaptures(ED);
     
@@ -2849,7 +2848,7 @@ public:
 
     checkInheritanceClause(SD);
 
-    checkAccessControl(TC, SD);
+    checkAccessControl(SD);
 
     checkExplicitAvailability(SD);
 
@@ -3097,7 +3096,7 @@ public:
 
     checkInheritanceClause(CD);
 
-    checkAccessControl(TC, CD);
+    checkAccessControl(CD);
 
     checkExplicitAvailability(CD);
 
@@ -3132,7 +3131,7 @@ public:
 
     TypeChecker::checkDeclAttributes(PD);
 
-    checkAccessControl(TC, PD);
+    checkAccessControl(PD);
 
     checkInheritanceClause(PD);
 
@@ -3246,7 +3245,7 @@ public:
       TypeChecker::checkProtocolSelfRequirements(FD);
     }
 
-    checkAccessControl(TC, FD);
+    checkAccessControl(FD);
 
     TypeChecker::checkParameterAttributes(FD->getParameters());
     TypeChecker::checkDeclAttributes(FD);
@@ -3360,7 +3359,7 @@ public:
       EED->setInvalid();
     }
 
-    checkAccessControl(TC, EED);
+    checkAccessControl(EED);
   }
 
   void visitExtensionDecl(ExtensionDecl *ED) {
@@ -3450,7 +3449,7 @@ public:
     TC.ConformanceContexts.push_back(ED);
 
     TypeChecker::checkDeclAttributes(ED);
-    checkAccessControl(TC, ED);
+    checkAccessControl(ED);
 
     checkExplicitAvailability(ED);
   }
@@ -3585,7 +3584,7 @@ public:
       }
     }
 
-    checkAccessControl(TC, CD);
+    checkAccessControl(CD);
 
     if (requiresDefinition(CD) && !CD->hasBody()) {
       // Complain if we should have a body.

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -682,7 +682,7 @@ getKnownProtocolKindIfAny(const ProtocolDecl *protocol) {
 Type TypeChecker::getDefaultType(ProtocolDecl *protocol, DeclContext *dc) {
   if (auto knownProtocolKindIfAny = getKnownProtocolKindIfAny(protocol)) {
     return evaluateOrDefault(
-        Context.evaluator,
+        protocol->getASTContext().evaluator,
         DefaultTypeRequest{knownProtocolKindIfAny.getValue(), dc}, nullptr);
   }
   return Type();

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -267,7 +267,7 @@ Expr *TypeChecker::findLHS(DeclContext *DC, Expr *E, Identifier name) {
 // The way we compute isEndOfSequence relies on the assumption that
 // the sequence-folding algorithm never recurses with a prefix of the
 // entire sequence.
-static Expr *makeBinOp(TypeChecker &TC, Expr *Op, Expr *LHS, Expr *RHS,
+static Expr *makeBinOp(ASTContext &Ctx, Expr *Op, Expr *LHS, Expr *RHS,
                        PrecedenceGroupDecl *opPrecedence,
                        bool isEndOfSequence) {
   if (!LHS || !RHS)
@@ -330,16 +330,17 @@ static Expr *makeBinOp(TypeChecker &TC, Expr *Op, Expr *LHS, Expr *RHS,
         (opPrecedence && opPrecedence->isAssignment())) {
       if (!isEndOfSequence) {
         if (isa<IfExpr>(Op)) {
-          TC.diagnose(RHS->getStartLoc(), diag::try_if_rhs_noncovering,
-                      static_cast<unsigned>(tryKind));
+          Ctx.Diags.diagnose(RHS->getStartLoc(), diag::try_if_rhs_noncovering,
+                             static_cast<unsigned>(tryKind));
         } else {
-          TC.diagnose(RHS->getStartLoc(), diag::try_assign_rhs_noncovering,
-                      static_cast<unsigned>(tryKind));
+          Ctx.Diags.diagnose(RHS->getStartLoc(),
+                             diag::try_assign_rhs_noncovering,
+                             static_cast<unsigned>(tryKind));
         }
       }
     } else {
-      TC.diagnose(RHS->getStartLoc(), diag::try_rhs,
-                  static_cast<unsigned>(tryKind));
+      Ctx.Diags.diagnose(RHS->getStartLoc(), diag::try_rhs,
+                         static_cast<unsigned>(tryKind));
     }
   }
 
@@ -390,9 +391,9 @@ static Expr *makeBinOp(TypeChecker &TC, Expr *Op, Expr *LHS, Expr *RHS,
   
   // Build the argument to the operation.
   Expr *ArgElts[] = { LHS, RHS };
-  auto ArgElts2 = TC.Context.AllocateCopy(MutableArrayRef<Expr*>(ArgElts));
-  TupleExpr *Arg = TupleExpr::create(TC.Context,
-                                     SourceLoc(), 
+  auto ArgElts2 = Ctx.AllocateCopy(MutableArrayRef<Expr*>(ArgElts));
+  TupleExpr *Arg = TupleExpr::create(Ctx,
+                                     SourceLoc(),
                                      ArgElts2, { }, { }, SourceLoc(),
                                      /*HasTrailingClosure=*/false,
                                      /*Implicit=*/true);
@@ -400,7 +401,7 @@ static Expr *makeBinOp(TypeChecker &TC, Expr *Op, Expr *LHS, Expr *RHS,
   
   
   // Build the operation.
-  return makeResultExpr(new (TC.Context) BinaryExpr(Op, Arg, Op->isImplicit()));
+  return makeResultExpr(new (Ctx) BinaryExpr(Op, Arg, Op->isImplicit()));
 }
 
 namespace {
@@ -411,12 +412,12 @@ namespace {
     PrecedenceBound(PrecedenceGroupDecl *decl, bool isStrict)
       : GroupAndIsStrict(decl, isStrict) {}
 
-    bool shouldConsider(TypeChecker &TC, PrecedenceGroupDecl *group) {
+    bool shouldConsider(PrecedenceGroupDecl *group) {
       auto storedGroup = GroupAndIsStrict.getPointer();
       if (!storedGroup) return true;
       if (!group) return false;
       if (storedGroup == group) return !GroupAndIsStrict.getInt();
-      return TC.Context.associateInfixOperators(group, storedGroup)
+      return group->getASTContext().associateInfixOperators(group, storedGroup)
                != Associativity::Right;
     }
   };
@@ -424,7 +425,7 @@ namespace {
 
 /// foldSequence - Take a sequence of expressions and fold a prefix of
 /// it into a tree of BinaryExprs using precedence parsing.
-static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
+static Expr *foldSequence(DeclContext *DC,
                           Expr *LHS,
                           ArrayRef<Expr*> &S,
                           PrecedenceBound precedenceBound) {
@@ -446,7 +447,7 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
 
     // If the operator's precedence is lower than the minimum, stop here.
     auto opPrecedence = TypeChecker::lookupPrecedenceGroupForInfixOperator(DC, op);
-    if (!precedenceBound.shouldConsider(TC, opPrecedence))
+    if (!precedenceBound.shouldConsider(opPrecedence))
       return {nullptr, nullptr};
     return {op, opPrecedence};
   };
@@ -459,15 +460,16 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
   // Pull out the prospective RHS and slice off the first two elements.
   Expr *RHS = S[1];
   S = S.slice(2);
-  
+
+  auto &Ctx = DC->getASTContext();
   while (!S.empty()) {
     assert((S.size() & 1) == 0);
-    assert(precedenceBound.shouldConsider(TC, op1.precedence));
+    assert(precedenceBound.shouldConsider(op1.precedence));
 
     // If the operator is a cast operator, the RHS can't extend past the type
     // that's part of the cast production.
     if (isa<ExplicitCastExpr>(op1.op)) {
-      LHS = makeBinOp(TC, op1.op, LHS, RHS, op1.precedence, S.empty());
+      LHS = makeBinOp(Ctx, op1.op, LHS, RHS, op1.precedence, S.empty());
       op1 = getNextOperator();
       if (!op1) return LHS;
       RHS = S[1];
@@ -480,7 +482,7 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
 
     // If the second operator's precedence is lower than the
     // precedence bound, break out of the loop.
-    if (!precedenceBound.shouldConsider(TC, op2.precedence)) break;
+    if (!precedenceBound.shouldConsider(op2.precedence)) break;
 
     // If we're missing precedence info for either operator, treat them
     // as non-associative.
@@ -489,13 +491,13 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
       associativity = Associativity::None;
     } else {
       associativity =
-        TC.Context.associateInfixOperators(op1.precedence, op2.precedence);
+        Ctx.associateInfixOperators(op1.precedence, op2.precedence);
     }
 
     // Apply left-associativity immediately by folding the first two
     // operands.
     if (associativity == Associativity::Left) {
-      LHS = makeBinOp(TC, op1.op, LHS, RHS, op1.precedence, S.empty());
+      LHS = makeBinOp(Ctx, op1.op, LHS, RHS, op1.precedence, S.empty());
       op1 = op2;
       RHS = S[1];
       S = S.slice(2);
@@ -508,7 +510,7 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
     // repeat.
     if (associativity == Associativity::Right &&
         op1.precedence != op2.precedence) {
-      RHS = foldSequence(TC, DC, RHS, S,
+      RHS = foldSequence(DC, RHS, S,
                          PrecedenceBound(op1.precedence, /*strict*/ true));
       continue;
     }
@@ -516,15 +518,15 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
     // Apply right-associativity by recursively folding operators
     // starting from this point, then immediately folding the LHS and RHS.
     if (associativity == Associativity::Right) {
-      RHS = foldSequence(TC, DC, RHS, S,
+      RHS = foldSequence(DC, RHS, S,
                          PrecedenceBound(op1.precedence, /*strict*/ false));
-      LHS = makeBinOp(TC, op1.op, LHS, RHS, op1.precedence, S.empty());
+      LHS = makeBinOp(Ctx, op1.op, LHS, RHS, op1.precedence, S.empty());
 
       // If we've drained the entire sequence, we're done.
       if (S.empty()) return LHS;
 
       // Otherwise, start all over with our new LHS.
-      return foldSequence(TC, DC, LHS, S, precedenceBound);
+      return foldSequence(DC, LHS, S, precedenceBound);
     }
 
     // If we ended up here, it's because we're either:
@@ -540,23 +542,25 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
     } else if (op1.precedence == op2.precedence) {
       assert(op1.precedence->isNonAssociative());
       // FIXME: QoI ranges
-      TC.diagnose(op1.op->getLoc(), diag::non_associative_adjacent_operators,
-                  op1.precedence->getName())
+      Ctx.Diags.diagnose(op1.op->getLoc(),
+                         diag::non_associative_adjacent_operators,
+                         op1.precedence->getName())
         .highlight(SourceRange(op2.op->getLoc(), op2.op->getLoc()));
 
     } else {
-      TC.diagnose(op1.op->getLoc(), diag::unordered_adjacent_operators,
-                  op1.precedence->getName(), op2.precedence->getName())
+      Ctx.Diags.diagnose(op1.op->getLoc(),
+                         diag::unordered_adjacent_operators,
+                         op1.precedence->getName(), op2.precedence->getName())
         .highlight(SourceRange(op2.op->getLoc(), op2.op->getLoc()));      
     }
     
     // Recover by arbitrarily binding the first two.
-    LHS = makeBinOp(TC, op1.op, LHS, RHS, op1.precedence, S.empty());
-    return foldSequence(TC, DC, LHS, S, precedenceBound);
+    LHS = makeBinOp(Ctx, op1.op, LHS, RHS, op1.precedence, S.empty());
+    return foldSequence(DC, LHS, S, precedenceBound);
   }
 
   // Fold LHS and RHS together and declare completion.
-  return makeBinOp(TC, op1.op, LHS, RHS, op1.precedence, S.empty());
+  return makeBinOp(Ctx, op1.op, LHS, RHS, op1.precedence, S.empty());
 }
 
 bool TypeChecker::requireOptionalIntrinsics(SourceLoc loc) {
@@ -731,7 +735,7 @@ Expr *TypeChecker::foldSequence(SequenceExpr *expr, DeclContext *dc) {
   Expr *LHS = Elts[0];
   Elts = Elts.slice(1);
 
-  Expr *Result = ::foldSequence(*this, dc, LHS, Elts, PrecedenceBound());
+  Expr *Result = ::foldSequence(dc, LHS, Elts, PrecedenceBound());
   assert(Elts.empty());
 
   return Result;

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -586,10 +586,11 @@ bool TypeChecker::requireArrayLiteralIntrinsics(SourceLoc loc) {
 
 Expr *TypeChecker::buildCheckedRefExpr(VarDecl *value, DeclContext *UseDC,
                                        DeclNameLoc loc, bool Implicit) {
-  auto type = getUnopenedTypeOfReference(value, Type(), UseDC);
+  auto type = TypeChecker::getUnopenedTypeOfReference(value, Type(), UseDC);
   auto semantics = value->getAccessSemanticsFromContext(UseDC,
                                                        /*isAccessOnSelf*/false);
-  return new (Context) DeclRefExpr(value, loc, Implicit, semantics, type);
+  return new (value->getASTContext())
+      DeclRefExpr(value, loc, Implicit, semantics, type);
 }
 
 Expr *TypeChecker::buildRefExpr(ArrayRef<ValueDecl *> Decls,
@@ -597,6 +598,7 @@ Expr *TypeChecker::buildRefExpr(ArrayRef<ValueDecl *> Decls,
                                 bool Implicit, FunctionRefKind functionRefKind) {
   assert(!Decls.empty() && "Must have at least one declaration");
 
+  auto &Context = UseDC->getASTContext();
   if (Decls.size() == 1 && !isa<ProtocolDecl>(Decls[0]->getDeclContext())) {
     auto semantics = Decls[0]->getAccessSemanticsFromContext(UseDC,
                                                        /*isAccessOnSelf*/false);

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -251,9 +251,9 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     // If we didn't find anything, try to apply typo-correction.
     bool resultsAreFromTypoCorrection = false;
     if (!lookup) {
-      TypoCorrectionResults corrections(*this, componentName,
+      TypoCorrectionResults corrections(componentName,
                                         DeclNameLoc(componentNameLoc));
-      performTypoCorrection(dc, DeclRefKind::Ordinary, lookupType,
+      TypeChecker::performTypoCorrection(dc, DeclRefKind::Ordinary, lookupType,
                             (lookupType ? defaultMemberTypeLookupOptions
                                         : defaultUnqualifiedLookupOptions),
                             corrections);

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -531,7 +531,7 @@ public:
       
     
     // Perform unqualified name lookup to find out what the UDRE is.
-    return getSubExprPattern(TC.resolveDeclRefExpr(ude, DC));
+    return getSubExprPattern(TypeChecker::resolveDeclRefExpr(ude, DC));
   }
   
   // Call syntax forms a pattern if:

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -839,9 +839,9 @@ public:
     if (elementTy->hasError())
       return nullptr;
 
-    auto *varRef =
-        TC.buildCheckedRefExpr(iterator, DC, DeclNameLoc(S->getInLoc()),
-                               /*implicit*/ true);
+    auto *varRef = TypeChecker::buildCheckedRefExpr(iterator, DC,
+                                                    DeclNameLoc(S->getInLoc()),
+                                                    /*implicit*/ true);
     if (!varRef)
       return nullptr;
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -718,8 +718,8 @@ public:
     options |= TypeResolutionFlags::AllowUnspecifiedTypes;
     options |= TypeResolutionFlags::AllowUnboundGenerics;
 
-    if (auto *P = TC.resolvePattern(S->getPattern(), DC,
-                                    /*isStmtCondition*/false)) {
+    if (auto *P = TypeChecker::resolvePattern(S->getPattern(), DC,
+                                              /*isStmtCondition*/false)) {
       S->setPattern(P);
     } else {
       S->getPattern()->setType(ErrorType::get(TC.Context));
@@ -1045,8 +1045,8 @@ public:
                                  SmallVectorImpl<VarDecl *> **prevCaseDecls,
                                  SmallVectorImpl<VarDecl *> **nextCaseDecls) {
     Pattern *pattern = labelItem.getPattern();
-    auto *newPattern = TC.resolvePattern(pattern, DC,
-                                         /*isStmtCondition*/ false);
+    auto *newPattern = TypeChecker::resolvePattern(pattern, DC,
+                                                   /*isStmtCondition*/ false);
     if (!newPattern) {
       pattern->collectVariables(**nextCaseDecls);
       std::swap(*prevCaseDecls, *nextCaseDecls);
@@ -1453,7 +1453,7 @@ bool TypeChecker::typeCheckCatchPattern(CatchStmt *S, DeclContext *DC) {
   Type exnType = getExceptionType(DC, S->getCatchLoc());
 
   Pattern *pattern = S->getErrorPattern();
-  if (Pattern *newPattern = resolvePattern(pattern, DC,
+  if (Pattern *newPattern = TypeChecker::resolvePattern(pattern, DC,
                                            /*isStmtCondition*/false)) {
     pattern = newPattern;
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -170,10 +170,9 @@ PatternBindingEntryRequest::evaluate(Evaluator &eval,
   auto &Context = binding->getASTContext();
 
   // Resolve the pattern.
-  auto *TC = binding->getASTContext().getLegacyGlobalTypeChecker();
-  auto *pattern = TC->resolvePattern(binding->getPattern(entryNumber),
-                                     binding->getDeclContext(),
-                                     /*isStmtCondition*/ true);
+  auto *pattern = TypeChecker::resolvePattern(binding->getPattern(entryNumber),
+                                              binding->getDeclContext(),
+                                              /*isStmtCondition*/ true);
   if (!pattern) {
     binding->setInvalid();
     binding->getPattern(entryNumber)->setType(ErrorType::get(Context));
@@ -213,6 +212,8 @@ PatternBindingEntryRequest::evaluate(Evaluator &eval,
     options |= TypeResolutionFlags::AllowUnboundGenerics;
   }
 
+  auto *TC =
+      static_cast<TypeChecker *>(binding->getASTContext().getLazyResolver());
   if (TC->typeCheckPattern(pattern, binding->getDeclContext(), options)) {
     swift::setBoundVarsTypeError(pattern, Context);
     binding->setInvalid();

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -212,8 +212,7 @@ PatternBindingEntryRequest::evaluate(Evaluator &eval,
     options |= TypeResolutionFlags::AllowUnboundGenerics;
   }
 
-  auto *TC =
-      static_cast<TypeChecker *>(binding->getASTContext().getLazyResolver());
+  auto *TC = binding->getASTContext().getLegacyGlobalTypeChecker();
   if (TC->typeCheckPattern(pattern, binding->getDeclContext(), options)) {
     swift::setBoundVarsTypeError(pattern, Context);
     binding->setInvalid();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -175,7 +175,7 @@ Type TypeResolution::resolveDependentMemberType(
     // Resolve the base to a potential archetype.
     // Perform typo correction.
     TypeChecker &tc = *ctx.getLegacyGlobalTypeChecker();
-    TypoCorrectionResults corrections(tc, ref->getIdentifier(),
+    TypoCorrectionResults corrections(ref->getIdentifier(),
                                       DeclNameLoc(ref->getIdLoc()));
     tc.performTypoCorrection(DC, DeclRefKind::Ordinary,
                              MetatypeType::get(baseTy),

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -174,13 +174,12 @@ Type TypeResolution::resolveDependentMemberType(
   } else {
     // Resolve the base to a potential archetype.
     // Perform typo correction.
-    TypeChecker &tc = *ctx.getLegacyGlobalTypeChecker();
     TypoCorrectionResults corrections(ref->getIdentifier(),
                                       DeclNameLoc(ref->getIdLoc()));
-    tc.performTypoCorrection(DC, DeclRefKind::Ordinary,
-                             MetatypeType::get(baseTy),
-                             NameLookupFlags::ProtocolMembers,
-                             corrections, builder);
+    TypeChecker::performTypoCorrection(DC, DeclRefKind::Ordinary,
+                                       MetatypeType::get(baseTy),
+                                       NameLookupFlags::ProtocolMembers,
+                                       corrections, builder);
 
     // Check whether we have a single type result.
     auto singleType = cast_or_null<TypeDecl>(

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -559,10 +559,6 @@ public:
   std::vector<AbstractClosureExpr *> ClosuresWithUncomputedCaptures;
 
 private:
-  /// The # of times we have performed typo correction.
-  unsigned NumTypoCorrections = 0;
-
-private:
   Type MaxIntegerType;
   Type NSObjectType;
   Type NSNumberType;
@@ -1911,13 +1907,13 @@ public:
   };
 
   /// Check for a typo correction.
-  void performTypoCorrection(DeclContext *DC,
-                             DeclRefKind refKind,
-                             Type baseTypeOrNull,
-                             NameLookupOptions lookupOptions,
-                             TypoCorrectionResults &corrections,
-                             GenericSignatureBuilder *gsb = nullptr,
-                             unsigned maxResults = 4);
+  static void performTypoCorrection(DeclContext *DC,
+                                    DeclRefKind refKind,
+                                    Type baseTypeOrNull,
+                                    NameLookupOptions lookupOptions,
+                                    TypoCorrectionResults &corrections,
+                                    GenericSignatureBuilder *gsb = nullptr,
+                                    unsigned maxResults = 4);
 
   /// Check if the given decl has a @_semantics attribute that gives it
   /// special case type-checking behavior.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -753,7 +753,8 @@ public:
   /// Bind an UnresolvedDeclRefExpr by performing name lookup and
   /// returning the resultant expression.  Context is the DeclContext used
   /// for the lookup.
-  Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context);
+  static Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
+                                  DeclContext *Context);
 
   /// Validate the given type.
   ///
@@ -1374,11 +1375,11 @@ public:
   /// \param wantInterfaceType Whether we want the interface type, if available.
   ///
   /// \param getType Optional callback to extract a type for given declaration.
-  Type getUnopenedTypeOfReference(VarDecl *value, Type baseType,
-                                  DeclContext *UseDC,
-                                  llvm::function_ref<Type(VarDecl *)> getType,
-                                  const DeclRefExpr *base = nullptr,
-                                  bool wantInterfaceType = false);
+  static Type
+  getUnopenedTypeOfReference(VarDecl *value, Type baseType, DeclContext *UseDC,
+                             llvm::function_ref<Type(VarDecl *)> getType,
+                             const DeclRefExpr *base = nullptr,
+                             bool wantInterfaceType = false);
 
   /// Return the type-of-reference of the given value.
   ///
@@ -1391,16 +1392,13 @@ public:
   /// \param base The optional base expression of this value reference
   ///
   /// \param wantInterfaceType Whether we want the interface type, if available.
-  Type getUnopenedTypeOfReference(VarDecl *value, Type baseType,
-                                  DeclContext *UseDC,
-                                  const DeclRefExpr *base = nullptr,
-                                  bool wantInterfaceType = false) {
+  static Type getUnopenedTypeOfReference(VarDecl *value, Type baseType,
+                                         DeclContext *UseDC,
+                                         const DeclRefExpr *base = nullptr,
+                                         bool wantInterfaceType = false) {
     return getUnopenedTypeOfReference(
         value, baseType, UseDC,
         [&](VarDecl *var) -> Type {
-          if (var->isInvalid())
-            return ErrorType::get(Context);
-
           return wantInterfaceType ? value->getInterfaceType()
                                    : value->getType();
         },
@@ -1636,14 +1634,14 @@ public:
                                         ValueDecl *decl2);
 
   /// Build a type-checked reference to the given value.
-  Expr *buildCheckedRefExpr(VarDecl *D, DeclContext *UseDC,
-                            DeclNameLoc nameLoc, bool Implicit);
+  static Expr *buildCheckedRefExpr(VarDecl *D, DeclContext *UseDC,
+                                   DeclNameLoc nameLoc, bool Implicit);
 
   /// Build a reference to a declaration, where name lookup returned
   /// the given set of declarations.
-  Expr *buildRefExpr(ArrayRef<ValueDecl *> Decls, DeclContext *UseDC,
-                     DeclNameLoc NameLoc, bool Implicit,
-                     FunctionRefKind functionRefKind);
+  static Expr *buildRefExpr(ArrayRef<ValueDecl *> Decls, DeclContext *UseDC,
+                            DeclNameLoc NameLoc, bool Implicit,
+                            FunctionRefKind functionRefKind);
 
   /// Build implicit autoclosure expression wrapping a given expression.
   /// Given expression represents computed result of the closure.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1413,7 +1413,7 @@ public:
   ///
   /// \returns the default type, or null if there is no default type for
   /// this protocol.
-  Type getDefaultType(ProtocolDecl *protocol, DeclContext *dc);
+  static Type getDefaultType(ProtocolDecl *protocol, DeclContext *dc);
 
   /// Convert the given expression to the given type.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1131,7 +1131,7 @@ private:
 public:
   /// Fold the given sequence expression into an (unchecked) expression
   /// tree.
-  Expr *foldSequence(SequenceExpr *expr, DeclContext *dc);
+  static Expr *foldSequence(SequenceExpr *expr, DeclContext *dc);
 
   /// Type check the given expression.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1308,8 +1308,8 @@ public:
 
   /// Resolve ambiguous pattern/expr productions inside a pattern using
   /// name lookup information. Must be done before type-checking the pattern.
-  Pattern *resolvePattern(Pattern *P, DeclContext *dc,
-                          bool isStmtCondition);
+  static Pattern *resolvePattern(Pattern *P, DeclContext *dc,
+                                 bool isStmtCondition);
 
   /// Type check the given pattern.
   ///

--- a/lib/Sema/TypoCorrection.h
+++ b/lib/Sema/TypoCorrection.h
@@ -48,15 +48,14 @@ public:
 /// A collection of typo-correction candidates.
 class TypoCorrectionResults {
 public:
-  TypeChecker &TC;
   DeclName WrittenName;
   DeclNameLoc Loc;
   bool ClaimedCorrection = false;
 
   SmallVector<ValueDecl *, 4> Candidates;
 
-  TypoCorrectionResults(TypeChecker &tc, DeclName writtenName, DeclNameLoc loc)
-    : TC(tc), WrittenName(writtenName), Loc(loc) {}
+  TypoCorrectionResults(DeclName writtenName, DeclNameLoc loc)
+    : WrittenName(writtenName), Loc(loc) {}
 
   /// Try to claim a unique correction from this collection that's simple
   /// enough to include "inline" in the primary diagnostic.  Note that

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -627,7 +627,12 @@ struct PatternBindingWithTwoVars3 { var x = y, y = x }
 // expected-note@-6 {{through reference here}}
 // expected-note@-7 {{through reference here}}
 // expected-note@-8 {{through reference here}}
-
+// expected-error@-9 {{circular reference}}
+// expected-note@-10 {{through reference here}}
+// expected-note@-11 {{through reference here}}
+// expected-note@-12 {{through reference here}}
+// expected-note@-13 {{through reference here}}
+// expected-note@-14 {{through reference here}}
 
 // https://bugs.swift.org/browse/SR-9015
 func sr9015() {


### PR DESCRIPTION
Drop TypeCheckers out of 

- Typo Correction
- Sequence folding
- Pattern checking
- A bunch of expression checking
- DeclRef building
- Pattern resolution
- Access enforcement
- Exportability