### PR TITLE
[build-presets] Don't build SwiftSyntax in linux preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -781,7 +781,6 @@ stress-test
 test-optimized
 foundation
 libdispatch
-swiftsyntax
 indexstore-db
 sourcekit-lsp
 lit-args=-v --time-tests


### PR DESCRIPTION
The Ubuntu 16 package bot does not check out SwiftSyntax and therefore
can't build it.

Until the bots check out SwiftSyntax, don't test SwiftSyntax in these builds.

This reverts the last part of #27855 that broke CI.