### PR TITLE
[NFC] Centralize TypeChecker Flags With TypeCheckerOptions

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -201,8 +201,9 @@ class ASTContext final {
   ASTContext(const ASTContext&) = delete;
   void operator=(const ASTContext&) = delete;
 
-  ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
-             SourceManager &SourceMgr, DiagnosticEngine &Diags);
+  ASTContext(LangOptions &langOpts, TypeCheckerOptions &typeckOpts,
+             SearchPathOptions &SearchPathOpts, SourceManager &SourceMgr,
+             DiagnosticEngine &Diags);
 
 public:
   // Members that should only be used by ASTContext.cpp.
@@ -213,10 +214,9 @@ public:
 
   void operator delete(void *Data) throw();
 
-  static ASTContext *get(LangOptions &langOpts,
+  static ASTContext *get(LangOptions &langOpts, TypeCheckerOptions &typeckOpts,
                          SearchPathOptions &SearchPathOpts,
-                         SourceManager &SourceMgr,
-                         DiagnosticEngine &Diags);
+                         SourceManager &SourceMgr, DiagnosticEngine &Diags);
   ~ASTContext();
 
   /// Optional table of counters to report, nullptr when not collecting.
@@ -227,6 +227,9 @@ public:
 
   /// The language options used for translation.
   LangOptions &LangOpts;
+
+  /// The type checker options.
+  TypeCheckerOptions &TypeCheckerOpts;
 
   /// The search path options used by this AST context.
   SearchPathOptions &SearchPathOpts;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -56,7 +56,7 @@ namespace swift {
 
   /// A collection of options that affect the language dialect and
   /// provide compiler debugging facilities.
-  class LangOptions {
+  class LangOptions final {
   public:
 
     /// The target we are building for.
@@ -455,6 +455,54 @@ namespace swift {
     llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 5>
         PlatformConditionValues;
     llvm::SmallVector<std::string, 2> CustomConditionalCompilationFlags;
+  };
+
+  class TypeCheckerOptions final {
+  public:
+    /// If non-zero, warn when a function body takes longer than this many
+    /// milliseconds to type-check.
+    ///
+    /// Intended for debugging purposes only.
+    unsigned WarnLongFunctionBodies = 0;
+
+    /// If non-zero, warn when type-checking an expression takes longer
+    /// than this many milliseconds.
+    ///
+    /// Intended for debugging purposes only.
+    unsigned WarnLongExpressionTypeChecking = 0;
+
+    /// If non-zero, abort the expression type checker if it takes more
+    /// than this many seconds.
+    unsigned ExpressionTimeoutThreshold = 600;
+
+    /// If non-zero, abort the switch statement exhaustiveness checker if
+    /// the Space::minus function is called more than this many times.
+    ///
+    /// Why this number? Times out in about a second on a 2017 iMac, Retina 5K,
+    /// 4.2 GHz Intel Core i7.
+    /// (It's arbitrary, but will keep the compiler from taking too much time.)
+    unsigned SwitchCheckingInvocationThreshold = 200000;
+
+    /// Whether to delay checking that benefits from having the entire
+    /// module parsed, e.g., Objective-C method override checking.
+    bool DelayWholeModuleChecking = false;
+
+    /// If true, the time it takes to type-check each function will be dumped
+    /// to llvm::errs().
+    bool DebugTimeFunctionBodies = false;
+
+    /// If true, the time it takes to type-check each expression will be
+    /// dumped to llvm::errs().
+    bool DebugTimeExpressions = false;
+
+    /// Indicate that the type checker is checking code that will be
+    /// immediately executed. This will suppress certain warnings
+    /// when executing scripts.
+    bool InImmediateMode = false;
+
+    /// Indicate that the type checker should skip type-checking non-inlinable
+    /// function bodies.
+    bool SkipNonInlinableFunctionBodies = false;
   };
 } // end namespace swift
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -83,6 +83,7 @@ struct ModuleBuffers {
 /// which manages the actual compiler execution.
 class CompilerInvocation {
   LangOptions LangOpts;
+  TypeCheckerOptions TypeCheckerOpts;
   FrontendOptions FrontendOpts;
   ClangImporterOptions ClangImporterOpts;
   SearchPathOptions SearchPathOpts;
@@ -213,6 +214,11 @@ public:
   }
   const LangOptions &getLangOptions() const {
     return LangOpts;
+  }
+
+  TypeCheckerOptions &getTypeCheckerOptions() { return TypeCheckerOpts; }
+  const TypeCheckerOptions &getTypeCheckerOptions() const {
+    return TypeCheckerOpts;
   }
 
   FrontendOptions &getFrontendOptions() { return FrontendOpts; }
@@ -648,14 +654,11 @@ private:
   bool
   parsePartialModulesAndLibraryFiles(const ImplicitImports &implicitImports);
 
-  OptionSet<TypeCheckingFlags> computeTypeCheckingOptions();
-
   void forEachFileToTypeCheck(llvm::function_ref<void(SourceFile &)> fn);
 
-  void parseAndTypeCheckMainFileUpTo(SourceFile::ASTStage_t LimitStage,
-                                     OptionSet<TypeCheckingFlags> TypeCheckOptions);
+  void parseAndTypeCheckMainFileUpTo(SourceFile::ASTStage_t LimitStage);
 
-  void finishTypeChecking(OptionSet<TypeCheckingFlags> TypeCheckOptions);
+  void finishTypeChecking();
 
 public:
   const PrimarySpecificPaths &

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -82,28 +82,6 @@ public:
   /// Emit index data for imported serialized swift system modules.
   bool IndexSystemModules = false;
 
-  /// If non-zero, warn when a function body takes longer than this many
-  /// milliseconds to type-check.
-  ///
-  /// Intended for debugging purposes only.
-  unsigned WarnLongFunctionBodies = 0;
-
-  /// If non-zero, warn when type-checking an expression takes longer
-  /// than this many milliseconds.
-  ///
-  /// Intended for debugging purposes only.
-  unsigned WarnLongExpressionTypeChecking = 0;
-
-  /// If non-zero, overrides the default threshold for how long we let
-  /// the expression type checker run before we consider an expression
-  /// too complex.
-  unsigned SolverExpressionTimeThreshold = 0;
-  
-  /// If non-zero, overrides the default threshold for how many times
-  /// the Space::minus function is called before we consider switch statement
-  /// exhaustiveness checking to be too complex.
-  unsigned SwitchCheckingInvocationThreshold = 0;
-
   /// The module for which we should verify all of the generic signatures.
   std::string VerifyGenericSignaturesInModule;
 
@@ -182,8 +160,6 @@ public:
   ///
   /// \sa swift::SharedTimer
   bool DebugTimeCompilation = false;
-
-  bool SkipNonInlinableFunctionBodies = false;
 
   /// The path to which we should output statistics files.
   std::string StatsOutputDir;

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -168,30 +168,6 @@ namespace swift {
   /// to add calls to externally provided functions that simulate
   /// "program counter"-like debugging events.
   void performPCMacro(SourceFile &SF, TopLevelContext &TLC);
-  
-  /// Flags used to control type checking.
-  enum class TypeCheckingFlags : unsigned {
-    /// Whether to delay checking that benefits from having the entire
-    /// module parsed, e.g., Objective-C method override checking.
-    DelayWholeModuleChecking = 1 << 0,
-
-    /// If set, dumps wall time taken to check each function body to
-    /// llvm::errs().
-    DebugTimeFunctionBodies = 1 << 1,
-
-    /// Indicates that the type checker is checking code that will be
-    /// immediately executed.
-    ForImmediateMode = 1 << 2,
-
-    /// If set, dumps wall time taken to type check each expression to
-    /// llvm::errs().
-    DebugTimeExpressions = 1 << 3,
-
-    /// If set, the typechecker will skip typechecking non-inlinable function
-    /// bodies. Set this if you're trying to quickly emit a module or module
-    /// interface without a full compilation.
-    SkipNonInlinableFunctionBodies = 1 << 4,
-  };
 
   /// Creates a type checker instance on the given AST context, if it
   /// doesn't already have one.
@@ -372,7 +348,8 @@ namespace swift {
   class ParserUnit {
   public:
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
-               const LangOptions &LangOpts, StringRef ModuleName,
+               const LangOptions &LangOpts, const TypeCheckerOptions &TyOpts,
+               StringRef ModuleName,
                std::shared_ptr<SyntaxParseActions> spActions = nullptr,
                SyntaxParsingCache *SyntaxCache = nullptr);
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID);

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -66,6 +66,7 @@ namespace swift {
   class Token;
   class TopLevelContext;
   class TypeChecker;
+  class TypeCheckerOptions;
   struct TypeLoc;
   class UnifiedStatsReporter;
   enum class SourceFileKind;
@@ -183,16 +184,8 @@ namespace swift {
   ///
   /// \param StartElem Where to start for incremental type-checking in the main
   /// source file.
-  ///
-  /// \param WarnLongFunctionBodies If non-zero, warn when a function body takes
-  /// longer than this many milliseconds to type-check
   void performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
-                           OptionSet<TypeCheckingFlags> Options,
-                           unsigned StartElem = 0,
-                           unsigned WarnLongFunctionBodies = 0,
-                           unsigned WarnLongExpressionTypeChecking = 0,
-                           unsigned ExpressionTimeoutThreshold = 0,
-                           unsigned SwitchCheckingInvocationThreshold = 0);
+                           unsigned StartElem = 0);
 
   /// Now that we have type-checked an entire module, perform any type
   /// checking that requires the full module, e.g., Objective-C method

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -504,6 +504,7 @@ void ASTContext::operator delete(void *Data) throw() {
 }
 
 ASTContext *ASTContext::get(LangOptions &langOpts,
+                            TypeCheckerOptions &typeckOpts,
                             SearchPathOptions &SearchPathOpts,
                             SourceManager &SourceMgr,
                             DiagnosticEngine &Diags) {
@@ -516,15 +517,16 @@ ASTContext *ASTContext::get(LangOptions &langOpts,
   auto impl = reinterpret_cast<void*>((char*)mem + sizeof(ASTContext));
   impl = reinterpret_cast<void*>(llvm::alignAddr(impl,alignof(Implementation)));
   new (impl) Implementation();
-  return new (mem) ASTContext(langOpts, SearchPathOpts, SourceMgr, Diags);
+  return new (mem)
+      ASTContext(langOpts, typeckOpts, SearchPathOpts, SourceMgr, Diags);
 }
 
-ASTContext::ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
+ASTContext::ASTContext(LangOptions &langOpts, TypeCheckerOptions &typeckOpts,
+                       SearchPathOptions &SearchPathOpts,
                        SourceManager &SourceMgr, DiagnosticEngine &Diags)
   : LangOpts(langOpts),
-    SearchPathOpts(SearchPathOpts),
-    SourceMgr(SourceMgr),
-    Diags(Diags),
+    TypeCheckerOpts(typeckOpts),
+    SearchPathOpts(SearchPathOpts), SourceMgr(SourceMgr), Diags(Diags),
     evaluator(Diags, langOpts.DebugDumpCycles),
     TheBuiltinModule(createBuiltinModule(*this)),
     StdlibModuleName(getIdentifier(STDLIB_NAME)),

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -90,15 +90,6 @@ bool ArgsToFrontendOptionsConverter::convert(
   computeDebugTimeOptions();
   computeTBDOptions();
 
-  setUnsignedIntegerArgument(OPT_warn_long_function_bodies, 10,
-                             Opts.WarnLongFunctionBodies);
-  setUnsignedIntegerArgument(OPT_warn_long_expression_type_checking, 10,
-                             Opts.WarnLongExpressionTypeChecking);
-  setUnsignedIntegerArgument(OPT_solver_expression_time_threshold_EQ, 10,
-                             Opts.SolverExpressionTimeThreshold);
-  setUnsignedIntegerArgument(OPT_switch_checking_invocation_threshold_EQ, 10,
-                             Opts.SwitchCheckingInvocationThreshold);
-
   Opts.CheckOnoneSupportCompleteness = Args.hasArg(OPT_check_onone_completeness);
 
   Opts.DebuggerTestingTransform = Args.hasArg(OPT_debugger_testing_transform);
@@ -163,7 +154,7 @@ bool ArgsToFrontendOptionsConverter::convert(
     return true;
 
   if (FrontendOptions::doesActionGenerateIR(Opts.RequestedAction)
-      && Opts.SkipNonInlinableFunctionBodies) {
+      && Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies)) {
     Diags.diagnose(SourceLoc(), diag::cannot_emit_ir_skipping_function_bodies);
     return true;
   }
@@ -222,17 +213,7 @@ void ArgsToFrontendOptionsConverter::computePrintStatsOptions() {
 
 void ArgsToFrontendOptionsConverter::computeDebugTimeOptions() {
   using namespace options;
-  Opts.DebugTimeFunctionBodies |= Args.hasArg(OPT_debug_time_function_bodies);
-  Opts.DebugTimeExpressionTypeChecking |=
-      Args.hasArg(OPT_debug_time_expression_type_checking);
   Opts.DebugTimeCompilation |= Args.hasArg(OPT_debug_time_compilation);
-  Opts.SkipNonInlinableFunctionBodies |=
-      Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies);
-
-  // If asked to perform InstallAPI, go ahead and enable non-inlinable function
-  // body skipping.
-  Opts.SkipNonInlinableFunctionBodies |=
-      Args.hasArg(OPT_tbd_is_installapi);
 
   if (const Arg *A = Args.getLastArg(OPT_stats_output_dir)) {
     Opts.StatsOutputDir = A->getValue();
@@ -262,19 +243,6 @@ void ArgsToFrontendOptionsConverter::computeTBDOptions() {
     } else {
       Diags.diagnose(SourceLoc(), diag::error_unsupported_option_argument,
                      A->getOption().getPrefixedName(), value);
-    }
-  }
-}
-
-void ArgsToFrontendOptionsConverter::setUnsignedIntegerArgument(
-    options::ID optionID, unsigned radix, unsigned &valueToSet) {
-  if (const Arg *A = Args.getLastArg(optionID)) {
-    unsigned attempt;
-    if (StringRef(A->getValue()).getAsInteger(radix, attempt)) {
-      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
-                     A->getAsString(Args), A->getValue());
-    } else {
-      valueToSet = attempt;
     }
   }
 }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.h
@@ -47,9 +47,6 @@ private:
   void computePrintStatsOptions();
   void computeTBDOptions();
 
-  void setUnsignedIntegerArgument(options::ID optionID, unsigned radix,
-                                  unsigned &valueToSet);
-
   bool setUpInputKindAndImmediateArgs();
 
   bool checkUnusedSupplementaryOutputPaths() const;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -552,6 +552,46 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   return HadError || UnsupportedOS || UnsupportedArch;
 }
 
+static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
+                                 DiagnosticEngine &Diags,
+                                 const FrontendOptions &FrontendOpts) {
+  using namespace options;
+
+  auto setUnsignedIntegerArgument = [&Args, &Diags](
+      options::ID optionID, unsigned radix, unsigned &valueToSet) {
+    if (const Arg *A = Args.getLastArg(optionID)) {
+      unsigned attempt;
+      if (StringRef(A->getValue()).getAsInteger(radix, attempt)) {
+        Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                       A->getAsString(Args), A->getValue());
+      } else {
+        valueToSet = attempt;
+      }
+    }
+  };
+
+  setUnsignedIntegerArgument(OPT_warn_long_function_bodies, 10,
+                             Opts.WarnLongFunctionBodies);
+  setUnsignedIntegerArgument(OPT_warn_long_expression_type_checking, 10,
+                             Opts.WarnLongExpressionTypeChecking);
+  setUnsignedIntegerArgument(OPT_solver_expression_time_threshold_EQ, 10,
+                             Opts.ExpressionTimeoutThreshold);
+  setUnsignedIntegerArgument(OPT_switch_checking_invocation_threshold_EQ, 10,
+                             Opts.SwitchCheckingInvocationThreshold);
+
+  Opts.DebugTimeFunctionBodies |= Args.hasArg(OPT_debug_time_function_bodies);
+  Opts.DebugTimeExpressions |=
+      Args.hasArg(OPT_debug_time_expression_type_checking);
+  Opts.SkipNonInlinableFunctionBodies |=
+      Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies);
+
+  // If asked to perform InstallAPI, go ahead and enable non-inlinable function
+  // body skipping.
+  Opts.SkipNonInlinableFunctionBodies |= Args.hasArg(OPT_tbd_is_installapi);
+
+  return false;
+}
+
 static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
                                    ArgList &Args,
                                    DiagnosticEngine &Diags,
@@ -1381,6 +1421,10 @@ bool CompilerInvocation::parseArgs(
   SaveModuleInterfaceArgs(ModuleInterfaceOpts, FrontendOpts, ParsedArgs, Diags);
 
   if (ParseLangArgs(LangOpts, ParsedArgs, Diags, FrontendOpts)) {
+    return true;
+  }
+
+  if (ParseTypeCheckerArgs(TypeCheckerOpts, ParsedArgs, Diags, FrontendOpts)) {
     return true;
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -912,27 +912,6 @@ void CompilerInstance::parseLibraryFile(
   performNameBinding(*NextInput);
 }
 
-OptionSet<TypeCheckingFlags> CompilerInstance::computeTypeCheckingOptions() {
-  OptionSet<TypeCheckingFlags> TypeCheckOptions;
-  if (isWholeModuleCompilation()) {
-    TypeCheckOptions |= TypeCheckingFlags::DelayWholeModuleChecking;
-  }
-  const auto &options = Invocation.getFrontendOptions();
-  if (options.DebugTimeFunctionBodies) {
-    TypeCheckOptions |= TypeCheckingFlags::DebugTimeFunctionBodies;
-  }
-  if (FrontendOptions::isActionImmediate(options.RequestedAction)) {
-    TypeCheckOptions |= TypeCheckingFlags::ForImmediateMode;
-  }
-  if (options.DebugTimeExpressionTypeChecking) {
-    TypeCheckOptions |= TypeCheckingFlags::DebugTimeExpressions;
-  }
-  if (options.SkipNonInlinableFunctionBodies) {
-    TypeCheckOptions |= TypeCheckingFlags::SkipNonInlinableFunctionBodies;
-  }
-  return TypeCheckOptions;
-}
-
 bool CompilerInstance::parsePartialModulesAndLibraryFiles(
     const ImplicitImports &implicitImports) {
   FrontendStatsTracer tracer(Context->Stats,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -190,9 +190,9 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
     return false;
   }
 
-  Context.reset(ASTContext::get(Invocation.getLangOptions(),
-                                Invocation.getSearchPathOptions(), SourceMgr,
-                                Diagnostics));
+  Context.reset(ASTContext::get(
+      Invocation.getLangOptions(), Invocation.getTypeCheckerOptions(),
+      Invocation.getSearchPathOptions(), SourceMgr, Diagnostics));
   registerParseRequestFunctions(Context->evaluator);
   registerTypeCheckerRequestFunctions(Context->evaluator);
 
@@ -222,15 +222,26 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
   setUpLLVMArguments();
   setUpDiagnosticOptions();
 
+  const auto &frontendOpts = Invocation.getFrontendOptions();
+
   // If we are asked to emit a module documentation file, configure lexing and
   // parsing to remember comments.
-  if (Invocation.getFrontendOptions().InputsAndOutputs.hasModuleDocOutputPath())
+  if (frontendOpts.InputsAndOutputs.hasModuleDocOutputPath())
     Invocation.getLangOptions().AttachCommentsToDecls = true;
 
   // If we are doing index-while-building, configure lexing and parsing to
   // remember comments.
-  if (!Invocation.getFrontendOptions().IndexStorePath.empty()) {
+  if (!frontendOpts.IndexStorePath.empty()) {
     Invocation.getLangOptions().AttachCommentsToDecls = true;
+  }
+
+  // Set up the type checker options.
+  auto &typeCkOpts = Invocation.getTypeCheckerOptions();
+  if (isWholeModuleCompilation()) {
+    typeCkOpts.DelayWholeModuleChecking = true;
+  }
+  if (FrontendOptions::isActionImmediate(frontendOpts.RequestedAction)) {
+    typeCkOpts.InImmediateMode = true;
   }
 
   assert(Lexer::isIdentifier(Invocation.getModuleName()));
@@ -825,14 +836,12 @@ void CompilerInstance::parseAndCheckTypesUpTo(
   if (hadLoadError)
     return;
 
-  OptionSet<TypeCheckingFlags> TypeCheckOptions = computeTypeCheckingOptions();
-
   // Type-check main file after parsing all other files so that
   // it can use declarations from other files.
   // In addition, the main file has parsing and type-checking
   // interwined.
   if (MainBufferID != NO_SUCH_BUFFER) {
-    parseAndTypeCheckMainFileUpTo(limitStage, TypeCheckOptions);
+    parseAndTypeCheckMainFileUpTo(limitStage);
   }
 
   assert(llvm::all_of(MainModule->getFiles(), [](const FileUnit *File) -> bool {
@@ -843,19 +852,13 @@ void CompilerInstance::parseAndCheckTypesUpTo(
   }) && "some files have not yet had their imports resolved");
   MainModule->setHasResolvedImports();
 
-  const auto &options = Invocation.getFrontendOptions();
-  forEachFileToTypeCheck([&](SourceFile &SF) {
-    if (limitStage == SourceFile::NameBound) {
-      bindExtensions(SF);
-      return;
-    }
+  // If the limiting AST stage is name binding, we're done.
+  if (limitStage <= SourceFile::NameBound) {
+    return;
+  }
 
-    performTypeChecking(SF, PersistentState->getTopLevelContext(),
-                        TypeCheckOptions, /*curElem*/ 0,
-                        options.WarnLongFunctionBodies,
-                        options.WarnLongExpressionTypeChecking,
-                        options.SolverExpressionTimeThreshold,
-                        options.SwitchCheckingInvocationThreshold);
+  forEachFileToTypeCheck([&](SourceFile &SF) {
+    performTypeChecking(SF, PersistentState->getTopLevelContext());
 
     if (!Context->hadError() && Invocation.getFrontendOptions().PCMacro) {
       performPCMacro(SF, PersistentState->getTopLevelContext());
@@ -871,17 +874,10 @@ void CompilerInstance::parseAndCheckTypesUpTo(
   });
 
   if (Invocation.isCodeCompletion()) {
-    assert(limitStage == SourceFile::NameBound);
     performCodeCompletionSecondPass(*PersistentState.get(),
                                     *Invocation.getCodeCompletionFactory());
   }
-
-  // If the limiting AST stage is name binding, we're done.
-  if (limitStage <= SourceFile::NameBound) {
-    return;
-  }
-
-  finishTypeChecking(TypeCheckOptions);
+  finishTypeChecking();
 }
 
 void CompilerInstance::parseLibraryFile(
@@ -937,8 +933,7 @@ bool CompilerInstance::parsePartialModulesAndLibraryFiles(
 }
 
 void CompilerInstance::parseAndTypeCheckMainFileUpTo(
-    SourceFile::ASTStage_t LimitStage,
-    OptionSet<TypeCheckingFlags> TypeCheckOptions) {
+    SourceFile::ASTStage_t LimitStage) {
   FrontendStatsTracer tracer(Context->Stats,
                              "parse-and-typecheck-main-file");
   bool mainIsPrimary =
@@ -971,16 +966,10 @@ void CompilerInstance::parseAndTypeCheckMainFileUpTo(
         llvm_unreachable("invalid limit stage");
       case SourceFile::NameBound:
         performNameBinding(MainFile, CurTUElem);
-        bindExtensions(MainFile);
         break;
       case SourceFile::TypeChecked:
-        const auto &options = Invocation.getFrontendOptions();
         performTypeChecking(MainFile, PersistentState->getTopLevelContext(),
-                            TypeCheckOptions, CurTUElem,
-                            options.WarnLongFunctionBodies,
-                            options.WarnLongExpressionTypeChecking,
-                            options.SolverExpressionTimeThreshold,
-                            options.SwitchCheckingInvocationThreshold);
+                            CurTUElem);
         break;
       }
     }
@@ -1020,9 +1009,8 @@ void CompilerInstance::forEachFileToTypeCheck(
   }
 }
 
-void CompilerInstance::finishTypeChecking(
-    OptionSet<TypeCheckingFlags> TypeCheckOptions) {
-  if (TypeCheckOptions & TypeCheckingFlags::DelayWholeModuleChecking) {
+void CompilerInstance::finishTypeChecking() {
+  if (getASTContext().TypeCheckerOpts.DelayWholeModuleChecking) {
     forEachSourceFileIn(MainModule, [&](SourceFile &SF) {
       performWholeModuleTypeChecking(SF);
     });

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -212,7 +212,8 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   do {
     parseIntoSourceFile(SF, *BufferID, &Done, nullptr, &PersistentState);
   } while (!Done);
-  performTypeChecking(SF, PersistentState.getTopLevelContext(), None,
+  llvm::SaveAndRestore<TypeCheckerOptions> clearTyOpts(Ctx.TypeCheckerOpts, {});
+  performTypeChecking(SF, PersistentState.getTopLevelContext(),
                       OriginalDeclCount);
 
   performCodeCompletionSecondPass(PersistentState, *CompletionCallbacksFactory);

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -212,7 +212,6 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   do {
     parseIntoSourceFile(SF, *BufferID, &Done, nullptr, &PersistentState);
   } while (!Done);
-  llvm::SaveAndRestore<TypeCheckerOptions> clearTyOpts(Ctx.TypeCheckerOpts, {});
   performTypeChecking(SF, PersistentState.getTopLevelContext(),
                       OriginalDeclCount);
 

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -193,8 +193,8 @@ typeCheckREPLInput(ModuleDecl *MostRecentModule, StringRef Name,
         parseIntoSourceFile(REPLInputFile, BufferID, &Done, nullptr,
                             &PersistentState);
   } while (!Done);
-  performTypeChecking(REPLInputFile, PersistentState.getTopLevelContext(),
-                      /*Options*/None);
+  llvm::SaveAndRestore<TypeCheckerOptions> clearTyOpts(Ctx.TypeCheckerOpts, {});
+  performTypeChecking(REPLInputFile, PersistentState.getTopLevelContext());
   return REPLModule;
 }
 

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -193,7 +193,6 @@ typeCheckREPLInput(ModuleDecl *MostRecentModule, StringRef Name,
         parseIntoSourceFile(REPLInputFile, BufferID, &Done, nullptr,
                             &PersistentState);
   } while (!Done);
-  llvm::SaveAndRestore<TypeCheckerOptions> clearTyOpts(Ctx.TypeCheckerOpts, {});
   performTypeChecking(REPLInputFile, PersistentState.getTopLevelContext());
   return REPLModule;
 }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3861,9 +3861,8 @@ getMemberDecls(InterestedMemberKind Kind) {
 ResolvedMemberResult
 swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name) {
   ResolvedMemberResult Result;
-  // If the current ast context has no type checker, create one for it.
-  auto *TC = DC.getASTContext().getLegacyGlobalTypeChecker();
-  assert(TC && "Must have type checker to make global query!");
+  assert(DC.getASTContext().getLegacyGlobalTypeChecker() &&
+         "Must have type checker to make global query!");
   ConstraintSystem CS(&DC, None);
 
   // Look up all members of BaseTy with the given Name.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -35,10 +35,10 @@ using namespace constraints;
 #define DEBUG_TYPE "ConstraintSystem"
 
 ExpressionTimer::ExpressionTimer(Expr *E, ConstraintSystem &CS)
-    : E(E), WarnLimit(CS.getTypeChecker().getWarnLongExpressionTypeChecking()),
+  : E(E),
       Context(CS.getASTContext()),
       StartTime(llvm::TimeRecord::getCurrentTime()),
-      PrintDebugTiming(CS.getTypeChecker().getDebugTimeExpressions()),
+      PrintDebugTiming(CS.getASTContext().TypeCheckerOpts.DebugTimeExpressions),
       PrintWarning(true) {
   if (auto *baseCS = CS.baseCS) {
     // If we already have a timer in the base constraint
@@ -66,6 +66,7 @@ ExpressionTimer::~ExpressionTimer() {
   if (!PrintWarning)
     return;
 
+  const auto WarnLimit = getWarnLimit();
   if (WarnLimit != 0 && elapsedMS >= WarnLimit && E->getLoc().isValid())
     Context.Diags.diagnose(E->getLoc(), diag::debug_long_expression,
                            elapsedMS, WarnLimit)

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -124,7 +124,6 @@ public:
 
 class ExpressionTimer {
   Expr* E;
-  unsigned WarnLimit;
   ASTContext &Context;
   llvm::TimeRecord StartTime;
 
@@ -136,6 +135,9 @@ public:
 
   ~ExpressionTimer();
 
+  unsigned getWarnLimit() const {
+    return Context.TypeCheckerOpts.WarnLongExpressionTypeChecking;
+  }
   llvm::TimeRecord startedAt() const { return StartTime; }
 
   /// Return the elapsed process time (including fractional seconds)
@@ -3723,7 +3725,7 @@ public:
     }
 
     const auto timeoutThresholdInMillis =
-        getTypeChecker().getExpressionTimeoutThresholdInSeconds();
+        getASTContext().TypeCheckerOpts.ExpressionTimeoutThreshold;
     if (Timer && Timer->isExpired(timeoutThresholdInMillis)) {
       // Disable warnings about expressions that go over the warning
       // threshold since we're arbitrarily ending evaluation and

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -116,9 +116,7 @@ bool InstrumenterBase::doTypeCheckImpl(ASTContext &Ctx, DeclContext *DC,
   DiagnosticSuppression suppression(Ctx.Diags);
   ErrorGatherer errorGatherer(Ctx.Diags);
 
-  auto *TC = Ctx.getLegacyGlobalTypeChecker();
-  assert(TC && "Must have type checker installed!");
-  TC->typeCheckExpression(parsedExpr, DC);
+  TypeChecker::typeCheckExpression(parsedExpr, DC);
 
   if (parsedExpr) {
     ErrorFinder errorFinder;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2161,6 +2161,7 @@ Type TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
   auto &Context = dc->getASTContext();
   FallbackDiagnosticListener diagListener(Context, options, listener);
   auto *TC = Context.getLegacyGlobalTypeChecker();
+  assert(TC && "Must have a global type checker set");
   return TC->typeCheckExpressionImpl(expr, dc, convertType, convertTypePurpose,
                                      options, diagListener, baseCS);
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1666,11 +1666,10 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
 
     
     {
-      auto *TC = ED->getASTContext().getLegacyGlobalTypeChecker();
-      assert(TC && "Must have a global type checker set");
       Expr *exprToCheck = prevValue;
-      if (TC->typeCheckExpression(exprToCheck, ED, TypeLoc::withoutLoc(rawTy),
-                                  CTP_EnumCaseRawValue)) {
+      if (TypeChecker::typeCheckExpression(exprToCheck, ED,
+                                           TypeLoc::withoutLoc(rawTy),
+                                           CTP_EnumCaseRawValue)) {
         TypeChecker::checkEnumElementErrorHandling(elt, exprToCheck);
       }
     }
@@ -3180,9 +3179,6 @@ public:
 
 
   bool shouldSkipBodyTypechecking(const AbstractFunctionDecl *AFD) {
-    // FIXME: Remove TypeChecker dependency.
-    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
-
     // Make sure we're in the mode that's skipping function bodies.
     if (!getASTContext().TypeCheckerOpts.SkipNonInlinableFunctionBodies)
       return false;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3184,7 +3184,7 @@ public:
     auto &TC = *Ctx.getLegacyGlobalTypeChecker();
 
     // Make sure we're in the mode that's skipping function bodies.
-    if (!TC.canSkipNonInlinableBodies())
+    if (!getASTContext().TypeCheckerOpts.SkipNonInlinableFunctionBodies)
       return false;
 
     // Make sure there even _is_ a body that we can skip.

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -208,14 +208,14 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     // because those have to be explicitly declared on the type somewhere
     // so won't be affected by whatever answer inference comes up with.
     auto selfTy = extension->getSelfInterfaceType();
-    auto *tc = getASTContext().getLegacyGlobalTypeChecker();
     for (const Requirement &reqt : extensionSig->getRequirements()) {
       switch (reqt.getKind()) {
       case RequirementKind::Conformance:
       case RequirementKind::Superclass:
         // FIXME: This is the wrong check
         if (selfTy->isEqual(reqt.getFirstType()) &&
-            !tc->isSubtypeOf(conformance->getType(), reqt.getSecondType(), dc))
+            !TypeChecker::isSubtypeOf(conformance->getType(),
+                                      reqt.getSecondType(), dc))
           return false;
         break;
 

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -255,10 +255,8 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
   BraceStmt *Body = builder.createBodyStmt(Loc, EndLoc);
   CE->setBody(Body, false);
 
-  // FIXME: Remove TypeChecker dependency.
-  auto &TC = *Context.getLegacyGlobalTypeChecker();
   TypeChecker::typeCheckClosureBody(CE);
-  TC.ClosuresWithUncomputedCaptures.push_back(CE);
+  TypeChecker::computeCaptures(CE);
 
   auto *TheCall = CallExpr::createImplicit(Context, CE, { E }, { });
   TheCall->getArg()->setType(AnyFunctionType::composeInput(Context, args, false));

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -178,13 +178,9 @@ namespace {
   class FunctionBodyTimer {
     AnyFunctionRef Function;
     llvm::TimeRecord StartTime = llvm::TimeRecord::getCurrentTime();
-    unsigned WarnLimit;
-    bool ShouldDump;
 
   public:
-    FunctionBodyTimer(AnyFunctionRef Fn, bool shouldDump,
-                      unsigned warnLimit)
-        : Function(Fn), WarnLimit(warnLimit), ShouldDump(shouldDump) {}
+    FunctionBodyTimer(AnyFunctionRef Fn) : Function(Fn) {}
 
     ~FunctionBodyTimer() {
       llvm::TimeRecord endTime = llvm::TimeRecord::getCurrentTime(false);
@@ -195,7 +191,7 @@ namespace {
       ASTContext &ctx = Function.getAsDeclContext()->getASTContext();
       auto *AFD = Function.getAbstractFunctionDecl();
 
-      if (ShouldDump) {
+      if (ctx.TypeCheckerOpts.WarnLongFunctionBodies) {
         // Round up to the nearest 100th of a millisecond.
         llvm::errs() << llvm::format("%0.2f", ceil(elapsed * 100000) / 100) << "ms\t";
         Function.getLoc().print(llvm::errs(), ctx.SourceMgr);
@@ -210,6 +206,7 @@ namespace {
         llvm::errs() << "\n";
       }
 
+      const auto WarnLimit = ctx.TypeCheckerOpts.DebugTimeFunctionBodies;
       if (WarnLimit != 0 && elapsedMS >= WarnLimit) {
         if (AFD) {
           ctx.Diags.diagnose(AFD, diag::debug_long_function_body,
@@ -1424,7 +1421,8 @@ public:
     }
 
     if (!switchStmt->isImplicit()) {
-      TC.checkSwitchExhaustiveness(switchStmt, DC, limitExhaustivityChecks);
+      TypeChecker::checkSwitchExhaustiveness(switchStmt, DC,
+                                             limitExhaustivityChecks);
     }
 
     return switchStmt;
@@ -2110,9 +2108,9 @@ TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
     ctx.Stats->getFrontendCounters().NumFunctionsTypechecked++;
 
   Optional<FunctionBodyTimer> timer;
-  TypeChecker &tc = *ctx.getLegacyGlobalTypeChecker();
-  if (tc.DebugTimeFunctionBodies || tc.WarnLongFunctionBodies)
-    timer.emplace(AFD, tc.DebugTimeFunctionBodies, tc.WarnLongFunctionBodies);
+  const auto &tyOpts = ctx.TypeCheckerOpts;
+  if (tyOpts.DebugTimeFunctionBodies || tyOpts.WarnLongFunctionBodies)
+    timer.emplace(AFD);
 
   BraceStmt *body = AFD->getBody();
   if (!body || AFD->isBodyTypeChecked())
@@ -2204,11 +2202,10 @@ bool TypeChecker::typeCheckClosureBody(ClosureExpr *closure) {
 
   BraceStmt *body = closure->getBody();
 
-  auto *TC = closure->getASTContext().getLegacyGlobalTypeChecker();
   Optional<FunctionBodyTimer> timer;
-  if (TC->DebugTimeFunctionBodies || TC->WarnLongFunctionBodies)
-    timer.emplace(closure, TC->DebugTimeFunctionBodies,
-                  TC->WarnLongFunctionBodies);
+  const auto &tyOpts = closure->getASTContext().TypeCheckerOpts;
+  if (tyOpts.DebugTimeFunctionBodies || tyOpts.WarnLongFunctionBodies)
+    timer.emplace(closure);
 
   bool HadError = StmtChecker(closure).typeCheckBody(body);
   if (body) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1280,9 +1280,6 @@ public:
   }
 
   Stmt *visitSwitchStmt(SwitchStmt *switchStmt) {
-    // FIXME: Remove TypeChecker dependency.
-    auto &TC = *Ctx.getLegacyGlobalTypeChecker();
-
     // Type-check the subject expression.
     Expr *subjectExpr = switchStmt->getSubjectExpr();
     auto resultTy = TypeChecker::typeCheckExpression(subjectExpr, DC);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -327,12 +327,7 @@ void swift::typeCheckExternalDefinitions(SourceFile &SF) {
 }
 
 void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
-                                OptionSet<TypeCheckingFlags> Options,
-                                unsigned StartElem,
-                                unsigned WarnLongFunctionBodies,
-                                unsigned WarnLongExpressionTypeChecking,
-                                unsigned ExpressionTimeoutThreshold,
-                                unsigned SwitchCheckingInvocationThreshold) {
+                                unsigned StartElem) {
   if (SF.ASTStage == SourceFile::TypeChecked)
     return;
 
@@ -340,12 +335,11 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
   // because type-checking expressions mutates the AST and that throws off the
   // scope-based lookups. Only the top-level scopes because extensions have not
   // been bound yet.
-  if (SF.getASTContext().LangOpts.EnableASTScopeLookup &&
-      SF.isSuitableForASTScopes())
+  auto &Ctx = SF.getASTContext();
+  if (Ctx.LangOpts.EnableASTScopeLookup && SF.isSuitableForASTScopes())
     SF.getScope()
         .buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals();
 
-  auto &Ctx = SF.getASTContext();
   BufferIndirectlyCausingDiagnosticRAII cpr(SF);
 
   // Make sure we have a type checker.
@@ -360,30 +354,12 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
   {
     SharedTimer timer("Type checking and Semantic analysis");
 
-    TC.setWarnLongFunctionBodies(WarnLongFunctionBodies);
-    TC.setWarnLongExpressionTypeChecking(WarnLongExpressionTypeChecking);
-    if (ExpressionTimeoutThreshold != 0)
-      TC.setExpressionTimeoutThreshold(ExpressionTimeoutThreshold);
-
-    if (SwitchCheckingInvocationThreshold != 0)
-      TC.setSwitchCheckingInvocationThreshold(
-          SwitchCheckingInvocationThreshold);
-
-    if (Options.contains(TypeCheckingFlags::DebugTimeFunctionBodies))
-      TC.enableDebugTimeFunctionBodies();
-
-    if (Options.contains(TypeCheckingFlags::DebugTimeExpressions))
-      TC.enableDebugTimeExpressions();
-
-    if (Options.contains(TypeCheckingFlags::ForImmediateMode))
-      TC.setInImmediateMode(true);
-
-    if (Options.contains(TypeCheckingFlags::SkipNonInlinableFunctionBodies))
+    if (Ctx.TypeCheckerOpts.SkipNonInlinableFunctionBodies)
       // Disable this optimization if we're compiling SwiftOnoneSupport, because
       // we _definitely_ need to look inside every declaration to figure out
       // what gets prespecialized.
-      if (!SF.getParentModule()->isOnoneSupportModule())
-        TC.setSkipNonInlinableBodies(true);
+      if (SF.getParentModule()->isOnoneSupportModule())
+        Ctx.TypeCheckerOpts.SkipNonInlinableFunctionBodies = false;
 
     if (!Ctx.LangOpts.DisableAvailabilityChecking) {
       // Build the type refinement hierarchy for the primary
@@ -416,7 +392,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
   }
 
   // Checking that benefits from having the whole module available.
-  if (!(Options & TypeCheckingFlags::DelayWholeModuleChecking)) {
+  if (!Ctx.TypeCheckerOpts.DelayWholeModuleChecking) {
     performWholeModuleTypeChecking(SF);
   }
 
@@ -439,7 +415,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
     // been cached, it will never be added to the ASTContext. The solution is to
     // skip verification and avoid caching it.
 #ifndef NDEBUG
-    if (!(Options & TypeCheckingFlags::DelayWholeModuleChecking) &&
+    if (!Ctx.TypeCheckerOpts.DelayWholeModuleChecking &&
         SF.Kind != SourceFileKind::REPL &&
         SF.Kind != SourceFileKind::SIL &&
         !Ctx.LangOpts.DebuggerSupport) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1059,8 +1059,9 @@ public:
   /// \param limitChecking The checking process relies on the switch statement
   /// being well-formed.  If it is not, pass true to this flag to run a limited
   /// form of analysis.
-  void checkSwitchExhaustiveness(const SwitchStmt *stmt, const DeclContext *DC,
-                                 bool limitChecking);
+  static void checkSwitchExhaustiveness(const SwitchStmt *stmt,
+                                        const DeclContext *DC,
+                                        bool limitChecking);
 
   /// Type check the given expression as a condition, which converts
   /// it to a logic value.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -544,47 +544,6 @@ public:
 private:
   ASTContext &Context;
 
-  /// If non-zero, warn when a function body takes longer than this many
-  /// milliseconds to type-check.
-  ///
-  /// Intended for debugging purposes only.
-  unsigned WarnLongFunctionBodies = 0;
-
-  /// If non-zero, warn when type-checking an expression takes longer
-  /// than this many milliseconds.
-  ///
-  /// Intended for debugging purposes only.
-  unsigned WarnLongExpressionTypeChecking = 0;
-
-  /// If non-zero, abort the expression type checker if it takes more
-  /// than this many seconds.
-  unsigned ExpressionTimeoutThreshold = 600;
-
-  /// If non-zero, abort the switch statement exhaustiveness checker if
-  /// the Space::minus function is called more than this many times.
-  ///
-  /// Why this number? Times out in about a second on a 2017 iMac, Retina 5K,
-  // 4.2 GHz Intel Core i7.
-  // (It's arbitrary, but will keep the compiler from taking too much time.)
-  unsigned SwitchCheckingInvocationThreshold = 200000;
-
-  /// If true, the time it takes to type-check each function will be dumped
-  /// to llvm::errs().
-  bool DebugTimeFunctionBodies = false;
-
-  /// If true, the time it takes to type-check each expression will be
-  /// dumped to llvm::errs().
-  bool DebugTimeExpressions = false;
-
-  /// Indicate that the type checker is checking code that will be
-  /// immediately executed. This will suppress certain warnings
-  /// when executing scripts.
-  bool InImmediateMode = false;
-
-  /// Indicate that the type checker should skip type-checking non-inlinable
-  /// function bodies.
-  bool SkipNonInlinableFunctionBodies = false;
-
   TypeChecker(ASTContext &Ctx);
   friend class ASTContext;
   friend class constraints::ConstraintSystem;
@@ -603,90 +562,6 @@ public:
   ~TypeChecker();
 
   LangOptions &getLangOpts() const { return Context.LangOpts; }
-
-  /// Dump the time it takes to type-check each function to llvm::errs().
-  void enableDebugTimeFunctionBodies() {
-    DebugTimeFunctionBodies = true;
-  }
-
-  /// Dump the time it takes to type-check each function to llvm::errs().
-  void enableDebugTimeExpressions() {
-    DebugTimeExpressions = true;
-  }
-
-  bool getDebugTimeExpressions() {
-    return DebugTimeExpressions;
-  }
-
-  /// If \p timeInMS is non-zero, warn when a function body takes longer than
-  /// this many milliseconds to type-check.
-  ///
-  /// Intended for debugging purposes only.
-  void setWarnLongFunctionBodies(unsigned timeInMS) {
-    WarnLongFunctionBodies = timeInMS;
-  }
-
-  /// If \p timeInMS is non-zero, warn when type-checking an expression
-  /// takes longer than this many milliseconds.
-  ///
-  /// Intended for debugging purposes only.
-  void setWarnLongExpressionTypeChecking(unsigned timeInMS) {
-    WarnLongExpressionTypeChecking = timeInMS;
-  }
-
-  /// Return the current setting for the number of milliseconds
-  /// threshold we use to determine whether to warn about an
-  /// expression taking a long time.
-  unsigned getWarnLongExpressionTypeChecking() {
-    return WarnLongExpressionTypeChecking;
-  }
-
-  /// Set the threshold that determines the upper bound for the number
-  /// of seconds we'll let the expression type checker run before
-  /// considering an expression "too complex".
-  void setExpressionTimeoutThreshold(unsigned timeInSeconds) {
-    ExpressionTimeoutThreshold = timeInSeconds;
-  }
-
-  /// Return the current setting for the threshold that determines
-  /// the upper bound for the number of seconds we'll let the
-  /// expression type checker run before considering an expression
-  /// "too complex".
-  /// If zero, do not limit the checking.
-  unsigned getExpressionTimeoutThresholdInSeconds() {
-    return ExpressionTimeoutThreshold;
-  }
-
-  /// Get the threshold that determines the upper bound for the number
-  /// of times we'll let the Space::minus routine run before
-  /// considering a switch statement "too complex".
-  /// If zero, do not limit the checking.
-  unsigned getSwitchCheckingInvocationThreshold() const {
-    return SwitchCheckingInvocationThreshold;
-  }
-
-  /// Set the threshold that determines the upper bound for the number
-  /// of times we'll let the Space::minus routine run before
-  /// considering a switch statement "too complex".
-  void setSwitchCheckingInvocationThreshold(unsigned invocationCount) {
-    SwitchCheckingInvocationThreshold = invocationCount;
-  }
-
-  void setSkipNonInlinableBodies(bool skip) {
-    SkipNonInlinableFunctionBodies = skip;
-  }
-
-  bool canSkipNonInlinableBodies() const {
-    return SkipNonInlinableFunctionBodies;
-  }
-
-  bool getInImmediateMode() {
-    return InImmediateMode;
-  }
-
-  void setInImmediateMode(bool InImmediateMode) {
-    this->InImmediateMode = InImmediateMode;
-  }
 
   static Type getArraySliceType(SourceLoc loc, Type elementType);
   static Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);

--- a/test/IRGen/objc_enum_multi_file.swift
+++ b/test/IRGen/objc_enum_multi_file.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -module-name main -primary-file %s %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -module-name main -primary-file %s %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir | %FileCheck %s
 
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -emit-module %S/Inputs/objc_enum_multi_file_helper.swift -o %t
 // RUN: %target-swift-frontend -module-name main -primary-file %s -I %t -DIMPORT -emit-ir | %FileCheck %s

--- a/test/IRGen/objc_protocol_multi_file.swift
+++ b/test/IRGen/objc_protocol_multi_file.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/objc_protocol_multi_file_helper.swift -g -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -primary-file %s %S/Inputs/objc_protocol_multi_file_helper.swift -g -emit-ir | %FileCheck %s
 
 // This used to crash <rdar://problem/17929944>.
 // To tickle the crash, SubProto must not be used elsewhere in this file.

--- a/test/decl/enum/objc_enum_multi_file.swift
+++ b/test/decl/enum/objc_enum_multi_file.swift
@@ -1,9 +1,9 @@
-// RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NO_RAW_TYPE 2>&1 | %FileCheck -check-prefix=NO_RAW_TYPE %s
-// RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D BAD_RAW_TYPE 2>&1 | %FileCheck -check-prefix=BAD_RAW_TYPE %s
-// RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NON_INT_RAW_TYPE 2>&1 | %FileCheck -check-prefix=NON_INT_RAW_TYPE %s
-// RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NON_INT_RAW_VALUE 2>&1 | %FileCheck -check-prefix=NON_INT_RAW_VALUE %s
-// RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NO_CASES 2>&1 | %FileCheck -check-prefix=NO_CASES %s
-// RUN: not %target-swift-frontend -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D DUPLICATE_CASES 2>&1 | %FileCheck -check-prefix=DUPLICATE_CASES %s
+// RUN: not %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NO_RAW_TYPE 2>&1 | %FileCheck -check-prefix=NO_RAW_TYPE %s
+// RUN: not %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D BAD_RAW_TYPE 2>&1 | %FileCheck -check-prefix=BAD_RAW_TYPE %s
+// RUN: not %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NON_INT_RAW_TYPE 2>&1 | %FileCheck -check-prefix=NON_INT_RAW_TYPE %s
+// RUN: not %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NON_INT_RAW_VALUE 2>&1 | %FileCheck -check-prefix=NON_INT_RAW_VALUE %s
+// RUN: not %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D NO_CASES 2>&1 | %FileCheck -check-prefix=NO_CASES %s
+// RUN: not %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -module-name main %s -primary-file %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -D DUPLICATE_CASES 2>&1 | %FileCheck -check-prefix=DUPLICATE_CASES %s
 // Note that the *other* file is the primary file in this test!
 
 #if NO_RAW_TYPE

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -700,6 +700,7 @@ public:
     Parser.reset(
                  new ParserUnit(SM, SourceFileKind::Main, BufferID,
                      CompInv.getLangOptions(),
+                     CompInv.getTypeCheckerOptions(),
                      CompInv.getModuleName(),
                      SynTreeCreator,
                      CompInv.getMainFileSyntaxParsingCache())

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -166,10 +166,11 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   SearchPathOpts.RuntimeResourcePath = RuntimeResourcePath.str();
 
   SourceManager SrcMgr;
+  TypeCheckerOptions TypeCheckOpts;
   LangOptions LangOpts;
   LangOpts.Target = Invocation.getTargetTriple();
-  ASTContext &ASTCtx = *ASTContext::get(LangOpts, SearchPathOpts, SrcMgr,
-                                        Instance.getDiags());
+  ASTContext &ASTCtx = *ASTContext::get(LangOpts, TypeCheckOpts, SearchPathOpts,
+                                        SrcMgr, Instance.getDiags());
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);
   

--- a/tools/driver/swift_indent_main.cpp
+++ b/tools/driver/swift_indent_main.cpp
@@ -61,6 +61,7 @@ public:
     BufferID = SM.addNewSourceBuffer(std::move(Buffer));
     Parser.reset(new ParserUnit(SM, SourceFileKind::Main,
                                 BufferID, CompInv.getLangOptions(),
+                                CompInv.getTypeCheckerOptions(),
                                 CompInv.getModuleName()));
     Parser->getDiagnosticEngine().addConsumer(DiagConsumer);
     Parser->parse();

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -274,6 +274,7 @@ swiftparse_client_node_t SynParser::parse(const char *source) {
   SourceManager SM;
   unsigned bufID = SM.addNewSourceBuffer(
     llvm::MemoryBuffer::getMemBuffer(source, "syntax_parse_source"));
+  TypeCheckerOptions tyckOpts;
   LangOptions langOpts;
   langOpts.BuildSyntaxTree = true;
   langOpts.CollectParsedToken = false;
@@ -285,7 +286,7 @@ swiftparse_client_node_t SynParser::parse(const char *source) {
     std::make_shared<CLibParseActions>(*this, SM, bufID);
   // We have to use SourceFileKind::Main to avoid diagnostics like
   // illegal_top_level_expr
-  ParserUnit PU(SM, SourceFileKind::Main, bufID, langOpts,
+  ParserUnit PU(SM, SourceFileKind::Main, bufID, langOpts, tyckOpts,
                 "syntax_parse_module", std::move(parseActions),
                 /*SyntaxCache=*/nullptr);
   // Evaluating pound conditions may lead to unknown syntax.

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -34,7 +34,8 @@ static void declareOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
 }
 
 TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
-    : Ctx(*ASTContext::get(LangOpts, SearchPathOpts, SourceMgr, Diags)) {
+    : Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SearchPathOpts, SourceMgr,
+                           Diags)) {
   registerParseRequestFunctions(Ctx.evaluator);
   registerTypeCheckerRequestFunctions(Ctx.evaluator);
   auto stdlibID = Ctx.getIdentifier(STDLIB_NAME);

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -27,6 +27,7 @@ namespace unittest {
 class TestContextBase {
 public:
   LangOptions LangOpts;
+  TypeCheckerOptions TypeCheckerOpts;
   SearchPathOptions SearchPathOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -69,12 +69,13 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   // Set up the importer and emit a bridging PCH.
   swift::LangOptions langOpts;
   langOpts.Target = llvm::Triple("x86_64", "apple", "darwin");
+  swift::TypeCheckerOptions typeckOpts;
   INITIALIZE_LLVM();
   swift::SearchPathOptions searchPathOpts;
   swift::SourceManager sourceMgr;
   swift::DiagnosticEngine diags(sourceMgr);
   std::unique_ptr<ASTContext> context(
-      ASTContext::get(langOpts, searchPathOpts, sourceMgr, diags));
+      ASTContext::get(langOpts, typeckOpts, searchPathOpts, sourceMgr, diags));
   auto importer = ClangImporter::create(*context, options);
 
   std::string PCH = createFilename(cache, "bridging.h.pch");

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -94,10 +94,12 @@ protected:
     PrintingDiagnosticConsumer printingConsumer;
     DiagnosticEngine diags(sourceMgr);
     diags.addConsumer(printingConsumer);
+    TypeCheckerOptions typeckOpts;
     LangOptions langOpts;
     langOpts.Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
     SearchPathOptions searchPathOpts;
-    auto ctx = ASTContext::get(langOpts, searchPathOpts, sourceMgr, diags);
+    auto ctx =
+        ASTContext::get(langOpts, typeckOpts, searchPathOpts, sourceMgr, diags);
 
     auto loader = ModuleInterfaceLoader::create(
         *ctx, cacheDir, prebuiltCacheDir,

--- a/unittests/Parse/TokenizerTests.cpp
+++ b/unittests/Parse/TokenizerTests.cpp
@@ -82,7 +82,8 @@ public:
   }
   
   std::vector<Token> parseAndGetSplitTokens(unsigned BufID) {
-    swift::ParserUnit PU(SM, SourceFileKind::Main, BufID, LangOpts, "unknown");
+    swift::ParserUnit PU(SM, SourceFileKind::Main, BufID,
+                         LangOpts, TypeCheckerOptions(), "unknown");
 
     bool Done = false;
     while (!Done) {


### PR DESCRIPTION
Merge TypeCheckingFlags, TypeChecker's Options and the TypeChecker-Oriented FrontendOptions into (the one true heir) `TypeCheckerOptions`.

Use this to simplify a bunch of things that only needed type checkers just for this bit of state and, importantly, pull all of this out of the TypeChecker.

@davidungar Could you make sure I haven't done something terrible to frontend argument parsing?
@harlanhaskins Same, but for function body skipping?
@rintaro For the ParserUnit parts (particularly the `llvm::SaveAndRestore`s to emulate the old behavior of passing `None` to the options).