### PR TITLE
[AutoDiff upstream] Update `@differentiable` syntax.

### DIFF
--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -209,7 +209,7 @@ ATTRIBUTE_NODES = [
     #     generic-where-clause?
     Node('DifferentiableAttributeArguments', kind='Syntax',
          description='''
-         The arguments for the `@differentiable` attribute: an optional \
+         The arguments for the `@differentiable` attribute: an optional
          differentiation parameter list and associated functions.
          ''',
          children=[
@@ -219,10 +219,6 @@ ATTRIBUTE_NODES = [
                    The comma following the differentiation parameters clause,
                    if it exists.
                    ''', is_optional=True),
-             Child('MaybePrimal', kind='DifferentiableAttributeFuncSpecifier',
-                   is_optional=True),
-             Child('MaybeAdjoint', kind='DifferentiableAttributeFuncSpecifier',
-                   is_optional=True),
              Child('MaybeJVP', kind='DifferentiableAttributeFuncSpecifier',
                    is_optional=True),
              Child('MaybeVJP', kind='DifferentiableAttributeFuncSpecifier',
@@ -266,7 +262,7 @@ ATTRIBUTE_NODES = [
     # differentiation-param -> ('self' | identifer) ','?
     Node('DifferentiationParam', kind='Syntax',
          description='''
-         A differentiation parameter: either the "self" identifier or a \
+         A differentiation parameter: either the "self" identifier or a
          function parameter name.
          ''',
          traits=['WithTrailingComma'],
@@ -283,7 +279,7 @@ ATTRIBUTE_NODES = [
     #     ('jvp' | 'vjp') ':' func-decl-name ','?
     Node('DifferentiableAttributeFuncSpecifier', kind='Syntax',
          description='''
-         A function specifier, consisting of an identifier, colon, and a \
+         A function specifier, consisting of an identifier, colon, and a
          function declaration name (e.g. `vjp: foo(_:_:)`).
          ''',
          traits=['WithTrailingComma'],
@@ -313,7 +309,7 @@ ATTRIBUTE_NODES = [
                    ]),
              Child('Arguments', kind='DeclNameArguments',
                    is_optional=True, description='''
-                   The argument labels of the referenced function, optionally \
+                   The argument labels of the referenced function, optionally
                    specified.
                    '''),
          ]),


### PR DESCRIPTION
Clean up unused syntax components and fix description strings.

Friend PR: https://github.com/apple/swift-syntax/pull/179
Resolves comments: https://github.com/apple/swift/pull/27506#pullrequestreview-315663528

---

Must be tested with https://github.com/apple/swift-syntax/pull/179 so that `--swiftsyntax-verify-generated-files` passes.