### PR TITLE
[DO NOT MERGE][pitch] Accessing ivar locations

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -246,11 +246,24 @@ public func _unsafeUncheckedDowncast<T: AnyObject>(_ x: AnyObject, to type: T.Ty
 @inline(__always)
 public func _getUnsafePointerToStoredProperties(_ x: AnyObject)
   -> UnsafeMutableRawPointer {
-  let storedPropertyOffset = _roundUp(
+  return _getUnsafePointerToStoredProperty(
+    atOffset: _offsetOfFirstStoredProperty(),
+    in: x)
+}
+
+@_alwaysEmitIntoClient
+internal func _offsetOfFirstStoredProperty() -> Int {
+  return _roundUp(
     MemoryLayout<SwiftShims.HeapObject>.size,
     toAlignment: MemoryLayout<Optional<AnyObject>>.alignment)
-  return UnsafeMutableRawPointer(Builtin.bridgeToRawPointer(x)) +
-    storedPropertyOffset
+}
+
+@_alwaysEmitIntoClient
+internal func _getUnsafePointerToStoredProperty(
+  atOffset offset: Int,
+  in object: AnyObject
+) -> UnsafeMutableRawPointer {
+  return UnsafeMutableRawPointer(Builtin.bridgeToRawPointer(object)) + offset
 }
 
 /// Get the minimum alignment for manually allocated memory.

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -186,6 +186,38 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
       }
     }
   }
+
+  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @usableFromInline // Exposed as public API by MemoryLayout<Root>.unsafeAddress(of:,in:)
+  internal var _storedInstanceOffset: Int? {
+    return withBuffer {
+      var buffer = $0
+
+      // The identity key path does not have a class offset.
+      if buffer.data.isEmpty { return nil }
+
+      var offset = 0
+      var (rawComponent, optNextType) = buffer.next()
+      switch rawComponent.header.kind {
+      case .class:
+        offset += rawComponent._structOrClassOffset
+      case .struct, .computed, .optionalChain, .optionalForce, .optionalWrap, .external:
+        return nil
+      }
+
+      while optNextType != nil {
+        (rawComponent, optNextType) = buffer.next()
+        switch rawComponent.header.kind {
+        case .struct:
+          offset += rawComponent._structOrClassOffset
+
+        case .class, .computed, .optionalChain, .optionalForce, .optionalWrap, .external:
+          return .none
+        }
+      }
+      return offset
+    }
+  }
 }
 
 /// A partially type-erased key path, from a concrete root type to any

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -229,6 +229,83 @@ extension MemoryLayout {
   }
 }
 
+extension MemoryLayout where T: AnyObject {
+  /// Return an unsafe mutable pointer to the memory location of
+  /// the stored property referred to by `key` within a class instance.
+  ///
+  /// The memory location is available only if the given key refers to directly
+  /// addressable storage within the in-memory representation of `T`, which must
+  /// be a class type.
+  ///
+  /// A class instance property has directly addressable storage when it is a
+  /// stored property for which no additional work is required to extract or set
+  /// the value. Properties are not directly accessible if they are potentially
+  /// overridable, trigger any `didSet` or `willSet` accessors, perform any
+  /// representation changes such as bridging or closure reabstraction, or mask
+  /// the value out of overlapping storage as for packed bitfields.
+  ///
+  /// For example, in the `ProductCategory` class defined here, only
+  /// `\.updateCounter`, `\.identifier`, and `\.identifier.name` refer to
+  /// properties with inline, directly addressable storage:
+  ///
+  ///     final class ProductCategory {
+  ///         struct Identifier {
+  ///             var name: String              // addressable
+  ///         }
+  ///
+  ///         var identifier: Identifier        // addressable
+  ///         var updateCounter: Int            // addressable
+  ///         var products: [Product] {         // not addressable: didSet handler
+  ///             didSet { updateCounter += 1 }
+  ///         }
+  ///         var productCount: Int {           // not addressable: computed property
+  ///             return products.count
+  ///         }
+  ///         var parent: ProductCategory?  // addressable
+  ///     }
+  ///
+  /// When the return value of this method is non-`nil`, then accessing the
+  /// value by key path or via the returned pointer are equivalent. For example:
+  ///
+  ///     let category: ProductCategory = ...
+  ///     category[keyPath: \.identifier.name] = "Cereal"
+  ///
+  ///     withExtendedLifetime(category) {
+  ///       let p = MemoryLayout.unsafeAddress(of: \.identifier.name, in: category)!
+  ///       p.pointee = "Cereal"
+  ///     }
+  ///
+  /// `unsafeAddress(of:in:)` returns nil if the supplied key path has directly
+  /// accessible storage but it's outside of the instance storage of the
+  /// specified `root` object. For example, this can happen with key paths that
+  /// have components with reference semantics, such as the `parent` field
+  /// above:
+  ///
+  ///     MemoryLayout.unsafeAddress(of: \.parent, in: category) // non-nil
+  ///     MemoryLayout.unsafeAddress(of: \.parent.name, in: category) // nil
+  ///
+  /// - Warning: The returned pointer is only valid until the root object gets
+  ///   deallocated. It is the responsibility of the caller to ensure that the
+  ///   object stays alive while it is using the pointer. (The
+  ///   `withExtendedLifetime` call above is one example of how this can be
+  ///   done.)
+  ///
+  ///   Additionally, the Law of Exclusivity still applies: the caller must
+  ///   ensure that any access of the instance variable through the returned
+  ///   pointer will not overlap with any other access to the same variable,
+  ///   unless both accesses are reads.
+  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @_transparent
+  public static func unsafeAddress<Value>(
+    of key: ReferenceWritableKeyPath<T, Value>,
+    in root: T
+  ) -> UnsafeMutablePointer<Value>? {
+    guard let offset = key._storedInstanceOffset else { return nil }
+    let p = _getUnsafePointerToStoredProperty(atOffset: offset, in: root)
+    return p.assumingMemoryBound(to: Value.self)
+  }
+}
+
 // Not-yet-public alignment conveniences
 extension MemoryLayout {
   internal static var _alignmentMask: Int { return alignment - 1 }

--- a/test/stdlib/ivar-access.swift
+++ b/test/stdlib/ivar-access.swift
@@ -1,0 +1,287 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+let suite = TestSuite("ivar-access")
+defer { runAllTests() }
+
+class Foo {
+  var value: Int = 100
+}
+
+struct S: Equatable {
+  var simpleIvar: Int = 1
+  var tupleIvar: (Int, Int) = (2, 3)
+  var labeledTupleIvar: (x: Int, y: Int) = (4, 5)
+  fileprivate(set) var secretlyMutableIvar: Int = 6
+
+  var strongReferenceIvar = Foo()
+  weak var weakReferenceIvar: C? = nil
+
+  var closureIvar: () -> Int = { 7 }
+  var cFunctionIvar: @convention(c) () -> Int = { 8 }
+  var computedProperty: Int {
+    get { 9 }
+    set { print("Nope") }
+  }
+  var storedPropertyWithDidSet: Int = 10 {
+    didSet { print("It changed") }
+  }
+  var storedPropertyWithWillSet: Int = 11 {
+    willSet { print("It will change") }
+  }
+  var computedPropertyWithGeneralizedAccessors: Int {
+    _read {
+      yield 12
+    }
+    _modify {
+      var value = 12
+      yield &value
+    }
+  }
+
+  static func ==(left: S, right: S) -> Bool {
+    guard left.simpleIvar == right.simpleIvar else { return false }
+    guard left.tupleIvar == right.tupleIvar else { return false }
+    guard left.labeledTupleIvar == right.labeledTupleIvar else { return false }
+    guard left.secretlyMutableIvar == right.secretlyMutableIvar else { return false }
+    guard left.strongReferenceIvar === right.strongReferenceIvar else { return false }
+    guard left.weakReferenceIvar === right.weakReferenceIvar else { return false }
+    return true
+  }
+}
+
+class C {
+  final var simpleIvar: Int = 1
+  final var tupleIvar: (Int, Int) = (2, 3)
+  final var labeledTupleIvar: (x: Int, y: Int) = (4, 5)
+  final fileprivate(set) var secretlyMutableIvar: Int = 6
+
+  final var strongReferenceIvar = Foo()
+  final weak var weakReferenceIvar: C? = nil
+
+  final var structIvar = S()
+
+  final var closureIvar: () -> Int = { 7 }
+  final var cFunctionIvar: @convention(c) () -> Int = { 8 }
+  final var computedProperty: Int {
+    get { 9 }
+    set { print("Nope") }
+  }
+  final var storedPropertyWithDidSet: Int = 10 {
+    didSet { print("It changed") }
+  }
+  final var storedPropertyWithWillSet: Int = 11 {
+    willSet { print("It will change") }
+  }
+  final var computedPropertyWithGeneralizedAccessors: Int {
+    _read {
+      yield 12
+    }
+    _modify {
+      var value = 12
+      yield &value
+    }
+  }
+  var nonFinalIvar: Int = 13
+}
+
+suite.test("simpleIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.simpleIvar, in: ref)
+  expectNotNil(p)
+  expectEqual(p?.pointee, 1)
+}
+
+suite.test("tupleIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.tupleIvar, in: ref)
+  expectNotNil(p)
+  expectEqual(p?.pointee.0, 2)
+  expectEqual(p?.pointee.1, 3)
+
+  let p0 = MemoryLayout<C>.unsafeAddress(of: \.tupleIvar.0, in: ref)
+  expectNotNil(p0)
+  expectEqual(p0?.pointee, 2)
+
+  let p1 = MemoryLayout<C>.unsafeAddress(of: \.tupleIvar.1, in: ref)
+  expectNotNil(p1)
+  expectEqual(p1?.pointee, 3)
+}
+
+suite.test("labeledTupleIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.labeledTupleIvar, in: ref)
+  expectNotNil(p)
+  expectEqual(p?.pointee.x, 4)
+  expectEqual(p?.pointee.y, 5)
+
+  let px = MemoryLayout<C>.unsafeAddress(of: \.labeledTupleIvar.x, in: ref)
+  expectNotNil(px)
+  expectEqual(px?.pointee, 4)
+
+  let py = MemoryLayout<C>.unsafeAddress(of: \.labeledTupleIvar.y, in: ref)
+  expectNotNil(py)
+  expectEqual(py?.pointee, 5)
+}
+
+suite.test("secretlyMutableIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.secretlyMutableIvar, in: ref)
+  expectNotNil(p)
+  expectEqual(p?.pointee, 6)
+}
+
+suite.test("strongReferenceIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.strongReferenceIvar, in: ref)
+  expectNotNil(p)
+  expectTrue(p?.pointee === ref.strongReferenceIvar)
+
+  let p1 = MemoryLayout<C>.unsafeAddress(of: \.strongReferenceIvar.value, in: ref)
+  expectNil(p1)
+}
+
+suite.test("weakReferenceIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+  ref.weakReferenceIvar = ref
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.weakReferenceIvar, in: ref)
+  expectNil(p)
+}
+
+suite.test("structIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+  ref.weakReferenceIvar = ref
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.structIvar, in: ref)
+  expectNotNil(p)
+  expectTrue(p?.pointee == ref.structIvar)
+
+  let p1 = MemoryLayout<C>.unsafeAddress(of: \.structIvar.simpleIvar, in: ref)
+  expectNotNil(p1)
+  expectTrue(p1?.pointee == 1)
+
+  let p2 = MemoryLayout<C>.unsafeAddress(of: \.structIvar.tupleIvar.0, in: ref)
+  expectNotNil(p2)
+  expectTrue(p2?.pointee == 2)
+
+  let p3 = MemoryLayout<C>.unsafeAddress(of: \.structIvar.tupleIvar.1, in: ref)
+  expectNotNil(p3)
+  expectTrue(p3?.pointee == 3)
+
+  let p4 = MemoryLayout<C>.unsafeAddress(of: \.structIvar.labeledTupleIvar.x, in: ref)
+  expectNotNil(p4)
+  expectTrue(p4?.pointee == 4)
+
+  let p5 = MemoryLayout<C>.unsafeAddress(of: \.structIvar.labeledTupleIvar.y, in: ref)
+  expectNotNil(p5)
+  expectTrue(p5?.pointee == 5)
+
+  let p6 = MemoryLayout<C>.unsafeAddress(of: \.structIvar.secretlyMutableIvar, in: ref)
+  expectNotNil(p6)
+  expectTrue(p6?.pointee == 6)
+
+  let p7 = MemoryLayout<C>.unsafeAddress(of: \.structIvar.strongReferenceIvar, in: ref)
+  expectNotNil(p7)
+  expectTrue(p7?.pointee === ref.structIvar.strongReferenceIvar)
+
+  expectNil(MemoryLayout<C>.unsafeAddress(of: \.structIvar.strongReferenceIvar.value, in: ref))
+
+  let p8 = MemoryLayout<C>.unsafeAddress(of: \.structIvar.weakReferenceIvar, in: ref)
+  expectNil(p8)
+
+  let p9 = MemoryLayout<C>.unsafeAddress(of: \.structIvar.cFunctionIvar, in: ref)
+  expectNotNil(p9)
+  expectTrue(p9?.pointee() == 8)
+
+  expectNil(MemoryLayout<C>.unsafeAddress(of: \.structIvar.closureIvar, in: ref))
+  expectNil(MemoryLayout<C>.unsafeAddress(of: \.structIvar.computedProperty, in: ref))
+  expectNil(MemoryLayout<C>.unsafeAddress(of: \.structIvar.storedPropertyWithDidSet, in: ref))
+  expectNil(MemoryLayout<C>.unsafeAddress(of: \.structIvar.storedPropertyWithWillSet, in: ref))
+  expectNil(MemoryLayout<C>.unsafeAddress(of: \.structIvar.computedPropertyWithGeneralizedAccessors, in: ref))
+}
+
+suite.test("closureIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.closureIvar, in: ref)
+  expectNil(p) // reabstracted
+}
+
+suite.test("cFunctionIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.cFunctionIvar, in: ref)
+  expectNotNil(p)
+  expectEqual(p?.pointee(), 8)
+}
+
+suite.test("computedProperty") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.computedProperty, in: ref)
+  expectNil(p)
+}
+
+suite.test("storedPropertyWithDidSet") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.storedPropertyWithDidSet, in: ref)
+  expectNil(p)
+}
+
+suite.test("storedPropertyWithWillSet") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.storedPropertyWithWillSet, in: ref)
+  expectNil(p)
+}
+
+suite.test("computedPropertyWithGeneralizedAccessors") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.computedPropertyWithGeneralizedAccessors, in: ref)
+  expectNil(p)
+}
+
+suite.test("nonFinalIvar") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  let ref = C()
+  defer { withExtendedLifetime(ref) {} }
+
+  let p = MemoryLayout<C>.unsafeAddress(of: \.nonFinalIvar, in: ref)
+  expectNil(p)
+}


### PR DESCRIPTION
This is the implementation for the potential new API introduced in the [Exposing the Memory Locations of Class Instance Variables][ivar-access] pitch on the evolution forums.

[ivar-access]: https://forums.swift.org/t/pitch-exposing-the-memory-locations-of-class-instance-variables/30584

```swift
extension MemoryLayout where T: AnyObject {
  static func unsafeAddress<Value>(
    of key: ReferenceWritableKeyPath<T, Value>,
    in root: T
  ) -> UnsafeMutablePointer<Value>?
}
```
