### PR TITLE
build: allow toolchain-tools to be relocated

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2398,7 +2398,7 @@ endmacro()
 
 function(add_swift_host_tool executable)
   set(options)
-  set(single_parameter_options SWIFT_COMPONENT)
+  set(single_parameter_options "SWIFT_COMPONENT;DESTINATION_PREFIX")
   set(multiple_parameter_options LINK_LIBRARIES)
 
   cmake_parse_arguments(ASHT
@@ -2423,7 +2423,7 @@ function(add_swift_host_tool executable)
   add_dependencies(${ASHT_SWIFT_COMPONENT} ${executable})
   swift_install_in_component(TARGETS ${executable}
                              RUNTIME
-                               DESTINATION bin
+                               DESTINATION "${ASHT_DESTINATION_PREFIX}bin"
                                COMPONENT ${ASHT_SWIFT_COMPONENT})
 
   swift_is_installing_component(${ASHT_SWIFT_COMPONENT} is_installing)

--- a/tools/swift-api-digester/CMakeLists.txt
+++ b/tools/swift-api-digester/CMakeLists.txt
@@ -3,6 +3,7 @@ add_swift_host_tool(swift-api-digester
   ModuleAnalyzerNodes.cpp
   ModuleDiagsConsumer.cpp
   SWIFT_COMPONENT toolchain-tools
+  DESTINATION_PREFIX "${TOOLCHAIN_TOOLS_PREFIX}"
 )
 target_link_libraries(swift-api-digester
                       PRIVATE

--- a/utils/api_checker/CMakeLists.txt
+++ b/utils/api_checker/CMakeLists.txt
@@ -1,12 +1,12 @@
 set(framework "FrameworkABIBaseline")
 swift_install_in_component(PROGRAMS "swift-api-checker.py"
-                           DESTINATION "bin"
+                           DESTINATION "${TOOLCHAIN_TOOLS_PREFIX}bin"
                            COMPONENT toolchain-tools)
 swift_install_in_component(DIRECTORY "sdk-module-lists"
-                           DESTINATION "bin"
+                           DESTINATION "${TOOLCHAIN_TOOLS_PREFIX}bin"
                            COMPONENT toolchain-tools)
 swift_install_in_component(DIRECTORY "${framework}"
-                           DESTINATION "lib/swift"
+                           DESTINATION "${TOOLCHAIN_TOOLS_PREFIX}lib/swift"
                            COMPONENT toolchain-tools)
 
 # Add symlink of FrameworkABIBaseline to the build dir. This ensures we can


### PR DESCRIPTION
This introduces a `TOOLCHAIN_TOOLS_PREFIX` CMake variable that would be used to nest toolchain-tools inside the usual position in the toolchain.

Supports rdar://problem/53670881