### PR TITLE
[Sema] Remove TypeChecker::diagnose[WithNotes] 

### DIFF
--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -30,8 +30,9 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
   if (expr->getObjCStringLiteralExpr() && !requireResultType) return None;
 
   // ObjC #keyPath only makes sense when we have the Objective-C runtime.
+  auto &diags = dc->getASTContext().Diags;
   if (!Context.LangOpts.EnableObjCInterop) {
-    diagnose(expr->getLoc(), diag::expr_keypath_no_objc_runtime);
+    diags.diagnose(expr->getLoc(), diag::expr_keypath_no_objc_runtime);
 
     expr->setObjCStringLiteralExpr(
       new (Context) StringLiteralExpr("", expr->getSourceRange(),
@@ -212,9 +213,9 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     case KeyPathExpr::Component::Kind::OptionalChain:
     case KeyPathExpr::Component::Kind::OptionalForce:
     case KeyPathExpr::Component::Kind::TupleElement:
-      diagnose(componentNameLoc,
-               diag::expr_unsupported_objc_key_path_component,
-               (unsigned)kind);
+      diags.diagnose(componentNameLoc,
+                     diag::expr_unsupported_objc_key_path_component,
+                     (unsigned)kind);
       continue;
     case KeyPathExpr::Component::Kind::OptionalWrap:
     case KeyPathExpr::Component::Kind::Property:
@@ -224,8 +225,8 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     
     auto componentFullName = component.getUnresolvedDeclName();
     if (!componentFullName.isSimpleName()) {
-      diagnose(componentNameLoc,
-               diag::expr_unsupported_objc_key_path_compound_name);
+      diags.diagnose(componentNameLoc,
+                     diag::expr_unsupported_objc_key_path_compound_name);
       continue;
     }
     auto componentName = componentFullName.getBaseName();
@@ -259,11 +260,11 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
                             corrections);
 
       if (currentType)
-        diagnose(componentNameLoc, diag::could_not_find_type_member,
-                 currentType, componentName);
+        diags.diagnose(componentNameLoc, diag::could_not_find_type_member,
+                       currentType, componentName);
       else
-        diagnose(componentNameLoc, diag::use_unresolved_identifier,
-                 componentName, false);
+        diags.diagnose(componentNameLoc, diag::use_unresolved_identifier,
+                       componentName, false);
 
       // Note all the correction candidates.
       corrections.noteAllCandidates();
@@ -300,15 +301,15 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
         break;
 
       if (lookupType)
-        diagnose(componentNameLoc, diag::ambiguous_member_overload_set,
-                 componentName);
+        diags.diagnose(componentNameLoc, diag::ambiguous_member_overload_set,
+                       componentName);
       else
-        diagnose(componentNameLoc, diag::ambiguous_decl_ref,
-                 componentName);
+        diags.diagnose(componentNameLoc, diag::ambiguous_decl_ref,
+                       componentName);
 
       for (auto result : lookup) {
-        diagnose(result.getValueDecl(), diag::decl_declared_here,
-                 result.getValueDecl()->getFullName());
+        diags.diagnose(result.getValueDecl(), diag::decl_declared_here,
+                       result.getValueDecl()->getFullName());
       }
       isInvalid = true;
       break;
@@ -327,11 +328,11 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
       // Check that the property is @objc.
       if (!var->isObjC()) {
-        diagnose(componentNameLoc, diag::expr_keypath_non_objc_property,
-                 componentName);
+        diags.diagnose(componentNameLoc, diag::expr_keypath_non_objc_property,
+                       componentName);
         if (var->getLoc().isValid() && var->getDeclContext()->isTypeContext()) {
-          diagnose(var, diag::make_decl_objc,
-                   var->getDescriptiveKind())
+          diags.diagnose(var, diag::make_decl_objc,
+                         var->getDescriptiveKind())
             .fixItInsert(var->getAttributeInsertionLoc(false),
                          "@objc ");
         }
@@ -341,10 +342,12 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
         if (attr->isSwift3Inferred() &&
             Context.LangOpts.WarnSwift3ObjCInference ==
               Swift3ObjCInferenceWarnings::Minimal) {
-          diagnose(componentNameLoc, diag::expr_keypath_swift3_objc_inference,
-                   var->getFullName(),
-                   var->getDeclContext()->getSelfNominalTypeDecl()->getName());
-          diagnose(var, diag::make_decl_objc, var->getDescriptiveKind())
+          auto *parent = var->getDeclContext()->getSelfNominalTypeDecl();
+          diags.diagnose(componentNameLoc,
+                         diag::expr_keypath_swift3_objc_inference,
+                         var->getFullName(),
+                         parent->getName());
+          diags.diagnose(var, diag::make_decl_objc, var->getDescriptiveKind())
             .fixItInsert(var->getAttributeInsertionLoc(false),
                          "@objc ");
         }
@@ -361,16 +364,16 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     if (auto type = dyn_cast<TypeDecl>(found)) {
       // We cannot refer to a type via a property.
       if (isResolvingProperty()) {
-        diagnose(componentNameLoc, diag::expr_keypath_type_of_property,
-                 componentName, currentType);
+        diags.diagnose(componentNameLoc, diag::expr_keypath_type_of_property,
+                       componentName, currentType);
         isInvalid = true;
         break;
       }
 
       // We cannot refer to a generic type.
       if (type->getDeclaredInterfaceType()->hasTypeParameter()) {
-        diagnose(componentNameLoc, diag::expr_keypath_generic_type,
-                 componentName);
+        diags.diagnose(componentNameLoc, diag::expr_keypath_generic_type,
+                       componentName);
         isInvalid = true;
         break;
       }
@@ -392,9 +395,9 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     }
 
     // Declarations that cannot be part of a key-path.
-    diagnose(componentNameLoc, diag::expr_keypath_not_property,
-             found->getDescriptiveKind(), found->getFullName(),
-             /*isForDynamicKeyPathMemberLookup=*/false);
+    diags.diagnose(componentNameLoc, diag::expr_keypath_not_property,
+                   found->getDescriptiveKind(), found->getFullName(),
+                   /*isForDynamicKeyPathMemberLookup=*/false);
     isInvalid = true;
     break;
   }
@@ -406,7 +409,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
   // Check for an empty key-path string.
   auto keyPathString = keyPathOS.str();
   if (keyPathString.empty() && !isInvalid)
-    diagnose(expr->getLoc(), diag::expr_keypath_empty);
+    diags.diagnose(expr->getLoc(), diag::expr_keypath_empty);
 
   // Set the string literal expression for the ObjC key path.
   if (!expr->getObjCStringLiteralExpr()) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -708,18 +708,6 @@ public:
     this->InImmediateMode = InImmediateMode;
   }
 
-  template<typename ...ArgTypes>
-  InFlightDiagnostic diagnose(ArgTypes &&...Args) {
-    return Diags.diagnose(std::forward<ArgTypes>(Args)...);
-  }
-
-  void diagnoseWithNotes(InFlightDiagnostic parentDiag,
-                         llvm::function_ref<void(void)> builder) {
-    CompoundDiagnosticTransaction transaction(Diags);
-    parentDiag.flush();
-    builder();
-  }
-
   static Type getArraySliceType(SourceLoc loc, Type elementType);
   static Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);
   static Type getOptionalType(SourceLoc loc, Type elementType);


### PR DESCRIPTION
Remove the last uses of `TypeChecker::diagnose` and remove it along with `TypeChecker::diagnoseWithNotes` to discourage future use of the TypeChecker to emit diagnostics.