### PR TITLE
Remove warning about @frozen without library evolution

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1481,8 +1481,6 @@ ERROR(indirect_case_without_payload,none,
       "enum case %0 without associated value cannot be 'indirect'", (Identifier))
 ERROR(indirect_case_in_indirect_enum,none,
       "enum case in 'indirect' enum cannot also be 'indirect'", ())
-WARNING(enum_frozen_nonresilient,none,
-        "%0 has no effect without -enable-library-evolution", (DeclAttribute))
 WARNING(enum_frozen_nonpublic,none,
         "%0 has no effect on non-public enums", (DeclAttribute))
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2464,7 +2464,6 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
 void AttributeChecker::visitFrozenAttr(FrozenAttr *attr) {
   if (auto *ED = dyn_cast<EnumDecl>(D)) {
     if (!ED->getModuleContext()->isResilient()) {
-      diagnoseAndRemoveAttr(attr, diag::enum_frozen_nonresilient, attr);
       return;
     }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2464,6 +2464,7 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
 void AttributeChecker::visitFrozenAttr(FrozenAttr *attr) {
   if (auto *ED = dyn_cast<EnumDecl>(D)) {
     if (!ED->getModuleContext()->isResilient()) {
+      attr->setInvalid();
       return;
     }
 

--- a/test/Serialization/attr-invalid.swift
+++ b/test/Serialization/attr-invalid.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/attr.swiftmodule %s -verify
+// RUN: %target-swift-frontend -emit-module -o %t/attr.swiftmodule %s -verify -warnings-as-errors
 // RUN: llvm-bcanalyzer -dump %t/attr.swiftmodule | %FileCheck -check-prefix=CHECK-NON-RESILIENT %s
 // RUN: %target-swift-frontend -emit-module -o %t/attr_resilient.swiftmodule -enable-library-evolution -warnings-as-errors %s
 // RUN: llvm-bcanalyzer -dump %t/attr_resilient.swiftmodule | %FileCheck -check-prefix=CHECK-RESILIENT %s
@@ -8,7 +8,7 @@
 // CHECK-RESILIENT: Frozen_DECL_ATTR
 // CHECK-NON-RESILIENT-NOT: Frozen_DECL_ATTR
 
-@frozen // expected-warning {{@frozen has no effect without -enable-library-evolution}}
+@frozen // expected-no-warning
 public enum SomeEnum {
   case x
 }

--- a/test/decl/enum/frozen-nonresilient.swift
+++ b/test/decl/enum/frozen-nonresilient.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -warnings-as-errors
 
-@frozen public enum Exhaustive {} // expected-warning {{@frozen has no effect without -enable-library-evolution}} {{1-9=}}
+@frozen public enum Exhaustive {} // expected-no-warning
 
-@frozen enum NotPublic {} // expected-warning {{@frozen has no effect without -enable-library-evolution}} {{1-9=}}
+@frozen enum NotPublic {} // expected-no-warning


### PR DESCRIPTION
This warning is produced if you annotate an enum with `@frozen` but
build without library evolution enabled. The problem is that if you
only build with library evolution enabled for release builds, this
leaves you with a warning for all debug builds. The downside of this
change is that if you never build with library evolution, you may have
this unnecessary annotation without noticing.