### PR TITLE
[NFC] Drop More Type Checkers

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -74,7 +74,7 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
 
   case DeclContextKind::AbstractFunctionDecl: {
     auto *AFD = cast<AbstractFunctionDecl>(DC);
-    typeCheckAbstractFunctionBodyUntil(AFD, Loc);
+    swift::typeCheckAbstractFunctionBodyUntil(AFD, Loc);
     break;
   }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5604,7 +5604,7 @@ ClosureExpr *ExprRewriter::coerceClosureExprToVoid(ClosureExpr *closureExpr) {
                  cs.getType(singleExpr)->getWithoutSpecifierType());
 
     cs.setExprTypes(singleExpr);
-    tc.checkIgnoredExpr(singleExpr);
+    TypeChecker::checkIgnoredExpr(singleExpr);
 
     SmallVector<ASTNode, 2> elements;
     elements.push_back(singleExpr);
@@ -5643,7 +5643,7 @@ ClosureExpr *ExprRewriter::coerceClosureExprFromNever(ClosureExpr *closureExpr) 
     auto singleExpr = returnStmt->getResult();
 
     cs.setExprTypes(singleExpr);
-    tc.checkIgnoredExpr(singleExpr);
+    TypeChecker::checkIgnoredExpr(singleExpr);
 
     SmallVector<ASTNode, 1> elements;
     elements.push_back(singleExpr);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2298,7 +2298,7 @@ namespace {
           // Okay, now it should be safe to coerce the pattern.
           // Pull the top-level pattern back out.
           pattern = clause->getErrorPattern();
-          Type exnType = CS.TC.getExceptionType(CS.DC, clause->getCatchLoc());
+          Type exnType = CS.getASTContext().getErrorDecl()->getDeclaredType();
           if (!exnType)
             return false;
           if (CS.TC.coercePatternToType(pattern,

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -84,17 +84,6 @@ TypeChecker::getFragileFunctionKind(const DeclContext *DC) {
   llvm_unreachable("Context is not nested inside a fragile function");
 }
 
-void TypeChecker::diagnoseInlinableLocalType(const NominalTypeDecl *NTD) {
-  auto *DC = NTD->getDeclContext();
-  auto expansion = DC->getResilienceExpansion();
-  if (expansion == ResilienceExpansion::Minimal) {
-    auto kind = getFragileFunctionKind(DC);
-    diagnose(NTD, diag::local_type_in_inlinable_function,
-             NTD->getFullName(),
-             static_cast<unsigned>(kind.first));
-  }
-}
-
 /// A uniquely-typed boolean to reduce the chances of accidentally inverting
 /// a check.
 enum class DowngradeToWarning: bool {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2735,7 +2735,12 @@ public:
   }
 
   void checkUnsupportedNestedType(NominalTypeDecl *NTD) {
-    TC.diagnoseInlinableLocalType(NTD);
+    auto *DC = NTD->getDeclContext();
+    if (DC->getResilienceExpansion() == ResilienceExpansion::Minimal) {
+      auto kind = TypeChecker::getFragileFunctionKind(DC);
+      NTD->diagnose(diag::local_type_in_inlinable_function, NTD->getFullName(),
+                    static_cast<unsigned>(kind.first));
+    }
 
     // We don't support protocols outside the top level of a file.
     if (isa<ProtocolDecl>(NTD) &&

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -565,9 +565,7 @@ static void checkGenericParams(GenericParamList *genericParams,
 
 /// Retrieve the set of protocols the given protocol inherits.
 static llvm::TinyPtrVector<ProtocolDecl *>
-getInheritedForCycleCheck(TypeChecker &tc,
-                          ProtocolDecl *proto,
-                          ProtocolDecl **scratch) {
+getInheritedForCycleCheck(ProtocolDecl *proto, ProtocolDecl **scratch) {
   TinyPtrVector<ProtocolDecl *> result;
 
   bool anyObject = false;
@@ -581,8 +579,7 @@ getInheritedForCycleCheck(TypeChecker &tc,
 }
 
 /// Retrieve the superclass of the given class.
-static ArrayRef<ClassDecl *> getInheritedForCycleCheck(TypeChecker &tc,
-                                                       ClassDecl *classDecl,
+static ArrayRef<ClassDecl *> getInheritedForCycleCheck(ClassDecl *classDecl,
                                                        ClassDecl **scratch) {
   if (classDecl->hasSuperclass()) {
     *scratch = classDecl->getSuperclassDecl();
@@ -592,8 +589,7 @@ static ArrayRef<ClassDecl *> getInheritedForCycleCheck(TypeChecker &tc,
 }
 
 /// Retrieve the raw type of the given enum.
-static ArrayRef<EnumDecl *> getInheritedForCycleCheck(TypeChecker &tc,
-                                                      EnumDecl *enumDecl,
+static ArrayRef<EnumDecl *> getInheritedForCycleCheck(EnumDecl *enumDecl,
                                                       EnumDecl **scratch) {
   if (enumDecl->hasRawType()) {
     *scratch = enumDecl->getRawType()->getEnumOrBoundGenericEnum();
@@ -603,9 +599,8 @@ static ArrayRef<EnumDecl *> getInheritedForCycleCheck(TypeChecker &tc,
 }
 
 /// Check for circular inheritance.
-template<typename T>
-static void checkCircularity(TypeChecker &tc, T *decl,
-                             Diag<Identifier> circularDiag,
+template <typename T>
+static void checkCircularity(T *decl, Diag<Identifier> circularDiag,
                              DescriptiveDeclKind declKind,
                              SmallVectorImpl<T *> &path) {
   switch (decl->getCircularityCheck()) {
@@ -627,19 +622,16 @@ static void checkCircularity(TypeChecker &tc, T *decl,
 
     // If the path length is 1 the type directly references itself.
     if (path.end() - cycleStart == 1) {
-      tc.diagnose(path.back()->getLoc(),
-                  circularDiag,
-                  path.back()->getName());
+      path.back()->diagnose(circularDiag, path.back()->getName());
 
       break;
     }
 
     // Diagnose the cycle.
-    tc.diagnose(decl->getLoc(), circularDiag,
-                (*cycleStart)->getName());
+    decl->diagnose(circularDiag, (*cycleStart)->getName());
     for (auto i = cycleStart + 1, iEnd = path.end(); i != iEnd; ++i) {
-      tc.diagnose(*i, diag::kind_declname_declared_here,
-                  declKind, (*i)->getName());
+      (*i)->diagnose(diag::kind_declname_declared_here, declKind,
+                     (*i)->getName());
     }
 
     break;
@@ -650,8 +642,8 @@ static void checkCircularity(TypeChecker &tc, T *decl,
     path.push_back(decl);
     decl->setCircularityCheck(CircularityCheck::Checking);
     T *scratch = nullptr;
-    for (auto inherited : getInheritedForCycleCheck(tc, decl, &scratch)) {
-      checkCircularity(tc, inherited, circularDiag, declKind, path);
+    for (auto inherited : getInheritedForCycleCheck(decl, &scratch)) {
+      checkCircularity(inherited, circularDiag, declKind, path);
     }
     decl->setCircularityCheck(CircularityCheck::Checked);
     path.pop_back();
@@ -2057,7 +2049,7 @@ static void checkDefaultArguments(TypeChecker &tc, ParameterList *params) {
 
     // Walk the checked initializer and contextualize any closures
     // we saw there.
-    (void)tc.contextualizeInitializer(initContext, e);
+    (void)TypeChecker::contextualizeInitializer(initContext, e);
   }
 }
 
@@ -2286,11 +2278,14 @@ public:
 
   explicit DeclChecker(TypeChecker &TC) : TC(TC) {}
 
-  void visit(Decl *decl) {
-    if (TC.Context.Stats)
-      TC.Context.Stats->getFrontendCounters().NumDeclsTypechecked++;
+  ASTContext &getASTContext() const { return TC.Context; }
 
-    FrontendStatsTracer StatsTracer(TC.Context.Stats, "typecheck-decl", decl);
+  void visit(Decl *decl) {
+    if (getASTContext().Stats)
+      getASTContext().Stats->getFrontendCounters().NumDeclsTypechecked++;
+
+    FrontendStatsTracer StatsTracer(getASTContext().Stats, "typecheck-decl",
+                                    decl);
     PrettyStackTraceDecl StackTrace("type-checking", decl);
     
     DeclVisitor<DeclChecker>::visit(decl);
@@ -2298,7 +2293,7 @@ public:
     TypeChecker::checkUnsupportedProtocolType(decl);
 
     if (auto VD = dyn_cast<ValueDecl>(decl)) {
-      auto &Context = TC.Context;
+      auto &Context = getASTContext();
       TypeChecker::checkForForbiddenPrefix(Context, VD->getBaseName());
       
       checkRedeclaration(Context, VD);
@@ -2324,9 +2319,10 @@ public:
            VD->getFullName().isSimpleName(Context.Id_Protocol)) &&
           VD->getNameLoc().isValid() &&
           Context.SourceMgr.extractText({VD->getNameLoc(), 1}) != "`") {
-        TC.diagnose(VD->getNameLoc(), diag::reserved_member_name,
+        auto &DE = getASTContext().Diags;
+        DE.diagnose(VD->getNameLoc(), diag::reserved_member_name,
                     VD->getFullName(), VD->getBaseName().getIdentifier().str());
-        TC.diagnose(VD->getNameLoc(), diag::backticks_to_escape)
+        DE.diagnose(VD->getNameLoc(), diag::backticks_to_escape)
             .fixItReplace(VD->getNameLoc(),
                           "`" + VD->getBaseName().userFacingName().str() + "`");
       }
@@ -2388,7 +2384,8 @@ public:
 
     // Add the '@_hasStorage' attribute if this property is stored.
     if (VD->hasStorage() && !VD->getAttrs().hasAttribute<HasStorageAttr>())
-      VD->getAttrs().add(new (TC.Context) HasStorageAttr(/*isImplicit=*/true));
+      VD->getAttrs().add(new (getASTContext())
+                             HasStorageAttr(/*isImplicit=*/true));
 
     // Reject cases where this is a variable that has storage but it isn't
     // allowed.
@@ -2408,10 +2405,9 @@ public:
         };
         auto unimplementedStatic = [&](unsigned diagSel) {
           auto staticLoc = PBD->getStaticLoc();
-          TC.diagnose(VD->getLoc(), diag::unimplemented_static_var,
-                      diagSel, PBD->getStaticSpelling(),
-                      diagSel == Classes)
-            .highlight(staticLoc);
+          VD->diagnose(diag::unimplemented_static_var, diagSel,
+                       PBD->getStaticSpelling(), diagSel == Classes)
+              .highlight(staticLoc);
         };
 
         auto DC = VD->getDeclContext();
@@ -2439,8 +2435,8 @@ public:
       auto overridden = VD->getOverriddenDecl();
       if (auto *OA = VD->getAttrs().getAttribute<OverrideAttr>()) {
         if (!overridden) {
-          TC.diagnose(VD, diag::property_does_not_override)
-            .highlight(OA->getLocation());
+          VD->diagnose(diag::property_does_not_override)
+              .highlight(OA->getLocation());
           OA->setInvalid();
         }
       }
@@ -2461,19 +2457,21 @@ public:
 
     // Under the Swift 3 inference rules, if we have @IBInspectable or
     // @GKInspectable but did not infer @objc, warn that the attribute is
-    if (!VD->isObjC() && TC.Context.LangOpts.EnableSwift3ObjCInference) {
+    auto &DE = getASTContext().Diags;
+    if (!VD->isObjC() &&
+        VD->getASTContext().LangOpts.EnableSwift3ObjCInference) {
       if (auto attr = VD->getAttrs().getAttribute<IBInspectableAttr>()) {
-        TC.diagnose(attr->getLocation(),
+        DE.diagnose(attr->getLocation(),
                     diag::attribute_meaningless_when_nonobjc,
                     attr->getAttrName())
-          .fixItRemove(attr->getRange());
+            .fixItRemove(attr->getRange());
       }
 
       if (auto attr = VD->getAttrs().getAttribute<GKInspectableAttr>()) {
-        TC.diagnose(attr->getLocation(),
+        DE.diagnose(attr->getLocation(),
                     diag::attribute_meaningless_when_nonobjc,
                     attr->getAttrName())
-          .fixItRemove(attr->getRange());
+            .fixItRemove(attr->getRange());
       }
     }
 
@@ -2494,10 +2492,10 @@ public:
       isInSILMode = sourceFile->Kind == SourceFileKind::SIL;
     bool isTypeContext = DC->isTypeContext();
 
+    auto &Ctx = getASTContext();
     for (auto i : range(PBD->getNumPatternEntries())) {
-      const auto *entry = evaluateOrDefault(TC.Context.evaluator,
-                                            PatternBindingEntryRequest{PBD, i},
-                                            nullptr);
+      const auto *entry = evaluateOrDefault(
+          Ctx.evaluator, PatternBindingEntryRequest{PBD, i}, nullptr);
       assert(entry && "No pattern binding entry?");
 
       PBD->getPattern(i)->forEachVariable([&](VarDecl *var) {
@@ -2508,7 +2506,7 @@ public:
           // across module generation, as required for TBDGen.
           if (var->hasStorage() &&
               !var->getAttrs().hasAttribute<HasInitialValueAttr>()) {
-            var->getAttrs().add(new (TC.Context)
+            var->getAttrs().add(new (Ctx)
                                     HasInitialValueAttr(/*IsImplicit=*/true));
           }
           return;
@@ -2533,13 +2531,13 @@ public:
         // Properties with an opaque return type need an initializer to
         // determine their underlying type.
         if (var->getOpaqueResultTypeDecl()) {
-          TC.diagnose(var->getLoc(), diag::opaque_type_var_no_init);
+          var->diagnose(diag::opaque_type_var_no_init);
         }
 
         // Non-member observing properties need an initializer.
         if (var->getWriteImpl() == WriteImplKind::StoredWithObservers &&
             !isTypeContext) {
-          TC.diagnose(var->getLoc(), diag::observingprop_requires_initializer);
+          var->diagnose(diag::observingprop_requires_initializer);
           markVarAndPBDInvalid();
           return;
         }
@@ -2558,8 +2556,8 @@ public:
             break;
           }
 
-          TC.diagnose(var->getLoc(), diag::static_requires_initializer,
-                      var->getCorrectStaticSpelling());
+          var->diagnose(diag::static_requires_initializer,
+                        var->getCorrectStaticSpelling());
           markVarAndPBDInvalid();
           return;
         }
@@ -2576,8 +2574,7 @@ public:
             break;
           }
 
-          TC.diagnose(var->getLoc(), diag::global_requires_initializer,
-                      var->isLet());
+          var->diagnose(diag::global_requires_initializer, var->isLet());
           markVarAndPBDInvalid();
           return;
         }
@@ -2620,7 +2617,7 @@ public:
           if (initContext) {
             // Check safety of error-handling in the declaration, too.
             TypeChecker::checkInitializerErrorHandling(initContext, init);
-            (void) TC.contextualizeInitializer(initContext, init);
+            (void)TypeChecker::contextualizeInitializer(initContext, init);
           }
         }
       }
@@ -2647,8 +2644,8 @@ public:
       // anything, complain.
       if (auto *OA = SD->getAttrs().getAttribute<OverrideAttr>()) {
         if (!SD->getOverriddenDecl()) {
-          TC.diagnose(SD, diag::subscript_does_not_override)
-            .highlight(OA->getLocation());
+          SD->diagnose(diag::subscript_does_not_override)
+              .highlight(OA->getLocation());
           OA->setInvalid();
         }
       }
@@ -2703,10 +2700,7 @@ public:
     checkProtocolSelfRequirements(proto, AT);
 
     if (proto->isObjC()) {
-      TC.diagnose(AT->getLoc(),
-                  diag::associated_type_objc,
-                  AT->getName(),
-                  proto->getName());
+      AT->diagnose(diag::associated_type_objc, AT->getName(), proto->getName());
     }
 
     checkAccessControl(AT);
@@ -2726,9 +2720,10 @@ public:
         });
 
       if (mentionsItself) {
-        TC.diagnose(AT->getDefaultDefinitionTypeRepr()->getLoc(),
-                    diag::recursive_decl_reference,
-                    AT->getDescriptiveKind(), AT->getName());
+        auto &DE = getASTContext().Diags;
+        DE.diagnose(AT->getDefaultDefinitionTypeRepr()->getLoc(),
+                    diag::recursive_decl_reference, AT->getDescriptiveKind(),
+                    AT->getName());
         AT->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
       }
     }
@@ -2745,9 +2740,7 @@ public:
     // We don't support protocols outside the top level of a file.
     if (isa<ProtocolDecl>(NTD) &&
         !NTD->getParent()->isModuleScopeContext()) {
-      TC.diagnose(NTD->getLoc(),
-                  diag::unsupported_nested_protocol,
-                  NTD->getName());
+      NTD->diagnose(diag::unsupported_nested_protocol, NTD->getName());
       NTD->setInvalid();
       return;
     }
@@ -2757,29 +2750,22 @@ public:
       auto DC = NTD->getDeclContext();
       if (auto proto = DC->getSelfProtocolDecl()) {
         if (DC->getExtendedProtocolDecl()) {
-          TC.diagnose(NTD->getLoc(),
-                      diag::unsupported_type_nested_in_protocol_extension,
-                      NTD->getName(),
-                      proto->getName());
+          NTD->diagnose(diag::unsupported_type_nested_in_protocol_extension,
+                        NTD->getName(), proto->getName());
         } else {
-          TC.diagnose(NTD->getLoc(),
-                      diag::unsupported_type_nested_in_protocol,
-                      NTD->getName(),
-                      proto->getName());
+          NTD->diagnose(diag::unsupported_type_nested_in_protocol,
+                        NTD->getName(), proto->getName());
         }
       }
 
       if (DC->isLocalContext() && DC->isGenericContext()) {
         // A local generic context is a generic function.
         if (auto AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
-          TC.diagnose(NTD->getLoc(),
-                      diag::unsupported_type_nested_in_generic_function,
-                      NTD->getName(),
-                      AFD->getFullName());
+          NTD->diagnose(diag::unsupported_type_nested_in_generic_function,
+                        NTD->getName(), AFD->getFullName());
         } else {
-          TC.diagnose(NTD->getLoc(),
-                      diag::unsupported_type_nested_in_generic_closure,
-                      NTD->getName());
+          NTD->diagnose(diag::unsupported_type_nested_in_generic_closure,
+                        NTD->getName());
         }
       }
     }
@@ -2797,7 +2783,7 @@ public:
       // Check for circular inheritance of the raw type.
       SmallVector<EnumDecl *, 8> path;
       path.push_back(ED);
-      checkCircularity(TC, ED, diag::circular_enum_inheritance,
+      checkCircularity(ED, diag::circular_enum_inheritance,
                        DescriptiveDeclKind::Enum, path);
     }
 
@@ -2810,27 +2796,27 @@ public:
 
     checkAccessControl(ED);
 
-    TC.checkPatternBindingCaptures(ED);
-    
+    TypeChecker::checkPatternBindingCaptures(ED);
+
+    auto &DE = getASTContext().Diags;
     if (auto rawTy = ED->getRawType()) {
       // The raw type must be one of the blessed literal convertible types.
       if (!computeAutomaticEnumValueKind(ED)) {
-        TC.diagnose(ED->getInherited().front().getSourceRange().Start,
-                    diag::raw_type_not_literal_convertible,
-                    rawTy);
-        ED->getInherited().front().setInvalidType(TC.Context);
+        DE.diagnose(ED->getInherited().front().getSourceRange().Start,
+                    diag::raw_type_not_literal_convertible, rawTy);
+        ED->getInherited().front().setInvalidType(getASTContext());
       }
       
       // We need at least one case to have a raw value.
       if (ED->getAllElements().empty()) {
-        TC.diagnose(ED->getInherited().front().getSourceRange().Start,
+        DE.diagnose(ED->getInherited().front().getSourceRange().Start,
                     diag::empty_enum_raw_type);
       }
     }
 
     checkExplicitAvailability(ED);
 
-    TC.checkDeclCircularity(ED);
+    TypeChecker::checkDeclCircularity(ED);
     TC.ConformanceContexts.push_back(ED);
   }
 
@@ -2847,7 +2833,7 @@ public:
     for (Decl *Member : SD->getMembers())
       visit(Member);
 
-    TC.checkPatternBindingCaptures(SD);
+    TypeChecker::checkPatternBindingCaptures(SD);
 
     TypeChecker::checkDeclAttributes(SD);
 
@@ -2857,7 +2843,7 @@ public:
 
     checkExplicitAvailability(SD);
 
-    TC.checkDeclCircularity(SD);
+    TypeChecker::checkDeclCircularity(SD);
     TC.ConformanceContexts.push_back(SD);
   }
 
@@ -2903,25 +2889,25 @@ public:
         llvm_unreachable("should have been marked invalid");
 
       case 1:
-        TC.diagnose(pbd->getLoc(), diag::missing_in_class_init_1,
-                    vars[0]->getName(), suggestNSManaged);
+        pbd->diagnose(diag::missing_in_class_init_1, vars[0]->getName(),
+                      suggestNSManaged);
         break;
 
       case 2:
-        TC.diagnose(pbd->getLoc(), diag::missing_in_class_init_2,
-                    vars[0]->getName(), vars[1]->getName(), suggestNSManaged);
+        pbd->diagnose(diag::missing_in_class_init_2, vars[0]->getName(),
+                      vars[1]->getName(), suggestNSManaged);
         break;
 
       case 3:
-        TC.diagnose(pbd->getLoc(), diag::missing_in_class_init_3plus,
-                    vars[0]->getName(), vars[1]->getName(), vars[2]->getName(),
-                    false, suggestNSManaged);
+        pbd->diagnose(diag::missing_in_class_init_3plus, vars[0]->getName(),
+                      vars[1]->getName(), vars[2]->getName(), false,
+                      suggestNSManaged);
         break;
 
       default:
-        TC.diagnose(pbd->getLoc(), diag::missing_in_class_init_3plus,
-                    vars[0]->getName(), vars[1]->getName(), vars[2]->getName(),
-                    true, suggestNSManaged);
+        pbd->diagnose(diag::missing_in_class_init_3plus, vars[0]->getName(),
+                      vars[1]->getName(), vars[2]->getName(), true,
+                      suggestNSManaged);
         break;
       }
 
@@ -2948,8 +2934,9 @@ public:
       }
 
       // Add a note describing why we need an initializer.
-      TC.diagnose(source, diag::requires_stored_property_inits_here,
-                  source->getDeclaredType(), cd == source, suggestNSManaged);
+      source->diagnose(diag::requires_stored_property_inits_here,
+                       source->getDeclaredType(), cd == source,
+                       suggestNSManaged);
     }
   }
 
@@ -2966,7 +2953,7 @@ public:
       // Check for circular inheritance.
       SmallVector<ClassDecl *, 8> path;
       path.push_back(CD);
-      checkCircularity(TC, CD, diag::circular_class_inheritance,
+      checkCircularity(CD, diag::circular_class_inheritance,
                        DescriptiveDeclKind::Class, path);
     }
 
@@ -2979,7 +2966,7 @@ public:
     for (Decl *Member : CD->getEmittedMembers())
       visit(Member);
 
-    TC.checkPatternBindingCaptures(CD);
+    TypeChecker::checkPatternBindingCaptures(CD);
 
     // If this class requires all of its stored properties to have
     // in-class initializers, diagnose this now.
@@ -3021,30 +3008,27 @@ public:
       bool isInvalidSuperclass = false;
 
       if (Super->isFinal()) {
-        TC.diagnose(CD, diag::inheritance_from_final_class,
-                    Super->getName());
+        CD->diagnose(diag::inheritance_from_final_class, Super->getName());
         // FIXME: should this really be skipping the rest of decl-checking?
         return;
       }
 
       if (Super->hasClangNode() && Super->getGenericParams()
           && superclassTy->hasTypeParameter()) {
-        TC.diagnose(CD,
-                    diag::inheritance_from_unspecialized_objc_generic_class,
-                    Super->getName());
+        CD->diagnose(diag::inheritance_from_unspecialized_objc_generic_class,
+                     Super->getName());
       }
 
       switch (Super->getForeignClassKind()) {
       case ClassDecl::ForeignKind::Normal:
         break;
       case ClassDecl::ForeignKind::CFType:
-        TC.diagnose(CD, diag::inheritance_from_cf_class,
-                    Super->getName());
+        CD->diagnose(diag::inheritance_from_cf_class, Super->getName());
         isInvalidSuperclass = true;
         break;
       case ClassDecl::ForeignKind::RuntimeOnly:
-        TC.diagnose(CD, diag::inheritance_from_objc_runtime_visible_class,
-                    Super->getName());
+        CD->diagnose(diag::inheritance_from_objc_runtime_visible_class,
+                     Super->getName());
         isInvalidSuperclass = true;
         break;
       }
@@ -3054,25 +3038,25 @@ public:
                               ResilienceExpansion::Minimal)) {
         auto *superFile = Super->getModuleScopeContext();
         if (auto *serialized = dyn_cast<SerializedASTFile>(superFile)) {
-          if (serialized->getLanguageVersionBuiltWith() !=
-              TC.getLangOpts().EffectiveLanguageVersion) {
-            TC.diagnose(CD,
-                        diag::inheritance_from_class_with_missing_vtable_entries_versioned,
-                        Super->getName(),
-                        serialized->getLanguageVersionBuiltWith(),
-                        TC.getLangOpts().EffectiveLanguageVersion);
+          const auto effVersion =
+              CD->getASTContext().LangOpts.EffectiveLanguageVersion;
+          if (serialized->getLanguageVersionBuiltWith() != effVersion) {
+            CD->diagnose(
+                diag::
+                    inheritance_from_class_with_missing_vtable_entries_versioned,
+                Super->getName(), serialized->getLanguageVersionBuiltWith(),
+                effVersion);
             isInvalidSuperclass = true;
           }
         }
         if (!isInvalidSuperclass) {
-          TC.diagnose(
-              CD, diag::inheritance_from_class_with_missing_vtable_entries,
-              Super->getName());
+          CD->diagnose(diag::inheritance_from_class_with_missing_vtable_entries,
+                       Super->getName());
           isInvalidSuperclass = true;
         }
       }
 
-      if (!TC.Context.isAccessControlDisabled()) {
+      if (!getASTContext().isAccessControlDisabled()) {
         // Require the superclass to be open if this is outside its
         // defining module.  But don't emit another diagnostic if we
         // already complained about the class being inherently
@@ -3080,7 +3064,7 @@ public:
         if (!isInvalidSuperclass &&
             !Super->hasOpenAccess(CD->getDeclContext()) &&
             Super->getModuleContext() != CD->getModuleContext()) {
-          TC.diagnose(CD, diag::superclass_not_open, superclassTy);
+          CD->diagnose(diag::superclass_not_open, superclassTy);
           isInvalidSuperclass = true;
         }
 
@@ -3091,8 +3075,8 @@ public:
         if (!isInvalidSuperclass &&
             CD->getFormalAccess() == AccessLevel::Open &&
             Super->getFormalAccess() != AccessLevel::Open) {
-          TC.diagnose(CD, diag::superclass_of_open_not_open, superclassTy);
-          TC.diagnose(Super, diag::superclass_here);
+          CD->diagnose(diag::superclass_of_open_not_open, superclassTy);
+          Super->diagnose(diag::superclass_here);
         }
       }
     }
@@ -3105,7 +3089,7 @@ public:
 
     checkExplicitAvailability(CD);
 
-    TC.checkDeclCircularity(CD);
+    TypeChecker::checkDeclCircularity(CD);
     TC.ConformanceContexts.push_back(CD);
   }
 
@@ -3117,7 +3101,7 @@ public:
       // Check for circular inheritance within the protocol.
       SmallVector<ProtocolDecl *, 8> path;
       path.push_back(PD);
-      checkCircularity(TC, PD, diag::circular_protocol_def,
+      checkCircularity(PD, diag::circular_protocol_def,
                        DescriptiveDeclKind::Protocol, path);
 
       if (SF) {
@@ -3140,12 +3124,12 @@ public:
 
     checkInheritanceClause(PD);
 
-    TC.checkDeclCircularity(PD);
+    TypeChecker::checkDeclCircularity(PD);
     if (PD->isResilient())
       if (!SF || SF->Kind != SourceFileKind::Interface)
-        TC.inferDefaultWitnesses(PD);
+        TypeChecker::inferDefaultWitnesses(PD);
 
-    if (TC.Context.LangOpts.DebugGenericSignatures) {
+    if (PD->getASTContext().LangOpts.DebugGenericSignatures) {
       auto requirementsSig =
         GenericSignature::get({PD->getProtocolSelfType()},
                               PD->getRequirementSignature());
@@ -3260,8 +3244,8 @@ public:
       // override anything, complain.
       if (auto *OA = FD->getAttrs().getAttribute<OverrideAttr>()) {
         if (!FD->getOverriddenDecl()) {
-          TC.diagnose(FD, diag::method_does_not_override)
-            .highlight(OA->getLocation());
+          FD->diagnose(diag::method_does_not_override)
+              .highlight(OA->getLocation());
           OA->setInvalid();
         }
       }
@@ -3269,10 +3253,10 @@ public:
 
     if (requiresDefinition(FD) && !FD->hasBody()) {
       // Complain if we should have a body.
-      TC.diagnose(FD->getLoc(), diag::func_decl_without_brace);
+      FD->diagnose(diag::func_decl_without_brace);
     } else if (FD->getDeclContext()->isLocalContext()) {
       // Check local function bodies right away.
-      TC.typeCheckAbstractFunctionBody(FD);
+      TypeChecker::typeCheckAbstractFunctionBody(FD);
     } else if (shouldSkipBodyTypechecking(FD)) {
       FD->setBodySkipped(FD->getBodySourceRange());
     } else {
@@ -3323,7 +3307,8 @@ public:
                                 errorConvention)) {
         if (FD->hasThrows()) {
           FD->setForeignErrorConvention(*errorConvention);
-          TC.diagnose(CDeclAttr->getLocation(), diag::cdecl_throws);
+          getASTContext().Diags.diagnose(CDeclAttr->getLocation(),
+                                         diag::cdecl_throws);
         }
       }
     }
@@ -3346,12 +3331,12 @@ public:
       checkDefaultArguments(TC, PL);
     }
 
+    auto &DE = getASTContext().Diags;
     // We don't yet support raw values on payload cases.
     if (EED->hasAssociatedValues()) {
       if (auto rawTy = ED->getRawType()) {
-        TC.diagnose(EED->getLoc(),
-                    diag::enum_with_raw_type_case_with_argument);
-        TC.diagnose(ED->getInherited().front().getSourceRange().Start,
+        EED->diagnose(diag::enum_with_raw_type_case_with_argument);
+        DE.diagnose(ED->getInherited().front().getSourceRange().Start,
                     diag::enum_raw_type_here, rawTy);
         EED->setInvalid();
       }
@@ -3360,7 +3345,7 @@ public:
     // Force the raw value expr then yell if our parent doesn't have a raw type.
     Expr *RVE = EED->getRawValueExpr();
     if (RVE && !ED->hasRawType()) {
-      TC.diagnose(RVE->getLoc(), diag::enum_raw_value_without_raw_type);
+      DE.diagnose(RVE->getLoc(), diag::enum_raw_value_without_raw_type);
       EED->setInvalid();
     }
 
@@ -3473,10 +3458,12 @@ public:
   void visitPoundDiagnosticDecl(PoundDiagnosticDecl *PDD) {
     if (PDD->hasBeenEmitted()) { return; }
     PDD->markEmitted();
-    TC.diagnose(PDD->getMessage()->getStartLoc(),
-      PDD->isError() ? diag::pound_error : diag::pound_warning,
-      PDD->getMessage()->getValue())
-      .highlight(PDD->getMessage()->getSourceRange());
+    getASTContext()
+        .Diags
+        .diagnose(PDD->getMessage()->getStartLoc(),
+                  PDD->isError() ? diag::pound_error : diag::pound_warning,
+                  PDD->getMessage()->getValue())
+        .highlight(PDD->getMessage()->getSourceRange());
   }
 
   void visitConstructorDecl(ConstructorDecl *CD) {
@@ -3503,8 +3490,8 @@ public:
       // anything, or overrides something that complain.
       if (auto *attr = CD->getAttrs().getAttribute<OverrideAttr>()) {
         if (!CD->getOverriddenDecl()) {
-          TC.diagnose(CD, diag::initializer_does_not_override)
-            .highlight(attr->getLocation());
+          CD->diagnose(diag::initializer_does_not_override)
+              .highlight(attr->getLocation());
           attr->setInvalid();
         } else if (attr->isImplicit()) {
           // Don't diagnose implicit attributes.
@@ -3514,23 +3501,24 @@ public:
           // need (only) the 'required' keyword.
           if (cast<ConstructorDecl>(CD->getOverriddenDecl())->isRequired()) {
             if (CD->getAttrs().hasAttribute<RequiredAttr>()) {
-              TC.diagnose(CD, diag::required_initializer_override_keyword)
-                .fixItRemove(attr->getLocation());
+              CD->diagnose(diag::required_initializer_override_keyword)
+                  .fixItRemove(attr->getLocation());
             } else {
-              TC.diagnose(CD, diag::required_initializer_override_wrong_keyword)
-                .fixItReplace(attr->getLocation(), "required");
-              CD->getAttrs().add(
-                new (TC.Context) RequiredAttr(/*IsImplicit=*/true));
+              CD->diagnose(diag::required_initializer_override_wrong_keyword)
+                  .fixItReplace(attr->getLocation(), "required");
+              CD->getAttrs().add(new (getASTContext())
+                                     RequiredAttr(/*IsImplicit=*/true));
             }
 
-            TC.diagnose(findNonImplicitRequiredInit(CD->getOverriddenDecl()),
-                        diag::overridden_required_initializer_here);
+            auto *reqInit =
+                findNonImplicitRequiredInit(CD->getOverriddenDecl());
+            reqInit->diagnose(diag::overridden_required_initializer_here);
           } else {
             // We tried to override a convenience initializer.
-            TC.diagnose(CD, diag::initializer_does_not_override)
-              .highlight(attr->getLocation());
-            TC.diagnose(CD->getOverriddenDecl(),
-                        diag::convenience_init_override_here);
+            CD->diagnose(diag::initializer_does_not_override)
+                .highlight(attr->getLocation());
+            CD->getOverriddenDecl()->diagnose(
+                diag::convenience_init_override_here);
           }
         }
       }
@@ -3542,11 +3530,10 @@ public:
       if (CD->isFailable() &&
           CD->getOverriddenDecl() &&
           !CD->getOverriddenDecl()->isFailable()) {
-        TC.diagnose(CD, diag::failable_initializer_override,
-                    CD->getFullName());
-        TC.diagnose(CD->getOverriddenDecl(),
-                    diag::nonfailable_initializer_override_here,
-                    CD->getOverriddenDecl()->getFullName());
+        CD->diagnose(diag::failable_initializer_override, CD->getFullName());
+        auto *OD = CD->getOverriddenDecl();
+        OD->diagnose(diag::nonfailable_initializer_override_here,
+                     OD->getFullName());
       }
     }
 
@@ -3554,14 +3541,14 @@ public:
     // be marked 'required'.
     if (!CD->getAttrs().hasAttribute<RequiredAttr>()) {
       if (CD->getOverriddenDecl() && CD->getOverriddenDecl()->isRequired()) {
-        TC.diagnose(CD, diag::required_initializer_missing_keyword)
-          .fixItInsert(CD->getLoc(), "required ");
+        CD->diagnose(diag::required_initializer_missing_keyword)
+            .fixItInsert(CD->getLoc(), "required ");
 
-        TC.diagnose(findNonImplicitRequiredInit(CD->getOverriddenDecl()),
-                    diag::overridden_required_initializer_here);
+        auto *reqInit = findNonImplicitRequiredInit(CD->getOverriddenDecl());
+        reqInit->diagnose(diag::overridden_required_initializer_here);
 
-        CD->getAttrs().add(
-            new (TC.Context) RequiredAttr(/*IsImplicit=*/true));
+        CD->getAttrs().add(new (getASTContext())
+                               RequiredAttr(/*IsImplicit=*/true));
       }
     }
 
@@ -3582,8 +3569,8 @@ public:
           break;
         }
         if (CD->getFormalAccess() < requiredAccess) {
-          auto diag = TC.diagnose(CD, diag::required_initializer_not_accessible,
-                                  nominal->getFullName());
+          auto diag = CD->diagnose(diag::required_initializer_not_accessible,
+                                   nominal->getFullName());
           fixItAccess(diag, CD, requiredAccess);
         }
       }
@@ -3593,10 +3580,10 @@ public:
 
     if (requiresDefinition(CD) && !CD->hasBody()) {
       // Complain if we should have a body.
-      TC.diagnose(CD->getLoc(), diag::missing_initializer_def);
+      CD->diagnose(diag::missing_initializer_def);
     } else if (CD->getDeclContext()->isLocalContext()) {
       // Check local function bodies right away.
-      TC.typeCheckAbstractFunctionBody(CD);
+      TypeChecker::typeCheckAbstractFunctionBody(CD);
     } else if (shouldSkipBodyTypechecking(CD)) {
       CD->setBodySkipped(CD->getBodySourceRange());
     } else {
@@ -3611,7 +3598,7 @@ public:
 
     if (DD->getDeclContext()->isLocalContext()) {
       // Check local function bodies right away.
-      TC.typeCheckAbstractFunctionBody(DD);
+      TypeChecker::typeCheckAbstractFunctionBody(DD);
     } else if (shouldSkipBodyTypechecking(DD)) {
       DD->setBodySkipped(DD->getBodySourceRange());
     } else {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5346,8 +5346,9 @@ namespace {
   class DefaultWitnessChecker : public WitnessChecker {
     
   public:
-    DefaultWitnessChecker(ASTContext &ctx, ProtocolDecl *proto)
-        : WitnessChecker(ctx, proto, proto->getDeclaredType(), proto) {}
+    DefaultWitnessChecker(ProtocolDecl *proto)
+        : WitnessChecker(proto->getASTContext(), proto,
+                         proto->getDeclaredType(), proto) {}
 
     ResolveWitnessResult resolveWitnessViaLookup(ValueDecl *requirement);
     void recordWitness(ValueDecl *requirement, const RequirementMatch &match);
@@ -5393,7 +5394,7 @@ void DefaultWitnessChecker::recordWitness(
 }
 
 void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
-  DefaultWitnessChecker checker(Context, proto);
+  DefaultWitnessChecker checker(proto);
 
   // Find the default for the given associated type.
   auto findAssociatedTypeDefault = [](AssociatedTypeDecl *assocType)

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -332,6 +332,8 @@ public:
   /// Used to distinguish the first BraceStmt that starts a TopLevelCodeDecl.
   bool IsBraceStmtFromTopLevelDecl;
 
+  ASTContext &getASTContext() const { return TC.Context; };
+  
   struct AddLabeledStmt {
     StmtChecker &SC;
     AddLabeledStmt(StmtChecker &SC, LabeledStmt *LS) : SC(SC) {
@@ -339,11 +341,12 @@ public:
       if (!LS->getLabelInfo().Name.empty())
         for (auto PrevLS : SC.ActiveLabeledStmts) {
           if (PrevLS->getLabelInfo().Name == LS->getLabelInfo().Name) {
-            SC.TC.diagnose(LS->getLabelInfo().Loc,
+            auto &DE = SC.getASTContext().Diags;
+            DE.diagnose(LS->getLabelInfo().Loc,
                         diag::label_shadowed, LS->getLabelInfo().Name);
-            SC.TC.diagnose(PrevLS->getLabelInfo().Loc,
-                           diag::invalid_redecl_prev, 
-                           PrevLS->getLabelInfo().Name);
+            DE.diagnose(PrevLS->getLabelInfo().Loc,
+                        diag::invalid_redecl_prev,
+                        PrevLS->getLabelInfo().Name);
           }
         }
 
@@ -401,8 +404,8 @@ public:
   
   template<typename StmtTy>
   bool typeCheckStmt(StmtTy *&S) {
-    FrontendStatsTracer StatsTracer(TC.Context.Stats, "typecheck-stmt", S);
-    PrettyStackTraceStmt trace(TC.Context, "type-checking", S);
+    FrontendStatsTracer StatsTracer(getASTContext().Stats, "typecheck-stmt", S);
+    PrettyStackTraceStmt trace(getASTContext(), "type-checking", S);
     StmtTy *S2 = cast_or_null<StmtTy>(visit(S));
     if (S2 == nullptr)
       return true;
@@ -426,13 +429,15 @@ public:
 
   Stmt *visitReturnStmt(ReturnStmt *RS) {
     if (!TheFunc.hasValue()) {
-      TC.diagnose(RS->getReturnLoc(), diag::return_invalid_outside_func);
+      getASTContext().Diags.diagnose(RS->getReturnLoc(),
+                                     diag::return_invalid_outside_func);
       return nullptr;
     }
     
     // If the return is in a defer, then it isn't valid either.
     if (isInDefer()) {
-      TC.diagnose(RS->getReturnLoc(), diag::jump_out_of_defer, "return");
+      getASTContext().Diags.diagnose(RS->getReturnLoc(),
+                                     diag::jump_out_of_defer, "return");
       return nullptr;
     }
 
@@ -442,7 +447,8 @@ public:
 
     if (!RS->hasResult()) {
       if (!ResultTy->isVoid())
-        TC.diagnose(RS->getReturnLoc(), diag::return_expr_missing);
+        getASTContext().Diags.diagnose(RS->getReturnLoc(),
+                                       diag::return_expr_missing);
       return RS;
     }
 
@@ -464,7 +470,8 @@ public:
       auto expr = TheFunc->getSingleExpressionBody();
       if (expr->isImplicit() && isa<TupleExpr>(expr) &&
           cast<TupleExpr>(expr)->getNumElements() == 0) {
-        TC.diagnose(RS->getReturnLoc(), diag::return_expr_missing);
+        getASTContext().Diags.diagnose(RS->getReturnLoc(),
+                                       diag::return_expr_missing);
         return RS;
       }
     }
@@ -479,7 +486,8 @@ public:
       // 'nil'.
       auto nilExpr = dyn_cast<NilLiteralExpr>(E->getSemanticsProvidingExpr());
       if (!nilExpr) {
-        TC.diagnose(RS->getReturnLoc(), diag::return_init_non_nil)
+        getASTContext().Diags.diagnose(RS->getReturnLoc(),
+                                       diag::return_init_non_nil)
           .highlight(E->getSourceRange());
         RS->setResult(nullptr);
         return RS;
@@ -487,9 +495,10 @@ public:
 
       // "return nil" is only permitted in a failable initializer.
       if (!ctor->isFailable()) {
-        TC.diagnose(RS->getReturnLoc(), diag::return_non_failable_init)
+        getASTContext().Diags.diagnose(RS->getReturnLoc(),
+                                       diag::return_non_failable_init)
           .highlight(E->getSourceRange());
-        TC.diagnose(ctor->getLoc(), diag::make_init_failable,
+        getASTContext().Diags.diagnose(ctor->getLoc(), diag::make_init_failable,
                     ctor->getFullName())
           .fixItInsertAfter(ctor->getLoc(), "?");
         RS->setResult(nullptr);
@@ -497,8 +506,9 @@ public:
       }
 
       // Replace the "return nil" with a new 'fail' statement.
-      return new (TC.Context) FailStmt(RS->getReturnLoc(), nilExpr->getLoc(),
-                                       RS->isImplicit());
+      return new (getASTContext()) FailStmt(RS->getReturnLoc(),
+                                            nilExpr->getLoc(),
+                                            RS->isImplicit());
     }
     
     TypeCheckExprOptions options = {};
@@ -521,7 +531,7 @@ public:
     }
 
     if (EndTypeCheckLoc.isValid()) {
-      assert(DiagnosticSuppression::isEnabled(TC.Diags) &&
+      assert(DiagnosticSuppression::isEnabled(getASTContext().Diags) &&
              "Diagnosing and AllowUnresolvedTypeVariables don't seem to mix");
       options |= TypeCheckExprFlags::AllowUnresolvedTypeVariables;
     }
@@ -540,7 +550,7 @@ public:
     RS->setResult(E);
 
     if (!exprTy) {
-      tryDiagnoseUnnecessaryCastOverOptionSet(TC.Context, E, ResultTy,
+      tryDiagnoseUnnecessaryCastOverOptionSet(getASTContext(), E, ResultTy,
                                               DC->getParentModule());
     }
 
@@ -550,7 +560,8 @@ public:
   Stmt *visitYieldStmt(YieldStmt *YS) {
     // If the yield is in a defer, then it isn't valid.
     if (isInDefer()) {
-      TC.diagnose(YS->getYieldLoc(), diag::jump_out_of_defer, "yield");
+      getASTContext().Diags.diagnose(YS->getYieldLoc(),
+                                     diag::jump_out_of_defer, "yield");
       return YS;
     }
 
@@ -559,7 +570,7 @@ public:
 
     auto yieldExprs = YS->getMutableYields();
     if (yieldExprs.size() != yieldResults.size()) {
-      TC.diagnose(YS->getYieldLoc(), diag::bad_yield_count,
+      getASTContext().Diags.diagnose(YS->getYieldLoc(), diag::bad_yield_count,
                   yieldResults.size());
       return YS;
     }
@@ -583,10 +594,10 @@ public:
           // about the unparented &.
           exprToCheck = inout->getSubExpr();
         } else {
-          TC.diagnose(exprToCheck->getLoc(),
+          getASTContext().Diags.diagnose(exprToCheck->getLoc(),
                       diag::missing_address_of_yield, yieldType)
             .highlight(exprToCheck->getSourceRange());
-          inout = new (TC.Context) InOutExpr(exprToCheck->getStartLoc(),
+          inout = new (getASTContext()) InOutExpr(exprToCheck->getStartLoc(),
                                              exprToCheck,
                                              Type(), /*implicit*/ true);
         }
@@ -614,7 +625,8 @@ public:
   Stmt *visitThrowStmt(ThrowStmt *TS) {
     // If the throw is in a defer, then it isn't valid.
     if (isInDefer()) {
-      TC.diagnose(TS->getThrowLoc(), diag::jump_out_of_defer, "throw");
+      getASTContext().Diags.diagnose(TS->getThrowLoc(),
+                                     diag::jump_out_of_defer, "throw");
       return nullptr;
     }
 
@@ -722,13 +734,13 @@ public:
                                               /*isStmtCondition*/false)) {
       S->setPattern(P);
     } else {
-      S->getPattern()->setType(ErrorType::get(TC.Context));
+      S->getPattern()->setType(ErrorType::get(getASTContext()));
       return nullptr;
     }
   
     if (TC.typeCheckPattern(S->getPattern(), DC, options)) {
       // FIXME: Handle errors better.
-      S->getPattern()->setType(ErrorType::get(TC.Context));
+      S->getPattern()->setType(ErrorType::get(getASTContext()));
       return nullptr;
     }
 
@@ -744,14 +756,14 @@ public:
 
     // Retrieve the 'Sequence' protocol.
     ProtocolDecl *sequenceProto = TypeChecker::getProtocol(
-        TC.Context, S->getForLoc(), KnownProtocolKind::Sequence);
+        getASTContext(), S->getForLoc(), KnownProtocolKind::Sequence);
     if (!sequenceProto) {
       return nullptr;
     }
 
     // Retrieve the 'Iterator' protocol.
     ProtocolDecl *iteratorProto = TypeChecker::getProtocol(
-        TC.Context, S->getForLoc(), KnownProtocolKind::IteratorProtocol);
+        getASTContext(), S->getForLoc(), KnownProtocolKind::IteratorProtocol);
     if (!iteratorProto) {
       return nullptr;
     }
@@ -771,13 +783,15 @@ public:
         return nullptr;
       S->setSequenceConformance(conformance);
 
-      iteratorTy = conformance.getTypeWitnessByName(sequenceType,
-                                                    TC.Context.Id_Iterator);
+      iteratorTy =
+          conformance.getTypeWitnessByName(sequenceType,
+                                           getASTContext().Id_Iterator);
       if (iteratorTy->hasError())
         return nullptr;
 
-      auto witness = conformance.getWitnessByName(sequenceType,
-                                                  TC.Context.Id_makeIterator);
+      auto witness =
+          conformance.getWitnessByName(sequenceType,
+                                       getASTContext().Id_makeIterator);
       if (!witness)
         return nullptr;
       S->setMakeIterator(witness);
@@ -788,25 +802,25 @@ public:
         name = "$"+np->getBoundName().str().str();
       name += "$generator";
 
-      iterator = new (TC.Context) VarDecl(
+      iterator = new (getASTContext()) VarDecl(
           /*IsStatic*/ false, VarDecl::Introducer::Var,
           /*IsCaptureList*/ false, S->getInLoc(),
-          TC.Context.getIdentifier(name), DC);
+          getASTContext().getIdentifier(name), DC);
       iterator->setInterfaceType(iteratorTy->mapTypeOutOfContext());
       iterator->setImplicit();
       S->setIteratorVar(iterator);
 
-      auto genPat = new (TC.Context) NamedPattern(iterator);
+      auto genPat = new (getASTContext()) NamedPattern(iterator);
       genPat->setImplicit();
 
       // TODO: test/DebugInfo/iteration.swift requires this extra info to
       // be around.
       auto nextResultType = OptionalType::get(conformance.getTypeWitnessByName(
-          sequenceType, TC.Context.Id_Element));
+          sequenceType, getASTContext().Id_Element));
       PatternBindingDecl::createImplicit(
-          TC.Context, StaticSpellingKind::None, genPat,
-          new (TC.Context) OpaqueValueExpr(S->getInLoc(), nextResultType), DC,
-          /*VarLoc*/ S->getForLoc());
+          getASTContext(), StaticSpellingKind::None, genPat,
+          new (getASTContext()) OpaqueValueExpr(S->getInLoc(), nextResultType),
+          DC, /*VarLoc*/ S->getForLoc());
 
       Type newSequenceType = cast<AbstractFunctionDecl>(witness.getDecl())
             ->getInterfaceType()
@@ -835,7 +849,8 @@ public:
       return nullptr;
 
     Type elementTy =
-        genConformance.getTypeWitnessByName(iteratorTy, TC.Context.Id_Element);
+        genConformance.getTypeWitnessByName(iteratorTy,
+                                            getASTContext().Id_Element);
     if (elementTy->hasError())
       return nullptr;
 
@@ -848,7 +863,7 @@ public:
     S->setIteratorVarRef(varRef);
 
     auto witness =
-        genConformance.getWitnessByName(iteratorTy, TC.Context.Id_next);
+        genConformance.getWitnessByName(iteratorTy, getASTContext().Id_next);
     S->setIteratorNext(witness);
 
     auto nextResultType = cast<FuncDecl>(S->getIteratorNext().getDecl())
@@ -859,7 +874,7 @@ public:
     auto optPatternType = OptionalType::get(S->getPattern()->getType());
     if (!optPatternType->isEqual(nextResultType)) {
       OpaqueValueExpr *elementExpr =
-          new (TC.Context) OpaqueValueExpr(S->getInLoc(), nextResultType);
+          new (getASTContext()) OpaqueValueExpr(S->getInLoc(), nextResultType);
       Expr *convertElementExpr = elementExpr;
       if (TC.convertToType(convertElementExpr, optPatternType, DC,
                            S->getPattern())) {
@@ -902,8 +917,9 @@ public:
           break;
         } else {
           unsigned distance =
-            TC.getCallEditDistance(S->getTargetName(), (*I)->getLabelInfo().Name,
-                                   TypeChecker::UnreasonableCallEditDistance);
+            TypeChecker::getCallEditDistance(
+                S->getTargetName(), (*I)->getLabelInfo().Name,
+                TypeChecker::UnreasonableCallEditDistance);
           if (distance < TypeChecker::UnreasonableCallEditDistance)
             labelCorrections.insert(distance, std::move(*I));
         }
@@ -915,7 +931,8 @@ public:
     if (!Target) {
       // If we're in a defer, produce a tailored diagnostic.
       if (isInDefer()) {
-        TC.diagnose(S->getLoc(), diag::jump_out_of_defer, "break");
+        getASTContext().Diags.diagnose(S->getLoc(),
+                                       diag::jump_out_of_defer, "break");
       } else if (S->getTargetName().empty()) {
         // If we're dealing with an unlabeled break inside of an 'if' or 'do'
         // statement, produce a more specific error.
@@ -924,13 +941,15 @@ public:
                         [&](Stmt *S) -> bool {
                           return isa<IfStmt>(S) || isa<DoStmt>(S);
                         })) {
-          TC.diagnose(S->getLoc(), diag::unlabeled_break_outside_loop);
+          getASTContext().Diags.diagnose(S->getLoc(),
+                                         diag::unlabeled_break_outside_loop);
         } else {
           // Otherwise produce a generic error.
-          TC.diagnose(S->getLoc(), diag::break_outside_loop);
+          getASTContext().Diags.diagnose(S->getLoc(), diag::break_outside_loop);
         }
       } else {
-        emitUnresolvedLabelDiagnostics(TC, S->getTargetLoc(), S->getTargetName(),
+        emitUnresolvedLabelDiagnostics(getASTContext().Diags,
+                                       S->getTargetLoc(), S->getTargetName(),
                                        labelCorrections);
       }
       return nullptr;
@@ -963,8 +982,9 @@ public:
           break;
         } else {
           unsigned distance =
-            TC.getCallEditDistance(S->getTargetName(), (*I)->getLabelInfo().Name,
-                                   TypeChecker::UnreasonableCallEditDistance);
+            TypeChecker::getCallEditDistance(
+                S->getTargetName(), (*I)->getLabelInfo().Name,
+                TypeChecker::UnreasonableCallEditDistance);
           if (distance < TypeChecker::UnreasonableCallEditDistance)
             labelCorrections.insert(distance, std::move(*I));
         }
@@ -976,19 +996,23 @@ public:
     if (Target) {
       // Continue cannot be used to repeat switches, use fallthrough instead.
       if (!Target->isPossibleContinueTarget()) {
-        TC.diagnose(S->getLoc(), diag::continue_not_in_this_stmt,
-                    isa<SwitchStmt>(Target) ? "switch" : "if");
+        getASTContext().Diags.diagnose(
+            S->getLoc(), diag::continue_not_in_this_stmt,
+            isa<SwitchStmt>(Target) ? "switch" : "if");
         return nullptr;
       }
     } else {
       // If we're in a defer, produce a tailored diagnostic.
       if (isInDefer()) {
-        TC.diagnose(S->getLoc(), diag::jump_out_of_defer, "break");
+        getASTContext().Diags.diagnose(S->getLoc(),
+                                       diag::jump_out_of_defer, "break");
       } else if (S->getTargetName().empty()) {
         // If we're dealing with an unlabeled continue, produce a generic error.
-        TC.diagnose(S->getLoc(), diag::continue_outside_loop);
+        getASTContext().Diags.diagnose(S->getLoc(),
+                                       diag::continue_outside_loop);
       } else {
-        emitUnresolvedLabelDiagnostics(TC, S->getTargetLoc(), S->getTargetName(),
+        emitUnresolvedLabelDiagnostics(getASTContext().Diags,
+                                       S->getTargetLoc(), S->getTargetName(),
                                        labelCorrections);
       }
       return nullptr;
@@ -998,26 +1022,27 @@ public:
   }
 
   static void
-  emitUnresolvedLabelDiagnostics(TypeChecker &tc, SourceLoc targetLoc, Identifier targetName,
+  emitUnresolvedLabelDiagnostics(DiagnosticEngine &DE,
+                                 SourceLoc targetLoc, Identifier targetName,
                                  TopCollection<unsigned, LabeledStmt *> corrections) {
     // If an unresolved label was used, but we have a single correction,
     // produce the specific diagnostic and fixit.
     if (corrections.size() == 1) {
-      tc.diagnose(targetLoc, diag::unresolved_label_corrected,
+      DE.diagnose(targetLoc, diag::unresolved_label_corrected,
                   targetName, corrections.begin()->Value->getLabelInfo().Name)
         .highlight(SourceRange(targetLoc))
         .fixItReplace(SourceRange(targetLoc),
                       corrections.begin()->Value->getLabelInfo().Name.str());
-      tc.diagnose(corrections.begin()->Value->getLabelInfo().Loc,
+      DE.diagnose(corrections.begin()->Value->getLabelInfo().Loc,
                   diag::decl_declared_here,
                   corrections.begin()->Value->getLabelInfo().Name);
     } else {
       // If we have multiple corrections or none, produce a generic diagnostic
       // and all corrections available.
-      tc.diagnose(targetLoc, diag::unresolved_label, targetName)
+      DE.diagnose(targetLoc, diag::unresolved_label, targetName)
         .highlight(SourceRange(targetLoc));
       for (auto &entry : corrections)
-        tc.diagnose(entry.Value->getLabelInfo().Loc, diag::note_typo_candidate,
+        DE.diagnose(entry.Value->getLabelInfo().Loc, diag::note_typo_candidate,
                     entry.Value->getLabelInfo().Name.str())
           .fixItReplace(SourceRange(targetLoc),
                         entry.Value->getLabelInfo().Name.str());
@@ -1026,11 +1051,13 @@ public:
   
   Stmt *visitFallthroughStmt(FallthroughStmt *S) {
     if (!SwitchLevel) {
-      TC.diagnose(S->getLoc(), diag::fallthrough_outside_switch);
+      getASTContext().Diags.diagnose(S->getLoc(),
+                                     diag::fallthrough_outside_switch);
       return nullptr;
     }
     if (!FallthroughDest) {
-      TC.diagnose(S->getLoc(), diag::fallthrough_from_last_case);
+      getASTContext().Diags.diagnose(S->getLoc(),
+                                     diag::fallthrough_from_last_case);
       return nullptr;
     }
     S->setFallthroughSource(FallthroughSource);
@@ -1139,7 +1166,7 @@ public:
         if (vd->getInterfaceType() && initialCaseVarDecl->getType() &&
             !initialCaseVarDecl->isInvalid() &&
             !vd->getType()->isEqual(initialCaseVarDecl->getType())) {
-          TC.diagnose(vd->getLoc(), diag::type_mismatch_multiple_pattern_list,
+          getASTContext().Diags.diagnose(vd->getLoc(), diag::type_mismatch_multiple_pattern_list,
                       vd->getType(), initialCaseVarDecl->getType());
           vd->setInvalid();
           initialCaseVarDecl->setInvalid();
@@ -1149,9 +1176,8 @@ public:
           return;
         }
 
-        auto diag = TC.diagnose(vd->getLoc(),
-                                diag::mutability_mismatch_multiple_pattern_list,
-                                vd->isLet(), initialCaseVarDecl->isLet());
+        auto diag = vd->diagnose(diag::mutability_mismatch_multiple_pattern_list,
+                                 vd->isLet(), initialCaseVarDecl->isLet());
 
         VarPattern *foundVP = nullptr;
         vd->getParentPattern()->forEachNode([&](Pattern *P) {
@@ -1178,27 +1204,31 @@ public:
     if (caseBlock->getCaseLabelItems().size() != 1) {
       assert(!caseBlock->getCaseLabelItems().empty() &&
              "parser should not produce case blocks with no items");
-      TC.diagnose(caseBlock->getLoc(), diag::unknown_case_multiple_patterns)
+      getASTContext().Diags.diagnose(caseBlock->getLoc(),
+                                     diag::unknown_case_multiple_patterns)
           .highlight(caseBlock->getCaseLabelItems()[1].getSourceRange());
       limitExhaustivityChecks = true;
     }
 
     if (FallthroughDest != nullptr) {
       if (!caseBlock->isDefault())
-        TC.diagnose(caseBlock->getLoc(), diag::unknown_case_must_be_last);
+        getASTContext().Diags.diagnose(caseBlock->getLoc(),
+                                       diag::unknown_case_must_be_last);
       limitExhaustivityChecks = true;
     }
 
     const auto &labelItem = caseBlock->getCaseLabelItems().front();
     if (labelItem.getGuardExpr() && !labelItem.isDefault()) {
-      TC.diagnose(labelItem.getStartLoc(), diag::unknown_case_where_clause)
+      getASTContext().Diags.diagnose(labelItem.getStartLoc(),
+                                     diag::unknown_case_where_clause)
           .highlight(labelItem.getGuardExpr()->getSourceRange());
     }
 
     const Pattern *pattern =
         labelItem.getPattern()->getSemanticsProvidingPattern();
     if (!isa<AnyPattern>(pattern)) {
-      TC.diagnose(labelItem.getStartLoc(), diag::unknown_case_must_be_catchall)
+      getASTContext().Diags.diagnose(labelItem.getStartLoc(),
+                                     diag::unknown_case_must_be_catchall)
           .highlight(pattern->getSourceRange());
     }
   }
@@ -1227,7 +1257,7 @@ public:
         }
 
         if (!previous->getType()->isEqual(expected->getType())) {
-          TC.diagnose(previous->getLoc(),
+          getASTContext().Diags.diagnose(previous->getLoc(),
                       diag::type_mismatch_fallthrough_pattern_list,
                       previous->getType(), expected->getType());
           previous->setInvalid();
@@ -1242,7 +1272,7 @@ public:
       }
 
       if (!matched) {
-        TC.diagnose(PreviousFallthrough->getLoc(),
+        getASTContext().Diags.diagnose(PreviousFallthrough->getLoc(),
                     diag::fallthrough_into_case_with_var_binding,
                     expected->getName());
       }
@@ -1372,8 +1402,8 @@ public:
         checkUnknownAttrRestrictions(caseBlock, limitExhaustivityChecks);
       }
 
-      // If the previous case fellthrough, similarly check that that case's bindings
-      // includes our first label item's pattern bindings and types.
+      // If the previous case fellthrough, similarly check that that case's
+      // bindings includes our first label item's pattern bindings and types.
       if (PreviousFallthrough && previousBlock) {
         checkFallthroughPatternBindingsAndTypes(caseBlock, previousBlock);
       }
@@ -1450,7 +1480,7 @@ public:
 
 bool TypeChecker::typeCheckCatchPattern(CatchStmt *S, DeclContext *DC) {
   // Grab the standard exception type.
-  Type exnType = getExceptionType(DC, S->getCatchLoc());
+  Type exnType = Context.getErrorDecl()->getDeclaredType();
 
   Pattern *pattern = S->getErrorPattern();
   if (Pattern *newPattern = TypeChecker::resolvePattern(pattern, DC,
@@ -1481,7 +1511,7 @@ static bool isDiscardableType(Type type) {
           type->lookThroughAllOptionalTypes()->isVoid());
 }
 
-static void diagnoseIgnoredLiteral(TypeChecker &TC, LiteralExpr *LE) {
+static void diagnoseIgnoredLiteral(ASTContext &Ctx, LiteralExpr *LE) {
   const auto getLiteralDescription = [](LiteralExpr *LE) -> StringRef {
     switch (LE->getKind()) {
     case ExprKind::IntegerLiteral: return "integer";
@@ -1512,8 +1542,8 @@ static void diagnoseIgnoredLiteral(TypeChecker &TC, LiteralExpr *LE) {
     llvm_unreachable("Unhandled ExprKind in switch.");
   };
 
-  TC.diagnose(LE->getLoc(), diag::expression_unused_literal,
-              getLiteralDescription(LE))
+  Ctx.Diags.diagnose(LE->getLoc(), diag::expression_unused_literal,
+                     getLiteralDescription(LE))
     .highlight(LE->getSourceRange());
 }
 
@@ -1535,6 +1565,8 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
   }
 
   // Complain about l-values that are neither loaded nor stored.
+  auto &Context = E->getType()->getASTContext();
+  auto &DE = Context.Diags;
   if (E->getType()->hasLValueType()) {
     // This must stay in sync with diag::expression_unused_lvalue.
     enum {
@@ -1549,7 +1581,7 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
       else if (decl->getDeclContext()->isTypeContext())
         storageKind = SK_Property;
     }
-    diagnose(E->getLoc(), diag::expression_unused_lvalue, storageKind)
+    DE.diagnose(E->getLoc(), diag::expression_unused_lvalue, storageKind)
       .highlight(E->getSourceRange());
     return;
   }
@@ -1594,8 +1626,8 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
 
     if (auto *Fn = dyn_cast<ApplyExpr>(expr)) {
       if (auto *declRef = dyn_cast<DeclRefExpr>(Fn->getFn())) {
-        if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(declRef->getDecl())) {
-          if (funcDecl->getAttrs().hasAttribute<DiscardableResultAttr>()) {
+        if (auto *FD = dyn_cast<AbstractFunctionDecl>(declRef->getDecl())) {
+          if (FD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
             isDiscardable = true;
           }
         }
@@ -1603,7 +1635,7 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
     }
 
     if (!isDiscardable) {
-      diagnose(E->getLoc(), diag::expression_unused_function)
+      DE.diagnose(E->getLoc(), diag::expression_unused_function)
           .highlight(E->getSourceRange());
       return;
     }
@@ -1617,21 +1649,21 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
   
   // Complain about '#selector'.
   if (auto *ObjCSE = dyn_cast<ObjCSelectorExpr>(valueE)) {
-    diagnose(ObjCSE->getLoc(), diag::expression_unused_selector_result)
+    DE.diagnose(ObjCSE->getLoc(), diag::expression_unused_selector_result)
       .highlight(E->getSourceRange());
     return;
   }
 
   // Complain about '#keyPath'.
   if (isa<KeyPathExpr>(valueE)) {
-    diagnose(valueE->getLoc(), diag::expression_unused_keypath_result)
+    DE.diagnose(valueE->getLoc(), diag::expression_unused_keypath_result)
       .highlight(E->getSourceRange());
     return;
   }
     
   // Always complain about 'try?'.
   if (auto *OTE = dyn_cast<OptionalTryExpr>(valueE)) {
-    diagnose(OTE->getTryLoc(), diag::expression_unused_optional_try)
+    DE.diagnose(OTE->getTryLoc(), diag::expression_unused_optional_try)
       .highlight(E->getSourceRange());
     return;
   }
@@ -1649,7 +1681,7 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
   }
 
   if (auto *LE = dyn_cast<LiteralExpr>(valueE)) {
-    diagnoseIgnoredLiteral(*this, LE);
+    diagnoseIgnoredLiteral(Context, LE);
     return;
   }
 
@@ -1699,14 +1731,14 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
           arg = TE->getElement(0);
 
       if (auto *LE = dyn_cast<LiteralExpr>(arg)) {
-        diagnoseIgnoredLiteral(*this, LE);
+        diagnoseIgnoredLiteral(Context, LE);
         return;
       }
     }
 
     // Other unused constructor calls.
     if (callee && isa<ConstructorDecl>(callee) && !call->isImplicit()) {
-      diagnose(fn->getLoc(), diag::expression_unused_init_result,
+      DE.diagnose(fn->getLoc(), diag::expression_unused_init_result,
                callee->getDeclContext()->getDeclaredInterfaceType())
         .highlight(call->getArg()->getSourceRange());
       return;
@@ -1725,7 +1757,7 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
         // Translate calls to implicit functions to their user-facing names
         if (callee->getBaseName() == ctx.Id_derived_enum_equals ||
             callee->getBaseName() == ctx.Id_derived_struct_equals) {
-          diagnose(fn->getLoc(), diag::expression_unused_result_operator,
+          DE.diagnose(fn->getLoc(), diag::expression_unused_result_operator,
                    ctx.Id_EqualsOperator)
             .highlight(SR1).highlight(SR2);
           return;
@@ -1736,10 +1768,10 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
       if (callee->getFullName().isOperator())
         diagID = diag::expression_unused_result_operator;
       
-      diagnose(fn->getLoc(), diagID, callee->getFullName())
+      DE.diagnose(fn->getLoc(), diagID, callee->getFullName())
         .highlight(SR1).highlight(SR2);
     } else
-      diagnose(fn->getLoc(), diag::expression_unused_result_unknown,
+      DE.diagnose(fn->getLoc(), diag::expression_unused_result_unknown,
                isa<ClosureExpr>(fn), valueE->getType())
         .highlight(SR1).highlight(SR2);
 
@@ -1747,12 +1779,13 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
   }
 
   // Produce a generic diagnostic.
-  diagnose(valueE->getLoc(), diag::expression_unused_result, valueE->getType())
+  DE.diagnose(valueE->getLoc(), diag::expression_unused_result,
+              valueE->getType())
     .highlight(valueE->getSourceRange());
 }
 
 Stmt *StmtChecker::visitBraceStmt(BraceStmt *BS) {
-  const SourceManager &SM = TC.Context.SourceMgr;
+  const SourceManager &SM = getASTContext().SourceMgr;
 
   // Diagnose defer statement being last one in block (only if
   // BraceStmt does not start a TopLevelDecl).
@@ -1762,7 +1795,8 @@ Stmt *StmtChecker::visitBraceStmt(BraceStmt *BS) {
     if (auto stmt =
             BS->getLastElement().dyn_cast<Stmt *>()) {
       if (auto deferStmt = dyn_cast<DeferStmt>(stmt)) {
-        TC.diagnose(deferStmt->getStartLoc(), diag::defer_stmt_at_block_end)
+        getASTContext().Diags.diagnose(deferStmt->getStartLoc(),
+                                       diag::defer_stmt_at_block_end)
             .fixItReplace(deferStmt->getStartLoc(), "do");
       }
     }
@@ -1778,13 +1812,13 @@ Stmt *StmtChecker::visitBraceStmt(BraceStmt *BS) {
       // Type check the expression.
       TypeCheckExprOptions options = TypeCheckExprFlags::IsExprStmt;
       bool isDiscarded = !(IsREPL && isa<TopLevelCodeDecl>(DC))
-        && !TC.Context.LangOpts.Playground
-        && !TC.Context.LangOpts.DebuggerSupport;
+        && !getASTContext().LangOpts.Playground
+        && !getASTContext().LangOpts.DebuggerSupport;
       if (isDiscarded)
         options |= TypeCheckExprFlags::IsDiscarded;
 
       if (EndTypeCheckLoc.isValid()) {
-        assert(DiagnosticSuppression::isEnabled(TC.Diags) &&
+        assert(DiagnosticSuppression::isEnabled(getASTContext().Diags) &&
                "Diagnosing and AllowUnresolvedTypeVariables don't seem to mix");
         options |= TypeCheckExprFlags::AllowUnresolvedTypeVariables;
       }
@@ -1796,15 +1830,17 @@ Stmt *StmtChecker::visitBraceStmt(BraceStmt *BS) {
       // to write "do { ... }".
       auto *CE = dyn_cast<ClosureExpr>(SubExpr);
       if (CE || isa<CaptureListExpr>(SubExpr)) {
-        TC.diagnose(SubExpr->getLoc(), diag::expression_unused_closure);
+        getASTContext().Diags.diagnose(SubExpr->getLoc(),
+                                       diag::expression_unused_closure);
         
         if (CE && CE->hasAnonymousClosureVars() &&
             CE->getParameters()->size() == 0) {
-          TC.diagnose(CE->getStartLoc(), diag::brace_stmt_suggest_do)
+          getASTContext().Diags.diagnose(CE->getStartLoc(),
+                                         diag::brace_stmt_suggest_do)
             .fixItInsert(CE->getStartLoc(), "do ");
         }
       } else if (isDiscarded && resultTy)
-        TC.checkIgnoredExpr(SubExpr);
+        TypeChecker::checkIgnoredExpr(SubExpr);
 
       elem = SubExpr;
       continue;
@@ -1848,9 +1884,9 @@ static Type getFunctionBuilderType(FuncDecl *FD) {
 }
 
 bool TypeChecker::typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD) {
-  auto result = typeCheckAbstractFunctionBodyUntil(AFD, SourceLoc());
+  auto res = TypeChecker::typeCheckAbstractFunctionBodyUntil(AFD, SourceLoc());
   TypeChecker::checkFunctionErrorHandling(AFD);
-  return result;
+  return res;
 }
 
 static Expr* constructCallToSuperInit(ConstructorDecl *ctor,
@@ -1868,7 +1904,7 @@ static Expr* constructCallToSuperInit(ConstructorDecl *ctor,
     r = new (Context) TryExpr(SourceLoc(), r, Type(), /*implicit=*/true);
 
   TypeChecker &tc = *Context.getLegacyGlobalTypeChecker();
-  DiagnosticSuppression suppression(tc.Diags);
+  DiagnosticSuppression suppression(ctor->getASTContext().Diags);
   auto resultTy =
       tc.typeCheckExpression(r, ctor, TypeLoc(), CTP_Unused,
                              TypeCheckExprFlags::IsDiscarded);
@@ -2077,7 +2113,8 @@ TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
 
   if (auto *func = dyn_cast<FuncDecl>(AFD)) {
     if (Type builderType = getFunctionBuilderType(func)) {
-      body = tc.applyFunctionBuilderBodyTransform(func, body, builderType);
+      body = TypeChecker::applyFunctionBuilderBodyTransform(func, body,
+                                                            builderType);
       if (!body)
         return true;
     } else if (func->hasSingleExpressionBody()) {
@@ -2144,7 +2181,7 @@ TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
 bool TypeChecker::typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
                                                      SourceLoc EndTypeCheckLoc) {
   return evaluateOrDefault(
-             Context.evaluator,
+             AFD->getASTContext().evaluator,
              TypeCheckFunctionBodyUntilRequest{AFD, EndTypeCheckLoc},
              true);
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1849,7 +1849,7 @@ static Type getFunctionBuilderType(FuncDecl *FD) {
 
 bool TypeChecker::typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD) {
   auto result = typeCheckAbstractFunctionBodyUntil(AFD, SourceLoc());
-  checkFunctionErrorHandling(AFD);
+  TypeChecker::checkFunctionErrorHandling(AFD);
   return result;
 }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -621,7 +621,7 @@ public:
     // Coerce the operand to the exception type.
     auto E = TS->getSubExpr();
 
-    Type exnType = TC.getExceptionType(DC, TS->getThrowLoc());
+    Type exnType = getASTContext().getErrorDecl()->getDeclaredType();
     if (!exnType) return TS;
 
     TC.typeCheckExpression(E, DC, TypeLoc::withoutLoc(exnType), CTP_ThrowStmt);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2216,7 +2216,7 @@ static void typeCheckSynthesizedWrapperInitializer(
   const auto i = pbd->getPatternEntryIndexForVarDecl(backingVar);
   if (auto initializerContext =
           dyn_cast_or_null<Initializer>(pbd->getInitContext(i))) {
-    tc.contextualizeInitializer(initializerContext, initializer);
+    TypeChecker::contextualizeInitializer(initializerContext, initializer);
   }
   TypeChecker::checkPropertyWrapperErrorHandling(pbd, initializer);
 }

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -121,7 +121,7 @@ namespace {
       DeclName Head;
       std::forward_list<Space> Spaces;
 
-      size_t computeSize(TypeChecker &TC, const DeclContext *DC,
+      size_t computeSize(const DeclContext *DC,
                          SmallPtrSetImpl<TypeBase *> &cache) const {
         switch (getKind()) {
         case SpaceKind::Empty:
@@ -137,11 +137,11 @@ namespace {
           cache.insert(getType().getPointer());
 
           SmallVector<Space, 4> spaces;
-          decompose(TC, DC, getType(), spaces);
+          decompose(DC, getType(), spaces);
           size_t acc = 0;
           for (auto &sp : spaces) {
             // Decomposed pattern spaces grow with the sum of the subspaces.
-            acc += sp.computeSize(TC, DC, cache);
+            acc += sp.computeSize(DC, cache);
           }
           
           cache.erase(getType().getPointer());
@@ -157,7 +157,7 @@ namespace {
             }
             
             // Constructor spaces grow with the product of their arguments.
-            acc *= sp.computeSize(TC, DC, cache);
+            acc *= sp.computeSize(DC, cache);
           }
           return acc;
         }
@@ -165,7 +165,7 @@ namespace {
           size_t acc = 0;
           for (auto &sp : getSpaces()) {
             // Disjoint grow with the sum of the subspaces.
-            acc += sp.computeSize(TC, DC, cache);
+            acc += sp.computeSize(DC, cache);
           }
           return acc;
         }
@@ -245,9 +245,9 @@ namespace {
 
       SWIFT_DEBUG_DUMP;
 
-      size_t getSize(TypeChecker &TC, const DeclContext *DC) const {
+      size_t getSize(const DeclContext *DC) const {
         SmallPtrSet<TypeBase *, 4> cache;
-        return computeSize(TC, DC, cache);
+        return computeSize(DC, cache);
       }
 
       bool isEmpty() const { return getKind() == SpaceKind::Empty; }
@@ -292,8 +292,7 @@ namespace {
 
       // An optimization that computes if the difference of this space and
       // another space is empty.
-      bool isSubspace(const Space &other, TypeChecker &TC,
-                      const DeclContext *DC) const {
+      bool isSubspace(const Space &other, const DeclContext *DC) const {
         if (this->isEmpty()) {
           return true;
         }
@@ -310,7 +309,7 @@ namespace {
         PAIRCASE (SpaceKind::Disjunct, SpaceKind::UnknownCase): {
           // (S1 | ... | Sn) <= S iff (S1 <= S) && ... && (Sn <= S)
           for (auto &space : this->getSpaces()) {
-            if (!space.isSubspace(other, TC, DC)) {
+            if (!space.isSubspace(other, DC)) {
               return false;
             }
           }
@@ -324,15 +323,15 @@ namespace {
 
           // (_ : Ty1) <= (_ : Ty2) iff D(Ty1) == D(Ty2)
           if (canDecompose(this->getType(), DC)) {
-            Space or1Space = decompose(TC, DC, this->getType());
-            if (or1Space.isSubspace(other, TC, DC)) {
+            Space or1Space = decompose(DC, this->getType());
+            if (or1Space.isSubspace(other, DC)) {
               return true;
             }
           }
 
           if (canDecompose(other.getType(), DC)) {
-            Space or2Space = decompose(TC, DC, other.getType());
-            return this->isSubspace(or2Space, TC, DC);
+            Space or2Space = decompose(DC, other.getType());
+            return this->isSubspace(or2Space, DC);
           }
 
           return false;
@@ -340,7 +339,7 @@ namespace {
         PAIRCASE (SpaceKind::Type, SpaceKind::Disjunct): {
           // (_ : Ty1) <= (S1 | ... | Sn) iff (S1 <= S) || ... || (Sn <= S)
           for (auto &dis : other.getSpaces()) {
-            if (this->isSubspace(dis, TC, DC)) {
+            if (this->isSubspace(dis, DC)) {
               return true;
             }
           }
@@ -349,14 +348,14 @@ namespace {
           if (!canDecompose(this->getType(), DC)) {
             return false;
           }
-          Space or1Space = decompose(TC, DC, this->getType());
-          return or1Space.isSubspace(other, TC, DC);
+          Space or1Space = decompose(DC, this->getType());
+          return or1Space.isSubspace(other, DC);
         }
         PAIRCASE (SpaceKind::Type, SpaceKind::Constructor): {
           // (_ : Ty1) <= H(p1 | ... | pn) iff D(Ty1) <= H(p1 | ... | pn)
           if (canDecompose(this->getType(), DC)) {
-            Space or1Space = decompose(TC, DC, this->getType());
-            return or1Space.isSubspace(other, TC, DC);
+            Space or1Space = decompose(DC, this->getType());
+            return or1Space.isSubspace(other, DC);
           }
           // An undecomposable type is always larger than its constructor space.
           return false;
@@ -390,7 +389,7 @@ namespace {
           auto j = other.getSpaces().begin();
           for (; i != this->getSpaces().end() && j != other.getSpaces().end();
                ++i, ++j) {
-            if (!(*i).isSubspace(*j, TC, DC)) {
+            if (!(*i).isSubspace(*j, DC)) {
               return false;
             }
           }
@@ -398,7 +397,7 @@ namespace {
         }
         PAIRCASE (SpaceKind::Constructor, SpaceKind::UnknownCase):
           for (auto &param : this->getSpaces()) {
-            if (param.isSubspace(other, TC, DC)) {
+            if (param.isSubspace(other, DC)) {
               return true;
             }
           }
@@ -409,7 +408,7 @@ namespace {
         PAIRCASE (SpaceKind::UnknownCase, SpaceKind::Disjunct): {
           // S <= (S1 | ... | Sn) <= S iff (S <= S1) || ... || (S <= Sn)
           for (auto &param : other.getSpaces()) {
-            if (this->isSubspace(param, TC, DC)) {
+            if (this->isSubspace(param, DC)) {
               return true;
             }
           }
@@ -448,13 +447,11 @@ namespace {
       // computation had to be abandoned.
       //
       // \p minusCount is an optional pointer counting the number of
-      // times minus has run.
+      // remaining calls to minus before the computation times out.
       // Returns None if the computation "timed out".
-      Optional<Space> minus(const Space &other, TypeChecker &TC,
-                            const DeclContext *DC, unsigned *minusCount) const {
-
-        if (minusCount && TC.getSwitchCheckingInvocationThreshold() &&
-            (*minusCount)++ >= TC.getSwitchCheckingInvocationThreshold())
+      Optional<Space> minus(const Space &other, const DeclContext *DC,
+                            unsigned *minusCount) const {
+        if (minusCount && (*minusCount)-- == 0)
           return None;
         
         if (this->isEmpty()) {
@@ -474,8 +471,8 @@ namespace {
         }
         PAIRCASE (SpaceKind::Type, SpaceKind::Constructor): {
           if (canDecompose(this->getType(), DC)) {
-            auto decomposition = decompose(TC, DC, this->getType());
-            return decomposition.minus(other, TC, DC, minusCount);
+            auto decomposition = decompose(DC, this->getType());
+            return decomposition.minus(other, DC, minusCount);
           } else {
             return *this;
           }
@@ -496,7 +493,7 @@ namespace {
         PAIRCASE (SpaceKind::UnknownCase, SpaceKind::Disjunct): {
           Space tot = *this;
           for (auto s : other.getSpaces()) {
-            if (auto diff = tot.minus(s, TC, DC, minusCount))
+            if (auto diff = tot.minus(s, DC, minusCount))
               tot = *diff;
             else
               return None;
@@ -511,7 +508,7 @@ namespace {
         PAIRCASE (SpaceKind::Disjunct, SpaceKind::UnknownCase): {
           SmallVector<Space, 4> smallSpaces;
           for (auto s : this->getSpaces()) {
-            auto diff = s.minus(other, TC, DC, minusCount);
+            auto diff = s.minus(other, DC, minusCount);
             if (!diff)
               return None;
             if (diff->getKind() == SpaceKind::Disjunct) {
@@ -532,7 +529,7 @@ namespace {
           for (const Space &space : smallSpaces) {
             bool alreadyHandled = llvm::any_of(usefulSmallSpaces,
                                                [&](const Space &previousSpace) {
-              return space.isSubspace(previousSpace, TC, DC);
+              return space.isSubspace(previousSpace, DC);
             });
             if (alreadyHandled)
               continue;
@@ -546,7 +543,7 @@ namespace {
         PAIRCASE (SpaceKind::Constructor, SpaceKind::UnknownCase): {
           SmallVector<Space, 4> newSubSpaces;
           for (auto subSpace : this->getSpaces()) {
-            auto nextSpace = subSpace.minus(other, TC, DC, minusCount);
+            auto nextSpace = subSpace.minus(other, DC, minusCount);
             if (!nextSpace)
               return None;
             if (nextSpace.getValue().isEmpty())
@@ -583,7 +580,7 @@ namespace {
 
             // If one constructor parameter doesn't cover the other then we've
             // got to report the uncovered cases in a user-friendly way.
-            if (!s1.isSubspace(s2, TC, DC)) {
+            if (!s1.isSubspace(s2, DC)) {
               foundBad = true;
             }
             // Copy the params and replace the parameter at each index with the
@@ -592,7 +589,7 @@ namespace {
             SmallVector<Space, 4> copyParams(this->getSpaces().begin(),
                                              this->getSpaces().end());
 
-            auto reducedSpaceOrNone = s1.minus(s2, TC, DC, minusCount);
+            auto reducedSpaceOrNone = s1.minus(s2, DC, minusCount);
             if (!reducedSpaceOrNone)
               return None;
             auto reducedSpace = *reducedSpaceOrNone;
@@ -636,8 +633,8 @@ namespace {
           }
 
           if (canDecompose(other.getType(), DC)) {
-            auto decomposition = decompose(TC, DC, other.getType());
-            return this->minus(decomposition, TC, DC, minusCount);
+            auto decomposition = decompose(DC, other.getType());
+            return this->minus(decomposition, DC, minusCount);
           }
           return *this;
         }
@@ -648,8 +645,8 @@ namespace {
 
         PAIRCASE (SpaceKind::Type, SpaceKind::BooleanConstant): {
           if (canDecompose(this->getType(), DC)) {
-            auto orSpace = decompose(TC, DC, this->getType());
-            return orSpace.minus(other, TC, DC, minusCount);
+            auto orSpace = decompose(DC, this->getType());
+            return orSpace.minus(other, DC, minusCount);
           } else {
             return *this;
           }
@@ -787,7 +784,7 @@ namespace {
       };
 
       // Decompose a type into its component spaces.
-      static void decompose(TypeChecker &TC, const DeclContext *DC, Type tp,
+      static void decompose(const DeclContext *DC, Type tp,
                             SmallVectorImpl<Space> &arr) {
         assert(canDecompose(tp, DC) && "Non-decomposable type?");
 
@@ -845,10 +842,9 @@ namespace {
         }
       }
 
-      static Space decompose(TypeChecker &TC, const DeclContext *DC,
-                             Type type) {
+      static Space decompose(const DeclContext *DC, Type type) {
         SmallVector<Space, 4> spaces;
-        decompose(TC, DC, type, spaces);
+        decompose(DC, type, spaces);
         return Space::forDisjunct(spaces);
       }
 
@@ -888,16 +884,18 @@ namespace {
       }
     };
 
-    TypeChecker &TC;
+    ASTContext &Context;
+    unsigned CheckingThreshold;
     const SwitchStmt *Switch;
     const DeclContext *DC;
     APIntMap<Expr *> IntLiteralCache;
     llvm::DenseMap<APFloat, Expr *, ::DenseMapAPFloatKeyInfo> FloatLiteralCache;
     llvm::DenseMap<StringRef, Expr *> StringLiteralCache;
     
-    SpaceEngine(TypeChecker &C, const SwitchStmt *SS, const DeclContext *DC)
-        : TC(C), Switch(SS), DC(DC) {}
-
+    SpaceEngine(ASTContext &C, unsigned Threashold,
+                const SwitchStmt *SS, const DeclContext *DC)
+        : Context(C), CheckingThreshold(Threashold), Switch(SS), DC(DC) {}
+    
     bool checkRedundantLiteral(const Pattern *Pat, Expr *&PrevPattern) {
       if (Pat->getKind() != PatternKind::Expr) {
           return false;
@@ -962,6 +960,7 @@ namespace {
 
       const CaseStmt *unknownCase = nullptr;
       SmallVector<Space, 4> spaces;
+      auto &DE = Context.Diags;
       for (auto *caseBlock : Switch->getCases()) {
         if (caseBlock->hasUnknownAttr()) {
           assert(unknownCase == nullptr && "multiple unknown cases");
@@ -979,13 +978,13 @@ namespace {
           if (caseItem.isDefault())
             return;
 
-          Space projection = projectPattern(TC, caseItem.getPattern());
+          Space projection = projectPattern(caseItem.getPattern());
           bool isRedundant = !projection.isEmpty() &&
                              llvm::any_of(spaces, [&](const Space &handled) {
-            return projection.isSubspace(handled, TC, DC);
+            return projection.isSubspace(handled, DC);
           });
           if (isRedundant) {
-            TC.diagnose(caseItem.getStartLoc(),
+            DE.diagnose(caseItem.getStartLoc(),
                           diag::redundant_particular_case)
               .highlight(caseItem.getSourceRange());
             continue;
@@ -994,10 +993,10 @@ namespace {
           Expr *cachedExpr = nullptr;
           if (checkRedundantLiteral(caseItem.getPattern(), cachedExpr)) {
             assert(cachedExpr && "Cache found hit but no expr?");
-            TC.diagnose(caseItem.getStartLoc(),
+            DE.diagnose(caseItem.getStartLoc(),
                         diag::redundant_particular_literal_case)
               .highlight(caseItem.getSourceRange());
-            TC.diagnose(cachedExpr->getLoc(),
+            DE.diagnose(cachedExpr->getLoc(),
                         diag::redundant_particular_literal_case_here)
               .highlight(cachedExpr->getSourceRange());
             continue;
@@ -1011,8 +1010,8 @@ namespace {
       Space totalSpace = Space::forType(subjectType, Identifier());
       Space coveredSpace = Space::forDisjunct(spaces);
 
-      unsigned minusCount = 0;
-      auto diff = totalSpace.minus(coveredSpace, TC, DC, &minusCount);
+      unsigned minusCount = CheckingThreshold;
+      auto diff = totalSpace.minus(coveredSpace, DC, &minusCount);
       if (!diff) {
         diagnoseMissingCases(RequiresDefault::SpaceTooLarge, Space(),
                              unknownCase);
@@ -1021,7 +1020,7 @@ namespace {
       
       auto uncovered = diff.getValue();
       if (unknownCase && uncovered.isEmpty()) {
-        TC.diagnose(unknownCase->getLoc(), diag::redundant_particular_case)
+        DE.diagnose(unknownCase->getLoc(), diag::redundant_particular_case)
           .highlight(unknownCase->getSourceRange());
       }
 
@@ -1029,7 +1028,7 @@ namespace {
       // all handled; otherwise, we ignore the ones that were added for enums
       // that are implicitly frozen.
       uncovered = *uncovered.minus(Space::forUnknown(unknownCase == nullptr),
-                                   TC, DC, /*&minusCount*/ nullptr);
+                                   DC, /*&minusCount*/ nullptr);
 
       if (uncovered.isEmpty())
         return;
@@ -1040,7 +1039,7 @@ namespace {
       if (uncovered.getKind() == SpaceKind::Type) {
         if (Space::canDecompose(uncovered.getType(), DC)) {
           SmallVector<Space, 4> spaces;
-          Space::decompose(TC, DC, uncovered.getType(), spaces);
+          Space::decompose(DC, uncovered.getType(), spaces);
           diagnoseMissingCases(RequiresDefault::No, Space::forDisjunct(spaces),
                                unknownCase);
         } else {
@@ -1064,6 +1063,7 @@ namespace {
 
     void diagnoseMissingCases(RequiresDefault defaultReason, Space uncovered,
                               const CaseStmt *unknownCase = nullptr) {
+      auto &DE = Context.Diags;
       SourceLoc startLoc = Switch->getStartLoc();
       SourceLoc insertLoc;
       if (unknownCase)
@@ -1074,7 +1074,7 @@ namespace {
       llvm::SmallString<128> buffer;
       llvm::raw_svector_ostream OS(buffer);
 
-      bool InEditor = TC.Context.LangOpts.DiagnosticsEditorMode;
+      bool InEditor = Context.LangOpts.DiagnosticsEditorMode;
 
       // Decide whether we want an error or a warning.
       Optional<decltype(diag::non_exhaustive_switch)> mainDiagType =
@@ -1092,8 +1092,8 @@ namespace {
           auto diagnostic = defaultReason == RequiresDefault::UncoveredSwitch
                                 ? diag::non_exhaustive_switch
                                 : diag::possibly_non_exhaustive_switch;
-          TC.diagnose(startLoc, diagnostic);
-          TC.diagnose(unknownCase->getLoc(),
+          DE.diagnose(startLoc, diagnostic);
+          DE.diagnose(unknownCase->getLoc(),
                       diag::non_exhaustive_switch_drop_unknown)
             .fixItRemoveChars(unknownCase->getStartLoc(),
                               unknownCase->getLoc());
@@ -1106,9 +1106,9 @@ namespace {
       case DowngradeToWarning::No:
         break;
       case DowngradeToWarning::ForUnknownCase: {
-        if (TC.Context.LangOpts.DebuggerSupport ||
-            TC.Context.LangOpts.Playground ||
-            !TC.getLangOpts().EnableNonFrozenEnumExhaustivityDiagnostics) {
+        if (Context.LangOpts.DebuggerSupport ||
+            Context.LangOpts.Playground ||
+            !Context.LangOpts.EnableNonFrozenEnumExhaustivityDiagnostics) {
           // Don't require covering unknown cases in the debugger or in
           // playgrounds.
           return;
@@ -1120,7 +1120,7 @@ namespace {
           shouldIncludeFutureVersionComment =
               theEnum->getParentModule()->isSystemModule();
         }
-        TC.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
+        DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
                     subjectType, shouldIncludeFutureVersionComment);
         mainDiagType = None;
       }
@@ -1132,21 +1132,21 @@ namespace {
         break;
       case RequiresDefault::EmptySwitchBody: {
         OS << tok::kw_default << ":\n" << placeholder << "\n";
-        TC.diagnose(startLoc, diag::empty_switch_stmt)
+        DE.diagnose(startLoc, diag::empty_switch_stmt)
           .fixItInsert(insertLoc, buffer.str());
       }
         return;
       case RequiresDefault::UncoveredSwitch: {
         OS << tok::kw_default << ":\n" << placeholder << "\n";
-        TC.diagnose(startLoc, mainDiagType.getValue());
-        TC.diagnose(startLoc, diag::missing_several_cases, /*default*/true)
+        DE.diagnose(startLoc, mainDiagType.getValue());
+        DE.diagnose(startLoc, diag::missing_several_cases, /*default*/true)
           .fixItInsert(insertLoc, buffer.str());
       }
         return;
       case RequiresDefault::SpaceTooLarge: {
         OS << tok::kw_default << ":\n" << "<#fatalError()#>" << "\n";
-        TC.diagnose(startLoc, diag::possibly_non_exhaustive_switch);
-        TC.diagnose(startLoc, diag::missing_several_cases, /*default*/true)
+        DE.diagnose(startLoc, diag::possibly_non_exhaustive_switch);
+        DE.diagnose(startLoc, diag::missing_several_cases, /*default*/true)
           .fixItInsert(insertLoc, buffer.str());
       }
         return;
@@ -1157,7 +1157,7 @@ namespace {
 
       // Check if we still have to emit the main diganostic.
       if (mainDiagType.hasValue())
-        TC.diagnose(startLoc, mainDiagType.getValue());
+        DE.diagnose(startLoc, mainDiagType.getValue());
 
       // Add notes to explain what's missing.
       auto processUncoveredSpaces =
@@ -1176,7 +1176,7 @@ namespace {
           flatsSortedBySize.push_back(&space);
         std::stable_sort(flatsSortedBySize.begin(), flatsSortedBySize.end(),
                          [&](const Space *left, const Space *right) {
-          return left->getSize(TC, DC) > right->getSize(TC, DC);
+          return left->getSize(DC) > right->getSize(DC);
         });
 
         // ...and then remove any of the later spaces that are contained
@@ -1185,7 +1185,7 @@ namespace {
         for (const Space *space : flatsSortedBySize) {
           bool alreadyHandled =
               llvm::any_of(flatsToEmit, [&](const Space *previousSpace) {
-            return space->isSubspace(*previousSpace, TC, DC);
+            return space->isSubspace(*previousSpace, DC);
           });
           if (alreadyHandled)
             continue;
@@ -1206,7 +1206,7 @@ namespace {
               // will later decompose the space into cases.
               continue;
             }
-            if (!TC.getLangOpts().EnableNonFrozenEnumExhaustivityDiagnostics)
+            if (!Context.LangOpts.EnableNonFrozenEnumExhaustivityDiagnostics)
               continue;
           }
 
@@ -1238,7 +1238,7 @@ namespace {
             OS << "@unknown " << tok::kw_default;
             if (onlyOneUncoveredSpace) {
               OS << ":\n<#fatalError()#>\n";
-              TC.diagnose(startLoc, diag::missing_unknown_case)
+              DE.diagnose(startLoc, diag::missing_unknown_case)
                 .fixItInsert(insertLoc, buffer.str());
               alreadyEmittedSomething = true;
               return;
@@ -1251,7 +1251,7 @@ namespace {
         });
 
         if (!alreadyEmittedSomething) {
-          TC.diagnose(startLoc, diag::missing_several_cases, false)
+          DE.diagnose(startLoc, diag::missing_several_cases, false)
             .fixItInsert(insertLoc, buffer.str());
         }
 
@@ -1259,7 +1259,7 @@ namespace {
         processUncoveredSpaces([&](const Space &space,
                                    bool onlyOneUncoveredSpace) {
           if (space.getKind() == SpaceKind::UnknownCase) {
-            auto note = TC.diagnose(startLoc, diag::missing_unknown_case);
+            auto note = DE.diagnose(startLoc, diag::missing_unknown_case);
             if (onlyOneUncoveredSpace)
               note.fixItInsert(insertLoc, "@unknown default:\n<#fatalError#>()\n");
             return;
@@ -1267,7 +1267,7 @@ namespace {
 
           buffer.clear();
           space.show(OS);
-          TC.diagnose(startLoc, diag::missing_particular_case, buffer.str());
+          DE.diagnose(startLoc, diag::missing_particular_case, buffer.str());
         });
       }
     }
@@ -1372,7 +1372,7 @@ namespace {
     }
 
     /// Recursively project a pattern into a Space.
-    static Space projectPattern(TypeChecker &TC, const Pattern *item) {
+    static Space projectPattern(const Pattern *item) {
       switch (item->getKind()) {
       case PatternKind::Any:
         return Space::forType(item->getType(), Identifier());
@@ -1388,7 +1388,7 @@ namespace {
         case CheckedCastKind::BridgingCoercion: {
           if (auto *subPattern = IP->getSubPattern()) {
             // Project the cast target's subpattern.
-            Space castSubSpace = projectPattern(TC, subPattern);
+            Space castSubSpace = projectPattern(subPattern);
             // If we recieved a type space from a named pattern or a wildcard
             // we have to re-project with the cast's target type to maintain
             // consistency with the scrutinee's type.
@@ -1419,17 +1419,18 @@ namespace {
         return Space();
       case PatternKind::Var: {
         auto *VP = cast<VarPattern>(item);
-        return projectPattern(TC, VP->getSubPattern());
+        return projectPattern(VP->getSubPattern());
       }
       case PatternKind::Paren: {
         auto *PP = cast<ParenPattern>(item);
-        return projectPattern(TC, PP->getSubPattern());
+        return projectPattern(PP->getSubPattern());
       }
       case PatternKind::OptionalSome: {
         auto *OSP = cast<OptionalSomePattern>(item);
-        Identifier name = TC.Context.getOptionalSomeDecl()->getName();
+        auto &Ctx = OSP->getElementDecl()->getASTContext();
+        Identifier name = Ctx.getOptionalSomeDecl()->getName();
 
-        auto subSpace = projectPattern(TC, OSP->getSubPattern());
+        auto subSpace = projectPattern(OSP->getSubPattern());
         // To match patterns like (_, _, ...)?, we must rewrite the underlying
         // tuple pattern to .some(_, _, ...) first.
         if (subSpace.getKind() == SpaceKind::Constructor &&
@@ -1455,7 +1456,7 @@ namespace {
           std::transform(TP->getElements().begin(), TP->getElements().end(),
                          std::back_inserter(conArgSpace),
                          [&](TuplePatternElt pate) {
-                           return projectPattern(TC, pate.getPattern());
+                           return projectPattern(pate.getPattern());
                          });
           return Space::forConstructor(item->getType(), VP->getName(),
                                        conArgSpace);
@@ -1477,9 +1478,9 @@ namespace {
             if (auto *TTy = outerType->getAs<TupleType>())
               Space::getTupleTypeSpaces(outerType, TTy, conArgSpace);
             else
-              conArgSpace.push_back(projectPattern(TC, SP));
+              conArgSpace.push_back(projectPattern(SP));
           } else if (SP->getKind() == PatternKind::Tuple) {
-            Space argTupleSpace = projectPattern(TC, SP);
+            Space argTupleSpace = projectPattern(SP);
             // Tuples are modeled as if they are enums with a single, nameless
             // case, which means argTupleSpace will either be a Constructor or
             // Empty space. If it's empty (i.e. it contributes nothing to the
@@ -1489,13 +1490,13 @@ namespace {
             assert(argTupleSpace.getKind() == SpaceKind::Constructor);
             conArgSpace.push_back(argTupleSpace);
           } else {
-            conArgSpace.push_back(projectPattern(TC, SP));
+            conArgSpace.push_back(projectPattern(SP));
           }
           return Space::forConstructor(item->getType(), VP->getName(),
                                        conArgSpace);
         }
         default:
-          return projectPattern(TC, SP);
+          return projectPattern(SP);
         }
       }
       case PatternKind::Tuple: {
@@ -1504,7 +1505,7 @@ namespace {
         std::transform(TP->getElements().begin(), TP->getElements().end(),
                        std::back_inserter(conArgSpace),
                        [&](TuplePatternElt pate) {
-          return projectPattern(TC, pate.getPattern());
+          return projectPattern(pate.getPattern());
         });
         return Space::forConstructor(item->getType(), Identifier(),
                                      conArgSpace);
@@ -1518,7 +1519,8 @@ namespace {
 void TypeChecker::checkSwitchExhaustiveness(const SwitchStmt *stmt,
                                             const DeclContext *DC,
                                             bool limited) {
-  SpaceEngine(*this, stmt, DC).checkExhaustiveness(limited);
+  SpaceEngine(Context, getSwitchCheckingInvocationThreshold(), stmt, DC)
+    .checkExhaustiveness(limited);
 }
 
 void SpaceEngine::Space::dump() const {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -410,14 +410,6 @@ Type TypeChecker::getUInt8Type(DeclContext *dc) {
   return Type();
 }
 
-/// Find the standard type of exceptions.
-///
-/// We call this the "exception type" to try to avoid confusion with
-/// the AST's ErrorType node.
-Type TypeChecker::getExceptionType(DeclContext *dc, SourceLoc loc) {
-  return Context.getErrorDecl()->getDeclaredType();
-}
-
 Type
 TypeChecker::getDynamicBridgedThroughObjCClass(DeclContext *dc,
                                                Type dynamicType,

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -718,8 +718,8 @@ bool swift::typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
   auto &Ctx = AFD->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
 
-  TypeChecker &TC = createTypeChecker(Ctx);
-  return !TC.typeCheckAbstractFunctionBodyUntil(AFD, EndTypeCheckLoc);
+  (void)createTypeChecker(Ctx);
+  return !TypeChecker::typeCheckAbstractFunctionBodyUntil(AFD, EndTypeCheckLoc);
 }
 
 bool swift::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -315,7 +315,7 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
       auto *AFD = TC.definedFunctions[currentFunctionIdx];
       assert(!AFD->getDeclContext()->isLocalContext());
 
-      TC.typeCheckAbstractFunctionBody(AFD);
+      TypeChecker::typeCheckAbstractFunctionBody(AFD);
     }
 
     // Type check synthesized functions and their bodies.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1014,7 +1014,7 @@ public:
                                           ReferenceOwnershipAttr *attr);
 
   /// Infer default value witnesses for all requirements in the given protocol.
-  void inferDefaultWitnesses(ProtocolDecl *proto);
+  static void inferDefaultWitnesses(ProtocolDecl *proto);
 
   /// For a generic requirement in a protocol, make sure that the requirement
   /// set didn't add any requirements to Self or its associated types.
@@ -1234,7 +1234,7 @@ public:
   ///
   /// \param decl The declaration to be type-checked. This process will not
   /// modify the declaration.
-  void checkDeclCircularity(NominalTypeDecl *decl);
+  static void checkDeclCircularity(NominalTypeDecl *decl);
 
   /// Type check whether the given switch statement exhaustively covers
   /// its domain.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -742,7 +742,6 @@ public:
   Type getUInt8Type(DeclContext *dc);
   Type getNSObjectType(DeclContext *dc);
   Type getObjCSelectorType(DeclContext *dc);
-  Type getExceptionType(DeclContext *dc, SourceLoc loc);
   
   /// Try to resolve an IdentTypeRepr, returning either the referenced
   /// Type or an ErrorType in case of error.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -981,8 +981,8 @@ public:
   /// of the function, set the result type of the expression to that sugar type.
   static Expr *substituteInputSugarTypeForResult(ApplyExpr *E);
 
-  bool typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
-                                          SourceLoc EndTypeCheckLoc);
+  static bool typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
+                                                 SourceLoc EndTypeCheckLoc);
   static bool typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD);
 
   static BraceStmt *applyFunctionBuilderBodyTransform(FuncDecl *FD,
@@ -1791,7 +1791,7 @@ public:
   ///
   /// An ignored expression is one that is not nested within a larger
   /// expression or statement.
-  void checkIgnoredExpr(Expr *E);
+  static void checkIgnoredExpr(Expr *E);
 
   // Emits a diagnostic, if necessary, for a reference to a declaration
   // that is potentially unavailable at the given source location.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1678,8 +1678,6 @@ public:
 
   /// \name Resilience diagnostics
 
-  void diagnoseInlinableLocalType(const NominalTypeDecl *NTD);
-
   /// Used in diagnostic %selects.
   enum class FragileFunctionKind : unsigned {
     Transparent,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -984,7 +984,7 @@ public:
 
   bool typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
                                           SourceLoc EndTypeCheckLoc);
-  bool typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD);
+  static bool typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD);
 
   static BraceStmt *applyFunctionBuilderBodyTransform(FuncDecl *FD,
                                                       BraceStmt *body,


### PR DESCRIPTION
Chase the Type Checker out of TypeCheckSwitchStmt and TypeCheckCircularity and try to drop most of the references to it in TypeCheckStmt.  I should be able to remove `TypeChecker::diagnose` soon...