### PR TITLE
Skip override checking for members of constrained extensions

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4354,42 +4354,28 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
   auto derivedGenericCtx = derived->getAsGenericContext();
   auto &ctx = base->getASTContext();
 
-  if (!baseGenericCtx) {
+  if (!baseGenericCtx || !derivedGenericCtx)
     return nullptr;
-  }
 
   auto baseClass = base->getDeclContext()->getSelfClassDecl();
-
-  if (!baseClass) {
+  if (!baseClass)
     return nullptr;
-  }
 
   auto derivedClass = derived->getDeclContext()->getSelfClassDecl();
+  if (!derivedClass)
+    return nullptr;
+
+  if (derivedClass->getSuperclass().isNull())
+    return nullptr;
+
+  if (baseGenericCtx->getGenericSignature().isNull() ||
+      derivedGenericCtx->getGenericSignature().isNull())
+    return nullptr;
+
   auto baseClassSig = baseClass->getGenericSignature();
-
-  if (!derivedClass) {
-    return nullptr;
-  }
-
-  if (derivedClass->getSuperclass().isNull()) {
-    return nullptr;
-  }
-
-  if (!derivedGenericCtx || !derivedGenericCtx->isGeneric()) {
-    return nullptr;
-  }
-
-  if (derivedClass->getGenericSignature().isNull() &&
-      !baseGenericCtx->isGeneric()) {
-    return nullptr;
-  }
-
   auto subMap = derivedClass->getSuperclass()->getContextSubstitutionMap(
       derivedClass->getModuleContext(), baseClass);
 
-  if (baseGenericCtx->getGenericSignature().isNull()) {
-    return nullptr;
-  }
   unsigned derivedDepth = 0;
 
   auto key = OverrideSignatureKey(baseGenericCtx->getGenericSignature(),
@@ -4405,9 +4391,11 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
     derivedDepth = derivedSig->getGenericParams().back()->getDepth() + 1;
 
   SmallVector<GenericTypeParamType *, 2> addedGenericParams;
-  for (auto gp : *derivedGenericCtx->getGenericParams()) {
-    addedGenericParams.push_back(
-        gp->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
+  if (auto *gpList = derivedGenericCtx->getGenericParams()) {
+    for (auto gp : *gpList) {
+      addedGenericParams.push_back(
+          gp->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
+    }
   }
 
   unsigned baseDepth = 0;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1221,16 +1221,21 @@ bool ExtensionDecl::hasValidParent() const {
 }
 
 bool ExtensionDecl::isConstrainedExtension() const {
-  // Non-generic extension.
-  if (!getGenericSignature())
+  auto nominal = getExtendedNominal();
+  if (!nominal)
     return false;
 
-  auto nominal = getExtendedNominal();
-  assert(nominal);
+  auto typeSig = nominal->getGenericSignature();
+  if (!typeSig)
+    return false;
+
+  auto extSig = getGenericSignature();
+  if (!extSig)
+    return false;
 
   // If the generic signature differs from that of the nominal type, it's a
   // constrained extension.
-  return !getGenericSignature()->isEqual(nominal->getGenericSignature());
+  return !typeSig->isEqual(extSig);
 }
 
 bool ExtensionDecl::isEquivalentToExtendedContext() const {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -234,6 +234,11 @@ static bool areOverrideCompatibleSimple(ValueDecl *decl,
     return false;
   }
 
+  // Ignore declarations that are defined inside constrained extensions.
+  if (auto *ext = dyn_cast<ExtensionDecl>(parentDecl->getDeclContext()))
+    if (ext->isConstrainedExtension())
+      return false;
+
   // The declarations must be of the same kind.
   if (decl->getKind() != parentDecl->getKind())
     return false;
@@ -1168,6 +1173,11 @@ bool swift::checkOverrides(ValueDecl *decl) {
 
     // Otherwise, we have more checking to do.
   }
+
+  // Members of constrained extensions are not considered to be overrides.
+  if (auto *ext = dyn_cast<ExtensionDecl>(decl->getDeclContext()))
+    if (ext->isConstrainedExtension())
+      return false;
 
   // Accessor methods get overrides through their storage declaration, and
   // all checking can be performed via that mechanism.

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -626,3 +626,25 @@ class SR_10198_Derived_1: SR_10198_Base_1 {
   init(_ arg1: Int) { super.init(SR_10198_Base_S()) } // okay, doesn't crash
 }
 
+// SR-11740
+
+public class SR_11740_Base<F, A> {}
+
+public class SR_11740_Derived<F, A>
+  : SR_11740_Base<SR_11740_Base<F, A>, A>,
+    SR_11740_Q {}
+
+public protocol SR_11740_P {}
+
+public protocol SR_11740_Q: SR_11740_P {
+    associatedtype A
+}
+
+public extension SR_11740_Base where F: SR_11740_Q {
+    static func foo(_: F.A) {}
+}
+
+extension SR_11740_Derived where F: SR_11740_P {
+    public static func foo(_: A) {}
+}
+


### PR DESCRIPTION
When a method in an extension of a class looks like an
override of a method from the base class, we emit a
diagnostic.
    
However due to a bug we used to skip this diagnostic for
certain members of constrained extensions.
    
Indeed it feels like we should not be doing this check
at all for members of constrained extensions, so lets
explicitly skip it, fixing a source compatibility problem
that was introduced when the unrelated bug was fixed.
   
Fixes <rdar://problem/57029805>, <https://bugs.swift.org/browse/SR-11740>.