### PR TITLE
[IDE] Fix CursorInfo crash on arg label when the called 'function' is actually a module decl.

### DIFF
--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -267,6 +267,12 @@ bool CursorInfoResolver::visitCallArgName(Identifier Name,
                                           ValueDecl *D) {
   if (isDone())
     return false;
+
+  // Handle invalid code where the called decl isn't actually callable, so this
+  // argument label doesn't really refer to it.
+  if (isa<ModuleDecl>(D))
+    return true;
+
   bool Found = tryResolve(D, nullptr, nullptr, Range.getStart(), /*IsRef=*/true);
   if (Found)
     CursorInfo.IsKeywordArgument = true;

--- a/test/SourceKit/CursorInfo/cursor_invalid.swift
+++ b/test/SourceKit/CursorInfo/cursor_invalid.swift
@@ -22,6 +22,8 @@ func ==(x: C, y: C)
 
 func resyncParser2() {}
 
+Swift(label: 3)
+
 // RUN: %sourcekitd-test -req=cursor -pos=4:13 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: source.lang.swift.decl.var.local (4:13-4:14)
 // CHECK1: c
@@ -59,3 +61,5 @@ func resyncParser2() {}
 
 // RUN: %sourcekitd-test -req=cursor -pos=21:6 %s -- %s | %FileCheck -check-prefix=EQEQ3 %s
 // EQEQ3: <decl.function.operator.infix><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>== </decl.name>(<decl.var.parameter><decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr="s:14cursor_invalid1CC">C</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>y</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr="s:14cursor_invalid1CC">C</ref.class></decl.var.parameter.type></decl.var.parameter>)</decl.function.operator.infix>
+
+// RUN: %sourcekitd-test -req=cursor -pos=25:7 %s -- %s | %FileCheck -check-prefix=DIAG %s


### PR DESCRIPTION
This fixes the crash @johnno1962 reported in https://github.com/apple/swift/pull/28051