### PR TITLE
Make TypeChecker's Context and Diags fields private

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5125,9 +5125,8 @@ Expr *ExprRewriter::coerceImplicitlyUnwrappedOptionalToValue(Expr *expr, Type ob
   if (optTy->is<LValueType>())
     objTy = LValueType::get(objTy);
 
-  expr = new (cs.getTypeChecker().Context) ForceValueExpr(expr,
-                                                          expr->getEndLoc(),
-                                                          /* forcedIUO=*/ true);
+  expr = new (cs.getASTContext()) ForceValueExpr(expr, expr->getEndLoc(),
+                                                 /* forcedIUO=*/ true);
   cs.setType(expr, objTy);
   expr->setImplicit();
   return expr;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -910,6 +910,7 @@ namespace {
 
   class PreCheckExpression : public ASTWalker {
     TypeChecker &TC;
+    ASTContext &Ctx;
     DeclContext *DC;
 
     Expr *ParentExpr;
@@ -1054,9 +1055,9 @@ namespace {
 
   public:
     PreCheckExpression(TypeChecker &tc, DeclContext *dc, Expr *parent)
-        : TC(tc), DC(dc), ParentExpr(parent) {}
+        : TC(tc), Ctx(dc->getASTContext()), DC(dc), ParentExpr(parent) {}
 
-    ASTContext &getASTContext() const { return TC.Context; }
+    ASTContext &getASTContext() const { return Ctx; }
 
     bool walkToClosureExprPre(ClosureExpr *expr);
 
@@ -1994,7 +1995,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
     return nullptr;
 
   // Don't bother to convert deprecated selector syntax.
-  if (auto selectorTy = TC.Context.getSelectorType()) {
+  if (auto selectorTy = getASTContext().getSelectorType()) {
     if (type->isEqual(selectorTy))
       return nullptr;
   }
@@ -2444,7 +2445,7 @@ void TypeChecker::getPossibleTypesOfExpressionWithoutApplying(
 static FunctionType *
 getTypeOfCompletionOperatorImpl(TypeChecker &TC, DeclContext *DC, Expr *expr,
                                 ConcreteDeclRef &referencedDecl) {
-  ASTContext &Context = TC.Context;
+  auto &Context = DC->getASTContext();
 
   FrontendStatsTracer StatsTracer(Context.Stats,
                                   "typecheck-completion-operator", expr);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -909,7 +909,6 @@ namespace {
   }
 
   class PreCheckExpression : public ASTWalker {
-    TypeChecker &TC;
     ASTContext &Ctx;
     DeclContext *DC;
 
@@ -1054,14 +1053,17 @@ namespace {
     }
 
   public:
-    PreCheckExpression(TypeChecker &tc, DeclContext *dc, Expr *parent)
-        : TC(tc), Ctx(dc->getASTContext()), DC(dc), ParentExpr(parent) {}
+    PreCheckExpression(DeclContext *dc, Expr *parent)
+        : Ctx(dc->getASTContext()), DC(dc), ParentExpr(parent) {}
 
     ASTContext &getASTContext() const { return Ctx; }
 
     bool walkToClosureExprPre(ClosureExpr *expr);
 
     std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+      // FIXME: Remove TypeChecker dependencies below.
+      auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
       // If this is a call, record the argument expression.
       if (auto call = dyn_cast<ApplyExpr>(expr)) {
         if (!isa<SelfApplyExpr>(expr)) {
@@ -2012,7 +2014,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
 /// Pre-check the expression, validating any types that occur in the
 /// expression and folding sequence expressions.
 bool TypeChecker::preCheckExpression(Expr *&expr, DeclContext *dc) {
-  PreCheckExpression preCheck(*this, dc, expr);
+  PreCheckExpression preCheck(dc, expr);
   // Perform the pre-check.
   if (auto result = expr->walk(preCheck)) {
     expr = result;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2275,10 +2275,11 @@ namespace {
 class DeclChecker : public DeclVisitor<DeclChecker> {
 public:
   TypeChecker &TC;
+  ASTContext &Ctx;
 
-  explicit DeclChecker(TypeChecker &TC) : TC(TC) {}
+  explicit DeclChecker(TypeChecker &TC, ASTContext &ctx) : TC(TC), Ctx(ctx) {}
 
-  ASTContext &getASTContext() const { return TC.Context; }
+  ASTContext &getASTContext() const { return Ctx; }
 
   void visit(Decl *decl) {
     if (getASTContext().Stats)
@@ -3658,7 +3659,7 @@ bool TypeChecker::isAvailabilitySafeForConformance(
 }
 
 void TypeChecker::typeCheckDecl(Decl *D) {
-  DeclChecker(*this).visit(D);
+  DeclChecker(*this, D->getASTContext()).visit(D);
 }
 
 // Returns 'nullptr' if this is the setter's 'newValue' parameter;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2274,10 +2274,9 @@ static void checkDynamicSelfType(ValueDecl *decl, Type type) {
 namespace {
 class DeclChecker : public DeclVisitor<DeclChecker> {
 public:
-  TypeChecker &TC;
   ASTContext &Ctx;
 
-  explicit DeclChecker(TypeChecker &TC, ASTContext &ctx) : TC(TC), Ctx(ctx) {}
+  explicit DeclChecker(ASTContext &ctx) : Ctx(ctx) {}
 
   ASTContext &getASTContext() const { return Ctx; }
 
@@ -2586,6 +2585,9 @@ public:
 
     checkAccessControl(PBD);
 
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     // If the initializers in the PBD aren't checked yet, do so now.
     for (auto i : range(PBD->getNumPatternEntries())) {
       if (!PBD->isInitialized(i))
@@ -2658,6 +2660,9 @@ public:
     (void) SD->getImplInfo();
 
     TypeChecker::checkParameterAttributes(SD->getIndices());
+
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
     checkDefaultArguments(TC, SD->getIndices());
 
     if (SD->getDeclContext()->getSelfClassDecl()) {
@@ -3214,6 +3219,9 @@ public:
 
 
   bool shouldSkipBodyTypechecking(const AbstractFunctionDecl *AFD) {
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     // Make sure we're in the mode that's skipping function bodies.
     if (!TC.canSkipNonInlinableBodies())
       return false;
@@ -3257,6 +3265,8 @@ public:
       }
     }
 
+    // FIXME: Remove TypeChecker dependencies below.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
     if (requiresDefinition(FD) && !FD->hasBody()) {
       // Complain if we should have a body.
       FD->diagnose(diag::func_decl_without_brace);
@@ -3334,6 +3344,9 @@ public:
 
     if (auto *PL = EED->getParameterList()) {
       TypeChecker::checkParameterAttributes(PL);
+
+      // FIXME: Remove TypeChecker dependency.
+      auto &TC = *Ctx.getLegacyGlobalTypeChecker();
       checkDefaultArguments(TC, PL);
     }
 
@@ -3584,6 +3597,8 @@ public:
 
     checkAccessControl(CD);
 
+    // FIXME: Remove TypeChecker dependencies below.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
     if (requiresDefinition(CD) && !CD->hasBody()) {
       // Complain if we should have a body.
       CD->diagnose(diag::missing_initializer_def);
@@ -3608,6 +3623,8 @@ public:
     } else if (shouldSkipBodyTypechecking(DD)) {
       DD->setBodySkipped(DD->getBodySourceRange());
     } else {
+      // FIXME: Remove TypeChecker dependency.
+      auto &TC = *Ctx.getLegacyGlobalTypeChecker();
       TC.definedFunctions.push_back(DD);
     }
   }
@@ -3659,7 +3676,7 @@ bool TypeChecker::isAvailabilitySafeForConformance(
 }
 
 void TypeChecker::typeCheckDecl(Decl *D) {
-  DeclChecker(*this, D->getASTContext()).visit(D);
+  DeclChecker(D->getASTContext()).visit(D);
 }
 
 // Returns 'nullptr' if this is the setter's 'newValue' parameter;

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -31,23 +31,21 @@ using namespace swift;
 
 namespace {
 struct REPLContext {
-  TypeChecker &TC;
   ASTContext &Context;
   SourceFile &SF;
   SmallVector<ValueDecl *, 4> PrintDecls;
   SmallVector<ValueDecl *, 4> DebugPrintlnDecls;
 
-  REPLContext(TypeChecker &TC, SourceFile &SF)
-      : TC(TC), Context(TC.Context), SF(SF) {}
+  REPLContext(SourceFile &SF) : Context(SF.getASTContext()), SF(SF) {}
 
   bool requirePrintDecls() {
     if (!PrintDecls.empty() && !DebugPrintlnDecls.empty())
       return false;
 
+    auto *stdlib = TypeChecker::getStdlibModule(&SF);
     {
       Identifier Id(Context.getIdentifier("_replPrintLiteralString"));
-      auto lookup = TypeChecker::lookupUnqualified(TC.getStdlibModule(&SF), Id,
-                                                   SourceLoc());
+      auto lookup = TypeChecker::lookupUnqualified(stdlib, Id, SourceLoc());
       if (!lookup)
         return true;
       for (auto result : lookup)
@@ -55,8 +53,7 @@ struct REPLContext {
     }
     {
       Identifier Id(Context.getIdentifier("_replDebugPrintln"));
-      auto lookup = TypeChecker::lookupUnqualified(TC.getStdlibModule(&SF), Id,
-                                                   SourceLoc());
+      auto lookup = TypeChecker::lookupUnqualified(stdlib, Id, SourceLoc());
       if (!lookup)
         return true;
       for (auto result : lookup)
@@ -191,8 +188,8 @@ namespace {
     unsigned NextResponseVariableIndex = 0;
 
   public:
-    REPLChecker(TypeChecker &TC, SourceFile &SF, TopLevelContext &TLC)
-      : REPLContext(TC, SF), TLC(TLC) {}
+    REPLChecker(SourceFile &SF, TopLevelContext &TLC)
+      : REPLContext(SF), TLC(TLC) {}
 
     void processREPLTopLevelExpr(Expr *E);
     void processREPLTopLevelPatternBinding(PatternBindingDecl *PBD);
@@ -257,6 +254,9 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
   // Typecheck the function.
   BraceStmt *Body = builder.createBodyStmt(Loc, EndLoc);
   CE->setBody(Body, false);
+
+  // FIXME: Remove TypeChecker dependency.
+  auto &TC = *Context.getLegacyGlobalTypeChecker();
   TC.typeCheckClosureBody(CE);
   TC.ClosuresWithUncomputedCaptures.push_back(CE);
 
@@ -437,7 +437,7 @@ void TypeChecker::processREPLTopLevel(SourceFile &SF, TopLevelContext &TLC,
   std::vector<Decl *> NewDecls(SF.Decls.begin()+FirstDecl, SF.Decls.end());
   SF.Decls.resize(FirstDecl);
 
-  REPLChecker RC(*this, SF, TLC);
+  REPLChecker RC(SF, TLC);
 
   // Loop over each of the new decls, processing them, adding them back to
   // the Decls list.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -297,7 +297,6 @@ static void tryDiagnoseUnnecessaryCastOverOptionSet(ASTContext &Ctx,
 namespace {
 class StmtChecker : public StmtVisitor<StmtChecker, Stmt*> {
 public:
-  TypeChecker &TC;
   ASTContext &Ctx;
 
   /// This is the current function or closure being checked.
@@ -374,16 +373,16 @@ public:
     }
   };
 
-  StmtChecker(TypeChecker &TC, AbstractFunctionDecl *AFD)
-      : TC(TC), Ctx(AFD->getASTContext()), TheFunc(AFD), DC(AFD), IsREPL(false),
+  StmtChecker(AbstractFunctionDecl *AFD)
+      : Ctx(AFD->getASTContext()), TheFunc(AFD), DC(AFD), IsREPL(false),
         IsBraceStmtFromTopLevelDecl(false) {}
 
-  StmtChecker(TypeChecker &TC, ClosureExpr *TheClosure)
-      : TC(TC), Ctx(TheClosure->getASTContext()), TheFunc(TheClosure),
+  StmtChecker(ClosureExpr *TheClosure)
+      : Ctx(TheClosure->getASTContext()), TheFunc(TheClosure),
         DC(TheClosure), IsREPL(false), IsBraceStmtFromTopLevelDecl(false) {}
 
-  StmtChecker(TypeChecker &TC, DeclContext *DC)
-      : TC(TC), Ctx(DC->getASTContext()), TheFunc(), DC(DC), IsREPL(false),
+  StmtChecker(DeclContext *DC)
+      : Ctx(DC->getASTContext()), TheFunc(), DC(DC), IsREPL(false),
         IsBraceStmtFromTopLevelDecl(false) {
     if (const SourceFile *SF = DC->getParentSourceFile())
       if (SF->Kind == SourceFileKind::REPL)
@@ -545,6 +544,8 @@ public:
       }
     }
 
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
     auto exprTy = TC.typeCheckExpression(E, DC, TypeLoc::withoutLoc(ResultTy),
                                          ctp,
                                          options);
@@ -606,6 +607,8 @@ public:
         contextTypePurpose = CTP_YieldByValue;
       }
 
+      // FIXME: Remove TypeChecker dependency.
+      auto &TC = *Ctx.getLegacyGlobalTypeChecker();
       TC.typeCheckExpression(exprToCheck, DC,
                              TypeLoc::withoutLoc(contextType),
                              contextTypePurpose);
@@ -637,6 +640,8 @@ public:
     Type exnType = getASTContext().getErrorDecl()->getDeclaredType();
     if (!exnType) return TS;
 
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
     TC.typeCheckExpression(E, DC, TypeLoc::withoutLoc(exnType), CTP_ThrowStmt);
     TS->setSubExpr(E);
     
@@ -644,6 +649,9 @@ public:
   }
 
   Stmt *visitPoundAssertStmt(PoundAssertStmt *PA) {
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     Expr *C = PA->getCondition();
     TC.typeCheckCondition(C, DC);
     PA->setCondition(C);
@@ -651,6 +659,9 @@ public:
   }
     
   Stmt *visitDeferStmt(DeferStmt *DS) {
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     TC.typeCheckDecl(DS->getTempDecl());
 
     Expr *theCall = DS->getCallExpr();
@@ -661,6 +672,9 @@ public:
   }
   
   Stmt *visitIfStmt(IfStmt *IS) {
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     StmtCondition C = IS->getCond();
     TC.typeCheckStmtCondition(C, DC, diag::if_always_true);
     IS->setCond(C);
@@ -680,6 +694,9 @@ public:
   }
   
   Stmt *visitGuardStmt(GuardStmt *GS) {
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     StmtCondition C = GS->getCond();
     TC.typeCheckStmtCondition(C, DC, diag::guard_always_succeeds);
     GS->setCond(C);
@@ -701,6 +718,9 @@ public:
   }
   
   Stmt *visitWhileStmt(WhileStmt *WS) {
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     StmtCondition C = WS->getCond();
     TC.typeCheckStmtCondition(C, DC, diag::while_always_true);
     WS->setCond(C);
@@ -719,7 +739,10 @@ public:
       typeCheckStmt(S);
       RWS->setBody(S);
     }
-    
+
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     Expr *E = RWS->getCond();
     TC.typeCheckCondition(E, DC);
     RWS->setCond(E);
@@ -738,7 +761,9 @@ public:
       S->getPattern()->setType(ErrorType::get(getASTContext()));
       return nullptr;
     }
-  
+
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
     if (TC.typeCheckPattern(S->getPattern(), DC, options)) {
       // FIXME: Handle errors better.
       S->getPattern()->setType(ErrorType::get(getASTContext()));
@@ -1081,6 +1106,9 @@ public:
       return;
     }
 
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     pattern = newPattern;
     // Coerce the pattern to the subject's type.
     TypeResolutionOptions patternOptions(TypeResolverContext::InExpression);
@@ -1281,6 +1309,9 @@ public:
   }
 
   Stmt *visitSwitchStmt(SwitchStmt *switchStmt) {
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     // Type-check the subject expression.
     Expr *subjectExpr = switchStmt->getSubjectExpr();
     auto resultTy = TC.typeCheckExpression(subjectExpr, DC);
@@ -1436,6 +1467,9 @@ public:
   }
 
   void checkCatchStmt(CatchStmt *S) {
+    // FIXME: Remove TypeChecker dependency.
+    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
+
     // Check the catch pattern.
     TC.typeCheckCatchPattern(S, DC);
 
@@ -1804,6 +1838,8 @@ Stmt *StmtChecker::visitBraceStmt(BraceStmt *BS) {
     }
   }
 
+  // FIXME: Remove TypeChecker dependencies below.
+  auto &TC = *Ctx.getLegacyGlobalTypeChecker();
   for (auto &elem : BS->getElements()) {
     if (auto *SubExpr = elem.dyn_cast<Expr*>()) {
       SourceLoc Loc = SubExpr->getStartLoc();
@@ -2150,7 +2186,7 @@ TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
   if (ctx.LangOpts.EnableASTScopeLookup)
     ASTScope::expandFunctionBody(AFD);
 
-  StmtChecker SC(tc, AFD);
+  StmtChecker SC(AFD);
   SC.EndTypeCheckLoc = endTypeCheckLoc;
   bool hadError = SC.typeCheckBody(body);
 
@@ -2203,7 +2239,7 @@ bool TypeChecker::typeCheckClosureBody(ClosureExpr *closure) {
   if (DebugTimeFunctionBodies || WarnLongFunctionBodies)
     timer.emplace(closure, DebugTimeFunctionBodies, WarnLongFunctionBodies);
 
-  bool HadError = StmtChecker(*this, closure).typeCheckBody(body);
+  bool HadError = StmtChecker(closure).typeCheckBody(body);
   if (body) {
     closure->setBody(body, closure->hasSingleExpressionBody());
   }
@@ -2214,7 +2250,7 @@ bool TypeChecker::typeCheckTapBody(TapExpr *expr, DeclContext *DC) {
   // We intentionally use typeCheckStmt instead of typeCheckBody here
   // because we want to contextualize TapExprs with the body they're in.
   BraceStmt *body = expr->getBody();
-  bool HadError = StmtChecker(*this, DC).typeCheckStmt(body);
+  bool HadError = StmtChecker(DC).typeCheckStmt(body);
   if (body) {
     expr->setBody(body);
   }
@@ -2226,7 +2262,7 @@ void TypeChecker::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
   // because we want to contextualize all the TopLevelCode
   // declarations simultaneously.
   BraceStmt *Body = TLCD->getBody();
-  StmtChecker(*this, TLCD).typeCheckStmt(Body);
+  StmtChecker(TLCD).typeCheckStmt(Body);
   TLCD->setBody(Body);
   checkTopLevelErrorHandling(TLCD);
   performTopLevelDeclDiagnostics(TLCD);

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -298,6 +298,7 @@ namespace {
 class StmtChecker : public StmtVisitor<StmtChecker, Stmt*> {
 public:
   TypeChecker &TC;
+  ASTContext &Ctx;
 
   /// This is the current function or closure being checked.
   /// This is null for top level code.
@@ -332,7 +333,7 @@ public:
   /// Used to distinguish the first BraceStmt that starts a TopLevelCodeDecl.
   bool IsBraceStmtFromTopLevelDecl;
 
-  ASTContext &getASTContext() const { return TC.Context; };
+  ASTContext &getASTContext() const { return Ctx; };
   
   struct AddLabeledStmt {
     StmtChecker &SC;
@@ -374,15 +375,15 @@ public:
   };
 
   StmtChecker(TypeChecker &TC, AbstractFunctionDecl *AFD)
-      : TC(TC), TheFunc(AFD), DC(AFD), IsREPL(false),
+      : TC(TC), Ctx(AFD->getASTContext()), TheFunc(AFD), DC(AFD), IsREPL(false),
         IsBraceStmtFromTopLevelDecl(false) {}
 
   StmtChecker(TypeChecker &TC, ClosureExpr *TheClosure)
-      : TC(TC), TheFunc(TheClosure), DC(TheClosure), IsREPL(false),
-        IsBraceStmtFromTopLevelDecl(false) {}
+      : TC(TC), Ctx(TheClosure->getASTContext()), TheFunc(TheClosure),
+        DC(TheClosure), IsREPL(false), IsBraceStmtFromTopLevelDecl(false) {}
 
   StmtChecker(TypeChecker &TC, DeclContext *DC)
-      : TC(TC), TheFunc(), DC(DC), IsREPL(false),
+      : TC(TC), Ctx(DC->getASTContext()), TheFunc(), DC(DC), IsREPL(false),
         IsBraceStmtFromTopLevelDecl(false) {
     if (const SourceFile *SF = DC->getParentSourceFile())
       if (SF->Kind == SourceFileKind::REPL)

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -545,9 +545,6 @@ enum class FunctionBuilderClosurePreCheck : uint8_t {
 /// type checking, and semantic analysis to produce a type-annotated AST.
 class TypeChecker final {
 public:
-  ASTContext &Context;
-  DiagnosticEngine &Diags;
-
   /// The list of function definitions we've encountered.
   std::vector<AbstractFunctionDecl *> definedFunctions;
 
@@ -556,6 +553,9 @@ public:
   std::vector<AbstractClosureExpr *> ClosuresWithUncomputedCaptures;
 
 private:
+  ASTContext &Context;
+  DiagnosticEngine &Diags;
+
   /// The set of expressions currently being analyzed for failures.
   llvm::DenseMap<Expr*, Expr*> DiagnosedExprs;
 


### PR DESCRIPTION
Remove the remaining external uses of TypeChecker's `Context` field, and make it private along with `Diags`.

Also remove TypeChecker fields from a few walkers, flipping things such that instead of storing a TypeChecker and asking for the ASTContext when needed, store an ASTContext, and ask for a TypeChecker when needed.