### PR TITLE
EscapeAnalysis cleanup and add utilities [nearly NFC]

### DIFF
--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -129,8 +129,8 @@ struct SILArgumentConvention {
     llvm_unreachable("covered switch isn't covered?!");
   }
 
-  /// Returns true if \p Value is a not-aliasing indirect parameter.
-  bool isNotAliasedIndirectParameter() {
+  /// Returns true if \p Value is a non-aliasing indirect parameter.
+  bool isExclusiveIndirectParameter() {
     switch (Value) {
     case SILArgumentConvention::Indirect_In:
     case SILArgumentConvention::Indirect_In_Constant:

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -281,19 +281,22 @@ public:
   /// address-only. This is the opposite of isLoadable.
   bool isAddressOnly(const SILFunction &F) const;
 
-  /// True if the type, or the referenced type of an address type, is trivial,
-  /// meaning it is loadable and can be trivially copied, moved or detroyed.
+  /// True if the underlying AST type is trivial, meaning it is loadable and can
+  /// be trivially copied, moved or detroyed. Returns false for address types
+  /// even though they are technically trivial.
   bool isTrivial(const SILFunction &F) const;
 
   /// True if the type, or the referenced type of an address type, is known to
-  /// be a scalar reference-counted type.
+  /// be a scalar reference-counted type such as a class, box, or thick function
+  /// type. Returns false for non-trivial aggregates.
   bool isReferenceCounted(SILModule &M) const;
 
   /// Returns true if the referenced type is a function type that never
   /// returns.
   bool isNoReturnFunction(SILModule &M) const;
 
-  /// Returns true if the referenced type has reference semantics.
+  /// Returns true if the referenced AST type has reference semantics, even if
+  /// the lowered SIL type is known to be trivial.
   bool hasReferenceSemantics() const {
     return getASTType().hasReferenceSemantics();
   }

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -147,14 +147,15 @@
 #ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ESCAPEANALYSIS_H_
 #define SWIFT_SILOPTIMIZER_ANALYSIS_ESCAPEANALYSIS_H_
 
-#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h"
+#include "swift/SILOptimizer/Analysis/ValueTracking.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallVector.h"
 
 struct CGForDotView;
 
@@ -236,8 +237,10 @@ class EscapeAnalysis : public BottomUpIPAnalysis {
 public:
   class CGNode;
   class ConnectionGraph;
+
 private:
   class CGNodeMap;
+  struct CGNodeWorklist;
 
   /// The int-part is an EdgeType and specifies which kind of predecessor it is.
   typedef llvm::PointerIntPair<CGNode *, 1> Predecessor;
@@ -249,9 +252,15 @@ public:
   /// pointer points to (see NodeType).
   class CGNode {
 
-    /// The associated value in the function. It is only used for debug printing.
-    /// There may be multiple nodes associated to the same value, e.g. a Content
-    /// node has the same V as its points-to predecessor.
+    /// The associated value in the function. This is always valid for Argument
+    /// and Value nodes, and always nullptr for Return nodes. For Content nodes,
+    /// i is only used for debug printing. A Content's value 'V' is unreliable
+    /// because it can change as a result of the order the the graph is
+    /// constructed and summary graphs are merged. Sometimes it is derived from
+    /// the instructions that access the content, other times, it's simply
+    /// inherited from its parent. There may be multiple nodes associated to the
+    /// same value, e.g. a Content node has the same V as its points-to
+    /// predecessor.
     ValueBase *V;
 
     /// The outgoing points-to edge (if any) to a Content node. See also:
@@ -259,8 +268,13 @@ public:
     /// If we ever want to distinguish between different fields of an object,
     /// then we should replace the single pointsTo edge with multiple edges -
     /// one for each field.
+    ///
+    /// Note: A content node with proper a "pointsTo" edge to another content
+    /// node often does *not* represent a pointer. There is no
+    /// indirection. Instead, these content nodes are all part of the same
+    /// object and only represent different layers within the object.
     CGNode *pointsTo = nullptr;
-    
+
     /// The outgoing defer edges.
     llvm::SmallVector<CGNode *, 8> defersTo;
     
@@ -281,7 +295,7 @@ public:
     EscapeState State = EscapeState::None;
 
     /// If true, the pointsTo is a real edge in the graph. Otherwise it is not
-    /// and edge (e.g. this does not appear in the pointsTo Preds list), but
+    /// an edge (e.g. this does not appear in the pointsTo Preds list), but
     /// still must point to the same Content node as all successor nodes.
     bool pointsToIsEdge = false;
     
@@ -313,15 +327,6 @@ public:
       }
     }
 
-    /// Merges the state from another state and returns true if it changed.
-    bool mergeEscapeState(EscapeState OtherState) {
-      if (OtherState > State) {
-        State = OtherState;
-        return true;
-      }
-      return false;
-    }
-
     /// Merges the use points from another node and returns true if there are
     /// any changes.
     bool mergeUsePoints(CGNode *RHS) {
@@ -330,10 +335,8 @@ public:
       return Changed;
     }
 
-    /// Returns the Content node if this node has an outgoing points-to edge.
-    CGNode *getPointsToEdge() const {
-      return pointsToIsEdge ? pointsTo : nullptr;
-    }
+    // Merge the properties of \p fromNode into this node.
+    void mergeProperties(CGNode *fromNode);
 
     /// Finds a successor node in the outgoing defer edges.
     llvm::SmallVectorImpl<CGNode *>::iterator findDeferred(CGNode *Def) {
@@ -352,22 +355,28 @@ public:
       Preds.erase(Iter);
     }
 
-    /// Adds a defer-edge to another node \p To. Not done if \p To is this node.
-    bool addDeferred(CGNode *To) {
-      assert(!To->isMerged);
+    bool canAddDeferred(CGNode *To) {
       if (To == this)
         return false;
       for (auto *Def : defersTo) {
         if (Def == To)
           return false;
       }
+      return true;
+    }
+
+    /// Adds a defer-edge to another node \p To. Not done if \p To is this node.
+    bool addDeferred(CGNode *To) {
+      assert(!To->isMerged);
+      if (!canAddDeferred(To))
+        return false;
       To->Preds.push_back(Predecessor(this, EdgeType::Defer));
       defersTo.push_back(To);
       return true;
     }
 
     /// Sets the outgoing points-to edge. The \p To node must be a Content node.
-    void setPointsTo(CGNode *To) {
+    void setPointsToEdge(CGNode *To) {
       assert(!To->mergeTo);
       assert(To->Type == NodeType::Content &&
              "Wrong node type for points-to edge");
@@ -392,12 +401,6 @@ public:
       UsePoints.set(Idx);
     }
 
-    /// For debug dumping.
-    void dump() const;
-
-    /// Returns a string representation of the node type. Also for debug dumping.
-    const char *getTypeStr() const;
-
     /// Checks an invariant of the connection graph: The points-to nodes of
     /// the defer-successors must match with the points-to of this node.
     bool matchPointToOfDefers() const {
@@ -411,13 +414,26 @@ public:
         return false;
       return true;
     }
-    
+
     friend class CGNodeMap;
     friend class ConnectionGraph;
     friend struct ::CGForDotView;
+    friend struct CGNodeWorklist;
 
   public:
-    
+    SILValue getValue() const {
+      assert(Type == NodeType::Argument || Type == NodeType::Value);
+      return V;
+    }
+    SILValue getValueOrNull() const { return V; }
+
+    void updateValue(SILValue newValue) {
+      assert(isContent());
+      V = newValue;
+    }
+
+    /// Return true if this node represents content.
+    bool isContent() const { return Type == NodeType::Content; }
     /// Returns the escape state.
     EscapeState getEscapeState() const { return State; }
 
@@ -425,18 +441,38 @@ public:
     /// the return instruction.
     bool escapes() const { return getEscapeState() != EscapeState::None; }
 
+    /// Specifies that this content node's memory escapes to global or
+    /// unidentified memory.
+    void markEscaping() {
+      assert(Type == NodeType::Content);
+      mergeEscapeState(EscapeState::Global);
+    }
+
+    /// Merges the state from another state and returns true if it changed.
+    bool mergeEscapeState(EscapeState OtherState) {
+      if (OtherState > State) {
+        State = OtherState;
+        return true;
+      }
+      return false;
+    }
+
     /// Returns true if the node's value escapes within the function. This
     /// means that any unidentified pointer in the function may alias to
     /// the node's value.
     /// Note that in the false-case the node's value can still escape via
     /// the return instruction.
-    bool escapesInsideFunction(bool isNotAliasingArgument) const {
+    ///
+    /// \p nodeValue is often the same as 'this->V', but is sometimes a more
+    /// refined value. For content nodes, 'this->V' is only a placeholder that
+    /// does not necessarilly represent the node's memory.
+    bool escapesInsideFunction(SILValue nodeValue) const {
       switch (getEscapeState()) {
         case EscapeState::None:
         case EscapeState::Return:
           return false;
         case EscapeState::Arguments:
-          return !isNotAliasingArgument;
+          return !isExclusiveArgument(nodeValue);
         case EscapeState::Global:
           return true;
       }
@@ -448,44 +484,31 @@ public:
     CGNode *getContentNodeOrNull() const {
       return pointsTo;
     }
-  };
 
-private:
-
-  /// Mapping from nodes in a callee-graph to nodes in a caller-graph.
-  class CGNodeMap {
-    /// The map itself.
-    llvm::DenseMap<CGNode *, CGNode *> Map;
-
-    /// The list of source nodes (= keys in Map), which is used as a work-list.
-    llvm::SmallVector<CGNode *, 8> MappedNodes;
-  public:
-
-    /// Adds a mapping and pushes the \p From node into the work-list
-    /// MappedNodes.
-    void add(CGNode *From, CGNode *To) {
-      assert(From && To && !From->isMerged && !To->isMerged);
-      Map[From] = To;
-      if (!From->isInWorkList) {
-        MappedNodes.push_back(From);
-        From->isInWorkList = true;
-      }
+    /// Returns the Content node if this node has an outgoing points-to edge.
+    CGNode *getPointsToEdge() const {
+      return pointsToIsEdge ? pointsTo : nullptr;
     }
-    /// Looks up a node in the mapping.
-    CGNode *get(CGNode *From) const {
-      auto Iter = Map.find(From);
-      if (Iter == Map.end())
-        return nullptr;
 
-      return Iter->second->getMergeTarget();
-    }
-    const SmallVectorImpl<CGNode *> &getMappedNodes() const {
-      return MappedNodes;
-    }
+    /// Visit all successors of this node in the connection graph until \p
+    /// visitor returns false. Return true if all successors were visited
+    /// without \p visitor returning false.
+    ///
+    /// Note that a node may be the pointsTo successor of itself.
+    template <typename Visitor> bool visitSuccessors(Visitor &&visitor) const;
+
+    /// Visit all adjacent defers. Halt when the visitor returns false. Return
+    /// true if the visitor returned true for all defers.
+    template <typename Visitor> bool visitDefers(Visitor &&visitor) const;
+
+    /// For debug dumping.
+    void dump() const;
+
+    /// Returns a string representation of the node type. For debug dumping.
+    const char *getTypeStr() const;
   };
 
 public:
-
   /// The connection graph for a function. See also: EdgeType, NodeType and
   /// CGNode.
   /// A connection graph has these invariants:
@@ -497,10 +520,18 @@ public:
   /// 4) For any node N, all paths starting at N which consist of only
   ///    defer-edges and a single trailing points-to edge must lead to the same
   ///    Content node.
+  ///
+  /// Additionally, all nodes in a path consisting of defer-edges must have the
+  /// same pointsTo field--either all pointsTo fields are null, or they all
+  /// point to the same target of the points-to edges at the leaves of the defer
+  /// web, which must have been merged into a single content node.
+  ///
+  /// Paths comprised of points-to edges may contain cycles and self-cycles.
   class ConnectionGraph {
-
     /// Backlink to the graph's function.
     SILFunction *F;
+    /// Backlink to the EscapeAnalysis
+    EscapeAnalysis *EA;
 
     /// Mapping from pointer SIL values to nodes in the graph. Such a value can
     /// never be a projection, because in case of projection-instruction the
@@ -529,11 +560,13 @@ public:
 
     /// True if this is a summary graph.
     bool isSummaryGraph;
-    
+
+    /// Track the currently active intrusive worklist -- one at a time.
+    CGNodeWorklist *activeWorklist = nullptr;
+
     /// Constructs a connection graph for a function.
-    ConnectionGraph(SILFunction *F, bool isSummaryGraph) :
-      F(F), isSummaryGraph(isSummaryGraph) {
-    }
+    ConnectionGraph(SILFunction *F, EscapeAnalysis *EA, bool isSummaryGraph)
+        : F(F), EA(EA), isSummaryGraph(isSummaryGraph) {}
 
     /// Returns true if the connection graph is empty.
     bool isEmpty() {
@@ -564,6 +597,7 @@ public:
       CGNode *FromMergeTarget = From->getMergeTarget();
       CGNode *ToMergeTarget = To->getMergeTarget();
       if (FromMergeTarget != ToMergeTarget) {
+        ToMergeTarget->mergeProperties(FromMergeTarget);
         FromMergeTarget->mergeTo = ToMergeTarget;
         ToMerge.push_back(FromMergeTarget);
       }
@@ -591,7 +625,7 @@ public:
     /// taken. This means the node is always created for the "outermost" value
     /// where V is contained.
     /// Returns null, if V is not a "pointer".
-    CGNode *getNode(ValueBase *V, EscapeAnalysis *EA, bool createIfNeeded = true);
+    CGNode *getNode(ValueBase *V, bool createIfNeeded = true);
 
     /// Gets or creates a content node to which \a AddrNode points to during
     /// initial graph construction. This may not be called after defer edges
@@ -676,8 +710,8 @@ public:
     /// Returns the \p From node or its merge-target in case \p From was merged
     /// during adding the edge.
     CGNode *defer(CGNode *From, CGNode *To) {
-      bool UnusedEdgeAddedFlag = false;
-      return defer(From, To, UnusedEdgeAddedFlag);
+      bool UnusedChangedFlag = false;
+      return defer(From, To, UnusedChangedFlag);
     }
 
     /// Merges the \p SourceGraph into this graph. The \p Mapping contains the
@@ -692,19 +726,51 @@ public:
     /// lookup-up with getNode() anymore.
     void removeFromGraph(ValueBase *V) { Values2Nodes.erase(V); }
 
-    /// Returns true if there is a path from \p From to \p To.
-    bool isReachable(CGNode *From, CGNode *To);
+    enum class Traversal { Follow, Backtrack, Halt };
+
+    /// Traverse backward from startNode, following predecessor edges.
+    ///
+    /// CGNodeVisitor takes the current CGNode and returns Traversal::Follow if
+    /// traversal should proceed along its predecessors, Traversal::Backtrack,
+    /// if it should not follow its predecessors, and Traversal::Halt if it
+    /// should immediately stop visiting nodes.
+    ///
+    /// Return true if the visitor did not halt traversal.
+    template <typename CGPredVisitor>
+    bool backwardTraverse(CGNode *startNode, CGPredVisitor &&visitor);
+
+    /// Traverse forward from startNode, following defer edges.
+    ///
+    /// CGNodeVisitor takes the current CGNode and returns Traversal::Follow if
+    /// traversal should proceed along its predecessors, Traversal::Backtrack,
+    /// if it should not follow its predecessors, and Traversal::Halt if it
+    /// should immediately stop visiting nodes.
+    ///
+    /// Return true if the visitor did not halt traversal.
+    template <typename CGNodeVisitor>
+    bool forwardTraverseDefer(CGNode *startNode, CGNodeVisitor &&visitor);
+
+    /// Follow transitive pointsTo edges from \p startNode. Return true if \p
+    /// visitor returns true for all visited nodes.
+    template <typename CGNodeVisitor>
+    bool forwardTraversePointsToEdges(CGNode *startNode,
+                                      CGNodeVisitor &&visitor);
+
+    // Returns the last content node in the chain of pointsTo edges pointed to
+    // by this node.
+    CGNode *getPointsToEnd(CGNode *node);
+
+    /// Return true if \p pointer may indirectly point to \pointee via pointers
+    /// and object references.
+    bool mayReach(CGNode *pointer, CGNode *pointee);
 
   public:
-
     /// Gets or creates a node for a value \p V.
     /// If V is a projection(-path) then the base of the projection(-path) is
     /// taken. This means the node is always created for the "outermost" value
     /// where V is contained.
     /// Returns null, if V is not a "pointer".
-    CGNode *getNodeOrNull(ValueBase *V, EscapeAnalysis *EA) {
-      return getNode(V, EA, false);
-    }
+    CGNode *getNodeOrNull(ValueBase *V) { return getNode(V, false); }
 
     /// Returns the number of use-points of a node.
     int getNumUsePoints(CGNode *Node) {
@@ -742,6 +808,9 @@ public:
     /// Global escaping nodes are red, argument escaping nodes are blue.
     void viewCG() const;
 
+    /// Dump the connection graph to a DOT file for remote debugging.
+    void dumpCG() const;
+
     /// Checks if the graph is OK.
     void verify() const;
 
@@ -751,13 +820,15 @@ public:
 
     friend struct ::CGForDotView;
     friend class EscapeAnalysis;
+    friend struct CGNodeWorklist;
   };
 
 private:
 
   /// All the information we keep for a function.
   struct FunctionInfo : public FunctionInfoBase<FunctionInfo> {
-    FunctionInfo(SILFunction *F) : Graph(F, false), SummaryGraph(F, true) { }
+    FunctionInfo(SILFunction *F, EscapeAnalysis *EA)
+        : Graph(F, EA, false), SummaryGraph(F, EA, true) {}
 
     /// The connection graph for the function. This is what clients of the
     /// analysis will see.
@@ -815,11 +886,21 @@ private:
 
   /// Returns true if \p V may encapsulate a "pointer" value.
   /// See EscapeAnalysis::NodeType::Value.
-  bool isPointer(ValueBase *V);
+  bool isPointer(ValueBase *V) const;
+
+  /// If EscapeAnalysis should consider the given value to be a derived address
+  /// or pointer based on one of its address or pointer operands, then return
+  /// that operand value. Otherwise, return an invalid value.
+  SILValue getPointerBase(SILValue value) const;
+
+  /// Recursively find the given value's pointer base. If the value cannot be
+  /// represented in EscapeAnalysis as one of its operands, then return the same
+  /// value.
+  SILValue getPointerRoot(SILValue value) const;
 
   /// If \p pointer is a pointer, set it to global escaping.
   void setEscapesGlobal(ConnectionGraph *ConGraph, ValueBase *pointer) {
-    if (CGNode *Node = ConGraph->getNode(pointer, this))
+    if (CGNode *Node = ConGraph->getNode(pointer))
       ConGraph->setEscapesGlobal(Node);
   }
 
@@ -827,7 +908,7 @@ private:
   FunctionInfo *getFunctionInfo(SILFunction *F) {
     FunctionInfo *&FInfo = Function2Info[F];
     if (!FInfo)
-      FInfo = new (Allocator.Allocate()) FunctionInfo(F);
+      FInfo = new (Allocator.Allocate()) FunctionInfo(F, this);
     return FInfo;
   }
 

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -750,16 +750,6 @@ public:
     template <typename CGNodeVisitor>
     bool forwardTraverseDefer(CGNode *startNode, CGNodeVisitor &&visitor);
 
-    /// Follow transitive pointsTo edges from \p startNode. Return true if \p
-    /// visitor returns true for all visited nodes.
-    template <typename CGNodeVisitor>
-    bool forwardTraversePointsToEdges(CGNode *startNode,
-                                      CGNodeVisitor &&visitor);
-
-    // Returns the last content node in the chain of pointsTo edges pointed to
-    // by this node.
-    CGNode *getPointsToEnd(CGNode *node);
-
     /// Return true if \p pointer may indirectly point to \pointee via pointers
     /// and object references.
     bool mayReach(CGNode *pointer, CGNode *pointee);

--- a/include/swift/SILOptimizer/Analysis/ValueTracking.h
+++ b/include/swift/SILOptimizer/Analysis/ValueTracking.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SILOPTIMIZER_ANALYSIS_VALUETRACKING_H
 #define SWIFT_SILOPTIMIZER_ANALYSIS_VALUETRACKING_H
 
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
 
@@ -24,16 +25,33 @@ namespace swift {
 
 /// Returns true if \p V is a function argument which may not alias to
 /// any other pointer in the function.
-/// The \p assumeInoutIsNotAliasing specifies in no-aliasing is assumed for
-/// the @inout convention. See swift::isNotAliasedIndirectParameter().
-bool isNotAliasingArgument(SILValue V);
+///
+/// This does not look through any projections. The caller must do that.
+bool isExclusiveArgument(SILValue V);
 
-/// Returns true if \p V is local inside its function. This means its underlying
-/// object either is a non-aliasing function argument or a locally allocated
-/// object.
-/// The \p assumeInoutIsNotAliasing specifies in no-aliasing is assumed for
-/// the @inout convention. See swift::isNotAliasedIndirectParameter().
+/// Returns true if \p V is a locally allocated object.
+///
+/// Note: this may look through a single level of indirection (via
+/// ref_element_addr) when \p V is the address of a class property. However, it
+/// does not look through init/open_existential_addr.
 bool pointsToLocalObject(SILValue V);
+
+/// Returns true if \p V is a uniquely identified address or reference. It may
+/// be any of:
+///
+/// - an address projection based on a locally allocated address with no
+/// indirection
+///
+/// - a locally allocated reference, or an address projection based on that
+/// reference with one level of indirection (an address into the locally
+/// allocated object).
+///
+/// - an address projection based on an exclusive argument with no levels of
+/// indirection.
+inline bool isUniquelyIdentified(SILValue V) {
+  return pointsToLocalObject(V)
+         || isExclusiveArgument(getUnderlyingAddressRoot(V));
+}
 
 enum class IsZeroKind {
   Zero,

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -38,6 +38,7 @@ SILValue swift::stripOwnershipInsts(SILValue v) {
 
 /// Strip off casts/indexing insts/address projections from V until there is
 /// nothing left to strip.
+///
 /// FIXME: Why don't we strip projections after stripping indexes?
 SILValue swift::getUnderlyingObject(SILValue v) {
   while (true) {
@@ -54,24 +55,24 @@ SILValue swift::getUnderlyingObject(SILValue v) {
 /// Strip off casts and address projections into the interior of a value. Unlike
 /// getUnderlyingObject, this does not find the root of a heap object--a class
 /// property is itself an address root.
-SILValue swift::getUnderlyingAddressRoot(SILValue V) {
+SILValue swift::getUnderlyingAddressRoot(SILValue v) {
   while (true) {
-    SILValue V2 = stripIndexingInsts(stripCasts(V));
-    switch (V2->getKind()) {
-      case ValueKind::StructElementAddrInst:
-      case ValueKind::TupleElementAddrInst:
-      case ValueKind::UncheckedTakeEnumDataAddrInst:
-        V2 = cast<SingleValueInstruction>(V2)->getOperand(0);
-        break;
-      default:
-        break;
+    SILValue v2 = stripIndexingInsts(stripCasts(v));
+    v2 = stripOwnershipInsts(v2);
+    switch (v2->getKind()) {
+    case ValueKind::StructElementAddrInst:
+    case ValueKind::TupleElementAddrInst:
+    case ValueKind::UncheckedTakeEnumDataAddrInst:
+      v2 = cast<SingleValueInstruction>(v2)->getOperand(0);
+      break;
+    default:
+      break;
     }
-    if (V2 == V)
-      return V2;
-    V = V2;
+    if (v2 == v)
+      return v2;
+    v = v2;
   }
 }
-
 
 SILValue swift::getUnderlyingObjectStopAtMarkDependence(SILValue v) {
   while (true) {

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -101,7 +101,10 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS, AliasResult R) {
   llvm_unreachable("Unhandled AliasResult in switch.");
 }
 
-SILValue getAccessedMemory(SILInstruction *User) {
+// Return the address of the directly accessed memory. If either the address is
+// unknown, or any other memory is accessed via indirection, return an invalid
+// SILValue.
+SILValue getDirectlyAccessedMemory(SILInstruction *User) {
   if (auto *LI = dyn_cast<LoadInst>(User)) {
     return LI->getOperand();
   }
@@ -128,7 +131,7 @@ static bool isFunctionArgument(SILValue V) {
 static bool isIdentifiableObject(SILValue V) {
   if (isa<AllocationInst>(V) || isa<LiteralInst>(V))
     return true;
-  if (isNotAliasingArgument(V))
+  if (isExclusiveArgument(V))
     return true;
   return false;
 }
@@ -178,8 +181,7 @@ static bool isLocalLiteral(SILValue V) {
 /// Is this a value that can be unambiguously identified as being defined at the
 /// function level.
 static bool isIdentifiedFunctionLocal(SILValue V) {
-  return isa<AllocationInst>(*V) || isNotAliasingArgument(V) ||
-         isLocalLiteral(V);
+  return isa<AllocationInst>(*V) || isExclusiveArgument(V) || isLocalLiteral(V);
 }
 
 /// Returns true if we can prove that the two input SILValues which do not equal
@@ -617,8 +619,12 @@ AliasResult AliasAnalysis::aliasInner(SILValue V1, SILValue V2,
   // non-escaping pointer with another (maybe escaping) pointer. Escape analysis
   // uses the connection graph to check if the pointers may point to the same
   // content.
-  // Note that escape analysis must work with the original pointers and not the
-  // underlying objects because it treats projections differently.
+  //
+  // canPointToSameMemory must take the original pointers used for memory
+  // access, not the underlying object, because objects projections can be
+  // modeled by escape analysis as different content, and canPointToSameMemory
+  // assumes that only the pointer itself may be accessed here, not any other
+  // address that can be derived from this pointer.
   if (!EA->canPointToSameMemory(V1, V2)) {
     LLVM_DEBUG(llvm::dbgs() << "            Found not-aliased objects based on "
                                "escape analysis\n");
@@ -711,24 +717,31 @@ bool AliasAnalysis::mayValueReleaseInterfereWithInstruction(SILInstruction *User
   if (!User->mayReadOrWriteMemory())
     return false;
 
-  // These instructions do read or write memory, get memory accessed.
-  SILValue V = getAccessedMemory(User);
+  // These instructions do read or write memory, get memory directly
+  // accessed. 'V' must be the only memory accessed by User, and it must be
+  // directly accessed. Any memory indirectly accessed via 'User' may have
+  // escaped.
+  SILValue V = getDirectlyAccessedMemory(User);
   if (!V)
     return true;
 
-  // Is this a local allocation ?
-  if (!pointsToLocalObject(V))
+  // If the 'User' instruction's memory is uniquely identified and does not
+  // escape in the local scope, then it can't be accessed by a deinit in the
+  // local scope. Note that an exclusive argument's content may have escaped in
+  // the caller, but the argument value itself can't be accessed via aliasing
+  // references and we know that User doesn't see through any indirection.
+  if (!isUniquelyIdentified(V))
     return true;
 
-  // This is a local allocation.
+  // This is a scoped allocation.
   // The most important check: does the object escape the current function?
   auto LO = getUnderlyingObject(V);
   auto *ConGraph = EA->getConnectionGraph(User->getFunction());
-  auto *Node = ConGraph->getNodeOrNull(LO, EA);
+  auto *Node = ConGraph->getNodeOrNull(LO);
   if (Node && !Node->escapes())
     return false;
 
-  // This is either a non-local allocation or a local allocation that escapes.
+  // This is either a non-local allocation or a scoped allocation that escapes.
   // We failed to prove anything, it could be read or written by the deinit.
   return true;
 }

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1837,28 +1837,6 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       ConGraph->setNode(TEI, ArrayElements);
       return;
     }
-    case SILInstructionKind::UncheckedRefCastInst:
-    case SILInstructionKind::ConvertFunctionInst:
-    case SILInstructionKind::UpcastInst:
-    case SILInstructionKind::InitExistentialRefInst:
-    case SILInstructionKind::OpenExistentialRefInst:
-    case SILInstructionKind::RawPointerToRefInst:
-    case SILInstructionKind::RefToRawPointerInst:
-    case SILInstructionKind::RefToBridgeObjectInst:
-    case SILInstructionKind::BridgeObjectToRefInst:
-    case SILInstructionKind::UncheckedAddrCastInst:
-    case SILInstructionKind::UnconditionalCheckedCastInst:
-    // DO NOT use LOADABLE_REF_STORAGE because unchecked references don't have
-    // retain/release instructions that trigger the 'default' case.
-#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-    case SILInstructionKind::RefTo##Name##Inst: \
-    case SILInstructionKind::Name##ToRefInst:
-#include "swift/AST/ReferenceStorage.def"
-      // A cast is almost like a projection.
-    if (CGNode *OpNode = ConGraph->getNode(I->getOperand(0))) {
-      ConGraph->setNode(cast<SingleValueInstruction>(I), OpNode);
-    }
-      break;
     case SILInstructionKind::UncheckedRefCastAddrInst: {
       auto *URCAI = cast<UncheckedRefCastAddrInst>(I);
       CGNode *SrcNode = ConGraph->getNode(URCAI->getSrc());

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -16,13 +16,120 @@
 #include "swift/SIL/SILArgument.h"
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
-#include "swift/SILOptimizer/Analysis/ValueTracking.h"
 #include "swift/SILOptimizer/PassManager/PassManager.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/GraphWriter.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
+using CGNode = EscapeAnalysis::CGNode;
+
+// Returns true if \p Ty recursively contains a reference.  If \p mustBeRef is
+// true, only return true if the type is guaranteed to hold a reference. If \p
+// mustBeRef is false, only return false if the type is guaranteed not to hold a
+// reference.
+//
+// If \p Ty is itself an address, return false.
+static bool findRecursiveRefType(SILType Ty, const SILFunction &F,
+                                 bool mustBeRef) {
+  if (mustBeRef) {
+    // An address *may* be converted into a reference via something like
+    // raw_pointer_to_ref. However, addresses don't normally refer to the head
+    // of a reference counted object.
+    //
+    // The check for trivial types catches types that have AST "reference
+    // semantics", but are determined by type lowering to be trivial, such as
+    // noescape function types.
+    if (Ty.isAddress() || Ty.isTrivial(F))
+      return false;
+  }
+
+  if (!mustBeRef) {
+    // Opaque types may contain a reference. Speculatively track them too.
+    //
+    // 1. It may be possible to optimize opaque values based on known mutation
+    // points.
+    //
+    // 2. A specialized function may call a generic function passing a concrete
+    // reference type via incomplete specialization.
+    //
+    // 3. A generic function may call a specialized function taking a concrete
+    // reference type via devirtualization.
+    if (Ty.isAddressOnly(F))
+      return true;
+
+    if (Ty.getASTType() == F.getModule().getASTContext().TheRawPointerType)
+      return true;
+  }
+
+  if (Ty.hasReferenceSemantics())
+    return true;
+
+  auto &Mod = F.getModule();
+
+  if (auto *Str = Ty.getStructOrBoundGenericStruct()) {
+    for (auto *Field : Str->getStoredProperties()) {
+      if (findRecursiveRefType(Ty.getFieldType(Field, Mod), F, mustBeRef))
+        return true;
+    }
+    return false;
+  }
+  if (auto TT = Ty.getAs<TupleType>()) {
+    for (unsigned i = 0, e = TT->getNumElements(); i != e; ++i) {
+      if (findRecursiveRefType(Ty.getTupleElementType(i), F, mustBeRef))
+        return true;
+    }
+    return false;
+  }
+  if (auto En = Ty.getEnumOrBoundGenericEnum()) {
+    for (auto *ElemDecl : En->getAllElements()) {
+      if (ElemDecl->hasAssociatedValues()
+          && findRecursiveRefType(Ty.getEnumElementType(ElemDecl, Mod), F,
+                                  mustBeRef))
+        return true;
+    }
+    return false;
+  }
+  // FIXME: without a covered switch, this is not robust for mayContainReference
+  // in the event that new reference-holding AST types are invented.
+  return false;
+}
+
+// Returns true if the type \p Ty is a reference or may transitively contain
+// a reference. If \p Ty is itself an address, return false.
+//
+// An address may contain a reference because addresses can be cast into
+// reference types.
+static bool mayContainReference(SILType Ty, const SILFunction &F) {
+  if (Ty.isAddress())
+    return true;
+  return findRecursiveRefType(Ty, F, false);
+}
+
+// Returns true if the type \p Ty must be a reference or must transitively
+// contain a reference. If \p Ty is itself an address, return false.
+// Will be used in a subsequent commit.
+// static bool mustContainReference(SILType Ty, const SILFunction &F) {
+//  return findRecursiveRefType(Ty, F, true);
+//}
+
+bool EscapeAnalysis::isPointer(ValueBase *V) const {
+  auto *F = V->getFunction();
+
+  // The function can be null, e.g. if V is an undef.
+  if (!F)
+    return false;
+
+  SILType Ty = V->getType();
+  auto Iter = isPointerCache.find(Ty);
+  if (Iter != isPointerCache.end())
+    return Iter->second;
+
+  bool IP = mayContainReference(Ty, *F);
+  const_cast<EscapeAnalysis *>(this)->isPointerCache[Ty] = IP;
+  return IP;
+}
 
 static bool isExtractOfArrayUninitializedPointer(TupleExtractInst *TEI) {
   if (TEI->getFieldNo() == 1) {
@@ -33,33 +140,67 @@ static bool isExtractOfArrayUninitializedPointer(TupleExtractInst *TEI) {
   return false;
 }
 
-static SingleValueInstruction *isProjection(SILNode *node) {
-  switch (node->getKind()) {
-  case SILNodeKind::IndexAddrInst:
-  case SILNodeKind::IndexRawPointerInst:
-  case SILNodeKind::StructElementAddrInst:
-  case SILNodeKind::TupleElementAddrInst:
-  case SILNodeKind::UncheckedTakeEnumDataAddrInst:
-  case SILNodeKind::StructExtractInst:
-  case SILNodeKind::UncheckedEnumDataInst:
-  case SILNodeKind::MarkDependenceInst:
-  case SILNodeKind::PointerToAddressInst:
-  case SILNodeKind::AddressToPointerInst:
-  case SILNodeKind::InitEnumDataAddrInst:
-    return cast<SingleValueInstruction>(node);
-  case SILNodeKind::TupleExtractInst: {
-    auto *TEI = cast<TupleExtractInst>(node);
+// If EscapeAnalysis should consider the given value to be a derived address or
+// pointer based on one of its address or pointer operands, then return that
+// operand value. Otherwise, return an invalid value.
+SILValue EscapeAnalysis::getPointerBase(SILValue value) const {
+  switch (value->getKind()) {
+  case ValueKind::IndexAddrInst:
+  case ValueKind::IndexRawPointerInst:
+  case ValueKind::StructElementAddrInst:
+  case ValueKind::StructExtractInst:
+  case ValueKind::TupleElementAddrInst:
+  case ValueKind::UncheckedTakeEnumDataAddrInst:
+  case ValueKind::UncheckedEnumDataInst:
+  case ValueKind::MarkDependenceInst:
+  case ValueKind::PointerToAddressInst:
+  case ValueKind::AddressToPointerInst:
+  case ValueKind::InitEnumDataAddrInst:
+  case ValueKind::UncheckedRefCastInst:
+  case ValueKind::ConvertFunctionInst:
+  case ValueKind::UpcastInst:
+  case ValueKind::InitExistentialRefInst:
+  case ValueKind::OpenExistentialRefInst:
+  case ValueKind::RawPointerToRefInst:
+  case ValueKind::RefToRawPointerInst:
+  case ValueKind::RefToBridgeObjectInst:
+  case ValueKind::BridgeObjectToRefInst:
+  case ValueKind::UncheckedAddrCastInst:
+  case ValueKind::UnconditionalCheckedCastInst:
+    // DO NOT use LOADABLE_REF_STORAGE because unchecked references don't have
+    // retain/release instructions that trigger the 'default' case.
+#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
+  case ValueKind::RefTo##Name##Inst:                                           \
+  case ValueKind::Name##ToRefInst:
+#include "swift/AST/ReferenceStorage.def"
+    return cast<SingleValueInstruction>(value)->getOperand(0);
+
+  case ValueKind::TupleExtractInst: {
+    auto *TEI = cast<TupleExtractInst>(value);
     // Special handling for extracting the pointer-result from an
     // array construction. We handle this like a ref_element_addr
     // rather than a projection. See the handling of tuple_extract
     // in analyzeInstruction().
     if (isExtractOfArrayUninitializedPointer(TEI))
-      return nullptr;
-    return TEI;
+      return SILValue();
+    return TEI->getOperand();
   }
   default:
-    return nullptr;
+    return SILValue();
   }
+}
+
+// Recursively find the given value's pointer base. If the value cannot be
+// represented in EscapeAnalysis as one of its operands, then return the same
+// value.
+SILValue EscapeAnalysis::getPointerRoot(SILValue value) const {
+  while (true) {
+    if (SILValue v2 = getPointerBase(value))
+      value = v2;
+    else
+      break;
+  }
+  return value;
 }
 
 static bool isNonWritableMemoryAddress(SILNode *V) {
@@ -84,15 +225,119 @@ static bool isNonWritableMemoryAddress(SILNode *V) {
   }
 }
 
-static ValueBase *skipProjections(ValueBase *V) {
-  for (;;) {
-    if (auto SVI = isProjection(V)) {
-      V = SVI->getOperand(0);
-    } else {
-      return V;
-    }
+// Implement an intrusive worklist of CGNode. Only one may be in use at a time.
+struct EscapeAnalysis::CGNodeWorklist {
+  llvm::SmallVector<CGNode *, 8> nodeVector;
+  EscapeAnalysis::ConnectionGraph *conGraph;
+
+  CGNodeWorklist(const CGNodeWorklist &) = delete;
+
+  CGNodeWorklist(EscapeAnalysis::ConnectionGraph *conGraph)
+      : conGraph(conGraph) {
+    conGraph->activeWorklist = this;
   }
-  llvm_unreachable("there is no escape from an infinite loop");
+  ~CGNodeWorklist() { reset(); }
+  // Clear the intrusive isInWorkList flags, but leave the nodeVector vector in
+  // place for subsequent iteration.
+  void reset() {
+    ConnectionGraph::clearWorkListFlags(nodeVector);
+    conGraph->activeWorklist = nullptr;
+  }
+  unsigned size() const { return nodeVector.size(); }
+
+  bool empty() const { return nodeVector.empty(); }
+
+  bool contains(CGNode *node) const {
+    assert(conGraph->activeWorklist == this);
+    return node->isInWorkList;
+  }
+  CGNode *operator[](unsigned idx) const {
+    assert(idx < size());
+    return nodeVector[idx];
+  }
+  bool tryPush(CGNode *node) {
+    assert(conGraph->activeWorklist == this);
+    if (node->isInWorkList)
+      return false;
+
+    node->isInWorkList = true;
+    nodeVector.push_back(node);
+    return true;
+  }
+  void push(CGNode *node) {
+    assert(conGraph->activeWorklist == this);
+    assert(!node->isInWorkList);
+    node->isInWorkList = true;
+    nodeVector.push_back(node);
+  }
+};
+
+/// Mapping from nodes in a callee-graph to nodes in a caller-graph.
+class EscapeAnalysis::CGNodeMap {
+  /// The map itself.
+  llvm::DenseMap<CGNode *, CGNode *> Map;
+
+  /// The list of source nodes (= keys in Map), which is used as a work-list.
+  CGNodeWorklist MappedNodes;
+
+public:
+  CGNodeMap(ConnectionGraph *conGraph) : MappedNodes(conGraph) {}
+  CGNodeMap(const CGNodeMap &) = delete;
+
+  /// Adds a mapping and pushes the \p From node into the work-list
+  /// MappedNodes.
+  void add(CGNode *From, CGNode *To) {
+    assert(From && To && !From->isMerged && !To->isMerged);
+    Map[From] = To;
+    MappedNodes.tryPush(From);
+  }
+  /// Looks up a node in the mapping.
+  CGNode *get(CGNode *From) const {
+    auto Iter = Map.find(From);
+    if (Iter == Map.end())
+      return nullptr;
+
+    return Iter->second->getMergeTarget();
+  }
+  CGNodeWorklist &getMappedNodes() { return MappedNodes; }
+};
+
+//===----------------------------------------------------------------------===//
+//                        ConnectionGraph Implementation
+//===----------------------------------------------------------------------===//
+
+void EscapeAnalysis::CGNode::mergeProperties(CGNode *fromNode) {
+  if (!V)
+    V = fromNode->V;
+}
+
+template <typename Visitor>
+bool EscapeAnalysis::CGNode::visitSuccessors(Visitor &&visitor) const {
+  if (CGNode *pointsToSucc = getPointsToEdge()) {
+    // Visit pointsTo, even if pointsTo == this.
+    if (!visitor(pointsToSucc))
+      return false;
+  }
+  for (CGNode *def : defersTo) {
+    if (!visitor(def))
+      return false;
+  }
+  return true;
+}
+
+template <typename Visitor>
+bool EscapeAnalysis::CGNode::visitDefers(Visitor &&visitor) const {
+  for (Predecessor pred : Preds) {
+    if (pred.getInt() != EdgeType::Defer)
+      continue;
+    if (!visitor(pred.getPointer(), false))
+      return false;
+  }
+  for (auto *deferred : defersTo) {
+    if (!visitor(deferred, true))
+      return false;
+  }
+  return true;
 }
 
 void EscapeAnalysis::ConnectionGraph::clear() {
@@ -105,16 +350,22 @@ void EscapeAnalysis::ConnectionGraph::clear() {
   assert(ToMerge.empty());
 }
 
-EscapeAnalysis::CGNode *EscapeAnalysis::ConnectionGraph::
-getNode(ValueBase *V, EscapeAnalysis *EA, bool createIfNeeded) {
+EscapeAnalysis::CGNode *
+EscapeAnalysis::ConnectionGraph::getNode(ValueBase *V, bool createIfNeeded) {
   if (isa<FunctionRefInst>(V) || isa<DynamicFunctionRefInst>(V) ||
       isa<PreviousDynamicFunctionRefInst>(V))
     return nullptr;
-  
+
+  // In the case of a struct or tuple extract, 'V' may not be a pointer
+  // even if it's pointer root is a pointer. Bail first because we only expect
+  // graph nodes for pointer values.
   if (!EA->isPointer(V))
     return nullptr;
-  
-  V = skipProjections(V);
+
+  // Look past address projections, pointer casts, and the like within the same
+  // object. Does not look past a dereference such as ref_element_addr, or
+  // project_box.
+  V = EA->getPointerRoot(V);
 
   if (!createIfNeeded)
     return lookupNode(V);
@@ -185,7 +436,7 @@ void EscapeAnalysis::ConnectionGraph::mergeAllScheduledNodes() {
         assert(PredNode->getPointsToEdge() == From &&
                "Incoming pointsTo edge not set in predecessor");
         if (PredNode != From)
-          PredNode->setPointsTo(To);
+          PredNode->setPointsToEdge(To);
       } else {
         assert(PredNode != From);
         auto Iter = PredNode->findDeferred(From);
@@ -206,7 +457,7 @@ void EscapeAnalysis::ConnectionGraph::mergeAllScheduledNodes() {
         // we can do is to merge both content nodes.
         scheduleToMerge(ExistingPT, PT);
       } else {
-        To->setPointsTo(PT);
+        To->setPointsToEdge(PT);
       }
     }
     // Unlink the outgoing defer edges.
@@ -294,7 +545,7 @@ updatePointsTo(CGNode *InitialNode, CGNode *pointsTo) {
         // This node is the end of a defer-edge path with no pointsTo connected.
         // We create an edge to pointsTo (agreed, this changes the structure of
         // the graph but adding this edge is harmless).
-        Node->setPointsTo(pointsTo);
+        Node->setPointsToEdge(pointsTo);
       } else {
         Node->pointsTo = pointsTo;
       }
@@ -365,7 +616,7 @@ updatePointsTo(CGNode *InitialNode, CGNode *pointsTo) {
         if (!Node->isInWorkList) {
           // We create a points-to edge for the first node which doesn't reach
           // a points-to edge yet.
-          Node->setPointsTo(pointsTo);
+          Node->setPointsToEdge(pointsTo);
           WorkList.push_back(Node);
           Node->isInWorkList = true;
           break;
@@ -394,6 +645,10 @@ void EscapeAnalysis::ConnectionGraph::propagateEscapeStates() {
 }
 
 void EscapeAnalysis::ConnectionGraph::computeUsePoints() {
+#ifndef NDEBUG
+  for (CGNode *Nd : Nodes)
+    assert(Nd->UsePoints.empty() && "premature use point computation");
+#endif
   // First scan the whole function and add relevant instructions as use-points.
   for (auto &BB : *F) {
     for (SILArgument *BBArg : BB.getArguments()) {
@@ -420,7 +675,7 @@ void EscapeAnalysis::ConnectionGraph::computeUsePoints() {
           int ValueIdx = -1;
           for (const Operand &Op : I.getAllOperands()) {
             ValueBase *OpV = Op.get();
-            if (CGNode *OpNd = lookupNode(skipProjections(OpV))) {
+            if (CGNode *OpNd = lookupNode(EA->getPointerRoot(OpV))) {
               if (ValueIdx < 0) {
                 ValueIdx = addUsePoint(OpNd, &I);
               } else {
@@ -440,15 +695,12 @@ void EscapeAnalysis::ConnectionGraph::computeUsePoints() {
   bool Changed = false;
   do {
     Changed = false;
-
     for (CGNode *Node : Nodes) {
       // Propagate the bits to all successor nodes.
-      if (Node->pointsTo) {
-        Changed |= Node->pointsTo->mergeUsePoints(Node);
-      }
-      for (CGNode *Def : Node->defersTo) {
-        Changed |= Def->mergeUsePoints(Node);
-      }
+      Node->visitSuccessors([&Changed, Node](CGNode *succ) {
+        Changed |= succ->mergeUsePoints(Node);
+        return true;
+      });
     }
   } while (Changed);
 }
@@ -507,11 +759,11 @@ bool EscapeAnalysis::ConnectionGraph::mergeFrom(ConnectionGraph *SourceGraph,
     }
   } while (NodesMerged);
 
-  clearWorkListFlags(Mapping.getMappedNodes());
+  Mapping.getMappedNodes().reset();
 
   // Second step: add the source graph's defer edges to this graph.
   llvm::SmallVector<CGNode *, 8> WorkList;
-  for (CGNode *SourceNd : Mapping.getMappedNodes()) {
+  for (CGNode *SourceNd : Mapping.getMappedNodes().nodeVector) {
     assert(WorkList.empty());
     WorkList.push_back(SourceNd);
     SourceNd->isInWorkList = true;
@@ -575,32 +827,111 @@ getUsePoints(CGNode *Node, llvm::SmallVectorImpl<SILNode *> &UsePoints) {
   }
 }
 
-bool EscapeAnalysis::ConnectionGraph::isReachable(CGNode *From, CGNode *To) {
-  // See if we can reach the From-node by transitively visiting the
-  // predecessor nodes of the To-node.
-  // Usually nodes have few predecessor nodes and the graph depth is small.
-  // So this should be fast.
-  llvm::SmallVector<CGNode *, 8> WorkList;
-  WorkList.push_back(From);
-  From->isInWorkList = true;
-  for (unsigned Idx = 0; Idx < WorkList.size(); ++Idx) {
-    CGNode *Reachable = WorkList[Idx];
-    if (Reachable == To) {
-      clearWorkListFlags(WorkList);
-      return true;
-    }
-    for (Predecessor Pred : Reachable->Preds) {
-      CGNode *PredNode = Pred.getPointer();
-      if (!PredNode->isInWorkList) {
-        PredNode->isInWorkList = true;
-        WorkList.push_back(PredNode);
+// Traverse backward from startNode and return true if \p visitor did not halt
+// traversal..
+//
+// The graph may have cycles.
+template <typename CGPredVisitor>
+bool EscapeAnalysis::ConnectionGraph::backwardTraverse(
+    CGNode *startNode, CGPredVisitor &&visitor) {
+  CGNodeWorklist worklist(this);
+  worklist.push(startNode);
+
+  for (unsigned idx = 0; idx < worklist.size(); ++idx) {
+    CGNode *reachingNode = worklist[idx];
+
+    for (Predecessor pred : reachingNode->Preds) {
+      switch (visitor(pred)) {
+      case Traversal::Follow: {
+        CGNode *predNode = pred.getPointer();
+        worklist.tryPush(predNode);
+        break;
+      }
+      case Traversal::Backtrack:
+        break;
+      case Traversal::Halt:
+        return false;
       }
     }
   }
-  clearWorkListFlags(WorkList);
-  return false;
+  return true;
 }
 
+// Traverse forward from startNode, following defer edges and return true if \p
+// visitor did not halt traversal.
+//
+// The graph may have cycles.
+template <typename CGNodeVisitor>
+bool EscapeAnalysis::ConnectionGraph::forwardTraverseDefer(
+    CGNode *startNode, CGNodeVisitor &&visitor) {
+  CGNodeWorklist worklist(this);
+  worklist.push(startNode);
+
+  for (unsigned idx = 0; idx < worklist.size(); ++idx) {
+    CGNode *reachableNode = worklist[idx];
+
+    for (CGNode *deferNode : reachableNode->defersTo) {
+      switch (visitor(deferNode)) {
+      case Traversal::Follow:
+        worklist.tryPush(deferNode);
+        break;
+      case Traversal::Backtrack:
+        break;
+      case Traversal::Halt:
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// Follow transitive pointsTo edges from \p startNode.
+// This path may not contain cycles.
+template <typename CGNodeVisitor>
+bool EscapeAnalysis::ConnectionGraph::forwardTraversePointsToEdges(
+    CGNode *startNode, CGNodeVisitor &&visitor) {
+  CGNodeWorklist visitedNodes(this);
+  CGNode *pointer = startNode;
+  while ((pointer = pointer->getPointsToEdge())) {
+    if (!visitedNodes.tryPush(pointer))
+      return true;
+
+    if (!visitor(pointer)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Returns the last content node in the chain of pointsTo edges pointed to by
+// this node.
+//
+// If this node has no content, return the node itself. If has content or is
+// already a content follow the chain of pointsTo edges and return the last
+// content node in the chain.
+CGNode *EscapeAnalysis::ConnectionGraph::getPointsToEnd(CGNode *node) {
+  CGNode *content = node->isContent() ? node : node->getContentNodeOrNull();
+  if (!content)
+    return node;
+  forwardTraversePointsToEdges(content, [&](CGNode *pointsTo) {
+    content = pointsTo;
+    return true;
+  });
+  return content;
+}
+
+bool EscapeAnalysis::ConnectionGraph::mayReach(CGNode *pointer,
+                                               CGNode *pointee) {
+  if (pointer == pointee)
+    return true;
+
+  // This query is successful when the traversal halts and returns false.
+  return !backwardTraverse(pointee, [pointer](Predecessor pred) {
+    if (pred.getPointer() == pointer)
+      return Traversal::Halt;
+    return Traversal::Follow;
+  });
+}
 
 //===----------------------------------------------------------------------===//
 //                      Dumping, Viewing and Verification
@@ -830,6 +1161,14 @@ void EscapeAnalysis::ConnectionGraph::viewCG() const {
 #endif
 }
 
+void EscapeAnalysis::ConnectionGraph::dumpCG() const {
+  /// When asserts are disabled, this should be a NoOp.
+#ifndef NDEBUG
+  CGForDotView CGDot(this);
+  llvm::WriteGraph(&CGDot, "connection-graph");
+#endif
+}
+
 void EscapeAnalysis::CGNode::dump() const {
   llvm::errs() << getTypeStr();
   if (V)
@@ -952,8 +1291,11 @@ void EscapeAnalysis::ConnectionGraph::verify() const {
 #ifndef NDEBUG
   verifyStructure();
 
-  // Check graph invariance 4)
+  // Check graph invariants
   for (CGNode *Nd : Nodes) {
+    // ConnectionGraph invariant #4: For any node N, all paths starting at N
+    // which consist of only defer-edges and a single trailing points-to edge
+    // must lead to the same
     assert(Nd->matchPointToOfDefers());
   }
 #endif
@@ -1019,72 +1361,6 @@ static bool linkBBArgs(SILBasicBlock *BB) {
   return true;
 }
 
-/// Returns true if the type \p Ty is a reference or may transitively contains
-/// a reference, i.e. if it is a "pointer" type.
-static bool mayContainReference(SILType Ty, const SILFunction &F) {
-  // Opaque types may contain a reference. Speculatively track them too.
-  //
-  // 1. It may be possible to optimize opaque values based on known mutation
-  // points.
-  //
-  // 2. A specialized function may call a generic function passing a conrete
-  // reference type via incomplete specialization.
-  //
-  // 3. A generic function may call a specialized function taking a concrete
-  // reference type via devirtualization.
-  if (Ty.isAddressOnly(F))
-    return true;
-
-  if (Ty.hasReferenceSemantics())
-    return true;
-
-  auto &Mod = F.getModule();
-
-  if (Ty.getASTType() == Mod.getASTContext().TheRawPointerType)
-    return true;
-
-  if (auto *Str = Ty.getStructOrBoundGenericStruct()) {
-    for (auto *Field : Str->getStoredProperties()) {
-      if (mayContainReference(Ty.getFieldType(Field, Mod), F))
-        return true;
-    }
-    return false;
-  }
-  if (auto TT = Ty.getAs<TupleType>()) {
-    for (unsigned i = 0, e = TT->getNumElements(); i != e; ++i) {
-      if (mayContainReference(Ty.getTupleElementType(i), F))
-        return true;
-    }
-    return false;
-  }
-  if (auto En = Ty.getEnumOrBoundGenericEnum()) {
-    for (auto *ElemDecl : En->getAllElements()) {
-      if (ElemDecl->hasAssociatedValues()
-          && mayContainReference(Ty.getEnumElementType(ElemDecl, Mod), F))
-        return true;
-    }
-    return false;
-  }
-  return false;
-}
-
-bool EscapeAnalysis::isPointer(ValueBase *V) {
-  auto *F = V->getFunction();
-
-  // The function can be null, e.g. if V is an undef.
-  if (!F)
-    return false;
-
-  SILType Ty = V->getType();
-  auto Iter = isPointerCache.find(Ty);
-  if (Iter != isPointerCache.end())
-    return Iter->second;
-
-  bool IP = (Ty.isAddress() || mayContainReference(Ty, *F));
-  isPointerCache[Ty] = IP;
-  return IP;
-}
-
 void EscapeAnalysis::buildConnectionGraph(FunctionInfo *FInfo,
                                           FunctionOrder &BottomUpOrder,
                                           int RecursionDepth) {
@@ -1126,24 +1402,23 @@ void EscapeAnalysis::buildConnectionGraph(FunctionInfo *FInfo,
     // Create defer-edges from the block arguments to it's values in the
     // predecessor's terminator instructions.
     for (SILArgument *BBArg : BB.getArguments()) {
-      CGNode *ArgNode = ConGraph->getNode(BBArg, this);
-      if (!ArgNode)
-        continue;
-
       llvm::SmallVector<SILValue,4> Incoming;
       if (!BBArg->getSingleTerminatorOperands(Incoming)) {
         // We don't know where the block argument comes from -> treat it
         // conservatively.
-        ConGraph->setEscapesGlobal(ArgNode);
+        setEscapesGlobal(ConGraph, BBArg);
         continue;
       }
+      CGNode *ArgNode = ConGraph->getNode(BBArg);
+      if (!ArgNode)
+        continue;
 
       for (SILValue Src : Incoming) {
-        CGNode *SrcArg = ConGraph->getNode(Src, this);
+        CGNode *SrcArg = ConGraph->getNode(Src);
         if (SrcArg) {
           ArgNode = ConGraph->defer(ArgNode, SrcArg);
         } else {
-          ConGraph->setEscapesGlobal(ArgNode);
+          setEscapesGlobal(ConGraph, BBArg);
           break;
         }
       }
@@ -1244,8 +1519,8 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
           // array.uninitialized may have a first argument which is the
           // allocated array buffer. The call is like a struct(buffer)
           // instruction.
-          if (CGNode *BufferNode = ConGraph->getNode(FAS.getArgument(0), this)) {
-            CGNode *ArrayNode = ConGraph->getNode(ASC.getCallResult(), this);
+          if (CGNode *BufferNode = ConGraph->getNode(FAS.getArgument(0))) {
+            CGNode *ArrayNode = ConGraph->getNode(ASC.getCallResult());
             CGNode *ArrayContent = ConGraph->getContentNode(ArrayNode);
             ConGraph->defer(ArrayContent, BufferNode);
           }
@@ -1253,13 +1528,13 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         }
         break;
       case ArrayCallKind::kGetElement:
-        if (CGNode *AddrNode = ConGraph->getNode(ASC.getSelf(), this)) {
+        if (CGNode *AddrNode = ConGraph->getNode(ASC.getSelf())) {
           CGNode *DestNode = nullptr;
           // This is like a load from a ref_element_addr.
           if (ASC.hasGetElementDirectResult()) {
-            DestNode = ConGraph->getNode(ASC.getCallResult(), this);
+            DestNode = ConGraph->getNode(ASC.getCallResult());
           } else {
-            CGNode *DestAddrNode = ConGraph->getNode(FAS.getArgument(0), this);
+            CGNode *DestAddrNode = ConGraph->getNode(FAS.getArgument(0));
             assert(DestAddrNode && "indirect result must have node");
             // The content of the destination address.
             DestNode = ConGraph->getContentNode(DestAddrNode);
@@ -1277,8 +1552,8 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         break;
       case ArrayCallKind::kGetElementAddress:
         // This is like a ref_element_addr.
-        if (CGNode *SelfNode = ConGraph->getNode(ASC.getSelf(), this)) {
-          ConGraph->defer(ConGraph->getNode(ASC.getCallResult(), this),
+        if (CGNode *SelfNode = ConGraph->getNode(ASC.getSelf())) {
+          ConGraph->defer(ConGraph->getNode(ASC.getCallResult()),
                           ConGraph->getContentNode(SelfNode));
         }
         return;
@@ -1286,7 +1561,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         // Model this like an escape of the elements of the array and a capture
         // of anything captured by the closure.
         // Self is passed inout.
-        if (CGNode *AddrArrayStruct = ConGraph->getNode(ASC.getSelf(), this)) {
+        if (CGNode *AddrArrayStruct = ConGraph->getNode(ASC.getSelf())) {
           CGNode *ArrayStructValueNode =
               ConGraph->getContentNode(AddrArrayStruct);
           // One content node for going from the array buffer pointer to
@@ -1361,8 +1636,12 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     }
   }
 
-  if (isProjection(I))
-    return;
+  // If this instruction produces a single value whose pointer is represented by
+  // a different base pointer, then skip it.
+  if (auto *SVI = dyn_cast<SingleValueInstruction>(I)) {
+    if (getPointerBase(SVI))
+      return;
+  }
 
   // Instructions which return the address of non-writable memory cannot have
   // an effect on escaping.
@@ -1373,7 +1652,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     case SILInstructionKind::AllocStackInst:
     case SILInstructionKind::AllocRefInst:
     case SILInstructionKind::AllocBoxInst:
-      ConGraph->getNode(cast<SingleValueInstruction>(I), this);
+      ConGraph->getNode(cast<SingleValueInstruction>(I));
       return;
 
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
@@ -1409,7 +1688,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     case SILInstructionKind::StrongReleaseInst:
     case SILInstructionKind::ReleaseValueInst: {
       SILValue OpV = I->getOperand(0);
-      if (CGNode *AddrNode = ConGraph->getNode(OpV, this)) {
+      if (CGNode *AddrNode = ConGraph->getNode(OpV)) {
         // A release instruction may deallocate the pointer operand. This may
         // capture any content of the released object, but not the pointer to
         // the object itself (because it will be a dangling pointer after
@@ -1441,10 +1720,10 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     case SILInstructionKind::OpenExistentialAddrInst: {
       auto SVI = cast<SingleValueInstruction>(I);
       if (isPointer(SVI)) {
-        CGNode *AddrNode = ConGraph->getNode(SVI->getOperand(0), this);
+        CGNode *AddrNode = ConGraph->getNode(SVI->getOperand(0));
         if (!AddrNode) {
           // A load from an address we don't handle -> be conservative.
-          CGNode *ValueNode = ConGraph->getNode(SVI, this);
+          CGNode *ValueNode = ConGraph->getNode(SVI);
           ConGraph->setEscapesGlobal(ValueNode);
           return;
         }
@@ -1463,16 +1742,15 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       }
 
       // A copy_addr is like a 'store (load src) to dest'.
-      CGNode *SrcAddrNode = ConGraph->getNode(I->getOperand(CopyAddrInst::Src),
-                                              this);
+      CGNode *SrcAddrNode = ConGraph->getNode(I->getOperand(CopyAddrInst::Src));
       if (!SrcAddrNode) {
         setAllEscaping(I, ConGraph);
         break;
       }
 
       CGNode *LoadedValue = ConGraph->getContentNode(SrcAddrNode);
-      CGNode *DestAddrNode = ConGraph->getNode(
-        I->getOperand(CopyAddrInst::Dest), this);
+      CGNode *DestAddrNode =
+          ConGraph->getNode(I->getOperand(CopyAddrInst::Dest));
       if (DestAddrNode) {
         // Create a defer-edge from the loaded to the stored value.
         CGNode *PointsTo = ConGraph->getContentNode(DestAddrNode);
@@ -1488,10 +1766,9 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     case SILInstructionKind::Store##Name##Inst:
 #include "swift/AST/ReferenceStorage.def"
     case SILInstructionKind::StoreInst:
-      if (CGNode *ValueNode = ConGraph->getNode(I->getOperand(StoreInst::Src),
-                                                this)) {
-        CGNode *AddrNode = ConGraph->getNode(I->getOperand(StoreInst::Dest),
-                                             this);
+      if (CGNode *ValueNode =
+              ConGraph->getNode(I->getOperand(StoreInst::Src))) {
+        CGNode *AddrNode = ConGraph->getNode(I->getOperand(StoreInst::Dest));
         if (AddrNode) {
           // Create a defer-edge from the content to the stored value.
           CGNode *PointsTo = ConGraph->getContentNode(AddrNode);
@@ -1507,10 +1784,10 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       // boxed partial applied arguments. We create defer-edges from the
       // partial_apply values to the arguments.
       auto PAI = cast<PartialApplyInst>(I);
-      CGNode *ResultNode = ConGraph->getNode(PAI, this);
+      CGNode *ResultNode = ConGraph->getNode(PAI);
       assert(ResultNode && "thick functions must have a CG node");
       for (const Operand &Op : PAI->getAllOperands()) {
-        if (CGNode *ArgNode = ConGraph->getNode(Op.get(), this)) {
+        if (CGNode *ArgNode = ConGraph->getNode(Op.get())) {
           ResultNode = ConGraph->defer(ResultNode, ArgNode);
         }
       }
@@ -1531,7 +1808,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       auto SVI = cast<SingleValueInstruction>(I);
       CGNode *ResultNode = nullptr;
       for (const Operand &Op : SVI->getAllOperands()) {
-        if (CGNode *FieldNode = ConGraph->getNode(Op.get(), this)) {
+        if (CGNode *FieldNode = ConGraph->getNode(Op.get())) {
           if (!ResultNode) {
             // A small optimization to reduce the graph size: we re-use the
             // first field node as result node.
@@ -1547,14 +1824,15 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     }
     case SILInstructionKind::TupleExtractInst: {
       // This is a tuple_extract which extracts the second result of an
-      // array.uninitialized call. The first result is the array itself.
+      // array.uninitialized call (otherwise getPointerBase should have already
+      // looked through it). The first result is the array itself.
       // The second result (which is a pointer to the array elements) must be
       // the content node of the first result. It's just like a ref_element_addr
       // instruction.
       auto *TEI = cast<TupleExtractInst>(I);
       assert(isExtractOfArrayUninitializedPointer(TEI)
              && "tuple_extract should be handled as projection");
-      CGNode *ArrayNode = ConGraph->getNode(TEI->getOperand(), this);
+      CGNode *ArrayNode = ConGraph->getNode(TEI->getOperand());
       CGNode *ArrayElements = ConGraph->getContentNode(ArrayNode);
       ConGraph->setNode(TEI, ArrayElements);
       return;
@@ -1577,21 +1855,21 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     case SILInstructionKind::Name##ToRefInst:
 #include "swift/AST/ReferenceStorage.def"
       // A cast is almost like a projection.
-      if (CGNode *OpNode = ConGraph->getNode(I->getOperand(0), this)) {
-        ConGraph->setNode(cast<SingleValueInstruction>(I), OpNode);
-      }
+    if (CGNode *OpNode = ConGraph->getNode(I->getOperand(0))) {
+      ConGraph->setNode(cast<SingleValueInstruction>(I), OpNode);
+    }
       break;
     case SILInstructionKind::UncheckedRefCastAddrInst: {
       auto *URCAI = cast<UncheckedRefCastAddrInst>(I);
-      CGNode *SrcNode = ConGraph->getNode(URCAI->getSrc(), this);
-      CGNode *DestNode = ConGraph->getNode(URCAI->getDest(), this);
+      CGNode *SrcNode = ConGraph->getNode(URCAI->getSrc());
+      CGNode *DestNode = ConGraph->getNode(URCAI->getDest());
       assert(SrcNode && DestNode && "must have nodes for address operands");
       ConGraph->defer(DestNode, SrcNode);
       return;
     }
     case SILInstructionKind::ReturnInst:
-      if (CGNode *ValueNd = ConGraph->getNode(cast<ReturnInst>(I)->getOperand(),
-                                              this)) {
+      if (CGNode *ValueNd =
+              ConGraph->getNode(cast<ReturnInst>(I)->getOperand())) {
         ConGraph->defer(ConGraph->getReturnNode(), ValueNd);
       }
       return;
@@ -1604,18 +1882,18 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
 
 template<class SelectInst> void EscapeAnalysis::
 analyzeSelectInst(SelectInst *SI, ConnectionGraph *ConGraph) {
-  if (auto *ResultNode = ConGraph->getNode(SI, this)) {
+  if (auto *ResultNode = ConGraph->getNode(SI)) {
     // Connect all case values to the result value.
     // Note that this does not include the first operand (the condition).
     for (unsigned Idx = 0, End = SI->getNumCases(); Idx < End; ++Idx) {
       SILValue CaseVal = SI->getCase(Idx).second;
-      auto *ArgNode = ConGraph->getNode(CaseVal, this);
+      auto *ArgNode = ConGraph->getNode(CaseVal);
       assert(ArgNode &&
              "there should be an argument node if there is a result node");
       ResultNode = ConGraph->defer(ResultNode, ArgNode);
     }
     // ... also including the default value.
-    auto *DefaultNode = ConGraph->getNode(SI->getDefaultResult(), this);
+    auto *DefaultNode = ConGraph->getNode(SI->getDefaultResult());
     assert(DefaultNode &&
            "there should be an argument node if there is a result node");
     ConGraph->defer(ResultNode, DefaultNode);
@@ -1644,8 +1922,8 @@ bool EscapeAnalysis::deinitIsKnownToNotCapture(SILValue V) {
       }
       return true;
     }
-    if (auto SVI = isProjection(V)) {
-      V = SVI->getOperand(0);
+    if (auto base = getPointerBase(V)) {
+      V = base;
       continue;
     }
     return false;
@@ -1725,7 +2003,6 @@ void EscapeAnalysis::recompute(FunctionInfo *Initial) {
                                       << FInfo->Graph.F->getName()
                                       << " into "
                                       << E.Caller->Graph.F->getName() << '\n');
-
               if (mergeCalleeGraph(E.FAS, &E.Caller->Graph,
                                    &FInfo->SummaryGraph)) {
                 E.Caller->NeedUpdateSummaryGraph = true;
@@ -1768,7 +2045,10 @@ void EscapeAnalysis::recompute(FunctionInfo *Initial) {
 bool EscapeAnalysis::mergeCalleeGraph(SILInstruction *AS,
                                       ConnectionGraph *CallerGraph,
                                       ConnectionGraph *CalleeGraph) {
-  CGNodeMap Callee2CallerMapping;
+  // This CGNodeMap uses an intrusive worklist to keep track of Mapped nodes
+  // from the CalleeGraph. Meanwhile, mergeFrom uses separate intrusive
+  // worklists to update nodes in the CallerGraph.
+  CGNodeMap Callee2CallerMapping(CalleeGraph);
 
   // First map the callee parameters to the caller arguments.
   SILFunction *Callee = CalleeGraph->F;
@@ -1789,11 +2069,11 @@ bool EscapeAnalysis::mergeCalleeGraph(SILInstruction *AS,
     else
       CallerArg = (Idx < numCallerArgs ? AS->getOperand(Idx) : SILValue());
 
-    CGNode *CalleeNd = CalleeGraph->getNode(Callee->getArgument(Idx), this);
+    CGNode *CalleeNd = CalleeGraph->getNode(Callee->getArgument(Idx));
     if (!CalleeNd)
       continue;
 
-    CGNode *CallerNd = CallerGraph->getNode(CallerArg, this);
+    CGNode *CallerNd = CallerGraph->getNode(CallerArg);
     // There can be the case that we see a callee argument as pointer but not
     // the caller argument. E.g. if the callee argument has a @convention(c)
     // function type and the caller passes a function_ref.
@@ -1814,7 +2094,7 @@ bool EscapeAnalysis::mergeCalleeGraph(SILInstruction *AS,
     } else {
       CallerReturnVal = cast<ApplyInst>(AS);
     }
-    CGNode *CallerRetNd = CallerGraph->getNode(CallerReturnVal, this);
+    CGNode *CallerRetNd = CallerGraph->getNode(CallerReturnVal);
     if (CallerRetNd)
       Callee2CallerMapping.add(RetNd, CallerRetNd);
   }
@@ -1824,11 +2104,14 @@ bool EscapeAnalysis::mergeCalleeGraph(SILInstruction *AS,
 bool EscapeAnalysis::mergeSummaryGraph(ConnectionGraph *SummaryGraph,
                                         ConnectionGraph *Graph) {
 
-  // Make a 1-to-1 mapping of all arguments and the return value.
-  CGNodeMap Mapping;
+  // Make a 1-to-1 mapping of all arguments and the return value. This CGNodeMap
+  // node map uses an intrusive worklist to keep track of Mapped nodes from the
+  // Graph. Meanwhile, mergeFrom uses separate intrusive worklists to
+  // update nodes in the SummaryGraph.
+  CGNodeMap Mapping(Graph);
   for (SILArgument *Arg : Graph->F->getArguments()) {
-    if (CGNode *ArgNd = Graph->getNode(Arg, this)) {
-      Mapping.add(ArgNd, SummaryGraph->getNode(Arg, this));
+    if (CGNode *ArgNd = Graph->getNode(Arg)) {
+      Mapping.add(ArgNd, SummaryGraph->getNode(Arg));
     }
   }
   if (CGNode *RetNd = Graph->getReturnNodeOrNull()) {
@@ -1844,13 +2127,13 @@ bool EscapeAnalysis::canEscapeToUsePoint(SILValue V, SILNode *UsePoint,
   assert((FullApplySite::isa(UsePoint) || isa<RefCountingInst>(UsePoint)) &&
          "use points are only created for calls and refcount instructions");
 
-  CGNode *Node = ConGraph->getNodeOrNull(V, this);
+  CGNode *Node = ConGraph->getNodeOrNull(V);
   if (!Node)
     return true;
 
   // First check if there are escape paths which we don't explicitly see
   // in the graph.
-  if (Node->escapesInsideFunction(isNotAliasingArgument(V)))
+  if (Node->escapesInsideFunction(V))
     return true;
 
   // No hidden escapes: check if the Node is reachable from the UsePoint.
@@ -1870,7 +2153,7 @@ bool EscapeAnalysis::canEscapeToUsePoint(SILValue V, SILNode *UsePoint,
   // As V1's content node is the same as V's content node, we also make the
   // check for the content node.
   CGNode *ContentNode = ConGraph->getContentNode(Node);
-  if (ContentNode->escapesInsideFunction(false))
+  if (ContentNode->escapesInsideFunction(V))
     return true;
 
   if (ConGraph->isUsePoint(UsePoint, ContentNode))
@@ -1881,20 +2164,21 @@ bool EscapeAnalysis::canEscapeToUsePoint(SILValue V, SILNode *UsePoint,
 
 bool EscapeAnalysis::canEscapeTo(SILValue V, FullApplySite FAS) {
   // If it's not a local object we don't know anything about the value.
-  if (!pointsToLocalObject(V))
+  if (!isUniquelyIdentified(V))
     return true;
   auto *ConGraph = getConnectionGraph(FAS.getFunction());
   return canEscapeToUsePoint(V, FAS.getInstruction(), ConGraph);
 }
 
+// FIXME: remove this to avoid confusion with SILType.hasReferenceSemantics.
 static bool hasReferenceSemantics(SILType T) {
   // Exclude address types.
   return T.isObject() && T.hasReferenceSemantics();
 }
 
 bool EscapeAnalysis::canEscapeTo(SILValue V, RefCountingInst *RI) {
-  // If it's not a local object we don't know anything about the value.
-  if (!pointsToLocalObject(V))
+  // If it's not uniquely identified we don't know anything about the value.
+  if (!isUniquelyIdentified(V))
     return true;
   auto *ConGraph = getConnectionGraph(RI->getFunction());
   return canEscapeToUsePoint(V, RI, ConGraph);
@@ -1913,7 +2197,7 @@ static SILFunction *getCommonFunction(SILValue V1, SILValue V2) {
 }
 
 bool EscapeAnalysis::canEscapeToValue(SILValue V, SILValue To) {
-  if (!pointsToLocalObject(V))
+  if (!isUniquelyIdentified(V))
     return true;
 
   SILFunction *F = getCommonFunction(V, To);
@@ -1921,20 +2205,20 @@ bool EscapeAnalysis::canEscapeToValue(SILValue V, SILValue To) {
     return true;
   auto *ConGraph = getConnectionGraph(F);
 
-  CGNode *Node = ConGraph->getNodeOrNull(V, this);
+  CGNode *Node = ConGraph->getNodeOrNull(V);
   if (!Node)
     return true;
-  CGNode *ToNode = ConGraph->getNodeOrNull(To, this);
+  CGNode *ToNode = ConGraph->getNodeOrNull(To);
   if (!ToNode)
     return true;
-  return ConGraph->isReachable(Node, ToNode);
+  return ConGraph->mayReach(ToNode, Node);
 }
 
 bool EscapeAnalysis::canPointToSameMemory(SILValue V1, SILValue V2) {
   // At least one of the values must be a non-escaping local object.
-  bool isLocal1 = pointsToLocalObject(V1);
-  bool isLocal2 = pointsToLocalObject(V2);
-  if (!isLocal1 && !isLocal2)
+  bool isUniq1 = isUniquelyIdentified(V1);
+  bool isUniq2 = isUniquelyIdentified(V2);
+  if (!isUniq1 && !isUniq2)
     return true;
 
   SILFunction *F = getCommonFunction(V1, V2);
@@ -1942,21 +2226,21 @@ bool EscapeAnalysis::canPointToSameMemory(SILValue V1, SILValue V2) {
     return true;
   auto *ConGraph = getConnectionGraph(F);
 
-  CGNode *Node1 = ConGraph->getNodeOrNull(V1, this);
+  CGNode *Node1 = ConGraph->getNodeOrNull(V1);
   if (!Node1)
     return true;
-  CGNode *Node2 = ConGraph->getNodeOrNull(V2, this);
+  CGNode *Node2 = ConGraph->getNodeOrNull(V2);
   if (!Node2)
     return true;
 
   // Finish the check for one value being a non-escaping local object.
-  if (isLocal1 && Node1->escapesInsideFunction(isNotAliasingArgument(V1)))
-    isLocal1 = false;
+  if (isUniq1 && Node1->escapesInsideFunction(V1))
+    isUniq1 = false;
 
-  if (isLocal2 && Node2->escapesInsideFunction(isNotAliasingArgument(V2)))
-    isLocal2 = false;
+  if (isUniq2 && Node2->escapesInsideFunction(V2))
+    isUniq2 = false;
 
-  if (!isLocal1 && !isLocal2)
+  if (!isUniq1 && !isUniq2)
     return true;
 
   // Check if both nodes may point to the same content.
@@ -1997,8 +2281,8 @@ bool EscapeAnalysis::canParameterEscape(FullApplySite FAS, int ParamIdx,
     if (!FInfo->isValid())
       recompute(FInfo);
 
-    CGNode *Node = FInfo->SummaryGraph.getNodeOrNull(
-                                         Callee->getArgument(ParamIdx), this);
+    CGNode *Node =
+        FInfo->SummaryGraph.getNodeOrNull(Callee->getArgument(ParamIdx));
     if (!Node)
       return true;
 

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -885,41 +885,6 @@ bool EscapeAnalysis::ConnectionGraph::forwardTraverseDefer(
   return true;
 }
 
-// Follow transitive pointsTo edges from \p startNode.
-// This path may not contain cycles.
-template <typename CGNodeVisitor>
-bool EscapeAnalysis::ConnectionGraph::forwardTraversePointsToEdges(
-    CGNode *startNode, CGNodeVisitor &&visitor) {
-  CGNodeWorklist visitedNodes(this);
-  CGNode *pointer = startNode;
-  while ((pointer = pointer->getPointsToEdge())) {
-    if (!visitedNodes.tryPush(pointer))
-      return true;
-
-    if (!visitor(pointer)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// Returns the last content node in the chain of pointsTo edges pointed to by
-// this node.
-//
-// If this node has no content, return the node itself. If has content or is
-// already a content follow the chain of pointsTo edges and return the last
-// content node in the chain.
-CGNode *EscapeAnalysis::ConnectionGraph::getPointsToEnd(CGNode *node) {
-  CGNode *content = node->isContent() ? node : node->getContentNodeOrNull();
-  if (!content)
-    return node;
-  forwardTraversePointsToEdges(content, [&](CGNode *pointsTo) {
-    content = pointsTo;
-    return true;
-  });
-  return content;
-}
-
 bool EscapeAnalysis::ConnectionGraph::mayReach(CGNode *pointer,
                                                CGNode *pointee) {
   if (pointer == pointee)

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -23,13 +23,13 @@
 using namespace swift;
 using namespace swift::PatternMatch;
 
-bool swift::isNotAliasingArgument(SILValue V) {
+bool swift::isExclusiveArgument(SILValue V) {
   auto *Arg = dyn_cast<SILFunctionArgument>(V);
   if (!Arg)
     return false;
 
   SILArgumentConvention Conv = Arg->getArgumentConvention();
-  return Conv.isNotAliasedIndirectParameter();
+  return Conv.isExclusiveIndirectParameter();
 }
 
 /// Check if the parameter \V is based on a local object, e.g. it is an
@@ -81,8 +81,7 @@ static bool isLocalObject(SILValue Obj) {
 }
 
 bool swift::pointsToLocalObject(SILValue V) {
-  V = getUnderlyingObject(V);
-  return isLocalObject(V) || isNotAliasingArgument(V);
+  return isLocalObject(getUnderlyingObject(V));
 }
 
 /// Check if the value \p Value is known to be zero, non-zero or unknown.

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -108,7 +108,7 @@ bool StackPromotion::tryPromoteAlloc(AllocRefInst *ARI, EscapeAnalysis *EA,
     return false;
 
   auto *ConGraph = EA->getConnectionGraph(ARI->getFunction());
-  auto *Node = ConGraph->getNodeOrNull(ARI, EA);
+  auto *Node = ConGraph->getNodeOrNull(ARI);
   if (!Node)
     return false;
 

--- a/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
@@ -11,11 +11,17 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "dump-ea"
-#include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/Analysis/EscapeAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace swift;
+
+// For manual debugging, dump graphs in DOT format.
+llvm::cl::opt<bool> EnableGraphWriter(
+    "escapes-enable-graphwriter", llvm::cl::init(false),
+    llvm::cl::desc("With -escapes-dump, also write .dot files."));
 
 namespace {
 
@@ -35,6 +41,8 @@ class EscapeAnalysisDumper : public SILModuleTransform {
       if (!F.isExternalDeclaration()) {
         auto *ConnectionGraph = EA->getConnectionGraph(&F);
         ConnectionGraph->print(llvm::outs());
+        if (EnableGraphWriter)
+          ConnectionGraph->dumpCG();
       }
     }
 #endif

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -591,6 +591,7 @@ bb5:
 // CHECK: bb3([[A:%[0-9]+]] : $Builtin.Int32):
 // CHECK-NOT: = load
 // CHECK: apply %{{[0-9]+}}([[A]])
+// CHECK-LABEL: } // end sil function 'load_to_load_conflicting_branches_diamond'
 sil @load_to_load_conflicting_branches_diamond : $@convention(thin) (@inout Builtin.Int32) -> () {
 // %0                                             // users: %1, %4, %9, %11, %16, %21
 bb0(%0 : $*Builtin.Int32):

--- a/test/SILOptimizer/unsafebufferpointer.swift
+++ b/test/SILOptimizer/unsafebufferpointer.swift
@@ -14,9 +14,9 @@ public func testIteration(_ p: UnsafeBufferPointer<Int>) -> Int {
 // Check for an optimal loop kernel
 // CHECK:       phi
 // CHECK-NEXT:  phi
+// CHECK-NEXT:  getelementptr
 // CHECK-NEXT:  bitcast
 // CHECK-NEXT:  load
-// CHECK-NEXT:  getelementptr
 // CHECK-NEXT:  add
 // CHECK-NEXT:  icmp
 // CHECK-NEXT:  br

--- a/test/SILOptimizer/unsafebufferpointer.swift
+++ b/test/SILOptimizer/unsafebufferpointer.swift
@@ -14,9 +14,9 @@ public func testIteration(_ p: UnsafeBufferPointer<Int>) -> Int {
 // Check for an optimal loop kernel
 // CHECK:       phi
 // CHECK-NEXT:  phi
-// CHECK-NEXT:  getelementptr
 // CHECK-NEXT:  bitcast
 // CHECK-NEXT:  load
+// CHECK-NEXT:  getelementptr
 // CHECK-NEXT:  add
 // CHECK-NEXT:  icmp
 // CHECK-NEXT:  br


### PR DESCRIPTION
This is the first in a series of patches that reworks
EscapeAnalysis. For this patch, I extracted every change that does not
introduce new features, rewrite logic, or appear to change
functionality.

These cleanups were done in preparation for:

    - adding a graph representation for reference counted objects

    - rewriting parts to the query logic

    - ...which then allows the analysis to safely assume that all
      exclusive arguments are unique

    - ...which then allows more aggressive optimization of local variables
      that don't escape

There are two possible functional changes:

1. getUnderlyingAddressRoot in InstructionUtils now sees through OSSA
    instructions: begin_borrow and copy_value

2. The getPointerBase helper in EscapeAnalysis now sees through all of
    these reference and pointer casts:

    +  case ValueKind::UncheckedRefCastInst:
    +  case ValueKind::ConvertFunctionInst:
    +  case ValueKind::UpcastInst:
    +  case ValueKind::InitExistentialRefInst:
    +  case ValueKind::OpenExistentialRefInst:
    +  case ValueKind::RawPointerToRefInst:
    +  case ValueKind::RefToRawPointerInst:
    +  case ValueKind::RefToBridgeObjectInst:
    +  case ValueKind::BridgeObjectToRefInst:
    +  case ValueKind::UncheckedAddrCastInst:
    +  case ValueKind::UnconditionalCheckedCastInst:
    +  case ValueKind::RefTo##Name##Inst:
    +  case ValueKind::Name##ToRefInst:

    This coalesces a whole bunch of nodes together that were just there
    because of casts. The existing code was already doing this for one
    level of casts, but there was a bug that prevented it from happening
    transitively. So, in theory, anything that breaks with this fix could
    also break without this fix, but may not have been exposed. The fact
    that this analysis coalesces address-to-reference casts at all is what
    caused me to spent vast amounts of time debugging any time I tried to
    force some structure on the graph via assertions. If it is done at
    all, it should be done everywhere consistently to expose issues as
    early as possible.

Here is a description of the changes in diff order. If something in
the diff is not listed here, then the code probably just moved around
in the file:

Rename isNotAliasedIndirectParameter to
isExclusiveIndirectParameter. The argument may be aliased in the
caller's scope and it's contents may have already escaped.

Add comments to SILType APIs (isTrivial, isReferenceCounted) that give
answers about the AST type which don't really make sense for address
SILTypes.

Add comments about CGNode's 'Value' field. I spent lots of time
attempting to tighten this down with asserts, but it's only possible
for non-content nodes. For content nodes, the node's value is highly
unpredictable and basically nonsense but needed for debugging.

Add comments about not assuming that the content nodes pointsTo edge
represents physical indirection. This matters when reasoning about
aliasing and it's a tempting assumption to make.

Add a CGNode::mergeProperties placeholder for adding node properties.

Factor out a CGNode::canAddDeferred helper for use later.

Rename `setPointsTo` to `setPointsToEdge` because it actually creates
an edge rather than just setting `pointsTo`.

Add CGNode::getValue() and related helpers to help maintain invariants.

Factor out a `markEscaping` helper.

Clean up the `escapesInsideFunction` helper.

Add node visitor helpers: visitSuccessors, visitDefers. This made is
much easier to prototype utilities.

Add comments to clarify the `pointsTo` invariant. In particular, an
entire defer web may have a null pointsTo for a while.

Add an `activeWorklist` to avoid nasty bugs when composing multiple
helpers that each use the worklist.

Remove the `EA` argument from `getNode`. I ended up needing access to
the `EA` context from the ConnectionGraph many times during
prototyping and passing `this` was all the `getNode` calls was very
silly.

Add graph visitor helpers: backwardTraverse, forwardTraverseDefer,
forwardTraversePointsToEdges, and mayReach for ease in developing new
logic and utilities.

Add isExclusiveArgument helper and distinguish exclusive arguments
from local objects. Confusing these properties could lead to scary
bugs. For example, unlike a local object, an exclusive argument's
contents may still escape even when the content's connection graph
node is non-escaping!

Add isUniquelyIdentified helper when we want to treat exclusive
arguments and local objects uniformly.

getUnderlyingAddressRoot now looks through OSSA instructions.

Rename `getAccessedMemory` to `getDirectlyAccessedMemory` with
comments. This is another dangerous API because it assumes the memory
access to a given address won't touch memory represented by different
graph nodes, but graph edges don't necessarily represent physical
indirection. Further clarify this issue in comments in
AliasAnalysis.cpp.

Factor out a 'findRecursiveRefType' helper from the old
'mayContainReference' for checking whether types may or must contain
references. Support both kinds of queries so the analysis can be
certain when a pointer's content is a physical heap object.

Factor out 'getPointerBase' and 'getPointerRoot' helpers that follow
address projections within what EscapeAnalysis will consider a single
node.

Create a CGNodeWorklist abstraction to safely formalize the worklist
mechanism that's used all over the place. In one place, there were
even two separate independent lists used independently (nodes added to
one list could appear to be in the other list).

The CGNodeMap abstraction did not significantly change, it was just moved.

Added 'dumpCG' for dumping .dot files making it possible to remote debug.

Added '-escapes-enable-graphwriter' option to dump .dot files, since
they are so much more useful than the textual dump of the connection
graph, which lacks node identity!

