### PR TITLE
SILGen: Fix assertion when emitting tuple conversion into a refutable pattern initialization

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -994,7 +994,7 @@ ManagedValue SILGenFunction::manageOpaqueValue(ManagedValue value,
                                                SGFContext C) {
   // If the opaque value is consumable, we can just return the
   // value with a cleanup. There is no need to retain it separately.
-  if (value.hasCleanup())
+  if (value.isPlusOne(*this))
     return value;
 
   // If the context wants a +0 value, guaranteed or immediate, we can

--- a/test/SILGen/tuple_conversion_refutable_pattern.swift
+++ b/test/SILGen/tuple_conversion_refutable_pattern.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// CHECK-LABEL: sil hidden [ossa] @$s34tuple_conversion_refutable_pattern2f13argySi1a_SiSg1bt_tF : $@convention(thin) (Int, Optional<Int>) -> () {
+func f1(arg: (a: Int, b: Int?)) {
+  guard case let (x, y?) = arg else { return }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34tuple_conversion_refutable_pattern2f13argyyXl1a_yXlSg1bt_tF : $@convention(thin) (@guaranteed AnyObject, @guaranteed Optional<AnyObject>) -> () {
+func f1(arg: (a: AnyObject, b: AnyObject?)) {
+  guard case let (x, y?) = arg else { return }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34tuple_conversion_refutable_pattern2f13argyyp1a_ypSg1bt_tF : $@convention(thin) (@in_guaranteed Any, @in_guaranteed Optional<Any>) -> () {
+func f1(arg: (a: Any, b: Any?)) {
+  guard case let (x, y?) = arg else { return }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34tuple_conversion_refutable_pattern2f23argySi1a_Si1bt_tF : $@convention(thin) (Int, Int) -> () {
+func f2(arg: (a: Int, b: Int)) {
+  guard case let (x, 4) = arg else { return }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34tuple_conversion_refutable_pattern2f23argySi1a_SS1bt_tF : $@convention(thin) (Int, @guaranteed String) -> () {
+func f2(arg: (a: Int, b: String)) {
+  guard case let (x, "") = arg else { return }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34tuple_conversion_refutable_pattern2f33argySi1a_Si1bt_tF : $@convention(thin) (Int, Int) -> () {
+func f3(arg: (a: Int, b: Int)) {
+  guard case let (x, is String) = arg else { return }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34tuple_conversion_refutable_pattern2f33argySi1a_yXl1bt_tF : $@convention(thin) (Int, @guaranteed AnyObject) -> () {
+func f3(arg: (a: Int, b: AnyObject)) {
+  guard case let (x, is String) = arg else { return }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34tuple_conversion_refutable_pattern2f33argySi1a_yp1bt_tF : $@convention(thin) (Int, @in_guaranteed Any) -> () {
+func f3(arg: (a: Int, b: Any)) {
+  guard case let (x, is String) = arg else { return }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34tuple_conversion_refutable_pattern2f43argySi1a_Sb1bt_tF : $@convention(thin) (Int, Bool) -> () {
+func f4(arg: (a: Int, b: Bool)) {
+  guard case let (x, false) = arg else { return }
+}


### PR DESCRIPTION
Refutable pattern initializations require that the 'isInit' parameter
is set to true, which transfers ownership of the input value.

One way it was getting set to false was when the pattern was bound to
an expression containing OpaqueValueExprs.

The opaque value of an open existential is +0, but that can't show
up here; only the result of a tuple conversion can. In principle this
is always a +1 value, however it could also be trivial, and we were
incorrectly treating it as a +0 value. We need to check isPlusOne()
instead of hasCleanup(); the latter returns false for trivial values.

Doing this lets us avoid going through the initialization altogether.

Fixes <rdar://problem/56809385>.