### PR TITLE
Fix reference to `range(of:)` in the contains doc

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSStringAPI.swift
+++ b/stdlib/public/Darwin/Foundation/NSStringAPI.swift
@@ -1671,7 +1671,7 @@ extension StringProtocol where Index == String.Index {
   /// Returns `true` if `other` is non-empty and contained within `self` by
   /// case-sensitive, non-literal search. Otherwise, returns `false`.
   ///
-  /// Equivalent to `self.rangeOfString(other) != nil`
+  /// Equivalent to `self.range(of: other) != nil`
   public func contains<T : StringProtocol>(_ other: T) -> Bool {
     let r = self.range(of: other) != nil
     if #available(macOS 10.10, iOS 8.0, *) {


### PR DESCRIPTION
Shepherd #20860