### PR TITLE
Check generic requirements of parent context when realizing non-generic types

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -629,8 +629,6 @@ Type ConstraintSystem::openUnboundGenericType(
     Type type, ConstraintLocatorBuilder locator) {
   assert(!type->getCanonicalType()->hasTypeParameter());
 
-  checkNestedTypeConstraints(*this, type, locator);
-
   if (!type->hasUnboundGenericType())
     return type;
 
@@ -988,6 +986,8 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
                                       TypeResolverContext::InExpression,
                                       /*isSpecialized=*/false);
 
+    checkNestedTypeConstraints(*this, type, locator);
+
     // Open the type.
     type = openUnboundGenericType(type, locator);
 
@@ -1241,6 +1241,9 @@ ConstraintSystem::getTypeOfMemberReference(
 
     auto memberTy = TypeChecker::substMemberTypeWithBase(DC->getParentModule(),
                                                          typeDecl, baseObjTy);
+
+    checkNestedTypeConstraints(*this, memberTy, locator);
+
     // Open the type if it was a reference to a generic type.
     memberTy = openUnboundGenericType(memberTy, locator);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -632,28 +632,6 @@ public:
 
   /// Apply generic arguments to the given type.
   ///
-  /// This function emits diagnostics about an invalid type or the wrong number
-  /// of generic arguments, whereas applyUnboundGenericArguments requires this
-  /// to be in a correct and valid form.
-  ///
-  /// \param type The generic type to which to apply arguments.
-  /// \param loc The source location for diagnostic reporting.
-  /// \param resolution The type resolution to perform.
-  /// \param generic The arguments to apply with the angle bracket range for
-  /// diagnostics.
-  /// \param options The type resolution context.
-  ///
-  /// \returns A BoundGenericType bound to the given arguments, or null on
-  /// error.
-  ///
-  /// \see applyUnboundGenericArguments
-  static Type applyGenericArguments(Type type, SourceLoc loc,
-                                    TypeResolution resolution,
-                                    GenericIdentTypeRepr *generic,
-                                    TypeResolutionOptions options);
-
-  /// Apply generic arguments to the given type.
-  ///
   /// This function requires a valid unbound generic type with the correct
   /// number of generic arguments given, whereas applyGenericArguments emits
   /// diagnostics in those cases.

--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -15,7 +15,7 @@ struct Z2: AssociatedType {
 }
 
 struct SameType<T> {}
-extension SameType where T == X { // expected-note 5 {{where 'T' = 'Y'}}
+extension SameType where T == X { // expected-note 13{{requirement specified as 'T' == 'X' [with T = Y]}}
     typealias TypeAlias1 = T
     typealias TypeAlias2 = Y
     typealias TypeAlias3<U> = (T, U) // expected-note {{requirement specified as 'T' == 'X' [with T = Y]}}
@@ -36,25 +36,24 @@ let _ = SameType<X>.Decl3.self
 let _ = SameType<X>.Decl4<X>.self
 let _ = SameType<X>.Decl5<X>.self
 
-let _ = SameType<Y>.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.TypeAlias1.self // expected-error {{'SameType<Y>.TypeAlias1' (aka 'X') requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.TypeAlias2.self // expected-error {{'SameType<Y>.TypeAlias2' (aka 'Y') requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.TypeAlias3<X>.self // expected-error {{'SameType<Y>.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.self // expected-error {{referencing struct 'Decl1' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl2.self // expected-error {{referencing enum 'Decl2' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl3.self // expected-error {{referencing class 'Decl3' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl2.self // expected-error {{'SameType<Y>.Decl2' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl3.self // expected-error {{'SameType<Y>.Decl3' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl4<X>.self // expected-error {{'SameType<Y>.Decl4' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl5<X>.self // expected-error {{'SameType<Y>.Decl5' requires the types 'Y' and 'X' be equivalent}}
 
-extension SameType: AssociatedType where T == X {} // expected-note {{where 'T' = 'Y'}}
-
-// (Y first here, because there were issues caused by running associated type
-// inference for the first time)
-let _ = SameType<Y>.T.self // expected-error {{referencing type alias 'T' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
+extension SameType: AssociatedType where T == X {}
+// expected-note@-1 {{requirement specified as 'T' == 'X' [with T = Y]}}
 
 let _ = SameType<X>.T.self
+let _ = SameType<Y>.T.self // expected-error {{'SameType<Y>.T' (aka 'X') requires the types 'Y' and 'X' be equivalent}}
+
 
 struct Conforms<T> {}
-extension Conforms where T: P { // expected-note 5 {{where 'T' = 'Y'}}
+extension Conforms where T: P {
     typealias TypeAlias1 = T
     typealias TypeAlias2 = Y
     typealias TypeAlias3<U> = (T, U)
@@ -75,33 +74,33 @@ let _ = Conforms<X>.Decl3.self
 let _ = Conforms<X>.Decl4<X>.self
 let _ = Conforms<X>.Decl5<X>.self
 
-let _ = Conforms<Y>.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'Conforms' requires that 'Y' conform to 'P'}}
-let _ = Conforms<Y>.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'Conforms' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.TypeAlias1.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
+let _ = Conforms<Y>.TypeAlias2.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 let _ = Conforms<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
-let _ = Conforms<Y>.Decl1.self // expected-error {{referencing struct 'Decl1' on 'Conforms' requires that 'Y' conform to 'P'}}
-let _ = Conforms<Y>.Decl2.self // expected-error {{referencing enum 'Decl2' on 'Conforms' requires that 'Y' conform to 'P'}}
-let _ = Conforms<Y>.Decl3.self // expected-error {{referencing class 'Decl3' on 'Conforms' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.Decl1.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
+let _ = Conforms<Y>.Decl2.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
+let _ = Conforms<Y>.Decl3.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 let _ = Conforms<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 let _ = Conforms<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 
-extension Conforms: AssociatedType where T: P {} // expected-note {{where 'T' = 'Y'}}
+extension Conforms: AssociatedType where T: P {}
 
-let _ = Conforms<Y>.T.self // expected-error {{referencing type alias 'T' on 'Conforms' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.T.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 
 let _ = Conforms<X>.T.self
 
 // Now, even more nesting!
 
-extension SameType.Decl1 { // expected-note 5 {{where 'T' = 'Y'}}
+extension SameType.Decl1 {
     typealias TypeAlias1 = T
     typealias TypeAlias2 = Y
-    typealias TypeAlias3<U> = (T, U) // expected-note {{requirement specified as 'T' == 'X' [with T = Y]}}
+    typealias TypeAlias3<U> = (T, U)
 
     struct Decl1 {}
     enum Decl2 {}
     class Decl3 {}
-    struct Decl4<U> {} // expected-note {{requirement specified as 'T' == 'X' [with T = Y]}}
-    enum Decl5<U: P> {} // expected-note {{requirement specified as 'T' == 'X' [with T = Y]}}
+    struct Decl4<U> {}
+    enum Decl5<U: P> {}
 }
 
 let _ = SameType<X>.Decl1.TypeAlias1.self
@@ -113,16 +112,16 @@ let _ = SameType<X>.Decl1.Decl3.self
 let _ = SameType<X>.Decl1.Decl4<X>.self
 let _ = SameType<X>.Decl1.Decl5<X>.self
 
-let _ = SameType<Y>.Decl1.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.TypeAlias3<X>.self // expected-error {{'SameType<Y>.Decl1.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl1.self // expected-error {{referencing struct 'Decl1' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl2.self // expected-error {{referencing enum 'Decl2' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl3.self // expected-error {{referencing class 'Decl3' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl4<X>.self // expected-error {{'SameType<Y>.Decl1.Decl4' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl5<X>.self // expected-error {{'SameType<Y>.Decl1.Decl5' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.TypeAlias1.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.TypeAlias2.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.TypeAlias3<X>.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl1.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl2.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl3.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl4<X>.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl5<X>.self // expected-error {{'SameType<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
 
-extension SameType.Decl4 where U == X { // expected-note 5 {{where 'U' = 'Y'}}
+extension SameType.Decl4 where U == X { // expected-note 5 {{requirement specified as 'U' == 'X' [with U = Y]}}
     typealias TypeAlias1 = T
     typealias TypeAlias2 = Y
     typealias TypeAlias3<V> = (T, U, V) // expected-note {{requirement specified as 'U' == 'X' [with U = Y]}}
@@ -145,12 +144,12 @@ let _ = SameType<X>.Decl4<X>.Decl3.self
 let _ = SameType<X>.Decl4<X>.Decl4<X>.self
 let _ = SameType<X>.Decl4<X>.Decl5<X>.self
 
-let _ = SameType<X>.Decl4<Y>.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.TypeAlias1.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias1' (aka 'X') requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.TypeAlias2.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias2' (aka 'Y') requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.TypeAlias3<X>.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.Decl1.self // expected-error {{referencing struct 'Decl1' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.Decl2.self // expected-error {{referencing enum 'Decl2' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.Decl3.self // expected-error {{referencing class 'Decl3' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.Decl1.self // expected-error {{'SameType<X>.Decl4<Y>.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.Decl2.self // expected-error {{'SameType<X>.Decl4<Y>.Decl2' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.Decl3.self // expected-error {{'SameType<X>.Decl4<Y>.Decl3' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.Decl4<X>.self // expected-error {{'SameType<X>.Decl4<Y>.Decl4' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.Decl5<X>.self // expected-error {{'SameType<X>.Decl4<Y>.Decl5' requires the types 'Y' and 'X' be equivalent}}
 
@@ -174,9 +173,6 @@ let _ = SameType<Y>.Decl4<Y>.Decl5<X>.self // expected-error {{'SameType<Y>.Decl
 
 // Finally, extra complicated:
 extension Conforms.Decl4 where U: AssociatedType, U.T: P {
-// expected-note@-1 5 {{where 'U' = 'Y'}}
-// expected-note@-2 5 {{'U.T' = 'Z2.T' (aka 'Y')}}
-// expected-note@-3 5 {{'U.T' = 'Y.T'}}
     typealias TypeAlias1 = T
     typealias TypeAlias2 = Y
     typealias TypeAlias3<V> = (T, U, V)
@@ -200,34 +196,29 @@ let _ = Conforms<X>.Decl4<Z1>.Decl5<X>.self
 // Two different forms of badness, corresponding to the two requirements:
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias1.self
-// expected-error@-1 {{referencing type alias 'TypeAlias1' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{referencing type alias 'TypeAlias1' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias2.self
-// expected-error@-1 {{referencing type alias 'TypeAlias2' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{referencing type alias 'TypeAlias2' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 let _ = Conforms<X>.Decl4<Y>.Decl1.self
-// expected-error@-1 {{referencing struct 'Decl1' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{referencing struct 'Decl1' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl2.self
-// expected-error@-1 {{referencing enum 'Decl2' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{referencing enum 'Decl2' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl3.self
-// expected-error@-1 {{referencing class 'Decl3' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{referencing class 'Decl3' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 let _ = Conforms<X>.Decl4<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.TypeAlias3<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{referencing struct 'Decl1' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{referencing enum 'Decl2' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{referencing class 'Decl3' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl4<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl5<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -6,26 +6,23 @@ struct S<T> {}
 
 class C : P {}
 
-extension S where T : P {
-// expected-note@-1 {{where 'T' = 'T'}}
-// expected-note@-2 {{where 'T' = 'Int'}}
+extension S where T : P { // expected-note {{where 'T' = 'T'}}
   typealias A = Int
   typealias B<U> = S<U>
 }
 
-extension S where T == Float { // expected-note {{where 'T' = 'Int'}}
+extension S where T == Float { // expected-note {{requirement specified as 'T' == 'Float' [with T = Int]}}
   typealias C = Int
 }
 
 class A<T, U> {}
 
-extension A where T == [U], U: P { // expected-note {{where 'U' = 'Float'}}
+extension A where T == [U], U: P {
   typealias S1 = Int
 }
 
 extension A where T == [U], U == Int {
-// expected-note@-1 {{where 'U' = 'String'}}
-// expected-note@-2 {{where 'T' = '[String]'}}
+// expected-note@-1 {{requirement specified as 'T' == '[Int]' [with T = [String]]}}
   typealias S2 = Int
 }
 
@@ -33,15 +30,14 @@ class B<U> : A<[U], U> {}
 
 _ = B<C>.S1()          // Ok
 _ = B<Int>.S2()        // Ok
-_ = B<Float>.S1()      // expected-error {{referencing type alias 'S1' on 'A' requires that 'Float' conform to 'P'}}
+_ = B<Float>.S1()      // expected-error {{type 'Float' does not conform to protocol 'P'}}
 _ = B<String>.S2()
-// expected-error@-1 {{referencing type alias 'S2' on 'A' requires the types '[String]' and '[Int]' be equivalent}}
-// expected-error@-2 {{referencing type alias 'S2' on 'A' requires the types 'String' and 'Int' be equivalent}}
+// expected-error@-1 {{'B<String>.S2' (aka 'Int') requires the types '[String]' and '[Int]' be equivalent}}
 
 _ = S<C>.A()           // Ok
-_ = S<Int>.A()         // expected-error {{referencing type alias 'A' on 'S' requires that 'Int' conform to 'P'}}
+_ = S<Int>.A()         // expected-error {{type 'Int' does not conform to protocol 'P'}}
 _ = S<String>.B<Int>() // expected-error {{type 'String' does not conform to protocol 'P'}}
-_ = S<Int>.C()         // expected-error {{referencing type alias 'C' on 'S' requires the types 'Int' and 'Float' be equivalent}}
+_ = S<Int>.C()         // expected-error {{'S<Int>.C' (aka 'Int') requires the types 'Int' and 'Float' be equivalent}}
 
 func foo<T>(_ s: S<T>.Type) {
   _ = s.A() // expected-error {{referencing type alias 'A' on 'S' requires that 'T' conform to 'P'}}

--- a/test/Constraints/requirement_failures_in_contextual_type.swift
+++ b/test/Constraints/requirement_failures_in_contextual_type.swift
@@ -2,8 +2,8 @@
 
 struct A<T> {}
 
-extension A where T == Int32 { // expected-note 2 {{where 'T' = 'Int'}}
-  struct B : ExpressibleByIntegerLiteral { // expected-note {{where 'T' = 'Int'}}
+extension A where T == Int32 { // expected-note 3{{requirement specified as 'T' == 'Int32' [with T = Int]}}
+  struct B : ExpressibleByIntegerLiteral {
     typealias E = Int
     typealias IntegerLiteralType = Int
 
@@ -14,8 +14,8 @@ extension A where T == Int32 { // expected-note 2 {{where 'T' = 'Int'}}
 }
 
 let _: A<Int>.B = 0
-// expected-error@-1 {{referencing struct 'B' on 'A' requires the types 'Int' and 'Int32' be equivalent}}
+// expected-error@-1 {{'A<Int>.B' requires the types 'Int' and 'Int32' be equivalent}}
 let _: A<Int>.C = 0
-// expected-error@-1 {{referencing type alias 'C' on 'A' requires the types 'Int' and 'Int32' be equivalent}}
+// expected-error@-1 {{'A<Int>.C' (aka 'Int') requires the types 'Int' and 'Int32' be equivalent}}
 let _: A<Int>.B.E = 0
-// expected-error@-1 {{referencing type alias 'E' on 'A.B' requires the types 'Int' and 'Int32' be equivalent}}
+// expected-error@-1 {{'A<Int>.B' requires the types 'Int' and 'Int32' be equivalent}}

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -341,3 +341,11 @@ extension Tree.LimbContent.Contents {
 extension Tree.BoughPayload.Contents {
  // expected-error@-1 {{constrained extension must be declared on the unspecialized generic type 'Nest'}}
 }
+
+// SR-10466 Check 'where' clause when referencing type defined inside extension
+struct SR_10466<T> {
+  var a : A // expected-error {{'SR_10466<T>.A' (aka 'Int') requires the types 'T' and 'Never' be equivalent}}
+}
+extension SR_10466 where T == Never { // expected-note {{requirement specified as 'T' == 'Never' [with T = T]}}
+  typealias A = Int
+}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1584,12 +1584,12 @@ struct SR_11288_S3: SR_11288_P3 {
 // typealias as propertyWrapper in a constrained protocol extension //
 
 protocol SR_11288_P4 {}
-extension SR_11288_P4 where Self: AnyObject { // expected-note 2 {{where 'Self' = 'SR_11288_S4'}}
+extension SR_11288_P4 where Self: AnyObject { // expected-note {{requirement specified as 'Self' : 'AnyObject' [with Self = SR_11288_S4]}}
   typealias SR_11288_Wrapper4 = SR_11288_S0
 }
 
 struct SR_11288_S4: SR_11288_P4 {
-  @SR_11288_Wrapper4 var answer = 42 // expected-error 2 {{referencing type alias 'SR_11288_Wrapper4' on 'SR_11288_P4' requires that 'SR_11288_S4' be a class type}}
+  @SR_11288_Wrapper4 var answer = 42 // expected-error {{'SR_11288_S4.SR_11288_Wrapper4' (aka 'SR_11288_S0') requires that 'SR_11288_S4' be a class type}}
 }
 
 class SR_11288_C0: SR_11288_P4 {

--- a/validation-test/compiler_crashers_2_fixed/sr10201.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr10201.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+struct A {
+  typealias Value = Int
+}
+
+protocol B {
+  typealias Value = A.Value
+  typealias T = String
+}
+
+protocol NestedProtocol {
+  typealias _B = B
+}
+
+struct Something: NestedProtocol {
+
+  struct InnerTest: _B {
+    var value: Value = 42
+    var t: T = "wait what?"
+  }
+}
+
+protocol X {}
+
+protocol Y {
+  typealias _X = X
+  var x: _X { get }
+}
+
+struct Struct: Y {
+  var x: _X = __X()
+}
+
+extension Struct {
+  struct __X: _X {}
+}


### PR DESCRIPTION
When realizing a type like Foo<A>.Bar, we have to account for the
possibility that Bar is defined in a constrained extension of Foo,
and has generic requirements beyond those that Foo itself places
on 'A'.
    
Previously we only handled this for types referenced from the
constraint system as part of openUnboundGenericType(), so we were
allowing invalid types through in type context.
    
Add the right checking to applyGenericArguments() to close the
hole. Note that the old code path still exists in the constraint
solver; it is used for member accesses on metatype bases only.
    
Fixes #48014.

Also add a regression test for <https://bugs.swift.org/browse/SR-10201>.