### PR TITLE
ABI/API checker: don't complain about changing var to let or vice versa

### DIFF
--- a/include/swift/AST/DiagnosticsModuleDiffer.def
+++ b/include/swift/AST/DiagnosticsModuleDiffer.def
@@ -80,8 +80,6 @@ ERROR(decl_kind_changed,none,"%0 has been changed to a %1", (StringRef, StringRe
 
 ERROR(optional_req_changed,none,"%0 is %select{now|no longer}1 an optional requirement", (StringRef, bool))
 
-ERROR(var_let_changed,none,"%0 changes from %select{var|let}1 to %select{let|var}1", (StringRef, bool))
-
 ERROR(no_longer_open,none,"%0 is no longer open for subclassing", (StringRef))
 
 ERROR(func_type_escaping_changed,none,"%0 has %select{removed|added}2 @escaping in %1", (StringRef, StringRef, bool))

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -76,8 +76,6 @@ cake: Protocol P4 is a new API without @available attribute
 cake: Struct C6 is now with @frozen
 cake: Var C1.CIIns1 changes from weak to strong
 cake: Var C1.CIIns2 changes from strong to weak
-cake: Var GlobalLetChangedToVar changes from let to var
-cake: Var GlobalVarChangedToLet changes from var to let
 cake: Var RequiementChanges.addedVar is a new API without @available attribute
 cake: Var fixedLayoutStruct.$__lazy_storage_$_lazy_d is a new API without @available attribute
 cake: Var fixedLayoutStruct.c is a new API without @available attribute

--- a/tools/swift-api-digester/ModuleDiagsConsumer.cpp
+++ b/tools/swift-api-digester/ModuleDiagsConsumer.cpp
@@ -42,7 +42,6 @@ static StringRef getCategoryName(uint32_t ID) {
     return "/* Renamed Decls */";
   case LocalDiagID::decl_attr_change:
   case LocalDiagID::decl_new_attr:
-  case LocalDiagID::var_let_changed:
   case LocalDiagID::func_self_access_change:
   case LocalDiagID::new_decl_without_intro:
     return "/* Decl Attribute changes */";

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -962,9 +962,6 @@ void swift::ide::api::SDKNodeDeclVar::diagnose(SDKNode *Right) {
     if (hasFixedBinaryOrder() != RV->hasFixedBinaryOrder()) {
       emitDiag(Loc, diag::var_has_fixed_order_change, hasFixedBinaryOrder());
     }
-    if (isLet() != RV->isLet()) {
-      emitDiag(Loc, diag::var_let_changed, isLet());
-    }
   }
 }
 


### PR DESCRIPTION
The tool diagnoses the removal of getter/setter for properties, so complaining about the keyword change can be redundant.

rdar://problem/57201030