### PR TITLE
[AutoDiff] Update `@differentiable` attribute API/ABI status.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -506,7 +506,7 @@ DECL_ATTR(_projectedValueProperty, ProjectedValueProperty,
 DECL_ATTR(differentiable, Differentiable,
   OnAccessor | OnConstructor | OnFunc | OnVar | OnSubscript | LongAttribute |
   AllowMultipleAttributes |
-  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove,
   90)
 DECL_ATTR(differentiating, Differentiating,
   OnFunc | LongAttribute | AllowMultipleAttributes |


### PR DESCRIPTION
Mark `@differentiable` attribute as:
- API/ABI stable to add. (The `@differentiable` declaration is unaffected.)
- API/ABI breaking to remove.

---

This is an experiment regarding https://github.com/apple/swift/pull/27506#discussion_r343990821.

Context: the `(ABI|API)(Stable|Breaking)To(Add|Remove)` tags were added in https://github.com/apple/swift/pull/27180 and became relevant for `@differentiable` during the `swift-DEVELOPMENT-SNAPSHOT-2019-09-16-a -> tensorflow` merge.

At the time, few attributes used `Breaking` (`final`, `frozen`, `_fixed_layout`). The previous default was `Stable`, so we used it for `@differentiable`. If `Breaking` is used, `swift-api-digester` diagnoses API/ABI-breaking attribute additions/removals in the stdlib, which may cause issues. Verifying now.