### PR TITLE
[Parse/CodeCompletion] Cleanup code completion facilities in Parse

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -43,6 +43,7 @@ namespace llvm {
 
 namespace swift {
   class CodeCompletionCallbacks;
+  class CodeCompletionCallbacksFactory;
   class DefaultArgumentInitializer;
   class DiagnosticEngine;
   class Expr;
@@ -867,8 +868,6 @@ public:
                                    BraceItemListKind::Brace);
   ParserResult<BraceStmt> parseBraceItemList(Diag<> ID);
   
-  void parseTopLevelCodeDeclDelayed();
-
   //===--------------------------------------------------------------------===//
   // Decl Parsing
 
@@ -918,8 +917,6 @@ public:
   ParserResult<Decl> parseDecl(ParseDeclOptions Flags,
                                bool IsAtStartOfLineOrPreviousHadSemi,
                                llvm::function_ref<void(Decl*)> Handler);
-
-  void parseDeclDelayed();
 
   std::vector<Decl *> parseDeclListDelayed(IterableDeclContext *IDC);
 
@@ -1089,7 +1086,6 @@ public:
                                        bool HasFuncKeyword = true);
   void parseAbstractFunctionBody(AbstractFunctionDecl *AFD);
   BraceStmt *parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
-  void parseAbstractFunctionBodyDelayed();
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes);
 
@@ -1583,6 +1579,16 @@ public:
   parsePlatformVersionConstraintSpec();
   ParserResult<PlatformAgnosticVersionConstraintAvailabilitySpec>
   parsePlatformAgnosticVersionConstraintSpec();
+
+  //===--------------------------------------------------------------------===//
+  // Code completion second pass.
+
+  static void
+  performCodeCompletionSecondPass(PersistentParserState &ParserState,
+                                  CodeCompletionCallbacksFactory &Factory);
+
+  void performCodeCompletionSecondPassImpl(
+      PersistentParserState::CodeCompletionDelayedDeclState &info);
 };
 
 /// Describes a parsed declaration name.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -895,8 +895,6 @@ public:
   /// Options that control the parsing of declarations.
   using ParseDeclOptions = OptionSet<ParseDeclFlags>;
 
-  void delayParseFromBeginningToHere(ParserPosition BeginParserPosition,
-                                     ParseDeclOptions Flags);
   void consumeDecl(ParserPosition BeginParserPosition, ParseDeclOptions Flags,
                    bool IsTopLevel);
 

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -25,7 +25,6 @@
 #include "llvm/ADT/DenseMap.h"
 
 namespace swift {
-  class AbstractFunctionDecl;
 
 /// Parser state persistent across multiple parses.
 class PersistentParserState {
@@ -35,22 +34,6 @@ public:
     SourceLoc PrevLoc;
 
     bool isValid() const { return Loc.isValid(); }
-  };
-
-  class FunctionBodyState {
-    ParserPos BodyPos;
-    SavedScope Scope;
-    friend class Parser;
-
-    SavedScope takeScope() {
-      return std::move(Scope);
-    }
-
-  public:
-    FunctionBodyState(SourceRange BodyRange, SourceLoc PreviousLoc,
-                      SavedScope &&Scope)
-      : BodyPos{BodyRange.Start, PreviousLoc}, Scope(std::move(Scope))
-    {}
   };
 
   enum class DelayedDeclKind {
@@ -89,10 +72,6 @@ public:
   bool PerformConditionEvaluation = true;
 private:
   ScopeInfo ScopeInfo;
-  using DelayedFunctionBodiesTy =
-      llvm::DenseMap<AbstractFunctionDecl *,
-                     std::unique_ptr<FunctionBodyState>>;
-  DelayedFunctionBodiesTy DelayedFunctionBodies;
 
   /// Parser sets this if it stopped parsing before the buffer ended.
   ParserPosition MarkedPos;

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -17,7 +17,6 @@
 #ifndef SWIFT_PARSE_PERSISTENTPARSERSTATE_H
 #define SWIFT_PARSE_PERSISTENTPARSERSTATE_H
 
-#include "swift/AST/LazyResolver.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Parse/LocalContext.h"
 #include "swift/Parse/ParserPosition.h"
@@ -25,6 +24,10 @@
 #include "llvm/ADT/DenseMap.h"
 
 namespace swift {
+
+class SourceFile;
+class DeclContext;
+class IterableDeclContext;
 
 /// Parser state persistent across multiple parses.
 class PersistentParserState {
@@ -36,16 +39,16 @@ public:
     bool isValid() const { return Loc.isValid(); }
   };
 
-  enum class DelayedDeclKind {
+  enum class CodeCompletionDelayedDeclKind {
     TopLevelCodeDecl,
     Decl,
     FunctionBody,
   };
 
-  class DelayedDeclState {
+  class CodeCompletionDelayedDeclState {
     friend class PersistentParserState;
     friend class Parser;
-    DelayedDeclKind Kind;
+    CodeCompletionDelayedDeclKind Kind;
     unsigned Flags;
     DeclContext *ParentContext;
     ParserPos BodyPos;
@@ -57,13 +60,13 @@ public:
     }
 
   public:
-    DelayedDeclState(DelayedDeclKind Kind, unsigned Flags,
-                     DeclContext *ParentContext, SourceRange BodyRange,
-                     SourceLoc PreviousLoc, SavedScope &&Scope)
-      : Kind(Kind), Flags(Flags), ParentContext(ParentContext),
-        BodyPos{BodyRange.Start, PreviousLoc},
-        BodyEnd(BodyRange.End), Scope(std::move(Scope))
-    {}
+    CodeCompletionDelayedDeclState(CodeCompletionDelayedDeclKind Kind,
+                                   unsigned Flags, DeclContext *ParentContext,
+                                   SourceRange BodyRange, SourceLoc PreviousLoc,
+                                   SavedScope &&Scope)
+        : Kind(Kind), Flags(Flags),
+          ParentContext(ParentContext), BodyPos{BodyRange.Start, PreviousLoc},
+          BodyEnd(BodyRange.End), Scope(std::move(Scope)) {}
   };
 
   bool InPoundLineEnvironment = false;
@@ -76,7 +79,7 @@ private:
   /// Parser sets this if it stopped parsing before the buffer ended.
   ParserPosition MarkedPos;
 
-  std::unique_ptr<DelayedDeclState> CodeCompletionDelayedDeclState;
+  std::unique_ptr<CodeCompletionDelayedDeclState> CodeCompletionDelayedDeclStat;
 
   std::vector<IterableDeclContext *> DelayedDeclLists;
 
@@ -89,27 +92,23 @@ public:
   PersistentParserState(ASTContext &ctx) : PersistentParserState() { }
   ~PersistentParserState();
 
-  void delayDecl(DelayedDeclKind Kind, unsigned Flags,
-                 DeclContext *ParentContext,
-                 SourceRange BodyRange, SourceLoc PreviousLoc);
+  void setCodeCompletionDelayedDeclState(CodeCompletionDelayedDeclKind Kind,
+                                         unsigned Flags,
+                                         DeclContext *ParentContext,
+                                         SourceRange BodyRange,
+                                         SourceLoc PreviousLoc);
+
+  bool hasCodeCompletionDelayedDeclState() {
+    return CodeCompletionDelayedDeclStat.get() != nullptr;
+  }
+
+  std::unique_ptr<CodeCompletionDelayedDeclState>
+  takeCodeCompletionDelayedDeclState() {
+    assert(hasCodeCompletionDelayedDeclState());
+    return std::move(CodeCompletionDelayedDeclStat);
+  }
 
   void delayDeclList(IterableDeclContext *D);
-
-  bool hasDelayedDecl() {
-    return CodeCompletionDelayedDeclState.get() != nullptr;
-  }
-  DelayedDeclKind getDelayedDeclKind() {
-    return CodeCompletionDelayedDeclState->Kind;
-  }
-  SourceLoc getDelayedDeclLoc() {
-    return CodeCompletionDelayedDeclState->BodyPos.Loc;
-  }
-  DeclContext *getDelayedDeclContext() {
-    return CodeCompletionDelayedDeclState->ParentContext;
-  }
-  std::unique_ptr<DelayedDeclState> takeDelayedDeclState() {
-    return std::move(CodeCompletionDelayedDeclState);
-  }
 
   void parseAllDelayedDeclLists();
 

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -95,9 +95,6 @@ public:
 
   void delayDeclList(IterableDeclContext *D);
 
-  void delayTopLevel(TopLevelCodeDecl *TLCD, SourceRange BodyRange,
-                     SourceLoc PreviousLoc);
-
   bool hasDelayedDecl() {
     return CodeCompletionDelayedDeclState.get() != nullptr;
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3008,9 +3008,10 @@ void Parser::consumeDecl(ParserPosition BeginParserPosition,
   backtrackToPosition(BeginParserPosition);
   SourceLoc BeginLoc = Tok.getLoc();
 
-  State->delayDecl(PersistentParserState::DelayedDeclKind::Decl, Flags.toRaw(),
-                   CurDeclContext, {BeginLoc, EndLoc},
-                   BeginParserPosition.PreviousLoc);
+  State->setCodeCompletionDelayedDeclState(
+      PersistentParserState::CodeCompletionDelayedDeclKind::Decl,
+      Flags.toRaw(), CurDeclContext, {BeginLoc, EndLoc},
+      BeginParserPosition.PreviousLoc);
 
   while (SourceMgr.isBeforeInBuffer(Tok.getLoc(), CurrentLoc))
     consumeToken();
@@ -3573,48 +3574,6 @@ std::vector<Decl *> Parser::parseDeclListDelayed(IterableDeclContext *IDC) {
   bool hadError = false;
   ParseDeclOptions Options = getMemberParseDeclOptions(IDC);
   return parseDeclList(LBLoc, RBLoc, Id, Options, IDC, hadError);
-}
-
-void Parser::parseDeclDelayed() {
-  auto DelayedState = State->takeDelayedDeclState();
-  assert(DelayedState.get() && "should have delayed state");
-
-  auto BeginParserPosition = getParserPosition(DelayedState->BodyPos);
-  auto EndLexerState = L->getStateForEndOfTokenLoc(DelayedState->BodyEnd);
-
-  // ParserPositionRAII needs a primed parser to restore to.
-  if (Tok.is(tok::NUM_TOKENS))
-    consumeTokenWithoutFeedingReceiver();
-
-  // Ensure that we restore the parser state at exit.
-  ParserPositionRAII PPR(*this);
-
-  // Create a lexer that cannot go past the end state.
-  Lexer LocalLex(*L, BeginParserPosition.LS, EndLexerState);
-
-  // Temporarily swap out the parser's current lexer with our new one.
-  llvm::SaveAndRestore<Lexer *> T(L, &LocalLex);
-
-  // Rewind to the beginning of the decl.
-  restoreParserPosition(BeginParserPosition);
-
-  // Re-enter the lexical scope.
-  Scope S(this, DelayedState->takeScope());
-  ContextChange CC(*this, DelayedState->ParentContext);
-
-  parseDecl(ParseDeclOptions(DelayedState->Flags),
-            /*IsAtStartOfLineOrPreviousHadSemi=*/true,
-            [&](Decl *D) {
-    if (auto *parent = DelayedState->ParentContext) {
-      if (auto *NTD = dyn_cast<NominalTypeDecl>(parent)) {
-        NTD->addMember(D);
-      } else if (auto *ED = dyn_cast<ExtensionDecl>(parent)) {
-        ED->addMember(D);
-      } else if (auto *SF = dyn_cast<SourceFile>(parent)) {
-        SF->Decls.push_back(D);
-      }
-    }
-  });
 }
 
 /// Parse an 'import' declaration, doing no token skipping on error.
@@ -5640,9 +5599,9 @@ void Parser::consumeAbstractFunctionBody(AbstractFunctionDecl *AFD,
 
   if (isCodeCompletionFirstPass()) {
     if (SourceMgr.rangeContainsCodeCompletionLoc(BodyRange)) {
-      State->delayDecl(PersistentParserState::DelayedDeclKind::FunctionBody,
-                       PD_Default, AFD, BodyRange,
-                       BeginParserPosition.PreviousLoc);
+      State->setCodeCompletionDelayedDeclState(
+          PersistentParserState::CodeCompletionDelayedDeclKind::FunctionBody,
+          PD_Default, AFD, BodyRange, BeginParserPosition.PreviousLoc);
     } else {
       AFD->setBodySkipped(BodyRange);
     }
@@ -5955,20 +5914,6 @@ BraceStmt *Parser::parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD) {
   setLocalDiscriminatorToParamList(AFD->getParameters());
 
   return parseBraceItemList(diag::func_decl_without_brace).getPtrOrNull();
-}
-
-/// Parse a delayed function body from the 'PersistentParserState'.
-void Parser::parseAbstractFunctionBodyDelayed() {
-  auto DelayedState = State->takeDelayedDeclState();
-  assert(DelayedState.get() && "should have delayed state");
-  auto CD = DelayedState->ParentContext->getAsDecl();
-  auto AFD = cast<AbstractFunctionDecl>(CD);
-
-  // Eagarly parse local decls or nested function bodies inside the body.
-  llvm::SaveAndRestore<bool> DisableDelayedBody(DelayBodyParsing, false);
-
-  auto body = parseAbstractFunctionBodyDelayed(AFD);
-  AFD->setBodyParsed(body);
 }
 
 /// Parse a 'enum' declaration, returning true (and doing no token

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -256,9 +256,9 @@ void Parser::consumeTopLevelDecl(ParserPosition BeginParserPosition,
   SourceLoc EndLoc = PreviousLoc;
   backtrackToPosition(BeginParserPosition);
   SourceLoc BeginLoc = Tok.getLoc();
-  State->delayDecl(PersistentParserState::DelayedDeclKind::TopLevelCodeDecl,
-                   PD_Default, TLCD, {BeginLoc, EndLoc},
-                   BeginParserPosition.PreviousLoc);
+  State->setCodeCompletionDelayedDeclState(
+      PersistentParserState::CodeCompletionDelayedDeclKind::TopLevelCodeDecl,
+      PD_Default, TLCD, {BeginLoc, EndLoc}, BeginParserPosition.PreviousLoc);
 
   // Skip the rest of the file to prevent the parser from constructing the AST
   // for it.  Forward references are not allowed at the top level.
@@ -518,53 +518,6 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
   }
 
   return BraceItemsStatus;
-}
-
-void Parser::parseTopLevelCodeDeclDelayed() {
-  auto DelayedState = State->takeDelayedDeclState();
-  assert(DelayedState.get() && "should have delayed state");
-
-  auto BeginParserPosition = getParserPosition(DelayedState->BodyPos);
-  auto EndLexerState = L->getStateForEndOfTokenLoc(DelayedState->BodyEnd);
-
-  // ParserPositionRAII needs a primed parser to restore to.
-  if (Tok.is(tok::NUM_TOKENS))
-    consumeTokenWithoutFeedingReceiver();
-
-  // Ensure that we restore the parser state at exit.
-  ParserPositionRAII PPR(*this);
-
-  // Create a lexer that cannot go past the end state.
-  Lexer LocalLex(*L, BeginParserPosition.LS, EndLexerState);
-
-  // Temporarily swap out the parser's current lexer with our new one.
-  llvm::SaveAndRestore<Lexer *> T(L, &LocalLex);
-
-  // Rewind to the beginning of the top-level code.
-  restoreParserPosition(BeginParserPosition);
-
-  // Re-enter the lexical scope.
-  Scope S(this, DelayedState->takeScope());
-
-  // Re-enter the top-level decl context.
-  // FIXME: this can issue discriminators out-of-order?
-  auto *TLCD = cast<TopLevelCodeDecl>(DelayedState->ParentContext);
-  ContextChange CC(*this, TLCD, &State->getTopLevelContext());
-
-  SourceLoc StartLoc = Tok.getLoc();
-  ASTNode Result;
-
-  // Expressions can't begin with a closure literal at statement position. This
-  // prevents potential ambiguities with trailing closure syntax.
-  if (Tok.is(tok::l_brace)) {
-    diagnose(Tok, diag::statement_begins_with_closure);
-  }
-
-  parseExprOrStmt(Result);
-  if (!Result.isNull()) {
-    auto Brace = BraceStmt::create(Context, StartLoc, Result, Tok.getLoc());
-    TLCD->setBody(Brace);
-  }
 }
 
 /// Recover from a 'case' or 'default' outside of a 'switch' by consuming up to

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -256,8 +256,9 @@ void Parser::consumeTopLevelDecl(ParserPosition BeginParserPosition,
   SourceLoc EndLoc = PreviousLoc;
   backtrackToPosition(BeginParserPosition);
   SourceLoc BeginLoc = Tok.getLoc();
-  State->delayTopLevel(TLCD, {BeginLoc, EndLoc},
-                       BeginParserPosition.PreviousLoc);
+  State->delayDecl(PersistentParserState::DelayedDeclKind::TopLevelCodeDecl,
+                   PD_Default, TLCD, {BeginLoc, EndLoc},
+                   BeginParserPosition.PreviousLoc);
 
   // Skip the rest of the file to prevent the parser from constructing the AST
   // for it.  Forward references are not allowed at the top level.

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -25,14 +25,12 @@ PersistentParserState::PersistentParserState() { }
 
 PersistentParserState::~PersistentParserState() { }
 
-void PersistentParserState::delayDecl(DelayedDeclKind Kind,
-                                      unsigned Flags,
-                                      DeclContext *ParentContext,
-                                      SourceRange BodyRange,
-                                      SourceLoc PreviousLoc) {
-  assert(!CodeCompletionDelayedDeclState.get() &&
+void PersistentParserState::setCodeCompletionDelayedDeclState(
+    CodeCompletionDelayedDeclKind Kind, unsigned Flags,
+    DeclContext *ParentContext, SourceRange BodyRange, SourceLoc PreviousLoc) {
+  assert(!CodeCompletionDelayedDeclStat.get() &&
          "only one decl can be delayed for code completion");
-  CodeCompletionDelayedDeclState.reset(new DelayedDeclState(
+  CodeCompletionDelayedDeclStat.reset(new CodeCompletionDelayedDeclState(
       Kind, Flags, ParentContext, BodyRange, PreviousLoc,
       ScopeInfo.saveCurrentScope()));
 }

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -45,10 +45,3 @@ void PersistentParserState::parseAllDelayedDeclLists() {
   for (auto IDC : DelayedDeclLists)
     IDC->loadAllMembers();
 }
-
-void PersistentParserState::delayTopLevel(TopLevelCodeDecl *TLCD,
-                                          SourceRange BodyRange,
-                                          SourceLoc PreviousLoc) {
-  delayDecl(DelayedDeclKind::TopLevelCodeDecl, 0U, TLCD, BodyRange,
-            PreviousLoc);
-}


### PR DESCRIPTION
- Remove unused `FunctionBodyState` from `PersistentParserState`
- Remove `delayParseFromBeginningToHere()`. Use delayDecl() instead
- Inline `PersistentParserState::delayTopLevel()`
- Cleanup completion handling in `parseDecl()`
- Rename code completion related names in `PersistentParserState` so it's clear when you are using
- Refactor `performCodeCompletionSecondPass()`: Inline and consolidate `parse*Delayed()` functions because they used to share some code

rdar://problem/56926367