### PR TITLE
[Gardening] Remove handleSILGenericParams from TypeChecker

### DIFF
--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -228,8 +228,7 @@ namespace swift {
                               bool ProduceDiagnostics = true);
 
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-  GenericEnvironment *handleSILGenericParams(ASTContext &Ctx,
-                                             GenericParamList *genericParams,
+  GenericEnvironment *handleSILGenericParams(GenericParamList *genericParams,
                                              DeclContext *DC);
 
   /// Turn the given module into SIL IR.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -634,32 +634,6 @@ HasCircularRawValueRequest::evaluate(Evaluator &evaluator,
   return result;
 }
 
-/// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-GenericEnvironment *
-TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
-                                    DeclContext *DC) {
-  if (genericParams == nullptr)
-    return nullptr;
-
-  SmallVector<GenericParamList *, 2> nestedList;
-  for (; genericParams; genericParams = genericParams->getOuterParameters()) {
-    nestedList.push_back(genericParams);
-  }
-
-  std::reverse(nestedList.begin(), nestedList.end());
-
-  for (unsigned i = 0, e = nestedList.size(); i < e; ++i) {
-    auto genericParams = nestedList[i];
-    genericParams->setDepth(i);
-  }
-
-  auto sig = TypeChecker::checkGenericSignature(
-             nestedList.back(), DC,
-             /*parentSig=*/nullptr,
-             /*allowConcreteGenericParams=*/true);
-  return (sig ? sig->getGenericEnvironment() : nullptr);
-}
-
 /// Check whether \c current is a redeclaration.
 static void checkRedeclaration(ASTContext &ctx, ValueDecl *current) {
   // If we've already checked this declaration, don't do it again.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -613,10 +613,6 @@ public:
   static void checkUnsupportedProtocolType(ASTContext &ctx,
                                            GenericParamList *genericParams);
 
-  /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-  static GenericEnvironment *
-  handleSILGenericParams(GenericParamList *genericParams, DeclContext *DC);
-
   /// Resolve a reference to the given type declaration within a particular
   /// context.
   ///


### PR DESCRIPTION
Inline TypeChecker::handleSILGenericParams into swift::handleSILGenericParams.