### PR TITLE
[AutoDiff] Fix invalid `@differentiable` attribute SILGen crash.

### DIFF
--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -83,14 +83,15 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
       !constant.autoDiffDerivativeFunctionIdentifier &&
       !constant.isStoredPropertyInitializer() &&
       !constant.isThunk()) {
-    // NOTE: Validate `@differentiable` attributes on `AccessorDecl`s by calling
-    // `getParameterIndices`. This is significant to prevent duplicate SIL
-    // `[differentiable]` attribute generation: `getParameterIndices` deletes
-    // `@differentiable` attributes whose original declaration is an
-    // `AbstractStorageDecl`.
-    if (isa<AccessorDecl>(decl))
-      for (auto *A : Attrs.getAttributes<DifferentiableAttr>())
-        (void)A->getParameterIndices();
+    // NOTE: Validate `@differentiable` attributes by calling
+    // `getParameterIndices`. This is important for:
+    // - Skiping invalid `@differentiable` attributes in non-primary files.
+    // - Preventing duplicate SIL `[differentiable]` attribute generation for
+    //   `@differentiable` attributes on `AbstractStorageDecl` declarations.
+    //   Such attributes are deleted and recreated on the getter `AccessorDecl`
+    //   of the `AbstractStorageDecl`.
+    for (auto *A : Attrs.getAttributes<DifferentiableAttr>())
+      (void)A->getParameterIndices();
     for (auto *A : Attrs.getAttributes<DifferentiableAttr>()) {
       // Get lowered argument indices.
       auto *paramIndices = A->getParameterIndices();

--- a/test/AutoDiff/compiler_crashers_fixed/Inputs/tf953-invalid-differentiable-attr-other-module.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/Inputs/tf953-invalid-differentiable-attr-other-module.swift
@@ -1,0 +1,6 @@
+// Invalid `@differentiable` attribute in non-primary-file should not crash
+// SILGen.
+@differentiable
+func foo(_ x: Int) -> Float {
+  return Float(x)
+}

--- a/test/AutoDiff/compiler_crashers_fixed/tf953-invalid-differentiable-attr-cross-module.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf953-invalid-differentiable-attr-cross-module.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-swift-frontend -c -primary-file %s %S/Inputs/tf953-invalid-differentiable-attr-other-module.swift -module-name main
+
+// Verify that invalid `@differentiable` attribute in non-primary file does not
+// crash SILGen.
+
+func bar(_ x: Int) -> Float {
+  return foo(2)
+}
+
+// Assertion failed: (paramIndices && "Parameter indices should have been resolved"), function addFunctionAttributes, file /Users/swiftninjas/s4tf/swift/lib/SIL/SILFunctionBuilder.cpp, line 97.
+// Stack dump:
+// 1.	Swift version 5.1.1-dev (Swift e242a8825f)
+// 2.	While emitting SIL for 'bar(_:)' (at /Users/danielzheng/swift-merge/swift/test/AutoDiff/compiler_crashers/tf953-invalid-differentiable-attr-cross-module.swift:3:1)
+// 3.	While silgen emitFunction SIL function "@$s4main3barySfSiF".
+//  for 'bar(_:)' (at /Users/danielzheng/swift-merge/swift/test/AutoDiff/compiler_crashers/tf953-invalid-differentiable-attr-cross-module.swift:3:1)


### PR DESCRIPTION
Fix SILGen crash for invalid `@differentiable` attributes in non-primary files.

`SILFunctionBuilder::addFunctionAttributes` now validates all `@differentiable`
attributes by calling `DifferentiableAttr::getParameterIndices`.

Resolves TF-953.