### PR TITLE
[stdlib-private][oslog] Remove OSLogArguments.serializeAt method

### DIFF
--- a/stdlib/private/OSLog/OSLog.swift
+++ b/stdlib/private/OSLog/OSLog.swift
@@ -66,12 +66,12 @@ internal func osLog(
   let preamble = message.interpolation.preamble
   let argumentCount = message.interpolation.argumentCount
   let bufferSize = message.bufferSize
+  let argumentClosures = message.interpolation.arguments.argumentClosures
+
   let formatStringPointer = _getGlobalStringTablePointer(formatString)
 
   // Code that will execute at runtime.
   guard logObject.isEnabled(type: logLevel) else { return }
-
-  let arguments = message.interpolation.arguments
 
   // Allocate a byte buffer to store the arguments. The buffer could be stack
   // allocated as it is local to this function and also its size is a
@@ -84,7 +84,7 @@ internal func osLog(
   var currentBufferPosition = bufferMemory
   serialize(preamble, at: &currentBufferPosition)
   serialize(argumentCount, at: &currentBufferPosition)
-  arguments.serializeAt(&currentBufferPosition, using: &stringStorageObjects)
+  argumentClosures.forEach { $0(&currentBufferPosition, &stringStorageObjects) }
 
   ___os_log_impl(UnsafeMutableRawPointer(mutating: #dsohandle),
                  logObject,
@@ -120,6 +120,7 @@ func _checkFormatStringAndBuffer(
   let preamble = message.interpolation.preamble
   let argumentCount = message.interpolation.argumentCount
   let bufferSize = message.bufferSize
+  let argumentClosures = message.interpolation.arguments.argumentClosures
 
   // Code that will execute at runtime.
   let bufferMemory = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
@@ -128,9 +129,7 @@ func _checkFormatStringAndBuffer(
   var currentBufferPosition = bufferMemory
   serialize(preamble, at: &currentBufferPosition)
   serialize(argumentCount, at: &currentBufferPosition)
-  message.interpolation.arguments.serializeAt(
-    &currentBufferPosition,
-    using: &stringStorageObjects)
+  argumentClosures.forEach { $0(&currentBufferPosition, &stringStorageObjects) }
 
   assertion(
     formatString,

--- a/stdlib/private/OSLog/OSLogMessage.swift
+++ b/stdlib/private/OSLog/OSLogMessage.swift
@@ -349,22 +349,6 @@ internal struct OSLogArguments {
   }
 
   /// `append` for other types must be implemented by extensions.
-
-  /// Serialize the arguments tracked by self in a byte buffer.
-  /// - Parameters:
-  ///   - bufferPosition: the pointer to a location within a byte buffer where
-  ///   the argument must be serialized. This will be incremented by the number
-  ///   of bytes used up to serialize the arguments.
-  ///   - storageObjects: An array to store references to objects representing
-  ///   auxiliary storage created during serialization. This is only used while
-  ///   serializing strings.
-  @usableFromInline
-  internal func serializeAt(
-    _ bufferPosition: inout ByteBufferPointer,
-    using storageObjects: inout StorageObjects
-  ) {
-    argumentClosures.forEach { $0(&bufferPosition, &storageObjects) }
-  }
 }
 
 /// Serialize a UInt8 value at the buffer location pointed to by `bufferPosition`,


### PR DESCRIPTION
and instead directly access the array stored in OSLogArguments. This will make constant folding of the arguments array possible when its contents are inferred at compile time by the OSLogOptimization pass.