### PR TITLE
Explicitly Specify a 64bit Shift to Fix Warning

### DIFF
--- a/include/swift/AST/IndexSubset.h
+++ b/include/swift/AST/IndexSubset.h
@@ -93,7 +93,7 @@ private:
     for (auto i : indices.set_bits()) {
       unsigned bitWordIndex, offset;
       std::tie(bitWordIndex, offset) = getBitWordIndexAndOffset(i);
-      getBitWord(bitWordIndex) |= (1 << offset);
+      getBitWord(bitWordIndex) |= (1ull << offset);
     }
   }
 
@@ -181,7 +181,7 @@ public:
   bool contains(unsigned index) const {
     unsigned bitWordIndex, offset;
     std::tie(bitWordIndex, offset) = getBitWordIndexAndOffset(index);
-    return getBitWord(bitWordIndex) & (1 << offset);
+    return getBitWord(bitWordIndex) & (1ull << offset);
   }
 
   bool isEmpty() const {


### PR DESCRIPTION
Explicitly doing a 64bit shift silences the otherwise noisy warning:
```
[1548/1735] Building CXX object
tools\swift\lib\Sema\CMakeFiles\swiftSema.dir\NameBinding.cpp.obj

S:\toolchain\swift\include\swift/AST/IndexSubset.h(96): warning C4334:
'<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit
shift intended?)

S:\toolchain\swift\include\swift/AST/IndexSubset.h(184): warning C4334:
'<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit
shift intended?)
```

