### PR TITLE
[build-presets] Don't build the stress tester in Swift PR testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1390,10 +1390,6 @@ install-llbuild
 install-swiftpm
 install-libcxx
 
-# Build the stress tester and SwiftEvolve
-skstresstester
-swiftevolve
-
 # Build Playground support
 playgroundsupport
 


### PR DESCRIPTION
The continuous PR status bots don't check out the stress tester repository and started failing. Don't build the stress tester until the bots check the repository out.