### PR TITLE
[DiagnosticVerifier] Add a -verify-tag frontend option to the verifier

### DIFF
--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -32,6 +32,10 @@ public:
     VerifyAndApplyFixes
   } VerifyMode = NoVerify;
 
+  /// Specifies a tag which denotes which diagnostics the verifier should expect
+  /// for a given invocation.
+  std::string VerifyTag = "";
+
   /// Indicates whether to allow diagnostics for \c <unknown> locations if
   /// \c VerifyMode is not \c NoVerify.
   bool VerifyIgnoreUnknown = false;

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -25,7 +25,7 @@ namespace swift {
 
   /// Set up the specified source manager so that diagnostics are captured
   /// instead of being printed.
-  void enableDiagnosticVerifier(SourceManager &SM);
+  void enableDiagnosticVerifier(SourceManager &SM, StringRef VerifyTag);
 
   /// Verify that captured diagnostics meet with the expectations of the source
   /// files corresponding to the specified \p BufferIDs and tear down our

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -103,6 +103,10 @@ def verify_apply_fixes : Flag<["-"], "verify-apply-fixes">,
   HelpText<"Like -verify, but updates the original source file">;
 def verify_ignore_unknown: Flag<["-"], "verify-ignore-unknown">,
   HelpText<"Allow diagnostics for '<unknown>' location in verify mode">;
+def verify_tag
+  : Joined<["-"], "verify-tag=">, MetaVarName<"<verify-tag>">,
+  HelpText<"A tag which denotes which diagnostics the verifier should expect">;
+  
 def verify_generic_signatures : Separate<["-"], "verify-generic-signatures">,
   MetaVarName<"<module-name>">,
   HelpText<"Verify the generic signatures in the given module">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -718,6 +718,8 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_verify_apply_fixes))
     Opts.VerifyMode = DiagnosticOptions::VerifyAndApplyFixes;
   Opts.VerifyIgnoreUnknown |= Args.hasArg(OPT_verify_ignore_unknown);
+  if (Arg *A = Args.getLastArg(OPT_verify_tag))
+    Opts.VerifyTag = A->getValue();
   Opts.SkipDiagnosticPasses |= Args.hasArg(OPT_disable_diagnostic_passes);
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1953,7 +1953,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   const DiagnosticOptions &diagOpts = Invocation.getDiagnosticOptions();
   if (diagOpts.VerifyMode != DiagnosticOptions::NoVerify) {
-    enableDiagnosticVerifier(Instance->getSourceMgr());
+    enableDiagnosticVerifier(Instance->getSourceMgr(), diagOpts.VerifyTag);
   }
 
   if (Invocation.getFrontendOptions()

--- a/test/Driver/swift-version.swift
+++ b/test/Driver/swift-version.swift
@@ -9,48 +9,48 @@
 // RUN: not %target-swiftc_driver -swift-version 4.3 %s 2>&1 | %FileCheck --check-prefix BAD %s
 // RUN: not %target-swiftc_driver -swift-version 5.1 %s 2>&1 | %FileCheck --check-prefix BAD %s
 
-// RUN: not %target-swiftc_driver -swift-version 4 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_4 %s
-// RUN: not %target-swiftc_driver -swift-version 5 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_5 %s
+// RUN: %target-typecheck-verify-swift -swift-version 4 -verify-tag=ERROR_4
+// RUN: %target-typecheck-verify-swift -swift-version 5 -verify-tag=ERROR_5
 
 // BAD: invalid value
 // BAD: note: valid arguments to '-swift-version' are '4', '4.2', '5'
 
 #if swift(>=3)
 asdf
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
-// ERROR_5: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+// expected-error(ERROR_4)@-1:1 {{use of unresolved identifier}}
+// expected-error(ERROR_5)@-2:1 {{use of unresolved identifier}}
 #else
 jkl
 #endif
 
 #if swift(>=3.1)
 asdf
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
-// ERROR_5: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+// expected-error(ERROR_4)@-1:1 {{use of unresolved identifier}}
+// expected-error(ERROR_5)@-2:1 {{use of unresolved identifier}}
 #else
 jkl
 #endif
 
 #if swift(>=4)
 asdf 
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
-// ERROR_5: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+// expected-error(ERROR_4)@-1:1 {{use of unresolved identifier}}
+// expected-error(ERROR_5)@-2:1 {{use of unresolved identifier}}
 #else
 jkl
 #endif
 
 #if swift(>=4.1)
 asdf
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
-// ERROR_5: [[@LINE-2]]:1: error: {{use of unresolved identifier}}
+// expected-error(ERROR_4)@-1:1 {{use of unresolved identifier}}
+// expected-error(ERROR_5)@-2:1 {{use of unresolved identifier}}
 #else
 jkl
 #endif
 
 #if swift(>=5)
 asdf
-// ERROR_5: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
+// expected-error(ERROR_5)@-1:1 {{use of unresolved identifier}}
 #else
 jkl
-// ERROR_4: [[@LINE-1]]:1: error: {{use of unresolved identifier}}
+// expected-error(ERROR_4)@-1:1 {{use of unresolved identifier}}
 #endif

--- a/test/Sema/exhaustive_switch_invocation_threshold.swift
+++ b/test/Sema/exhaustive_switch_invocation_threshold.swift
@@ -2,18 +2,8 @@
 // stopping the check, producing the correct diagnostic, and not producing the
 // diagnostic for a completed check.
 //
-// RUN: %empty-directory(%t)
-//
-// RUN: not %target-swift-frontend -typecheck %s -switch-checking-invocation-threshold=1 2>%t/unproven.txt
-// RUN: %FileCheck %s --check-prefix UNABLE-TO-CHECK <%t/unproven.txt
-// RUN: not %FileCheck %s --check-prefix MUST-BE-EXHAUSTIVE <%t/unproven.txt
-//
-// RUN: not %target-swift-frontend -typecheck %s  2>%t/disproved.txt
-// RUN: %FileCheck %s --check-prefix MUST-BE-EXHAUSTIVE <%t/disproved.txt
-// RUN: not %FileCheck %s --check-prefix UNABLE-TO-CHECK <%t/disproved.txt
-//
-// UNABLE-TO-CHECK: error: the compiler is unable to check that this switch is exhaustive in reasonable time
-// MUST-BE-EXHAUSTIVE: error: switch must be exhaustive
+// RUN: %target-typecheck-verify-swift -verify-tag=UNABLE-TO-CHECK -switch-checking-invocation-threshold=1
+// RUN: %target-typecheck-verify-swift -verify-tag=MUST-BE-EXHAUSTIVE
 
 
 enum A {
@@ -25,6 +15,10 @@ enum B {
 
 func f(a: A, b: B) {
   switch (a, b) {
+    // expected-error(UNABLE-TO-CHECK)@-1 {{the compiler is unable to check that this switch is exhaustive in reasonable time}}
+    // expected-note(UNABLE-TO-CHECK)@-2 {{do you want to add a default clause?}}
+    // expected-error(MUST-BE-EXHAUSTIVE)@-3 {{switch must be exhaustive}}
+    // expected-note(MUST-BE-EXHAUSTIVE)@-4 {{add missing case}}
     case
 //    (.a1, .b1),
     (.a2, .b1),

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -408,8 +408,10 @@ int main(int argc, char **argv) {
 
   // If we're in verify mode, install a custom diagnostic handling for
   // SourceMgr.
+  // TODO: It might be useful to support specifying a verifier tag here instead
+  // of always passing an empty string.
   if (VerifyMode)
-    enableDiagnosticVerifier(CI.getSourceMgr());
+    enableDiagnosticVerifier(CI.getSourceMgr(), /*VerifyTag*/ StringRef());
 
   if (CI.getSILModule())
     CI.getSILModule()->setSerializeSILAction([]{});


### PR DESCRIPTION
If `-verify-tag=TAG` is passed when the diagnostic verifier is enabled,
it will only look for expected diagnostics of the form
expected{error|warning|note|remark}(TAG). This is similar to `-check-prefix`
in FileCheck, and makes it easier to invoke the verifier multiple times
per test.

I updated a couple of tests which benefited from this, but haven't come up with a systematic way to find them. I have a few use cases in mind for the future though as diagnostics get more configurable.