### PR TITLE
Remove SourceFile::SynthesizedDecls

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -553,10 +553,6 @@ public:
                                ForeignLanguage language,
                                const DeclContext *dc);
 
-  /// Add a declaration that was synthesized to a per-source file list if
-  /// if is part of a source file.
-  void addSynthesizedDecl(Decl *decl);
-
   /// Add a cleanup function to be called when the ASTContext is deallocated.
   void addCleanup(std::function<void(void)> cleanup);
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -147,11 +147,6 @@ public:
   /// A set of synthesized declarations that need to be type checked.
   llvm::SmallVector<Decl *, 8> SynthesizedDecls;
 
-  /// We might perform type checking on the same source file more than once,
-  /// if its the main file or a REPL instance, so keep track of the last
-  /// checked synthesized declaration to avoid duplicating work.
-  unsigned LastCheckedSynthesizedDecl = 0;
-
   /// A mapping from Objective-C selectors to the methods that have
   /// those selectors.
   llvm::DenseMap<ObjCSelector, llvm::TinyPtrVector<AbstractFunctionDecl *>>

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1366,12 +1366,6 @@ bool ASTContext::hasArrayLiteralIntrinsics() const {
     && getDeallocateUninitializedArray();
 }
 
-void ASTContext::addSynthesizedDecl(Decl *decl) {
-  auto *fileUnit = decl->getDeclContext()->getModuleScopeContext();
-  if (auto *sf = dyn_cast<SourceFile>(fileUnit))
-    sf->SynthesizedDecls.push_back(decl);
-}
-
 void ASTContext::addCleanup(std::function<void(void)> cleanup) {
   getImpl().Cleanups.push_back(std::move(cleanup));
 }

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -741,9 +741,8 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
   encodeDecl->copyFormalAccessFrom(derived.Nominal,
                                    /*sourceIsParentContext*/ true);
 
-  C.addSynthesizedDecl(encodeDecl);
-
   derived.addMembersToConformanceContext({encodeDecl});
+
   return encodeDecl;
 }
 
@@ -1019,9 +1018,8 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
   initDecl->copyFormalAccessFrom(derived.Nominal,
                                  /*sourceIsParentContext*/ true);
 
-  C.addSynthesizedDecl(initDecl);
-
   derived.addMembersToConformanceContext({initDecl});
+
   return initDecl;
 }
 

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -145,9 +145,8 @@ static ValueDecl *deriveInitDecl(DerivedConformance &derived, Type paramType,
 
   initDecl->setAccess(derived.Nominal->getFormalAccess());
 
-  C.addSynthesizedDecl(initDecl);
-
   derived.addMembersToConformanceContext({initDecl});
+
   return initDecl;
 }
 
@@ -176,9 +175,7 @@ static ValueDecl *deriveProperty(DerivedConformance &derived, Type type,
   // Synthesize the body.
   synthesizer(getterDecl);
 
-  auto *dc = cast<IterableDeclContext>(derived.ConformanceDecl);
-  dc->addMember(propDecl);
-  dc->addMember(pbDecl);
+  derived.addMembersToConformanceContext({propDecl, pbDecl});
   return propDecl;
 }
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -769,8 +769,6 @@ deriveEquatable_eq(
 
   eqDecl->copyFormalAccessFrom(derived.Nominal, /*sourceIsParentContext*/ true);
 
-  C.addSynthesizedDecl(eqDecl);
-
   // Add the operator to the parent scope.
   derived.addMembersToConformanceContext({eqDecl});
 
@@ -890,9 +888,8 @@ deriveHashable_hashInto(
 
   hashDecl->copyFormalAccessFrom(derived.Nominal);
 
-  C.addSynthesizedDecl(hashDecl);
-
   derived.addMembersToConformanceContext({hashDecl});
+
   return hashDecl;
 }
 
@@ -1253,8 +1250,6 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   auto *patDecl = PatternBindingDecl::createImplicit(
       C, StaticSpellingKind::None, hashValuePat, /*InitExpr*/ nullptr,
       parentDC);
-  C.addSynthesizedDecl(hashValueDecl);
-  C.addSynthesizedDecl(getterDecl);
 
   derived.addMembersToConformanceContext({hashValueDecl, patDecl});
   return hashValueDecl;

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1251,7 +1251,11 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
       C, StaticSpellingKind::None, hashValuePat, /*InitExpr*/ nullptr,
       parentDC);
 
-  derived.addMembersToConformanceContext({hashValueDecl, patDecl});
+  // If any of the members we synthesized didn't typecheck, bail out.
+  if (derived.addMembersToConformanceContext({hashValueDecl, patDecl})) {
+    return nullptr;
+  }
+
   return hashValueDecl;
 }
 

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -434,8 +434,6 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
   // an instance without function call overhead.
   maybeMarkAsInlinable(derived, initDecl);
 
-  C.addSynthesizedDecl(initDecl);
-
   derived.addMembersToConformanceContext({initDecl});
   return initDecl;
 }

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -311,7 +311,6 @@ DerivedConformance::declareDerivedPropertyGetter(VarDecl *property,
 
   getterDecl->copyFormalAccessFrom(property);
 
-  C.addSynthesizedDecl(getterDecl);
 
   return getterDecl;
 }

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -35,13 +35,16 @@ DeclContext *DerivedConformance::getConformanceContext() const {
   return cast<DeclContext>(ConformanceDecl);
 }
 
-void DerivedConformance::addMembersToConformanceContext(
+bool DerivedConformance::addMembersToConformanceContext(
     ArrayRef<Decl *> children) {
   auto IDC = cast<IterableDeclContext>(ConformanceDecl);
+  bool anyInvalid = false;
   for (auto child : children) {
     IDC->addMember(child);
     TypeChecker::typeCheckDecl(child);
+    anyInvalid |= child->isInvalid();
   }
+  return anyInvalid;
 }
 
 Type DerivedConformance::getProtocolType() const {

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -40,6 +40,7 @@ void DerivedConformance::addMembersToConformanceContext(
   auto IDC = cast<IterableDeclContext>(ConformanceDecl);
   for (auto child : children) {
     IDC->addMember(child);
+    TypeChecker::typeCheckDecl(child);
   }
 }
 
@@ -281,38 +282,28 @@ DerivedConformance::createSelfDeclRef(AbstractFunctionDecl *fn) {
 AccessorDecl *DerivedConformance::
 addGetterToReadOnlyDerivedProperty(VarDecl *property,
                                    Type propertyContextType) {
-  auto getter =
-    declareDerivedPropertyGetter(property, propertyContextType);
-
-  property->setImplInfo(StorageImplInfo::getImmutableComputed());
-  property->setAccessors(SourceLoc(), {getter}, SourceLoc());
-
-  return getter;
-}
-
-AccessorDecl *
-DerivedConformance::declareDerivedPropertyGetter(VarDecl *property,
-                                                 Type propertyContextType) {
   auto &C = property->getASTContext();
   auto parentDC = property->getDeclContext();
   ParameterList *params = ParameterList::createEmpty(C);
 
   Type propertyInterfaceType = property->getInterfaceType();
-  
-  auto getterDecl = AccessorDecl::create(C,
+
+  auto getter = AccessorDecl::create(C,
     /*FuncLoc=*/SourceLoc(), /*AccessorKeywordLoc=*/SourceLoc(),
     AccessorKind::Get, property,
     /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
     /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
     /*GenericParams=*/nullptr, params,
     TypeLoc::withoutLoc(propertyInterfaceType), parentDC);
-  getterDecl->setImplicit();
-  getterDecl->setIsTransparent(false);
+  getter->setImplicit();
+  getter->setIsTransparent(false);
 
-  getterDecl->copyFormalAccessFrom(property);
+  getter->copyFormalAccessFrom(property);
 
+  property->setImplInfo(StorageImplInfo::getImmutableComputed());
+  property->setAccessors(SourceLoc(), {getter}, SourceLoc());
 
-  return getterDecl;
+  return getter;
 }
 
 std::pair<VarDecl *, PatternBindingDecl *>

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -197,12 +197,7 @@ public:
   /// Add a getter to a derived property.  The property becomes read-only.
   static AccessorDecl *
   addGetterToReadOnlyDerivedProperty(VarDecl *property,
-                                     Type propertyContextType);
-
-  /// Declare a getter for a derived property.
-  /// The getter will not be added to the property yet.
-  static AccessorDecl *declareDerivedPropertyGetter(VarDecl *property,
-                                                    Type propertyContextType);
+                                            Type propertyContextType);
 
   /// Build a reference to the 'self' decl of a derived function.
   static DeclRefExpr *createSelfDeclRef(AbstractFunctionDecl *fn);

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -46,7 +46,10 @@ public:
   DeclContext *getConformanceContext() const;
 
   /// Add \c children as members of the context that declares the conformance.
-  void addMembersToConformanceContext(ArrayRef<Decl *> children);
+  ///
+  /// \returns True if any of the added members were found to be invalid after type
+  /// checking.
+  bool addMembersToConformanceContext(ArrayRef<Decl *> children);
 
   /// Get the declared type of the protocol that this is conformance is for.
   Type getProtocolType() const;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3675,6 +3675,7 @@ void TypeChecker::typeCheckDecl(Decl *D) {
 // Returns 'nullptr' if this is the setter's 'newValue' parameter;
 // otherwise, returns the corresponding parameter of the subscript
 // declaration.
+
 static ParamDecl *getOriginalParamFromAccessor(AbstractStorageDecl *storage,
                                                AccessorDecl *accessor,
                                                ParamDecl *param) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -294,7 +294,6 @@ static void bindExtensions(SourceFile &SF) {
 
 static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) {
   unsigned currentFunctionIdx = 0;
-  unsigned currentSynthesizedDecl = SF.LastCheckedSynthesizedDecl;
   do {
     // Type check the body of each of the function in turn.  Note that outside
     // functions must be visited before nested functions for type-checking to
@@ -306,18 +305,7 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
 
       TypeChecker::typeCheckAbstractFunctionBody(AFD);
     }
-
-    // Type check synthesized functions and their bodies.
-    for (unsigned n = SF.SynthesizedDecls.size();
-         currentSynthesizedDecl != n;
-         ++currentSynthesizedDecl) {
-      auto decl = SF.SynthesizedDecls[currentSynthesizedDecl];
-      TypeChecker::typeCheckDecl(decl);
-    }
-
-  } while (currentFunctionIdx < TC.definedFunctions.size() ||
-           currentSynthesizedDecl < SF.SynthesizedDecls.size());
-
+  } while (currentFunctionIdx < TC.definedFunctions.size());
 
   // Compute captures for functions and closures we visited.
   for (auto *closure : TC.ClosuresWithUncomputedCaptures) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -318,8 +318,6 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
   } while (currentFunctionIdx < TC.definedFunctions.size() ||
            currentSynthesizedDecl < SF.SynthesizedDecls.size());
 
-  // FIXME: Horrible hack. Store this somewhere more appropriate.
-  SF.LastCheckedSynthesizedDecl = currentSynthesizedDecl;
 
   // Compute captures for functions and closures we visited.
   for (auto *closure : TC.ClosuresWithUncomputedCaptures) {

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -61,7 +61,7 @@ func customHashable() {
 enum InvalidCustomHashable {
   case A, B
 
-  var hashValue: String { return "" } // expected-note{{previously declared here}}
+  var hashValue: String { return "" } // expected-note 2 {{previously declared here}}
 }
 func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String {
   return ""
@@ -72,7 +72,7 @@ func invalidCustomHashable() {
   s = InvalidCustomHashable.A.hashValue
   _ = s
   var _: Int = InvalidCustomHashable.A.hashValue
-  InvalidCustomHashable.A.hash(into: &hasher)
+  InvalidCustomHashable.A.hash(into: &hasher) // expected-error {{value of type 'InvalidCustomHashable' has no member 'hash'}}
 }
 
 // Check use of an enum's synthesized members before the enum is actually declared.


### PR DESCRIPTION
This list used to matter a lot more when `typeCheckFunctionsAndExternalDecls` actually did what it said and dealt with external functions.  Nowadays it's just dead weight.  Drop it and clean up after it.  We now eagerly typecheck derived declarations as soon as they're inserted into their parent decl context.  The final commit also works around Hashable not quite having the smarts to pre-reject invalid derivation contexts so we don't emit a "Hashable is broken" message.