### PR TITLE
[Tests] Remove `no_asserts` from sema perf tests

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
+++ b/validation-test/Sema/type_checker_perf/fast/expression_too_complex_4.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4 -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func test(_ i: Int, _ j: Int) -> Int {
   return 1 + (((i >> 1) + (i >> 2) + (i >> 3) + (i >> 4) << 1) << 1) & 0x40 +

--- a/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17024694.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 _ = (2...100).reversed().filter({ $0 % 11 == 0 }).map {
   "\($0) bottles of beer on the wall, \($0) bottles of beer;\n"

--- a/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17077404.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func memoize<A: Hashable, R>(
   f: @escaping ((A) -> R, A) -> R

--- a/validation-test/Sema/type_checker_perf/fast/rdar17170728.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar17170728.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 let i: Int? = 1
 let j: Int?

--- a/validation-test/Sema/type_checker_perf/fast/rdar18522024.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18522024.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func test(a: [String], b: String, c: String) -> [String] {
   return a.map { $0 + ": " + b + "(" + c + $0 + ")" }

--- a/validation-test/Sema/type_checker_perf/fast/rdar19029974.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19029974.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 infix operator <*> : AdditionPrecedence
 func <*><A, B>(lhs: ((A) -> B)?, rhs: A?) -> B? {

--- a/validation-test/Sema/type_checker_perf/fast/rdar19157118.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19157118.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 public func expectEqualMethodsForDomain<
 SelfType, ArgumentType, Result : Equatable

--- a/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func test(strings: [String]) {
   for string in strings {

--- a/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 let _: (Character) -> Bool = { c in
   ("a" <= c && c <= "z") || ("A" <= c && c <= "Z") || c == "_"

--- a/validation-test/Sema/type_checker_perf/fast/rdar20875936.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20875936.swift
@@ -1,4 +1,4 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 let _ = Array([0].lazy.reversed().filter { $0 % 2 == 0 }.map { $0 / 2 })

--- a/validation-test/Sema/type_checker_perf/fast/rdar21374729.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21374729.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 protocol P {
   associatedtype A

--- a/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22022980.swift
@@ -1,4 +1,4 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -swift-version 5
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 _ = [1, 3, 5, 7, 11].filter{ $0 == 1 || $0 == 3 || $0 == 11 || $0 == 1 || $0 == 3 || $0 == 11 } == [ 1, 3, 11 ]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22249571.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22249571.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func rdar22249571() -> [UInt8] {
   return (0...10).map { _ in

--- a/validation-test/Sema/type_checker_perf/fast/rdar22282851.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22282851.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 struct S {
   let s: String

--- a/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22466245.swift
@@ -1,4 +1,4 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 _ = (1...10).map(String.init) + [": hi"]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func test(n: Int) -> Int {
   return n == 0 ? 0 : (0..<n).reduce(0) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23429943.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 let _ = [0].reduce([Int]()) {
   return $0.count == 0 && ($1 == 0 || $1 == 2 || $1 == 3) ? [] : $0 + [$1]

--- a/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 // REQUIRES: rdar38378503
 
 // expected-no-diagnostics

--- a/validation-test/Sema/type_checker_perf/fast/rdar28018866.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar28018866.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 struct P {
   let x: Float

--- a/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 let a = 1
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar31742586.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31742586.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func rdar31742586() -> Double {
   return -(1 + 2) + -(3 + 4) + 5 - (-(1 + 2) + -(3 + 4) + 5)

--- a/validation-test/Sema/type_checker_perf/fast/rdar32221800.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32221800.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func test(header_field_mark: Bool?, header_value_mark: Bool?,
   url_mark: Bool?, body_mark: Bool?, status_mark: Bool?) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func rdar32998180(value: UInt16) -> UInt16 {
   let result = ((((value >> 1) ^ (value >> 1) ^ (value >> 1) ^ (value >> 1)) & 1) << 1)

--- a/validation-test/Sema/type_checker_perf/fast/rdar33688063.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33688063.swift
@@ -1,4 +1,4 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 let _ = 1 | UInt32(0) << 0 | UInt32(1) << 1 | UInt32(2) << 2 | UInt32(3) << 3 | UInt32(4) << 4

--- a/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33806601.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 class P {
   var x : Int = 0

--- a/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar35213699.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink -disable-constraint-solver-performance-hacks -solver-enable-operator-designated-types
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func test() {
   let _: UInt = 1 * 2 + 3 * 4 + 5 * 6 + 7 * 8 + 9 * 10 + 11 * 12 + 13 * 14

--- a/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 struct T {
   enum B {

--- a/validation-test/Sema/type_checker_perf/slow/rdar18800950.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar18800950.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 // Mixed Float and Double arithmetic
 func rdar18800950(v: Float) -> Double {

--- a/validation-test/Sema/type_checker_perf/slow/rdar18994321.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar18994321.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 precedencegroup ExponentiationPrecedence {
   associativity: right

--- a/validation-test/Sema/type_checker_perf/slow/rdar19368383.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19368383.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 // Missing force of optional result of dictionary lookup.
 func rdar19368383(d: [String : String]) -> [String] {

--- a/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 struct Stringly {
   init(string: String) {}
   init(format: String, _ args: Any...) {}

--- a/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 let a = "a"
 let b = "b"

--- a/validation-test/Sema/type_checker_perf/slow/rdar19915443.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19915443.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 var counts = [ 0, 0, 0, 0 ]
 // NOTE: This is using mixed types, and would result in a type checking error if it completed.

--- a/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 struct Stringly {
   init(string: String) {}

--- a/validation-test/Sema/type_checker_perf/slow/rdar22079400.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22079400.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 let _ = (0...1).lazy.flatMap {
   a in (1...2).lazy.map { b in (a, b) }

--- a/validation-test/Sema/type_checker_perf/slow/rdar22877285.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22877285.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 let j = 1
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar22949523.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22949523.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 _ = [0,1,2,3].lazy.map { String($0)+"hi" }.sorted(by: { $0 > $1 && $1 < $0 && ($1 + $0) < 1000 })
 // expected-error@-1 {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar23224583.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar23224583.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 // Mixed UInt32 and Double
 let x: UInt32 = 1

--- a/validation-test/Sema/type_checker_perf/slow/rdar23682605.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar23682605.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func memoize<T: Hashable, U>( body: @escaping ((T)->U, T)->U ) -> (T)->U {
   var memo = Dictionary<T, U>()

--- a/validation-test/Sema/type_checker_perf/slow/rdar23861629.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar23861629.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 struct S { var s: String? }
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar26564101.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar26564101.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 // REQUIRES: rdar46850561
 
 func rdar26564101(a: [Double], m: Double) -> Double {

--- a/validation-test/Sema/type_checker_perf/slow/rdar30631148.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar30631148.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 func fun(_ x: Double) -> Double { fatalError() }
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar32034560.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar32034560.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: rdar42744631
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 struct S {
   var A: [[UInt32]]

--- a/validation-test/Sema/type_checker_perf/slow/rdar33476240.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar33476240.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 // Mixed Int/Double slow to emit diagnostics
 func rdar33476240(col: Int, row: Int, maxCol: Int, maxRow: Int) {

--- a/validation-test/Sema/type_checker_perf/slow/rdar33935430.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar33935430.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asserts
+// REQUIRES: tools-release
 
 // Mixed Int/Float arithmetic
 func rdar33935430(a: Int, b: Int, c: Float, d: Float, n: Int) {

--- a/validation-test/Sema/type_checker_perf/slow/rdar46713933.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar46713933.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// REQUIRES: tools-release,no_asserts
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release
 
 func wrap<T>(_ key: String, _ value: T) -> T { return value }
 func wrap<T: ExpressibleByIntegerLiteral>(_ key: String, _ value: T) -> T { return value }


### PR DESCRIPTION
This discourages regressions. Also add a timeout to a slow test.