### PR TITLE
[AutoDiff] Revamp and fix variedness propagation in activity analysis.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1436,7 +1436,7 @@ private:
   /// Marks the given value as varied and propagates variedness to users.
   void setVariedAndPropagateToUsers(SILValue value,
                                     unsigned independentVariableIndex);
-  /// Propagates variedness for the given operand to its user's result.
+  /// Propagates variedness for the given operand to its user's results.
   void propagateVaried(Operand *operand, unsigned independentVariableIndex);
   /// Marks the given value as varied and recursively propagates variedness
   /// inwards (to operands) through projections. Skips `@noDerivative` struct

--- a/test/AutoDiff/activity_analysis.swift
+++ b/test/AutoDiff/activity_analysis.swift
@@ -38,16 +38,13 @@ func TF_781_function(_ x: Float, _ y: Float) -> Float {
   return result
 }
 
-// FIXME(TF-781): `%4 = alloc_stack $Float` is active, so all `begin_access`
-// users (and the results of their users, recursively) should also be active.
-
 // CHECK-LABEL: [AD] Activity info for ${{.*}}TF_781_function{{.*}} at (source=0 parameters=(0))
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Float
 // CHECK: [USEFUL] %1 = argument of bb0 : $Float
 // CHECK: [ACTIVE]   %4 = alloc_stack $Float, var, name "result"
-// CHECK: [USEFUL]   %19 = begin_access [read] [static] %4 : $*Float
-// CHECK: [USEFUL]   %20 = load [trivial] %19 : $*Float
+// CHECK: [ACTIVE]   %19 = begin_access [read] [static] %4 : $*Float
+// CHECK: [ACTIVE]   %20 = load [trivial] %19 : $*Float
 // CHECK: [ACTIVE]   %23 = apply %22(%20, %0, %18) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
 // CHECK: [ACTIVE]   %24 = begin_access [modify] [static] %4 : $*Float
-// CHECK: [USEFUL]   %31 = begin_access [read] [static] %4 : $*Float
-// CHECK: [USEFUL]   %32 = load [trivial] %31 : $*Float
+// CHECK: [ACTIVE]   %31 = begin_access [read] [static] %4 : $*Float
+// CHECK: [ACTIVE]   %32 = load [trivial] %31 : $*Float

--- a/test/AutoDiff/control_flow.swift
+++ b/test/AutoDiff/control_flow.swift
@@ -375,9 +375,7 @@ ControlFlowTests.test("NestedConditionals") {
       }
     }
     let x: Float = 10
-    // FIXME(TF-781): Fix zero gradients (related to activity analysis).
-    // expectEqual(TF_781.TangentVector(w: x), gradient(at: TF_781()) { $0(x) })
-    expectEqual(TF_781.TangentVector(w: 0), gradient(at: TF_781()) { $0(x) })
+    expectEqual(TF_781.TangentVector(w: x), gradient(at: TF_781()) { $0(x) })
   }
 
   // Non-method version of TF-781.
@@ -393,9 +391,7 @@ ControlFlowTests.test("NestedConditionals") {
       return result
     }
     let x: Float = 10
-    // FIXME(TF-781): Fix zero gradients (related to activity analysis).
-    // expectEqual(x, gradient(at: 3) { TF_781($0, x) })
-    expectEqual(0, gradient(at: 3) { TF_781($0, x) })
+    expectEqual(x, gradient(at: 3) { TF_781($0, x) })
   }
 }
 
@@ -439,20 +435,11 @@ ControlFlowTests.test("Recursion") {
     }
     return y
   }
-  // FIXME(TF-933): Fix zero gradients (related to activity analysis).
-  // See `factorial_var1` for the working version.
-  /*
   expectEqual(0, gradient(at: 1, in: factorial_var2))
   expectEqual(1, gradient(at: 2, in: factorial_var2))
   expectEqual(5, gradient(at: 3, in: factorial_var2))
   expectEqual(26, gradient(at: 4, in: factorial_var2))
   expectEqual(154, gradient(at: 5, in: factorial_var2))
-  */
-  expectEqual(0, gradient(at: 1, in: factorial_var2))
-  expectEqual(0, gradient(at: 2, in: factorial_var2))
-  expectEqual(0, gradient(at: 3, in: factorial_var2))
-  expectEqual(0, gradient(at: 4, in: factorial_var2))
-  expectEqual(0, gradient(at: 5, in: factorial_var2))
 
   func product(_ x: Float, count: Int) -> Float {
     precondition(count > 0)
@@ -579,12 +566,8 @@ ControlFlowTests.test("Loops") {
     }
     return result
   }
-  // FIXME(TF-933): Fix incorrect derivatives when `var result` is not initially
-  // assigned to `x`.
-  // expectEqual((4, 4), valueWithGradient(at: 2, in: for_loop_nonactive_initial_value))
-  // expectEqual((9, 6), valueWithGradient(at: 3, in: for_loop_nonactive_initial_value))
-  expectEqual((4, 2), valueWithGradient(at: 2, in: for_loop_nonactive_initial_value))
-  expectEqual((9, 3), valueWithGradient(at: 3, in: for_loop_nonactive_initial_value))
+  expectEqual((4, 4), valueWithGradient(at: 2, in: for_loop_nonactive_initial_value))
+  expectEqual((9, 6), valueWithGradient(at: 3, in: for_loop_nonactive_initial_value))
 
   func while_loop(_ x: Float) -> Float {
     var result = x
@@ -607,12 +590,8 @@ ControlFlowTests.test("Loops") {
     }
     return result
   }
-  // FIXME(TF-933): Fix incorrect derivatives when `var result` is not initially
-  // assigned to `x`.
-  // expectEqual((4, 4), valueWithGradient(at: 2, in: while_loop_nonactive_initial_value))
-  // expectEqual((9, 6), valueWithGradient(at: 3, in: while_loop_nonactive_initial_value))
-  expectEqual((4, 2), valueWithGradient(at: 2, in: while_loop_nonactive_initial_value))
-  expectEqual((9, 3), valueWithGradient(at: 3, in: while_loop_nonactive_initial_value))
+  expectEqual((4, 4), valueWithGradient(at: 2, in: while_loop_nonactive_initial_value))
+  expectEqual((9, 6), valueWithGradient(at: 3, in: while_loop_nonactive_initial_value))
 
   func repeat_while_loop(_ x: Float) -> Float {
     var result = x
@@ -623,8 +602,8 @@ ControlFlowTests.test("Loops") {
     } while i < 2
     return result
   }
-  // FIXME(TF-584): Investigate incorrect (too big) gradient values
-  // for repeat-while loops.
+  // FIXME(TF-584): Investigate incorrect (too big) gradient values for
+  // repeat-while loops.
   // expectEqual((8, 12), valueWithGradient(at: 2, in: repeat_while_loop))
   // expectEqual((27, 27), valueWithGradient(at: 3, in: repeat_while_loop))
   expectEqual((8, 18), valueWithGradient(at: 2, in: repeat_while_loop))
@@ -639,12 +618,12 @@ ControlFlowTests.test("Loops") {
     } while i < 2
     return result
   }
-  // FIXME(TF-584, TF-933): Fix incorrect derivatives when `var result` is not
-  // initially assigned to `x`.
+  // FIXME(TF-584): Investigate incorrect (too big) gradient values for
+  // repeat-while loops.
   // expectEqual((4, 4), valueWithGradient(at: 2, in: repeat_while_loop_nonactive_initial_value))
   // expectEqual((9, 6), valueWithGradient(at: 3, in: repeat_while_loop_nonactive_initial_value))
-  expectEqual((4, 3), valueWithGradient(at: 2, in: repeat_while_loop_nonactive_initial_value))
-  expectEqual((9, 4), valueWithGradient(at: 3, in: repeat_while_loop_nonactive_initial_value))
+  expectEqual((4, 5), valueWithGradient(at: 2, in: repeat_while_loop_nonactive_initial_value))
+  expectEqual((9, 7), valueWithGradient(at: 3, in: repeat_while_loop_nonactive_initial_value))
 
   func loop_continue(_ x: Float) -> Float {
     var result = x


### PR DESCRIPTION
Varied values are those that depend on (specific) independent variable,
i.e. function arguments.

For addresses: all projections of a varied address should be varied.
This has special support:
`DifferentiableActivityInfo::propagateVariedInwardsThroughProjections`.

Previously:
- Variedness was propagated by iterating through all instructions in dominance
  order. This is not efficient because irrelevant instructions may be visited.
- For varied addresses, `propagateVariedInwardsThroughProjections` propagated
  variedness one step to projections, but not recursively to users of the
  projections. This caused some values to incorrectly be marked as non-varied.

Now:
- Variedness is propagated by following use-def chains, starting from
  independent variables (function arguments). This is handled by the
  following helpers:
  - `setVariedAndPropagateToUsers(SILValue, unsigned)`: marks a value as varied
    and propagates variedness to users.
  - `propagateVaried(SILInstruction *inst, unsigned)`: propagates
    variedness for the given instruction from operands to results.
- `DifferentiableActivityInfo::propagateVariedInwardsThroughProjections`
  now propagates variedness recursively through projections, which is desired.

Resolves various control flow differentiation correctness issues:
TF-681, TF-781, TF-933.

All of these issues involve incorrect variedness propagation for
initially non-varied addresses.

TF-947 tracks further improvements to varied propagation.
TF-949 tracks similar revamping for usefulness propagation.

---

Visual demonstration using activity info output from `-Xllvm -debug-only=differentiation`:

```swift
// TF-781: check activity analysis for active local address + nested conditionals.
// If an address is varied, all its projections and their users should be varied.

@differentiable(wrt: x)
func TF_781_function(_ x: Float, _ y: Float) -> Float {
  var result = y
  if true {
    if true {
      result = result * x
    }
  }
  return result
}
```

Before:
```
// FIXME(TF-781): `%4 = alloc_stack $Float` is active, so all `begin_access`
// users (and the results of their users, recursively) should also be active.

[AD] Activity info for ${{.*}}TF_781_function{{.*}} at (source=0 parameters=(0))
[ACTIVE] %0 = argument of bb0 : $Float
[USEFUL] %1 = argument of bb0 : $Float
[ACTIVE]   %4 = alloc_stack $Float, var, name "result"
[USEFUL]   %19 = begin_access [read] [static] %4 : $*Float
[USEFUL]   %20 = load [trivial] %19 : $*Float
[ACTIVE]   %23 = apply %22(%20, %0, %18) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
[ACTIVE]   %24 = begin_access [modify] [static] %4 : $*Float
[USEFUL]   %31 = begin_access [read] [static] %4 : $*Float
[USEFUL]   %32 = load [trivial] %31 : $*Float
```

After:
```
[AD] Activity info for ${{.*}}TF_781_function{{.*}} at (source=0 parameters=(0))
[ACTIVE] %0 = argument of bb0 : $Float
[USEFUL] %1 = argument of bb0 : $Float
[ACTIVE]   %4 = alloc_stack $Float, var, name "result"
[ACTIVE]   %19 = begin_access [read] [static] %4 : $*Float
[ACTIVE]   %20 = load [trivial] %19 : $*Float
[ACTIVE]   %23 = apply %22(%20, %0, %18) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
[ACTIVE]   %24 = begin_access [modify] [static] %4 : $*Float
[ACTIVE]   %31 = begin_access [read] [static] %4 : $*Float
[ACTIVE]   %32 = load [trivial] %31 : $*Float
```