### PR TITLE
Relax an assert in witness access diagnostics

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2388,11 +2388,8 @@ static void diagnoseWitnessFixAccessLevel(DiagnosticEngine &diags,
       if (extAccess < requiredAccess) {
         shouldMoveToAnotherExtension = true;
       } else if (extAccess == requiredAccess) {
-        auto declAttr = decl->getAttrs().getAttribute<AccessControlAttr>();
-        assert(declAttr && declAttr->getAccess() < requiredAccess &&
-            "expect an explicitly specified access control level which is "
-            "less accessible than required.");
-        (void)declAttr;
+        assert(decl->getFormalAccess() < requiredAccess &&
+              "witness is accessible?");
         shouldUseDefaultAccess = true;
       }
     }


### PR DESCRIPTION
apple/swift#22235 added an assert that was a little overzealous about
the structure of access control attributes in the AST.  It used to
always expect that we reached diagnoseWitnessFixAccessLevel when there
was an explicit mismatch in user-written access markers.  But declarations
may also have their access levels rewritten and their access attributes
stripped if they are invalid.  If you can get all of these to occur by
the time you diagnose the witness, you see no attribute for a witness
with insufficient ACLs for a requirement and crash.

Relax the assert by using the formal access level and resolve rdar://56818960