### PR TITLE
[AutoDiff] Use PrettyStackTrace in differentiation transform.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -39,6 +39,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/LoopInfo.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/TypeSubstCloner.h"
@@ -3343,6 +3344,7 @@ public:
                               context, original, attr->getIndices(), vjp)),
         pullbackInfo(context, AutoDiffLinearMapKind::Pullback, original, vjp,
                      attr->getIndices(), activityInfo) {
+    PrettyStackTraceSILFunction trace("generating VJP for", original);
     // Create empty pullback function.
     pullback = createEmptyPullback();
     context.getGeneratedFunctions().push_back(pullback);
@@ -5234,6 +5236,8 @@ public:
         differentialBuilder(SILBuilder(*createEmptyDifferential(
             context, original, attr, &differentialInfo))),
         diffLocalAllocBuilder(getDifferential()) {
+    PrettyStackTraceSILFunction trace("generating JVP and differential for",
+                                      original);
     // Create empty differential function.
     context.getGeneratedFunctions().push_back(&getDifferential());
   }
@@ -5787,6 +5791,8 @@ public:
   explicit PullbackEmitter(VJPEmitter &vjpEmitter)
       : vjpEmitter(vjpEmitter), builder(getPullback()),
         localAllocBuilder(getPullback()) {
+    PrettyStackTraceSILFunction trace("generating pullback for",
+                                      &getOriginal());
     // Get dominance and post-order info for the original function.
     auto &passManager = getContext().getPassManager();
     auto *domAnalysis = passManager.getAnalysis<DominanceAnalysis>();
@@ -7969,6 +7975,14 @@ static SILFunction *createEmptyJVP(
 bool ADContext::processDifferentiableAttribute(
     SILFunction *original, SILDifferentiableAttr *attr,
     DifferentiationInvoker invoker) {
+  std::string traceMessage;
+  llvm::raw_string_ostream OS(traceMessage);
+  OS << "processing `[differentiable ";
+  attr->print(OS);
+  OS << "]` attribute on";
+  OS.flush();
+  PrettyStackTraceSILFunction trace(traceMessage.c_str(), original);
+
   auto &module = getModule();
   // Try to look up JVP only if attribute specifies JVP name or if original
   // function is an external declaration. If JVP function cannot be found,
@@ -8750,17 +8764,21 @@ void ADContext::foldDifferentiableFunctionExtraction(
 
 bool ADContext::processDifferentiableFunctionInst(
     DifferentiableFunctionInst *dfi) {
+  PrettyStackTraceSILNode dfiTrace("canonicalizing `differentiable_function`",
+                                   cast<SILInstruction>(dfi));
+  PrettyStackTraceSILFunction fnTrace("...in", dfi->getFunction());
   LLVM_DEBUG({
     auto &s = getADDebugStream() << "Processing DifferentiableFunctionInst:\n";
     dfi->printInContext(s);
   });
+
+  // If `dfi` already has derivative functions, do not process.
   if (dfi->hasDerivativeFunctions())
     return false;
 
   SILFunction *parent = dfi->getFunction();
   auto loc = dfi->getLoc();
   SILBuilder builder(dfi);
-
   auto differentiableFnValue =
       promoteToDifferentiableFunction(dfi, builder, loc, dfi);
   // Mark `dfi` as processed so that it won't be reprocessed after deletion.


### PR DESCRIPTION
Add `PrettyStackTrace` in the differentiation transform for the following actions:
- Processing SIL `[differentiable]` attributes.
  - Generating JVP/differential functions.
  - Generating VJP functions.
  - Generating pullback functions.
- Canonicalizing `differentiable_function` instructions.

---

Examples:

```
Assertion failed: (false), function processDifferentiableFunctionInst, file /Users/danielzheng/swift-build/swift/lib/SILOptimizer/Mandatory/Differentiation.cpp, line 8771.
Stack dump:
0.	Program arguments: /Users/danielzheng/swift-build/build/Ninja-ReleaseAssert+stdlib-Release/swift-macosx-x86_64/bin/swift -frontend -interpret simple_math.swift -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -color-diagnostics -module-name simple_math
1.	Swift version 5.1.1-dev (LLVM 6e04008c7f, Swift ccfec5fc42)
2.	While running pass #24 SILModuleTransform "Differentiation".
3.	While canonicalizing `differentiable_function` SIL node   %18 = differentiable_function [parameters 0] %17 : $@callee_guaranteed (Float, Int) -> Float // users: %22, %19
4.	While ...in SIL function "@main".
```

```
Assertion failed: (false), function VJPEmitter, file /Users/danielzheng/swift-build/swift/lib/SILOptimizer/Mandatory/Differentiation.cpp, line 3348.
Stack dump:
0.	Program arguments: /Users/danielzheng/swift-build/build/Ninja-ReleaseAssert+stdlib-Release/swift-macosx-x86_64/bin/swift -frontend -interpret simple_math.swift -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -color-diagnostics -module-name simple_math
1.	Swift version 5.1.1-dev (LLVM 6e04008c7f, Swift ccfec5fc42)
2.	While running pass #24 SILModuleTransform "Differentiation".
3.	While canonicalizing `differentiable_function` SIL node   %18 = differentiable_function [parameters 0] %17 : $@callee_guaranteed (Float, Int) -> Float // users: %22, %19
4.	While ...in SIL function "@main".
5.	While processing `[differentiable source 0 wrt 0]` attribute on SIL function "@$s11simple_mathS2f_SitcfU_".
 for expression at [simple_math.swift:5:25 - line:5:48] RangeText="{ x, y in x + Float(y) "
6.	While generating VJP for SIL function "@$s11simple_mathS2f_SitcfU_".
 for expression at [simple_math.swift:5:25 - line:5:48] RangeText="{ x, y in x + Float(y) "
```

---

@pschuh mentioned this enhancement months ago. 🙂