### PR TITLE
Update checkout for tensorflow/swift-apis.

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -29,7 +29,7 @@ list(APPEND swift_stdlib_compile_flags "-force-single-frontend-invocation")
 # FIXME(SR-7972): Some tests fail when TensorFlow is optimized.
 # list(APPEND swift_stdlib_compile_flags "-O" "-whole-module-optimization")
 list(APPEND swift_stdlib_compile_flags "-Onone")
-list(APPEND swift_stdlib_compile_flags "-DCOMPILING_TENSORFLOW_MODULE")
+list(APPEND swift_stdlib_compile_flags "-DCOMPILING_TENSORFLOW_STDLIB_MODULE")
 
 set(SOURCES "")
 

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -267,7 +267,7 @@
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",
                 "tensorflow": "7c7d924821a8b1b20433c2f3f484bbd409873a84",
-                "tensorflow-swift-apis": "e70b979b7a3c2ebd38457b8d4058a0b310b4e4b0",
+                "tensorflow-swift-apis": "1aceb2d801ff8e0cc8eeb15f5c8957f2c9d2e1f7",
                 "tensorflow-swift-quote": "4faabf7b04827b9c522eef15387eea3895eaf001"
             }
         }


### PR DESCRIPTION
tensorflow/swift-apis@1aceb2d

`-DCOMPILING_TENSORFLOW_MODULE` has been renamed to
`-DCOMPILING_TENSORFLOW_STDLIB_MODULE` for clarity.

"STDLIB" emphasizes that the flag is relevant for building the Swift stdlib.

---

Friend PR: https://github.com/tensorflow/swift-apis/pull/546