### PR TITLE
[NFC] [DiagnosticEngine] Improve output for malformed diagnostic messages

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -669,9 +669,8 @@ void DiagnosticEngine::formatDiagnosticText(
     }
     
     if (Modifier == "error") {
-      assert(false && "encountered %error in diagnostic text");
-      Out << StringRef("<<ERROR>>");
-      break;
+      Out << StringRef("<<INTERNAL ERROR: encountered %error in diagnostic text>>");
+      continue;
     }
 
     // Parse the optional argument list for a modifier, which is brace-enclosed.
@@ -684,11 +683,19 @@ void DiagnosticEngine::formatDiagnosticText(
     // Find the digit sequence, and parse it into an argument index.
     size_t Length = InText.find_if_not(isdigit);
     unsigned ArgIndex;      
-    bool Result = InText.substr(0, Length).getAsInteger(10, ArgIndex);
-    assert(!Result && "Unparseable argument index value?");
-    (void)Result;
-    assert(ArgIndex < Args.size() && "Out-of-range argument index");
+    bool IndexParseFailed = InText.substr(0, Length).getAsInteger(10, ArgIndex);
+
+    if (IndexParseFailed) {
+      Out << StringRef("<<INTERNAL ERROR: unparseable argument index in diagnostic text>>");
+      continue;
+    }
+
     InText = InText.substr(Length);
+
+    if (ArgIndex >= Args.size()) {
+      Out << StringRef("<<INTERNAL ERROR: out-of-range argument index in diagnostic text>>");
+      continue;
+    }
 
     // Convert the argument to a string.
     formatDiagnosticArgument(Modifier, ModifierArguments, Args, ArgIndex,


### PR DESCRIPTION
This change modifies the DiagnosticEngine so that, if we discover a mis-formatted diagnostic, we insert a hard-to-miss string into the message and continue. The idea here is to (a) make the location in the string and nature of the bug more obvious, and (b) make sure users clearly perceive the diagnostics as erroneous rather than misunderstanding them when information is missing.

This change is NFC as long as you assume there are no bad diagnostics. We don't currently test the compiler's behavior for malformed diagnostics; I suppose we could.