### PR TITLE
Optimize string switch

### DIFF
--- a/include/swift/AST/SemanticAttrs.h
+++ b/include/swift/AST/SemanticAttrs.h
@@ -24,7 +24,8 @@
 
 namespace swift {
 namespace semantics {
-#define SEMANTICS_ATTR(NAME, C_STR) constexpr static const StringLiteral NAME = C_STR;
+#define SEMANTICS_ATTR(NAME, C_STR)                                            \
+  constexpr static const StringLiteral NAME = C_STR;
 #include "SemanticAttrs.def"
 }
 }

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -332,6 +332,8 @@ PASS(StackPromotion, "stack-promotion",
      "Stack Promotion of Class Objects")
 PASS(StripDebugInfo, "strip-debug-info",
      "Strip Debug Information")
+PASS(StringSwitchPass, "string-switch",
+     "Optimize one or many comparisons of one string to one of many string literals")
 PASS(StringOptimization, "string-optimization",
      "Optimization for String operations")
 PASS(SwiftArrayPropertyOpt, "array-property-opt",

--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -24,9 +24,12 @@
 #ifndef SWIFT_SILOPTIMIZER_CONSTEXPR_H
 #define SWIFT_SILOPTIMIZER_CONSTEXPR_H
 
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILFunction.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 namespace swift {
@@ -39,6 +42,132 @@ class SymbolicValue;
 class SymbolicValueAllocator;
 class ConstExprFunctionState;
 class UnknownReason;
+
+/// This class is a utility used for evaluating string literals. It retrieves
+/// info about the string and allows conversion from a swift string literal to a
+/// StringRef. The class is designed to be used in conjunction with
+/// SILInstructions or SILValues.
+class StringLiteralInitializerInfo {
+  StringLiteralInitializerInfo() = default;
+
+public:
+  bool isAscii;
+  StringRef value;
+  StringLiteralInst *inst;
+
+  /// Create an instance of StringLiteralInitializerInfo by casting v to an
+  /// ApplyInst.
+  ///
+  /// \param v SILValue to be cast to ApplyInst and used in creation of the
+  /// string literal. v should be an ApplyInst that calls a function with the
+  /// semantic attribute "string.makeUTF8".
+  static Optional<StringLiteralInitializerInfo> getFromCallsite(SILValue v) {
+    if (auto *inst = dyn_cast<ApplyInst>(v))
+      return getFromCallsite(inst);
+    return {};
+  }
+
+  /// Create an instance of StringLiteralInitializerInfo using inst.
+  ///
+  /// \param inst The instruction to be used in creation of the string literal.
+  /// inst should be an ApplyInst that calls a function with the semantic
+  /// attribute "string.makeUTF8".
+  static Optional<StringLiteralInitializerInfo>
+  getFromCallsite(SILInstruction *inst) {
+    ApplyInst *makeStr = getStringMakeUTF8Apply(inst);
+    if (!makeStr)
+      return {};
+
+    auto strVal = getUTF8StringValue(makeStr);
+    if (!strVal)
+      return {};
+
+    StringLiteralInitializerInfo info;
+    info.value = strVal.getValue();
+    info.isAscii = getIsAscii(makeStr);
+    info.inst = getUTF8String(makeStr);
+    return info;
+  }
+
+  /// If the given instruction is a call to the compiler-intrinsic initializer
+  /// of String that accepts string literals, return the called function.
+  /// Otherwise, return nullptr.
+  ///
+  /// \param inst Should be an ApplyInst that calls the string init function:
+  /// \code
+  ///  String(_builtinStringLiteral start: Builtin.RawPointer,
+  ///         utf8CodeUnitCount: Builtin.Word,
+  ///         isASCII: Builtin.Int1)
+  /// \endcode
+  /// with the semantic attribute "string.makeUTF8"
+  static SILFunction *getStringMakeUTF8InitFunction(SILInstruction *inst) {
+    if (auto apply = getStringMakeUTF8Apply(inst))
+      return apply->getCalleeFunction();
+    return nullptr;
+  }
+
+  /// Similar to getStringMakeUTF8Init but, gets the apply instruction instead.
+  static ApplyInst *getStringMakeUTF8Apply(SILInstruction *inst) {
+    auto *apply = dyn_cast<ApplyInst>(inst);
+    if (!apply)
+      return nullptr;
+
+    SILFunction *callee = apply->getCalleeFunction();
+    if (!callee || !callee->hasSemanticsAttr(semantics::STRING_MAKE_UTF8))
+      return nullptr;
+    return apply;
+  }
+
+  /// \returns a StringLiteralInst pointer from a string init function if \p
+  /// makeStr is an ApplyInst that calls a function with the semantics attribute
+  /// 'string.makeUTF8', and if its first argument is a StringLiteralInst.
+  /// Otherwise, the pointer will be null.
+  static StringLiteralInst *getUTF8String(ApplyInst *makeStr) {
+    SILFunction *callee = makeStr->getCalleeFunction();
+    if (!callee || !callee->hasSemanticsAttr(semantics::STRING_MAKE_UTF8))
+      return nullptr;
+
+    if (makeStr->getNumArguments() < 1)
+      return nullptr;
+
+    return dyn_cast<StringLiteralInst>(makeStr->getOperand(1));
+  }
+
+  /// \returns an optional StringRef from a string init function if \p makeStr
+  /// is an ApplyInst that calls a function with the semantics attribute
+  /// 'string.makeUTF8', and if its first argument is a StringLiteralInst.
+  static Optional<StringRef> getUTF8StringValue(ApplyInst *makeStr) {
+    if (auto stringLiteralInst = getUTF8String(makeStr)) {
+      return stringLiteralInst->getValue();
+    }
+
+    return {};
+  }
+
+  /// \returns the third argument of the string initialization function, which
+  /// describes whether the string is ASCII, only if \p makeStr is an ApplyInst
+  /// that calls a function with the semantics attribute 'string.makeUTF8', and
+  /// if its third argument is an IntegerLiteralInst. Otherwise, returns false.
+  ///
+  /// \p makeStr must call a function with the following form:
+  /// \code
+  ///  String(_builtinStringLiteral start: Builtin.RawPointer,
+  ///         utf8CodeUnitCount: Builtin.Word,
+  ///         isASCII: Builtin.Int1)
+  /// \endcode
+  static bool getIsAscii(ApplyInst *makeStr) {
+    SILFunction *callee = makeStr->getCalleeFunction();
+    if (!callee || !callee->hasSemanticsAttr(semantics::STRING_MAKE_UTF8))
+      return {};
+
+    if (makeStr->getNumArguments() < 3)
+      return false;
+
+    if (auto *isAscii = dyn_cast<IntegerLiteralInst>(makeStr->getOperand(3)))
+      return isAscii->getValue().getBoolValue();
+    return false;
+  }
+};
 
 /// This class is the main entrypoint for evaluating constant expressions.  It
 /// also handles caching of previously computed constexpr results.

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -117,20 +117,6 @@ static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
 
 namespace {
 
-/// If the given instruction is a call to the compiler-intrinsic initializer
-/// of String that accepts string literals, return the called function.
-/// Otherwise, return nullptr.
-static SILFunction *getStringMakeUTF8Init(SILInstruction *inst) {
-  auto *apply = dyn_cast<ApplyInst>(inst);
-  if (!apply)
-    return nullptr;
-
-  SILFunction *callee = apply->getCalleeFunction();
-  if (!callee || !callee->hasSemanticsAttr(semantics::STRING_MAKE_UTF8))
-    return nullptr;
-  return callee;
-}
-
 // A cache of string-related, SIL information that is needed to create and
 // initalize strings from raw string literals. This information is
 // extracted from instructions while they are constant evaluated. Though the
@@ -152,7 +138,8 @@ public:
     if (stringInitIntrinsic)
       return;
 
-    SILFunction *callee = getStringMakeUTF8Init(inst);
+    SILFunction *callee =
+        StringLiteralInitializerInfo::getStringMakeUTF8InitFunction(inst);
     if (!callee)
       return;
 
@@ -298,7 +285,8 @@ static bool isFoldableIntOrBool(SILValue value, ASTContext &astContext) {
 static bool isFoldableString(SILValue value, ASTContext &astContext) {
   return isStringType(value->getType(), astContext) &&
          (!isa<ApplyInst>(value) ||
-          !getStringMakeUTF8Init(cast<ApplyInst>(value)));
+          !StringLiteralInitializerInfo::getStringMakeUTF8InitFunction(
+              cast<ApplyInst>(value)));
 }
 
 /// Return true iff the given value is an array and is not an initialization

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -218,6 +218,7 @@ void addSimplifyCFGSILCombinePasses(SILPassPipelinePlan &P) {
   P.addSILCombine();
   // Which can expose opportunity for simplifcfg.
   P.addSimplifyCFG();
+  P.addStringSwitchPass();
 }
 
 /// Perform semantic annotation/loop base optimizations.

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(swiftSILOptimizer PRIVATE
   SpeculativeDevirtualizer.cpp
   StackPromotion.cpp
   StringOptimization.cpp
+  StringSwitch.cpp
   TempLValueOpt.cpp
   TempRValueElimination.cpp
   UnsafeGuaranteedPeephole.cpp)

--- a/lib/SILOptimizer/Transforms/StringSwitch.cpp
+++ b/lib/SILOptimizer/Transforms/StringSwitch.cpp
@@ -1,0 +1,347 @@
+//===--- StringSwitch.cpp - Optimization of string comparisons ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/ConstExpr.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
+#include "llvm/ADT/MapVector.h"
+
+using namespace swift;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+//                            StringSwitchPass
+//===----------------------------------------------------------------------===//
+
+// Optimize multiple string literal comparisons against a single String type.
+// This can be used to optimize a series of string comparison ifs
+// or, more commonly, a string-switch-statement.
+class StringSwitchPass : public SILFunctionTransform {
+  // Keep track of our current function.
+  SILFunction *F;
+
+  bool
+  optimizeStringCompare(SmallVectorImpl<StringLiteralInst *> &stringLiterals,
+                        SmallVectorImpl<ApplyInst *> &stringCompares,
+                        SILValue subject) {
+    // Set the insert point after the subject.
+    SILInstruction *insertionPoint = isa<SILArgument>(subject)
+                                         ? &subject->getParentBlock()->front()
+                                         : subject.getDefiningInstruction();
+
+    SILBuilder builder(std::next(insertionPoint->getIterator()));
+    SILOptFunctionBuilder funcBuilder(*this);
+
+    // Clone the string literals right after the subject so that we don't have
+    // dominance errors later.
+    for (auto i : indices(stringLiterals)) {
+      auto *str = stringLiterals[i];
+      auto newStr = builder.createStringLiteral(str->getLoc(), str->getValue(),
+                                                str->getEncoding());
+      stringLiterals[i] = newStr;
+    }
+
+    auto dummyLoc = F->getLocation();
+    SmallVector<ValueDecl *, 1> results;
+    // We'll let ObjectOutliner::replaceFindStringCall do the heavy lifting.
+    builder.getASTContext().lookupInSwiftModule("_findStringSwitchCase",
+                                                results);
+    assert(results.size());
+    if (results.size() != 1)
+      return false;
+
+    auto *funcDecl = dyn_cast<FuncDecl>(results.front());
+    if (!funcDecl)
+      return false;
+
+    auto funcDeclRef = SILDeclRef(funcDecl, SILDeclRef::Kind::Func);
+    auto replacementFunc = funcBuilder.getOrCreateFunction(
+        dummyLoc, funcDeclRef, ForDefinition_t::NotForDefinition);
+    if (!replacementFunc)
+      return false;
+
+    results.pop_back();
+    // Look up "assert" to get the StaticString type.
+    builder.getASTContext().lookupInSwiftModule("assert", results);
+    assert(results.size());
+    if (results.size() != 1)
+      return false;
+
+    funcDecl = dyn_cast<FuncDecl>(results.front());
+    if (!funcDecl)
+      return false;
+
+    funcDeclRef = SILDeclRef(funcDecl, SILDeclRef::Kind::Func);
+    SILFunction *assertFn = funcBuilder.getOrCreateFunction(
+        dummyLoc, funcDeclRef, ForDefinition_t::NotForDefinition);
+    if (!assertFn)
+      return false;
+
+    FuncDecl *arrayAllocateDecl =
+        builder.getASTContext().getAllocateUninitializedArray();
+    assert(arrayAllocateDecl);
+    std::string allocatorMangledName =
+        SILDeclRef(arrayAllocateDecl, SILDeclRef::Kind::Func).mangle();
+    SILFunction *arrayAllocateFn = builder.getModule().findFunction(
+        allocatorMangledName, SILLinkage::PublicExternal);
+    if (!arrayAllocateFn)
+      return false;
+
+    FuncDecl *arrayFinalizeDecl =
+        builder.getASTContext().getFinalizeUninitializedArray();
+    std::string finalizeMangledName =
+        SILDeclRef(arrayFinalizeDecl, SILDeclRef::Kind::Func).mangle();
+    SILFunction *arrayFinalizeFn = builder.getModule().findFunction(
+        finalizeMangledName, SILLinkage::SharedExternal);
+    if (!arrayFinalizeFn)
+      return false;
+    builder.getModule().linkFunction(arrayFinalizeFn);
+
+    // General variables we'll need later.
+    auto wordTy = SILType::getBuiltinWordType(builder.getASTContext());
+    auto byteTy = SILType::getBuiltinIntegerType(8, builder.getASTContext());
+    auto boolTy = SILType::getBuiltinIntegerType(1, builder.getASTContext());
+    auto i32Ty = SILType::getBuiltinIntegerType(32, builder.getASTContext());
+    auto assertFnFuncTy = assertFn->getLoweredFunctionType();
+    auto staticStringBaseTy =
+        assertFnFuncTy->getParameters()[2].getSILStorageInterfaceType();
+    auto staticStringTy = staticStringBaseTy.getObjectType();
+    auto staticStringAddrTy = staticStringBaseTy.getAddressType();
+    auto replacementFuncTy = replacementFunc->getLoweredFunctionType();
+    auto staticStringArrayTy = replacementFuncTy->getParameters()[0]
+                                   .getSILStorageInterfaceType()
+                                   .getAddressType();
+    auto boolObjTy = SILType::getPrimitiveObjectType(builder.getASTContext()
+                                                         .getBoolDecl()
+                                                         ->getDeclaredType()
+                                                         ->getCanonicalType());
+
+    // Move all the strings to the top of the function.
+    for (auto *str : stringLiterals) {
+      str->moveBefore(stringLiterals.front());
+    }
+
+    // Build an array of static strings.
+    auto staticStringSubst =
+        staticStringArrayTy.getASTType()->getContextSubstitutionMap(
+            builder.getModule().getSwiftModule(),
+            builder.getASTContext().getArrayDecl());
+    auto size =
+        builder.createIntegerLiteral(dummyLoc, wordTy, stringLiterals.size());
+    auto makeArrayRef = builder.createFunctionRef(dummyLoc, arrayAllocateFn);
+    auto arrayTuple =
+        builder.createApply(dummyLoc, makeArrayRef, staticStringSubst, {size});
+    auto arrayRawPtr = builder.createTupleExtract(dummyLoc, arrayTuple, 1);
+    SILValue array = builder.createTupleExtract(dummyLoc, arrayTuple, 0);
+    auto arrayAddr = builder.createPointerToAddress(dummyLoc, arrayRawPtr,
+                                                    staticStringAddrTy,
+                                                    /*is strct*/ true);
+    auto ptrToIntName = builder.getASTContext().getIdentifier("ptrtoint_Word");
+    // Add the strings literals to the array of static strings.
+    size_t index = 0;
+    for (auto *str : stringLiterals) {
+      auto elementIndex =
+          builder.createIntegerLiteral(dummyLoc, wordTy, index++);
+      auto arrayIndexAddr =
+          builder.createIndexAddr(dummyLoc, arrayAddr, elementIndex);
+      // Build the static string.
+      auto strPtr = builder.createBuiltin(dummyLoc, ptrToIntName, wordTy,
+                                          SubstitutionMap(), {str});
+      // TODO: better way to get the string size?
+      auto strSize = builder.createIntegerLiteral(dummyLoc, wordTy,
+                                                  str->getValue().size());
+      auto strOpts = builder.createIntegerLiteral(dummyLoc, byteTy,
+                                                  2); // See StaticString._flags
+      auto staticString = builder.createStruct(dummyLoc, staticStringTy,
+                                               {strPtr, strSize, strOpts});
+      // Store it in the array.
+      builder.createStore(dummyLoc, staticString, arrayIndexAddr,
+                          StoreOwnershipQualifier::Unqualified);
+    }
+
+    // "Finalize" the array of static strings.
+    auto finalizeFnRef = builder.createFunctionRef(dummyLoc, arrayFinalizeFn);
+    array = builder.createApply(dummyLoc, finalizeFnRef, staticStringSubst,
+                                {array});
+
+    // Generate a call to the new comparison function.
+    auto replacementRef = builder.createFunctionRef(dummyLoc, replacementFunc);
+    auto cmpResultInt = builder.createApply(
+        dummyLoc, replacementRef, SubstitutionMap(), {array, subject});
+    auto cmpResultExtract = builder.createStructExtract(
+        dummyLoc, cmpResultInt,
+        builder.getASTContext().getIntDecl()->getStoredProperties()[0]);
+    // `_findStringSwitchCase` returns an Int32 but for some reason
+    // `select_value` promotes this to an Int64 creating issues in some cases.
+    auto cmpResult =
+        builder.createUncheckedBitCast(dummyLoc, cmpResultExtract, i32Ty);
+
+    // Update all the string comparisons to compare the result of the
+    // new comparison function.
+    index = 0;
+    std::map<StringRef, unsigned> indexMap;
+    for (auto *cmp : stringCompares) {
+      SILBuilder stringCompareBuilder(cmp);
+
+      // It's possible that we will compare against two strings that are equal.
+      // In this case, use the index of the other string (because that's what
+      // will be returned from `_findStringSwitchCase`).
+      unsigned findResultIndex;
+      // If we've already counted this string, then use that index.
+      if (indexMap.count(stringLiterals[index]->getValue())) {
+        findResultIndex = indexMap[stringLiterals[index]->getValue()];
+      } else {
+        // Otherwise use the current index and record it for later.
+        findResultIndex = index;
+        indexMap[stringLiterals[index]->getValue()] = index;
+      }
+      // Either way, make sure to increment the index for the next iteration.
+      index++;
+
+      auto elementIndex = stringCompareBuilder.createIntegerLiteral(
+          dummyLoc, i32Ty, findResultIndex);
+      auto newCmp = stringCompareBuilder.createBuiltinBinaryFunction(
+          dummyLoc, "cmp_eq", i32Ty, boolTy, {elementIndex, cmpResult});
+      auto newResult =
+          stringCompareBuilder.createStruct(dummyLoc, boolObjTy, {newCmp});
+      cmp->replaceAllUsesWith(newResult);
+      // Remove the apply so that we don't find it when we run this pass again.
+      cmp->eraseFromParent();
+    }
+
+    return true;
+  }
+
+public:
+  StringSwitchPass() = default;
+
+  /// The entry point to the transformation.
+  void run() override {
+    F = getFunction();
+
+    // A vector of string literals and string compares that are associated with
+    // a single subject stirng.
+    struct CompareSet {
+      SmallVector<StringLiteralInst *, 12> stringLiterals;
+      SmallVector<ApplyInst *, 12> stringCompares;
+    };
+
+    // Maps the 'subject' to a list of string-compare sets. The elements in the
+    // set are vectors of string compares and string literals where the
+    // dominance order is valid such that movement between the blocks (if any)
+    // will not cause issue.
+    llvm::MapVector<SILValue, SmallVector<CompareSet, 1>> compareMap;
+    // A map where each element is all the string literals used in a series of
+    // comparisons agains one "normal" (the key).
+    SILValue subject;
+
+    DominanceAnalysis *domAnalysis = PM->getAnalysis<DominanceAnalysis>();
+    DominanceInfo *domInfo = domAnalysis->get(F);
+    DominanceOrder domOrder(&F->front(), domInfo);
+
+    // Iterate through all the blocks in the function using dominance order
+    // so that we don't miss the first comparison because we started with the
+    // seconcd comparison (hypothetically).
+    while (auto *block = domOrder.getNext()) {
+      domOrder.pushChildren(block);
+
+      for (auto &inst : *block) {
+        auto *apply = dyn_cast<ApplyInst>(&inst);
+        if (!apply || !apply->getReferencedFunctionOrNull())
+          continue;
+        // Filter out the string.equals functions.
+        if (!apply->getReferencedFunctionOrNull()->hasSemanticsAttr(
+                semantics::STRING_EQUALS))
+          continue;
+
+        unsigned subjectArgIndex = 1;
+        auto info = StringLiteralInitializerInfo::getFromCallsite(
+            apply->getArgument(0));
+        if (!info) {
+          info = StringLiteralInitializerInfo::getFromCallsite(
+              apply->getArgument(1));
+          subjectArgIndex = 0;
+        }
+        // TODO: currently, we don't support non-ascii strings. In the future
+        // we could support these strings, though.
+        if (!info || !info->isAscii)
+          continue;
+
+        // Now that we know the subject's argument index, we can figure out
+        // what it is.
+        subject = apply->getArgument(subjectArgIndex);
+
+        // It's possible that we have two string compares against the same
+        // subject that are unrelated. For example:
+        // if ... { compare1 } else { compare2 }
+        // In this case, we check every set associated with our subject and if
+        // one succeeds we will add it to that set.
+        // Otherwise, we will create a new set.
+        bool foundOthers = false;
+        for (auto &otherSet : compareMap[subject]) {
+          // If we've already collected one comparison and the first string
+          // literal isn't dominated by the comparison call, then continue
+          // allowing a new set to be added to the map.
+          if (!otherSet.stringLiterals.empty() &&
+              !domAnalysis->get(F)->dominates(otherSet.stringLiterals.front(),
+                                              apply))
+            continue;
+
+          foundOthers = true;
+
+          // Add this to the compareMap for its corresponding "subject".
+          otherSet.stringLiterals.push_back(info.getValue().inst);
+          otherSet.stringCompares.push_back(apply);
+        }
+
+        // If we haven't found any sets associated with our subject where we
+        // could add this compare / literal, then create a new set associated
+        // with our subject.
+        if (!foundOthers) {
+          CompareSet &newSet = compareMap[subject].emplace_back();
+          newSet.stringLiterals.push_back(info.getValue().inst);
+          newSet.stringCompares.push_back(apply);
+        }
+      }
+    }
+
+    // Go through the compareMap and figure out if we made any changes.
+    bool madeChange = false;
+    // Find all the sets that are related to a subject.
+    for (auto &item : compareMap) {
+      // Try to optimize each set that is related to a subject.
+      for (auto &associatedSet : item.second) {
+        if (associatedSet.stringCompares.size() < 2)
+          continue;
+
+        madeChange |=
+            optimizeStringCompare(associatedSet.stringLiterals,
+                                  associatedSet.stringCompares, item.first);
+      }
+    }
+
+    // Make sure we clear the list before running again.
+    compareMap.clear();
+    if (madeChange)
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createStringSwitchPass() { return new StringSwitchPass(); }

--- a/test/SILOptimizer/string_switch.sil
+++ b/test/SILOptimizer/string_switch.sil
@@ -1,0 +1,66 @@
+// RUN: %target-swift-frontend -primary-file %s -O -emit-sil | %FileCheck %s
+
+import Builtin
+import Swift
+import SwiftShims
+
+// Make sure that we are able to optimize out of order blocks
+
+// CHECK-LABEL: sil @test
+// CHECK: function_ref @${{.*}}_findStringSwitchCase5case{{.*}}
+sil @test_ss : $@convention(thin) (@guaranteed String) -> Bool {
+bb0(%0 : $String):
+  %2 = metatype $@thin String.Type
+  %3 = integer_literal $Builtin.Word, 1
+  %4 = integer_literal $Builtin.Int1, -1
+  br bb2
+bb1(%5 : $Builtin.RawPointer, %6 : $Builtin.RawPointer):
+  // function_ref String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+  %7 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %8 = apply %7(%5, %3, %4, %2) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %9 = apply %7(%6, %3, %4, %2) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  // function_ref static String.== infix(_:_:)
+  %10 = function_ref @$sSS2eeoiySbSS_SStFZ : $@convention(method) (@guaranteed String, @guaranteed String, @thin String.Type) -> Bool
+  %11 = apply %10(%0, %8, %2) : $@convention(method) (@guaranteed String, @guaranteed String, @thin String.Type) -> Bool
+  %12 = apply %10(%0, %9, %2) : $@convention(method) (@guaranteed String, @guaranteed String, @thin String.Type) -> Bool
+  br bb3(%11 : $Bool, %12 : $Bool)
+bb2:
+  %13 = string_literal utf8 "a"
+  %14 = string_literal utf8 "b"
+  br bb1(%13 : $Builtin.RawPointer, %14 : $Builtin.RawPointer)
+bb3(%15 : $Bool, %16 : $Bool):
+  %17 = struct_extract %15 : $Bool, #Bool._value
+  cond_br %17, bb4, bb5
+bb4:
+  br bb6(%16 : $Bool)
+bb5:
+  %18 = integer_literal $Builtin.Int1, 0
+  %19 = struct $Bool (%18 : $Builtin.Int1)
+  br bb6(%19 : $Bool)
+bb6(%20 : $Bool):
+  return %20 : $Bool
+}
+
+// static String.== infix(_:_:)
+sil [serialized] [always_inline] [readonly] [_semantics "string.equals"] @$sSS2eeoiySbSS_SStFZ : $@convention(method) (@guaranteed String, @guaranteed String, @thin String.Type) -> Bool
+
+// _allocateUninitializedArray<A>(_:)
+sil [serialized] [always_inline] [_semantics "array.uninitialized_intrinsic"] @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+
+// StaticString.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+sil [transparent] [serialized] [readonly] @$ss12StaticStringV08_builtinB7Literal17utf8CodeUnitCount7isASCIIABBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin StaticString.Type) -> StaticString
+
+// Array.init(arrayLiteral:)
+sil [serialized] @$sSa12arrayLiteralSayxGxd_tcfC : $@convention(method) <τ_0_0> (@owned Array<τ_0_0>, @thin Array<τ_0_0>.Type) -> @owned Array<τ_0_0>
+
+// _findStringSwitchCase(cases:string:)
+sil [_semantics "findStringSwitchCase"] @$ss21_findStringSwitchCase5cases6stringSiSays06StaticB0VG_SStF : $@convention(thin) (@guaranteed Array<StaticString>, @guaranteed String) -> Int
+
+// Int.init(_builtinIntegerLiteral:)
+sil [transparent] [serialized] @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+
+// ~= infix<A>(_:_:)
+sil [transparent] [serialized] @$ss2teoiySbx_xtSQRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> Bool
+
+// String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+sil [serialized] [always_inline] [readonly] [_semantics "string.makeUTF8"] @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String

--- a/test/SILOptimizer/string_switch.swift
+++ b/test/SILOptimizer/string_switch.swift
@@ -1,0 +1,165 @@
+// RUN: %target-swift-frontend -primary-file %s -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -module-name=test -emit-sil -enforce-exclusivity=unchecked | %FileCheck %s
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// REQUIRES: executable_test
+
+import Swift
+
+// CHECK-LABEL: sil @$s4test5test03strSiSS_tF : $@convention(thin) (@guaranteed String) -> Int
+
+// CHECK: [[FN:%[0-9]+]] = function_ref @${{.*}}_findStringSwitchCase
+// CHECK-NOT: _findStringSwitchCase
+// CHECK: [[CMP:%[0-9]+]] = apply [[FN]]
+// CHECK: [[CMP_RES:%[0-9]+]] = struct_extract [[CMP]]
+// CHECK: [[CMP_RES_32:%[0-9]+]] = unchecked_trivial_bit_cast [[CMP_RES]] : $Builtin.Int64 to $Builtin.Int32
+// CHECK: [[ZERO:%[0-9]+]] = integer_literal $Builtin.Int32, 0
+// CHECK: [[ICMP:%[0-9]+]] = builtin "cmp_eq_Int32"([[CMP_RES_32]] : $Builtin.Int32, [[ZERO]] : $Builtin.Int32) : $Builtin.Int1
+// CHECK: cond_br [[ICMP]], [[BB3:.*]], [[BB4:.*]] //
+
+// CHECK: [[BB3]]:
+// CHECK: [[ZERO:%.*]] = integer_literal $Builtin.{{Int64|Int32}}, 0
+// CHECK: br [[DONE:.*]]([[ZERO]]
+
+// CHECK: [[BB4]]:
+// CHECK: [[ONE:%.*]] = integer_literal $Builtin.Int32, 1
+// CHECK: [[ICMP2:%.*]] = builtin "cmp_eq_Int32"([[CMP_RES_32]] : $Builtin.Int32, [[ONE]] : $Builtin.Int32) : $Builtin.Int1
+// CHECK: cond_br [[ICMP2]], [[BB5:.*]], [[BB6:.*]] //
+
+// CHECK: [[BB5]]:
+// CHECK: [[ONE_OUT:%.*]] = integer_literal $Builtin.{{Int64|Int32}}, 1
+// CHECK: br [[DONE]]([[ONE_OUT]]
+
+// CHECK: [[BB6]]:
+// CHECK: [[TWO:%.*]] = integer_literal $Builtin.Int32, 2
+// CHECK: [[ICMP3:%.*]] = builtin "cmp_eq_Int32"([[CMP_RES_32]] : $Builtin.Int32, [[TWO]] : $Builtin.Int32) : $Builtin.Int1
+// CHECK: cond_br [[ICMP3]], [[BB7:.*]], [[BB8:.*]] //
+
+// CHECK: [[BB7]]:
+// CHECK: [[TWO_OUT:%.*]] = integer_literal $Builtin.{{Int64|Int32}}, 2
+// CHECK: br [[DONE]]([[TWO_OUT]]
+
+// CHECK: [[BB8]]:
+// CHECK: [[NEGATIVE_ONE:%.*]] = integer_literal $Builtin.{{Int64|Int32}}, -1
+// CHECK: br [[DONE]]([[NEGATIVE_ONE]]
+
+// CHECK: [[DONE]]([[OUT_VAL:%.*]] : $Builtin.{{Int64|Int32}}):
+// CHECK: [[OUT_INT:%.*]] = struct $Int ([[OUT_VAL]]
+// CHECK: return [[OUT_INT]] : $Int
+
+// CHECK-LABEL: end sil function '$s4test5test03strSiSS_tF'
+public func test0(str: String) -> Int {
+  switch str {
+    case "0": return 0
+    case "2": return 1
+    case "3": return 2
+    default: return -1
+  }
+}
+
+// CHECK-LABEL: sil @$s4test5test11x5inputS2i_SStF : $@convention(thin) (Int, @guaranteed String) -> Int
+
+// CHECK: [[FN:%[0-9]+]] = function_ref @${{.*}}_findStringSwitchCase
+// CHECK-NOT: _findStringSwitchCase
+// CHECK: [[CMP1:%[0-9]+]] = apply [[FN]]
+
+// CHECK: [[CMP2:%[0-9]+]] = apply [[FN]]
+// CHECK: struct_extract [[CMP2]]
+// CHECK: [[ICMP2:%[0-9]+]] = builtin "cmp_eq_Int32"
+// CHECK: cond_br [[ICMP2]]
+
+// CHECK: struct_extract [[CMP1]]
+// CHECK: [[ICMP1:%[0-9]+]] = builtin "cmp_eq_Int32"
+// CHECK: cond_br [[ICMP1]]
+
+// CHECK-LABEL: end sil function '$s4test5test11x5inputS2i_SStF'
+public func test1(x: Int, input: String) -> Int {
+  if x == 1 {
+    if input == "a" { return 1 }
+    else if input == "aa" { return 2 }
+    return 3
+  } else {
+    if input == "x" { return x}
+    else if input == "b" { return 2 }
+    return 0
+  }
+}
+
+// CHECK-LABEL: sil @$s4test5test21xSiSaySSG_tF : $@convention(thin) (@guaranteed Array<String>) -> Int
+// CHECK: [[FN:%[0-9]+]] = function_ref @${{.*}}_findStringSwitchCase{{.*}}
+// CHECK: [[CMP:%[0-9]+]] = apply [[FN]]
+// CHECK: struct_extract [[CMP]]
+// CHECK: [[ICMP:%[0-9]+]] = builtin "cmp_eq_Int32"
+// CHECK: cond_br [[ICMP]]
+// CHECK-LABEL: end sil function '$s4test5test21xSiSaySSG_tF'
+public func test2(x: [String]) -> Int {
+  for str in x {
+    if str == "foo" { return 0 }
+    else if str == "bar" { return 1 }
+  }
+  return 1
+}
+
+// Make sure that we only optimize 2+ comparisons.
+// CHECK-LABEL: sil @$s4test5test31xSbSS_tF : $@convention(thin) (@guaranteed String) -> Bool
+// CHECK-NOT: _findStringSwitchCase
+// CHECK-LABEL: end sil function '$s4test5test31xSbSS_tF'
+public func test3(x: String) -> Bool {
+  return x == "str"
+}
+
+// TODO: we could eventually support unicode.
+// Make sure that we don't optimize unicode (non-ascii) strings. We currently
+// can't optimize these strings because C++ can't compare them correctly, so,
+// in the following case, the string "ṩ" will be added to
+// "_findStringSwitchCase" twice (because C++ thinks there are two different
+// strings). But "_findStringSwitchCase" thinks both of those strings are the
+// same, so it will always return the same index.
+// CHECK-LABEL: sil @$s4test0A7UnicodeySbSSF : $@convention(thin) (@guaranteed String) -> Bool
+// CHECK-NOT: _findStringSwitchCase
+// CHECK-LABEL: end sil function '$s4test0A7UnicodeySbSSF'
+public func testUnicode(_ subject: String) -> Bool {
+  let a = "s\u{323}\u{307}"
+  let b = "\u{1e69}"
+  let comp1 = a == subject
+  let comp2 = b == subject
+  if comp1 != comp2 { fatalError() }
+  return comp1 && comp2
+}
+
+// CHECK-OUTPUT: CHECK-ME
+print("CHECK-ME")
+// CHECK-OUTPUT-NEXT: 1
+print(test1(x: 1, input: "a"))
+// CHECK-OUTPUT-NEXT: 0
+print(test1(x: 2, input: "a"))
+// CHECK-OUTPUT-NEXT: 3
+print(test1(x: 1, input: "x"))
+// CHECK-OUTPUT-NEXT: 2
+print(test1(x: 2, input: "b"))
+// CHECK-OUTPUT-NEXT: 0
+print(test1(x: 2, input: "c"))
+
+// CHECK-OUTPUT-NEXT: 1
+print(test2(x: ["a", "b", "c"]))
+// CHECK-OUTPUT-NEXT: 0
+print(test2(x: ["foo", "b", "c"]))
+// CHECK-OUTPUT-NEXT: 0
+print(test2(x: ["a", "foo", "c"]))
+// CHECK-OUTPUT-NEXT: 0
+print(test2(x: ["a", "b", "foo"]))
+// CHECK-OUTPUT-NEXT: 0
+print(test2(x: ["foo", "bar", "x"]))
+// CHECK-OUTPUT-NEXT: 1
+print(test2(x: ["bar", "foo", "x"]))
+
+// CHECK-OUTPUT-NEXT: true
+print(testUnicode("ṩ"))
+// CHECK-OUTPUT-NEXT: true
+print(testUnicode("s\u{323}\u{307}"))
+// CHECK-OUTPUT-NEXT: true
+print(testUnicode("\u{1e69}"))
+// CHECK-OUTPUT-NEXT: false
+print(testUnicode("X"))


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch optimizes a series of string literal comparisons to a single `String` into a call to `_findStringSwitchCase`. This will reduce code size and also allow the call to be optimized into a call to `_findStringSwitchCaseWithCache` which will improve performance. 

Example:
<details><summary>Input</summary>
<p>

```swift
func test(input: String) -> Int {
  switch input {
    case "0": return 0
    case "1": return 1
    case "2": return 2
    case "3": return 3
    case "4": return 4
    case "5": return 5
    case "6": return 6
    case "7": return 7
    case "8": return 8
    case "9": return 9
    default: return 0
  }
}
```

</p>
</details>

<details><summary>Old Output (SIL 406 lines, Assembly 171 lines)</summary>
<p>

**SIL**
```
// test(input:)
sil hidden @$s3run4test5inputSiSS_tF : $@convention(thin) (@guaranteed String) -> Int {
// %0                                             // users: %7, %204, %183, %162, %141, %120, %99, %78, %57, %36, %2, %1
bb0(%0 : $String):
  debug_value %0 : $String, let, name "input", argno 1 // id: %1
  debug_value %0 : $String, let, name "$match"    // id: %2
  %3 = integer_literal $Builtin.Int1, -1          // users: %212, %191, %170, %149, %128, %107, %86, %65, %44, %23
  %4 = integer_literal $Builtin.Int64, 48         // users: %17, %29
  %5 = integer_literal $Builtin.Int64, -2233785415175766016 // user: %6
  %6 = value_to_bridge_object %5 : $Builtin.Int64 // users: %218, %197, %176, %155, %134, %113, %92, %71, %50, %9, %30
  %7 = struct_extract %0 : $String, #String._guts // users: %221, %200, %179, %158, %137, %116, %95, %74, %53, %33, %10
  %8 = enum $_StringComparisonResult, #_StringComparisonResult.equal!enumelt // users: %221, %200, %179, %158, %137, %116, %95, %74, %53, %33
  %9 = unchecked_trivial_bit_cast %6 : $Builtin.BridgeObject to $UInt64 // user: %14
  %10 = struct_extract %7 : $_StringGuts, #_StringGuts._object // users: %12, %11
  %11 = struct_extract %10 : $_StringObject, #_StringObject._object // user: %13
  %12 = struct_extract %10 : $_StringObject, #_StringObject._countAndFlagsBits // user: %15
  %13 = unchecked_trivial_bit_cast %11 : $Builtin.BridgeObject to $UInt64 // user: %16
  %14 = struct_extract %9 : $UInt64, #UInt64._value // users: %209, %188, %167, %146, %125, %104, %83, %62, %41, %20
  %15 = struct_extract %12 : $UInt64, #UInt64._value // users: %206, %185, %164, %143, %122, %101, %80, %59, %38, %17
  %16 = struct_extract %13 : $UInt64, #UInt64._value // users: %209, %188, %167, %146, %125, %104, %83, %62, %41, %20
  %17 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int1 // user: %18
  cond_br %17, bb2, bb1                           // id: %18

bb1:                                              // Preds: bb0
  br bb6                                          // id: %19

bb2:                                              // Preds: bb0
  %20 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %21
  cond_br %20, bb4, bb3                           // id: %21

bb3:                                              // Preds: bb2
  br bb6                                          // id: %22

bb4:                                              // Preds: bb2
  %23 = struct $Bool (%3 : $Builtin.Int1)         // user: %24
  br bb5(%23 : $Bool)                             // id: %24

// %25                                            // user: %27
bb5(%25 : $Bool):                                 // Preds: bb6 bb4
  %26 = integer_literal $Builtin.Int64, 0         // users: %225, %35
  %27 = struct_extract %25 : $Bool, #Bool._value  // user: %28
  cond_br %27, bb7, bb8                           // id: %28

bb6:                                              // Preds: bb3 bb1
  %29 = struct $UInt64 (%4 : $Builtin.Int64)      // user: %30
  %30 = struct $_StringObject (%29 : $UInt64, %6 : $Builtin.BridgeObject) // user: %31
  %31 = struct $_StringGuts (%30 : $_StringObject) // user: %33
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %32 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %33
  %33 = apply %32(%31, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %34
  br bb5(%33 : $Bool)                             // id: %34

bb7:                                              // Preds: bb5
  br bb81(%26 : $Builtin.Int64)                   // id: %35

bb8:                                              // Preds: bb5
  debug_value %0 : $String, let, name "$match"    // id: %36
  %37 = integer_literal $Builtin.Int64, 49        // users: %38, %49
  %38 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %37 : $Builtin.Int64) : $Builtin.Int1 // user: %39
  cond_br %38, bb10, bb9                          // id: %39

bb9:                                              // Preds: bb8
  br bb14                                         // id: %40

bb10:                                             // Preds: bb8
  %41 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %42
  cond_br %41, bb12, bb11                         // id: %42

bb11:                                             // Preds: bb10
  br bb14                                         // id: %43

bb12:                                             // Preds: bb10
  %44 = struct $Bool (%3 : $Builtin.Int1)         // user: %45
  br bb13(%44 : $Bool)                            // id: %45

// %46                                            // user: %47
bb13(%46 : $Bool):                                // Preds: bb14 bb12
  %47 = struct_extract %46 : $Bool, #Bool._value  // user: %48
  cond_br %47, bb15, bb16                         // id: %48

bb14:                                             // Preds: bb11 bb9
  %49 = struct $UInt64 (%37 : $Builtin.Int64)     // user: %50
  %50 = struct $_StringObject (%49 : $UInt64, %6 : $Builtin.BridgeObject) // user: %51
  %51 = struct $_StringGuts (%50 : $_StringObject) // user: %53
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %52 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %53
  %53 = apply %52(%51, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %54
  br bb13(%53 : $Bool)                            // id: %54

bb15:                                             // Preds: bb13
  %55 = integer_literal $Builtin.Int64, 1         // user: %56
  br bb81(%55 : $Builtin.Int64)                   // id: %56

bb16:                                             // Preds: bb13
  debug_value %0 : $String, let, name "$match"    // id: %57
  %58 = integer_literal $Builtin.Int64, 50        // users: %59, %70
  %59 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %58 : $Builtin.Int64) : $Builtin.Int1 // user: %60
  cond_br %59, bb18, bb17                         // id: %60

bb17:                                             // Preds: bb16
  br bb22                                         // id: %61

bb18:                                             // Preds: bb16
  %62 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %63
  cond_br %62, bb20, bb19                         // id: %63

bb19:                                             // Preds: bb18
  br bb22                                         // id: %64

bb20:                                             // Preds: bb18
  %65 = struct $Bool (%3 : $Builtin.Int1)         // user: %66
  br bb21(%65 : $Bool)                            // id: %66

// %67                                            // user: %68
bb21(%67 : $Bool):                                // Preds: bb22 bb20
  %68 = struct_extract %67 : $Bool, #Bool._value  // user: %69
  cond_br %68, bb23, bb24                         // id: %69

bb22:                                             // Preds: bb19 bb17
  %70 = struct $UInt64 (%58 : $Builtin.Int64)     // user: %71
  %71 = struct $_StringObject (%70 : $UInt64, %6 : $Builtin.BridgeObject) // user: %72
  %72 = struct $_StringGuts (%71 : $_StringObject) // user: %74
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %73 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %74
  %74 = apply %73(%72, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %75
  br bb21(%74 : $Bool)                            // id: %75

bb23:                                             // Preds: bb21
  %76 = integer_literal $Builtin.Int64, 2         // user: %77
  br bb81(%76 : $Builtin.Int64)                   // id: %77

bb24:                                             // Preds: bb21
  debug_value %0 : $String, let, name "$match"    // id: %78
  %79 = integer_literal $Builtin.Int64, 51        // users: %80, %91
  %80 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %79 : $Builtin.Int64) : $Builtin.Int1 // user: %81
  cond_br %80, bb26, bb25                         // id: %81

bb25:                                             // Preds: bb24
  br bb30                                         // id: %82

bb26:                                             // Preds: bb24
  %83 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %84
  cond_br %83, bb28, bb27                         // id: %84

bb27:                                             // Preds: bb26
  br bb30                                         // id: %85

bb28:                                             // Preds: bb26
  %86 = struct $Bool (%3 : $Builtin.Int1)         // user: %87
  br bb29(%86 : $Bool)                            // id: %87

// %88                                            // user: %89
bb29(%88 : $Bool):                                // Preds: bb30 bb28
  %89 = struct_extract %88 : $Bool, #Bool._value  // user: %90
  cond_br %89, bb31, bb32                         // id: %90

bb30:                                             // Preds: bb27 bb25
  %91 = struct $UInt64 (%79 : $Builtin.Int64)     // user: %92
  %92 = struct $_StringObject (%91 : $UInt64, %6 : $Builtin.BridgeObject) // user: %93
  %93 = struct $_StringGuts (%92 : $_StringObject) // user: %95
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %94 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %95
  %95 = apply %94(%93, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %96
  br bb29(%95 : $Bool)                            // id: %96

bb31:                                             // Preds: bb29
  %97 = integer_literal $Builtin.Int64, 3         // user: %98
  br bb81(%97 : $Builtin.Int64)                   // id: %98

bb32:                                             // Preds: bb29
  debug_value %0 : $String, let, name "$match"    // id: %99
  %100 = integer_literal $Builtin.Int64, 52       // users: %101, %112
  %101 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %100 : $Builtin.Int64) : $Builtin.Int1 // user: %102
  cond_br %101, bb34, bb33                        // id: %102

bb33:                                             // Preds: bb32
  br bb38                                         // id: %103

bb34:                                             // Preds: bb32
  %104 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %105
  cond_br %104, bb36, bb35                        // id: %105

bb35:                                             // Preds: bb34
  br bb38                                         // id: %106

bb36:                                             // Preds: bb34
  %107 = struct $Bool (%3 : $Builtin.Int1)        // user: %108
  br bb37(%107 : $Bool)                           // id: %108

// %109                                           // user: %110
bb37(%109 : $Bool):                               // Preds: bb38 bb36
  %110 = struct_extract %109 : $Bool, #Bool._value // user: %111
  cond_br %110, bb39, bb40                        // id: %111

bb38:                                             // Preds: bb35 bb33
  %112 = struct $UInt64 (%100 : $Builtin.Int64)   // user: %113
  %113 = struct $_StringObject (%112 : $UInt64, %6 : $Builtin.BridgeObject) // user: %114
  %114 = struct $_StringGuts (%113 : $_StringObject) // user: %116
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %115 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %116
  %116 = apply %115(%114, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %117
  br bb37(%116 : $Bool)                           // id: %117

bb39:                                             // Preds: bb37
  %118 = integer_literal $Builtin.Int64, 4        // user: %119
  br bb81(%118 : $Builtin.Int64)                  // id: %119

bb40:                                             // Preds: bb37
  debug_value %0 : $String, let, name "$match"    // id: %120
  %121 = integer_literal $Builtin.Int64, 53       // users: %122, %133
  %122 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %121 : $Builtin.Int64) : $Builtin.Int1 // user: %123
  cond_br %122, bb42, bb41                        // id: %123

bb41:                                             // Preds: bb40
  br bb46                                         // id: %124

bb42:                                             // Preds: bb40
  %125 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %126
  cond_br %125, bb44, bb43                        // id: %126

bb43:                                             // Preds: bb42
  br bb46                                         // id: %127

bb44:                                             // Preds: bb42
  %128 = struct $Bool (%3 : $Builtin.Int1)        // user: %129
  br bb45(%128 : $Bool)                           // id: %129

// %130                                           // user: %131
bb45(%130 : $Bool):                               // Preds: bb46 bb44
  %131 = struct_extract %130 : $Bool, #Bool._value // user: %132
  cond_br %131, bb47, bb48                        // id: %132

bb46:                                             // Preds: bb43 bb41
  %133 = struct $UInt64 (%121 : $Builtin.Int64)   // user: %134
  %134 = struct $_StringObject (%133 : $UInt64, %6 : $Builtin.BridgeObject) // user: %135
  %135 = struct $_StringGuts (%134 : $_StringObject) // user: %137
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %136 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %137
  %137 = apply %136(%135, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %138
  br bb45(%137 : $Bool)                           // id: %138

bb47:                                             // Preds: bb45
  %139 = integer_literal $Builtin.Int64, 5        // user: %140
  br bb81(%139 : $Builtin.Int64)                  // id: %140

bb48:                                             // Preds: bb45
  debug_value %0 : $String, let, name "$match"    // id: %141
  %142 = integer_literal $Builtin.Int64, 54       // users: %143, %154
  %143 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %142 : $Builtin.Int64) : $Builtin.Int1 // user: %144
  cond_br %143, bb50, bb49                        // id: %144

bb49:                                             // Preds: bb48
  br bb54                                         // id: %145

bb50:                                             // Preds: bb48
  %146 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %147
  cond_br %146, bb52, bb51                        // id: %147

bb51:                                             // Preds: bb50
  br bb54                                         // id: %148

bb52:                                             // Preds: bb50
  %149 = struct $Bool (%3 : $Builtin.Int1)        // user: %150
  br bb53(%149 : $Bool)                           // id: %150

// %151                                           // user: %152
bb53(%151 : $Bool):                               // Preds: bb54 bb52
  %152 = struct_extract %151 : $Bool, #Bool._value // user: %153
  cond_br %152, bb55, bb56                        // id: %153

bb54:                                             // Preds: bb51 bb49
  %154 = struct $UInt64 (%142 : $Builtin.Int64)   // user: %155
  %155 = struct $_StringObject (%154 : $UInt64, %6 : $Builtin.BridgeObject) // user: %156
  %156 = struct $_StringGuts (%155 : $_StringObject) // user: %158
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %157 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %158
  %158 = apply %157(%156, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %159
  br bb53(%158 : $Bool)                           // id: %159

bb55:                                             // Preds: bb53
  %160 = integer_literal $Builtin.Int64, 6        // user: %161
  br bb81(%160 : $Builtin.Int64)                  // id: %161

bb56:                                             // Preds: bb53
  debug_value %0 : $String, let, name "$match"    // id: %162
  %163 = integer_literal $Builtin.Int64, 55       // users: %164, %175
  %164 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %163 : $Builtin.Int64) : $Builtin.Int1 // user: %165
  cond_br %164, bb58, bb57                        // id: %165

bb57:                                             // Preds: bb56
  br bb62                                         // id: %166

bb58:                                             // Preds: bb56
  %167 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %168
  cond_br %167, bb60, bb59                        // id: %168

bb59:                                             // Preds: bb58
  br bb62                                         // id: %169

bb60:                                             // Preds: bb58
  %170 = struct $Bool (%3 : $Builtin.Int1)        // user: %171
  br bb61(%170 : $Bool)                           // id: %171

// %172                                           // user: %173
bb61(%172 : $Bool):                               // Preds: bb62 bb60
  %173 = struct_extract %172 : $Bool, #Bool._value // user: %174
  cond_br %173, bb63, bb64                        // id: %174

bb62:                                             // Preds: bb59 bb57
  %175 = struct $UInt64 (%163 : $Builtin.Int64)   // user: %176
  %176 = struct $_StringObject (%175 : $UInt64, %6 : $Builtin.BridgeObject) // user: %177
  %177 = struct $_StringGuts (%176 : $_StringObject) // user: %179
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %178 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %179
  %179 = apply %178(%177, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %180
  br bb61(%179 : $Bool)                           // id: %180

bb63:                                             // Preds: bb61
  %181 = integer_literal $Builtin.Int64, 7        // user: %182
  br bb81(%181 : $Builtin.Int64)                  // id: %182

bb64:                                             // Preds: bb61
  debug_value %0 : $String, let, name "$match"    // id: %183
  %184 = integer_literal $Builtin.Int64, 56       // users: %185, %196
  %185 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %184 : $Builtin.Int64) : $Builtin.Int1 // user: %186
  cond_br %185, bb66, bb65                        // id: %186

bb65:                                             // Preds: bb64
  br bb70                                         // id: %187

bb66:                                             // Preds: bb64
  %188 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %189
  cond_br %188, bb68, bb67                        // id: %189

bb67:                                             // Preds: bb66
  br bb70                                         // id: %190

bb68:                                             // Preds: bb66
  %191 = struct $Bool (%3 : $Builtin.Int1)        // user: %192
  br bb69(%191 : $Bool)                           // id: %192

// %193                                           // user: %194
bb69(%193 : $Bool):                               // Preds: bb70 bb68
  %194 = struct_extract %193 : $Bool, #Bool._value // user: %195
  cond_br %194, bb71, bb72                        // id: %195

bb70:                                             // Preds: bb67 bb65
  %196 = struct $UInt64 (%184 : $Builtin.Int64)   // user: %197
  %197 = struct $_StringObject (%196 : $UInt64, %6 : $Builtin.BridgeObject) // user: %198
  %198 = struct $_StringGuts (%197 : $_StringObject) // user: %200
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %199 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %200
  %200 = apply %199(%198, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %201
  br bb69(%200 : $Bool)                           // id: %201

bb71:                                             // Preds: bb69
  %202 = integer_literal $Builtin.Int64, 8        // user: %203
  br bb81(%202 : $Builtin.Int64)                  // id: %203

bb72:                                             // Preds: bb69
  debug_value %0 : $String, let, name "$match"    // id: %204
  %205 = integer_literal $Builtin.Int64, 57       // users: %206, %217
  %206 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %205 : $Builtin.Int64) : $Builtin.Int1 // user: %207
  cond_br %206, bb74, bb73                        // id: %207

bb73:                                             // Preds: bb72
  br bb78                                         // id: %208

bb74:                                             // Preds: bb72
  %209 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %16 : $Builtin.Int64) : $Builtin.Int1 // user: %210
  cond_br %209, bb76, bb75                        // id: %210

bb75:                                             // Preds: bb74
  br bb78                                         // id: %211

bb76:                                             // Preds: bb74
  %212 = struct $Bool (%3 : $Builtin.Int1)        // user: %213
  br bb77(%212 : $Bool)                           // id: %213

// %214                                           // user: %215
bb77(%214 : $Bool):                               // Preds: bb78 bb76
  %215 = struct_extract %214 : $Bool, #Bool._value // user: %216
  cond_br %215, bb79, bb80                        // id: %216

bb78:                                             // Preds: bb75 bb73
  %217 = struct $UInt64 (%205 : $Builtin.Int64)   // user: %218
  %218 = struct $_StringObject (%217 : $UInt64, %6 : $Builtin.BridgeObject) // user: %219
  %219 = struct $_StringGuts (%218 : $_StringObject) // user: %221
  // function_ref _stringCompareWithSmolCheck(_:_:expecting:)
  %220 = function_ref @$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %221
  %221 = apply %220(%219, %7, %8) : $@convention(thin) (@guaranteed _StringGuts, @guaranteed _StringGuts, _StringComparisonResult) -> Bool // user: %222
  br bb77(%221 : $Bool)                           // id: %222

bb79:                                             // Preds: bb77
  %223 = integer_literal $Builtin.Int64, 9        // user: %224
  br bb81(%223 : $Builtin.Int64)                  // id: %224

bb80:                                             // Preds: bb77
  br bb81(%26 : $Builtin.Int64)                   // id: %225

// %226                                           // user: %227
bb81(%226 : $Builtin.Int64):                      // Preds: bb80 bb79 bb71 bb63 bb55 bb47 bb39 bb31 bb23 bb15 bb7
  %227 = struct $Int (%226 : $Builtin.Int64)      // user: %228
  return %227 : $Int                              // id: %228
} // end sil function '$s3run4test5inputSiSS_tF'
```

**Assembly**
```
_$s3run4test5inputSiSS_tF:
	.cfi_startproc
	pushq	%rbp
	.cfi_def_cfa_offset 16
	.cfi_offset %rbp, -16
	movq	%rsp, %rbp
	.cfi_def_cfa_register %rbp
	pushq	%r15
	pushq	%r14
	pushq	%r12
	pushq	%rbx
	.cfi_offset %rbx, -48
	.cfi_offset %r12, -40
	.cfi_offset %r14, -32
	.cfi_offset %r15, -24
	movq	%rsi, %r14
	movq	%rdi, %rbx
	movabsq	$-2233785415175766016, %r15
	cmpq	$48, %rdi
	jne	LBB9_3
	cmpq	%r15, %r14
	jne	LBB9_3
	xorl	%r12d, %r12d
	jmp	LBB9_31
LBB9_3:
	xorl	%r12d, %r12d
	movl	$48, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	testb	$1, %al
	jne	LBB9_31
	movl	$1, %r12d
	cmpq	$49, %rbx
	jne	LBB9_6
	cmpq	%r15, %r14
	je	LBB9_31
LBB9_6:
	movl	$49, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	testb	$1, %al
	jne	LBB9_31
	movl	$2, %r12d
	cmpq	$50, %rbx
	jne	LBB9_9
	cmpq	%r15, %r14
	je	LBB9_31
LBB9_9:
	movl	$50, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	testb	$1, %al
	jne	LBB9_31
	movl	$3, %r12d
	cmpq	$51, %rbx
	jne	LBB9_12
	cmpq	%r15, %r14
	je	LBB9_31
LBB9_12:
	movl	$51, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	testb	$1, %al
	jne	LBB9_31
	movl	$4, %r12d
	cmpq	$52, %rbx
	jne	LBB9_15
	cmpq	%r15, %r14
	je	LBB9_31
LBB9_15:
	movl	$52, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	testb	$1, %al
	jne	LBB9_31
	movl	$5, %r12d
	cmpq	$53, %rbx
	jne	LBB9_18
	cmpq	%r15, %r14
	je	LBB9_31
LBB9_18:
	movl	$53, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	testb	$1, %al
	jne	LBB9_31
	movl	$6, %r12d
	cmpq	$54, %rbx
	jne	LBB9_21
	cmpq	%r15, %r14
	je	LBB9_31
LBB9_21:
	movl	$54, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	testb	$1, %al
	jne	LBB9_31
	movl	$7, %r12d
	cmpq	$55, %rbx
	jne	LBB9_24
	cmpq	%r15, %r14
	je	LBB9_31
LBB9_24:
	movl	$55, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	testb	$1, %al
	jne	LBB9_31
	movl	$8, %r12d
	cmpq	$56, %rbx
	jne	LBB9_27
	cmpq	%r15, %r14
	je	LBB9_31
LBB9_27:
	movl	$56, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	testb	$1, %al
	jne	LBB9_31
	cmpq	$57, %rbx
	jne	LBB9_30
	movl	$9, %r12d
	cmpq	%r15, %r14
	je	LBB9_31
LBB9_30:
	movl	$57, %edi
	movq	%r15, %rsi
	movq	%rbx, %rdx
	movq	%r14, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	movzbl	%al, %eax
	andl	$1, %eax
	leaq	(%rax,%rax,8), %r12
LBB9_31:
	movq	%r12, %rax
	popq	%rbx
	popq	%r12
	popq	%r14
	popq	%r15
	popq	%rbp
	retq
	.cfi_endproc

	.p2align	4, 0x90
```

</p>
</details>

<details><summary>New Output (SIL 184 lines, Assembly 131 lines)</summary>
<p>

**SIL**
```
// test(input:)
sil hidden @$s3run4test5inputSiSS_tF : $@convention(thin) (@guaranteed String) -> Int {
// %0                                             // users: %82, %127, %122, %117, %112, %107, %102, %97, %92, %87, %2, %1
bb0(%0 : $String):
  debug_value %0 : $String, let, name "input", argno 1 // id: %1
  debug_value %0 : $String, let, name "$match"    // id: %2
  %3 = string_literal utf8 "1"                    // user: %38
  %4 = string_literal utf8 "2"                    // user: %43
  %5 = string_literal utf8 "3"                    // user: %48
  %6 = string_literal utf8 "4"                    // user: %53
  %7 = string_literal utf8 "5"                    // user: %58
  %8 = string_literal utf8 "6"                    // user: %63
  %9 = string_literal utf8 "7"                    // user: %68
  %10 = string_literal utf8 "8"                   // user: %73
  %11 = string_literal utf8 "9"                   // user: %78
  %12 = string_literal utf8 "0"                   // user: %32
  %13 = integer_literal $Builtin.Word, 10         // user: %16
  %14 = integer_literal $Builtin.Int64, 10        // user: %15
  %15 = struct $Int (%14 : $Builtin.Int64)        // user: %22
  %16 = alloc_ref [tail_elems $StaticString * %13 : $Builtin.Word] $_ContiguousArrayStorage<StaticString> // users: %29, %17
  %17 = upcast %16 : $_ContiguousArrayStorage<StaticString> to $__ContiguousArrayStorageBase // users: %31, %24, %18
  %18 = struct $_ContiguousArrayBuffer<StaticString> (%17 : $__ContiguousArrayStorageBase) // user: %28
  %19 = integer_literal $Builtin.Int64, 0         // users: %84, %132, %86, %26
  %20 = integer_literal $Builtin.Int64, 20        // user: %21
  %21 = struct $UInt (%20 : $Builtin.Int64)       // user: %22
  %22 = struct $_SwiftArrayBodyStorage (%15 : $Int, %21 : $UInt) // user: %23
  %23 = struct $_ArrayBody (%22 : $_SwiftArrayBodyStorage) // user: %25
  %24 = ref_element_addr %17 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity // user: %25
  store %23 to %24 : $*_ArrayBody                 // id: %25
  %26 = struct $Int (%19 : $Builtin.Int64)        // user: %28
  // function_ref specialized _ArrayBuffer.init(_buffer:shiftedToStartIndex:)
  %27 = function_ref @$ss12_ArrayBufferV7_buffer19shiftedToStartIndexAByxGs011_ContiguousaB0VyxG_SitcfCs12StaticStringV_Tg5Tf4gnd_n : $@convention(thin) (@guaranteed _ContiguousArrayBuffer<StaticString>, Int) -> @owned _ArrayBuffer<StaticString> // user: %28
  %28 = apply %27(%18, %26) : $@convention(thin) (@guaranteed _ContiguousArrayBuffer<StaticString>, Int) -> @owned _ArrayBuffer<StaticString> // user: %30
  strong_release %16 : $_ContiguousArrayStorage<StaticString> // id: %29
  %30 = struct $Array<StaticString> (%28 : $_ArrayBuffer<StaticString>) // user: %82
  %31 = ref_tail_addr %17 : $__ContiguousArrayStorageBase, $StaticString // users: %37, %42, %47, %52, %57, %62, %67, %72, %77, %36
  %32 = builtin "ptrtoint_Word"(%12 : $Builtin.RawPointer) : $Builtin.Word // user: %35
  %33 = integer_literal $Builtin.Word, 1          // users: %79, %74, %69, %64, %59, %54, %49, %44, %39, %37, %35
  %34 = integer_literal $Builtin.Int8, 2          // users: %79, %74, %69, %64, %59, %54, %49, %44, %39, %35
  %35 = struct $StaticString (%32 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %36
  store %35 to %31 : $*StaticString               // id: %36
  %37 = index_addr %31 : $*StaticString, %33 : $Builtin.Word // user: %40
  %38 = builtin "ptrtoint_Word"(%3 : $Builtin.RawPointer) : $Builtin.Word // user: %39
  %39 = struct $StaticString (%38 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %40
  store %39 to %37 : $*StaticString               // id: %40
  %41 = integer_literal $Builtin.Word, 2          // user: %42
  %42 = index_addr %31 : $*StaticString, %41 : $Builtin.Word // user: %45
  %43 = builtin "ptrtoint_Word"(%4 : $Builtin.RawPointer) : $Builtin.Word // user: %44
  %44 = struct $StaticString (%43 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %45
  store %44 to %42 : $*StaticString               // id: %45
  %46 = integer_literal $Builtin.Word, 3          // user: %47
  %47 = index_addr %31 : $*StaticString, %46 : $Builtin.Word // user: %50
  %48 = builtin "ptrtoint_Word"(%5 : $Builtin.RawPointer) : $Builtin.Word // user: %49
  %49 = struct $StaticString (%48 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %50
  store %49 to %47 : $*StaticString               // id: %50
  %51 = integer_literal $Builtin.Word, 4          // user: %52
  %52 = index_addr %31 : $*StaticString, %51 : $Builtin.Word // user: %55
  %53 = builtin "ptrtoint_Word"(%6 : $Builtin.RawPointer) : $Builtin.Word // user: %54
  %54 = struct $StaticString (%53 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %55
  store %54 to %52 : $*StaticString               // id: %55
  %56 = integer_literal $Builtin.Word, 5          // user: %57
  %57 = index_addr %31 : $*StaticString, %56 : $Builtin.Word // user: %60
  %58 = builtin "ptrtoint_Word"(%7 : $Builtin.RawPointer) : $Builtin.Word // user: %59
  %59 = struct $StaticString (%58 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %60
  store %59 to %57 : $*StaticString               // id: %60
  %61 = integer_literal $Builtin.Word, 6          // user: %62
  %62 = index_addr %31 : $*StaticString, %61 : $Builtin.Word // user: %65
  %63 = builtin "ptrtoint_Word"(%8 : $Builtin.RawPointer) : $Builtin.Word // user: %64
  %64 = struct $StaticString (%63 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %65
  store %64 to %62 : $*StaticString               // id: %65
  %66 = integer_literal $Builtin.Word, 7          // user: %67
  %67 = index_addr %31 : $*StaticString, %66 : $Builtin.Word // user: %70
  %68 = builtin "ptrtoint_Word"(%9 : $Builtin.RawPointer) : $Builtin.Word // user: %69
  %69 = struct $StaticString (%68 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %70
  store %69 to %67 : $*StaticString               // id: %70
  %71 = integer_literal $Builtin.Word, 8          // user: %72
  %72 = index_addr %31 : $*StaticString, %71 : $Builtin.Word // user: %75
  %73 = builtin "ptrtoint_Word"(%10 : $Builtin.RawPointer) : $Builtin.Word // user: %74
  %74 = struct $StaticString (%73 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %75
  store %74 to %72 : $*StaticString               // id: %75
  %76 = integer_literal $Builtin.Word, 9          // user: %77
  %77 = index_addr %31 : $*StaticString, %76 : $Builtin.Word // user: %80
  %78 = builtin "ptrtoint_Word"(%11 : $Builtin.RawPointer) : $Builtin.Word // user: %79
  %79 = struct $StaticString (%78 : $Builtin.Word, %33 : $Builtin.Word, %34 : $Builtin.Int8) // user: %80
  store %79 to %77 : $*StaticString               // id: %80
  // function_ref _findStringSwitchCase(cases:string:)
  %81 = function_ref @$ss21_findStringSwitchCase5cases6stringSiSays06StaticB0VG_SStF : $@convention(thin) (@guaranteed Array<StaticString>, @guaranteed String) -> Int // user: %82
  %82 = apply %81(%30, %0) : $@convention(thin) (@guaranteed Array<StaticString>, @guaranteed String) -> Int // user: %83
  %83 = struct_extract %82 : $Int, #Int._value    // users: %84, %89, %94, %99, %104, %109, %114, %119, %124, %129
  %84 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %19 : $Builtin.Int64) : $Builtin.Int1 // user: %85
  cond_br %84, bb1, bb2                           // id: %85

bb1:                                              // Preds: bb0
  br bb21(%19 : $Builtin.Int64)                   // id: %86

bb2:                                              // Preds: bb0
  debug_value %0 : $String, let, name "$match"    // id: %87
  %88 = integer_literal $Builtin.Int64, 1         // users: %91, %89
  %89 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %88 : $Builtin.Int64) : $Builtin.Int1 // user: %90
  cond_br %89, bb3, bb4                           // id: %90

bb3:                                              // Preds: bb2
  br bb21(%88 : $Builtin.Int64)                   // id: %91

bb4:                                              // Preds: bb2
  debug_value %0 : $String, let, name "$match"    // id: %92
  %93 = integer_literal $Builtin.Int64, 2         // users: %96, %94
  %94 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %93 : $Builtin.Int64) : $Builtin.Int1 // user: %95
  cond_br %94, bb5, bb6                           // id: %95

bb5:                                              // Preds: bb4
  br bb21(%93 : $Builtin.Int64)                   // id: %96

bb6:                                              // Preds: bb4
  debug_value %0 : $String, let, name "$match"    // id: %97
  %98 = integer_literal $Builtin.Int64, 3         // users: %101, %99
  %99 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %98 : $Builtin.Int64) : $Builtin.Int1 // user: %100
  cond_br %99, bb7, bb8                           // id: %100

bb7:                                              // Preds: bb6
  br bb21(%98 : $Builtin.Int64)                   // id: %101

bb8:                                              // Preds: bb6
  debug_value %0 : $String, let, name "$match"    // id: %102
  %103 = integer_literal $Builtin.Int64, 4        // users: %106, %104
  %104 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %103 : $Builtin.Int64) : $Builtin.Int1 // user: %105
  cond_br %104, bb9, bb10                         // id: %105

bb9:                                              // Preds: bb8
  br bb21(%103 : $Builtin.Int64)                  // id: %106

bb10:                                             // Preds: bb8
  debug_value %0 : $String, let, name "$match"    // id: %107
  %108 = integer_literal $Builtin.Int64, 5        // users: %111, %109
  %109 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %108 : $Builtin.Int64) : $Builtin.Int1 // user: %110
  cond_br %109, bb11, bb12                        // id: %110

bb11:                                             // Preds: bb10
  br bb21(%108 : $Builtin.Int64)                  // id: %111

bb12:                                             // Preds: bb10
  debug_value %0 : $String, let, name "$match"    // id: %112
  %113 = integer_literal $Builtin.Int64, 6        // users: %116, %114
  %114 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %113 : $Builtin.Int64) : $Builtin.Int1 // user: %115
  cond_br %114, bb13, bb14                        // id: %115

bb13:                                             // Preds: bb12
  br bb21(%113 : $Builtin.Int64)                  // id: %116

bb14:                                             // Preds: bb12
  debug_value %0 : $String, let, name "$match"    // id: %117
  %118 = integer_literal $Builtin.Int64, 7        // users: %121, %119
  %119 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %118 : $Builtin.Int64) : $Builtin.Int1 // user: %120
  cond_br %119, bb15, bb16                        // id: %120

bb15:                                             // Preds: bb14
  br bb21(%118 : $Builtin.Int64)                  // id: %121

bb16:                                             // Preds: bb14
  debug_value %0 : $String, let, name "$match"    // id: %122
  %123 = integer_literal $Builtin.Int64, 8        // users: %126, %124
  %124 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %123 : $Builtin.Int64) : $Builtin.Int1 // user: %125
  cond_br %124, bb17, bb18                        // id: %125

bb17:                                             // Preds: bb16
  br bb21(%123 : $Builtin.Int64)                  // id: %126

bb18:                                             // Preds: bb16
  debug_value %0 : $String, let, name "$match"    // id: %127
  %128 = integer_literal $Builtin.Int64, 9        // users: %131, %129
  %129 = builtin "cmp_eq_Int64"(%83 : $Builtin.Int64, %128 : $Builtin.Int64) : $Builtin.Int1 // user: %130
  cond_br %129, bb19, bb20                        // id: %130

bb19:                                             // Preds: bb18
  br bb21(%128 : $Builtin.Int64)                  // id: %131

bb20:                                             // Preds: bb18
  br bb21(%19 : $Builtin.Int64)                   // id: %132

// %133                                           // user: %134
bb21(%133 : $Builtin.Int64):                      // Preds: bb20 bb19 bb17 bb15 bb13 bb11 bb9 bb7 bb5 bb3 bb1
  %134 = struct $Int (%133 : $Builtin.Int64)      // user: %135
  return %134 : $Int                              // id: %135
} // end sil function '$s3run4test5inputSiSS_tF'
```

**Assembly**
```
_$s3run4test5inputSiSS_tF:
	.cfi_startproc
	pushq	%rbp
	.cfi_def_cfa_offset 16
	.cfi_offset %rbp, -16
	movq	%rsp, %rbp
	.cfi_def_cfa_register %rbp
	pushq	%r15
	pushq	%r14
	pushq	%r12
	pushq	%rbx
	.cfi_offset %rbx, -48
	.cfi_offset %r12, -40
	.cfi_offset %r14, -32
	.cfi_offset %r15, -24
	movq	%rsi, %r14
	movq	%rdi, %r15
	leaq	_$ss23_ContiguousArrayStorageCys12StaticStringVGMD(%rip), %rdi
	callq	___swift_instantiateConcreteTypeFromMangledName
	movl	$272, %esi
	movl	$7, %edx
	movq	%rax, %rdi
	callq	_swift_allocObject
	movq	%rax, %rbx
	movaps	LCPI9_0(%rip), %xmm0
	movups	%xmm0, 16(%rax)
	xorl	%edi, %edi
	callq	_$ss28__ContiguousArrayStorageBaseCMa
	movq	%rax, %r12
	movq	%rbx, %rdi
	callq	_swift_retain
	movq	%r12, %rdi
	callq	__swift_objcClassUsesNativeSwiftReferenceCounting
	testb	$1, %al
	je	LBB9_1
	movq	%rbx, %rdi
	callq	_swift_release
	leaq	L___unnamed_1(%rip), %rax
	movdqa	LCPI9_1(%rip), %xmm0
	movdqa	%xmm0, %xmm1
	pinsrq	$0, %rax, %xmm1
	movdqu	%xmm1, 32(%rbx)
	movb	$2, 48(%rbx)
	leaq	L___unnamed_2(%rip), %rax
	movdqa	%xmm0, %xmm1
	pinsrq	$0, %rax, %xmm1
	movdqu	%xmm1, 56(%rbx)
	movb	$2, 72(%rbx)
	leaq	L___unnamed_3(%rip), %rax
	movdqa	%xmm0, %xmm1
	pinsrq	$0, %rax, %xmm1
	movdqu	%xmm1, 80(%rbx)
	leaq	L___unnamed_4(%rip), %rax
	movdqa	%xmm0, %xmm1
	pinsrq	$0, %rax, %xmm1
	movb	$2, 96(%rbx)
	movdqu	%xmm1, 104(%rbx)
	movb	$2, 120(%rbx)
	leaq	L___unnamed_5(%rip), %rax
	movdqa	%xmm0, %xmm1
	pinsrq	$0, %rax, %xmm1
	movdqu	%xmm1, 128(%rbx)
	movb	$2, 144(%rbx)
	leaq	L___unnamed_6(%rip), %rax
	movq	%rax, 152(%rbx)
	movq	$1, 160(%rbx)
	movb	$2, 168(%rbx)
	leaq	L___unnamed_7(%rip), %rax
	movdqa	%xmm0, %xmm1
	pinsrq	$0, %rax, %xmm1
	movdqu	%xmm1, 176(%rbx)
	movb	$2, 192(%rbx)
	leaq	L___unnamed_8(%rip), %rax
	movdqa	%xmm0, %xmm1
	pinsrq	$0, %rax, %xmm1
	movdqu	%xmm1, 200(%rbx)
	leaq	L___unnamed_9(%rip), %rax
	movdqa	%xmm0, %xmm1
	pinsrq	$0, %rax, %xmm1
	movb	$2, 216(%rbx)
	movdqu	%xmm1, 224(%rbx)
	movb	$2, 240(%rbx)
	leaq	L___unnamed_10(%rip), %rax
	pinsrq	$0, %rax, %xmm0
	movdqu	%xmm0, 248(%rbx)
	movb	$2, 264(%rbx)
	movq	%rbx, %rdi
	movq	%r15, %rsi
	movq	%r14, %rdx
	callq	_$ss21_findStringSwitchCase5cases6stringSiSays06StaticB0VG_SStF
	leaq	-1(%rax), %rcx
	xorl	%edx, %edx
	cmpq	$9, %rcx
	cmovaeq	%rdx, %rax
	popq	%rbx
	popq	%r12
	popq	%r14
	popq	%r15
	popq	%rbp
	retq
LBB9_1:
	subq	$8, %rsp
	leaq	L___unnamed_11(%rip), %rax
	leaq	L___unnamed_12(%rip), %rdi
	leaq	L___unnamed_13(%rip), %rcx
	movl	$11, %esi
	movl	$2, %edx
	movl	$0, %r8d
	movl	$2, %r9d
	pushq	$1
	pushq	$60
	pushq	$2
	pushq	$78
	pushq	%rax
	callq	_$ss18_fatalErrorMessage__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF
	addq	$48, %rsp
	ud2
	.cfi_endproc

	.section	__TEXT,__literal16,16byte_literals
	.p2align	4
LCPI10_0:
	.quad	3
	.quad	6
LCPI10_1:
	.space	8
	.quad	1
	.section	__TEXT,__text,regular,pure_instructions
	.private_extern	_$s3run1EO8rawValueACSgSS_tcfCTf4gd_n
	.globl	_$s3run1EO8rawValueACSgSS_tcfCTf4gd_n
	.weak_def_can_be_hidden	_$s3run1EO8rawValueACSgSS_tcfCTf4gd_n
	.p2align	4, 0x90
```

</p>
</details>


Based on #27909.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-9440](https://bugs.swift.org/browse/SR-9440).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
