### PR TITLE
Disable objc_mangling and SwiftObjectNSObject test for watchOS (56959…

### DIFF
--- a/test/Interpreter/SDK/objc_mangling.swift
+++ b/test/Interpreter/SDK/objc_mangling.swift
@@ -6,6 +6,9 @@
 
 // REQUIRES: objc_interop
 
+// rdar://problem/56959761
+// UNSUPPORTED: OS=watchos
+
 import Foundation
 
 /* FIXME: SwiftObject doesn't support -description

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -21,6 +21,9 @@
 
 // REQUIRES: objc_interop
 
+// rdar://problem/56959761
+// UNSUPPORTED: OS=watchos
+
 import Foundation
 
 class C { 


### PR DESCRIPTION
…761)
