### PR TITLE
[AutoDiff] Add negative tests for TF-954.

### DIFF
--- a/test/AutoDiff/control_flow.swift
+++ b/test/AutoDiff/control_flow.swift
@@ -56,6 +56,23 @@ ControlFlowTests.test("Conditionals") {
   expectEqual((5, 4), gradient(at: 4, 5, in: cond3))
   expectEqual((-1, 1), gradient(at: -3, -2, in: cond3))
 
+  func cond4_var(_ x: Float) -> Float {
+    var outer = x
+    outerIf: if true {
+      var inner = outer
+      inner = inner * x
+      if false {
+        break outerIf
+      }
+      outer = inner
+    }
+    return outer
+  }
+  // FIXME(TF-954): Investigate incorrect derivative related to addresses and
+  // nested control flow.
+  // expectEqual((9, 6), valueWithGradient(at: 3, in: cond4_var))
+  expectEqual((9, 0), valueWithGradient(at: 3, in: cond4_var))
+
   func cond_tuple(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
     let y: (Float, Float) = (x, x)
@@ -690,8 +707,16 @@ ControlFlowTests.test("Loops") {
     }
     return outer
   }
+  // FIXME(TF-954): Investigate incorrect derivative related to addresses and
+  // nested control flow.
+  // expectEqual((6, 5), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 1) }))
+  // expectEqual((20, 22), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 2) }))
+  // expectEqual((52, 80), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 3) }))
+  // expectEqual((24, 28), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 4) }))
+  expectEqual((6, 0), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 1) }))
+  expectEqual((20, 0), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 2) }))
+  expectEqual((52, 26), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 3) }))
   expectEqual((24, 12), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 4) }))
-  expectEqual((16, 8), valueWithGradient(at: 4, in: { x in nested_loop2(x, count: 4) }))
 }
 
 runAllTests()


### PR DESCRIPTION
Add negative tests for TF-954: addresses incorrectly not marked useful.
- Activity analysis test for TF-954 minimal reproducer.
- Correctness tests for TF-954 minimal reproducer and existing reproducer.