### PR TITLE
[pmo] Fix load_borrow for strong control equivalence issues.

### DIFF
--- a/test/SILOptimizer/predictable_memaccess_opts.sil
+++ b/test/SILOptimizer/predictable_memaccess_opts.sil
@@ -21,9 +21,12 @@ struct IntPair {
   var y: Builtin.Int32
 }
 
-sil @guaranteed_object_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+sil @nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 sil @intpair_user : $@convention(thin) (IntPair) -> ()
+sil @nativeobjectpair_user : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
 sil @inout_int32_user : $@convention(thin) (@inout Builtin.Int32) -> ()
+sil @get_object : $@convention(thin) () -> @owned Builtin.NativeObject
+sil @nativeobject_tuple_user : $@convention(thin) (@guaranteed (Builtin.NativeObject, Builtin.NativeObject)) -> ()
 
 /// Needed to avoid tuple scalarization code in the use gatherer.
 struct NativeObjectAndTuple {
@@ -545,13 +548,36 @@ bb0(%0 : @owned $Builtin.NativeObject):
 
 // CHECK-LABEL: sil [ossa] @load_borrow_promotion : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 // CHECK: bb0([[ARG:%.*]] :
+// Block where we have our store and do our lifetime extending copy_value.
 // CHECK:   [[STACK:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:   store [[ARG]] to [init] [[STACK]]
-// CHECK:   [[BORROWED_ARG_COPY:%.*]] = begin_borrow [[ARG_COPY]]
+// CHECK:   br bb1
+//
+// Our load block. Here, we insert our copy_value + begin_borrow that is
+// associated with the load_borrow. We can not use the original copy since even
+// though in this situation we know that our copy/borrow would be strongly
+// control equivalent, this is not always true. To simplify the algorithm, we
+// always insert the copy here. We insert a destroy_value to end the lifetime of
+// ARG_COPY since we do not have a loop here.
+//
+// CHECK: bb1:
+// CHECK:   [[CONTROL_EQUIVALENT_ARG_COPY:%.*]] = copy_value [[ARG_COPY]]
+// CHECK:   [[BORROWED_ARG_COPY:%.*]] = begin_borrow [[CONTROL_EQUIVALENT_ARG_COPY]]
+// CHECK:   destroy_value [[ARG_COPY]]
+// CHECK:   br bb2
+//
+// The block where the load_borrow is actually used. We destroy the control
+// equivalent arg copy here after the end_borrow.
+//
+// CHECK: bb2:
 // CHECK:   [[RESULT:%.*]] = copy_value [[BORROWED_ARG_COPY]]
 // CHECK:   end_borrow [[BORROWED_ARG_COPY]]
-// CHECK:   destroy_value [[ARG_COPY]]
+// CHECK:   destroy_value [[CONTROL_EQUIVALENT_ARG_COPY]]
+// CHECK:   br bb3
+//
+// The block after the load_borrow is ever used.
+// CHECK: bb3:
 // CHECK:   destroy_addr [[STACK]] 
 // CHECK:   return [[RESULT]]
 // CHECK: } // end sil function 'load_borrow_promotion'
@@ -559,9 +585,18 @@ sil [ossa] @load_borrow_promotion : $@convention(thin) (@owned Builtin.NativeObj
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = alloc_stack $Builtin.NativeObject
   store %0 to [init] %1 : $*Builtin.NativeObject
+  br bb1
+
+bb1:
   %2 = load_borrow %1 : $*Builtin.NativeObject
+  br bb2
+
+bb2:
   %3 = copy_value %2 : $Builtin.NativeObject
   end_borrow %2 : $Builtin.NativeObject
+  br bb3
+
+bb3:
   destroy_addr %1 : $*Builtin.NativeObject
   dealloc_stack %1 : $*Builtin.NativeObject
   return %3 : $Builtin.NativeObject
@@ -579,7 +614,7 @@ bb0(%0 : @owned $NativeObjectPair):
 
 bb2:
   %3 = load_borrow %2 : $*Builtin.NativeObject
-  %4 = function_ref @guaranteed_object_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %4 = function_ref @nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   apply %4(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   end_borrow %3 : $Builtin.NativeObject
   br bb2
@@ -597,7 +632,7 @@ bb0(%0 : @owned $NativeObjectPair):
 
 bb2:
   %3 = load_borrow %2 : $*Builtin.NativeObject
-  %4 = function_ref @guaranteed_object_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %4 = function_ref @nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   apply %4(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   end_borrow %3 : $Builtin.NativeObject
   cond_br undef, bb3, bb4
@@ -662,17 +697,21 @@ bb9:
 // CHECK:   ([[TUP_0:%.*]], [[TUP_1:%.*]]) = destructure_tuple [[TUP]]
 // CHECK:   [[TUP_0_COPY:%.*]] = copy_value [[TUP_0]]
 // CHECK:   [[TUP_1_COPY:%.*]] = copy_value [[TUP_1]]
-// CHECK:   [[BORROWED_TUP_0_COPY:%.*]] = begin_borrow [[TUP_0_COPY]]
-// CHECK:   [[BORROWED_TUP_1_COPY:%.*]] = begin_borrow [[TUP_1_COPY]]
+// CHECK:   [[CONTROL_EQUIVALENT_TUP_0_COPY:%.*]] = copy_value [[TUP_0_COPY]]
+// CHECK:   [[BORROWED_TUP_0_COPY:%.*]] = begin_borrow [[CONTROL_EQUIVALENT_TUP_0_COPY]]
+// CHECK:   destroy_value [[TUP_0_COPY]]
+// CHECK:   [[CONTROL_EQUIVALENT_TUP_1_COPY:%.*]] = copy_value [[TUP_1_COPY]]
+// CHECK:   [[BORROWED_TUP_1_COPY:%.*]] = begin_borrow [[CONTROL_EQUIVALENT_TUP_1_COPY]]
+// CHECK:   destroy_value [[TUP_1_COPY]]
 // CHECK:   [[BORROWED_TUP:%.*]] = tuple ([[BORROWED_TUP_0_COPY]] : ${{.*}}, [[BORROWED_TUP_1_COPY]] :
 // CHECK:   [[TUP_EXT_1:%.*]] = tuple_extract [[BORROWED_TUP]] :
 // CHECK:   [[TUP_EXT_2:%.*]] = tuple_extract [[BORROWED_TUP]] :
 // CHECK:   apply {{%.*}}([[TUP_EXT_1]])
 // CHECK:   apply {{%.*}}([[TUP_EXT_2]])
 // CHECK:   end_borrow [[BORROWED_TUP_0_COPY]]
-// CHECK:   destroy_value [[TUP_0_COPY]]
+// CHECK:   destroy_value [[CONTROL_EQUIVALENT_TUP_0_COPY]]
 // CHECK:   end_borrow [[BORROWED_TUP_1_COPY]]
-// CHECK:   destroy_value [[TUP_1_COPY]]
+// CHECK:   destroy_value [[CONTROL_EQUIVALENT_TUP_1_COPY]]
 // CHECK: } // end sil function 'load_borrow_tuple_scalarize'
 sil [canonical] [ossa] @load_borrow_tuple_scalarize : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
@@ -683,7 +722,7 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   %4 = load_borrow %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
   %5 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 0
   %6 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
-  %7 = function_ref @guaranteed_object_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %7 = function_ref @nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   apply %7(%5) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   apply %7(%6) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   end_borrow %4 : $(Builtin.NativeObject, Builtin.NativeObject)
@@ -694,12 +733,12 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @multiple_available_values_diamond_followed_by_loop_trivial : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> () {
+// CHECK-LABEL: sil [ossa] @trivial_multiple_available_values_diamond_followed_by_loop_trivial : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> () {
 // CHECK: bb0(
 // CHECK-NOT: load [trivial] %{{[0-9][0-9]*}} : $*IntPair
 // CHECK-NOT: bb{{[0-9][0-9]*}}(
-// CHECK: } // end sil function 'multiple_available_values_diamond_followed_by_loop_trivial'
-sil [ossa] @multiple_available_values_diamond_followed_by_loop_trivial : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> () {
+// CHECK: } // end sil function 'trivial_multiple_available_values_diamond_followed_by_loop_trivial'
+sil [ossa] @trivial_multiple_available_values_diamond_followed_by_loop_trivial : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> () {
 bb0(%0a : $Builtin.Int32, %0b : $Builtin.Int32):
   %func = function_ref @intpair_user : $@convention(thin) (IntPair) -> ()
   %1 = alloc_stack $IntPair
@@ -738,12 +777,12 @@ bb7:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @multiple_available_values_diamond_followed_by_loop_trivial_reload : $@convention(thin) (Builtin.Int32, Builtin.Int32, Builtin.Int32) -> () {
+// CHECK-LABEL: sil [ossa] @trivial_multiple_available_values_diamond_followed_by_loop_trivial_reload : $@convention(thin) (Builtin.Int32, Builtin.Int32, Builtin.Int32) -> () {
 // CHECK: bb0(
 // CHECK-NOT: load [trivial] %{{[0-9][0-9]*}} : $*IntPair
 // CHECK-NOT: bb{{[0-9][0-9]*}}(
-// CHECK: } // end sil function 'multiple_available_values_diamond_followed_by_loop_trivial_reload'
-sil [ossa] @multiple_available_values_diamond_followed_by_loop_trivial_reload : $@convention(thin) (Builtin.Int32, Builtin.Int32, Builtin.Int32) -> () {
+// CHECK: } // end sil function 'trivial_multiple_available_values_diamond_followed_by_loop_trivial_reload'
+sil [ossa] @trivial_multiple_available_values_diamond_followed_by_loop_trivial_reload : $@convention(thin) (Builtin.Int32, Builtin.Int32, Builtin.Int32) -> () {
 bb0(%0a : $Builtin.Int32, %0b : $Builtin.Int32, %0c : $Builtin.Int32):
   %func = function_ref @intpair_user : $@convention(thin) (IntPair) -> ()
   %1 = alloc_stack $IntPair
@@ -782,7 +821,10 @@ bb7:
   return %9999 : $()
 }
 
-sil [ossa] @multiple_available_values_diamond_followed_by_loop_trivial_store_in_loop : $@convention(thin) (Builtin.Int32, Builtin.Int32, Builtin.Int32) -> () {
+// CHECK-LABEL: sil [ossa] @trivial_multiple_available_values_diamond_followed_by_loop_trivial_store_in_loop : $@convention(thin) (Builtin.Int32, Builtin.Int32, Builtin.Int32) -> () {
+// CHECK-NOT: load
+// CHECK: } // end sil function 'trivial_multiple_available_values_diamond_followed_by_loop_trivial_store_in_loop'
+sil [ossa] @trivial_multiple_available_values_diamond_followed_by_loop_trivial_store_in_loop : $@convention(thin) (Builtin.Int32, Builtin.Int32, Builtin.Int32) -> () {
 bb0(%0a : $Builtin.Int32, %0b : $Builtin.Int32, %0c : $Builtin.Int32):
   %func = function_ref @intpair_user : $@convention(thin) (IntPair) -> ()
   %1 = alloc_stack $IntPair
@@ -821,3 +863,480 @@ bb7:
   %9999 = tuple()
   return %9999 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @multiple_available_values_diamond_followed_by_loop : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0(
+// CHECK-NOT: load_borrow
+// CHECK: } // end sil function 'multiple_available_values_diamond_followed_by_loop'
+sil [ossa] @multiple_available_values_diamond_followed_by_loop : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0a : @owned $Builtin.NativeObject, %0b : @owned $Builtin.NativeObject):
+  %func = function_ref @nativeobjectpair_user : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  %1 = alloc_stack $NativeObjectPair
+  %1a = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.x
+  %1b = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.y
+  cond_br undef, bb1, bb2
+
+bb1:
+  store %0a to [init] %1a : $*Builtin.NativeObject
+  store %0b to [init] %1b : $*Builtin.NativeObject
+  br bb3
+
+bb2:
+  store %0a to [init] %1a : $*Builtin.NativeObject
+  store %0b to [init] %1b : $*Builtin.NativeObject
+  br bb3
+
+bb3:
+  br bb4
+
+bb4:
+  br bb5
+
+bb5:
+  %2 = load_borrow %1 : $*NativeObjectPair
+  cond_br undef, bb6, bb7
+
+bb6:
+  apply %func(%2) : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  end_borrow %2 : $NativeObjectPair
+  br bb5
+
+bb7:
+  apply %func(%2) : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  end_borrow %2 : $NativeObjectPair
+  destroy_addr %1 : $*NativeObjectPair
+  dealloc_stack %1 : $*NativeObjectPair
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_available_values_diamond_followed_by_loop_reload : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK-NOT: load_borrow
+// CHECK: } // end sil function 'multiple_available_values_diamond_followed_by_loop_reload'
+sil [ossa] @multiple_available_values_diamond_followed_by_loop_reload : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0a : @owned $Builtin.NativeObject, %0b : @owned $Builtin.NativeObject, %0c : @owned $Builtin.NativeObject):
+  %func = function_ref @nativeobjectpair_user : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  %1 = alloc_stack $NativeObjectPair
+  %1a = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.x
+  %1b = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.y
+  cond_br undef, bb1, bb2
+
+bb1:
+  store %0a to [init] %1a : $*Builtin.NativeObject
+  store %0c to [init] %1b : $*Builtin.NativeObject
+  destroy_value %0b : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  store %0a to [init] %1a : $*Builtin.NativeObject
+  store %0b to [init] %1b : $*Builtin.NativeObject
+  destroy_value %0c : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  br bb4
+
+bb4:
+  br bb5
+
+bb5:
+  %2 = load_borrow %1 : $*NativeObjectPair
+  cond_br undef, bb6, bb7
+
+bb6:
+  apply %func(%2) : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  end_borrow %2 : $NativeObjectPair
+  br bb5
+
+bb7:
+  apply %func(%2) : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  end_borrow %2 : $NativeObjectPair
+  destroy_addr %1 : $*NativeObjectPair
+  dealloc_stack %1 : $*NativeObjectPair
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_available_values_diamond_followed_by_loop_store_in_loop : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+// CHECK-NOT: load_borrow
+// CHECK: } // end sil function 'multiple_available_values_diamond_followed_by_loop_store_in_loop'
+sil [ossa] @multiple_available_values_diamond_followed_by_loop_store_in_loop : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0a : @owned $Builtin.NativeObject, %0b : @owned $Builtin.NativeObject, %0c : @guaranteed $Builtin.NativeObject):
+  %func = function_ref @nativeobjectpair_user : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  %1 = alloc_stack $NativeObjectPair
+  %1a = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.x
+  %1b = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.y
+  %0bhat = copy_value %0b : $Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  store %0a to [init] %1a : $*Builtin.NativeObject
+  store %0b to [init] %1b : $*Builtin.NativeObject
+  br bb3
+
+bb2:
+  store %0a to [init] %1a : $*Builtin.NativeObject
+  store %0b to [init] %1b : $*Builtin.NativeObject
+  br bb3
+
+bb3:
+  br bb4
+
+bb4:
+  br bb5
+
+bb5:
+  %2 = load_borrow %1 : $*NativeObjectPair
+  cond_br undef, bb6, bb7
+
+bb6:
+  apply %func(%2) : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  end_borrow %2 : $NativeObjectPair
+  destroy_addr %1b : $*Builtin.NativeObject
+  %0bhat2 = copy_value %0bhat : $Builtin.NativeObject
+  store %0bhat2 to [init] %1b : $*Builtin.NativeObject
+  br bb5
+
+bb7:
+  apply %func(%2) : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  end_borrow %2 : $NativeObjectPair
+  destroy_value %0bhat : $Builtin.NativeObject
+  destroy_addr %1 : $*NativeObjectPair
+  dealloc_stack %1 : $*NativeObjectPair
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [canonical] [ossa] @loop_carry_loadborrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK-NOT: load_borrow
+// CHECK: } // end sil function 'loop_carry_loadborrow'
+sil [canonical] [ossa] @loop_carry_loadborrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %func = function_ref @nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %1 = alloc_stack $Builtin.NativeObject
+  store %0 to [init] %1 : $*Builtin.NativeObject
+  cond_br undef, bb1, bb7
+
+bb1:
+  br bb2
+
+bb2:
+  br bb3
+
+bb3:
+  %2 = load_borrow %1 : $*Builtin.NativeObject
+  cond_br undef, bb4, bb5
+
+bb4:
+  apply %func(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  br bb2
+
+bb5:
+  apply %func(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  br bb6
+
+bb6:
+  br bb8
+
+bb7:
+  br bb8
+
+bb8:
+  destroy_addr %1 : $*Builtin.NativeObject
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [canonical] [ossa] @loop_carry_loadborrow_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK-NOT: load_borrow
+// CHECK: } // end sil function 'loop_carry_loadborrow_2'
+sil [canonical] [ossa] @loop_carry_loadborrow_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %func = function_ref @nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %1 = alloc_stack $Builtin.NativeObject
+  store %0 to [init] %1 : $*Builtin.NativeObject
+  cond_br undef, bb1, bb7
+
+bb1:
+  br bb2
+
+bb2:
+  br bb3
+
+bb3:
+  %2 = load_borrow %1 : $*Builtin.NativeObject
+  cond_br undef, bb4, bb5
+
+bb4:
+  apply %func(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  br bb2
+
+bb5:
+  apply %func(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  br bb6
+
+bb6:
+  br bb8
+
+bb7:
+  br bb8
+
+bb8:
+  destroy_addr %1 : $*Builtin.NativeObject
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [canonical] [ossa] @loop_carry_loadborrow_3 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+// CHECK-NOT: load_borrow
+// CHECK: } // end sil function 'loop_carry_loadborrow_3'
+sil [canonical] [ossa] @loop_carry_loadborrow_3 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0a : @owned $Builtin.NativeObject, %0b : @owned $Builtin.NativeObject, %0c : @guaranteed $Builtin.NativeObject):
+  %func = function_ref @nativeobject_tuple_user : $@convention(thin) (@guaranteed (Builtin.NativeObject, Builtin.NativeObject)) -> ()
+  %1 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  %1a = tuple_element_addr %1 : $*(Builtin.NativeObject, Builtin.NativeObject), 0
+  %1b = tuple_element_addr %1 : $*(Builtin.NativeObject, Builtin.NativeObject), 1
+  store %0a to [init] %1a : $*Builtin.NativeObject
+  store %0b to [init] %1b : $*Builtin.NativeObject
+  cond_br undef, bb1, bb7
+
+bb1:
+  br bb2
+
+bb2:
+  br bb3
+
+bb3:
+  %0ccopy = copy_value %0c : $Builtin.NativeObject
+  destroy_addr %1a : $*Builtin.NativeObject
+  store %0ccopy to [init] %1a : $*Builtin.NativeObject
+  %2 = load_borrow %1 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  cond_br undef, bb4, bb5
+
+bb4:
+  apply %func(%2) : $@convention(thin) (@guaranteed (Builtin.NativeObject, Builtin.NativeObject)) -> ()
+  end_borrow %2 : $(Builtin.NativeObject, Builtin.NativeObject)
+  br bb2
+
+bb5:
+  apply %func(%2) : $@convention(thin) (@guaranteed (Builtin.NativeObject, Builtin.NativeObject)) -> ()
+  end_borrow %2 : $(Builtin.NativeObject, Builtin.NativeObject)
+  br bb6
+
+bb6:
+  br bb8
+
+bb7:
+  br bb8
+
+bb8:
+  destroy_addr %1 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %1 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [canonical] [ossa] @loop_carry_loadborrow_4 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+// CHECK-NOT: load_borrow
+// CHECK: } // end sil function 'loop_carry_loadborrow_4'
+sil [canonical] [ossa] @loop_carry_loadborrow_4 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0a : @owned $Builtin.NativeObject, %0b : @owned $Builtin.NativeObject, %0c : @guaranteed $Builtin.NativeObject):
+  %func = function_ref @nativeobjectpair_user : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  %1 = alloc_stack $NativeObjectPair
+  %1a = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.x
+  %1b = struct_element_addr %1 : $*NativeObjectPair, #NativeObjectPair.y
+  store %0a to [init] %1a : $*Builtin.NativeObject
+  store %0b to [init] %1b : $*Builtin.NativeObject
+  cond_br undef, bb1, bb7
+
+bb1:
+  br bb2
+
+bb2:
+  br bb3
+
+bb3:
+  %0ccopy = copy_value %0c : $Builtin.NativeObject
+  destroy_addr %1a : $*Builtin.NativeObject
+  store %0ccopy to [init] %1a : $*Builtin.NativeObject
+  %2 = load_borrow %1 : $*NativeObjectPair
+  cond_br undef, bb4, bb5
+
+bb4:
+  apply %func(%2) : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  end_borrow %2 : $NativeObjectPair
+  br bb2
+
+bb5:
+  apply %func(%2) : $@convention(thin) (@guaranteed NativeObjectPair) -> ()
+  end_borrow %2 : $NativeObjectPair
+  br bb6
+
+bb6:
+  br bb8
+
+bb7:
+  br bb8
+
+bb8:
+  destroy_addr %1 : $*NativeObjectPair
+  dealloc_stack %1 : $*NativeObjectPair
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @loop_carry_load_borrow_phi_not_control_equivalent : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK-NOT: load_borrow
+// CHECK: } // end sil function 'loop_carry_load_borrow_phi_not_control_equivalent'
+sil [ossa] @loop_carry_load_borrow_phi_not_control_equivalent : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%arg : @owned $Builtin.NativeObject):
+  %func = function_ref @nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %0 = alloc_stack $Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  cond_br undef, bb3, bb4
+
+bb2:
+  store %arg to [init] %0 : $*Builtin.NativeObject
+  br bb5
+
+bb3:
+  store %arg to [init] %0 : $*Builtin.NativeObject
+  br bb6
+
+bb4:
+  store %arg to [init] %0 : $*Builtin.NativeObject
+  br bb7
+
+bb5:
+  br bb8
+
+bb6:
+  br bb8
+
+bb7:
+  br bbPreLoopHeader
+
+bb8:
+  br bbPreLoopHeader
+
+bbPreLoopHeader:
+  br bbLoop
+
+bbLoop:
+  br bbLoop1
+
+bbLoop1:
+  br bbLoop2
+
+bbLoop2:
+  %2 = load_borrow %0 : $*Builtin.NativeObject
+  cond_br undef, bbLoop3, bbLoop4
+
+bbLoop3:
+  apply %func(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  br bbLoop2
+
+bbLoop4:
+  apply %func(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  br bbEnd
+
+bbEnd:
+  destroy_addr %0 : $*Builtin.NativeObject
+  dealloc_stack %0 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// In this case, we will have that we need to separately lifetime extend our phi
+// node's copy to prevent leaks along the edge skipping the loop.
+// CHECK-LABEL: sil [ossa] @loop_carry_load_borrow_phi_not_control_equivalent_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK-NOT: load_borrow
+// CHECK: } // end sil function 'loop_carry_load_borrow_phi_not_control_equivalent_2'
+sil [ossa] @loop_carry_load_borrow_phi_not_control_equivalent_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%arg : @owned $Builtin.NativeObject):
+  %func = function_ref @nativeobject_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %0 = alloc_stack $Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  cond_br undef, bb3, bb4
+
+bb2:
+  store %arg to [init] %0 : $*Builtin.NativeObject
+  br bb5
+
+bb3:
+  store %arg to [init] %0 : $*Builtin.NativeObject
+  br bb6
+
+bb4:
+  store %arg to [init] %0 : $*Builtin.NativeObject
+  br bb7
+
+bb5:
+  br bb8a
+
+bb6:
+  br bb8a
+
+bb7:
+  br bbPreLoopHeader
+
+bb8a:
+  br bb8
+
+bb8:
+  cond_br undef, bbPreLoopHeader1, bbSkipLoop
+
+bbPreLoopHeader:
+  br bbLoop
+
+bbPreLoopHeader1:
+  br bbLoop
+
+bbLoop:
+  br bbLoop1
+
+bbLoop1:
+  br bbLoop2
+
+bbLoop2:
+  %2 = load_borrow %0 : $*Builtin.NativeObject
+  br bbLoop6
+
+bbLoop6:
+  cond_br undef, bbLoop3, bbLoop4
+
+bbLoop3:
+  apply %func(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  br bbLoop5
+
+bbLoop5:
+  br bbLoop2
+
+bbLoop4:
+  apply %func(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  br bbEnd
+
+bbSkipLoop:
+  br bbEnd
+
+bbEnd:
+  destroy_addr %0 : $*Builtin.NativeObject
+  dealloc_stack %0 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+


### PR DESCRIPTION
This entailed untangling a few issues. I have purposefully only fixed this for
now for load_borrow to make the change in tree smaller (the reason for my
splitting the code paths in a previous group of commits). I am going to follow
up with a load copy version of the patch. I think that the code should be the
same. The interesting part about this is that all of these code conditions are
caught by the ownership verifier, suggesting to me that the code in the
stdlib/overlays is simple enough that we didn't hit these code patterns.

Anyways, the main change here is that we now eliminate control equivalence
issues arising from @owned values that are not control equivalent being
forwarded into aggregates and phis. This would cause our outer value to be
destroyed early since we would be destroying it once for every time iteration in
a loop.

The way that this is done is that (noting that this is only for borrows today):

* The AvailableValueAggregator always copies values at available value points to
  lifetime extend the values to the load block. In the load block, the
  aggregator will take the incoming values and borrow the value to form tuples,
  structs as needed. This new guaranteed aggregate is then copied. If we do not
  need to form an aggregate, we just copy. Since the copy is in our load block,
  we know that we can use it for our load_borrow. Importantly note how we no
  longer allow for these aggregates to forward owned ownership preventing the
  control equivalence problem above.

* Since the aggregator may use the SSA updater if it finds multiple available
  values, we need to also make sure that any phis are strongly control
  equivalent on all of its incoming values. So we insert copies along those
  edges and then lifetime extend the phi as appropriate.

* Since in all of the above all copy_value inserted by the available value
  aggregator are never consumed, we can just add destroy_values in the
  appropriate places and everything works.
