### PR TITLE
[AutoDiff] Fix usefulness propagation for array literal initialization.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1426,6 +1426,10 @@ private:
   SILFunction &getFunction();
 
   /// The conformance lookup function.
+  // FIXME(TF-945): `LookupConformanceFn` is a type alias for
+  // `llvm::function_ref`, which does not own the underlying callable and should
+  // not be stored. Instead, delete `getLookupConformanceFunction()` and define
+  // a `hasTangentSpace(SILValue)` helper.
   LookupConformanceFn getLookupConformanceFunction() {
     // Look up in derivative generic signature, if defined.
     if (derivativeGenericSignature)
@@ -1436,7 +1440,7 @@ private:
         getFunction().getModule().getSwiftModule());
   }
 
-  /// Perform analysis and populate sets.
+  /// Perform analysis and populate variedness and usefulness sets.
   void analyze(DominanceInfo *di, PostDominanceInfo *pdi);
 
   /// Marks the given value as varied and propagates variedness to users.
@@ -1450,9 +1454,8 @@ private:
   void propagateVariedInwardsThroughProjections(
       SILValue value, unsigned independentVariableIndex);
 
+  /// Marks the given value as useful for the given dependent variable index.
   void setUseful(SILValue value, unsigned dependentVariableIndex);
-  void setUsefulAcrossArrayInitialization(SILValue value,
-                                          unsigned dependentVariableIndex);
   /// Marks the given value as useful and recursively propagates usefulness to:
   /// - Defining instruction operands, if the value has a defining instruction.
   /// - Incoming values, if the value is a basic block argument.
@@ -1465,20 +1468,35 @@ private:
   /// field projections.
   void propagateUsefulThroughAddress(SILValue value,
                                      unsigned dependentVariableIndex);
+  /// If the given value is an `array.uninitialized_intrinsic` application,
+  /// selectively propagate usefulness through its `RawPointer` result.
+  void setUsefulAcrossArrayInitialization(SILValue value,
+                                          unsigned dependentVariableIndex);
 
 public:
   explicit DifferentiableActivityInfo(
       DifferentiableActivityCollection &parent,
       GenericSignature derivativeGenericSignature);
 
+  /// Returns true if the given value is varied for the given independent
+  /// variable index.
   bool isVaried(SILValue value, unsigned independentVariableIndex) const;
-  bool isUseful(SILValue value, unsigned dependentVariableIndex) const;
+
+  /// Returns true if the given value is varied for any of the given parameter
+  /// (independent variable) indices.
   bool isVaried(SILValue value, IndexSubset *parameterIndices) const;
+
+  /// Returns true if the given value is useful for the given dependent variable
+  /// index.
+  bool isUseful(SILValue value, unsigned dependentVariableIndex) const;
+
+  /// Returns true if the given value is active for the given
+  /// `SILAutoDiffIndices` (parameter indices and result index).
   bool isActive(SILValue value, const SILAutoDiffIndices &indices) const;
 
+  /// Returns the activity of the given value for the given `SILAutoDiffIndices`
+  /// (parameter indices and result index).
   Activity getActivity(SILValue value,
-                       const SILAutoDiffIndices &indices) const;
-  Activity getActivity(SILInstruction *inst,
                        const SILAutoDiffIndices &indices) const;
 };
 
@@ -1892,6 +1910,49 @@ SILFunction &DifferentiableActivityInfo::getFunction() {
   return parent.function;
 }
 
+void DifferentiableActivityInfo::analyze(DominanceInfo *di,
+                                         PostDominanceInfo *pdi) {
+  auto &function = getFunction();
+  LLVM_DEBUG(getADDebugStream()
+             << "Running activity analysis on @" << function.getName() << '\n');
+  // Inputs are just function's arguments, count `n`.
+  auto paramArgs = function.getArgumentsWithoutIndirectResults();
+  for (auto value : paramArgs)
+    inputValues.push_back(value);
+  LLVM_DEBUG({
+    auto &s = getADDebugStream();
+    s << "Inputs in @" << function.getName() << ":\n";
+    for (auto val : inputValues)
+      s << val << '\n';
+  });
+  // Outputs are indirect result buffers and return values, count `m`.
+  collectAllFormalResultsInTypeOrder(function, outputValues);
+  LLVM_DEBUG({
+    auto &s = getADDebugStream();
+    s << "Outputs in @" << function.getName() << ":\n";
+    for (auto val : outputValues)
+      s << val << '\n';
+  });
+
+  // Propagate variedness starting from the inputs.
+  assert(variedValueSets.empty());
+  for (auto inputAndIdx : enumerate(inputValues)) {
+    auto input = inputAndIdx.value();
+    unsigned i = inputAndIdx.index();
+    variedValueSets.push_back({});
+    setVariedAndPropagateToUsers(input, i);
+  }
+
+  // Mark differentiable outputs as useful.
+  assert(usefulValueSets.empty());
+  for (auto outputAndIdx : enumerate(outputValues)) {
+    auto output = outputAndIdx.value();
+    unsigned i = outputAndIdx.index();
+    usefulValueSets.push_back({});
+    setUsefulAndPropagateToOperands(output, i);
+  }
+}
+
 void DifferentiableActivityInfo::setVariedAndPropagateToUsers(
     SILValue value, unsigned independentVariableIndex) {
   // Skip already-varied values to prevent infinite recursion.
@@ -1992,6 +2053,33 @@ void DifferentiableActivityInfo::propagateVaried(
   }
 }
 
+void DifferentiableActivityInfo::propagateVariedInwardsThroughProjections(
+    SILValue value, unsigned independentVariableIndex) {
+  // Skip `@noDerivative` struct projections.
+#define SKIP_NODERIVATIVE(INST) \
+  if (auto *sei = dyn_cast<INST##Inst>(value)) \
+    if (sei->getField()->getAttrs().hasAttribute<NoDerivativeAttr>()) \
+      return;
+  SKIP_NODERIVATIVE(StructExtract)
+  SKIP_NODERIVATIVE(StructElementAddr)
+#undef SKIP_NODERIVATIVE
+  // Set value as varied and propagate to users.
+  setVariedAndPropagateToUsers(value, independentVariableIndex);
+  auto *inst = value->getDefiningInstruction();
+  if (!inst || isa<ApplyInst>(inst))
+    return;
+  // Standard propagation.
+  for (auto &op : inst->getAllOperands())
+    propagateVariedInwardsThroughProjections(
+        op.get(), independentVariableIndex);
+}
+
+void DifferentiableActivityInfo::setUseful(SILValue value,
+                                           unsigned dependentVariableIndex) {
+  usefulValueSets[dependentVariableIndex].insert(value);
+  setUsefulAcrossArrayInitialization(value, dependentVariableIndex);
+}
+
 void DifferentiableActivityInfo::setUsefulAndPropagateToOperands(
     SILValue value, unsigned dependentVariableIndex) {
   // Skip already-useful values to prevent infinite recursion.
@@ -2057,46 +2145,31 @@ void DifferentiableActivityInfo::propagateUseful(
   }
 }
 
-void DifferentiableActivityInfo::analyze(DominanceInfo *di,
-                                         PostDominanceInfo *pdi) {
-  auto &function = getFunction();
-  LLVM_DEBUG(getADDebugStream()
-             << "Running activity analysis on @" << function.getName() << '\n');
-  // Inputs are just function's arguments, count `n`.
-  auto paramArgs = function.getArgumentsWithoutIndirectResults();
-  for (auto value : paramArgs)
-    inputValues.push_back(value);
-  LLVM_DEBUG({
-    auto &s = getADDebugStream();
-    s << "Inputs in @" << function.getName() << ":\n";
-    for (auto val : inputValues)
-      s << val << '\n';
-  });
-  // Outputs are indirect result buffers and return values, count `m`.
-  collectAllFormalResultsInTypeOrder(function, outputValues);
-  LLVM_DEBUG({
-    auto &s = getADDebugStream();
-    s << "Outputs in @" << function.getName() << ":\n";
-    for (auto val : outputValues)
-      s << val << '\n';
-  });
-
-  // Propagate variedness starting from the inputs.
-  assert(variedValueSets.empty());
-  for (auto inputAndIdx : enumerate(inputValues)) {
-    auto input = inputAndIdx.value();
-    unsigned i = inputAndIdx.index();
-    variedValueSets.push_back({});
-    setVariedAndPropagateToUsers(input, i);
-  }
-
-  // Mark differentiable outputs as useful.
-  assert(usefulValueSets.empty());
-  for (auto outputAndIdx : enumerate(outputValues)) {
-    auto output = outputAndIdx.value();
-    unsigned i = outputAndIdx.index();
-    usefulValueSets.push_back({});
-    setUsefulAndPropagateToOperands(output, i);
+void DifferentiableActivityInfo::propagateUsefulThroughAddress(
+    SILValue value, unsigned dependentVariableIndex) {
+  assert(value->getType().isAddress());
+  // Skip already-useful values to prevent infinite recursion.
+  if (isUseful(value, dependentVariableIndex))
+    return;
+  setUseful(value, dependentVariableIndex);
+  if (auto *inst = value->getDefiningInstruction())
+    propagateUseful(inst, dependentVariableIndex);
+  // Recursively propagate usefulness through users that are projections or
+  // `begin_access` instructions.
+  for (auto use : value->getUses()) {
+    // Propagate usefulness through user's operands.
+    propagateUseful(use->getUser(), dependentVariableIndex);
+    for (auto res : use->getUser()->getResults()) {
+#define SKIP_NODERIVATIVE(INST) \
+if (auto *sei = dyn_cast<INST##Inst>(res)) \
+if (sei->getField()->getAttrs().hasAttribute<NoDerivativeAttr>()) \
+continue;
+      SKIP_NODERIVATIVE(StructExtract)
+      SKIP_NODERIVATIVE(StructElementAddr)
+#undef SKIP_NODERIVATIVE
+      if (Projection::isAddressProjection(res) || isa<BeginAccessInst>(res))
+        propagateUsefulThroughAddress(res, dependentVariableIndex);
+    }
   }
 }
 
@@ -2120,10 +2193,10 @@ void DifferentiableActivityInfo::setUsefulAcrossArrayInitialization(
       // Propagate usefulness through `pointer_to_address` users' operands.
       // Note: `propagateUseful(use->getUser(), ...)` is intentionally not used
       // because it marks more values than necessary as useful, including:
-      // - The `Builtin.RawPointer` result of the intrinsic.
-      // - The `pointer_to_address` user of the `Builtin.RawPointer`.
+      // - The `RawPointer` result of the intrinsic.
+      // - The `pointer_to_address` user of the `RawPointer`.
       // - `index_addr` and `integer_literal` instructions for indexing the
-      //   `Builtin.RawPointer`.
+      //   `RawPointer`.
       for (auto use : ptai->getUses()) {
         auto *user = use->getUser();
         if (auto *si = dyn_cast<StoreInst>(user)) {
@@ -2148,61 +2221,6 @@ void DifferentiableActivityInfo::setUsefulAcrossArrayInitialization(
   }
 }
 
-void DifferentiableActivityInfo::setUseful(SILValue value,
-                                           unsigned dependentVariableIndex) {
-  usefulValueSets[dependentVariableIndex].insert(value);
-  setUsefulAcrossArrayInitialization(value, dependentVariableIndex);
-}
-
-void DifferentiableActivityInfo::propagateVariedInwardsThroughProjections(
-    SILValue value, unsigned independentVariableIndex) {
-  // Skip `@noDerivative` struct projections.
-#define SKIP_NODERIVATIVE(INST) \
-  if (auto *sei = dyn_cast<INST##Inst>(value)) \
-    if (sei->getField()->getAttrs().hasAttribute<NoDerivativeAttr>()) \
-      return;
-  SKIP_NODERIVATIVE(StructExtract)
-  SKIP_NODERIVATIVE(StructElementAddr)
-#undef SKIP_NODERIVATIVE
-  // Set value as varied and propagate to users.
-  setVariedAndPropagateToUsers(value, independentVariableIndex);
-  auto *inst = value->getDefiningInstruction();
-  if (!inst || isa<ApplyInst>(inst))
-    return;
-  // Standard propagation.
-  for (auto &op : inst->getAllOperands())
-    propagateVariedInwardsThroughProjections(
-        op.get(), independentVariableIndex);
-}
-
-void DifferentiableActivityInfo::propagateUsefulThroughAddress(
-    SILValue value, unsigned dependentVariableIndex) {
-  assert(value->getType().isAddress());
-  // Check whether value is already useful to prevent infinite recursion.
-  if (isUseful(value, dependentVariableIndex))
-    return;
-  setUseful(value, dependentVariableIndex);
-  if (auto *inst = value->getDefiningInstruction())
-    propagateUseful(inst, dependentVariableIndex);
-  // Recursively propagate usefulness through users that are projections or
-  // `begin_access` instructions.
-  for (auto use : value->getUses()) {
-    // Propagate usefulness through user's operands.
-    propagateUseful(use->getUser(), dependentVariableIndex);
-    for (auto res : use->getUser()->getResults()) {
-#define SKIP_NODERIVATIVE(INST) \
-      if (auto *sei = dyn_cast<INST##Inst>(res)) \
-        if (sei->getField()->getAttrs().hasAttribute<NoDerivativeAttr>()) \
-          continue;
-      SKIP_NODERIVATIVE(StructExtract)
-      SKIP_NODERIVATIVE(StructElementAddr)
-#undef SKIP_NODERIVATIVE
-      if (Projection::isAddressProjection(res) || isa<BeginAccessInst>(res))
-        propagateUsefulThroughAddress(res, dependentVariableIndex);
-    }
-  }
-}
-
 bool DifferentiableActivityInfo::isVaried(
     SILValue value, unsigned independentVariableIndex) const {
   assert(independentVariableIndex < variedValueSets.size() &&
@@ -2212,9 +2230,9 @@ bool DifferentiableActivityInfo::isVaried(
 }
 
 bool DifferentiableActivityInfo::isVaried(
-    SILValue value, IndexSubset *parameterIndices) const {
-  for (auto paramIdx : parameterIndices->getIndices())
-    if (isVaried(value, paramIdx))
+    SILValue value, IndexSubset *independentVariableIndices) const {
+  for (auto i : independentVariableIndices->getIndices())
+    if (isVaried(value, i))
       return true;
   return false;
 }
@@ -2239,14 +2257,6 @@ Activity DifferentiableActivityInfo::getActivity(
     activity |= ActivityFlags::Varied;
   if (isUseful(value, indices.source))
     activity |= ActivityFlags::Useful;
-  return activity;
-}
-
-Activity DifferentiableActivityInfo::getActivity(
-    SILInstruction *inst, const SILAutoDiffIndices &indices) const {
-  Activity activity;
-  for (auto result : inst->getResults())
-    activity |= getActivity(result, indices);
   return activity;
 }
 

--- a/test/AutoDiff/activity_analysis.swift
+++ b/test/AutoDiff/activity_analysis.swift
@@ -71,10 +71,10 @@ func testArrayUninitializedIntrinsic(_ x: Float, _ y: Float) -> [Float] {
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [ACTIVE]   %6 = apply %5<Float>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
-// CHECK: [VARIED]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
+// CHECK: [ACTIVE] (%7, **%8**) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
+// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [ACTIVE]   %11 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
 
 @differentiable(where T: Differentiable)
 func testArrayUninitializedIntrinsicGeneric<T>(_ x: T, _ y: T) -> [T] {
@@ -82,16 +82,16 @@ func testArrayUninitializedIntrinsicGeneric<T>(_ x: T, _ y: T) -> [T] {
 }
 
 // CHECK-LABEL: [AD] Activity info for ${{.*}}testArrayUninitializedIntrinsicGeneric{{.*}} at (source=0 parameters=(0 1))
-// CHECK: [VARIED] %0 = argument of bb0 : $*T
-// CHECK: [VARIED] %1 = argument of bb0 : $*T
+// CHECK: [ACTIVE] %0 = argument of bb0 : $*T
+// CHECK: [ACTIVE] %1 = argument of bb0 : $*T
 // CHECK: [USEFUL]   %4 = integer_literal $Builtin.Word, 2
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [ACTIVE]   %6 = apply %5<T>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
-// CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
-// CHECK: [VARIED]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*T
-// CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
-// CHECK: [VARIED]   %12 = index_addr %9 : $*T, %11 : $Builtin.Word
+// CHECK: [ACTIVE] (%7, **%8**) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
+// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*T
+// CHECK: [ACTIVE]   %11 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %12 = index_addr %9 : $*T, %11 : $Builtin.Word
 
 // TF-952: Test array literal initialized from an address (e.g. `var`).
 @differentiable
@@ -101,24 +101,24 @@ func testArrayUninitializedIntrinsicAddress(_ x: Float, _ y: Float) -> [Float] {
   return [result, result]
 }
 // CHECK-LABEL: [AD] Activity info for ${{.*}}testArrayUninitializedIntrinsicAddress{{.*}} at (source=0 parameters=(0 1))
-// CHECK: [VARIED] %0 = argument of bb0 : $Float
-// CHECK: [VARIED] %1 = argument of bb0 : $Float
-// CHECK: [VARIED]   %4 = alloc_stack $Float, var, name "result"
-// CHECK: [VARIED]   %7 = begin_access [read] [static] %4 : $*Float
-// CHECK: [VARIED]   %8 = load [trivial] %7 : $*Float
+// CHECK: [ACTIVE] %0 = argument of bb0 : $Float
+// CHECK: [ACTIVE] %1 = argument of bb0 : $Float
+// CHECK: [ACTIVE]   %4 = alloc_stack $Float, var, name "result"
+// CHECK: [ACTIVE]   %7 = begin_access [read] [static] %4 : $*Float
+// CHECK: [ACTIVE]   %8 = load [trivial] %7 : $*Float
 // CHECK: [NONE]   // function_ref static Float.* infix(_:_:)
-// CHECK: [VARIED]   %11 = apply %10(%8, %1, %6) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
-// CHECK: [VARIED]   %12 = begin_access [modify] [static] %4 : $*Float
+// CHECK: [ACTIVE]   %11 = apply %10(%8, %1, %6) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK: [ACTIVE]   %12 = begin_access [modify] [static] %4 : $*Float
 // CHECK: [USEFUL]   %15 = integer_literal $Builtin.Word, 2
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [ACTIVE]   %17 = apply %16<Float>(%15) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%18**, %19) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED] (%18, **%19**) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED]   %20 = pointer_to_address %19 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [VARIED]   %21 = begin_access [read] [static] %4 : $*Float
-// CHECK: [VARIED]   %24 = integer_literal $Builtin.Word, 1
-// CHECK: [VARIED]   %25 = index_addr %20 : $*Float, %24 : $Builtin.Word
-// CHECK: [VARIED]   %26 = begin_access [read] [static] %4 : $*Float
+// CHECK: [ACTIVE] (%18, **%19**) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
+// CHECK: [ACTIVE]   %20 = pointer_to_address %19 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [ACTIVE]   %21 = begin_access [read] [static] %4 : $*Float
+// CHECK: [ACTIVE]   %24 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %25 = index_addr %20 : $*Float, %24 : $Builtin.Word
+// CHECK: [ACTIVE]   %26 = begin_access [read] [static] %4 : $*Float
 
 // TF-952: Test array literal initialized with function call results.
 @differentiable

--- a/test/AutoDiff/activity_analysis.swift
+++ b/test/AutoDiff/activity_analysis.swift
@@ -71,10 +71,10 @@ func testArrayUninitializedIntrinsic(_ x: Float, _ y: Float) -> [Float] {
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [ACTIVE]   %6 = apply %5<Float>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [ACTIVE] (%7, **%8**) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [ACTIVE]   %11 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
+// CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
+// CHECK: [VARIED]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
+// CHECK: [VARIED]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
 
 @differentiable(where T: Differentiable)
 func testArrayUninitializedIntrinsicGeneric<T>(_ x: T, _ y: T) -> [T] {
@@ -88,10 +88,10 @@ func testArrayUninitializedIntrinsicGeneric<T>(_ x: T, _ y: T) -> [T] {
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [ACTIVE]   %6 = apply %5<T>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
-// CHECK: [ACTIVE] (%7, **%8**) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
-// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*T
-// CHECK: [ACTIVE]   %11 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %12 = index_addr %9 : $*T, %11 : $Builtin.Word
+// CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
+// CHECK: [VARIED]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*T
+// CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
+// CHECK: [VARIED]   %12 = index_addr %9 : $*T, %11 : $Builtin.Word
 
 // TF-952: Test array literal initialized from an address (e.g. `var`).
 @differentiable
@@ -113,11 +113,11 @@ func testArrayUninitializedIntrinsicAddress(_ x: Float, _ y: Float) -> [Float] {
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [ACTIVE]   %17 = apply %16<Float>(%15) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%18**, %19) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [ACTIVE] (%18, **%19**) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [ACTIVE]   %20 = pointer_to_address %19 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [VARIED] (%18, **%19**) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
+// CHECK: [VARIED]   %20 = pointer_to_address %19 : $Builtin.RawPointer to [strict] $*Float
 // CHECK: [ACTIVE]   %21 = begin_access [read] [static] %4 : $*Float
-// CHECK: [ACTIVE]   %24 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %25 = index_addr %20 : $*Float, %24 : $Builtin.Word
+// CHECK: [VARIED]   %24 = integer_literal $Builtin.Word, 1
+// CHECK: [VARIED]   %25 = index_addr %20 : $*Float, %24 : $Builtin.Word
 // CHECK: [ACTIVE]   %26 = begin_access [read] [static] %4 : $*Float
 
 // TF-952: Test array literal initialized with function call results.

--- a/test/AutoDiff/array.swift
+++ b/test/AutoDiff/array.swift
@@ -49,11 +49,8 @@ ArrayAutoDiffTests.testWithLeakChecking("ArrayLiteral") {
     }
     let pb = pullback(at: 3, 4, in: twoElementLiteralAddress)
     let (gradX, gradY) = pb(TrackedFloatArrayTan([1, 1]))
-    // FIXME(TF-952): Fix incorrect zero derivatives.
-    // expectEqual(8, gradX)
-    // expectEqual(6, gradY)
-    expectEqual(0, gradX)
-    expectEqual(0, gradY)
+    expectEqual(8, gradX)
+    expectEqual(6, gradY)
   }
 
   do {


### PR DESCRIPTION
Previously, `setUsefulAcrossArrayInitialization` used ad-hoc logic to
propagate usefulness to `pointer_to_address` users. However, there were
at least two unhandled cases:
- `copy_addr` user of `pointer_to_address` result.
- `copy_addr` user of `index_addr` user of `pointer_to_address` result.

Now, `setUsefulAcrossArrayInitialization` calls `propagateUseful` to
propagate usefulness through `pointer_to_address` users' operands.

Update correctness and activity analysis tests.

Partially resolves TF-952.

---

Depends on https://github.com/apple/swift/pull/28258; rebase after it is merged.