### PR TITLE
[Long runtime tests] Link the Objective-C runtime.

### DIFF
--- a/unittests/runtime/LongTests/CMakeLists.txt
+++ b/unittests/runtime/LongTests/CMakeLists.txt
@@ -16,6 +16,9 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
 #      ${FOUNDATION_LIBRARY}
 #      swiftStdlibUnittest${SWIFT_PRIMARY_VARIANT_SUFFIX}
 #      )
+
+    # Link the Objective-C runtime.
+    list(APPEND PLATFORM_TARGET_LINK_LIBRARIES "objc")
   elseif(SWIFT_HOST_VARIANT STREQUAL "linux")
     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
       "atomic"


### PR DESCRIPTION
The long-running runtime tests depend on the Objective-C runtime on
Darwin, so link it directly rather than relying on various uses of
`__builtin_available` to link CoreFoundation for us.
