### PR TITLE
[windows] Avoid warning in header in test turning into fatal error.

### DIFF
--- a/test/ClangImporter/Inputs/enum-inferred-exhaustivity.h
+++ b/test/ClangImporter/Inputs/enum-inferred-exhaustivity.h
@@ -5,6 +5,8 @@
 // Make this C-compatible by leaving out the type.
 #define CF_ENUM(_name) enum _name _name; enum _name
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmicrosoft-enum-forward-reference"
 typedef CF_ENUM(EnumWithDefaultExhaustivity) {
   EnumWithDefaultExhaustivityLoneCase
 };
@@ -14,3 +16,4 @@ typedef CF_ENUM(EnumWithDefaultExhaustivity) {
 typedef CF_ENUM(EnumWithSpecialAttributes) {
   EnumWithSpecialAttributesLoneCase
 } __CF_ENUM_ATTRIBUTES;
+#pragma clang diagnostic pop


### PR DESCRIPTION
In Windows, ClangImporter seems to execute with Microsoft compatibility,
and there are some more warnings that do not happen in Unix. One of them
seems to be -Wmicrosoft-enum-forward-reference which warns about forward
defined enums, like the one that happens in this header. Since the
-warnings-as-errors flag is now passed down to ClangImporter, this
warning will make this test fail.

Simply use the #pragma to disable the warning for this piece of code.

The problem was introduced in #28142 and started failing in https://ci-external.swift.org/job/oss-swift-windows-x86_64/1888/