### PR TITLE
getInterfaceType() always returns a type

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3426,11 +3426,7 @@ Type TypeDecl::getDeclaredInterfaceType() const {
         selfTy, const_cast<AssociatedTypeDecl *>(ATD));
   }
 
-  Type interfaceType = getInterfaceType();
-  if (!interfaceType)
-    return ErrorType::get(getASTContext());
-
-  return interfaceType->getMetatypeInstanceType();
+  return getInterfaceType()->getMetatypeInstanceType();
 }
 
 int TypeDecl::compare(const TypeDecl *type1, const TypeDecl *type2) {
@@ -4770,10 +4766,6 @@ ProtocolDecl::findProtocolSelfReferences(const ValueDecl *value,
     return SelfReferenceKind::None();
 
   auto type = value->getInterfaceType();
-
-  // FIXME: Deal with broken recursion.
-  if (!type)
-    return SelfReferenceKind::None();
 
   // Skip invalid declarations.
   if (type->hasError())

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -242,8 +242,6 @@ swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
   }
 
   auto declIFaceTy = D->getInterfaceType();
-  if (!declIFaceTy)
-    return std::string();
 
   // Invalid code.
   if (declIFaceTy.findIf([](Type t) -> bool {

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -288,9 +288,6 @@ static void collectPossibleCalleesByQualifiedLookup(
     if (!isMemberDeclApplied(&DC, baseTy->getMetatypeInstanceType(), VD))
       continue;
     Type declaredMemberType = VD->getInterfaceType();
-    if (!declaredMemberType) {
-      continue;
-    }
     if (!declaredMemberType->is<AnyFunctionType>())
       continue;
     if (VD->getDeclContext()->isTypeContext()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5274,10 +5274,6 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       return;
     }
 
-    // FIXME: Deal with broken recursion
-    if (!decl->hasInterfaceType())
-      return;
-
     // Dig out the instance type and figure out what members of the instance type
     // we are going to see.
     auto baseTy = candidate.getBaseType();
@@ -5648,10 +5644,6 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
         result.markErrorAlreadyDiagnosed();
         return result;
       }
-
-      // FIXME: Deal with broken recursion
-      if (!cand->hasInterfaceType())
-        continue;
 
       result.addUnviable(getOverloadChoice(cand, /*isBridged=*/false,
                                            /*isUnwrappedOptional=*/false),

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -602,8 +602,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
       auto ctors = TypeChecker::lookupConstructors(
           CS.DC, instanceType, NameLookupFlags::IgnoreAccessControl);
       for (auto ctor : ctors) {
-        if (ctor.getValueDecl()->getInterfaceType())
-          candidates.push_back({ ctor.getValueDecl(), 1 });
+        candidates.push_back({ ctor.getValueDecl(), 1 });
       }
     }
     

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1470,7 +1470,7 @@ Type ConstraintSystem::getEffectiveOverloadType(const OverloadChoice &overload,
 
   // Retrieve the interface type.
   auto type = decl->getInterfaceType();
-  if (!type || type->hasError()) {
+  if (type->hasError()) {
     return Type();
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3939,11 +3939,8 @@ bool swift::isMemberOperator(FuncDecl *decl, Type type) {
   // Check the parameters for a reference to 'Self'.
   bool isProtocol = selfNominal && isa<ProtocolDecl>(selfNominal);
   for (auto param : *decl->getParameters()) {
-    auto paramType = param->getInterfaceType();
-    if (!paramType) break;
-
     // Look through a metatype reference, if there is one.
-    paramType = paramType->getMetatypeInstanceType();
+    auto paramType = param->getInterfaceType()->getMetatypeInstanceType();
 
     auto nominal = paramType->getAnyNominal();
     if (type.isNull()) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -225,12 +225,10 @@ static void diagnoseFunctionParamNotRepresentable(
     AFD->diagnose(diag::objc_invalid_on_func_param_type,
                   ParamIndex + 1, getObjCDiagnosticAttrKind(Reason));
   }
-  if (Type ParamTy = P->getType()) {
-    SourceRange SR;
-    if (auto typeRepr = P->getTypeRepr())
-      SR = typeRepr->getSourceRange();
-    diagnoseTypeNotRepresentableInObjC(AFD, ParamTy, SR);
-  }
+  SourceRange SR;
+  if (auto typeRepr = P->getTypeRepr())
+    SR = typeRepr->getSourceRange();
+  diagnoseTypeNotRepresentableInObjC(AFD, P->getType(), SR);
   describeObjCReason(AFD, Reason);
 }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -282,9 +282,6 @@ diagnoseMismatchedOptionals(const ValueDecl *member,
     Type paramTy = decl->getType();
     Type parentParamTy = parentDecl->getType();
 
-    if (!paramTy || !parentParamTy)
-      return;
-
     auto *repr = decl->getTypeRepr();
     if (!repr)
       return;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1488,10 +1488,7 @@ void TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
     if (param->isInvalid())
       return true;
 
-    if (auto type = param->getType())
-      return !isValidType(type);
-
-    return true;
+    return !isValidType(param->getType());
   };
 
   auto handleParameter = [&](ParamDecl *param, Type ty, bool forceMutable) {

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -546,7 +546,7 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
 
   // Compute the type of the property to plug in to the wrapper type.
   Type propertyType = var->getType();
-  if (!propertyType || propertyType->hasError())
+  if (propertyType->hasError())
     return Type();
 
   using namespace constraints;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1166,7 +1166,7 @@ public:
         }
         assert(isa<CaseStmt>(initialCaseVarDecl->getParentPatternStmt()));
 
-        if (initialCaseVarDecl->getType() && !initialCaseVarDecl->isInvalid() &&
+        if (!initialCaseVarDecl->isInvalid() &&
             !vd->getType()->isEqual(initialCaseVarDecl->getType())) {
           getASTContext().Diags.diagnose(vd->getLoc(), diag::type_mismatch_multiple_pattern_list,
                       vd->getType(), initialCaseVarDecl->getType());

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1166,8 +1166,7 @@ public:
         }
         assert(isa<CaseStmt>(initialCaseVarDecl->getParentPatternStmt()));
 
-        if (vd->getInterfaceType() && initialCaseVarDecl->getType() &&
-            !initialCaseVarDecl->isInvalid() &&
+        if (initialCaseVarDecl->getType() && !initialCaseVarDecl->isInvalid() &&
             !vd->getType()->isEqual(initialCaseVarDecl->getType())) {
           getASTContext().Diags.diagnose(vd->getLoc(), diag::type_mismatch_multiple_pattern_list,
                       vd->getType(), initialCaseVarDecl->getType());

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1122,11 +1122,8 @@ static void filterValues(Type expectedTy, ModuleDecl *expectedModule,
       return true;
 
     // If we're expecting a type, make sure this decl has the expected type.
-    if (canTy)  {
-      auto ifaceTy = value->getInterfaceType();
-      if (!ifaceTy || !ifaceTy->isEqual(canTy))
-        return true;
-    }
+    if (canTy && !value->getInterfaceType()->isEqual(canTy))
+      return true;
 
     if (value->isStatic() != isStatic)
       return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -778,12 +778,11 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   unsigned USREnd = SS.size();
 
   unsigned TypenameBegin = SS.size();
-  if (auto vdType = VD->getInterfaceType()) {
-    llvm::raw_svector_ostream OS(SS);
-    PrintOptions Options;
-    Options.PrintTypeAliasUnderlyingType = true;
-    vdType.print(OS, Options);
-  }
+  llvm::raw_svector_ostream OS(SS);
+  PrintOptions Options;
+  Options.PrintTypeAliasUnderlyingType = true;
+  VD->getInterfaceType().print(OS, Options);
+
   unsigned TypenameEnd = SS.size();
 
   unsigned MangledTypeStart = SS.size();


### PR DESCRIPTION
Remove a handful of checks for whether `getInterfaceType()` returns a non-null type, as it now always returns a non-null type. Also remove a couple of unnecessary calls to `hasInterfaceType()`.