### PR TITLE
Fix some SourceKit assertion hits

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -911,8 +911,12 @@ ERROR(invalid_arg_count_for_operator,none,
       "operators must have one or two arguments", ())
 ERROR(operator_in_local_scope,none,
       "operator functions can only be declared at global or in type scope", ())
-ERROR(nonstatic_operator_in_type,none,
-      "operator %0 declared in type %1 must be 'static'", (Identifier, Type))
+ERROR(nonstatic_operator_in_nominal,none,
+      "operator %0 declared in type %1 must be 'static'",
+      (Identifier, DeclName))
+ERROR(nonstatic_operator_in_extension,none,
+      "operator %0 declared in extension of %1 must be 'static'",
+      (Identifier, TypeRepr*))
 ERROR(nonfinal_operator_in_class,none,
       "operator %0 declared in non-final class %1 must be 'final'",
       (Identifier, Type))

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2866,15 +2866,6 @@ public:
 
     void verifyParsed(ConstructorDecl *CD) {
       PrettyStackTraceDecl debugStack("verifying ConstructorDecl", CD);
-
-      auto *DC = CD->getDeclContext();
-      if (!isa<NominalTypeDecl>(DC) && !isa<ExtensionDecl>(DC) &&
-          !CD->isInvalid()) {
-        Out << "ConstructorDecls outside nominal types and extensions "
-               "should be marked invalid";
-        abort();
-      }
-
       verifyParsedBase(CD);
     }
 
@@ -2955,15 +2946,6 @@ public:
         Out << "DestructorDecl cannot be generic";
         abort();
       }
-
-      auto *DC = DD->getDeclContext();
-      if (!isa<NominalTypeDecl>(DC) && !isa<ExtensionDecl>(DC) &&
-          !DD->isInvalid()) {
-        Out << "DestructorDecls outside nominal types and extensions "
-               "should be marked invalid";
-        abort();
-      }
-
       verifyParsedBase(DD);
     }
 

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -904,10 +904,6 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
     pushStructureNode(SN, NTD);
 
   } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
-    // Normally bindExtension() would take care of computing the extended
-    // nominal. It must be done before asking for generic parameters.
-    if (!inInactiveClause || ASTScope::areInactiveIfConfigClausesSupported())
-      ED->computeExtendedNominal();
     SyntaxStructureNode SN;
     setDecl(SN, D);
     SN.Kind = SyntaxStructureKind::Extension;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1258,10 +1258,18 @@ IsStaticRequest::evaluate(Evaluator &evaluator, FuncDecl *decl) const {
       decl->isOperator() &&
       dc->isTypeContext()) {
     auto operatorName = decl->getFullName().getBaseIdentifier();
-    decl->diagnose(diag::nonstatic_operator_in_type,
-                   operatorName, dc->getDeclaredInterfaceType())
-        .fixItInsert(decl->getAttributeInsertionLoc(/*forModifier=*/true),
-                     "static ");
+    if (auto ED = dyn_cast<ExtensionDecl>(dc->getAsDecl())) {
+      decl->diagnose(diag::nonstatic_operator_in_extension,
+                     operatorName, ED->getExtendedTypeRepr())
+          .fixItInsert(decl->getAttributeInsertionLoc(/*forModifier=*/true),
+                       "static ");
+    } else {
+      auto *NTD = cast<NominalTypeDecl>(dc->getAsDecl());
+      decl->diagnose(diag::nonstatic_operator_in_nominal, operatorName,
+                     NTD->getName())
+          .fixItInsert(decl->getAttributeInsertionLoc(/*forModifier=*/true),
+                       "static ");
+    }
     result = true;
   }
 

--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -139,3 +139,11 @@ class OneMore {
 class Chain<A> {
   func + (lhs: Chain<A>, rhs: Chain<A>) -> Chain<A> { fatalError() }
 }
+
+public init() {
+    fatalError()
+}
+
+deinit {
+    fatalError()
+}

--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -147,3 +147,9 @@ public init() {
 deinit {
     fatalError()
 }
+
+#if false
+ extension Result {
+   func foo() {}
+ }
+ #endif

--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -149,7 +149,19 @@ deinit {
 }
 
 #if false
- extension Result {
-   func foo() {}
- }
- #endif
+extension Result {
+  func foo() {}
+}
+
+extension Outer {
+  class Inner {
+    deinit {}
+  }
+}
+
+public extension Outer2 {
+  class Inner2 {
+    deinit {}
+  }
+}
+#endif

--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -135,3 +135,7 @@ class OneMore {
     fatalError()
   }
 }
+
+class Chain<A> {
+  func + (lhs: Chain<A>, rhs: Chain<A>) -> Chain<A> { fatalError() }
+}

--- a/test/SourceKit/DocumentStructure/access_parse.swift.response
+++ b/test/SourceKit/DocumentStructure/access_parse.swift.response
@@ -777,7 +777,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "DefAccess",
       key.offset: 1399,
       key.length: 43,
@@ -788,7 +787,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "defFunc()",
           key.offset: 1423,
           key.length: 17,
@@ -801,7 +799,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "PubAccess",
       key.offset: 1443,
       key.length: 43,
@@ -812,7 +809,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "defFunc()",
           key.offset: 1467,
           key.length: 17,
@@ -825,7 +821,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "IntAccess",
       key.offset: 1487,
       key.length: 43,
@@ -836,7 +831,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "defFunc()",
           key.offset: 1511,
           key.length: 17,
@@ -849,7 +843,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "PrivAccess",
       key.offset: 1531,
       key.length: 44,
@@ -860,7 +853,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "defFunc()",
           key.offset: 1556,
           key.length: 17,

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2259,
+  key.length: 2348,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1398,6 +1398,69 @@
               key.nameoffset: 2240,
               key.namelength: 10,
               key.bodyoffset: 2251,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "Chain",
+      key.offset: 2260,
+      key.length: 87,
+      key.nameoffset: 2266,
+      key.namelength: 5,
+      key.bodyoffset: 2276,
+      key.bodylength: 70,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "A",
+          key.offset: 2272,
+          key.length: 1,
+          key.nameoffset: 2272,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.static,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "+(_:_:)",
+          key.offset: 2279,
+          key.length: 66,
+          key.typename: "Chain<A>",
+          key.nameoffset: 2284,
+          key.namelength: 32,
+          key.bodyoffset: 2330,
+          key.bodylength: 14,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "lhs",
+              key.offset: 2287,
+              key.length: 13,
+              key.typename: "Chain<A>",
+              key.nameoffset: 0,
+              key.namelength: 0
+            },
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "rhs",
+              key.offset: 2302,
+              key.length: 13,
+              key.typename: "Chain<A>",
+              key.nameoffset: 0,
+              key.namelength: 0
+            },
+            {
+              key.kind: source.lang.swift.expr.call,
+              key.name: "fatalError",
+              key.offset: 2331,
+              key.length: 12,
+              key.nameoffset: 2331,
+              key.namelength: 10,
+              key.bodyoffset: 2342,
               key.bodylength: 0
             }
           ]

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2348,
+  key.length: 2472,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -223,7 +223,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "OuterCls",
       key.offset: 377,
       key.length: 45,
@@ -234,7 +233,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.class,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "InnerCls2",
           key.offset: 402,
           key.length: 18,
@@ -558,7 +556,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "Foo",
       key.offset: 999,
       key.length: 58,
@@ -569,7 +566,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "anExtendedFooFunction()",
           key.offset: 1019,
           key.length: 36,
@@ -1466,6 +1462,81 @@
           ]
         }
       ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "init()",
+      key.offset: 2356,
+      key.length: 27,
+      key.nameoffset: 2356,
+      key.namelength: 6,
+      key.bodyoffset: 2364,
+      key.bodylength: 18,
+      key.attributes: [
+        {
+          key.offset: 2349,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.call,
+          key.name: "fatalError",
+          key.offset: 2369,
+          key.length: 12,
+          key.nameoffset: 2369,
+          key.namelength: 10,
+          key.bodyoffset: 2380,
+          key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.private,
+      key.name: "deinit",
+      key.offset: 2385,
+      key.length: 27,
+      key.nameoffset: 2385,
+      key.namelength: 6,
+      key.bodyoffset: 2393,
+      key.bodylength: 18,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.call,
+          key.name: "fatalError",
+          key.offset: 2398,
+          key.length: 12,
+          key.nameoffset: 2398,
+          key.namelength: 10,
+          key.bodyoffset: 2409,
+          key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Result",
+      key.offset: 2425,
+      key.length: 38,
+      key.nameoffset: 2435,
+      key.namelength: 6,
+      key.bodyoffset: 2443,
+      key.bodylength: 19,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "foo()",
+          key.offset: 2447,
+          key.length: 13,
+          key.nameoffset: 2452,
+          key.namelength: 5,
+          key.bodyoffset: 2459,
+          key.bodylength: 0
+        }
+      ]
     }
   ],
   key.diagnostics: [
@@ -1502,6 +1573,20 @@
           key.sourcetext: "func "
         }
       ]
+    },
+    {
+      key.line: 143,
+      key.column: 12,
+      key.severity: source.diagnostic.severity.error,
+      key.description: "initializers may only be declared within a type",
+      key.diagnostic_stage: source.diagnostic.stage.swift.parse
+    },
+    {
+      key.line: 147,
+      key.column: 1,
+      key.severity: source.diagnostic.severity.error,
+      key.description: "deinitializers may only be declared within a class",
+      key.diagnostic_stage: source.diagnostic.stage.swift.parse
     }
   ]
 }

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2472,
+  key.length: 2587,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1519,22 +1519,100 @@
     {
       key.kind: source.lang.swift.decl.extension,
       key.name: "Result",
-      key.offset: 2425,
-      key.length: 38,
-      key.nameoffset: 2435,
+      key.offset: 2424,
+      key.length: 36,
+      key.nameoffset: 2434,
       key.namelength: 6,
-      key.bodyoffset: 2443,
-      key.bodylength: 19,
+      key.bodyoffset: 2442,
+      key.bodylength: 17,
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "foo()",
-          key.offset: 2447,
+          key.offset: 2445,
           key.length: 13,
-          key.nameoffset: 2452,
+          key.nameoffset: 2450,
           key.namelength: 5,
-          key.bodyoffset: 2459,
+          key.bodyoffset: 2457,
           key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Outer",
+      key.offset: 2462,
+      key.length: 53,
+      key.nameoffset: 2472,
+      key.namelength: 5,
+      key.bodyoffset: 2479,
+      key.bodylength: 35,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.name: "Inner",
+          key.offset: 2482,
+          key.length: 31,
+          key.nameoffset: 2488,
+          key.namelength: 5,
+          key.bodyoffset: 2495,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.name: "deinit",
+              key.offset: 2500,
+              key.length: 9,
+              key.nameoffset: 2500,
+              key.namelength: 6,
+              key.bodyoffset: 2508,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "Outer2",
+      key.offset: 2524,
+      key.length: 55,
+      key.nameoffset: 2534,
+      key.namelength: 6,
+      key.bodyoffset: 2542,
+      key.bodylength: 36,
+      key.attributes: [
+        {
+          key.offset: 2517,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.accessibility: source.lang.swift.accessibility.public,
+          key.name: "Inner2",
+          key.offset: 2545,
+          key.length: 32,
+          key.nameoffset: 2551,
+          key.namelength: 6,
+          key.bodyoffset: 2559,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.accessibility: source.lang.swift.accessibility.public,
+              key.name: "deinit",
+              key.offset: 2564,
+              key.length: 9,
+              key.nameoffset: 2564,
+              key.namelength: 6,
+              key.bodyoffset: 2572,
+              key.bodylength: 0
+            }
+          ]
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2259,
+  key.length: 2348,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1398,6 +1398,69 @@
               key.nameoffset: 2240,
               key.namelength: 10,
               key.bodyoffset: 2251,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "Chain",
+      key.offset: 2260,
+      key.length: 87,
+      key.nameoffset: 2266,
+      key.namelength: 5,
+      key.bodyoffset: 2276,
+      key.bodylength: 70,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "A",
+          key.offset: 2272,
+          key.length: 1,
+          key.nameoffset: 2272,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.static,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "+(_:_:)",
+          key.offset: 2279,
+          key.length: 66,
+          key.typename: "Chain<A>",
+          key.nameoffset: 2284,
+          key.namelength: 32,
+          key.bodyoffset: 2330,
+          key.bodylength: 14,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "lhs",
+              key.offset: 2287,
+              key.length: 13,
+              key.typename: "Chain<A>",
+              key.nameoffset: 0,
+              key.namelength: 0
+            },
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "rhs",
+              key.offset: 2302,
+              key.length: 13,
+              key.typename: "Chain<A>",
+              key.nameoffset: 0,
+              key.namelength: 0
+            },
+            {
+              key.kind: source.lang.swift.expr.call,
+              key.name: "fatalError",
+              key.offset: 2331,
+              key.length: 12,
+              key.nameoffset: 2331,
+              key.namelength: 10,
+              key.bodyoffset: 2342,
               key.bodylength: 0
             }
           ]

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2348,
+  key.length: 2472,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -223,7 +223,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "OuterCls",
       key.offset: 377,
       key.length: 45,
@@ -234,7 +233,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.class,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "InnerCls2",
           key.offset: 402,
           key.length: 18,
@@ -558,7 +556,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "Foo",
       key.offset: 999,
       key.length: 58,
@@ -569,7 +566,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "anExtendedFooFunction()",
           key.offset: 1019,
           key.length: 36,
@@ -1466,6 +1462,81 @@
           ]
         }
       ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "init()",
+      key.offset: 2356,
+      key.length: 27,
+      key.nameoffset: 2356,
+      key.namelength: 6,
+      key.bodyoffset: 2364,
+      key.bodylength: 18,
+      key.attributes: [
+        {
+          key.offset: 2349,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.call,
+          key.name: "fatalError",
+          key.offset: 2369,
+          key.length: 12,
+          key.nameoffset: 2369,
+          key.namelength: 10,
+          key.bodyoffset: 2380,
+          key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.private,
+      key.name: "deinit",
+      key.offset: 2385,
+      key.length: 27,
+      key.nameoffset: 2385,
+      key.namelength: 6,
+      key.bodyoffset: 2393,
+      key.bodylength: 18,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.call,
+          key.name: "fatalError",
+          key.offset: 2398,
+          key.length: 12,
+          key.nameoffset: 2398,
+          key.namelength: 10,
+          key.bodyoffset: 2409,
+          key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Result",
+      key.offset: 2425,
+      key.length: 38,
+      key.nameoffset: 2435,
+      key.namelength: 6,
+      key.bodyoffset: 2443,
+      key.bodylength: 19,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "foo()",
+          key.offset: 2447,
+          key.length: 13,
+          key.nameoffset: 2452,
+          key.namelength: 5,
+          key.bodyoffset: 2459,
+          key.bodylength: 0
+        }
+      ]
     }
   ],
   key.diagnostics: [
@@ -1505,6 +1576,22 @@
           key.sourcetext: "func "
         }
       ]
+    },
+    {
+      key.line: 143,
+      key.column: 12,
+      key.filepath: "-foobar",
+      key.severity: source.diagnostic.severity.error,
+      key.description: "initializers may only be declared within a type",
+      key.diagnostic_stage: source.diagnostic.stage.swift.parse
+    },
+    {
+      key.line: 147,
+      key.column: 1,
+      key.filepath: "-foobar",
+      key.severity: source.diagnostic.severity.error,
+      key.description: "deinitializers may only be declared within a class",
+      key.diagnostic_stage: source.diagnostic.stage.swift.parse
     }
   ]
 }

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2472,
+  key.length: 2587,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1519,22 +1519,100 @@
     {
       key.kind: source.lang.swift.decl.extension,
       key.name: "Result",
-      key.offset: 2425,
-      key.length: 38,
-      key.nameoffset: 2435,
+      key.offset: 2424,
+      key.length: 36,
+      key.nameoffset: 2434,
       key.namelength: 6,
-      key.bodyoffset: 2443,
-      key.bodylength: 19,
+      key.bodyoffset: 2442,
+      key.bodylength: 17,
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "foo()",
-          key.offset: 2447,
+          key.offset: 2445,
           key.length: 13,
-          key.nameoffset: 2452,
+          key.nameoffset: 2450,
           key.namelength: 5,
-          key.bodyoffset: 2459,
+          key.bodyoffset: 2457,
           key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Outer",
+      key.offset: 2462,
+      key.length: 53,
+      key.nameoffset: 2472,
+      key.namelength: 5,
+      key.bodyoffset: 2479,
+      key.bodylength: 35,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.name: "Inner",
+          key.offset: 2482,
+          key.length: 31,
+          key.nameoffset: 2488,
+          key.namelength: 5,
+          key.bodyoffset: 2495,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.name: "deinit",
+              key.offset: 2500,
+              key.length: 9,
+              key.nameoffset: 2500,
+              key.namelength: 6,
+              key.bodyoffset: 2508,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "Outer2",
+      key.offset: 2524,
+      key.length: 55,
+      key.nameoffset: 2534,
+      key.namelength: 6,
+      key.bodyoffset: 2542,
+      key.bodylength: 36,
+      key.attributes: [
+        {
+          key.offset: 2517,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.accessibility: source.lang.swift.accessibility.public,
+          key.name: "Inner2",
+          key.offset: 2545,
+          key.length: 32,
+          key.nameoffset: 2551,
+          key.namelength: 6,
+          key.bodyoffset: 2559,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.accessibility: source.lang.swift.accessibility.public,
+              key.name: "deinit",
+              key.offset: 2564,
+              key.length: 9,
+              key.nameoffset: 2564,
+              key.namelength: 6,
+              key.bodyoffset: 2572,
+              key.bodylength: 0
+            }
+          ]
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.invalid.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.invalid.response
@@ -16,7 +16,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "OuterCls",
       key.offset: 12,
       key.length: 43,
@@ -27,7 +26,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.class,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "InnerCls1",
           key.offset: 35,
           key.length: 18,

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2259,
+  key.length: 2348,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1398,6 +1398,69 @@
               key.nameoffset: 2240,
               key.namelength: 10,
               key.bodyoffset: 2251,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "Chain",
+      key.offset: 2260,
+      key.length: 87,
+      key.nameoffset: 2266,
+      key.namelength: 5,
+      key.bodyoffset: 2276,
+      key.bodylength: 70,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.generic_type_param,
+          key.name: "A",
+          key.offset: 2272,
+          key.length: 1,
+          key.nameoffset: 2272,
+          key.namelength: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.static,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "+(_:_:)",
+          key.offset: 2279,
+          key.length: 66,
+          key.typename: "Chain<A>",
+          key.nameoffset: 2284,
+          key.namelength: 32,
+          key.bodyoffset: 2330,
+          key.bodylength: 14,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "lhs",
+              key.offset: 2287,
+              key.length: 13,
+              key.typename: "Chain<A>",
+              key.nameoffset: 0,
+              key.namelength: 0
+            },
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "rhs",
+              key.offset: 2302,
+              key.length: 13,
+              key.typename: "Chain<A>",
+              key.nameoffset: 0,
+              key.namelength: 0
+            },
+            {
+              key.kind: source.lang.swift.expr.call,
+              key.name: "fatalError",
+              key.offset: 2331,
+              key.length: 12,
+              key.nameoffset: 2331,
+              key.namelength: 10,
+              key.bodyoffset: 2342,
               key.bodylength: 0
             }
           ]

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2348,
+  key.length: 2472,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -223,7 +223,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "OuterCls",
       key.offset: 377,
       key.length: 45,
@@ -234,7 +233,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.class,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "InnerCls2",
           key.offset: 402,
           key.length: 18,
@@ -558,7 +556,6 @@
     },
     {
       key.kind: source.lang.swift.decl.extension,
-      key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "Foo",
       key.offset: 999,
       key.length: 58,
@@ -569,7 +566,6 @@
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.internal,
           key.name: "anExtendedFooFunction()",
           key.offset: 1019,
           key.length: 36,
@@ -1466,6 +1462,81 @@
           ]
         }
       ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "init()",
+      key.offset: 2356,
+      key.length: 27,
+      key.nameoffset: 2356,
+      key.namelength: 6,
+      key.bodyoffset: 2364,
+      key.bodylength: 18,
+      key.attributes: [
+        {
+          key.offset: 2349,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.call,
+          key.name: "fatalError",
+          key.offset: 2369,
+          key.length: 12,
+          key.nameoffset: 2369,
+          key.namelength: 10,
+          key.bodyoffset: 2380,
+          key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.accessibility: source.lang.swift.accessibility.private,
+      key.name: "deinit",
+      key.offset: 2385,
+      key.length: 27,
+      key.nameoffset: 2385,
+      key.namelength: 6,
+      key.bodyoffset: 2393,
+      key.bodylength: 18,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.call,
+          key.name: "fatalError",
+          key.offset: 2398,
+          key.length: 12,
+          key.nameoffset: 2398,
+          key.namelength: 10,
+          key.bodyoffset: 2409,
+          key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Result",
+      key.offset: 2425,
+      key.length: 38,
+      key.nameoffset: 2435,
+      key.namelength: 6,
+      key.bodyoffset: 2443,
+      key.bodylength: 19,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "foo()",
+          key.offset: 2447,
+          key.length: 13,
+          key.nameoffset: 2452,
+          key.namelength: 5,
+          key.bodyoffset: 2459,
+          key.bodylength: 0
+        }
+      ]
     }
   ],
   key.diagnostics: [
@@ -1505,6 +1576,22 @@
           key.sourcetext: "func "
         }
       ]
+    },
+    {
+      key.line: 143,
+      key.column: 12,
+      key.filepath: main.swift,
+      key.severity: source.diagnostic.severity.error,
+      key.description: "initializers may only be declared within a type",
+      key.diagnostic_stage: source.diagnostic.stage.swift.parse
+    },
+    {
+      key.line: 147,
+      key.column: 1,
+      key.filepath: main.swift,
+      key.severity: source.diagnostic.severity.error,
+      key.description: "deinitializers may only be declared within a class",
+      key.diagnostic_stage: source.diagnostic.stage.swift.parse
     }
   ]
 }

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 2472,
+  key.length: 2587,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1519,22 +1519,100 @@
     {
       key.kind: source.lang.swift.decl.extension,
       key.name: "Result",
-      key.offset: 2425,
-      key.length: 38,
-      key.nameoffset: 2435,
+      key.offset: 2424,
+      key.length: 36,
+      key.nameoffset: 2434,
       key.namelength: 6,
-      key.bodyoffset: 2443,
-      key.bodylength: 19,
+      key.bodyoffset: 2442,
+      key.bodylength: 17,
       key.substructure: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "foo()",
-          key.offset: 2447,
+          key.offset: 2445,
           key.length: 13,
-          key.nameoffset: 2452,
+          key.nameoffset: 2450,
           key.namelength: 5,
-          key.bodyoffset: 2459,
+          key.bodyoffset: 2457,
           key.bodylength: 0
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.name: "Outer",
+      key.offset: 2462,
+      key.length: 53,
+      key.nameoffset: 2472,
+      key.namelength: 5,
+      key.bodyoffset: 2479,
+      key.bodylength: 35,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.name: "Inner",
+          key.offset: 2482,
+          key.length: 31,
+          key.nameoffset: 2488,
+          key.namelength: 5,
+          key.bodyoffset: 2495,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.name: "deinit",
+              key.offset: 2500,
+              key.length: 9,
+              key.nameoffset: 2500,
+              key.namelength: 6,
+              key.bodyoffset: 2508,
+              key.bodylength: 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.extension,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "Outer2",
+      key.offset: 2524,
+      key.length: 55,
+      key.nameoffset: 2534,
+      key.namelength: 6,
+      key.bodyoffset: 2542,
+      key.bodylength: 36,
+      key.attributes: [
+        {
+          key.offset: 2517,
+          key.length: 6,
+          key.attribute: source.decl.attribute.public
+        }
+      ],
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.class,
+          key.accessibility: source.lang.swift.accessibility.public,
+          key.name: "Inner2",
+          key.offset: 2545,
+          key.length: 32,
+          key.nameoffset: 2551,
+          key.namelength: 6,
+          key.bodyoffset: 2559,
+          key.bodylength: 17,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.function.method.instance,
+              key.accessibility: source.lang.swift.accessibility.public,
+              key.name: "deinit",
+              key.offset: 2564,
+              key.length: 9,
+              key.nameoffset: 2564,
+              key.namelength: 6,
+              key.bodyoffset: 2572,
+              key.bodylength: 0
+            }
+          ]
         }
       ]
     }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
@@ -1554,7 +1554,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "GlobalToMember_Class_Container",
     key.offset: 410,
     key.length: 87,
@@ -1659,7 +1658,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToGlobal_Class_Container",
     key.offset: 649,
     key.length: 105,
@@ -1750,7 +1748,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_Class_Swift3",
     key.offset: 934,
     key.length: 117,
@@ -1779,7 +1776,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_Class_Swift4",
     key.offset: 1052,
     key.length: 88,
@@ -1853,7 +1849,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameContainer_Class_Container",
     key.offset: 1269,
     key.length: 198,
@@ -1974,7 +1969,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameName_Class_Swift3",
     key.offset: 1657,
     key.length: 127,
@@ -2003,7 +1997,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameName_Class_Swift4",
     key.offset: 1785,
     key.length: 93,
@@ -2093,7 +2086,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "GlobalToMember_Typedef_Container",
     key.offset: 2250,
     key.length: 82,
@@ -2169,7 +2161,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToGlobal_Typedef_Container",
     key.offset: 2485,
     key.length: 109,
@@ -2260,7 +2251,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_Typedef_Swift3",
     key.offset: 2778,
     key.length: 121,
@@ -2289,7 +2279,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_Typedef_Swift4",
     key.offset: 2900,
     key.length: 83,
@@ -2349,7 +2338,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
     key.offset: 3114,
     key.length: 195,
@@ -2456,7 +2444,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
     key.offset: 3503,
     key.length: 131,
@@ -2485,7 +2472,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
     key.offset: 3635,
     key.length: 88,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
@@ -1088,7 +1088,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "GlobalToMember_Class_Container",
     key.offset: 323,
     key.length: 87,
@@ -1255,7 +1254,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_Class_Swift4",
     key.offset: 741,
     key.length: 88,
@@ -1329,7 +1327,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameContainer_Class_Container",
     key.offset: 958,
     key.length: 105,
@@ -1434,7 +1431,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameName_Class_Swift4",
     key.offset: 1253,
     key.length: 93,
@@ -1508,7 +1504,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "GlobalToMember_Typedef_Container",
     key.offset: 1627,
     key.length: 82,
@@ -1646,7 +1641,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_Typedef_Swift4",
     key.offset: 2045,
     key.length: 83,
@@ -1706,7 +1700,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
     key.offset: 2259,
     key.length: 100,
@@ -1797,7 +1790,6 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
     key.offset: 2553,
     key.length: 88,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -6535,7 +6535,6 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "FooClassBase",
     key.offset: 5587,
     key.length: 66,
@@ -6565,7 +6564,6 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "FooClassBase",
     key.offset: 5700,
     key.length: 107,
@@ -6612,7 +6610,6 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.decl.extension,
-    key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "FooClassBase",
     key.offset: 5809,
     key.length: 66,

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -243,7 +243,7 @@ struct S1 {
 }
 
 extension S1 {
-  func %%%%(lhs: S1, rhs: S1) -> S1 { return lhs } // expected-error{{operator '%%%%' declared in type 'S1' must be 'static'}}{{3-3=static }}
+  func %%%%(lhs: S1, rhs: S1) -> S1 { return lhs } // expected-error{{operator '%%%%' declared in extension of 'S1' must be 'static'}}{{3-3=static }}
 }
 
 class C0 {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1120,6 +1120,73 @@ static UIdent getAccessLevelUID(AccessLevel Access) {
   llvm_unreachable("Unhandled access level in switch.");
 }
 
+static Optional<AccessLevel>
+inferDefaultAccessSyntactically(const ExtensionDecl *ED) {
+  // Check if the extension has an explicit access control attribute.
+  if (auto *AA = ED->getAttrs().getAttribute<AccessControlAttr>())
+    return std::min(std::max(AA->getAccess(), AccessLevel::FilePrivate),
+                    AccessLevel::Public);
+  return None;
+}
+
+/// Document structure is a purely syntactic request that shouldn't require name lookup
+/// or type-checking, so this is a best-effort computation, particularly where extensions
+/// are concerned.
+static Optional<AccessLevel> inferAccessSyntactically(const ValueDecl *D) {
+  assert(D);
+
+  // Check if the decl has an explicit access control attribute.
+  if (auto *AA = D->getAttrs().getAttribute<AccessControlAttr>())
+    return AA->getAccess();
+
+  DeclContext *DC = D->getDeclContext();
+
+  if (D->getKind() == DeclKind::Destructor ||
+      D->getKind() == DeclKind::EnumElement) {
+    if (auto container = dyn_cast<NominalTypeDecl>(D->getDeclContext()))
+      return std::max(container->getFormalAccess(), AccessLevel::Internal);
+    return AccessLevel::Private;
+  }
+
+  switch (DC->getContextKind()) {
+  case DeclContextKind::TopLevelCodeDecl:
+    return AccessLevel::FilePrivate;
+  case DeclContextKind::SerializedLocal:
+  case DeclContextKind::AbstractClosureExpr:
+  case DeclContextKind::EnumElementDecl:
+  case DeclContextKind::Initializer:
+  case DeclContextKind::AbstractFunctionDecl:
+  case DeclContextKind::SubscriptDecl:
+    return AccessLevel::Private;
+  case DeclContextKind::Module:
+  case DeclContextKind::FileUnit:
+    return AccessLevel::Internal;
+  case DeclContextKind::GenericTypeDecl: {
+    auto generic = cast<GenericTypeDecl>(DC);
+    AccessLevel access = AccessLevel::Internal;
+    if (isa<ProtocolDecl>(generic)) {
+      if (auto protoAccess = inferAccessSyntactically(generic))
+        access = std::max(AccessLevel::FilePrivate, protoAccess.getValue());
+    }
+    return access;
+  }
+  case DeclContextKind::ExtensionDecl:
+    auto *ED = cast<ExtensionDecl>(DC);
+    return inferDefaultAccessSyntactically(ED);
+  }
+
+  llvm_unreachable("Unhandled DeclContextKind in switch.");
+}
+
+static Optional<AccessLevel>
+inferSetterAccessSyntactically(const AbstractStorageDecl *D) {
+  if (!D->isSettable(/*UseDC=*/nullptr))
+    return None;
+  if (auto *AA = D->getAttrs().getAttribute<SetterAccessAttr>())
+    return AA->getAccess();
+  return inferAccessSyntactically(D);
+}
+
 class SwiftDocumentStructureWalker: public ide::SyntaxModelWalker {
   SourceManager &SrcManager;
   EditorConsumer &Consumer;
@@ -1176,16 +1243,15 @@ public:
         Node.Kind != SyntaxStructureKind::LocalVariable &&
         Node.Kind != SyntaxStructureKind::GenericTypeParam) {
       if (auto *VD = dyn_cast_or_null<ValueDecl>(Node.Dcl)) {
-        AccessLevel = getAccessLevelUID(VD->getFormalAccess());
+        if (auto Access = inferAccessSyntactically(VD))
+          AccessLevel = getAccessLevelUID(Access.getValue());
       } else if (auto *ED = dyn_cast_or_null<ExtensionDecl>(Node.Dcl)) {
-        auto StrictAccess = ED->getDefaultAccessLevel();
-        AccessLevel = getAccessLevelUID(StrictAccess);
+        if (auto DefaultAccess = inferDefaultAccessSyntactically(ED))
+          AccessLevel = getAccessLevelUID(DefaultAccess.getValue());
       }
       if (auto *ASD = dyn_cast_or_null<AbstractStorageDecl>(Node.Dcl)) {
-        if (ASD->isSettable(/*UseDC=*/nullptr)) {
-          swift::AccessLevel SetAccess = ASD->getSetterFormalAccess();
-          SetterAccessLevel = getAccessLevelUID(SetAccess);
-        }
+        if (auto SetAccess = inferSetterAccessSyntactically(ASD))
+          SetterAccessLevel = getAccessLevelUID(SetAccess.getValue());
       }
     }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1143,8 +1143,11 @@ static Optional<AccessLevel> inferAccessSyntactically(const ValueDecl *D) {
 
   if (D->getKind() == DeclKind::Destructor ||
       D->getKind() == DeclKind::EnumElement) {
-    if (auto container = dyn_cast<NominalTypeDecl>(D->getDeclContext()))
-      return std::max(container->getFormalAccess(), AccessLevel::Internal);
+    if (auto container = dyn_cast<NominalTypeDecl>(D->getDeclContext())) {
+      if (auto containerAccess = inferAccessSyntactically(container))
+        return std::max(containerAccess.getValue(), AccessLevel::Internal);
+      return None;
+    }
     return AccessLevel::Private;
   }
 


### PR DESCRIPTION
SourceKit's purely syntactic requests don't install a type-checker and so were hitting the below assertion in `ValueDecl::getInterfaceType()` when they inadvertently invoked some logic that required a type-checker:
```
assert(ctx.getLegacyGlobalTypeChecker()
         && "The type checker must be installed to make semantic queries!");
```

This was happening in calls to:
1) `FuncDecl::isStatic()`, which was calling `getInterfaceType()` unnecessarily in order to print it in a diagnostic message.
2) `ASTVerifier::verifyParsed()` for initializers and deinitializers which both call `isInvalid()` when the `init`/`deinit` isn't contained in a type/class decl. I just removed these checks since they're already being checked in `ASTVerifier::verifyChecked()` as well. 
3) `ValueDecl::getFormalAccess()` to provide the access level in the document structure response. ~~We could avoid this by approximating the access level syntactically, and actually used to do this before getFormalAccess was requestified, but the access level info doesn't seem like it's being used anywhere (at least not in Xcode or Swift Playgrounds) so I just removed it.~~ ~~This method was calling `isInvalid()` too (which I've replaced with what is hopefully an equivalent check), and also hit problems in inactive ifconfig clauses. It asserts that extensions are already bound and they're not in inactive ifconfig clauses (ASTScope doesn't support this at the moment).~~ This method calls `isInvalid()` too (though doesn't need to) but also triggers a different assertion if extensions aren't bound, and we don't want to do that here for performance reasons (these requests run on every keypress in the editor). I've resurrected the old `inferAccessLevel()` logic we used to use prior to `getFormalAccess()`.

Resolves rdar://problem/57202584