### PR TITLE
[stdlib] Document Windows implementation of SystemRandomNumberGenerator

### DIFF
--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -144,6 +144,7 @@ extension RandomNumberGenerator {
 /// - Apple platforms use `arc4random_buf(3)`.
 /// - Linux platforms use `getrandom(2)` when available; otherwise, they read
 ///   from `/dev/urandom`.
+/// - Windows uses `BCryptGenRandom`.
 @frozen
 public struct SystemRandomNumberGenerator: RandomNumberGenerator {
   /// Creates a new instance of the system's default random number generator.


### PR DESCRIPTION
Salvaged from #26294.