### PR TITLE
[msvc] Fix another test using forward declared enums.

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.h
+++ b/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.h
@@ -5,6 +5,9 @@
   enum _name _name; \
   enum __attribute__((enum_extensibility(closed))) _name
 
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmicrosoft-enum-forward-reference"
 typedef MY_ENUM(RegularEnum) {
   RegularEnumA,
   RegularEnumB
@@ -47,3 +50,4 @@ enum __attribute__((enum_extensibility(closed))) UnavailableCases {
   UnavailableCasesB,
   UnavailableCasesThisIsTheUnavailableOne __attribute__((availability(swift, unavailable)))
 };
+#pragma clang diagnostic pop


### PR DESCRIPTION
Forward declared enums create a warning in MSVC which turns into an
error when -warnings-as-errors is passed. This disable the warning in
the header to avoid the error making the test fail.

For some reason it failed suddenly in https://ci-external.swift.org/job/oss-swift-windows-x86_64/1941/console. In #28175 I fixed a similar case, but this one haven't appeared until now, and I don't know what triggered (that CI build has no commit related to it).