### PR TITLE
[ModuleInterface] Don't print @_staticInitializeObjCMetadata

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -196,7 +196,13 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(bool preferTypeRepr) {
   // the default to 'public' and mark the 'internal' things.
   result.PrintAccess = true;
 
-  result.ExcludeAttrList = {DAK_AccessControl, DAK_SetterAccess, DAK_Lazy};
+  result.ExcludeAttrList = {
+    DAK_AccessControl,
+    DAK_SetterAccess,
+    DAK_Lazy,
+    DAK_StaticInitializeObjCMetadata,
+    DAK_RestatedObjCConformance
+  };
 
   return result;
 }

--- a/test/ModuleInterface/static-initialize-objc-metadata-attr.swift
+++ b/test/ModuleInterface/static-initialize-objc-metadata-attr.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -enable-library-evolution -target %target-pre-stable-abi-triple -module-name Module | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+// To infer @_staticInitializeObjCMetadata, the following needs to be true
+// Our class needs to be:
+// - A subclass of a generic Objective-C class
+// - That inherits a conformance to a protocol
+// - Declared in a module with a deployment target before the stable ABI
+
+public class Super<T>: NSObject, NSCoding {
+  required public init(coder: NSCoder) {}
+  public func encode(with: NSCoder) {}
+}
+
+// CHECK-NOT: @_staticInitializeObjCMetadata
+// CHECK: public class Sub : Module.Super<Swift.Int>
+public class Sub: Super<Int> {
+  required public init(coder: NSCoder) {}
+  override public func encode(with: NSCoder) {}
+}


### PR DESCRIPTION
This attribute is computed during the build and is rejected by the
parser. Make sure not to print it.

Fixes rdar://56923079