### PR TITLE
Update WindowsBuild.md

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -98,45 +98,20 @@ ninja -C S:\b\libdispatch check
 ## Build swift-corelibs-foundation
 
 ```cmd
-md "S:\b\foundation"
-cd "S:\b\foundation
-cmake -G Ninja^
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo^
-  -DCMAKE_C_COMPILER=clang-cl^
-  -DCMAKE_SWIFT_COMPILER=S:\b\toolchain\bin\swiftc.exe^
-  -DCURL_LIBRARY="S:/Library/libcurl-development/usr/lib/libcurl.lib"^
-  -DCURL_INCLUDE_DIR="S:/Library/libcurl-development/usr/include"^
-  -DENABLE_TESTING=NO^
-  -DICU_ROOT="S:/Library/icu-64"^
-  -DLIBXML2_LIBRARY="S:/Library/libxml2-development/usr/lib/libxml2.lib"^
-  -DLIBXML2_INCLUDE_DIR="S:/Library/libxml2-development/usr/include"^
-  -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=S:\swift-corelibs-libdispatch^
-  -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=S:\b\libdispatch^
-   S:\swift-corelibs-foundation
-ninja
+cmake -B S:\b\foundation -G Ninja -S S:\toolchain\swift-corelibs-foundation -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=clang-cl -DCMAKE_Swift_COMPILER=S:\b\toolchain\bin\swiftc.exe -DCURL_LIBRARY="S:/Library/libcurl-development/usr/lib/libcurl.lib" -DCURL_INCLUDE_DIR="S:/Library/libcurl-development/usr/include" -DICU_ROOT="S:/Library/icu-64" -DLIBXML2_LIBRARY="S:/Library/libxml2-development/usr/lib/libxml2.lib" -DLIBXML2_INCLUDE_DIR="S:/Library/libxml2-development/usr/include" -DENABLE_TESTING=NO -Ddisptch_DIR=S:/b/libdispatch/cmake/modules
+ninja -C S:\b\foundation
 ```
 
 - Add Foundation to your path:
 ```cmd
-path S:\b\foundation;%PATH%
+path S:\b\foundation\Foundation;%PATH%
 ```
 
 ## Build swift-corelibs-xctest
 
 ```cmd
-md "S:\b\xctest"
-cd "S:\b\xctest"
-cmake -G Ninja^
-  -DBUILD_SHARED_LIBS=YES^
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo^
-  -DCMAKE_SWIFT_COMPILER=S:\b\toolchain\bin\swiftc.exe^
-  -DXCTEST_PATH_TO_FOUNDATION_BUILD=S:\b\foundation^
-  -DXCTEST_PATH_TO_LIBDISPATCH_SOURCE=S:\swift-corelibs-libdispatch^
-  -DXCTEST_PATH_TO_LIBDISPATCH_BUILD=S:\b\libdispatch^
-  -DLIT_COMMAND=S:\llvm\utils\lit\lit.py^
-  -DPYTHON_EXECUTABLE=C:\Python27\python.exe^
-  S:\swift-corelibs-xctest
-ninja
+cmake -B S:\b\xctest -G Ninja -S S:\toolchain\swift-corelibs-xctest -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_Swift_COMPILER=S:/b/toolchain/bin/swiftc.exe -Ddispatch_DIR=S:\b\dispatch\cmake\modules -DFoundation_DIR=S:\b\foundation\cmake\modules -DLIT_COMMAND=S:\toolchain\llvm\utils\lit\lit.py -DPYTHON_EXECUTABLE=C:\Python27\python.exe
+ninja -C S:\b\xctest
 ```
 
 - Add XCTest to your path:
@@ -153,21 +128,8 @@ ninja -C S:\b\xctest check-xctest
 ## Rebuild Foundation
 
 ```cmd
-cd "S:\b\foundation
-cmake -G Ninja^
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo^
-  -DCMAKE_C_COMPILER=clang-cl^
-  -DCMAKE_Swift_COMPILER=S:\b\toolchain\bin\swiftc.exe^
-  -DCURL_LIBRARY="S:/Library/libcurl-development/usr/lib/libcurl.lib"^
-  -DCURL_INCLUDE_DIR="S:/Library/libcurl-development/usr/include"^
-  -DENABLE_TESTING=YES^
-  -DICU_ROOT="S:/Library/icu-64"^
-  -DLIBXML2_LIBRARY="S:/Library/libxml2-development/usr/lib/libxml2.lib"^
-  -DLIBXML2_INCLUDE_DIR="S:/Library/libxml2-development/usr/include"^
-  -Ddispatch_DIR=S:\b\libdispatch\cmake\modules^
-  -DFOUNDATION_PATH_TO_XCTEST_BUILD=S:\b\xctest^
-   S:\swift-corelibs-foundation
-ninja
+cmake -B S:\b\foundation -G Ninja -S S:\toolchain\swift-corelibs-foundation -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=clang-cl -DCMAKE_Swift_COMPILER=S:/b/toolchain/bin/swiftc.exe -DCURL_LIBRARY="S:/Library/libcurl-development/usr/lib/libcurl.lib" -DCURL_INCLUDE_DIR="S:/Library/libcurl-development/usr/include" -DICU_ROOT="S:/Library/icu-64" -DLIBXML2_LIBRARY="S:/Library/libxml2-development/usr/lib/libxml2.lib" -DLIBXML2_INCLUDE_DIR="S:/Library/libxml2-development/usr/include" -DENABLE_TESTING=YES -Ddisptch_DIR=S:/b/libdispatch/cmake/modules -DXCTest_DIR=S:/b/xctest/cmake/modules
+ninja -C S:\b\foundation
 ```
 
 ## Test Foundation


### PR DESCRIPTION
Update rules for the Windows build after CMake 3.15 upgrade.  This simplifies the rules, relies on the export targets and removes the unnecessary variables.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
