### PR TITLE
[PropertyWrappers] Fix a crash when using multiple wrappers of the same type

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/sr10937.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr10937.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+@propertyWrapper
+struct Foo<T> {
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+
+  var wrappedValue: T
+}
+
+@propertyWrapper
+struct Bar<T> {
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+
+  var wrappedValue: T
+}
+
+struct Container {
+  @Foo @Foo var x: Int = 0
+  @Foo @Foo @Bar @Bar var y: Int = 1
+  @Foo @Bar @Foo @Foo var z: Int = 2
+}
+
+_ = Container()


### PR DESCRIPTION
At the moment, using multiple wrappers of the same type (consecutively) causes a crash in SILGen because `findOriginalPropertyWrapperInitialValue` does not consider that possibility. Instead, we end up accidentally setting the innermost call expression as the initial value and causing a crash.

```swift
@propertyWrapper
struct Foo<T> {
  init(wrappedValue: T) {
    self.wrappedValue = wrappedValue
  }

  var wrappedValue: T
}

@propertyWrapper
struct Bar<T> {
  init(wrappedValue: T) {
    self.wrappedValue = wrappedValue
  }

  var wrappedValue: T
}

struct PropertyContainer {
  @Foo @Bar var x: Int = 0 // This works
  @Foo @Foo var y: Int = 1 // This crashes
}
```

Resolves SR-10937.
