### PR TITLE
IRGen: We need to emit metadata for types that are emitted with shared linkage

### DIFF
--- a/test/IRGen/foreign_type_metadata.swift
+++ b/test/IRGen/foreign_type_metadata.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend %s -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// Make sure we emit a metadata accessor for foreign types even if the type
+// metadata is not required by this TU. Another TU could require it and the
+// linker could choose the less defined one of the two.
+
+// CHECK: @"$sSo8_NSRangeVMn" = linkonce_odr hidden constant <{ {{.*}}sSo8_NSRangeVMa{{.*}} }>, section "__TEXT,__const"
+
+func use(_ closure: @escaping (Int) -> ()) {}
+
+public func captureRange(_ r: NSRange?) {
+  var l = r
+  use {
+    if $0 == 0 {
+      l = NSRange()
+    }
+  }
+}

--- a/test/Interpreter/ForeignMetadata.swift
+++ b/test/Interpreter/ForeignMetadata.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -o %t/main %S/Inputs/ForeignTypeMetadata1.swift  %S/Inputs/ForeignTypeMetadata2.swift %t/main.swift -swift-version 5
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+useType()

--- a/test/Interpreter/Inputs/ForeignTypeMetadata1.swift
+++ b/test/Interpreter/Inputs/ForeignTypeMetadata1.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+func use(_ closure: @escaping (Int) -> ()) {}
+
+public func captureRange(_ r: NSRange?) {
+  var l = r
+  use {
+    if $0 == 0 {
+      l = NSRange()
+    }
+  }
+}

--- a/test/Interpreter/Inputs/ForeignTypeMetadata2.swift
+++ b/test/Interpreter/Inputs/ForeignTypeMetadata2.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public func useType() {
+  var x = [NSRange]()
+  x.append(NSRange())
+  print(x)
+}


### PR DESCRIPTION
Otherwise one TU could only require the type descriptor without metadata
and another TU could require metadata and type descriptor. Whether the
metadata access function is available would then depend on the linking
order of the two TUs.

rdar://56929811
