### PR TITLE
[CMake] Set the C++ standard to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ endif()
 
 ENABLE_LANGUAGE(C)
 
+# Use C++14.
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to conform to")
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS NO)
+
 # First include general CMake utilities.
 include(SwiftUtils)
 include(CheckSymbolExists)


### PR DESCRIPTION
Swift inherited C++14 when LLVM made the switch. However, the C++
standard is not set in the Swift project itself. This lead to compile
errors for files that include C++11 incompatible code.

(I'm not sure why this started showing up now) 

https://forums.swift.org/t/llvm-is-now-on-c-14/27931