### PR TITLE
[Typechecker] Fix _modify for properties using a property wrapper

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1525,7 +1525,7 @@ synthesizeSetterBody(AccessorDecl *setter, ASTContext &ctx) {
       return synthesizePropertyWrapperSetterBody(setter, ctx);
     }
 
-    // Synthesize a getter for the storage wrapper property of a property
+    // Synthesize a setter for the storage wrapper property of a property
     // with an attached wrapper.
     if (auto original = var->getOriginalWrappedProperty(
             PropertyWrapperSynthesizedPropertyKind::StorageWrapper)) {
@@ -1571,10 +1571,16 @@ synthesizeCoroutineAccessorBody(AccessorDecl *accessor, ASTContext &ctx) {
                    : TargetImpl::Implementation);
 
   // If this is a variable with an attached property wrapper, then
-  // the accessors need to yield the wrapped value.
-  if (isa<VarDecl>(storage) &&
-      cast<VarDecl>(storage)->hasAttachedPropertyWrapper()) {
-    target = TargetImpl::Wrapper;
+  // the accessors need to yield the wrappedValue or projectedValue.
+  if (auto var = dyn_cast<VarDecl>(storage)) {
+    if (var->hasAttachedPropertyWrapper()) {
+      target = TargetImpl::Wrapper;
+    }
+
+    if (var->getOriginalWrappedProperty(
+            PropertyWrapperSynthesizedPropertyKind::StorageWrapper)) {
+      target = TargetImpl::WrapperStorage;
+    }
   }
 
   SourceLoc loc = storage->getLoc();

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -765,6 +765,14 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
   if (isMemberLValue)
     isSelfLValue |= storage->isSetterMutating();
 
+  // If we're accessing a property wrapper, determine if
+  // the self requires an lvalue.
+  if (auto mut = propertyWrapperMutability(storage)) {
+    isSelfLValue = mut->first;
+    if (isMemberLValue)
+      isSelfLValue |= mut->second;
+  }
+
   Expr *selfDRE =
     buildSelfReference(selfDecl, selfAccessKind, isSelfLValue,
                        ctx);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2263,9 +2263,15 @@ PropertyWrapperMutabilityRequest::evaluate(Evaluator &,
     isProjectedValue = true;
   }
 
-  if (var->getParsedAccessor(AccessorKind::Get))
+  // Make sure we don't ignore .swiftinterface files, because those will
+  // have the accessors printed
+  auto varSourceFile = var->getDeclContext()->getParentSourceFile();
+  auto isVarNotInInterfaceFile =
+      varSourceFile && varSourceFile->Kind != SourceFileKind::Interface;
+
+  if (var->getParsedAccessor(AccessorKind::Get) && isVarNotInInterfaceFile)
     return None;
-  if (var->getParsedAccessor(AccessorKind::Set))
+  if (var->getParsedAccessor(AccessorKind::Set) && isVarNotInInterfaceFile)
     return None;
 
   // Figure out which member we're looking through.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -765,14 +765,6 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
   if (isMemberLValue)
     isSelfLValue |= storage->isSetterMutating();
 
-  // If we're accessing a property wrapper, determine if
-  // the self requires an lvalue.
-  if (auto mut = propertyWrapperMutability(storage)) {
-    isSelfLValue = mut->first;
-    if (isMemberLValue)
-      isSelfLValue |= mut->second;
-  }
-
   Expr *selfDRE =
     buildSelfReference(selfDecl, selfAccessKind, isSelfLValue,
                        ctx);

--- a/test/ModuleInterface/property_wrappers.swift
+++ b/test/ModuleInterface/property_wrappers.swift
@@ -44,6 +44,7 @@ public struct HasWrappers {
   // CHECK: @TestResilient.Wrapper public var x: {{(Swift.)?}}Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: set
+  // CHECK-NEXT: _modify  
   // CHECK-NEXT: }  
   @Wrapper public var x: Int
 
@@ -59,6 +60,7 @@ public struct HasWrappers {
   // CHECK: @TestResilient.WrapperWithInitialValue @_projectedValueProperty($z) public var z: Swift.Bool {
   // CHECK-NEXT: get
   // CHECK-NEXT: set
+  // CHECK-NEXT: _modify
   // CHECK-NEXT: }  
   @WrapperWithInitialValue(alternate: false) public var z
 }

--- a/test/SILGen/property_wrapper_coroutine.swift
+++ b/test/SILGen/property_wrapper_coroutine.swift
@@ -9,18 +9,22 @@ struct State {
   @TestWrapper var values: [String] = []
 }
 
+protocol StateProtocol {
+  @_borrowed var someValues: [String] { get set }
+}
+
+struct State1: StateProtocol {
+  @TestWrapper var someValues: [String] = []
+}
+
 var state = State()
 state.values = Array(repeating: "", count: 20000)
-
-for i in 0..<20000 {
-  // CHECK: bb3([[INDEX:%.*]] : $Int):
-  // CHECK:  [[BEGIN_ACCESS_MODIFY:%.*]] = begin_access [modify] [dynamic] {{%.*}} : $*State
-  // CHECK:  [[REF_MODIFY:%.*]] = function_ref @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
-  // CHECK:  ([[RES1:%.*]], {{%.*}}) = begin_apply [[REF_MODIFY]]([[BEGIN_ACCESS_MODIFY]]) : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
-  // CHECK:  [[REF_ARRAY_SUBSCRIPT:%.*]] = function_ref @$sSayxSiciM : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
-  // CHECK:  ({{%.*}}, {{%.*}}) = begin_apply [[REF_ARRAY_SUBSCRIPT]]<String>([[INDEX]], [[RES1]]) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
-  state.values[i] = String(i)
-}
+// CHECK:  [[BEGIN_ACCESS_MODIFY:%.*]] = begin_access [modify] [dynamic] {{%.*}} : $*State
+// CHECK:  [[REF_MODIFY:%.*]] = function_ref @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
+// CHECK:  ([[RES1:%.*]], {{%.*}}) = begin_apply [[REF_MODIFY]]([[BEGIN_ACCESS_MODIFY]]) : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
+// CHECK:  [[REF_ARRAY_SUBSCRIPT:%.*]] = function_ref @$sSayxSiciM : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+// CHECK:  ({{%.*}}, {{%.*}}) = begin_apply [[REF_ARRAY_SUBSCRIPT]]<String>({{%.*}}, [[RES1]]) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+state.values[1000] = "foo"
 
 // CHECK-LABEL: sil hidden [transparent] [ossa] @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String> {
 // CHECK: bb0([[STATE:%.*]] : $*State):
@@ -37,5 +41,29 @@ for i in 0..<20000 {
 //
 // CHECK: bb2:
 // CHECK:  end_access [[BEGIN_ACCESS]] : $*State
+// CHECK:  unwind
+// CHECK-END: }
+
+var state1 = State1()
+_ = state1.someValues
+
+// CHECK-LABEL: sil shared [ossa] @$s26property_wrapper_coroutine6State1V10someValuesSaySSGvr : $@yield_once @convention(method) (@guaranteed State1) -> @yields @guaranteed Array<String> {
+// CHECK: bb0([[STATE1:%.*]] : @guaranteed $State1):
+// CHECK:  debug_value [[SELF:%.*]] : $State1, let, name "self", argno {{.*}}
+// CHECK:  [[EXTRACT_VALUE:%.*]] = struct_extract %0 : $State1, #State1._someValues
+// CHECK:  [[COPY_VALUE:%.*]] = copy_value [[EXTRACT_VALUE]] : $TestWrapper<Array<String>>
+// CHECK:  [[BEGIN_BORROW:%.*]] = begin_borrow [[COPY]] : $TestWrapper<Array<String>>
+// CHECK:  [[EXTRACT_WRAPPEDVALUE:%.*]] = struct_extract [[BEGIN_BORROW]] : $TestWrapper<Array<String>>, #TestWrapper.wrappedValue
+// CHECK:  yield [[EXTRACT_WRAPPEDVALUE]] : $Array<String>, resume bb1, unwind bb2
+//
+// CHECK: bb1:
+// CHECK:  end_borrow [[BEGIN_BORROW]] : $TestWrapper<Array<String>>
+// CHECK:  destroy_value [[COPY_VALUE]] : $TestWrapper<Array<String>>
+// CHECK:  [[RETURN:%.*]] = tuple ()
+// CHECK:  return [[RETURN]] : $()
+//
+// CHECK: bb2:
+// CHECK:  end_borrow [[BEGIN_BORROW]] : $TestWrapper<Array<String>>
+// CHECK:  destroy_value [[COPY_VALUE]] : $TestWrapper<Array<String>>
 // CHECK:  unwind
 // CHECK-END: }

--- a/test/SILGen/property_wrapper_coroutine.swift
+++ b/test/SILGen/property_wrapper_coroutine.swift
@@ -19,12 +19,20 @@ struct State1: StateProtocol {
 
 var state = State()
 state.values = Array(repeating: "", count: 20000)
-// CHECK:  [[BEGIN_ACCESS_MODIFY:%.*]] = begin_access [modify] [dynamic] {{%.*}} : $*State
-// CHECK:  [[REF_MODIFY:%.*]] = function_ref @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
-// CHECK:  ([[RES1:%.*]], {{%.*}}) = begin_apply [[REF_MODIFY]]([[BEGIN_ACCESS_MODIFY]]) : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
+state.values[1000] = "foo"
+
+let state1 = State1()
+_ = state1.someValues
+
+// >> Check that the subscript assignment uses the _modify coroutine
+
+// CHECK:  {{%.*}} = begin_access [modify] [dynamic] {{%.*}} : $*State
+// CHECK:  [[REF_VALUES_MODIFY:%.*]] = function_ref @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
+// CHECK:  ([[RES1:%.*]], {{%.*}}) = begin_apply [[REF_VALUES_MODIFY]]({{%.*}}) : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
 // CHECK:  [[REF_ARRAY_SUBSCRIPT:%.*]] = function_ref @$sSayxSiciM : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
 // CHECK:  ({{%.*}}, {{%.*}}) = begin_apply [[REF_ARRAY_SUBSCRIPT]]<String>({{%.*}}, [[RES1]]) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
-state.values[1000] = "foo"
+
+// >> Check that the _modify coroutine is synthesized properly
 
 // CHECK-LABEL: sil hidden [transparent] [ossa] @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String> {
 // CHECK: bb0([[STATE:%.*]] : $*State):
@@ -44,15 +52,14 @@ state.values[1000] = "foo"
 // CHECK:  unwind
 // CHECK-END: }
 
-var state1 = State1()
-_ = state1.someValues
+// >> Check that the _read coroutine is synthesized properly
 
 // CHECK-LABEL: sil shared [ossa] @$s26property_wrapper_coroutine6State1V10someValuesSaySSGvr : $@yield_once @convention(method) (@guaranteed State1) -> @yields @guaranteed Array<String> {
 // CHECK: bb0([[STATE1:%.*]] : @guaranteed $State1):
 // CHECK:  debug_value [[SELF:%.*]] : $State1, let, name "self", argno {{.*}}
 // CHECK:  [[EXTRACT_VALUE:%.*]] = struct_extract %0 : $State1, #State1._someValues
 // CHECK:  [[COPY_VALUE:%.*]] = copy_value [[EXTRACT_VALUE]] : $TestWrapper<Array<String>>
-// CHECK:  [[BEGIN_BORROW:%.*]] = begin_borrow [[COPY]] : $TestWrapper<Array<String>>
+// CHECK:  [[BEGIN_BORROW:%.*]] = begin_borrow [[COPY_VALUE]] : $TestWrapper<Array<String>>
 // CHECK:  [[EXTRACT_WRAPPEDVALUE:%.*]] = struct_extract [[BEGIN_BORROW]] : $TestWrapper<Array<String>>, #TestWrapper.wrappedValue
 // CHECK:  yield [[EXTRACT_WRAPPEDVALUE]] : $Array<String>, resume bb1, unwind bb2
 //

--- a/test/SILGen/property_wrapper_coroutine.swift
+++ b/test/SILGen/property_wrapper_coroutine.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+@propertyWrapper
+struct TestWrapper<ValueType> {
+  var wrappedValue: ValueType
+}
+
+struct State {
+  @TestWrapper var values: [String] = []
+}
+
+var state = State()
+state.values = Array(repeating: "", count: 20000)
+
+for i in 0..<20000 {
+  // CHECK: bb3([[INDEX:%.*]] : $Int):
+  // CHECK:  [[BEGIN_ACCESS_MODIFY:%.*]] = begin_access [modify] [dynamic] {{%.*}} : $*State
+  // CHECK:  [[REF_MODIFY:%.*]] = function_ref @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
+  // CHECK:  ([[RES1:%.*]], {{%.*}}) = begin_apply [[REF_MODIFY]]([[BEGIN_ACCESS_MODIFY]]) : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String>
+  // CHECK:  [[REF_ARRAY_SUBSCRIPT:%.*]] = function_ref @$sSayxSiciM : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+  // CHECK:  ({{%.*}}, {{%.*}}) = begin_apply [[REF_ARRAY_SUBSCRIPT]]<String>([[INDEX]], [[RES1]]) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+  state.values[i] = String(i)
+}
+
+// CHECK-LABEL: sil hidden [transparent] [ossa] @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String> {
+// CHECK: bb0([[STATE:%.*]] : $*State):
+// CHECK:  debug_value_addr [[STATE]] : $*State, var, name "self", argno {{.*}}
+// CHECK:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [unknown] [[STATE]] : $*State
+// CHECK:  [[BACKING_ADDR:%.*]] = struct_element_addr [[BEGIN_ACCESS]] : $*State, #State._values
+// CHECK:  [[VALUE_ADDR:%.*]] = struct_element_addr [[BACKING_ADDR]] : $*TestWrapper<Array<String>>, #TestWrapper.wrappedValue
+// CHECK:  yield [[VALUE_ADDR]] : $*Array<String>, resume bb1, unwind bb2
+//
+// CHECK: bb1:
+// CHECK:  end_access [[BEGIN_ACCESS]] : $*State
+// CHECK:  [[RETURN:%.*]] = tuple ()
+// CHECK:  return [[RETURN]] : $()
+//
+// CHECK: bb2:
+// CHECK:  end_access [[BEGIN_ACCESS]] : $*State
+// CHECK:  unwind
+// CHECK-END: }

--- a/test/decl/var/property_wrappers_synthesis.swift
+++ b/test/decl/var/property_wrappers_synthesis.swift
@@ -21,7 +21,7 @@ struct UseWrapper<T: DefaultInit> {
 
   // CHECK: accessor_decl{{.*}}_modify_for=wrapped
   // CHECK: yield_stmt
-  // CHECK: member_ref_expr{{.*}}UseWrapper.wrapped
+  // CHECK: member_ref_expr{{.*}}Wrapper.wrappedValue
   @Wrapper
   var wrapped = T()
 


### PR DESCRIPTION
Follow up to https://forums.swift.org/t/property-wrapper-causing-excessive-array-copying

1. We weren't correctly synthesising `_modify` for properties with an attached property wrapper. It was yielding the property itself, instead of the `wrappedValue`.
2. The `ReadWriteImplKind` wasn't `Modify` so the synthesised `_modify` was never used (although even if it was then transparent inlining would error out, due to the incorrect synthesis of the coroutine).

Resolves SR-11762