### PR TITLE
[Diagnostics] SR-11419 Diagnose protocol stub note in editor mode only

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2755,8 +2755,10 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
           // because editor may assume the fixit is in the same file with the note.
           Diags.diagnose(MissingTypeWitness, diag::no_witnesses_type,
                          MissingTypeWitness->getName());
-          Diags.diagnose(ComplainLoc, diag::missing_witnesses_general).
-            fixItInsertAfter(FixitLocation, FixIt);
+          if (EditorMode) {
+            Diags.diagnose(ComplainLoc, diag::missing_witnesses_general).
+              fixItInsertAfter(FixitLocation, FixIt);
+          }
         }
         continue;
       }
@@ -2776,8 +2778,10 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
           // because editor may assume the fixit is in the same file with the note.
           Diags.diagnose(VD, diag::no_witnesses, getRequirementKind(VD),
             VD->getFullName(), RequirementType, false);
-          Diags.diagnose(ComplainLoc, diag::missing_witnesses_general).
-            fixItInsertAfter(FixitLocation, FixIt);
+          if (EditorMode) {
+            Diags.diagnose(ComplainLoc, diag::missing_witnesses_general).
+              fixItInsertAfter(FixitLocation, FixIt);
+          }
         }
       } else {
         Diags.diagnose(VD, diag::no_witnesses, getRequirementKind(VD),

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2756,8 +2756,8 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
           Diags.diagnose(MissingTypeWitness, diag::no_witnesses_type,
                          MissingTypeWitness->getName());
           if (EditorMode) {
-            Diags.diagnose(ComplainLoc, diag::missing_witnesses_general).
-              fixItInsertAfter(FixitLocation, FixIt);
+            Diags.diagnose(ComplainLoc, diag::missing_witnesses_general)
+              .fixItInsertAfter(FixitLocation, FixIt);
           }
         }
         continue;
@@ -2771,16 +2771,16 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
           // we can directly associate the fixit with the note issued to the
           // requirement.
           Diags.diagnose(VD, diag::no_witnesses, getRequirementKind(VD),
-            VD->getFullName(), RequirementType, true).
-              fixItInsertAfter(FixitLocation, FixIt);
+            VD->getFullName(), RequirementType, true)
+              .fixItInsertAfter(FixitLocation, FixIt);
         } else {
           // Otherwise, we have to issue another note to carry the fixit,
           // because editor may assume the fixit is in the same file with the note.
           Diags.diagnose(VD, diag::no_witnesses, getRequirementKind(VD),
             VD->getFullName(), RequirementType, false);
           if (EditorMode) {
-            Diags.diagnose(ComplainLoc, diag::missing_witnesses_general).
-              fixItInsertAfter(FixitLocation, FixIt);
+            Diags.diagnose(ComplainLoc, diag::missing_witnesses_general)
+              .fixItInsertAfter(FixitLocation, FixIt);
           }
         }
       } else {

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -371,13 +371,13 @@ class ProtocolAdopter2 : FooProto {
     set { /* do nothing! */ }
   }
 }
-class ProtocolAdopterBad1 : FooProto { // expected-error {{type 'ProtocolAdopterBad1' does not conform to protocol 'FooProto'}} expected-note {{do you want to add protocol stubs?}}
+class ProtocolAdopterBad1 : FooProto { // expected-error {{type 'ProtocolAdopterBad1' does not conform to protocol 'FooProto'}}
   @objc var bar: Int = 0 // expected-note {{candidate has non-matching type 'Int'}}
 }
-class ProtocolAdopterBad2 : FooProto { // expected-error {{type 'ProtocolAdopterBad2' does not conform to protocol 'FooProto'}} expected-note {{do you want to add protocol stubs?}}
+class ProtocolAdopterBad2 : FooProto { // expected-error {{type 'ProtocolAdopterBad2' does not conform to protocol 'FooProto'}}
   let bar: CInt = 0 // expected-note {{candidate is not settable, but protocol requires it}}
 }
-class ProtocolAdopterBad3 : FooProto { // expected-error {{type 'ProtocolAdopterBad3' does not conform to protocol 'FooProto'}} expected-note {{do you want to add protocol stubs?}}
+class ProtocolAdopterBad3 : FooProto { // expected-error {{type 'ProtocolAdopterBad3' does not conform to protocol 'FooProto'}}
   var bar: CInt { // expected-note {{candidate is not settable, but protocol requires it}}
     return 42
   }

--- a/test/ClangImporter/subclass_existentials.swift
+++ b/test/ClangImporter/subclass_existentials.swift
@@ -21,7 +21,7 @@ class SwiftLaundryService : NSLaundry {
 
 // FIXME: Consider better diagnostics here.
 
-class OldSwiftLaundryService : NSLaundry { // expected-note 3 {{do you want to add protocol stubs?}}
+class OldSwiftLaundryService : NSLaundry { 
 // expected-error@-1 {{type 'OldSwiftLaundryService' does not conform to protocol 'NSLaundry'}}
 
   var g: Coat? = nil

--- a/test/Constraints/invalid_stdlib_2.swift
+++ b/test/Constraints/invalid_stdlib_2.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-class Dictionary<K, V> : ExpressibleByDictionaryLiteral { // expected-error {{type 'Dictionary<K, V>' does not conform to protocol 'ExpressibleByDictionaryLiteral'}} expected-note {{do you want to add protocol stubs?}}
+class Dictionary<K, V> : ExpressibleByDictionaryLiteral { // expected-error {{type 'Dictionary<K, V>' does not conform to protocol 'ExpressibleByDictionaryLiteral'}} 
   typealias Key = K
   typealias Value = V
   init(dictionaryLiteral xs: (K)...){} // expected-note {{candidate has non-matching type '(dictionaryLiteral: (K)...)'}}

--- a/test/Generics/inheritance.swift
+++ b/test/Generics/inheritance.swift
@@ -56,10 +56,10 @@ func testGenericInherit() {
 
 
 struct SS<T> : T { } // expected-error{{inheritance from non-protocol type 'T'}}
-enum SE<T> : T { case X } // expected-error{{raw type 'T' is not expressible by a string, integer, or floating-point literal}} // expected-error {{SE<T>' declares raw type 'T', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error{{RawRepresentable conformance cannot be synthesized because raw type 'T' is not Equatable}} expected-note {{do you want to add protocol stubs?}}
+enum SE<T> : T { case X } // expected-error{{raw type 'T' is not expressible by a string, integer, or floating-point literal}} // expected-error {{SE<T>' declares raw type 'T', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error{{RawRepresentable conformance cannot be synthesized because raw type 'T' is not Equatable}} 
 
 // Also need Equatable for init?(RawValue)
-enum SE2<T : ExpressibleByIntegerLiteral> // expected-note {{do you want to add protocol stubs?}}
+enum SE2<T : ExpressibleByIntegerLiteral> 
   : T // expected-error {{'SE2<T>' declares raw type 'T', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error{{RawRepresentable conformance cannot be synthesized because raw type 'T' is not Equatable}}
 { case X }
 

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -117,19 +117,19 @@ enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} //
 // NO-TYREPR: {{^}}enum EnumWithInheritance2 : <<error type>>, <<error type>> {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
-enum EnumWithInheritance3 : FooClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-note {{do you want to add protocol stubs?}}
+enum EnumWithInheritance3 : FooClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} 
 // expected-error@-1{{'EnumWithInheritance3' declares raw type 'FooClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2{{RawRepresentable conformance cannot be synthesized because raw type 'FooClass' is not Equatable}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance3 : <<error type>> {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance3 : FooClass {{{$}}
 
-enum EnumWithInheritance4 : FooClass, FooProtocol { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-note {{do you want to add protocol stubs?}}
+enum EnumWithInheritance4 : FooClass, FooProtocol { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} 
 // expected-error@-1{{'EnumWithInheritance4' declares raw type 'FooClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2{{RawRepresentable conformance cannot be synthesized because raw type 'FooClass' is not Equatable}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance4 : <<error type>>, FooProtocol {{{$}}
 // TYREPR: {{^}}enum EnumWithInheritance4 : FooClass, FooProtocol {{{$}}
 
-enum EnumWithInheritance5 : FooClass, BarClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-error {{multiple enum raw types 'FooClass' and 'BarClass'}} expected-note {{do you want to add protocol stubs?}}
+enum EnumWithInheritance5 : FooClass, BarClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-error {{multiple enum raw types 'FooClass' and 'BarClass'}} 
 // expected-error@-1{{'EnumWithInheritance5' declares raw type 'FooClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2{{RawRepresentable conformance cannot be synthesized because raw type 'FooClass' is not Equatable}}
 // NO-TYREPR: {{^}}enum EnumWithInheritance5 : <<error type>>, <<error type>> {{{$}}

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -130,7 +130,7 @@ enum Recovery6 {
   case Tusk, // expected-error {{expected identifier after comma in enum 'case' declaration}}
 } 
 
-enum RawTypeEmpty : Int {} // expected-error {{an enum with no cases cannot declare a raw type}} expected-note {{do you want to add protocol stubs?}}
+enum RawTypeEmpty : Int {} // expected-error {{an enum with no cases cannot declare a raw type}}
 // expected-error@-1{{'RawTypeEmpty' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
 
 enum Raw : Int {
@@ -146,7 +146,7 @@ enum RawTypeNotFirst : RawTypeNotFirstProtocol, Int { // expected-error {{raw ty
   case E
 }
 
-enum ExpressibleByRawTypeNotLiteral : Array<Int> { // expected-error {{raw type 'Array<Int>' is not expressible by a string, integer, or floating-point literal}} expected-note {{do you want to add protocol stubs?}}
+enum ExpressibleByRawTypeNotLiteral : Array<Int> { // expected-error {{raw type 'Array<Int>' is not expressible by a string, integer, or floating-point literal}}
   // expected-error@-1{{'ExpressibleByRawTypeNotLiteral' declares raw type 'Array<Int>', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case Ladd, Elliott, Sixteenth, Harrison
 }
@@ -170,7 +170,7 @@ enum RawTypeCircularityB : RawTypeCircularityA, ExpressibleByIntegerLiteral { //
 struct ExpressibleByFloatLiteralOnly : ExpressibleByFloatLiteral {
     init(floatLiteral: Double) {}
 }
-enum ExpressibleByRawTypeNotIntegerLiteral : ExpressibleByFloatLiteralOnly { // expected-error {{'ExpressibleByRawTypeNotIntegerLiteral' declares raw type 'ExpressibleByFloatLiteralOnly', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error {{RawRepresentable conformance cannot be synthesized because raw type 'ExpressibleByFloatLiteralOnly' is not Equatable}} expected-note {{do you want to add protocol stubs?}}
+enum ExpressibleByRawTypeNotIntegerLiteral : ExpressibleByFloatLiteralOnly { // expected-error {{'ExpressibleByRawTypeNotIntegerLiteral' declares raw type 'ExpressibleByFloatLiteralOnly', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error {{RawRepresentable conformance cannot be synthesized because raw type 'ExpressibleByFloatLiteralOnly' is not Equatable}}
   case Everett // expected-error {{enum cases require explicit raw values when the raw type is not expressible by integer or string literal}}
   case Flanders
 }
@@ -184,13 +184,13 @@ enum RawTypeWithNegativeValues : Int {
   case AutoIncAcrossZero = -1, Zero, One
 }
 
-enum RawTypeWithUnicodeScalarValues : UnicodeScalar { // expected-error {{'RawTypeWithUnicodeScalarValues' declares raw type 'UnicodeScalar' (aka 'Unicode.Scalar'), but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum RawTypeWithUnicodeScalarValues : UnicodeScalar { // expected-error {{'RawTypeWithUnicodeScalarValues' declares raw type 'UnicodeScalar' (aka 'Unicode.Scalar'), but does not conform to RawRepresentable and conformance could not be synthesized}}
   case Kearney = "K"
   case Lovejoy // expected-error {{enum cases require explicit raw values when the raw type is not expressible by integer or string literal}}
   case Marshall = "M"
 }
 
-enum RawTypeWithCharacterValues : Character { // expected-error {{'RawTypeWithCharacterValues' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum RawTypeWithCharacterValues : Character { // expected-error {{'RawTypeWithCharacterValues' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case First = "い"
   case Second // expected-error {{enum cases require explicit raw values when the raw type is not expressible by integer or string literal}}
   case Third = "は"
@@ -203,11 +203,11 @@ enum RawTypeWithCharacterValues_Correct : Character {
   case Fourth = "\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}" // ok
 }
 
-enum RawTypeWithCharacterValues_Error1 : Character { // expected-error {{'RawTypeWithCharacterValues_Error1' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum RawTypeWithCharacterValues_Error1 : Character { // expected-error {{'RawTypeWithCharacterValues_Error1' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case First = "abc" // expected-error {{cannot convert value of type 'String' to raw type 'Character'}}
 }
 
-enum RawTypeWithFloatValues : Float { // expected-error {{'RawTypeWithFloatValues' declares raw type 'Float', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum RawTypeWithFloatValues : Float { // expected-error {{'RawTypeWithFloatValues' declares raw type 'Float', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case Northrup = 1.5
   case Overton // expected-error {{enum case must declare a raw value when the preceding raw value is not an integer}}
   case Pettygrove = 2.25
@@ -318,12 +318,12 @@ enum NonliteralRawValue : Int {
   case Yeon = 100 + 20 + 3 // expected-error {{raw value for enum case must be a literal}}
 }
 
-enum RawTypeWithPayload : Int { // expected-error {{'RawTypeWithPayload' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int' here}} expected-note {{declared raw type 'Int' here}} expected-note {{do you want to add protocol stubs?}}
+enum RawTypeWithPayload : Int { // expected-error {{'RawTypeWithPayload' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int' here}} expected-note {{declared raw type 'Int' here}}
   case Powell(Int) // expected-error {{enum with raw type cannot have cases with arguments}}
   case Terwilliger(Int) = 17 // expected-error {{enum with raw type cannot have cases with arguments}}
 }
 
-enum RawTypeMismatch : Int { // expected-error {{'RawTypeMismatch' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum RawTypeMismatch : Int { // expected-error {{'RawTypeMismatch' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case Barbur = "foo" // expected-error {{}}
 }
 
@@ -343,12 +343,12 @@ enum DuplicateMembers3 {
   case Foo(Int) // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
-enum DuplicateMembers4 : Int { // expected-error {{'DuplicateMembers4' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum DuplicateMembers4 : Int { // expected-error {{'DuplicateMembers4' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case Foo = 1 // expected-note {{'Foo' previously declared here}}
   case Foo = 2 // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
-enum DuplicateMembers5 : Int { // expected-error {{'DuplicateMembers5' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum DuplicateMembers5 : Int { // expected-error {{'DuplicateMembers5' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case Foo = 1 // expected-note {{'Foo' previously declared here}}
   case Foo = 1 + 1 // expected-error {{invalid redeclaration of 'Foo'}} expected-error {{raw value for enum case must be a literal}}
 }
@@ -359,7 +359,7 @@ enum DuplicateMembers6 {
   case Foo // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
-enum DuplicateMembers7 : String { // expected-error {{'DuplicateMembers7' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum DuplicateMembers7 : String { // expected-error {{'DuplicateMembers7' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case Foo // expected-note {{'Foo' previously declared here}}
   case Foo = "Bar" // expected-error {{invalid redeclaration of 'Foo'}}
 }
@@ -411,7 +411,7 @@ enum ManyLiteralA : ManyLiteralable {
   case B = 0 // expected-error {{raw value for enum case is not unique}}
 }
 
-enum ManyLiteralB : ManyLiteralable { // expected-error {{'ManyLiteralB' declares raw type 'ManyLiteralable', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum ManyLiteralB : ManyLiteralable { // expected-error {{'ManyLiteralB' declares raw type 'ManyLiteralable', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case A = "abc"
   case B // expected-error {{enum case must declare a raw value when the preceding raw value is not an integer}}
 }
@@ -440,7 +440,7 @@ enum RawValueBTest: Double, RawValueB {
   case A, B
 }
 
-enum foo : String { // expected-error {{'foo' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum foo : String { // expected-error {{'foo' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case bar = nil // expected-error {{cannot convert 'nil' to raw type 'String'}}
 }
 

--- a/test/Parse/objc_enum.swift
+++ b/test/Parse/objc_enum.swift
@@ -30,7 +30,7 @@ class Bar {
 }
 
 // <rdar://problem/23681566> @objc enums with payloads rejected with no source location info
-@objc enum r23681566 : Int32 {  // expected-error {{'r23681566' declares raw type 'Int32', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int32' here}} expected-note {{do you want to add protocol stubs?}}
+@objc enum r23681566 : Int32 {  // expected-error {{'r23681566' declares raw type 'Int32', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{declared raw type 'Int32' here}}
   case Foo(progress: Int)     // expected-error {{enum with raw type cannot have cases with arguments}}
 }
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -761,7 +761,7 @@ let ￼tryx  = 123        // expected-error 2 {{invalid character in source file
 
 
 // <rdar://problem/21369926> Malformed Swift Enums crash playground service
-enum Rank: Int {  // expected-error {{'Rank' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum Rank: Int {  // expected-error {{'Rank' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case Ace = 1
   case Two = 2.1  // expected-error {{cannot convert value of type 'Double' to raw type 'Int'}}
 }

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -193,7 +193,7 @@ extension Container {
   fileprivate typealias PrivateAlias = VeryPrivateStruct // expected-error {{type alias cannot be declared fileprivate because its underlying type uses a private type}} {{none}}
   fileprivate subscript(_: VeryPrivateStruct) -> Void { return () } // expected-error {{subscript cannot be declared fileprivate because its index uses a private type}} {{none}}
   fileprivate func privateMethod(_: VeryPrivateStruct) -> Void {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}} {{none}}
-  fileprivate enum PrivateRawValue: VeryPrivateStruct {} // expected-error {{enum cannot be declared fileprivate because its raw type uses a private type}} {{none}} expected-note {{do you want to add protocol stubs?}}
+  fileprivate enum PrivateRawValue: VeryPrivateStruct {} // expected-error {{enum cannot be declared fileprivate because its raw type uses a private type}} {{none}}
   // expected-error@-1 {{raw type 'Container.VeryPrivateStruct' is not expressible by a string, integer, or floating-point literal}}
   // expected-error@-2 {{'Container.PrivateRawValue' declares raw type 'Container.VeryPrivateStruct', but does not conform to RawRepresentable and conformance could not be synthesized}}
   // expected-error@-3 {{RawRepresentable conformance cannot be synthesized because raw type 'Container.VeryPrivateStruct' is not Equatable}}

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -145,7 +145,7 @@ func enumWithHashablePayload() {
 
 // Enums with non-hashable payloads don't derive conformance.
 struct NotHashable {}
-enum EnumWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}} expected-note {{do you want to add protocol stubs?}}
+enum EnumWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}}
   case A(NotHashable) //expected-note {{associated value type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'EnumWithNonHashablePayload' to 'Hashable'}}
   // expected-note@-1 {{associated value type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'EnumWithNonHashablePayload' to 'Equatable'}}
 }
@@ -223,16 +223,16 @@ enum Complex2 {
   case B
 }
 extension Complex2 : Hashable {}
-extension Complex2 : CaseIterable {}  // expected-error {{type 'Complex2' does not conform to protocol 'CaseIterable'}} expected-note {{do you want to add protocol stubs?}}
-extension FromOtherFile: CaseIterable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}} expected-error {{does not conform to protocol 'CaseIterable'}} expected-note {{do you want to add protocol stubs?}}
+extension Complex2 : CaseIterable {}  // expected-error {{type 'Complex2' does not conform to protocol 'CaseIterable'}}
+extension FromOtherFile: CaseIterable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}} expected-error {{does not conform to protocol 'CaseIterable'}}
 
 // No explicit conformance and it cannot be derived.
 enum NotExplicitlyHashableAndCannotDerive {
   case A(NotHashable) //expected-note {{associated value type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Hashable'}}
   // expected-note@-1 {{associated value type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Equatable'}}
 }
-extension NotExplicitlyHashableAndCannotDerive : Hashable {} // expected-error 2 {{does not conform}} expected-note {{do you want to add protocol stubs?}}
-extension NotExplicitlyHashableAndCannotDerive : CaseIterable {} // expected-error {{does not conform}} expected-note {{do you want to add protocol stubs?}}
+extension NotExplicitlyHashableAndCannotDerive : Hashable {} // expected-error 2 {{does not conform}}
+extension NotExplicitlyHashableAndCannotDerive : CaseIterable {} // expected-error {{does not conform}}
 
 // Verify that conformance (albeit manually implemented) can still be added to
 // a type in a different file.
@@ -244,7 +244,7 @@ extension OtherFileNonconforming: Hashable {
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
 extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}
-extension YetOtherFileNonconforming: CaseIterable {} // expected-error {{does not conform}} expected-note {{do you want to add protocol stubs?}}
+extension YetOtherFileNonconforming: CaseIterable {} // expected-error {{does not conform}}
 
 // Verify that an indirect enum doesn't emit any errors as long as its "leaves"
 // are conformant.
@@ -282,7 +282,7 @@ case only([Int])
 
 struct NotEquatable { }
 
-enum ArrayOfNotEquatables : Equatable { // expected-error{{type 'ArrayOfNotEquatables' does not conform to protocol 'Equatable'}} expected-note {{do you want to add protocol stubs?}}
+enum ArrayOfNotEquatables : Equatable { // expected-error{{type 'ArrayOfNotEquatables' does not conform to protocol 'Equatable'}}
 case only([NotEquatable]) //expected-note {{associated value type '[NotEquatable]' does not conform to protocol 'Equatable', preventing synthesized conformance of 'ArrayOfNotEquatables' to 'Equatable'}}
 }
 
@@ -298,7 +298,7 @@ enum BadGenericDeriveExtension<T> {
     case A(T) //expected-note {{associated value type 'T' does not conform to protocol 'Hashable', preventing synthesized conformance of 'BadGenericDeriveExtension<T>' to 'Hashable'}}
   //expected-note@-1 {{associated value type 'T' does not conform to protocol 'Equatable', preventing synthesized conformance of 'BadGenericDeriveExtension<T>' to 'Equatable'}}
 }
-extension BadGenericDeriveExtension: Equatable {} // expected-note {{do you want to add protocol stubs?}}
+extension BadGenericDeriveExtension: Equatable {} //
 // expected-error@-1 {{type 'BadGenericDeriveExtension<T>' does not conform to protocol 'Equatable'}}
 extension BadGenericDeriveExtension: Hashable where T: Equatable {}
 // expected-error@-1 {{type 'BadGenericDeriveExtension' does not conform to protocol 'Hashable'}}

--- a/test/Sema/enum_equatable_conditional.swift
+++ b/test/Sema/enum_equatable_conditional.swift
@@ -2,11 +2,11 @@
 
 struct NotEquatable { }
 
-enum WithArrayOfNotEquatables : Equatable { // expected-error{{type 'WithArrayOfNotEquatables' does not conform to protocol 'Equatable'}} expected-note {{do you want to add protocol stubs?}}
+enum WithArrayOfNotEquatables : Equatable { // expected-error{{type 'WithArrayOfNotEquatables' does not conform to protocol 'Equatable'}}
   case only([NotEquatable]) // expected-note{{associated value type '[NotEquatable]' does not conform to protocol 'Equatable', preventing synthesized conformance of 'WithArrayOfNotEquatables' to 'Equatable'}}
 }
 
-enum WithArrayOfNotEquatables2<T> : Equatable { // expected-error{{type 'WithArrayOfNotEquatables2<T>' does not conform to protocol 'Equatable'}} expected-note {{do you want to add protocol stubs?}}
+enum WithArrayOfNotEquatables2<T> : Equatable { // expected-error{{type 'WithArrayOfNotEquatables2<T>' does not conform to protocol 'Equatable'}}
   case only([T]) // expected-note{{associated value type '[T]' does not conform to protocol 'Equatable', preventing synthesized conformance of 'WithArrayOfNotEquatables2<T>' to 'Equatable'}}
 }
 

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -64,7 +64,7 @@ var colorRaw: Color.RawValue = 7.5
 
 // Mismatched case types
 
-enum BadPlain : UInt { // expected-error {{'BadPlain' declares raw type 'UInt', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-note {{do you want to add protocol stubs?}}
+enum BadPlain : UInt { // expected-error {{'BadPlain' declares raw type 'UInt', but does not conform to RawRepresentable and conformance could not be synthesized}}
     case a = "hello"   // expected-error {{cannot convert value of type 'String' to raw type 'UInt'}}
 }
 
@@ -188,5 +188,4 @@ enum ArrayOfNewEquatable : Array<NotEquatable> { }
 // expected-error@-1{{raw type 'Array<NotEquatable>' is not expressible by a string, integer, or floating-point literal}}
 // expected-error@-2{{'ArrayOfNewEquatable' declares raw type 'Array<NotEquatable>', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-3{{RawRepresentable conformance cannot be synthesized because raw type 'Array<NotEquatable>' is not Equatable}}
-// expected-note@-4{{do you want to add protocol stubs?}}
-// expected-error@-5 {{an enum with no cases cannot declare a raw type}}
+// expected-error@-4{{an enum with no cases cannot declare a raw type}}

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -120,7 +120,7 @@ func structWithoutExplicitConformance() {
 
 // Structs with non-hashable/equatable stored properties don't derive conformance.
 struct NotHashable {}
-struct StructWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}} expected-note {{do you want to add protocol stubs?}}
+struct StructWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}}
   let a: NotHashable // expected-note {{stored property type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'StructWithNonHashablePayload' to 'Hashable'}}
   // expected-note@-1 {{stored property type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'StructWithNonHashablePayload' to 'Equatable'}}
 }
@@ -182,7 +182,7 @@ struct NotExplicitlyHashableAndCannotDerive {
   let v: NotHashable // expected-note {{stored property type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Hashable'}}
   // expected-note@-1 {{stored property type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Equatable'}}
 }
-extension NotExplicitlyHashableAndCannotDerive : Hashable {}  // expected-error 2 {{does not conform}} expected-note {{do you want to add protocol stubs?}}
+extension NotExplicitlyHashableAndCannotDerive : Hashable {}  // expected-error 2 {{does not conform}}
 
 // A struct with no stored properties trivially derives conformance.
 struct NoStoredProperties: Hashable {}
@@ -240,7 +240,6 @@ struct BadGenericDeriveExtension<T> {
 }
 extension BadGenericDeriveExtension: Equatable {}
 // expected-error@-1 {{type 'BadGenericDeriveExtension<T>' does not conform to protocol 'Equatable'}}
-// expected-note@-2 {{do you want to add protocol stubs?}}
 extension BadGenericDeriveExtension: Hashable where T: Equatable {}
 // expected-error@-1 {{type 'BadGenericDeriveExtension' does not conform to protocol 'Hashable'}}
 

--- a/test/Serialization/Recovery/types-4-to-5.swift
+++ b/test/Serialization/Recovery/types-4-to-5.swift
@@ -17,7 +17,7 @@ func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
 class Sub: Base {} // okay
-class Impl: Proto {} // expected-error {{type 'Impl' does not conform to protocol 'Proto'}} expected-note {{do you want to add protocol stubs?}}
+class Impl: Proto {} // expected-error {{type 'Impl' does not conform to protocol 'Proto'}}
 
 #else // TEST
 

--- a/test/TypeCoercion/integer_literals.swift
+++ b/test/TypeCoercion/integer_literals.swift
@@ -44,7 +44,7 @@ struct meters : ExpressibleByIntegerLiteral {
   }
 }
 
-struct supermeters : ExpressibleByIntegerLiteral { // expected-error{{type 'supermeters' does not conform to protocol 'ExpressibleByIntegerLiteral'}} expected-note {{do you want to add protocol stubs?}}
+struct supermeters : ExpressibleByIntegerLiteral { // expected-error{{type 'supermeters' does not conform to protocol 'ExpressibleByIntegerLiteral'}}
   var value : meters
 
   typealias IntegerLiteralType = meters // expected-note{{possibly intended match 'supermeters.IntegerLiteralType' (aka 'meters') does not conform to '_ExpressibleByBuiltinIntegerLiteral'}}

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -93,7 +93,6 @@ struct P6Conformer : P6 { // expected-error 2 {{does not conform}}
 }
 
 // rdar://problem/23033862
-// expected-note@+3 2 {{do you want to add protocol stubs?}}
 // expected-error@+2{{type 'A' does not conform to protocol 'OptionSet'}}
 // expected-error@+1{{type 'A' does not conform to protocol 'RawRepresentable'}}
 struct A: OptionSet {
@@ -127,7 +126,6 @@ extension UInt32: ExpressibleByStringLiteral {}
 // expected-error@-1 {{type 'UInt32' does not conform to protocol 'ExpressibleByStringLiteral'}}
 // expected-error@-2 {{type 'UInt32' does not conform to protocol 'ExpressibleByExtendedGraphemeClusterLiteral'}}
 // expected-error@-3 {{type 'UInt32' does not conform to protocol 'ExpressibleByUnicodeScalarLiteral'}}
-// expected-note@-4 {{do you want to add protocol stubs?}}
 
 // After successfully type-checking this (due to the presumption of
 // the type actually conforming), do not crash when failing to find

--- a/test/decl/protocol/conforms/fixit_stub_batch_mode.swift
+++ b/test/decl/protocol/conforms/fixit_stub_batch_mode.swift
@@ -1,3 +1,3 @@
 // RUN: %target-typecheck-verify-swift -enable-batch-mode %S/Inputs/fixit_stub_batch_mode_helper.swift
 
-extension C: P {} // expected-error{{type 'C' does not conform to protocol 'P'}} expected-note {{do you want to add protocol stubs?}}
+extension C: P {} // expected-error{{type 'C' does not conform to protocol 'P'}}

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -17,7 +17,6 @@ extension LikeOptionSet where RawValue : FixedWidthInteger {
 struct X : LikeOptionSet {}
 // expected-error@-1 {{type 'X' does not conform to protocol 'LikeSetAlgebra'}}
 // expected-error@-2 {{type 'X' does not conform to protocol 'RawRepresentable'}}
-// expected-note@-3 {{do you want to add protocol stubs?}}
 
 protocol IterProtocol {}
 protocol LikeSequence {

--- a/test/decl/protocol/special/coding/enum_coding_key.swift
+++ b/test/decl/protocol/special/coding/enum_coding_key.swift
@@ -35,16 +35,16 @@ let _ = IntKey(intValue: 3)
 
 // Enums with a different raw value conforming to CodingKey should not get
 // implicit derived conformance.
-enum Int8Key : Int8, CodingKey { // expected-error {{type 'Int8Key' does not conform to protocol 'CodingKey'}} expected-note 4 {{do you want to add protocol stubs?}}
+enum Int8Key : Int8, CodingKey { // expected-error {{type 'Int8Key' does not conform to protocol 'CodingKey'}}
     case a = -1, b = 0, c = 1
 }
 
 // Structs conforming to CodingKey should not get implicit derived conformance.
-struct StructKey : CodingKey { // expected-error {{type 'StructKey' does not conform to protocol 'CodingKey'}} expected-note 4 {{do you want to add protocol stubs?}}
+struct StructKey : CodingKey { // expected-error {{type 'StructKey' does not conform to protocol 'CodingKey'}}
 }
 
 // Classes conforming to CodingKey should not get implict derived conformance.
-class ClassKey : CodingKey { //expected-error {{type 'ClassKey' does not conform to protocol 'CodingKey'}} expected-note 4 {{do you want to add protocol stubs?}}
+class ClassKey : CodingKey { //expected-error {{type 'ClassKey' does not conform to protocol 'CodingKey'}}
 }
 
 // Types which are valid for CodingKey derived conformance should not get that

--- a/test/multifile/Inputs/protocol-conformance/broken.swift
+++ b/test/multifile/Inputs/protocol-conformance/broken.swift
@@ -1,1 +1,1 @@
-extension X : P { } // expected-error{{type 'X' does not conform to protocol 'P'}} expected-note{{do you want to add protocol stubs?}}
+extension X : P { } // expected-error{{type 'X' does not conform to protocol 'P'}}

--- a/test/stdlib/BinaryIntegerRequirements.swift
+++ b/test/stdlib/BinaryIntegerRequirements.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
-struct MyInt: FixedWidthInteger { // expected-error {{type 'MyInt' does not conform to protocol 'BinaryInteger'}} expected-note 3 {{do you want to add protocol stubs?}}
+struct MyInt: FixedWidthInteger { // expected-error {{type 'MyInt' does not conform to protocol 'BinaryInteger'}}
   typealias IntegerLiteralType = Int
   static let isSigned = false
   init(integerLiteral value: Int) { fatalError() }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -28,7 +28,7 @@ func bad_containers_3(bc: BadContainer3) {
 
 struct BadIterator1 {}
 
-struct BadContainer4 : Sequence { // expected-error{{type 'BadContainer4' does not conform to protocol 'Sequence'}} expected-note 2 {{do you want to add protocol stubs?}}
+struct BadContainer4 : Sequence { // expected-error{{type 'BadContainer4' does not conform to protocol 'Sequence'}}
   typealias Iterator = BadIterator1 // expected-note{{possibly intended match 'BadContainer4.Iterator' (aka 'BadIterator1') does not conform to 'IteratorProtocol'}}
   func makeIterator() -> BadIterator1 { }
 }

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -7,7 +7,6 @@ import StdlibCollectionUnittest
 // Check that Collection.SubSequence is constrained to Collection.
 //
 
-// expected-note@+2 {{do you want to add protocol stubs?}}
 // expected-error@+1 {{type 'CollectionWithBadSubSequence' does not conform to protocol 'Collection'}}
 struct CollectionWithBadSubSequence : Collection {
   var startIndex: MinimalIndex {
@@ -71,7 +70,6 @@ struct AnotherGoodIndexable1 : Indexable {
   subscript(pos: Int) -> Int { return 0 }
 }
 
-// expected-note@+4 {{do you want to add protocol stubs?}}
 // expected-warning@+3 {{'Indexable' is deprecated: renamed to 'Collection'}}
 // expected-error@+2 {{type 'BadIndexable2' does not conform to protocol 'Collection'}}
 // expected-note@+1 {{use 'Collection' instead}}


### PR DESCRIPTION
Check for editor mode when emitting stub diagnostic stub note.
Fixing all the tests where there was **no** `-diagnostics-editor-mode`
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-11419](https://bugs.swift.org/browse/SR-11419).

cc @CodaFi :)