### PR TITLE
[semantics] Add support for annotating VarDecls with @_semantics.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -203,7 +203,7 @@ DECL_ATTR(inline, Inline,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   20)
 DECL_ATTR(_semantics, Semantics,
-  OnAbstractFunction | OnSubscript | OnNominalType |
+  OnAbstractFunction | OnSubscript | OnNominalType | OnVar |
   AllowMultipleAttributes | UserInaccessible |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   21)

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5179,6 +5179,20 @@ public:
   /// backing property will be treated as the member-initialized property.
   bool isMemberwiseInitialized(bool preferDeclaredProperties) const;
 
+  /// Return the range of semantics attributes attached to this VarDecl.
+  auto getSemanticsAttrs() const
+      -> decltype(getAttrs().getAttributes<SemanticsAttr>()) {
+    return getAttrs().getAttributes<SemanticsAttr>();
+  }
+
+  /// Returns true if this VarDelc has the string \p attrValue as a semantics
+  /// attribute.
+  bool hasSemanticsAttr(StringRef attrValue) const {
+    return llvm::any_of(getSemanticsAttrs(), [&](const SemanticsAttr *attr) {
+      return attrValue.equals(attr->Value);
+    });
+  }
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) { 
     return D->getKind() == DeclKind::Var || D->getKind() == DeclKind::Param; 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1263,14 +1263,6 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       return false;
     }
 
-    // Diagnose using @_semantics in a local scope.  These don't
-    // actually work.
-    if (CurDeclContext->isLocalContext()) {
-      // Emit an error, but do not discard the attribute.  This enables
-      // better recovery in the parser.
-      diagnose(Loc, diag::attr_only_at_non_local_scope, AttrName);
-    }
-
     if (!DiscardAttribute)
       Attributes.add(new (Context) SemanticsAttr(Value.getValue(), AtLoc,
                                                  AttrRange,

--- a/test/attr/attr_semantics.swift
+++ b/test/attr/attr_semantics.swift
@@ -5,7 +5,7 @@
 func duplicatesemantics() {}
 
 func func_with_nested_semantics_1() {
-   @_semantics("exit") // expected-error {{attribute '_semantics' can only be used in a non-local scope}}
+   @_semantics("exit") 
    func exit(_ code : UInt32) -> Void
    exit(0)
 }
@@ -15,7 +15,7 @@ func func_with_nested_semantics_1() {
 func somethingThatShouldParseFine() {}
 
 func func_with_nested_semantics_2() {
-   @_semantics("exit") // expected-error {{attribute '_semantics' can only be used in a non-local scope}}
+   @_semantics("exit") 
    func exit(_ code : UInt32) -> Void
    exit(0)
 }
@@ -32,3 +32,34 @@ enum EnumWithSemantics {}
 @_semantics("struct1")
 @_semantics("struct2")
 struct StructWithDuplicateSemantics {}
+
+@_semantics("globalVar1")
+@_semantics("globalVar2")
+var globalVarWithSemantics : Int = 5
+
+@_semantics("globalLet1")
+@_semantics("globalLet2")
+let globalLetWithSemantics : Int = 5
+
+func varDeclLocalVars() {
+  @_semantics("localVar1")
+  @_semantics("localVar2")
+  var localVarWithSemantics : Int = 5
+  localVarWithSemantics = 6
+  let _ = localVarWithSemantics
+  
+  @_semantics("localLet1")
+  @_semantics("localLet2")
+  let localLetWithSemantics : Int = 5
+  let _ = localLetWithSemantics
+}
+
+struct IVarTest {
+  @_semantics("localVar1")
+  @_semantics("localVar2")
+  var localVarWithSemantics : Int = 5
+  
+  @_semantics("localLet1")
+  @_semantics("localLet2")
+  let localLetWithSemantics : Int = 5
+}


### PR DESCRIPTION
This is just for prototyping purposes. I also had to loosen a small restriction
where semantics functions were not allowed in local contexts. There really is no
reason to enforce this and I think since it came in the first commit that
introduced semanitcs it was most likely NadavR just being conservative and
careful.

----

Another small patch pushing this forward on the bus.