### PR TITLE
Remove The Defined Functions List

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1127,8 +1127,8 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     // synthesized, it will be synthesized.
     auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
     auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
-    if (!evaluateTargetConformanceTo(decodableProto)) {
-      (void)evaluateTargetConformanceTo(encodableProto);
+    if (!evaluateTargetConformanceTo(encodableProto)) {
+      (void)evaluateTargetConformanceTo(decodableProto);
     }
   }
     break;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -736,16 +736,16 @@ static void checkRedeclaration(ASTContext &ctx, ValueDecl *current) {
     if (!conflicting(currentSig, otherSig))
       continue;
 
-    // Skip invalid declarations.
-    if (other->isInvalid())
-      continue;
-
     // Skip declarations in other files.
     // In practice, this means we will warn on a private declaration that
     // shadows a non-private one, but only in the file where the shadowing
     // happens. We will warn on conflicting non-private declarations in both
     // files.
     if (!other->isAccessibleFrom(currentDC))
+      continue;
+    
+    // Skip invalid declarations.
+    if (other->isInvalid())
       continue;
 
     // Thwart attempts to override the same declaration more than once.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3237,8 +3237,9 @@ public:
     } else if (shouldSkipBodyTypechecking(FD)) {
       FD->setBodySkipped(FD->getBodySourceRange());
     } else {
-      // Record the body.
-      TC.definedFunctions.push_back(FD);
+      TypeChecker::typeCheckAbstractFunctionBody(FD);
+
+      TC.ClosuresWithUncomputedCaptures.push_back(FD);
     }
 
     checkExplicitAvailability(FD);
@@ -3567,7 +3568,9 @@ public:
     } else if (shouldSkipBodyTypechecking(CD)) {
       CD->setBodySkipped(CD->getBodySourceRange());
     } else {
-      TC.definedFunctions.push_back(CD);
+      TypeChecker::typeCheckAbstractFunctionBody(CD);
+
+      TC.ClosuresWithUncomputedCaptures.push_back(CD);
     }
 
     checkDefaultArguments(CD->getParameters());
@@ -3584,7 +3587,9 @@ public:
     } else {
       // FIXME: Remove TypeChecker dependency.
       auto &TC = *Ctx.getLegacyGlobalTypeChecker();
-      TC.definedFunctions.push_back(DD);
+      TypeChecker::typeCheckAbstractFunctionBody(DD);
+
+      TC.ClosuresWithUncomputedCaptures.push_back(DD);
     }
   }
 };

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -293,31 +293,11 @@ static void bindExtensions(SourceFile &SF) {
 }
 
 static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) {
-  unsigned currentFunctionIdx = 0;
-  do {
-    // Type check the body of each of the function in turn.  Note that outside
-    // functions must be visited before nested functions for type-checking to
-    // work correctly.
-    for (unsigned n = TC.definedFunctions.size(); currentFunctionIdx != n;
-         ++currentFunctionIdx) {
-      auto *AFD = TC.definedFunctions[currentFunctionIdx];
-      assert(!AFD->getDeclContext()->isLocalContext());
-
-      TypeChecker::typeCheckAbstractFunctionBody(AFD);
-    }
-  } while (currentFunctionIdx < TC.definedFunctions.size());
-
   // Compute captures for functions and closures we visited.
-  for (auto *closure : TC.ClosuresWithUncomputedCaptures) {
+  for (auto closure : llvm::reverse(TC.ClosuresWithUncomputedCaptures)) {
     TypeChecker::computeCaptures(closure);
   }
   TC.ClosuresWithUncomputedCaptures.clear();
-
-  for (AbstractFunctionDecl *FD : llvm::reverse(TC.definedFunctions)) {
-    TypeChecker::computeCaptures(FD);
-  }
-
-  TC.definedFunctions.clear();
 }
 
 void swift::typeCheckExternalDefinitions(SourceFile &SF) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -534,12 +534,9 @@ enum class CheckedCastContextKind {
 /// type checking, and semantic analysis to produce a type-annotated AST.
 class TypeChecker final {
 public:
-  /// The list of function definitions we've encountered.
-  std::vector<AbstractFunctionDecl *> definedFunctions;
-
   /// A list of closures for the most recently type-checked function, which we
   /// will need to compute captures for.
-  std::vector<AbstractClosureExpr *> ClosuresWithUncomputedCaptures;
+  std::vector<AnyFunctionRef> ClosuresWithUncomputedCaptures;
 
 private:
   ASTContext &Context;

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -343,3 +343,7 @@ extension LazyFilterSequence {
     }
   }
 }
+
+extension LazyFilterSequence where Base: Collection {
+  public typealias Indices = DefaultIndices<LazyFilterSequence<Base>>
+}

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -137,6 +137,9 @@ extension LazySequenceProtocol where Element: Sequence {
 public typealias FlattenCollection<T: Collection> = FlattenSequence<T> where T.Element: Collection
 
 extension FlattenSequence where Base: Collection, Base.Element: Collection {
+  public typealias SubSequence = Slice<FlattenSequence<Base>>
+  public typealias Indices = DefaultIndices<FlattenSequence<Base>>
+
   /// A position in a FlattenCollection
   @frozen // lazy-performance
   public struct Index {

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -149,6 +149,10 @@ extension LazyPrefixWhileCollection {
   }
 }
 
+extension LazyPrefixWhileSequence where Base: Collection {
+  public typealias Indices = DefaultIndices<LazyPrefixWhileSequence<Base>>
+}
+
 // FIXME: should work on the typealias
 extension LazyPrefixWhileSequence.Index: Comparable where Base: Collection {
   @inlinable // lazy-performance

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -113,12 +113,10 @@ struct Generic<T> { // expected-note {{'T' declared as parameter to type 'Generi
 }
 
 protocol P { // expected-note {{'P' previously declared here}}
-  // expected-note@-1 {{did you mean 'P'?}}
   typealias a = Generic
 }
 
 protocol P {} // expected-error {{invalid redeclaration of 'P'}}
-// expected-note@-1 {{did you mean 'P'?}}
 
 func hasTypo() {
   _ = P.a.a // expected-error {{type 'Generic<T>' has no member 'a'}}
@@ -173,7 +171,7 @@ class CircularValidationWithTypo {
 // Crash with invalid extension that has not been bound -- https://bugs.swift.org/browse/SR-8984
 protocol PP {}
 
-func boo() {
+func boo() { // expected-note {{did you mean 'boo'?}}
   extension PP { // expected-error {{declaration is only valid at file scope}}
     func g() {
       booo() // expected-error {{use of unresolved identifier 'booo'}}
@@ -215,7 +213,7 @@ protocol P2 {
 }
 
 extension P2 {
-  func f() { // expected-note {{did you mean 'f'?}}
+  func f() {
     _ = a // expected-error {{use of unresolved identifier 'a'}}
   }
 }

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -499,31 +499,31 @@ struct SR_10084_S {
 }
 
 enum SR_10084_E {
-  case foo(SR_10084_S) // expected-note {{'foo' previously declared here}}
+  case foo(SR_10084_S) // expected-note {{'foo' previously declared here}} expected-note 3 {{found this candidate}}
     
   static func foo(_ name: String) -> SR_10084_E { // Okay
-    return .foo(SR_10084_S(name: name))
+    return .foo(SR_10084_S(name: name)) // expected-error {{ambiguous use of 'foo'}}
   }
 
   func foo(_ name: Bool) -> SR_10084_E { // Okay
-    return .foo(SR_10084_S(name: "Test"))
+    return .foo(SR_10084_S(name: "Test")) // expected-error {{ambiguous use of 'foo'}}
   }
 
-  static func foo(_ value: SR_10084_S) -> SR_10084_E { // expected-error {{invalid redeclaration of 'foo'}}
-    return .foo(value)
+  static func foo(_ value: SR_10084_S) -> SR_10084_E { // expected-error {{invalid redeclaration of 'foo'}} expected-note 3 {{found this candidate}}
+    return .foo(value) // expected-error {{ambiguous use of 'foo'}}
   }
 }
 
 enum SR_10084_E_1 {
   static func foo(_ name: String) -> SR_10084_E_1 { // Okay
-    return .foo(SR_10084_S(name: name))
+    return .foo(SR_10084_S(name: name))  // expected-error {{ambiguous use of 'foo'}}
   }
 
-  static func foo(_ value: SR_10084_S) -> SR_10084_E_1 { // expected-note {{'foo' previously declared here}}
-    return .foo(value)
+  static func foo(_ value: SR_10084_S) -> SR_10084_E_1 { // expected-note {{'foo' previously declared here}} expected-note 2 {{found this candidate}}
+    return .foo(value)  // expected-error {{ambiguous use of 'foo'}}
   }
 
-  case foo(SR_10084_S) // expected-error {{invalid redeclaration of 'foo'}}
+  case foo(SR_10084_S) // expected-error {{invalid redeclaration of 'foo'}} expected-note 2 {{found this candidate}}
 }
 
 enum SR_10084_E_2 {

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -407,7 +407,7 @@ var x23: Int, x24: Int { // expected-error{{'var' declarations with multiple var
 
 var x25: Int { // expected-error{{'var' declarations with multiple variables cannot have explicit getters/setters}}
   return 42
-}, x26: Int // expected-warning{{variable 'x26' was never used; consider replacing with '_' or removing it}}
+}, x26: Int
 
 // Properties of struct/enum/extensions
 struct S {


### PR DESCRIPTION
Turns out we can do this now! This exposed a *bunch* of cursed behavior, including:

- Closure capture computation order affecting the type of declarations
- `ContextualizeClosures` fighting `RecontextualizeClosures` - which is a thing now
- `Encodable` being forced at some point after `Decodable` failed being a relied-upon behavior to force `CodingKeys` to exist
- Redeclaration checking for multiple primaries affecting the way we typecheck things, in turn affecting the kinds of dependency edges we record depending on the order of primaries at the command line
- Some, but not all, sequences in stdlib that document `Indices` existing for `BidirectionalCollection` bases actually expose `Indices` for mere `Collection`s.  Whoops.

I'd like somebody from stdlib to look over the changes there, and especially give me a hand documenting these things if this is the right fix.