### PR TITLE
Fix gnu-anonmyous-struct warning.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -144,11 +144,11 @@ private:
   SourceLoc Loc;
   Kind Kind;
   union Value {
-    struct { Identifier Name; }; // Named
-    struct { unsigned Index; }; // Ordered
-    struct {};                  // Self
-    Value(Identifier name) : Name(name) {}
-    Value(unsigned index) : Index(index) {}
+    struct { Identifier Name; } Named;
+    struct { unsigned Index; } Ordered;
+    struct {} Self;
+    Value(Identifier name) : Named({name}) {}
+    Value(unsigned index) : Ordered({index}) {}
     Value() {}
   } V;
 
@@ -175,11 +175,11 @@ public:
 
   Identifier getName() const {
     assert(Kind == Kind::Named);
-    return V.Name;
+    return V.Named.Name;
   }
   
   unsigned getIndex() const {
-    return V.Index;
+    return V.Ordered.Index;
   }
 
   enum Kind getKind() const {


### PR DESCRIPTION
The latest build script triggers a compilation error when anonymous struct is used. This PR fixes the anonymous struct used in AutoDiff. 

Here is an example PR on master: https://github.com/apple/swift/commit/e40759b335bc789cc795e7698134c0bb289f5526