### PR TITLE
EscapeAnalysis: rework graph update and merge algorithms

### DIFF
--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -99,8 +99,8 @@ bb0(%0 : $Int):
 // CHECK-NEXT:    Con %0.1 Esc: A, Succ: %2
 // CHECK-NEXT:    Arg %1 Esc: G, Succ:
 // CHECK-NEXT:    Val %2 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: A, Succ: (%2.2)
-// CHECK-NEXT:    Con %2.2 Esc: G, Succ: %1
+// CHECK-NEXT:    Con %2.1 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: G, Succ: %1
 // CHECK-NEXT:  End
 sil @test_simple : $@convention(thin) (@inout Y, @owned X) -> () {
 bb0(%0 : $*Y, %1 : $X):
@@ -120,8 +120,8 @@ bb0(%0 : $*Y, %1 : $X):
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%3.1)
 // CHECK-NEXT:    Arg %1 Esc: A, Succ:
 // CHECK-NEXT:    Val %3 Esc: %3, Succ: (%3.1), %0
-// CHECK-NEXT:    Con %3.1 Esc: A, Succ: (%3.2)
-// CHECK-NEXT:    Con %3.2 Esc: A, Succ: %1
+// CHECK-NEXT:    Con %3.1 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con %4 Esc: A, Succ: %1
 // CHECK-NEXT:    Ret Esc: R, Succ: %0
 // CHECK-NEXT:  End
 sil @deferringEdge : $@convention(thin) (@owned LinkedNode, @owned LinkedNode) -> @owned LinkedNode {
@@ -151,12 +151,12 @@ bb0:
 // CHECK-LABEL: CG of test_linked_list
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%1.1)
 // CHECK-NEXT:    Val %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%11.1)
+// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: A, Succ: %0, %1, %4
 // CHECK-NEXT:    Val %4 Esc: A, Succ: (%1.1)
 // CHECK-NEXT:    Val %7 Esc: %11, Succ: (%1.1)
-// CHECK-NEXT:    Val %11 Esc: %11, Succ: (%1.1), %7, %11.1
-// CHECK-NEXT:    Con %11.1 Esc: A, Succ: (%1.1), %0, %1, %4
-// CHECK-NEXT:    Ret Esc: R, Succ: %11.1
+// CHECK-NEXT:    Val %11 Esc: %11, Succ: (%1.1), %2, %7
+// CHECK-NEXT:    Ret Esc: R, Succ: %2
 // CHECK-NEXT:  End
 sil @test_linked_list : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -186,11 +186,11 @@ bb2:
 // CHECK-LABEL: CG of create_chain
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%7.1)
 // CHECK-NEXT:    Val %1 Esc: A, Succ: (%7.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: %0, %1, %4
 // CHECK-NEXT:    Val %4 Esc: A, Succ: (%7.1)
 // CHECK-NEXT:    Val %7 Esc: %11, Succ: (%7.1)
-// CHECK-NEXT:    Con %7.1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Val %11 Esc: R, Succ: (%7.1), %1.1
+// CHECK-NEXT:    Con %7.1 Esc: A, Succ: (%8)
+// CHECK-NEXT:    Con %8 Esc: A, Succ: %0, %1, %4
+// CHECK-NEXT:    Val %11 Esc: R, Succ: (%7.1), %8
 // CHECK-NEXT:    Ret Esc: R, Succ: %11
 // CHECK-NEXT:  End
 sil @create_chain : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -212,10 +212,10 @@ bb0(%0 : $LinkedNode):
 
 // CHECK-LABEL: CG of loadNext
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Val %2 Esc: %2, Succ: (%2.1), %0, %2.2
-// CHECK-NEXT:    Con %2.1 Esc: A, Succ: (%2.2)
-// CHECK-NEXT:    Con %2.2 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Ret Esc: R, Succ: %2.2
+// CHECK-NEXT:    Val %2 Esc: %2, Succ: (%2.1), %0, %3
+// CHECK-NEXT:    Con %2.1 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:    Ret Esc: R, Succ: %3
 // CHECK-NEXT:  End
 sil @loadNext : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -252,13 +252,13 @@ bb0(%0 : $LinkedNode):
 
 // CHECK-LABEL: CG of load_next3
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.3)
-// CHECK-NEXT:    Con %0.3 Esc: A, Succ: (%0.4)
-// CHECK-NEXT:    Con %0.4 Esc: A, Succ: (%0.5)
-// CHECK-NEXT:    Con %0.5 Esc: A, Succ: (%0.6)
-// CHECK-NEXT:    Con %0.6 Esc: A, Succ:
-// CHECK-NEXT:    Ret Esc: R, Succ: %0.6
+// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%1)
+// CHECK-NEXT:    Con %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con %4 Esc: A, Succ: (%5)
+// CHECK-NEXT:    Con %5 Esc: A, Succ:
+// CHECK-NEXT:    Ret Esc: R, Succ: %5
 // CHECK-NEXT:  End
 sil @load_next3 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -278,9 +278,9 @@ sil_global @global_x : $X
 
 // CHECK-LABEL: CG of call_store_pointer
 // CHECK-NEXT:    Arg %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ:
-// CHECK-NEXT:    Ret Esc: R, Succ: %0.2
+// CHECK-NEXT:    Con %0.1 Esc: G, Succ: (%5)
+// CHECK-NEXT:    Con %5 Esc: G, Succ:
+// CHECK-NEXT:    Ret Esc: R, Succ: %5
 // CHECK-NEXT:  End
 sil @call_store_pointer : $@convention(thin) (@owned Pointer) -> @owned X {
 bb0(%0 : $Pointer):
@@ -311,10 +311,10 @@ bb0(%0 : $Pointer):
 
 // CHECK-LABEL: CG of store_content
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ:
+// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%3)
 // CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ: %0.2
+// CHECK-NEXT:    Con %1.1 Esc: G, Succ: %3
+// CHECK-NEXT:    Con %3 Esc: G, Succ:
 // CHECK-NEXT:  End
 sil  @store_content : $@convention(thin) (@owned Pointer) -> () {
 bb0(%0 : $Pointer):
@@ -329,9 +329,9 @@ bb0(%0 : $Pointer):
 
 // CHECK-LABEL: CG of call_store_content
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ:
-// CHECK-NEXT:    Ret Esc: R, Succ: %0.2
+// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con %4 Esc: G, Succ:
+// CHECK-NEXT:    Ret Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @call_store_content : $@convention(thin) (@owned Pointer) -> @owned X {
 bb0(%0 : $Pointer):
@@ -405,12 +405,12 @@ sil @call_copy_addr_content : $@convention(thin) () -> () {
 
 // CHECK-LABEL: CG of test_partial_apply
 // CHECK-NEXT:    Arg %1 Esc: G, Succ:
-// CHECK-NEXT:    Arg %2 Esc: A, Succ: (%6.3)
+// CHECK-NEXT:    Arg %2 Esc: A, Succ: (%7.1)
 // CHECK-NEXT:    Val %3 Esc: %14,%15,%17, Succ: (%6.1)
 // CHECK-NEXT:    Val %6 Esc: %14,%15,%16, Succ: (%6.1)
-// CHECK-NEXT:    Con %6.1 Esc: %14,%15,%16,%17, Succ: (%6.2)
-// CHECK-NEXT:    Con %6.2 Esc: %14,%15,%16,%17, Succ: %2
-// CHECK-NEXT:    Con %6.3 Esc: G, Succ:
+// CHECK-NEXT:    Con %6.1 Esc: %14,%15,%16,%17, Succ: (%7)
+// CHECK-NEXT:    Con %7 Esc: %14,%15,%16,%17, Succ: %2
+// CHECK-NEXT:    Con %7.1 Esc: G, Succ:
 // CHECK-NEXT:    Val %12 Esc: %14,%15, Succ: %3, %6
 // CHECK-NEXT:  End
 sil @test_partial_apply : $@convention(thin) (Int64, @owned X, @owned Y) -> Int64 {
@@ -460,10 +460,10 @@ bb0(%0 : $X, %1 : $<τ_0_0> { var τ_0_0 } <Int64>, %2 : $<τ_0_0> { var τ_0_0 
 // CHECK-LABEL: CG of closure2
 // CHECK-NEXT:    Arg %0 Esc: G, Succ:
 // CHECK-NEXT:    Arg %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: A, Succ: (%1.3)
-// CHECK-NEXT:    Con %1.3 Esc: G, Succ: (%1.4)
-// CHECK-NEXT:    Con %1.4 Esc: G, Succ: %0
+// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: G, Succ: (%4)
+// CHECK-NEXT:    Con %4 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @closure2 : $@convention(thin) (@owned X, @owned <τ_0_0> { var τ_0_0 } <Y>) -> () {
 bb0(%0 : $X, %1 : $<τ_0_0> { var τ_0_0 } <Y>):
@@ -565,9 +565,9 @@ sil_global @global_ln : $LinkedNode
 
 // CHECK-LABEL: CG of load_next_recursive
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ:
-// CHECK-NEXT:    Val %4 Esc: G, Succ: %0.2
+// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%1)
+// CHECK-NEXT:    Con %1 Esc: G, Succ:
+// CHECK-NEXT:    Val %4 Esc: G, Succ: %1
 // CHECK-NEXT:    Ret Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @load_next_recursive : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -580,8 +580,8 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of let_escape
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ:
+// CHECK-NEXT:    Arg %0 Esc: G, Succ:
+// CHECK-NEXT:    Con %0.1 Esc: G, Succ: 
 // CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
 // CHECK-NEXT:    Con %1.1 Esc: G, Succ: %0
 // CHECK-NEXT:    Val %4 Esc: G, Succ: %0
@@ -621,11 +621,11 @@ bb2(%5 : $LinkedNode):
 
 // CHECK-LABEL: CG of loadNext2
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.3)
-// CHECK-NEXT:    Con %0.3 Esc: A, Succ: (%0.4)
-// CHECK-NEXT:    Con %0.4 Esc: A, Succ: (%4.1)
-// CHECK-NEXT:    Val %4 Esc: R, Succ: %0.4
+// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%1)
+// CHECK-NEXT:    Con %1 Esc: A, Succ: (%1.1)
+// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%1.2)
+// CHECK-NEXT:    Con %1.2 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Val %4 Esc: R, Succ: %1.2, %4.2
 // CHECK-NEXT:    Con %4.1 Esc: A, Succ: (%4.2)
 // CHECK-NEXT:    Con %4.2 Esc: A, Succ: (%4.1)
 // CHECK-NEXT:    Ret Esc: R, Succ: %4
@@ -641,12 +641,12 @@ bb0(%0 : $LinkedNode):
 
 // CHECK-LABEL: CG of returnNext2
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.3)
-// CHECK-NEXT:    Con %0.3 Esc: A, Succ: (%0.4)
-// CHECK-NEXT:    Con %0.4 Esc: A, Succ: (%0.3)
-// CHECK-NEXT:    Val %3 Esc: R, Succ: (%0.3), %0.4
-// CHECK-NEXT:    Val %8 Esc: R, Succ: %0.2, %3
+// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%5)
+// CHECK-NEXT:    Val %3 Esc: R, Succ: (%5.1), %5.2
+// CHECK-NEXT:    Con %5 Esc: A, Succ: (%5.1)
+// CHECK-NEXT:    Con %5.1 Esc: A, Succ: (%5.2)
+// CHECK-NEXT:    Con %5.2 Esc: A, Succ: (%5.1)
+// CHECK-NEXT:    Val %8 Esc: R, Succ: %3, %5
 // CHECK-NEXT:    Ret Esc: R, Succ: %8
 // CHECK-NEXT:  End
 sil @returnNext2 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -670,10 +670,10 @@ bb3(%8 : $LinkedNode):
 // A single-cycle recursion test.
 
 // CHECK-LABEL: CG of single_cycle_recursion
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Val %5 Esc: R, Succ: (%0.2), %0.1
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:    Con %2 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:    Con %2.1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Val %5 Esc: R, Succ: (%2.1), %2
 // CHECK-NEXT:    Val %7 Esc: R, Succ: %0, %5
 // CHECK-NEXT:    Ret  Esc: R, Succ: %7
 // CHECK-NEXT:  End
@@ -758,11 +758,11 @@ sil @unknown_throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error 
 // Test that the deinit of a box itself does not capture anything.
 
 // CHECK-LABEL: CG of test_release_of_partial_apply_with_box
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%1.3)
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%2.1)
 // CHECK-NEXT:    Val %1 Esc: %6, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: %6, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: %6, Succ: %0
-// CHECK-NEXT:    Con %1.3 Esc: G, Succ:
+// CHECK-NEXT:    Con %1.1 Esc: %6, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: %6, Succ: %0
+// CHECK-NEXT:    Con %2.1 Esc: G, Succ:
 // CHECK-NEXT:    Val %5 Esc: %6, Succ: %1
 // CHECK-NEXT:  End
 sil @test_release_of_partial_apply_with_box : $@convention(thin) (@owned Y) -> () {
@@ -784,8 +784,8 @@ sil @take_y_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Y>) -> ()
 // CHECK-LABEL: CG of store_to_unknown_reference
 // CHECK-NEXT:    Arg %0 Esc: G, Succ:
 // CHECK-NEXT:    Val %2 Esc: G, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: G, Succ: (%2.2)
-// CHECK-NEXT:    Con %2.2 Esc: G, Succ: %0
+// CHECK-NEXT:    Con %2.1 Esc: G, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @store_to_unknown_reference : $@convention(thin) (@owned X) -> () {
 bb0(%0 : $X):
@@ -833,8 +833,8 @@ bb0:
 // CHECK-LABEL: CG of create_and_store_x
 // CHECK-NEXT:    Val %0 Esc: G, Succ:
 // CHECK-NEXT:    Val %2 Esc: G, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: G, Succ: (%2.2)
-// CHECK-NEXT:    Con %2.2 Esc: G, Succ: %0
+// CHECK-NEXT:    Con %2.1 Esc: G, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @create_and_store_x : $@convention(thin) () -> () {
 bb0:
@@ -850,9 +850,10 @@ bb0:
 // Test types which are considered as pointers.
 
 // CHECK-LABEL: CG of pointer_types
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: %1
+// CHECK-NEXT:    Arg %0 Esc: A, Succ:
 // CHECK-NEXT:    Arg %1 Esc: A, Succ:
-// CHECK-NEXT:    Val %7 Esc: R, Succ: %0
+// CHECK-NEXT:    Val %4 Esc: R, Succ: %0, %1
+// CHECK-NEXT:    Val %7 Esc: R, Succ: %4
 // CHECK-NEXT:    Ret Esc: R, Succ: %7
 // CHECK-NEXT:  End
 sil @pointer_types : $@convention(thin) (@owned Y, @owned Y) -> @owned Y {
@@ -871,11 +872,11 @@ bb1(%7 : $(Pointer, Pointer)):
 
 // CHECK-LABEL: CG of defer_edge_cycle
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: %1.1
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.3)
-// CHECK-NEXT:    Con %0.3 Esc: A, Succ:
+// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%2), %1.1
 // CHECK-NEXT:    Arg %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%0.2), %0.1
+// CHECK-NEXT:    Con %1.1 Esc: A, Succ: %0.1
+// CHECK-NEXT:    Con %2 Esc: A, Succ: (%6)
+// CHECK-NEXT:    Con %6 Esc: A, Succ:
 // CHECK-NEXT:  End
 sil @defer_edge_cycle : $@convention(thin) (@inout Y, @inout Y) -> () {
 entry(%0 : $*Y, %1 : $*Y):
@@ -968,8 +969,8 @@ bb0(%0 : $Builtin.Int64, %1 : $X, %2 : $X, %3 : $X):
 // CHECK-LABEL: CG of test_existential_addr
 // CHECK-NEXT:    Arg %0 Esc: A, Succ:
 // CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: , Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: , Succ: %0
+// CHECK-NEXT:    Con %1.1 Esc: , Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @test_existential_addr : $@convention(thin) (@owned Pointer) -> () {
 bb0(%0 : $Pointer):
@@ -1073,10 +1074,11 @@ bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
 sil_global @global_y : $SomeData
 
 // CHECK-LABEL: CG of test_node_merge_during_struct_inst
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: (%4.1)
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%4.1)
 // CHECK-NEXT:    Val %1 Esc: G, Succ: (%4.1)
-// CHECK-NEXT:    Val %4 Esc: G, Succ: (%4.1)
-// CHECK-NEXT:    Con %4.1 Esc: G, Succ: (%4.1), %0, %1, %4
+// CHECK-NEXT:    Val %4 Esc: , Succ: (%4.1)
+// CHECK-NEXT:    Con %4.1 Esc: G, Succ: (%4.1), %1
+// CHECK-NEXT:    Val %10 Esc: , Succ: %0, %4, %4.1
 // CHECK-NEXT:  End
 sil @test_node_merge_during_struct_inst : $@convention(thin) (Y) -> () {
 bb0(%0 : $Y):
@@ -1244,10 +1246,10 @@ bb(%0 : $*Array<X>, %1 : $@callee_owned (@inout X) -> (@out (), @error Error)):
 
 // CHECK-LABEL: CG of arraysemantics_createUninitialized
 // CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Val %2 Esc: R, Succ: (%4.2)
+// CHECK-NEXT:    Val %2 Esc: R, Succ: (%6)
 // CHECK-NEXT:    Val %4 Esc: R, Succ: (%4.1)
 // CHECK-NEXT:    Con %4.1 Esc: R, Succ: %2
-// CHECK-NEXT:    Con %4.2 Esc: R, Succ: %0
+// CHECK-NEXT:    Con %6 Esc: R, Succ: %0
 // CHECK-NEXT:    Ret  Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @arraysemantics_createUninitialized : $@convention(thin) (@owned X) -> @owned Array<X> {
@@ -1451,10 +1453,10 @@ bb0(%0 : $X):
 // Z.deinit
 // CHECK-LABEL: CG of $s4main1ZCfD
 // CHECK:        Arg %0 Esc: A, Succ: (%0.1)
-// CHECK:        Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK:        Con %0.2 Esc: G, Succ:
+// CHECK:        Con %0.1 Esc: A, Succ: (%1)
+// CHECK:        Con %1 Esc: G, Succ:
 // CHECK:        Val %3 Esc: G, Succ: (%3.1)
-// CHECK:        Con %3.1 Esc: G, Succ: %0.2
+// CHECK:        Con %3.1 Esc: G, Succ: %1
 // CHECK:      End
 sil @$s4main1ZCfD: $@convention(method) (@owned Z) -> () {
 bb0(%0 : $Z):


### PR DESCRIPTION
Here is a change-by-change description in diff order:

Replace `updatePointsTo` with `initializePointsTo` and
`mergePointsTo`. Merging is very simple on its own. Initialization
requires some extra consideration for graph invariants. This
separation makes it possible to write stong asserts and to
independently reason about the correctness of each step based on
static invariants.

Replace `getContentNode` with `createContentNode`, and add two higher
level APIs `createMergedContent`, and `getFieldContent`. This makes
explicit the important cases of merging nodes and creating a special
nodes for class fields. This slightly simplifies adding properties to
content nodes and helps understand the structure of the graph.

Factor out an `escapeContentsOf` helper for use elsewhere...

Add a `getValueContent` helper. This is where we can tie the
properties of content nodes to the address values that are used to
address that content. This now also ensures that a Value node's
value field is consistent with all SILValues that map to it.

Add -escapes-internal-verify to check that the graph is in a valid
state after every merge or update step. This verification drove the
partial rewrite of mergeAllScheduledNodes.

ConnectionGraph::defer implementation: explictly handle the three
possible cases of pointsTo initialization or pointsTo merging at the
top level, so that those underlying implementations do not need to
dynamically handle weirdly different scenarios.

ConnectionGraph::initializePointsTo implementation: this simplified
implementation is possible by relying on invariants that can be
checked at each merge/update step. The major functional difference is
that it avoids creating unnecessary pointsTo edges. The previous
implementation often created pointsTo edges when adding defer edges
just to be conservative. Fixing this saved my sanity during debugging
because the pointsTo edges now always correspond to a SIL operations
that dereference the pointer. I'm also arguing without evidence that
this should be much more efficient.

ConnectionGraph::mergeAllScheduledNodes implementation: Add
verification to each step so that we can prove the other utilities
that are used while merging aren't making incorrect assumptions about
the graph state. Remove checks for merged nodes now that the graph is
consistently valid. Also remove a loop at the end that didn't seem to
do anything. The diff is impossible to review, but the idea is
basically the same. As long as it's still possible to scan through the
steps in the new code without getting totally lost, then the goal was
achieved.

ConnectionGraph::mergePointsTo: This is extremely simple now. In all
the places where we used to call updatePointsTo, and now call
mergePointsTo, it's a lot easier for someone debugging the code to
reason about what could possibly happen at that point.

`createMergedContent` is a placeholder for transferring node properties.

The `getFieldContent` helper may seem silly, but I find it helpful to
see all the important ways that content can be created in one place
next to the createContentNode, and I like the way that the creation of
the special "field content" node is more explicit in the source.

ConnectionGraph::mergeFrom implementation: this is only a minor
cleanup to remove some control flow nesting and use the CGNodeWorklist
abstraction.

In AnalyzeInstruction, add EscapeAnalysis::getValueContent helper. It
eliminates an extra step of going through the value node to get at its
content node. This is where we can derive content node properties from
the SILValue that dereferences the content. We can update the content
node's associated value 'V' if it's useful. It's also a place to put
assertions specific to the first level of content.

In AnalyzeInstruction, Array semantic calls: add support for
getValueContent so we can derive node properties. This is also nice
because it's explicit about which nodes are value content vs. field
content.

In AnalyzeInstruction, cleanup Release handling: use the explicit
APIs: getValueContent, getFieldContent, and escapeContentsOf.

In AnalyzeInstruction, assert that load-like things can't produce addresses.

In AnalyzeInstruction, add comments to clarify object projection handling.

In AnalyzeInstruction, add comments to explain store handling.

In AnalyzeInstruction, drop the assumption that all partial applies hold pointers.

In AnalyzeInstruction, handle aggregates differently so that Value
nodes are always consistent with their SILValue and can be
verified. Aggregates nodes are still coalesced if they only have a
single pointer-type subelement. If we arbitrarily coalesced an
aggregate with just one of its subelements then there would be no
consistent way to identify the value that corresponds to a connection
graph node.