### PR TITLE
[ConstraintSystem] Missing generic args/hole refactoring

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -347,12 +347,10 @@ protected:
     NumProtocols : 16
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 4+32,
-    : NumPadBits,
-
+  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 5+32,
     /// Type variable options.
-    Options : 4,
-
+    Options : 5,
+    : NumPadBits,
     /// The unique number assigned to this type variable.
     ID : 32
   );

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -175,7 +175,7 @@ public:
 
   /// Does a type with these properties have an unresolved type somewhere in it?
   bool hasUnresolvedType() const { return Bits & HasUnresolvedType; }
-  
+
   /// Is a type with these properties an lvalue?
   bool isLValue() const { return Bits & IsLValue; }
 
@@ -563,7 +563,12 @@ public:
   bool hasUnresolvedType() const {
     return getRecursiveProperties().hasUnresolvedType();
   }
-  
+
+  /// Determine whether this type involves a hole.
+  bool hasHole() const {
+    return getRecursiveProperties().hasUnresolvedType();
+  }
+
   /// Determine whether the type involves a context-dependent archetype.
   bool hasArchetype() const {
     return getRecursiveProperties().hasArchetype();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7379,9 +7379,8 @@ bool ConstraintSystem::applySolutionFixes(Expr *E, const Solution &solution) {
           auto *primaryFix = fixes[0];
           ArrayRef<ConstraintFix *> secondaryFixes{fixes.begin() + 1, fixes.end()};
 
-          auto *coalescedFix = primaryFix->coalescedWith(secondaryFixes);
-          auto diagnosed = coalescedFix->diagnose();
-          if (coalescedFix->isWarning()) {
+          auto diagnosed = primaryFix->coalesceAndDiagnose(secondaryFixes);
+          if (primaryFix->isWarning()) {
             assert(diagnosed && "warnings should always be diagnosed");
             (void)diagnosed;
           } else {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -991,11 +991,11 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
     cs.DefaultedConstraints.push_back(Binding.DefaultableBinding);
 
     if (locator->isForGenericParameter() && type->isHole()) {
-      // Drop `generic parameter '...'` part of the locator to group all of the
-      // missing generic parameters related to the same path together.
+      // Drop `generic parameter` locator element so that all missing
+      // generic parameters related to the same path can be coalesced later.
       auto path = locator->getPath();
       auto genericParam = locator->getGenericParameter();
-      auto *fix = ExplicitlySpecifyGenericArguments::create(cs, {genericParam},
+      auto *fix = DefaultGenericArgument::create(cs, genericParam,
           cs.getConstraintLocator(locator->getAnchor(), path.drop_back()));
       if (cs.recordFix(fix))
         return true;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -734,10 +734,9 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
                                 constraint->getLocator()});
   }
 
-  // If we don't have any potential bindings, allow generic
-  // parameters and potential holes to default to `Unresolved`.
+  // If there are no bindings, typeVar may be a hole.
   if (shouldAttemptFixes() && result.Bindings.empty() &&
-      (isPotentialHole(typeVar) || result.isGenericParameter())) {
+      typeVar->getImpl().canBindToHole()) {
     result.IsHole = true;
     result.addPotentialBinding({getASTContext().TheUnresolvedType,
         AllowedBindingKind::Exact, ConstraintKind::Defaultable, nullptr,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -183,10 +183,8 @@ enum class FixKind : uint8_t {
   /// function to `Void` to conform to expected result type.
   RemoveReturn,
 
-  /// Generic parameters could not be inferred and have to be explicitly
-  /// specified in the source. This fix groups all of the missing arguments
-  /// associated with single declaration.
-  ExplicitlySpecifyGenericArguments,
+  /// Default ambiguous generic arguments to \c Any
+  DefaultGenericArgument,
 
   /// Skip any unhandled constructs that occur within a closure argument that
   /// matches up with a
@@ -254,13 +252,17 @@ public:
 
   virtual std::string getName() const = 0;
 
-  /// Diagnose a failure associated with this fix given
-  /// root expression and information from constraint system.
-  virtual bool diagnose(bool asNote = false) const = 0;
-
-  virtual ConstraintFix *coalescedWith(ArrayRef<ConstraintFix *> fixes) {
-    return this;
+  /// Coalesce this fix with the given secondary fixes and diagnose the failure.
+  ///
+  /// The default implementation ignores \c secondaryFixes and calls
+  /// \c diagnose.
+  virtual bool coalesceAndDiagnose(ArrayRef<ConstraintFix *> secondaryFixes,
+                                   bool asNote = false) const {
+    return diagnose(asNote);
   }
+
+  /// Diagnose a failure associated with this fix.
+  virtual bool diagnose(bool asNote = false) const = 0;
 
   void print(llvm::raw_ostream &Out) const;
 
@@ -1251,49 +1253,32 @@ public:
          ConstraintLocator *locator);
 };
 
-class ExplicitlySpecifyGenericArguments final
-    : public ConstraintFix,
-      private llvm::TrailingObjects<ExplicitlySpecifyGenericArguments,
-                                    GenericTypeParamType *> {
-  friend TrailingObjects;
+class DefaultGenericArgument final : public ConstraintFix {
+  GenericTypeParamType *Param;
 
-  unsigned NumMissingParams;
-
-  ExplicitlySpecifyGenericArguments(ConstraintSystem &cs,
-                                    ArrayRef<GenericTypeParamType *> params,
-                                    ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::ExplicitlySpecifyGenericArguments, locator),
-        NumMissingParams(params.size()) {
-    assert(!params.empty());
-    std::uninitialized_copy(params.begin(), params.end(),
-                            getParametersBuf().begin());
-  }
+  DefaultGenericArgument(ConstraintSystem &cs, GenericTypeParamType *param,
+                         ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::DefaultGenericArgument, locator),
+        Param(param) {}
 
 public:
   static bool classof(const ConstraintFix *fix) {
-    return fix->getKind() == FixKind::ExplicitlySpecifyGenericArguments;
+    return fix->getKind() == FixKind::DefaultGenericArgument;
   }
 
   std::string getName() const override {
-    return "default missing generic arguments to `Any`";
+    auto paramName = Param->getString();
+    return "default generic argument '" + paramName + "' to 'Any'";
   }
 
-  ArrayRef<GenericTypeParamType *> getParameters() const {
-    return {getTrailingObjects<GenericTypeParamType *>(), NumMissingParams};
-  }
+  bool coalesceAndDiagnose(ArrayRef<ConstraintFix *> secondaryFixes,
+                           bool asNote = false) const override;
 
   bool diagnose(bool asNote = false) const override;
 
-  ConstraintFix *coalescedWith(ArrayRef<ConstraintFix *> fixes) override;
-
-  static ExplicitlySpecifyGenericArguments *
-  create(ConstraintSystem &cs, ArrayRef<GenericTypeParamType *> params,
-         ConstraintLocator *locator);
-
-private:
-  MutableArrayRef<GenericTypeParamType *> getParametersBuf() {
-    return {getTrailingObjects<GenericTypeParamType *>(), NumMissingParams};
-  }
+  static DefaultGenericArgument *create(ConstraintSystem &cs,
+                                        GenericTypeParamType *param,
+                                        ConstraintLocator *locator);
 };
 
 class SkipUnhandledConstructInFunctionBuilder final : public ConstraintFix {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -47,9 +47,11 @@ class Solution;
 
 /// Describes the kind of fix to apply to the given constraint before
 /// visiting it.
+///
+/// Note: values 0 and 1 are reserved for empty and tombstone kinds.
 enum class FixKind : uint8_t {
   /// Introduce a '!' to force an optional unwrap.
-  ForceOptional,
+  ForceOptional = 2,
 
   /// Unwrap an optional base when we have a member access.
   UnwrapOptionalBase,
@@ -1552,5 +1554,24 @@ public:
 
 } // end namespace constraints
 } // end namespace swift
+
+namespace llvm {
+  template <>
+  struct DenseMapInfo<swift::constraints::FixKind> {
+    using FixKind = swift::constraints::FixKind;
+    static inline FixKind getEmptyKey() {
+      return static_cast<FixKind>(0);
+    }
+    static inline FixKind getTombstoneKey() {
+      return static_cast<FixKind>(1);
+    }
+    static unsigned getHashValue(FixKind kind) {
+      return static_cast<unsigned>(kind);
+    }
+    static bool isEqual(FixKind lhs, FixKind rhs) {
+      return lhs == rhs;
+    }
+  };
+}
 
 #endif // SWIFT_SEMA_CSFIX_H

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8390,7 +8390,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowAnyObjectKeyPathRoot:
   case FixKind::TreatKeyPathSubscriptIndexAsHashable:
   case FixKind::AllowInvalidRefInKeyPath:
-  case FixKind::ExplicitlySpecifyGenericArguments:
+  case FixKind::DefaultGenericArgument:
   case FixKind::GenericArgumentsMismatch:
   case FixKind::AllowMutatingMemberOnRValueBase:
   case FixKind::AllowTupleSplatForSingleParameter:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6780,8 +6780,9 @@ ConstraintSystem::simplifyKeyPathConstraint(
 
       if (auto *fix = AllowInvalidRefInKeyPath::forRef(
               *this, choices[i].getDecl(), componentLoc)) {
-        if (!shouldAttemptFixes() || recordFix(fix))
-          return SolutionKind::Error;
+        if (!hasFixFor(componentLoc, FixKind::AllowTypeOrInstanceMember))
+          if (!shouldAttemptFixes() || recordFix(fix))
+            return SolutionKind::Error;
 
         // If this was a method reference let's mark it as read-only.
         if (!storage) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3089,7 +3089,7 @@ bool ConstraintSystem::repairFailures(
     }
 
     // If either type has a hole, consider this fixed.
-    if (lhs->hasUnresolvedType() || rhs->hasUnresolvedType())
+    if (lhs->hasHole() || rhs->hasHole())
       return true;
 
     conversionsOrFixes.push_back(
@@ -3155,7 +3155,7 @@ bool ConstraintSystem::repairFailures(
   case ConstraintLocator::TypeParameterRequirement:
   case ConstraintLocator::ConditionalRequirement: {
     // If either type has a hole, consider this fixed.
-    if (lhs->hasUnresolvedType() || rhs->hasUnresolvedType())
+    if (lhs->hasHole() || rhs->hasHole())
       return true;
 
     // If dependent members are present here it's because
@@ -3415,7 +3415,7 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::InstanceType: {
-    if (lhs->hasUnresolvedType() || rhs->hasUnresolvedType())
+    if (lhs->hasHole() || rhs->hasHole())
       return true;
 
     break;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -436,7 +436,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numSavedBindings = cs.solverState->savedBindings.size();
   numConstraintRestrictions = cs.ConstraintRestrictions.size();
   numFixes = cs.Fixes.size();
-  numHoles = cs.Holes.size();
   numFixedRequirements = cs.FixedRequirements.size();
   numDisjunctionChoices = cs.DisjunctionChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
@@ -483,9 +482,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any fixes.
   truncate(cs.Fixes, numFixes);
-
-  // Remove any holes encountered along the current path.
-  truncate(cs.Holes, numHoles);
 
   // Remove any disjunction choices.
   truncate(cs.DisjunctionChoices, numDisjunctionChoices);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1120,7 +1120,8 @@ void ConstraintSystem::openGenericParameters(DeclContext *outerDC,
     auto *paramLocator = getConstraintLocator(
         locator.withPathElement(LocatorPathElt::GenericParameter(gp)));
 
-    auto typeVar = createTypeVariable(paramLocator, TVO_PrefersSubtypeBinding);
+    auto typeVar = createTypeVariable(paramLocator, TVO_PrefersSubtypeBinding |
+                                                    TVO_CanBindToHole);
     auto result = replacements.insert(std::make_pair(
         cast<GenericTypeParamType>(gp->getCanonicalType()), typeVar));
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -68,13 +68,12 @@ void TypeVariableType::Implementation::print(llvm::raw_ostream &OS) {
 }
 
 SavedTypeVariableBinding::SavedTypeVariableBinding(TypeVariableType *typeVar)
-  : TypeVarAndOptions(typeVar, typeVar->getImpl().getRawOptions()),
+  : TypeVar(typeVar), Options(typeVar->getImpl().getRawOptions()),
     ParentOrFixed(typeVar->getImpl().ParentOrFixed) { }
 
 void SavedTypeVariableBinding::restore() {
-  auto *typeVar = getTypeVariable();
-  typeVar->getImpl().setRawOptions(getOptions());
-  typeVar->getImpl().ParentOrFixed = ParentOrFixed;
+  TypeVar->getImpl().setRawOptions(Options);
+  TypeVar->getImpl().ParentOrFixed = ParentOrFixed;
 }
 
 GenericTypeParamType *

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -454,6 +454,7 @@ CurriedClass.method3(c)(1.0, b: 1)       // expected-error {{cannot convert valu
 CurriedClass.method3(c)(1)               // expected-error {{missing argument for parameter 'b' in call}}
 CurriedClass.method3(c)(c: 1.0)          // expected-error {{incorrect argument labels in call (have 'c:', expected '_:b:')}}
 // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+// expected-error@-2 {{missing argument for parameter #1 in call}}
 
 
 extension CurriedClass {
@@ -1295,6 +1296,7 @@ rdar43525641(1, c: 2, 3) // Ok
 
 struct Array {}
 let foo: Swift.Array = Array() // expected-error {{cannot convert value of type 'Array' to specified type 'Array<Element>'}}
+// expected-error@-1 {{generic parameter 'Element' could not be inferred}}
 
 struct Error {}
 let bar: Swift.Error = Error() //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -212,6 +212,7 @@ func staticExistential(_ p: P.Type, pp: P.Protocol) {
   // Instance member of existential metatype -- not allowed
   _ = p.bar // expected-error{{instance member 'bar' cannot be used on type 'P'}}
   _ = p.mut // expected-error{{instance member 'mut' cannot be used on type 'P'}}
+  // expected-error@-1 {{partial application of 'mutating' method is not allowed}}
 
   // Static member of metatype -- not allowed
   _ = pp.tum // expected-error{{static member 'tum' cannot be used on protocol metatype 'P.Protocol'}}

--- a/test/decl/init/nonnominal_init.swift
+++ b/test/decl/init/nonnominal_init.swift
@@ -8,9 +8,12 @@ indirect enum Or<A, B> {
 }
 
 func deMorgan<A, B>(_ ne: Not<Or<A, B>>) -> And<Not<A>, Not<B>> {
+  // FIXME(diagnostics): The error message about initialization here is confusing
   return And<Not<A>, Not<B>>(
-    Not<A> { a in ne(.left(a)) }, // expected-error {{non-nominal type 'Not<A>' (aka '(A) -> Never') does not support explicit initialization}}
-    Not<B> { a in ne(.right(a)) }
+    Not<A> { a in ne(.left(a)) }, // expected-error {{type 'Not<A>' (aka '(A) -> Never') has no member 'init'}}
+    // expected-error@-1 {{type 'Or<A, B>' has no member 'left'}}
+    Not<B> { a in ne(.right(a)) } // expected-error {{type 'Not<B>' (aka '(B) -> Never') has no member 'init'}}
+    // expected-error@-1 {{type 'Or<A, B>' has no member 'right'}}
   )
 }
 

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -327,6 +327,7 @@ class ClassConformingToRefinedProtocol: RefinedProtocol {}
 
 struct GenSubscriptFixitTest {
   subscript<T>(_ arg: T) -> Bool { return true } // expected-note 3 {{declared here}}
+  // expected-note@-1 2 {{in call to 'subscript(_:)'}}
 }
 
 func testGenSubscriptFixit(_ s0: GenSubscriptFixitTest) {
@@ -339,9 +340,11 @@ func testUnresolvedMemberSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
   _ = s0.subscript
   // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-19=[<#index#>]}}
+  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
 
   s0.subscript = true
   // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{5-15=[<#index#>]}}
+  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
 }
 
 struct SubscriptTest1 {

--- a/test/expr/delayed-ident/static_var.swift
+++ b/test/expr/delayed-ident/static_var.swift
@@ -50,4 +50,5 @@ var _: HasClosure = .factoryOpt(3)
 // expected-error@-1 {{value of optional type '((Int) -> HasClosure)?' must be unwrapped to a value of type '(Int) -> HasClosure'}}
 // expected-note@-2 {{coalesce}}
 // expected-note@-3 {{force-unwrap}}
-var _: HasClosure = .factoryOpt!(4) // expected-error {{type '((Int) -> HasClosure)?' has no member 'factoryOpt'}}
+// FIXME: we should accept this
+var _: HasClosure = .factoryOpt!(4) // expected-error {{type 'Optional<_>' has no member 'factoryOpt'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -593,7 +593,8 @@ func conversionTest(_ a: inout Double, b: inout Int) {
   var e3 = Empty(Float(d)) // expected-warning {{variable 'e3' inferred to have type 'Empty', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}  {{9-9=: Empty}}
 }
 
-struct Rule {
+// FIXME(diagnostics): This note is pointing to a synthesized init
+struct Rule { // expected-note {{'init(target:dependencies:)' declared here}}
   var target: String
   var dependencies: String
 }
@@ -603,7 +604,7 @@ var ruleVar: Rule
 // does argument belong to in this case. If the `target` was of a different type, we currently suggest to add an argument for `dependencies:`
 // which is incorrect.
 ruleVar = Rule("a") // expected-error {{missing argument label 'target:' in call}}
-
+// expected-error@-1 {{missing argument for parameter 'dependencies' in call}}
 
 class C {
   var x: C?

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -36,7 +36,7 @@ struct A: Hashable {
   func hash(into hasher: inout Hasher) { fatalError() }
 }
 struct B {}
-struct C<T> { // expected-note 2 {{'T' declared as parameter to type 'C'}}
+struct C<T> { // expected-note 3 {{'T' declared as parameter to type 'C'}}
   var value: T
   subscript() -> T { get { return value } }
   subscript(sub: Sub) -> T { get { return value } set { } }
@@ -230,9 +230,9 @@ func testDisembodiedStringInterpolation(x: Int) {
 
 func testNoComponents() {
   let _: KeyPath<A, A> = \A // expected-error{{must have at least one component}}
-  // FIXME(diagnostics): This should be diagnosed as `missing generic parameter 'T'` instead of a contextual failure.
   let _: KeyPath<C, A> = \C // expected-error{{must have at least one component}} expected-error{{}}
-  // expected-error@-1 {{cannot convert value of type 'KeyPath<Root, Value>' to specified type 'KeyPath<C<T>, A>'}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-2 {{cannot convert value of type 'KeyPath<Root, Value>' to specified type 'KeyPath<C<T>, A>'}}
 }
 
 struct TupleStruct {

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -122,7 +122,8 @@ func typeIdentity() {
     var af = alice
     af = alice
     af = bob // expected-error{{}}
-    af = grace // expected-error{{}}
+    af = grace // expected-error{{generic parameter 'T' could not be inferred}}
+    // expected-error@-1 {{cannot assign value of type '(T) -> some P' to type '() -> some P'}}
   }
 
   do {


### PR DESCRIPTION
* Only coalesce fixes of the same kind in `applySolutionFixes`. This allows us to diagnose multiple, separate issues related to the same locator.
* Add `TypeBase::hasHole` and use this instead of `hasUnresolvedType` in the context of hole checking.
* Rather than creating a coalesced fix right before diagnosing failures in `applySolutionFixes`, coalesce fixes and diagnose failures in one method on `ConstraintFix`.
* Rename `ExplicitlySpecifyGenericArguments` to `DefaultGenericArgument`.
* Add `TVO_CanBindToHole` to `TypeVariableOptions` so that we don't need a separate data structure in the constraint system for tracking potential holes.