### PR TITLE
[AutoDiff] Revamp usefulness propagation in activity analysis.

### DIFF
--- a/test/AutoDiff/activity_analysis.swift
+++ b/test/AutoDiff/activity_analysis.swift
@@ -140,12 +140,12 @@ func TF_954(_ x: Float) -> Float {
 // CHECK: bb1:
 // CHECK: [ACTIVE]   %10 = alloc_stack $Float, var, name "inner"
 // CHECK: [ACTIVE]   %11 = begin_access [read] [static] %2 : $*Float
-// CHECK: [NONE]   %14 = metatype $@thin Float.Type
+// CHECK: [USEFUL]   %14 = metatype $@thin Float.Type
 // CHECK: [ACTIVE]   %15 = begin_access [read] [static] %10 : $*Float
-// CHECK: [VARIED]   %16 = load [trivial] %15 : $*Float
+// CHECK: [ACTIVE]   %16 = load [trivial] %15 : $*Float
 // CHECK: [NONE]   // function_ref static Float.* infix(_:_:)
 // CHECK:   %18 = function_ref @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
-// CHECK: [VARIED]   %19 = apply %18(%16, %0, %14) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK: [ACTIVE]   %19 = apply %18(%16, %0, %14) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
 // CHECK: [ACTIVE]   %20 = begin_access [modify] [static] %10 : $*Float
 // CHECK: bb3:
 // CHECK: [ACTIVE]   %31 = begin_access [read] [static] %10 : $*Float

--- a/test/AutoDiff/control_flow.swift
+++ b/test/AutoDiff/control_flow.swift
@@ -68,10 +68,7 @@ ControlFlowTests.test("Conditionals") {
     }
     return outer
   }
-  // FIXME(TF-954): Investigate incorrect derivative related to addresses and
-  // nested control flow.
-  // expectEqual((9, 6), valueWithGradient(at: 3, in: cond4_var))
-  expectEqual((9, 0), valueWithGradient(at: 3, in: cond4_var))
+  expectEqual((9, 6), valueWithGradient(at: 3, in: cond4_var))
 
   func cond_tuple(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
@@ -707,16 +704,10 @@ ControlFlowTests.test("Loops") {
     }
     return outer
   }
-  // FIXME(TF-954): Investigate incorrect derivative related to addresses and
-  // nested control flow.
-  // expectEqual((6, 5), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 1) }))
-  // expectEqual((20, 22), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 2) }))
-  // expectEqual((52, 80), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 3) }))
-  // expectEqual((24, 28), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 4) }))
-  expectEqual((6, 0), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 1) }))
-  expectEqual((20, 0), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 2) }))
-  expectEqual((52, 26), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 3) }))
-  expectEqual((24, 12), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 4) }))
+  expectEqual((6, 5), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 1) }))
+  expectEqual((20, 22), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 2) }))
+  expectEqual((52, 80), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 3) }))
+  expectEqual((24, 28), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 4) }))
 }
 
 runAllTests()

--- a/test/AutoDiff/control_flow_diagnostics.swift
+++ b/test/AutoDiff/control_flow_diagnostics.swift
@@ -113,10 +113,12 @@ enum Tree : Differentiable & AdditiveArithmetic {
 
   // expected-error @+1 {{function is not differentiable}}
   @differentiable
-  // expected-note @+1 {{when differentiating this function definition}}
+  // TODO(TF-956): Improve location of active enum non-differentiability errors
+  // so that they are closer to the source of the non-differentiability.
+  // expected-note @+2 {{when differentiating this function definition}}
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
   static func +(_ lhs: Self, _ rhs: Self) -> Self {
     switch (lhs, rhs) {
-    // expected-note @+1 {{differentiating enum values is not yet supported}}
     case let (.leaf(x), .leaf(y)):
       return .leaf(x + y)
     case let (.branch(x1, x2), .branch(y1, y2)):
@@ -128,10 +130,12 @@ enum Tree : Differentiable & AdditiveArithmetic {
 
   // expected-error @+1 {{function is not differentiable}}
   @differentiable
-  // expected-note @+1 {{when differentiating this function definition}}
+  // TODO(TF-956): Improve location of active enum non-differentiability errors
+  // so that they are closer to the source of the non-differentiability.
+  // expected-note @+2 {{when differentiating this function definition}}
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
   static func -(_ lhs: Self, _ rhs: Self) -> Self {
     switch (lhs, rhs) {
-    // expected-note @+1 {{differentiating enum values is not yet supported}}
     case let (.leaf(x), .leaf(y)):
       return .leaf(x - y)
     case let (.branch(x1, x2), .branch(y1, y2)):
@@ -147,7 +151,9 @@ enum Tree : Differentiable & AdditiveArithmetic {
 // expected-note @+1 {{when differentiating this function definition}}
 func loop_array(_ array: [Float]) -> Float {
   var result: Float = 1
-  // expected-note @+1 {{differentiating enum values is not yet supported}}
+  // TODO(TF-957): Improve non-differentiability errors for for-in loops
+  // (`Collection.makeIterator` and `IteratorProtocol.next`).
+  // expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}}
   for x in array {
     result = result * x
   }

--- a/test/AutoDiff/differentiation_transform_diagnostics.swift
+++ b/test/AutoDiff/differentiation_transform_diagnostics.swift
@@ -65,9 +65,9 @@ _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) {
 //===----------------------------------------------------------------------===//
 
 func uses_optionals(_ x: Float) -> Float {
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
   var maybe: Float? = 10
   maybe = x
-  // expected-note @+1 {{differentiating enum values is not yet supported}}
   return maybe!
 }
 


### PR DESCRIPTION
Useful values are those that contribute to (specific) dependent variables,
i.e. function results.

For addresses: all projections of a useful address should be useful.
This has special support:
`DifferentiableActivityInfo::propagateUsefulThroughAddress`.

Previously:
- Usefulness was propagated by iterating through all instructions in
  post-dominance order. This is not efficient because irrelevant instructions
  may be visited.
- For useful addresses, `propagateUsefulThroughAddress` propagated
  usefulness one step to projections, but not recursively to users of the
  projections. This caused some values to incorrectly not be marked useful.

Now:
- Usefulness is propagated by following use-def chains, starting from
  dependent variables (function results). This is handled by the
  following helpers:
  - `setUsefulAndPropagateToOperands(SILValue, unsigned)`: marks a value as
    useful and recursively propagates usefulness through defining instruction
    operands and basic block argument incoming values.
  - `propagateUseful(SILInstruction *inst, unsigned)`: propagates usefulness
    to the operands of the given instruction.
- `DifferentiableActivityInfo::propagateUsefulThroughAddress` now calls
  `propagateUseful` to propagate usefulness recursively through users'
  operands.

Effects:
- More values are now (correctly) marked as useful, affecting
  non-differentiability diagnostics for active enum values (TF-956) and for-in
  loops (TF-957). Both have room for improvement.

Resolves control flow differentiation correctness issue: TF-954.