### PR TITLE
[build-presets] Don't build SwiftSyntax on continuous incremental bots

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -328,12 +328,6 @@ swiftpm
 indexstore-db
 sourcekit-lsp
 
-swiftsyntax
-swiftsyntax-verify-generated-files
-
-skstresstester
-swiftevolve
-
 # Build Playground support
 playgroundsupport
 
@@ -1025,7 +1019,6 @@ swiftpm
 xctest
 foundation
 libdispatch
-swiftsyntax
 indexstore-db
 sourcekit-lsp
 dash-dash


### PR DESCRIPTION
Continuous incremental bots don't currently check out SwiftSyntax, so building it fails.

Until the bots check out SwiftSyntax, don't test SwiftSyntax in these builds.

This reverts the parts of https://github.com/apple/swift/pull/27855 that broke CI.