### PR TITLE
[windows] Adapt pcm-emit-and-import for Windows separators.

### DIFF
--- a/test/ClangImporter/pcm-emit-and-import.swift
+++ b/test/ClangImporter/pcm-emit-and-import.swift
@@ -6,7 +6,7 @@
 // RUN: %swift-dump-pcm %t/script.pcm | %FileCheck %s --check-prefix=CHECK-DUMP
 // CHECK-DUMP: Information for module file '{{.*}}/script.pcm':
 // CHECK-DUMP:   Module name: script
-// CHECK-DUMP:   Module map file: {{.*}}/Inputs/custom-modules/module.map
+// CHECK-DUMP:   Module map file: {{.*[/\\]}}Inputs{{/|\\}}custom-modules{{/|\\}}module.map
 
 // Compile a source file that imports the explicit module.
 // RUN: %target-swift-frontend -typecheck -verify -Xcc -fmodule-file=%t/script.pcm %s


### PR DESCRIPTION
Introduced in #28107 and started failing in https://ci-external.swift.org/job/oss-swift-windows-x86_64/1963/

/cc @allevato @DougGregor 