### PR TITLE
[windows] Quote argument for Windows compatibility.

### DIFF
--- a/test/IDE/print_type_interface.swift
+++ b/test/IDE/print_type_interface.swift
@@ -97,7 +97,7 @@ extension Array.Inner where Element: P2 {
 extension Int: P2 {}
 
 // Print interface for Array<Int>.Inner
-// RUN: %target-swift-ide-test -print-type-interface -usr=\$sSa20print_type_interfaceE5InnerVySi_GD -module-name print_type_interface -source-filename %s | %FileCheck %s -check-prefix=TYPE6
+// RUN: %target-swift-ide-test -print-type-interface -usr='$sSa20print_type_interfaceE5InnerVySi_GD' -module-name print_type_interface -source-filename %s | %FileCheck %s -check-prefix=TYPE6
 
 // TYPE6-LABEL: public struct Inner {
 // TYPE6:   public func innerFoo()


### PR DESCRIPTION
In Windows the dollar doesn't introduce variables, so it doesn't need to
be escaped, and was creating an error when running the test on Windows.
However, the unescaped dollar will be interpreted like a variable in
Unix shells, and will fail the test. The solution is quoting the inside
of the argument, which disables the variable substitution on Linux, and
doesn't seem to affect the Windows command line parser.

The error was introduced in #28027 and started appearing in CI on Friday afternoon. https://ci-external.swift.org/job/oss-swift-windows-x86_64/1924/ shows the error in a run from today.