### PR TITLE
Remove some more TypeChecker uses

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3722,7 +3722,7 @@ namespace {
         // If we're performing an assignment to a weak or unowned variable from
         // a constructor call, emit a warning that the instance will be
         // immediately deallocated.
-        diagnoseUnownedImmediateDeallocation(cs.getTypeChecker(), expr);
+        diagnoseUnownedImmediateDeallocation(cs.getASTContext(), expr);
       }
       return expr;
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2151,7 +2151,7 @@ namespace {
       // Make the integer literals for the parameters.
       auto buildExprFromUnsigned = [&](unsigned value) {
         LiteralExpr *expr = IntegerLiteralExpr::createFromUnsigned(ctx, value);
-        cs.setType(expr, cs.getTypeChecker().getIntType(cs.DC));
+        cs.setType(expr, TypeChecker::getIntType(ctx));
         return handleIntegerLiteralExpr(expr);
       };
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2547,10 +2547,7 @@ bool FailureDiagnosis::diagnoseCallContextualConversionErrors(
   if (!contextualType || contextualType->hasUnresolvedType())
     return false;
 
-  auto &TC = CS.TC;
-  auto *DC = CS.DC;
-
-  auto typeCheckExpr = [&](TypeChecker &TC, Expr *expr, DeclContext *DC,
+  auto typeCheckExpr = [&](Expr *expr, DeclContext *DC,
                            SmallPtrSetImpl<TypeBase *> &types) {
     getPossibleTypesOfExpressionWithoutApplying(
         expr, DC, types, FreeTypeVariableBinding::Disallow);
@@ -2560,7 +2557,7 @@ bool FailureDiagnosis::diagnoseCallContextualConversionErrors(
   // see if that's going to produce a type, if so, let's type-check
   // again, this time using given contextual type.
   SmallPtrSet<TypeBase *, 4> withoutContextual;
-  typeCheckExpr(TC, callExpr, DC, withoutContextual);
+  typeCheckExpr(callExpr, CS.DC, withoutContextual);
 
   // If there are no types returned, it means that problem was
   // nothing to do with contextual information, probably parameter/argument

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1533,7 +1533,7 @@ bool TrailingClosureAmbiguityFailure::diagnoseAsNote() {
     auto diag = emitDiagnostic(
         expr->getLoc(), diag::ambiguous_because_of_trailing_closure,
         choicePair.first.empty(), choicePair.second->getFullName());
-    swift::fixItEncloseTrailingClosure(getTypeChecker(), diag, callExpr,
+    swift::fixItEncloseTrailingClosure(getASTContext(), diag, callExpr,
                                        choicePair.first);
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2416,9 +2416,9 @@ bool ContextualFailure::diagnoseThrowsTypeMismatch() const {
 
   // If we tried to throw the error code of an error type, suggest object
   // construction.
-  auto &TC = getTypeChecker();
+  auto &Ctx = getASTContext();
   if (auto errorCodeProtocol =
-          TC.Context.getProtocol(KnownProtocolKind::ErrorCodeProtocol)) {
+          Ctx.getProtocol(KnownProtocolKind::ErrorCodeProtocol)) {
     Type errorCodeType = getFromType();
     auto conformance = TypeChecker::conformsToProtocol(
         errorCodeType, errorCodeProtocol, getDC(),
@@ -2641,11 +2641,8 @@ bool ContextualFailure::trySequenceSubsequenceFixIts(
   if (!getASTContext().getStdlibModule())
     return false;
 
-  auto &TC = getTypeChecker();
-  auto *DC = getDC();
-
-  auto String = TC.getStringType(DC);
-  auto Substring = TC.getSubstringType(DC);
+  auto String = TypeChecker::getStringType(getASTContext());
+  auto Substring = TypeChecker::getSubstringType(getASTContext());
 
   if (!String || !Substring)
     return false;

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -998,7 +998,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // compatibility under Swift 4 mode by ensuring we don't introduce any new
     // ambiguities. This will become a more general "is more specialised" rule
     // in Swift 5 mode.
-    if (!tc.Context.isSwiftVersionAtLeast(5) &&
+    if (!cs.getASTContext().isSwiftVersionAtLeast(5) &&
         choice1.getKind() != OverloadChoiceKind::DeclViaDynamic &&
         choice2.getKind() != OverloadChoiceKind::DeclViaDynamic &&
         isa<VarDecl>(decl1) && isa<VarDecl>(decl2)) {
@@ -1158,7 +1158,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
   // All other things being equal, apply the Swift 4.1 compatibility hack for
   // preferring var members in concrete types over a protocol requirement
   // (see the comment above for the rationale of this hack).
-  if (!tc.Context.isSwiftVersionAtLeast(5) && score1 == score2) {
+  if (!cs.getASTContext().isSwiftVersionAtLeast(5) && score1 == score2) {
     score1 += isVarAndNotProtocol1;
     score2 += isVarAndNotProtocol2;
   }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -255,7 +255,7 @@ void ConstraintLocator::dump(SourceManager *sm) const {
 }
 
 void ConstraintLocator::dump(ConstraintSystem *CS) const {
-  dump(&CS->TC.Context.SourceMgr, llvm::errs());
+  dump(&CS->getASTContext().SourceMgr, llvm::errs());
   llvm::errs() << "\n";
 }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1184,7 +1184,6 @@ private:
   /// to reduce scopes of the overload sets (disjunctions) in the system.
   class Candidate {
     Expr *E;
-    TypeChecker &TC;
     DeclContext *DC;
     llvm::BumpPtrAllocator &Allocator;
 
@@ -1197,7 +1196,7 @@ private:
   public:
     Candidate(ConstraintSystem &cs, Expr *expr, Type ct = Type(),
               ContextualTypePurpose ctp = ContextualTypePurpose::CTP_Unused)
-        : E(expr), TC(cs.TC), DC(cs.DC), Allocator(cs.Allocator), BaseCS(cs),
+        : E(expr), DC(cs.DC), Allocator(cs.Allocator), BaseCS(cs),
           CT(ct), CTP(ctp) {}
 
     /// Return underlying expression.
@@ -3699,12 +3698,12 @@ public:
     if (isExpressionAlreadyTooComplex)
       return true;
 
-    auto used = TC.Context.getSolverMemory();
+    auto used = getASTContext().getSolverMemory();
     for (auto const& s : solutions) {
       used += s.getTotalMemory();
     }
     MaxMemory = std::max(used, MaxMemory);
-    auto threshold = TC.Context.LangOpts.SolverMemoryThreshold;
+    auto threshold = getASTContext().LangOpts.SolverMemoryThreshold;
     if (MaxMemory > threshold) {
       return isExpressionAlreadyTooComplex= true;
     }
@@ -3721,7 +3720,7 @@ public:
 
     // Bail out once we've looked at a really large number of
     // choices.
-    if (CountScopes > TC.Context.LangOpts.SolverBindingThreshold) {
+    if (CountScopes > getASTContext().LangOpts.SolverBindingThreshold) {
       return isExpressionAlreadyTooComplex = true;
     }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2974,7 +2974,7 @@ static void checkSwitch(ASTContext &ctx, const SwitchStmt *stmt) {
   }
 }
 
-void swift::fixItEncloseTrailingClosure(TypeChecker &TC,
+void swift::fixItEncloseTrailingClosure(ASTContext &ctx,
                                         InFlightDiagnostic &diag,
                                         const CallExpr *call,
                                         Identifier closureLabel) {
@@ -3010,7 +3010,7 @@ void swift::fixItEncloseTrailingClosure(TypeChecker &TC,
     replacement += ": ";
   }
 
-  lastLoc = Lexer::getLocForEndOfToken(TC.Context.SourceMgr, lastLoc);
+  lastLoc = Lexer::getLocForEndOfToken(ctx.SourceMgr, lastLoc);
   diag
     .fixItReplaceChars(lastLoc, closureRange.Start, replacement)
     .fixItInsertAfter(closureRange.End, ")");

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -61,8 +61,7 @@ static Expr *isImplicitPromotionToOptional(Expr *E) {
 ///   - Error about collection literals that default to Any collections in
 ///     invalid positions.
 ///
-static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
-                                         const DeclContext *DC,
+static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
                                          bool isExprStmt) {
   class DiagnoseWalker : public ASTWalker {
     SmallPtrSet<Expr*, 4> AlreadyDiagnosedMetatypes;
@@ -77,11 +76,11 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
     bool IsExprStmt;
 
   public:
-    TypeChecker &TC;
+    ASTContext &Ctx;
     const DeclContext *DC;
 
-    DiagnoseWalker(TypeChecker &TC, const DeclContext *DC, bool isExprStmt)
-      : IsExprStmt(isExprStmt), TC(TC), DC(DC) {}
+    DiagnoseWalker(const DeclContext *DC, bool isExprStmt)
+      : IsExprStmt(isExprStmt), Ctx(DC->getASTContext()), DC(DC) {}
 
     // Not interested in going outside a basic expression.
     std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
@@ -226,7 +225,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       if (auto *DAE = dyn_cast<DiscardAssignmentExpr>(E)) {
         if (!CorrectDiscardAssignmentExprs.count(DAE) &&
             !DAE->getType()->hasError())
-          TC.diagnose(DAE->getLoc(), diag::discard_expr_outside_of_assignment);
+          Ctx.Diags.diagnose(DAE->getLoc(),
+                             diag::discard_expr_outside_of_assignment);
       }
 
       // Diagnose 'self.init' or 'super.init' nested in another expression
@@ -235,8 +235,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         if (!Parent.isNull() || !IsExprStmt || DC->getParent()->isLocalContext()) {
           bool isChainToSuper;
           (void)rebindSelfExpr->getCalledConstructor(isChainToSuper);
-          TC.diagnose(E->getLoc(), diag::init_delegation_nested,
-                      isChainToSuper, !IsExprStmt);
+          Ctx.Diags.diagnose(E->getLoc(), diag::init_delegation_nested,
+                             isChainToSuper, !IsExprStmt);
         }
       }
 
@@ -244,8 +244,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       if (auto *tupleExpr = dyn_cast<TupleExpr>(E)) {
         if (!CallArgs.count(tupleExpr)) {
           if (tupleExpr->getNumElements() == 1) {
-            TC.diagnose(tupleExpr->getElementNameLoc(0),
-                        diag::tuple_single_element)
+            Ctx.Diags.diagnose(tupleExpr->getElementNameLoc(0),
+                               diag::tuple_single_element)
               .fixItRemoveChars(tupleExpr->getElementNameLoc(0),
                                 tupleExpr->getElement(0)->getStartLoc());
           }
@@ -283,7 +283,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
           }
 
           if (diagnose) {
-            TC.diagnose(tupleExpr->getLoc(), diag::tuple_duplicate_label);
+            Ctx.Diags.diagnose(tupleExpr->getLoc(),
+                               diag::tuple_duplicate_label);
           }
         }
       }
@@ -387,13 +388,13 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       // produce an error with a fixit to add the type as an explicit
       // annotation.
       if (c->getNumElements() == 0)
-        TC.diagnose(c->getLoc(), diag::collection_literal_empty)
+        Ctx.Diags.diagnose(c->getLoc(), diag::collection_literal_empty)
           .highlight(c->getSourceRange());
       else {
         assert(c->getType()->hasTypeRepr() &&
                "a defaulted type should always be printable");
-        TC.diagnose(c->getLoc(), diag::collection_literal_heterogeneous,
-                    c->getType())
+        Ctx.Diags.diagnose(c->getLoc(), diag::collection_literal_heterogeneous,
+                           c->getType())
           .highlight(c->getSourceRange())
           .fixItInsertAfter(c->getEndLoc(), " as " + c->getType()->getString());
       }
@@ -430,7 +431,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
           return;
       }
 
-      TC.diagnose(E->getStartLoc(), diag::value_of_module_type);
+      Ctx.Diags.diagnose(E->getStartLoc(), diag::value_of_module_type);
     }
 
     // Diagnose metatype values that don't appear as part of a property,
@@ -463,7 +464,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
 
       // Is this a protocol metatype?
 
-      TC.diagnose(E->getStartLoc(), diag::value_of_metatype_type);
+      Ctx.Diags.diagnose(E->getStartLoc(), diag::value_of_metatype_type);
 
       // Add fix-it to insert '()', only if this is a metatype of
       // non-existential type and has any initializers.
@@ -475,13 +476,13 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
             instanceTy->mayHaveMembers() &&
             !TypeChecker::lookupConstructors(const_cast<DeclContext *>(DC),
                                              instanceTy).empty()) {
-          TC.diagnose(E->getEndLoc(), diag::add_parens_to_type)
+          Ctx.Diags.diagnose(E->getEndLoc(), diag::add_parens_to_type)
             .fixItInsertAfter(E->getEndLoc(), "()");
         }
       }
 
       // Add fix-it to insert ".self".
-      auto diag = TC.diagnose(E->getEndLoc(), diag::add_self_to_type);
+      auto diag = Ctx.Diags.diagnose(E->getEndLoc(), diag::add_self_to_type);
       if (E->canAppendPostfixExpression()) {
         diag.fixItInsertAfter(E->getEndLoc(), ".self");
       } else {
@@ -517,13 +518,15 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         declParent = VD->getDeclContext()->getParentModule();
       }
 
-      TC.diagnose(DRE->getLoc(), diag::warn_unqualified_access,
-                  VD->getBaseName().getIdentifier(), VD->getDescriptiveKind(),
-                  declParent->getDescriptiveKind(), declParent->getFullName());
-      TC.diagnose(VD, diag::decl_declared_here, VD->getFullName());
+      Ctx.Diags.diagnose(DRE->getLoc(), diag::warn_unqualified_access,
+                         VD->getBaseName().getIdentifier(),
+                         VD->getDescriptiveKind(),
+                         declParent->getDescriptiveKind(),
+                         declParent->getFullName());
+      Ctx.Diags.diagnose(VD, diag::decl_declared_here, VD->getFullName());
 
       if (VD->getDeclContext()->isTypeContext()) {
-        TC.diagnose(DRE->getLoc(), diag::fix_unqualified_access_member)
+        Ctx.Diags.diagnose(DRE->getLoc(), diag::fix_unqualified_access_member)
           .fixItInsert(DRE->getStartLoc(), "self.");
       }
 
@@ -560,8 +563,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         SmallString<32> namePlusDot = pair.first->getName().str();
         namePlusDot.push_back('.');
 
-        TC.diagnose(DRE->getLoc(), topLevelDiag,
-                    namePlusDot, k, pair.first->getName())
+        Ctx.Diags.diagnose(DRE->getLoc(), topLevelDiag,
+                           namePlusDot, k, pair.first->getName())
           .fixItInsert(DRE->getStartLoc(), namePlusDot);
       }
     }
@@ -572,8 +575,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       // special-case behavior in a closure someday...
       if (TypeChecker::getDeclTypeCheckingSemantics(DRE->getDecl())
             != DeclTypeCheckingSemantics::Normal) {
-        TC.diagnose(DRE->getLoc(), diag::unsupported_special_decl_ref,
-                    DRE->getDecl()->getBaseName().getIdentifier());
+        Ctx.Diags.diagnose(DRE->getLoc(), diag::unsupported_special_decl_ref,
+                           DRE->getDecl()->getBaseName().getIdentifier());
       }
     }
     
@@ -595,7 +598,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
     BitcastableNumberKind getBitcastableNumberKind(Type t) const {
       auto decl = t->getNominalOrBoundGenericNominal();
 #define MATCH_DECL(type) \
-      if (decl == TC.Context.get##type##Decl()) \
+      if (decl == Ctx.get##type##Decl()) \
         return BNK_##type;
       MATCH_DECL(Int8)
       MATCH_DECL(Int16)
@@ -621,7 +624,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
     
     void checkForSuspiciousBitCasts(DeclRefExpr *DRE,
                                     Expr *Parent = nullptr) {
-      if (DRE->getDecl() != TC.Context.getUnsafeBitCast())
+      if (DRE->getDecl() != Ctx.getUnsafeBitCast())
         return;
       
       if (DRE->getDeclRef().getSubstitutions().empty())
@@ -647,15 +650,14 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
           subExpr = args->getElement(0);
           // Determine the fixit range from the start of the application to
           // the first argument, `unsafeBitCast(`
-          removeBeforeRange = CharSourceRange(TC.Context.SourceMgr,
-                                              DRE->getLoc(),
+          removeBeforeRange = CharSourceRange(Ctx.SourceMgr, DRE->getLoc(),
                                               subExpr->getStartLoc());
           // Determine the fixit range from the end of the first argument to
           // the end of the application, `, to: T.self)`
-          removeAfterRange = CharSourceRange(TC.Context.SourceMgr,
-                         Lexer::getLocForEndOfToken(TC.Context.SourceMgr,
+          removeAfterRange = CharSourceRange(Ctx.SourceMgr,
+                         Lexer::getLocForEndOfToken(Ctx.SourceMgr,
                                                     subExpr->getEndLoc()),
-                         Lexer::getLocForEndOfToken(TC.Context.SourceMgr,
+                         Lexer::getLocForEndOfToken(Ctx.SourceMgr,
                                                     apply->getEndLoc()));          
         }
       }
@@ -663,8 +665,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       // Casting to the same type or a superclass is a no-op.
       if (toTy->isEqual(fromTy) ||
           toTy->isExactSuperclassOf(fromTy)) {
-        auto d = TC.diagnose(DRE->getLoc(), diag::bitcasting_is_no_op,
-                             fromTy, toTy);
+        auto d = Ctx.Diags.diagnose(DRE->getLoc(), diag::bitcasting_is_no_op,
+                                    fromTy, toTy);
         if (subExpr) {
           d.fixItRemoveChars(removeBeforeRange.getStart(),
                              removeBeforeRange.getEnd())
@@ -679,14 +681,15 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
           // Casting a nonescaping function to escaping is UB.
           // `withoutActuallyEscaping` ought to be used instead.
           if (fromFnTy->isNoEscape() && !toFnTy->isNoEscape()) {
-            TC.diagnose(DRE->getLoc(), diag::bitcasting_away_noescape,
-                        fromTy, toTy);
+            Ctx.Diags.diagnose(DRE->getLoc(), diag::bitcasting_away_noescape,
+                               fromTy, toTy);
           }
           // Changing function representation (say, to try to force a
           // @convention(c) function pointer to exist) is also unlikely to work.
           if (fromFnTy->getRepresentation() != toFnTy->getRepresentation()) {
-            TC.diagnose(DRE->getLoc(), diag::bitcasting_to_change_function_rep,
-                        fromTy, toTy);
+            Ctx.Diags.diagnose(DRE->getLoc(),
+                               diag::bitcasting_to_change_function_rep, fromTy,
+                               toTy);
           }
           return;
         }
@@ -694,8 +697,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       
       // Unchecked casting to a subclass is better done by unsafeDowncast.
       if (fromTy->isBindableToSuperclassOf(toTy)) {
-        TC.diagnose(DRE->getLoc(), diag::bitcasting_to_downcast,
-                    fromTy, toTy)
+        Ctx.Diags.diagnose(DRE->getLoc(), diag::bitcasting_to_downcast,
+                           fromTy, toTy)
           .fixItReplace(DRE->getNameLoc().getBaseNameLoc(),
                         "unsafeDowncast");
         return;
@@ -711,10 +714,10 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         // normal initializers on the destination type.
         if (toPointee->isEqual(fromPointee)
             || isRawPointerKind(toPTK)) {
-          auto d = TC.diagnose(DRE->getLoc(),
-                         diag::bitcasting_to_change_pointer_kind,
-                         fromTy, toTy,
-                         toTy->getStructOrBoundGenericStruct()->getName());
+          auto d = Ctx.Diags.diagnose(DRE->getLoc(),
+                              diag::bitcasting_to_change_pointer_kind,
+                              fromTy, toTy,
+                              toTy->getStructOrBoundGenericStruct()->getName());
           if (subExpr) {
             StringRef before, after;
             switch (toPTK) {
@@ -756,9 +759,9 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         // Casting to a different typed pointer type should use
         // withMemoryRebound.
         if (!isRawPointerKind(fromPTK) && !isRawPointerKind(toPTK)) {
-          TC.diagnose(DRE->getLoc(),
-                      diag::bitcasting_to_change_pointee_type,
-                      fromTy, toTy);
+          Ctx.Diags.diagnose(DRE->getLoc(),
+                             diag::bitcasting_to_change_pointee_type,
+                             fromTy, toTy);
           return;
         }
         
@@ -766,9 +769,9 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         // (or assume it's already bound).
         assert(isRawPointerKind(fromPTK) && !isRawPointerKind(toPTK)
                && "unhandled cast combo?!");
-        TC.diagnose(DRE->getLoc(),
-                    diag::bitcasting_to_give_type_to_raw_pointer,
-                    fromTy, toTy);
+        Ctx.Diags.diagnose(DRE->getLoc(),
+                           diag::bitcasting_to_give_type_to_raw_pointer,
+                           fromTy, toTy);
         if (subExpr) {
           SmallString<64> fixitBuf;
           {
@@ -777,9 +780,9 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
             toPointee->print(os);
             os << ".self)";
           }
-          TC.diagnose(DRE->getLoc(),
-                      diag::bitcast_assume_memory_rebound,
-                      toPointee)
+          Ctx.Diags.diagnose(DRE->getLoc(),
+                             diag::bitcast_assume_memory_rebound,
+                             toPointee)
             .fixItRemoveChars(removeBeforeRange.getStart(),
                               removeBeforeRange.getEnd())
             .fixItReplaceChars(removeAfterRange.getStart(),
@@ -792,9 +795,9 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
             toPointee->print(os);
             os << ".self, capacity: <""#capacity#"">)";
           }
-          TC.diagnose(DRE->getLoc(),
-                      diag::bitcast_bind_memory,
-                      toPointee)
+          Ctx.Diags.diagnose(DRE->getLoc(),
+                             diag::bitcast_bind_memory,
+                             toPointee)
             .fixItRemoveChars(removeBeforeRange.getStart(),
                               removeBeforeRange.getEnd())
             .fixItReplaceChars(removeAfterRange.getStart(),
@@ -1071,7 +1074,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       }
       
       if (diagID) {
-        auto d = TC.diagnose(DRE->getLoc(), *diagID, fromTy, toTy);
+        auto d = Ctx.Diags.diagnose(DRE->getLoc(), *diagID, fromTy, toTy);
         if (subExpr) {
           d.fixItReplaceChars(removeBeforeRange.getStart(),
                               removeBeforeRange.getEnd(),
@@ -1104,7 +1107,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
 
       // First case -- Optional.none
       if (auto DRE = dyn_cast<DeclRefExpr>(CE->getSemanticFn()))
-        return DRE->getDecl() == TC.Context.getOptionalNoneDecl();
+        return DRE->getDecl() == Ctx.getOptionalNoneDecl();
 
       return false;
     }
@@ -1139,8 +1142,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       Expr *subExpr = nullptr;
       if (calleeName == "??" &&
           (subExpr = isImplicitPromotionToOptional(lhs))) {
-        TC.diagnose(DRE->getLoc(), diag::use_of_qq_on_non_optional_value,
-                    subExpr->getType())
+        Ctx.Diags.diagnose(DRE->getLoc(), diag::use_of_qq_on_non_optional_value,
+                           subExpr->getType())
           .highlight(lhs->getSourceRange())
           .fixItRemove(SourceRange(DRE->getLoc(), rhs->getEndLoc()));
         return;
@@ -1154,8 +1157,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
              (subExpr = isImplicitPromotionToOptional(rhs)))) {
           bool isTrue = calleeName == "!=" || calleeName == "!==";
               
-          TC.diagnose(DRE->getLoc(), diag::nonoptional_compare_to_nil,
-                      subExpr->getType(), isTrue)
+          Ctx.Diags.diagnose(DRE->getLoc(), diag::nonoptional_compare_to_nil,
+                             subExpr->getType(), isTrue)
             .highlight(lhs->getSourceRange())
             .highlight(rhs->getSourceRange());
           return;
@@ -1164,7 +1167,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
     }
   };
 
-  DiagnoseWalker Walker(TC, DC, isExprStmt);
+  DiagnoseWalker Walker(DC, isExprStmt);
   const_cast<Expr *>(E)->walk(Walker);
 
   // Diagnose uses of collection literals with defaulted types at the top
@@ -1180,8 +1183,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
 
 
 /// Diagnose recursive use of properties within their own accessors
-static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
-                                        const DeclContext *DC) {
+static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
   auto fn = dyn_cast<AccessorDecl>(DC);
   if (!fn)
     return;
@@ -1191,14 +1193,13 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
     return;
 
   class DiagnoseWalker : public ASTWalker {
-    TypeChecker &TC;
+    ASTContext &Ctx;
     VarDecl *Var;
     const AccessorDecl *Accessor;
 
   public:
-    explicit DiagnoseWalker(TypeChecker &TC, VarDecl *var,
-                            const AccessorDecl *Accessor)
-      : TC(TC), Var(var), Accessor(Accessor) {}
+    explicit DiagnoseWalker(VarDecl *var, const AccessorDecl *Accessor)
+      : Ctx(var->getASTContext()), Var(var), Accessor(Accessor) {}
 
     /// Return true if this is an implicit reference to self.
     static bool isImplicitSelfUse(Expr *E) {
@@ -1249,8 +1250,9 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
               shouldDiagnose = false;
 
             if (shouldDiagnose) {
-              TC.diagnose(subExpr->getLoc(), diag::recursive_accessor_reference,
-                          Var->getName(), Accessor->isSetter());
+              Ctx.Diags.diagnose(subExpr->getLoc(),
+                                 diag::recursive_accessor_reference,
+                                 Var->getName(), Accessor->isSetter());
             }
           }
           
@@ -1259,7 +1261,8 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
           if (isStore &&
               DRE->getAccessSemantics() == AccessSemantics::DirectToStorage &&
               Accessor->getAccessorKind() == AccessorKind::WillSet) {
-            TC.diagnose(E->getLoc(), diag::store_in_willset, Var->getName());
+            Ctx.Diags.diagnose(E->getLoc(), diag::store_in_willset,
+                               Var->getName());
           }
         }
 
@@ -1281,10 +1284,11 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
               shouldDiagnose = isStore;
 
             if (shouldDiagnose) {
-              TC.diagnose(subExpr->getLoc(), diag::recursive_accessor_reference,
-                          Var->getName(), Accessor->isSetter());
-              TC.diagnose(subExpr->getLoc(),
-                          diag::recursive_accessor_reference_silence)
+              Ctx.Diags.diagnose(subExpr->getLoc(),
+                                 diag::recursive_accessor_reference,
+                                 Var->getName(), Accessor->isSetter());
+              Ctx.Diags.diagnose(subExpr->getLoc(),
+                                 diag::recursive_accessor_reference_silence)
               .fixItInsert(subExpr->getStartLoc(), "self.");
             }
           }
@@ -1294,8 +1298,8 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
           if (isStore &&
               MRE->getAccessSemantics() == AccessSemantics::DirectToStorage &&
               Accessor->getAccessorKind() == AccessorKind::WillSet) {
-              TC.diagnose(subExpr->getLoc(), diag::store_in_willset,
-                          Var->getName());
+            Ctx.Diags.diagnose(subExpr->getLoc(), diag::store_in_willset,
+                               Var->getName());
           }
         }
 
@@ -1305,7 +1309,7 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
     }
   };
 
-  DiagnoseWalker walker(TC, var, fn);
+  DiagnoseWalker walker(var, fn);
   const_cast<Expr *>(E)->walk(walker);
 }
 
@@ -1313,14 +1317,14 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
 /// Within a closure, we require that the source code contain "self." explicitly
 /// because 'self' is captured, not the property value.  This is a common source
 /// of confusion, so we force an explicit self.
-static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
+static void diagnoseImplicitSelfUseInClosure(const Expr *E,
                                              const DeclContext *DC) {
   class DiagnoseWalker : public ASTWalker {
-    TypeChecker &TC;
+    ASTContext &Ctx;
     unsigned InClosure;
   public:
-    explicit DiagnoseWalker(TypeChecker &TC, bool isAlreadyInClosure)
-        : TC(TC), InClosure(isAlreadyInClosure) {}
+    explicit DiagnoseWalker(ASTContext &ctx, bool isAlreadyInClosure)
+        : Ctx(ctx), InClosure(isAlreadyInClosure) {}
 
     /// Return true if this is an implicit reference to self.
     static bool isImplicitSelfUse(Expr *E) {
@@ -1376,11 +1380,13 @@ static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
       // closure, then reject it as requiring an explicit "self." qualifier.  We
       // do this in explicit closures, not autoclosures, because otherwise the
       // transparence of autoclosures is lost.
+      auto &Diags = Ctx.Diags;
       if (auto *MRE = dyn_cast<MemberRefExpr>(E))
         if (isImplicitSelfUse(MRE->getBase())) {
-          TC.diagnose(MRE->getLoc(),
-                      diag::property_use_in_closure_without_explicit_self,
-                      MRE->getMember().getDecl()->getBaseName().getIdentifier())
+          auto baseName = MRE->getMember().getDecl()->getBaseName();
+          Diags.diagnose(MRE->getLoc(),
+                         diag::property_use_in_closure_without_explicit_self,
+                         baseName.getIdentifier())
             .fixItInsert(MRE->getLoc(), "self.");
           return { false, E };
         }
@@ -1390,16 +1396,16 @@ static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
         if (isImplicitSelfUse(DSCE->getBase()) &&
             isa<DeclRefExpr>(DSCE->getFn())) {
           auto MethodExpr = cast<DeclRefExpr>(DSCE->getFn());
-          TC.diagnose(DSCE->getLoc(),
-                      diag::method_call_in_closure_without_explicit_self,
-                      MethodExpr->getDecl()->getBaseName().getIdentifier())
-            .fixItInsert(DSCE->getLoc(), "self.");
+          Diags.diagnose(DSCE->getLoc(),
+                         diag::method_call_in_closure_without_explicit_self,
+                         MethodExpr->getDecl()->getBaseName().getIdentifier())
+              .fixItInsert(DSCE->getLoc(), "self.");
           return { false, E };
         }
 
       // Catch any other implicit uses of self with a generic diagnostic.
       if (isImplicitSelfUse(E))
-        TC.diagnose(E->getLoc(), diag::implicit_use_of_self_in_closure);
+        Diags.diagnose(E->getLoc(), diag::implicit_use_of_self_in_closure);
 
       return { true, E };
     }
@@ -1425,7 +1431,8 @@ static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
       DC = DC->getParent();
     }
   }
-  const_cast<Expr *>(E)->walk(DiagnoseWalker(TC, isAlreadyInClosure));
+  auto &ctx = DC->getASTContext();
+  const_cast<Expr *>(E)->walk(DiagnoseWalker(ctx, isAlreadyInClosure));
 }
 
 bool TypeChecker::getDefaultGenericArgumentsString(
@@ -3135,7 +3142,7 @@ parseObjCSelector(ASTContext &ctx, StringRef string) {
 namespace {
 
 class ObjCSelectorWalker : public ASTWalker {
-  TypeChecker &TC;
+  ASTContext &Ctx;
   const DeclContext *DC;
   Type SelectorTy;
 
@@ -3181,8 +3188,8 @@ class ObjCSelectorWalker : public ASTWalker {
   }
 
 public:
-  ObjCSelectorWalker(TypeChecker &tc, const DeclContext *dc, Type selectorTy)
-    : TC(tc), DC(dc), SelectorTy(selectorTy) { }
+  ObjCSelectorWalker(const DeclContext *dc, Type selectorTy)
+    : Ctx(dc->getASTContext()), DC(dc), SelectorTy(selectorTy) { }
 
   bool shouldWalkIntoNonSingleExpressionClosure() override { return false; }
 
@@ -3231,7 +3238,7 @@ public:
       if (argNames.size() != 1) return { true, expr };
 
       // Is this the init(stringLiteral:) initializer or init(_:) initializer?
-      if (argNames[0] == TC.Context.Id_stringLiteral)
+      if (argNames[0] == Ctx.Id_stringLiteral)
         fromStringLiteral = true;
       else if (!argNames[0].empty())
         return { true, expr };
@@ -3282,7 +3289,7 @@ public:
       if (auto coerce = getParentCoercion()) {
         // If the string literal was coerced to Selector, replace the
         // coercion with the ")".
-        SourceLoc endLoc = Lexer::getLocForEndOfToken(TC.Context.SourceMgr,
+        SourceLoc endLoc = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
                                                       expr->getEndLoc());
         diag.fixItReplace(SourceRange(endLoc, coerce->getEndLoc()), ")");
       } else {
@@ -3293,10 +3300,10 @@ public:
 
     // Try to parse the string literal as an Objective-C selector, and complain
     // if it isn't one.
-    auto selector = parseObjCSelector(TC.Context, stringLiteral->getValue());
+    auto selector = parseObjCSelector(Ctx, stringLiteral->getValue());
     if (!selector) {
-      auto diag = TC.diagnose(stringLiteral->getLoc(),
-                              diag::selector_literal_invalid);
+      auto diag = Ctx.Diags.diagnose(stringLiteral->getLoc(),
+                                     diag::selector_literal_invalid);
       diag.highlight(stringLiteral->getSourceRange());
       addSelectorConstruction(diag);
       return { true, expr };
@@ -3314,9 +3321,9 @@ public:
         return { true, expr };
 
       {
-        auto diag = TC.diagnose(stringLiteral->getLoc(),
-                                diag::selector_literal_undeclared,
-                                *selector);
+        auto diag = Ctx.Diags.diagnose(stringLiteral->getLoc(),
+                                       diag::selector_literal_undeclared,
+                                       *selector);
         addSelectorConstruction(diag);
       }
 
@@ -3324,8 +3331,8 @@ public:
       // separate note that suggests wrapping the selector in
       // parentheses to silence the warning.
       if (!fromStringLiteral) {
-        TC.diagnose(stringLiteral->getLoc(),
-                    diag::selector_construction_suppress_warning)
+        Ctx.Diags.diagnose(stringLiteral->getLoc(),
+                           diag::selector_construction_suppress_warning)
           .fixItInsert(stringLiteral->getStartLoc(), "(")
           .fixItInsertAfter(stringLiteral->getEndLoc(), ")");
       }
@@ -3450,18 +3457,20 @@ public:
       if (auto coerce = getParentCoercion())
         replacementRange.End = coerce->getEndLoc();
 
-      TC.diagnose(expr->getLoc(),
-                  fromStringLiteral ? diag::selector_literal_deprecated_suggest
-                                    : diag::selector_construction_suggest)
-        .fixItReplace(replacementRange, replacement);
+      Ctx.Diags
+          .diagnose(expr->getLoc(),
+                    fromStringLiteral
+                        ? diag::selector_literal_deprecated_suggest
+                        : diag::selector_construction_suggest)
+          .fixItReplace(replacementRange, replacement);
       return { true, expr };
     }
 
     // If we couldn't pick a method to use for #selector, just wrap
     // the string literal in Selector(...).
     if (fromStringLiteral) {
-      auto diag = TC.diagnose(stringLiteral->getLoc(),
-                              diag::selector_literal_deprecated);
+      auto diag = Ctx.Diags.diagnose(stringLiteral->getLoc(),
+                                     diag::selector_literal_deprecated);
       addSelectorConstruction(diag);
       return { true, expr };
     }
@@ -3472,12 +3481,12 @@ public:
 };
 } // end anonymous namespace
 
-static void diagDeprecatedObjCSelectors(TypeChecker &tc, const DeclContext *dc,
+static void diagDeprecatedObjCSelectors(const DeclContext *dc,
                                         const Expr *expr) {
   auto selectorTy = dc->getASTContext().getSelectorType();
   if (!selectorTy) return;
 
-  const_cast<Expr *>(expr)->walk(ObjCSelectorWalker(tc, dc, selectorTy));
+  const_cast<Expr *>(expr)->walk(ObjCSelectorWalker(dc, selectorTy));
 }
 
         
@@ -3521,13 +3530,13 @@ checkImplicitPromotionsInCondition(const StmtConditionElement &cond,
   }
 }
 
-static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
+static void diagnoseUnintendedOptionalBehavior(const Expr *E,
                                                const DeclContext *DC) {
   if (!E || isa<ErrorExpr>(E) || !E->getType())
     return;
 
   class UnintendedOptionalBehaviorWalker : public ASTWalker {
-    TypeChecker &TC;
+    ASTContext &Ctx;
     SmallPtrSet<Expr *, 16> IgnoredExprs;
 
     class OptionalToAnyCoercion {
@@ -3610,8 +3619,8 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
       coercionString += " as ";
       coercionString += destType->getWithoutParens()->getString();
 
-      TC.diagnose(E->getLoc(), diag::silence_optional_to_any,
-                  destType, coercionString.substr(1))
+      Ctx.Diags.diagnose(E->getLoc(), diag::silence_optional_to_any,
+                         destType, coercionString.substr(1))
         .highlight(E->getSourceRange())
         .fixItInsertAfter(E->getEndLoc(), coercionString);
     }
@@ -3664,7 +3673,7 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
 
       // Do not warn on coercions from implicitly unwrapped optionals
       // for Swift versions less than 5.
-      if (!TC.Context.isSwiftVersionAtLeast(5) &&
+      if (!Ctx.isSwiftVersionAtLeast(5) &&
           hasImplicitlyUnwrappedResult(subExpr))
         return;
 
@@ -3684,25 +3693,26 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
       // diagnostic
       if (hasImplicitlyUnwrappedResult(subExpr)) {
         if (auto decl = getDeclForImplicitlyUnwrappedExpr(subExpr)) {
-          TC.diagnose(subExpr->getStartLoc(), diag::iuo_to_any_coercion,
-                      /* from */ srcType, /* to */ destType)
+          Ctx.Diags.diagnose(subExpr->getStartLoc(), diag::iuo_to_any_coercion,
+                             /* from */ srcType, /* to */ destType)
               .highlight(subExpr->getSourceRange());
 
           auto noteDiag = isa<FuncDecl>(decl)
                               ? diag::iuo_to_any_coercion_note_func_result
                               : diag::iuo_to_any_coercion_note;
 
-          TC.diagnose(decl->getLoc(), noteDiag, decl->getDescriptiveKind(),
-                      decl->getFullName());
+          Ctx.Diags.diagnose(decl->getLoc(), noteDiag,
+                             decl->getDescriptiveKind(), decl->getFullName());
         }
       } else {
-        TC.diagnose(subExpr->getStartLoc(), diag::optional_to_any_coercion,
-                    /* from */ srcType, /* to */ destType)
+        Ctx.Diags.diagnose(subExpr->getStartLoc(),
+                           diag::optional_to_any_coercion,
+                           /* from */ srcType, /* to */ destType)
             .highlight(subExpr->getSourceRange());
       }
       
       if (optionalityDifference == 1) {
-        TC.diagnose(subExpr->getLoc(), diag::default_optional_to_any)
+        Ctx.Diags.diagnose(subExpr->getLoc(), diag::default_optional_to_any)
             .highlight(subExpr->getSourceRange())
             .fixItInsertAfter(subExpr->getEndLoc(), " ?? <#default value#>");
       }
@@ -3711,7 +3721,7 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
       for (size_t i = 0; i < optionalityDifference; i++)
         forceUnwrapString += "!";
 
-      TC.diagnose(subExpr->getLoc(), diag::force_optional_to_any)
+      Ctx.Diags.diagnose(subExpr->getLoc(), diag::force_optional_to_any)
         .highlight(subExpr->getSourceRange())
         .fixItInsertAfter(subExpr->getEndLoc(), forceUnwrapString);
 
@@ -3737,8 +3747,8 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
 
       auto subExpr = E->getSubExpr();
 
-      TC.diagnose(subExpr->getStartLoc(), diag::optional_to_any_coercion,
-                  /* from */ subExpr->getType(), /* to */ E->getType())
+      Ctx.Diags.diagnose(subExpr->getStartLoc(), diag::optional_to_any_coercion,
+                         /* from */ subExpr->getType(), /* to */ E->getType())
         .highlight(subExpr->getSourceRange());
 
       emitSilenceOptionalAnyWarningWithCoercion(subExpr, E->getType());
@@ -3770,7 +3780,7 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
     };
 
     void visitInterpolatedStringLiteralExpr(InterpolatedStringLiteralExpr *E) {
-      E->forEachSegment(TC.Context,
+      E->forEachSegment(Ctx,
           [&](bool isInterpolation, CallExpr *segment) -> void {
         if (isInterpolation) {
           diagnoseIfUnintendedInterpolation(segment,
@@ -3861,22 +3871,25 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
     }
 
     void diagnoseUnintendedInterpolation(Expr * arg, UnintendedInterpolationKind kind) {
-      TC.diagnose(arg->getStartLoc(),
-                  diag::debug_description_in_string_interpolation_segment,
-                  (bool)kind)
-        .highlight(arg->getSourceRange());
+      Ctx.Diags
+          .diagnose(arg->getStartLoc(),
+                    diag::debug_description_in_string_interpolation_segment,
+                    (bool)kind)
+          .highlight(arg->getSourceRange());
 
       // Suggest 'String(describing: <expr>)'.
       auto argStart = arg->getStartLoc();
-      TC.diagnose(arg->getLoc(),
-                  diag::silence_debug_description_in_interpolation_segment_call)
-        .highlight(arg->getSourceRange())
-        .fixItInsert(argStart, "String(describing: ")
-        .fixItInsertAfter(arg->getEndLoc(), ")");
+      Ctx.Diags
+          .diagnose(
+              arg->getLoc(),
+              diag::silence_debug_description_in_interpolation_segment_call)
+          .highlight(arg->getSourceRange())
+          .fixItInsert(argStart, "String(describing: ")
+          .fixItInsertAfter(arg->getEndLoc(), ")");
 
       if (kind == UnintendedInterpolationKind::Optional) {
         // Suggest inserting a default value.
-        TC.diagnose(arg->getLoc(), diag::default_optional_to_any)
+        Ctx.Diags.diagnose(arg->getLoc(), diag::default_optional_to_any)
           .highlight(arg->getSourceRange())
           .fixItInsertAfter(arg->getEndLoc(), " ?? <#default value#>");
       }
@@ -3907,20 +3920,20 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
     }
 
   public:
-    UnintendedOptionalBehaviorWalker(TypeChecker &tc) : TC(tc) { }
+    UnintendedOptionalBehaviorWalker(ASTContext &ctx) : Ctx(ctx) { }
   };
 
-  UnintendedOptionalBehaviorWalker Walker(TC);
+  UnintendedOptionalBehaviorWalker Walker(DC->getASTContext());
   const_cast<Expr *>(E)->walk(Walker);
 }
 
-static void diagnoseDeprecatedWritableKeyPath(TypeChecker &TC, const Expr *E,
+static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
                                               const DeclContext *DC) {
   if (!E || isa<ErrorExpr>(E) || !E->getType())
     return;
 
   class DeprecatedWritableKeyPathWalker : public ASTWalker {
-    TypeChecker &TC;
+    ASTContext &Ctx;
     const DeclContext *DC;
 
     void visitKeyPathApplicationExpr(KeyPathApplicationExpr *E) {
@@ -3935,8 +3948,8 @@ static void diagnoseDeprecatedWritableKeyPath(TypeChecker &TC, const Expr *E,
 
       if (auto *keyPathExpr = dyn_cast<KeyPathExpr>(E->getKeyPath())) {
         auto *decl = keyPathExpr->getType()->getNominalOrBoundGenericNominal();
-        if (decl != TC.Context.getWritableKeyPathDecl() &&
-            decl != TC.Context.getReferenceWritableKeyPathDecl())
+        if (decl != Ctx.getWritableKeyPathDecl() &&
+            decl != Ctx.getReferenceWritableKeyPathDecl())
           return;
 
         assert(keyPathExpr->getComponents().size() > 0);
@@ -3946,9 +3959,9 @@ static void diagnoseDeprecatedWritableKeyPath(TypeChecker &TC, const Expr *E,
             cast<AbstractStorageDecl>(component.getDeclRef().getDecl());
           if (!storage->isSettable(nullptr) ||
               !storage->isSetterAccessibleFrom(DC)) {
-            TC.diagnose(keyPathExpr->getLoc(),
-                        swift::diag::expr_deprecated_writable_keypath,
-                        storage->getFullName());
+            Ctx.Diags.diagnose(keyPathExpr->getLoc(),
+                               swift::diag::expr_deprecated_writable_keypath,
+                               storage->getFullName());
           }
         }
       }
@@ -3969,11 +3982,11 @@ static void diagnoseDeprecatedWritableKeyPath(TypeChecker &TC, const Expr *E,
     }
 
   public:
-    DeprecatedWritableKeyPathWalker(TypeChecker &TC, const DeclContext *DC)
-        : TC(TC), DC(DC) {}
+    DeprecatedWritableKeyPathWalker(const DeclContext *DC)
+        : Ctx(DC->getASTContext()), DC(DC) {}
   };
 
-  DeprecatedWritableKeyPathWalker Walker(TC, DC);
+  DeprecatedWritableKeyPathWalker Walker(DC);
   const_cast<Expr *>(E)->walk(Walker);
 }
 
@@ -3982,20 +3995,21 @@ static void diagnoseDeprecatedWritableKeyPath(TypeChecker &TC, const Expr *E,
 //===----------------------------------------------------------------------===//
 
 /// Emit diagnostics for syntactic restrictions on a given expression.
-void swift::performSyntacticExprDiagnostics(TypeChecker &TC, const Expr *E,
+void swift::performSyntacticExprDiagnostics(const Expr *E,
                                             const DeclContext *DC,
                                             bool isExprStmt) {
+  auto &ctx = DC->getASTContext();
   TypeChecker::diagnoseSelfAssignment(E);
-  diagSyntacticUseRestrictions(TC, E, DC, isExprStmt);
-  diagRecursivePropertyAccess(TC, E, DC);
-  diagnoseImplicitSelfUseInClosure(TC, E, DC);
-  diagnoseUnintendedOptionalBehavior(TC, E, DC);
-  if (!TC.Context.isSwiftVersionAtLeast(5))
-    diagnoseDeprecatedWritableKeyPath(TC, E, DC);
-  if (!TC.getLangOpts().DisableAvailabilityChecking)
+  diagSyntacticUseRestrictions(E, DC, isExprStmt);
+  diagRecursivePropertyAccess(E, DC);
+  diagnoseImplicitSelfUseInClosure(E, DC);
+  diagnoseUnintendedOptionalBehavior(E, DC);
+  if (!ctx.isSwiftVersionAtLeast(5))
+    diagnoseDeprecatedWritableKeyPath(E, DC);
+  if (!ctx.LangOpts.DisableAvailabilityChecking)
     diagAvailability(E, const_cast<DeclContext*>(DC));
-  if (TC.Context.LangOpts.EnableObjCInterop)
-    diagDeprecatedObjCSelectors(TC, DC, E);
+  if (ctx.LangOpts.EnableObjCInterop)
+    diagDeprecatedObjCSelectors(DC, E);
 }
 
 void swift::performStmtDiagnostics(ASTContext &ctx, const Stmt *S) {

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -40,7 +40,7 @@ void performSyntacticExprDiagnostics(TypeChecker &TC, const Expr *E,
                                      bool isExprStmt);
 
 /// Emit diagnostics for a given statement.
-void performStmtDiagnostics(TypeChecker &TC, const Stmt *S);
+void performStmtDiagnostics(ASTContext &ctx, const Stmt *S);
 
 void performAbstractFuncDeclDiagnostics(AbstractFunctionDecl *AFD,
                                         BraceStmt *body);

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -42,12 +42,11 @@ void performSyntacticExprDiagnostics(TypeChecker &TC, const Expr *E,
 /// Emit diagnostics for a given statement.
 void performStmtDiagnostics(TypeChecker &TC, const Stmt *S);
 
-void performAbstractFuncDeclDiagnostics(TypeChecker &TC,
-                                        AbstractFunctionDecl *AFD,
+void performAbstractFuncDeclDiagnostics(AbstractFunctionDecl *AFD,
                                         BraceStmt *body);
 
 /// Perform diagnostics on the top level code declaration.
-void performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl *TLCD);
+void performTopLevelDeclDiagnostics(TopLevelCodeDecl *TLCD);
   
 /// Emit a fix-it to set the access of \p VD to \p desiredAccess.
 ///

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -101,7 +101,7 @@ bool computeFixitsForOverridenDeclaration(
     llvm::function_ref<Optional<InFlightDiagnostic>(bool)> diag);
 
 /// Emit fix-its to enclose trailing closure in argument parens.
-void fixItEncloseTrailingClosure(TypeChecker &TC,
+void fixItEncloseTrailingClosure(ASTContext &ctx,
                                  InFlightDiagnostic &diag,
                                  const CallExpr *call,
                                  Identifier closureLabel);

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -35,8 +35,7 @@ namespace swift {
   class ValueDecl;
 
 /// Emit diagnostics for syntactic restrictions on a given expression.
-void performSyntacticExprDiagnostics(TypeChecker &TC, const Expr *E,
-                                     const DeclContext *DC,
+void performSyntacticExprDiagnostics(const Expr *E, const DeclContext *DC,
                                      bool isExprStmt);
 
 /// Emit diagnostics for a given statement.

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -75,13 +75,13 @@ bool diagnoseArgumentLabelError(ASTContext &ctx,
 /// with a non-owning attribute, such as 'weak' or 'unowned' and the initializer
 /// expression refers to a class constructor, emit a warning that the assigned
 /// instance will be immediately deallocated.
-void diagnoseUnownedImmediateDeallocation(TypeChecker &TC,
+void diagnoseUnownedImmediateDeallocation(ASTContext &ctx,
                                           const AssignExpr *assignExpr);
 
 /// If \p pattern binds to a declaration with a non-owning attribute, such as
 /// 'weak' or 'unowned' and \p initializer refers to a class constructor,
 /// emit a warning that the bound instance will be immediately deallocated.
-void diagnoseUnownedImmediateDeallocation(TypeChecker &TC,
+void diagnoseUnownedImmediateDeallocation(ASTContext &ctx,
                                           const Pattern *pattern,
                                           SourceLoc equalLoc,
                                           const Expr *initializer);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2285,7 +2285,7 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   if (!cs.shouldSuppressDiagnostics() &&
       !options.contains(TypeCheckExprFlags::DisableStructuralChecks)) {
     bool isExprStmt = options.contains(TypeCheckExprFlags::IsExprStmt);
-    performSyntacticExprDiagnostics(*this, result, dc, isExprStmt);
+    performSyntacticExprDiagnostics(result, dc, isExprStmt);
   }
 
   expr = result;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2600,9 +2600,9 @@ public:
         // If we're performing an binding to a weak or unowned variable from a
         // constructor call, emit a warning that the instance will be immediately
         // deallocated.
-        diagnoseUnownedImmediateDeallocation(TC, PBD->getPattern(i),
-                                              PBD->getEqualLoc(i),
-                                              init);
+        diagnoseUnownedImmediateDeallocation(Ctx, PBD->getPattern(i),
+                                             PBD->getEqualLoc(i),
+                                             init);
 
         // If we entered an initializer context, contextualize any
         // auto-closures we might have created.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2178,7 +2178,7 @@ TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
 
   // If nothing went wrong yet, perform extra checking.
   if (!hadError && endTypeCheckLoc.isInvalid())
-    performAbstractFuncDeclDiagnostics(tc, AFD, body);
+    performAbstractFuncDeclDiagnostics(AFD, body);
 
   // Wire up the function body now.
   AFD->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
@@ -2228,5 +2228,5 @@ void TypeChecker::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   StmtChecker(*this, TLCD).typeCheckStmt(Body);
   TLCD->setBody(Body);
   checkTopLevelErrorHandling(TLCD);
-  performTopLevelDeclDiagnostics(*this, TLCD);
+  performTopLevelDeclDiagnostics(TLCD);
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -410,7 +410,7 @@ public:
     if (S2 == nullptr)
       return true;
     S = S2;
-    performStmtDiagnostics(TC, S);
+    performStmtDiagnostics(getASTContext(), S);
     return false;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -375,35 +375,35 @@ Type TypeChecker::getOptionalType(SourceLoc loc, Type elementType) {
   return OptionalType::get(elementType);
 }
 
-Type TypeChecker::getStringType(DeclContext *dc) {
+Type TypeChecker::getStringType(ASTContext &Context) {
   if (auto typeDecl = Context.getStringDecl())
     return typeDecl->getDeclaredInterfaceType();
 
   return Type();
 }
 
-Type TypeChecker::getSubstringType(DeclContext *dc) {
+Type TypeChecker::getSubstringType(ASTContext &Context) {
   if (auto typeDecl = Context.getSubstringDecl())
     return typeDecl->getDeclaredInterfaceType();
 
   return Type();
 }
 
-Type TypeChecker::getIntType(DeclContext *dc) {
+Type TypeChecker::getIntType(ASTContext &Context) {
   if (auto typeDecl = Context.getIntDecl())
     return typeDecl->getDeclaredInterfaceType();
 
   return Type();
 }
 
-Type TypeChecker::getInt8Type(DeclContext *dc) {
+Type TypeChecker::getInt8Type(ASTContext &Context) {
   if (auto typeDecl = Context.getInt8Decl())
     return typeDecl->getDeclaredInterfaceType();
 
   return Type();
 }
 
-Type TypeChecker::getUInt8Type(DeclContext *dc) {
+Type TypeChecker::getUInt8Type(ASTContext &Context) {
   if (auto typeDecl = Context.getUInt8Decl())
     return typeDecl->getDeclaredInterfaceType();
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -599,7 +599,8 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
-  TypeChecker &TC = createTypeChecker(Ctx);
+  assert(Ctx.getLegacyGlobalTypeChecker() &&
+         "Should have a TypeChecker registered");
   return TypeChecker::validateType(Ctx, T, resolution, options);
 }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -600,7 +600,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
   TypeChecker &TC = createTypeChecker(Ctx);
-  return TypeChecker::validateType(TC.Context, T, resolution, options);
+  return TypeChecker::validateType(Ctx, T, resolution, options);
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -723,11 +723,11 @@ public:
   static Type getArraySliceType(SourceLoc loc, Type elementType);
   static Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);
   static Type getOptionalType(SourceLoc loc, Type elementType);
-  Type getStringType(DeclContext *dc);
-  Type getSubstringType(DeclContext *dc);
-  Type getIntType(DeclContext *dc);
-  Type getInt8Type(DeclContext *dc);
-  Type getUInt8Type(DeclContext *dc);
+  static Type getStringType(ASTContext &ctx);
+  static Type getSubstringType(ASTContext &ctx);
+  static Type getIntType(ASTContext &ctx);
+  static Type getInt8Type(ASTContext &ctx);
+  static Type getUInt8Type(ASTContext &ctx);
 
   /// Try to resolve an IdentTypeRepr, returning either the referenced
   /// Type or an ErrorType in case of error.


### PR DESCRIPTION
This PR removes uses of TypeChecker from MiscDiagnostics as well as a bunch of cases from the constraint system, cherry-picked from https://github.com/apple/swift/commit/413cb3f29f9208c0ad54132ad304b40d5091ef62. It also removes an unnecessary call to `createTypeChecker` from `performTypeLocChecking`.