### PR TITLE
[Gardening] Strip TypeChecker of its ASTContext

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -362,7 +362,7 @@ ConstraintSystem::SolverState::SolverState(
 
   // If we're supposed to debug a specific constraint solver attempt,
   // turn on debugging now.
-  ASTContext &ctx = CS.getTypeChecker().Context;
+  ASTContext &ctx = CS.getASTContext();
   auto &tyOpts = ctx.TypeCheckerOpts;
   OldDebugConstraintSolver = tyOpts.DebugConstraintSolver;
   if (tyOpts.DebugConstraintSolverAttempt &&
@@ -409,7 +409,7 @@ ConstraintSystem::SolverState::~SolverState() {
   }
 
   // Restore debugging state.
-  TypeCheckerOptions &tyOpts = CS.getTypeChecker().Context.TypeCheckerOpts;
+  TypeCheckerOptions &tyOpts = CS.getASTContext().TypeCheckerOpts;
   tyOpts.DebugConstraintSolver = OldDebugConstraintSolver;
 
   // Write our local statistics back to the overall statistics.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2172,6 +2172,7 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
                                           TypeCheckExprOptions options,
                                           ExprTypeCheckListener &listener,
                                           ConstraintSystem *baseCS) {
+  auto &Context = dc->getASTContext();
   FrontendStatsTracer StatsTracer(Context.Stats, "typecheck-expr", expr);
   PrettyStackTraceExpr stackTrace(Context, "type-checking", expr);
 
@@ -3717,14 +3718,14 @@ void ConstraintSystem::print(raw_ostream &out) const {
   out << "\nActive Constraints:\n";
   for (auto &constraint : ActiveConstraints) {
     out.indent(2);
-    constraint.print(out, &getTypeChecker().Context.SourceMgr);
+    constraint.print(out, &getASTContext().SourceMgr);
     out << "\n";
   }
 
   out << "\nInactive Constraints:\n";
   for (auto &constraint : InactiveConstraints) {
     out.indent(2);
-    constraint.print(out, &getTypeChecker().Context.SourceMgr);
+    constraint.print(out, &getASTContext().SourceMgr);
     out << "\n";
   }
 
@@ -3732,7 +3733,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
     out << "\nRetired Constraints:\n";
     solverState->forEachRetired([&](Constraint &constraint) {
       out.indent(2);
-      constraint.print(out, &getTypeChecker().Context.SourceMgr);
+      constraint.print(out, &getASTContext().SourceMgr);
       out << "\n";
     });
   }
@@ -3786,7 +3787,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
     out << "\nDisjunction choices:\n";
     for (auto &choice : DisjunctionChoices) {
       out.indent(2);
-      choice.first->dump(&getTypeChecker().Context.SourceMgr, out);
+      choice.first->dump(&getASTContext().SourceMgr, out);
       out << " is #" << choice.second << "\n";
     }
   }
@@ -3795,7 +3796,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
     out << "\nOpened types:\n";
     for (const auto &opened : OpenedTypes) {
       out.indent(2);
-      opened.first->dump(&getTypeChecker().Context.SourceMgr, out);
+      opened.first->dump(&getASTContext().SourceMgr, out);
       out << " opens ";
       interleave(opened.second.begin(), opened.second.end(),
                  [&](OpenedType opened) {
@@ -3814,7 +3815,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
     out << "\nOpened existential types:\n";
     for (const auto &openedExistential : OpenedExistentialTypes) {
       out.indent(2);
-      openedExistential.first->dump(&getTypeChecker().Context.SourceMgr, out);
+      openedExistential.first->dump(&getASTContext().SourceMgr, out);
       out << " opens to " << openedExistential.second->getString(PO);
       out << "\n";
     }
@@ -3823,7 +3824,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
   if (!DefaultedConstraints.empty()) {
     out << "\nDefaulted constraints: ";
     interleave(DefaultedConstraints, [&](ConstraintLocator *locator) {
-      locator->dump(&getTypeChecker().Context.SourceMgr, out);
+      locator->dump(&getASTContext().SourceMgr, out);
     }, [&] {
       out << ", ";
     });
@@ -3832,7 +3833,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
   if (failedConstraint) {
     out << "\nFailed constraint:\n";
     out.indent(2);
-    failedConstraint->print(out, &getTypeChecker().Context.SourceMgr);
+    failedConstraint->print(out, &getASTContext().SourceMgr);
     out << "\n";
   }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -55,16 +55,11 @@ using namespace swift;
 TypeChecker &TypeChecker::createForContext(ASTContext &ctx) {
   assert(!ctx.getLegacyGlobalTypeChecker() &&
          "Cannot install more than one instance of the global type checker!");
-  auto *TC = new TypeChecker(ctx);
+  auto *TC = new TypeChecker();
   ctx.installGlobalTypeChecker(TC);
   ctx.addCleanup([=](){ delete TC; });
   return *ctx.getLegacyGlobalTypeChecker();
 }
-
-TypeChecker::TypeChecker(ASTContext &Ctx)
-  : Context(Ctx) {}
-
-TypeChecker::~TypeChecker() {}
 
 ProtocolDecl *TypeChecker::getProtocol(ASTContext &Context, SourceLoc loc,
                                        KnownProtocolKind kind) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -542,9 +542,9 @@ public:
   std::vector<AbstractClosureExpr *> ClosuresWithUncomputedCaptures;
 
 private:
-  ASTContext &Context;
+  TypeChecker() = default;
+  ~TypeChecker() = default;
 
-  TypeChecker(ASTContext &Ctx);
   friend class ASTContext;
   friend class constraints::ConstraintSystem;
   friend class TypeCheckFunctionBodyUntilRequest;
@@ -559,7 +559,6 @@ public:
 public:
   TypeChecker(const TypeChecker&) = delete;
   TypeChecker& operator=(const TypeChecker&) = delete;
-  ~TypeChecker();
 
   static Type getArraySliceType(SourceLoc loc, Type elementType);
   static Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -930,6 +930,12 @@ public:
   /// tree.
   static Expr *foldSequence(SequenceExpr *expr, DeclContext *dc);
 
+private:
+  /// Given an pre-folded expression, find LHS from the expression if a binary
+  /// operator \c name appended to the expression.
+  static Expr *findLHS(DeclContext *DC, Expr *E, Identifier name);
+
+public:
   /// Type check the given expression.
   ///
   /// \param expr The expression to type-check, which will be modified in
@@ -1326,11 +1332,6 @@ public:
   ///
   /// Routines that perform name lookup.
   ///
-  /// During type checking, these routines should be used instead of
-  /// \c MemberLookup and \c UnqualifiedLookup, because these routines will
-  /// lazily introduce declarations and (FIXME: eventually) perform recursive
-  /// type-checking that the AST-level lookup routines don't.
-  ///
   /// @{
 
   /// Perform unqualified name lookup at the given source location
@@ -1405,9 +1406,6 @@ public:
                                                     Identifier name,
                                                     SourceLoc nameLoc);
 
-  /// Given an pre-folded expression, find LHS from the expression if a binary
-  /// operator \c name appended to the expression.
-  static Expr *findLHS(DeclContext *DC, Expr *E, Identifier name);
   /// Check whether the given declaration can be written as a
   /// member of the given base type.
   static bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -546,8 +546,6 @@ private:
   ~TypeChecker() = default;
 
   friend class ASTContext;
-  friend class constraints::ConstraintSystem;
-  friend class TypeCheckFunctionBodyUntilRequest;
 
 public:
   /// Create a new type checker instance for the given ASTContext, if it

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -925,9 +925,6 @@ public:
   /// struct or class.
   static void addImplicitConstructors(NominalTypeDecl *typeDecl);
 
-private:
-  Optional<Type> boolType;
-
 public:
   /// Fold the given sequence expression into an (unchecked) expression
   /// tree.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -925,16 +925,6 @@ public:
   /// struct or class.
   static void addImplicitConstructors(NominalTypeDecl *typeDecl);
 
-  /// \name Name lookup
-  ///
-  /// Routines that perform name lookup.
-  ///
-  /// During type checking, these routines should be used instead of
-  /// \c MemberLookup and \c UnqualifiedLookup, because these routines will
-  /// lazily introduce declarations and (FIXME: eventually) perform recursive
-  /// type-checking that the AST-level lookup routines don't.
-  ///
-  /// @{
 private:
   Optional<Type> boolType;
 
@@ -1335,6 +1325,17 @@ public:
   static Type deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
                                 AssociatedTypeDecl *assocType);
 
+  /// \name Name lookup
+  ///
+  /// Routines that perform name lookup.
+  ///
+  /// During type checking, these routines should be used instead of
+  /// \c MemberLookup and \c UnqualifiedLookup, because these routines will
+  /// lazily introduce declarations and (FIXME: eventually) perform recursive
+  /// type-checking that the AST-level lookup routines don't.
+  ///
+  /// @{
+
   /// Perform unqualified name lookup at the given source location
   /// within a particular declaration context.
   ///
@@ -1370,10 +1371,6 @@ public:
   static LookupResult lookupMember(DeclContext *dc, Type type, DeclName name,
                                    NameLookupOptions options
                                      = defaultMemberLookupOptions);
-
-  /// Check whether the given declaration can be written as a
-  /// member of the given base type.
-  static bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
 
   /// Look up a member type within the given type.
   ///
@@ -1414,6 +1411,9 @@ public:
   /// Given an pre-folded expression, find LHS from the expression if a binary
   /// operator \c name appended to the expression.
   static Expr *findLHS(DeclContext *DC, Expr *E, Identifier name);
+  /// Check whether the given declaration can be written as a
+  /// member of the given base type.
+  static bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
 
   /// @}
 


### PR DESCRIPTION
Clean up TypeChecker's header a bit by removing dead members and friends and putting the doc comments back in order.