### PR TITLE
Fix unused variable warning.

### DIFF
--- a/lib/Sema/DerivedConformanceVectorProtocol.cpp
+++ b/lib/Sema/DerivedConformanceVectorProtocol.cpp
@@ -72,7 +72,6 @@ static Type getVectorProtocolVectorSpaceScalarAssocType(
 // the given context, or `nullptr` if `VectorSpaceScalar` cannot be derived.
 static Type deriveVectorProtocol_VectorSpaceScalar(NominalTypeDecl *nominal,
                                                    DeclContext *DC) {
-  auto &C = DC->getASTContext();
   // Nominal type must be a struct. (Zero stored properties is okay.)
   if (!isa<StructDecl>(nominal))
     return nullptr;


### PR DESCRIPTION
Introduced in https://github.com/apple/swift/pull/28080: `swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a -> tensorflow` merge.