### PR TITLE
EscapeAnalysis: add a refcount flag to content nodes.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ValueTracking.h
+++ b/include/swift/SILOptimizer/Analysis/ValueTracking.h
@@ -47,7 +47,7 @@ bool pointsToLocalObject(SILValue V);
 /// allocated object).
 ///
 /// - an address projection based on an exclusive argument with no levels of
-/// indirection.
+/// indirection (e.g. ref_element_addr, project_box, etc.).
 inline bool isUniquelyIdentified(SILValue V) {
   return pointsToLocalObject(V)
          || isExclusiveArgument(getUnderlyingAddressRoot(V));


### PR DESCRIPTION
This property will allow alias analysis to be safely optmistic when
querying the connection graph. A node that is known to have a ref
count is know to keep alive everything it points to. Therefore,
calling a deinitializer on a different reference cannot release the RC
node's contents.
