### PR TITLE
[Constant Evaluator] Make symbolic closures store the substitution map that maps captured argument types to the types of their symbolic values .

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -18,9 +18,9 @@
 #ifndef SWIFT_SIL_CONSTANTS_H
 #define SWIFT_SIL_CONSTANTS_H
 
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/Support/CommandLine.h"
-
 
 namespace swift {
 class SingleValueInstruction;
@@ -572,6 +572,7 @@ public:
   static SymbolicValue makeClosure(
       SILFunction *target,
       ArrayRef<std::pair<SILValue, Optional<SymbolicValue>>> capturedArguments,
+      SubstitutionMap substMap, SILType closureType,
       SymbolicValueAllocator &allocator);
 
   SymbolicClosure *getClosure() const {
@@ -680,19 +681,29 @@ private:
   // The number of SIL values captured by the closure.
   unsigned numCaptures;
 
-  // True iff there exists captured arguments whose constant value is not known.
+  // True iff there exists a captured argument whose constant value is not
+  // known.
   bool hasNonConstantCaptures = true;
+
+  // A substitution map that partially maps the generic paramters of the
+  // applied function to the generic arguments of passed to the call.
+  SubstitutionMap substitutionMap;
+
+  SILType closureType;
 
   SymbolicClosure() = delete;
   SymbolicClosure(const SymbolicClosure &) = delete;
   SymbolicClosure(SILFunction *callee, unsigned numArguments,
+                  SubstitutionMap substMap, SILType closureType,
                   bool nonConstantCaptures)
       : target(callee), numCaptures(numArguments),
-        hasNonConstantCaptures(nonConstantCaptures) {}
+        hasNonConstantCaptures(nonConstantCaptures), substitutionMap(substMap),
+        closureType(closureType) {}
 
 public:
   static SymbolicClosure *create(SILFunction *callee,
                                  ArrayRef<SymbolicClosureArgument> args,
+                                 SubstitutionMap substMap, SILType closureType,
                                  SymbolicValueAllocator &allocator);
 
   ArrayRef<SymbolicClosureArgument> getCaptures() const {
@@ -707,6 +718,10 @@ public:
   SILFunction *getTarget() {
     return target;
   }
+
+  SILType getClosureType() { return closureType; }
+
+  SubstitutionMap getCallSubstitutionMap() { return substitutionMap; }
 };
 
 } // end namespace swift


### PR DESCRIPTION
Make symbolic closures, which are representations of closure literals in the constant evaluator, store the substitution map that was in the constant evaluator state when the closure creation site (partial_apply or thin_to_thick_function) that created the symbolic closure was evaluated.

A substitution map is a mapping from generic type parameters to types. This map is updated and maintained by the constant evaluator as it evaluates function calls. At a partial-application site, the substitution map captures the mapping from the types of the captured arguments (which
could be generic types) to the types of the symbolic value they represent (which has to be concrete types). The substitution map would be necessary to fold the symbolic closure into SIL code that constructs the closure it represents. 