### PR TITLE
[AutoDiff] Simplify varied propagation in activity analysis.

### DIFF
--- a/test/AutoDiff/activity_analysis.swift
+++ b/test/AutoDiff/activity_analysis.swift
@@ -64,7 +64,7 @@ func testArrayUninitializedIntrinsic(_ x: Float, _ y: Float) -> [Float] {
   return [x, y]
 }
 
-// CHECK: [AD] Activity info for ${{.*}}testArrayUninitializedIntrinsic{{.*}} at (source=0 parameters=(0 1))
+// CHECK-LABEL: [AD] Activity info for ${{.*}}testArrayUninitializedIntrinsic{{.*}} at (source=0 parameters=(0 1))
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Float
 // CHECK: [ACTIVE] %1 = argument of bb0 : $Float
 // CHECK: [USEFUL]   %4 = integer_literal $Builtin.Word, 2
@@ -76,18 +76,22 @@ func testArrayUninitializedIntrinsic(_ x: Float, _ y: Float) -> [Float] {
 // CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
 // CHECK: [VARIED]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
 
-// [AD] Activity info for $s5array31testArrayUninitializedIntrinsicySaySfGSf_SftF at (source=0 parameters=(0 1))
-// [ACTIVE] %0 = argument of bb0 : $Float
-// [ACTIVE] %1 = argument of bb0 : $Float
-// [USEFUL]   %4 = integer_literal $Builtin.Word, 2           // user: %6
-// [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
-//   %5 = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer) // user: %6
-// [ACTIVE]   %6 = apply %5<Float>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer) // user: %7
-// [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer) // user: %14
-// [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer) // user: %9
-// [VARIED]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float // users: %12, %10
-// [VARIED]   %11 = integer_literal $Builtin.Word, 1          // user: %12
-// [VARIED]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word // user: %13
+@differentiable(where T: Differentiable)
+func testArrayUninitializedIntrinsicGeneric<T>(_ x: T, _ y: T) -> [T] {
+  return [x, y]
+}
+
+// CHECK-LABEL: [AD] Activity info for ${{.*}}testArrayUninitializedIntrinsicGeneric{{.*}} at (source=0 parameters=(0 1))
+// CHECK: [VARIED] %0 = argument of bb0 : $*T
+// CHECK: [VARIED] %1 = argument of bb0 : $*T
+// CHECK: [USEFUL]   %4 = integer_literal $Builtin.Word, 2
+// CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
+// CHECK: [ACTIVE]   %6 = apply %5<T>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
+// CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
+// CHECK: [VARIED]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*T
+// CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
+// CHECK: [VARIED]   %12 = index_addr %9 : $*T, %11 : $Builtin.Word
 
 // TF-781: check activity analysis for active local address + nested conditionals.
 

--- a/test/AutoDiff/array.swift
+++ b/test/AutoDiff/array.swift
@@ -56,6 +56,28 @@ ArrayAutoDiffTests.test("ArrayLiteralIndirect") {
   expectEqual(Float(2), gradY)
 }
 
+ArrayAutoDiffTests.test("ExpressibleByArrayLiteralIndirect") {
+  struct Indirect<T: Differentiable>: Differentiable & ExpressibleByArrayLiteral {
+    var x: T
+
+    typealias ArrayLiteralElement = T
+    init(arrayLiteral: T...) {
+      assert(arrayLiteral.count > 1)
+      self.x = arrayLiteral[0]
+    }
+  }
+
+  func testArrayUninitializedIntrinsic<T>(_ x: T, _ y: T) -> Indirect<T> {
+    return [x, y]
+  }
+
+  let (gradX, gradY) = pullback(at: Float(1), Float(1), in: {
+    x, y in testArrayUninitializedIntrinsic(x, y)
+  })(Indirect<Float>.TangentVector(x: 1))
+  expectEqual(1, gradX)
+  expectEqual(0, gradY)
+}
+
 ArrayAutoDiffTests.test("ArrayConcat") {
   struct TwoArrays : Differentiable {
     var a: [Float]


### PR DESCRIPTION
- Remove `setVaried`.
  - `setVaried` has only one user and can be inlined. Addresses [feedback](https://github.com/apple/swift/pull/28155#discussion_r344401285) from @marcrasi.
- Remove `setVariedAcrossArrayInitialization`.
  - Activity info does not change when removing special variedness propagation
    support for `array.uninitialized_intrinsic` applications.
  - Verified with array initialization activity info test case.