### PR TITLE
[Diagnostics] Produce a tailored diagnostic for property wrapper argu…

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1845,6 +1845,11 @@ public:
   /// reference equality operators `===` and `!==`.
   bool diagnoseUseOfReferenceEqualityOperator() const;
 
+  /// Tailored diagnostics for type mismatches associated with
+  /// property wrapper initialization via implicit `init(wrappedValue:)`
+  /// or now deprecated `init(initialValue:)`.
+  bool diagnosePropertyWrapperMismatch() const;
+
 protected:
   /// \returns The position of the argument being diagnosed, starting at 1.
   unsigned getArgPosition() const { return Info->getArgPosition(); }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3078,16 +3078,6 @@ bool ConstraintSystem::repairFailures(
                        locator);
     }
 
-    // Let's not complain about argument type mismatch if we have a synthesized
-    // wrappedValue initializer, because we already emit a diagnostic for a
-    // type mismatch between the property's type and the wrappedValue type.
-    if (auto CE = dyn_cast<CallExpr>(loc->getAnchor())) {
-      if (CE->isImplicit() && !CE->getArgumentLabels().empty() &&
-          CE->getArgumentLabels().front() == getASTContext().Id_wrappedValue) {
-        break;
-      }
-    }
-
     // If either type has a hole, consider this fixed.
     if (lhs->hasUnresolvedType() || rhs->hasUnresolvedType())
       return true;

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -245,7 +245,7 @@ struct Initialization {
   var y = true
 
   @WrapperWithInitialValue<Int>
-  var y2 = true // expected-error{{Bool' is not convertible to 'Int}}
+  var y2 = true // expected-error{{cannot convert value of type 'Bool' to specified type 'Int'}}
 
   mutating func checkTypes(s: String) {
     x2 = s // expected-error{{cannot assign value of type 'String' to type 'Double'}}


### PR DESCRIPTION
…ment mismatch

Diagnose an attempt to initialize a property, which has a property
wrapper, with a value of an incorrect type.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
