### PR TITLE
[android] Split the Android CI build presets.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -818,13 +818,22 @@ mixin-preset=
     mixin_buildbot_linux,no_test
 
 [preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build]
-mixin-preset=buildbot_linux
-
-host-test
+mixin-preset=
+    mixin_lightweight_assertions
+    mixin_linux_install_components_with_clang
+build-subdir=buildbot_linux
 
 release
-assertions
-extra-cmake-options=-DSWIFT_ENABLE_LLD_LINKER:BOOL=OFF
+test
+validation-test
+long-test
+stress-test
+test-optimized
+lit-args=-v --time-tests
+
+build-ninja
+libicu
+libcxx
 
 dash-dash
 
@@ -837,23 +846,30 @@ android-icu-i18n=%(arm_dir)s/libicui18nswift.so
 android-icu-i18n-include=%(arm_dir)s/icu/source/i18n
 android-icu-data=%(arm_dir)s/libicudataswift.so
 
-# Disable many build host products. They are unrelated to Android. Foundation,
-# libdispatch and XCTest are also disabled because build-script-impl doesn't
-# build them for cross-compiled Android.
+build-swift-static-stdlib
+build-swift-static-sdk-overlay
+build-swift-stdlib-unittest-extra
+
+# Path to the root of the installation filesystem.
+install-destdir=%(install_destdir)s
+
+# Path to the .tar.gz package we would create.
+installable-package=%(installable_package)s
+
+host-test
+
+extra-cmake-options=-DSWIFT_ENABLE_LLD_LINKER:BOOL=OFF
+
+install-prefix=/usr
+install-swift
+install-libicu
+install-libcxx
+
 skip-test-linux
-skip-build-lldb
-skip-build-llbuild
-skip-build-libdispatch
-skip-build-foundation
-skip-build-xctest
-skip-build-playgroundsupport
 skip-build-benchmarks
-swiftpm=0
-indexstore-db=0
-sourcekit-lsp=0
-toolchain-benchmarks=0
-test-installable-package=
-install-swiftpm=0
+skip-build-playgroundsupport
+
+reconfigure
 
 [preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build,aarch64]
 mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build


### PR DESCRIPTION
By not depending on buildbot_linux, the changes there will not affect
the Android builders. It will mean having to move the intended changes
manually, but it will hopefully be more stable.

The Android CI builds started failing after #27855 in
https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/4401/ and https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/2671/.

[Edit: correct PR link]