### PR TITLE
Register a Deleter for the Global TypeChecker Harder This Time

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -56,7 +56,7 @@ TypeChecker &TypeChecker::createForContext(ASTContext &ctx) {
          "Cannot install more than one instance of the global type checker!");
   auto *TC = new TypeChecker(ctx);
   ctx.installGlobalTypeChecker(TC);
-  ctx.addDestructorCleanup(TC);
+  ctx.addCleanup([=](){ delete TC; });
   return *ctx.getLegacyGlobalTypeChecker();
 }
 


### PR DESCRIPTION
My first go at this merely called the destructor.  It did not free the
memory allocation associated with the instance.