### PR TITLE
[build-presets] Test SwiftSyntax and related projects in CI

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -328,6 +328,12 @@ swiftpm
 indexstore-db
 sourcekit-lsp
 
+swiftsyntax
+swiftsyntax-verify-generated-files
+
+skstresstester
+swiftevolve
+
 # Build Playground support
 playgroundsupport
 
@@ -1019,6 +1025,7 @@ swiftpm
 xctest
 foundation
 libdispatch
+swiftsyntax
 indexstore-db
 sourcekit-lsp
 dash-dash
@@ -1389,6 +1396,10 @@ install-swift
 install-llbuild
 install-swiftpm
 install-libcxx
+
+# Build the stress tester and SwiftEvolve
+skstresstester
+swiftevolve
 
 # Build Playground support
 playgroundsupport


### PR DESCRIPTION
Re-enable testing of SwiftSyntax and downstream projects in CI testing.

This was first enabled in https://github.com/apple/swift/pull/27855, then reverted in https://github.com/apple/swift/pull/28159 and https://github.com/apple/swift/pull/28169 because the corresponding bots did not check out the SwiftSyntax or stress tester repositories. Re-enable it once the bots check out these repos.