### PR TITLE
[MiscDiagnostics] Diagnose passing a non-@objc dynamic KeyPath property to KVO observe

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4540,6 +4540,9 @@ WARNING(variable_never_mutated, none,
 WARNING(variable_never_read, none,
         "variable %0 was written to, but never read",
         (Identifier))
+WARNING(observe_keypath_property_not_objc_dynamic, none,
+        "passing reference to non-'@objc dynamic' property %0 to KVO method %1 "
+        "may lead to unexpected behavior or runtime trap", (DeclName, DeclName))
 
 //------------------------------------------------------------------------------
 // MARK: Debug diagnostics

--- a/test/expr/primary/keypath/keypath-observe-objc.swift
+++ b/test/expr/primary/keypath/keypath-observe-objc.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: objc_interop
+
+import Foundation
+
+class Foo: NSObject {
+  var number1 = 1
+  dynamic var number2 = 2
+  @objc var number3 = 3
+  @objc dynamic var number4 = 4
+}
+
+class Bar: NSObject {
+  @objc dynamic let foo: Foo
+  
+  init(foo: Foo) {
+    self.foo = foo
+    super.init()
+    
+    _ = observe(\.foo.number1, options: [.new]) { _, change in
+      // expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number1' to KVO method 'observe(_:options:changeHandler:)' may lead to unexpected behavior or runtime trap}}
+      print("observer1")
+    }
+    
+    _ = observe(\.foo.number2, options: [.new]) { _, change in
+      // expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number2' to KVO method 'observe(_:options:changeHandler:)' may lead to unexpected behavior or runtime trap}}
+      print("observer2")
+    }
+    
+    _ = observe(\.foo.number3, options: [.new]) { _, change in
+      // expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number3' to KVO method 'observe(_:options:changeHandler:)' may lead to unexpected behavior or runtime trap}}
+      print("observer3")
+    }
+    
+    _ = observe(\.foo.number4, options: [.new]) { _, change in // Okay
+      print("observer4")
+    }
+  }
+}


### PR DESCRIPTION
Passing a KeyPath to a property which is not marked `@objc dynamic` to the KVO observe method can cause unexpected behavior or a runtime trap.

Resolves [SR-5115](https://bugs.swift.org/browse/SR-5115)
Resolves [SR-5159](https://bugs.swift.org/browse/SR-5159)
Resolves [SR-5177](https://bugs.swift.org/browse/SR-5177)
Resolves rdar://problem/32593787
Resolves rdar://problem/32775952