### PR TITLE
[Diagnostics] Port explicit closure result contextual mismatch

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3243,35 +3243,6 @@ bool FailureDiagnosis::diagnoseClosureExpr(
       return true;
   }
 
-  // If the body of the closure looked ok, then look for a contextual type
-  // error.  This is necessary because FailureDiagnosis::diagnoseExprFailure
-  // doesn't do this for closures.
-  if (contextualType) {
-    auto fnType = contextualType->getAs<AnyFunctionType>();
-    if (!fnType || fnType->isEqual(CS.getType(CE)))
-      return false;
-
-    auto contextualResultType = fnType->getResult();
-    // If the result type was unknown, it doesn't really make
-    // sense to diagnose from expected to unknown here.
-    if (isInvalidClosureResultType(contextualResultType))
-      return false;
-
-    // If the closure had an explicitly written return type incompatible with
-    // the contextual type, diagnose that.
-    if (CE->hasExplicitResultType() &&
-        CE->getExplicitResultTypeLoc().getTypeRepr()) {
-      auto explicitResultTy = CE->getExplicitResultTypeLoc().getType();
-      if (fnType && !explicitResultTy->isEqual(contextualResultType)) {
-        auto repr = CE->getExplicitResultTypeLoc().getTypeRepr();
-        diagnose(repr->getStartLoc(), diag::incorrect_explicit_closure_result,
-                 explicitResultTy, fnType->getResult())
-          .fixItReplace(repr->getSourceRange(),fnType->getResult().getString());
-        return true;
-      }
-    }
-  }
-
   // Otherwise, we can't produce a specific diagnostic.
   return false;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1986,6 +1986,17 @@ bool ContextualFailure::diagnoseAsError() {
   Diag<Type, Type> diagnostic;
   switch (path.back().getKind()) {
   case ConstraintLocator::ClosureResult: {
+    auto *closure = cast<ClosureExpr>(getRawAnchor());
+    if (closure->hasExplicitResultType() &&
+        closure->getExplicitResultTypeLoc().getTypeRepr()) {
+      auto resultRepr = closure->getExplicitResultTypeLoc().getTypeRepr();
+      emitDiagnostic(resultRepr->getStartLoc(),
+                     diag::incorrect_explicit_closure_result, getFromType(),
+                     getToType())
+          .fixItReplace(resultRepr->getSourceRange(), getToType().getString());
+      return true;
+    }
+
     diagnostic = diag::cannot_convert_closure_result;
     break;
   }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -765,7 +765,7 @@ overloaded { print("hi"); print("bye") } // multiple expression closure without 
 func not_overloaded(_ handler: () -> Int) {}
 
 not_overloaded { } // empty body
-// expected-error@-1 {{cannot convert value of type '() -> ()' to expected argument type '() -> Int'}}
+// expected-error@-1 {{cannot convert value of type '()' to closure result type 'Int'}}
 
 not_overloaded { print("hi") } // single-expression closure
 // expected-error@-1 {{cannot convert value of type '()' to closure result type 'Int'}}
@@ -786,7 +786,7 @@ func test() -> Int? {
 }
 
 var fn: () -> [Int] = {}
-// expected-error@-1 {{cannot convert value of type '() -> ()' to specified type '() -> [Int]'}}
+// expected-error@-1 {{cannot convert value of type '()' to closure result type '[Int]'}}
 
 fn = {}
 // expected-error@-1 {{cannot assign value of type '() -> ()' to type '() -> [Int]'}}

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -656,8 +656,8 @@ func sr4214() {
   let closure = { val in val.x = 7 } as (inout MutableSubscripts) -> () // Ok
   var v = MutableSubscripts()
   closure(&v)
-  // FIXME: This diagnostic isn't really all that much better
-  // expected-error@+1 {{cannot convert value of type '(inout MutableSubscripts) -> ()' to expected argument type '(_) -> _'}}
+  // expected-error@+2 {{declared closure result '()' is incompatible with contextual type 'MutableSubscripts'}}
+  // expected-error@+1 {{cannot convert value of type '(inout MutableSubscripts) -> ()' to expected argument type '(MutableSubscripts) -> MutableSubscripts'}}
   sequence(v) { (state : inout MutableSubscripts) -> () in
     _ = MutableSubscripts.initialize(from: &state)
     return ()

--- a/test/Sema/substring_to_string_conversion_swift4.swift
+++ b/test/Sema/substring_to_string_conversion_swift4.swift
@@ -45,7 +45,7 @@ do {
 
 // CTP_ClosureResult
 do {
-  [ss].map { (x: Substring) -> String in x } // expected-error {{cannot convert value of type 'Substring' to closure result type 'String'}} {{42-42=String(}} {{43-43=)}}
+  [ss].map { (x: Substring) -> String in x } // expected-error {{declared closure result 'Substring' is incompatible with contextual type 'String'}}
 }
 
 // CTP_ArrayElement


### PR DESCRIPTION
Detect and diagnose a problem when explicitly specified closure
result type doesn't match what is expected by the context:

Example:

```swift
func foo(_: () -> Int) {}

foo { () -> String in "" } // `Int` vs. `String`
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
