### PR TITLE
[Constraint solver] Remove expression from the constructor.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -530,11 +530,6 @@ public:
   /// the parent map.
   llvm::DenseMap<Expr *, Expr *> getParentMap();
 
-  /// Produce a mapping from each subexpression to its depth and parent,
-  /// in the root expression. The root expression has depth 0, its children have
-  /// depth 1, etc.
-  llvm::DenseMap<Expr *, std::pair<unsigned, Expr *>> getDepthMap();
-
   /// Produce a mapping from each expression to its index according to a
   /// preorder traversal of the expressions. The parent has index 0, its first
   /// child has index 1, its second child has index 2 if the first child is a

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -530,12 +530,6 @@ public:
   /// the parent map.
   llvm::DenseMap<Expr *, Expr *> getParentMap();
 
-  /// Produce a mapping from each expression to its index according to a
-  /// preorder traversal of the expressions. The parent has index 0, its first
-  /// child has index 1, its second child has index 2 if the first child is a
-  /// leaf node, etc.
-  llvm::DenseMap<Expr *, unsigned> getPreorderIndexMap();
-
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &OS, unsigned Indent = 0) const;
   void dump(raw_ostream &OS, llvm::function_ref<Type(const Expr *)> getType,

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -721,34 +721,6 @@ llvm::DenseMap<Expr *, Expr *> Expr::getParentMap() {
   return parentMap;
 }
 
-llvm::DenseMap<Expr *, std::pair<unsigned, Expr *>> Expr::getDepthMap() {
-  class RecordingTraversal : public ASTWalker {
-  public:
-    llvm::DenseMap<Expr *, std::pair<unsigned, Expr *>> &DepthMap;
-    unsigned Depth = 0;
-
-    explicit RecordingTraversal(
-        llvm::DenseMap<Expr *, std::pair<unsigned, Expr *>> &depthMap)
-        : DepthMap(depthMap) {}
-
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-      DepthMap[E] = {Depth, Parent.getAsExpr()};
-      Depth++;
-      return { true, E };
-    }
-
-    Expr *walkToExprPost(Expr *E) override {
-      Depth--;
-      return E;
-    }
-  };
-
-  llvm::DenseMap<Expr *, std::pair<unsigned, Expr *>> depthMap;
-  RecordingTraversal traversal(depthMap);
-  walk(traversal);
-  return depthMap;
-}
-
 llvm::DenseMap<Expr *, unsigned> Expr::getPreorderIndexMap() {
   class RecordingTraversal : public ASTWalker {
   public:

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -721,28 +721,6 @@ llvm::DenseMap<Expr *, Expr *> Expr::getParentMap() {
   return parentMap;
 }
 
-llvm::DenseMap<Expr *, unsigned> Expr::getPreorderIndexMap() {
-  class RecordingTraversal : public ASTWalker {
-  public:
-    llvm::DenseMap<Expr *, unsigned> &IndexMap;
-    unsigned Index = 0;
-
-    explicit RecordingTraversal(llvm::DenseMap<Expr *, unsigned> &indexMap)
-      : IndexMap(indexMap) { }
-
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-      IndexMap[E] = Index;
-      Index++;
-      return { true, E };
-    }
-  };
-
-  llvm::DenseMap<Expr *, unsigned> indexMap;
-  RecordingTraversal traversal(indexMap);
-  walk(traversal);
-  return indexMap;
-}
-
 //===----------------------------------------------------------------------===//
 // Support methods for Exprs.
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3754,6 +3754,8 @@ namespace {
 } // end anonymous namespace
 
 Expr *ConstraintSystem::generateConstraints(Expr *expr, DeclContext *dc) {
+  InputExprs.insert(expr);
+
   // Remove implicit conversions from the expression.
   expr = expr->walk(SanitizeExpr(*this));
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -574,7 +574,7 @@ bool ConstraintSystem::Candidate::solve(
   };
 
   // Allocate new constraint system for sub-expression.
-  ConstraintSystem cs(DC, None, E);
+  ConstraintSystem cs(DC, None);
   cs.baseCS = &BaseCS;
 
   // Set up expression type checker timer for the candidate.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -75,16 +75,11 @@ ExpressionTimer::~ExpressionTimer() {
 
 
 ConstraintSystem::ConstraintSystem(DeclContext *dc,
-                                   ConstraintSystemOptions options,
-                                   Expr *expr)
+                                   ConstraintSystemOptions options)
   : Context(dc->getASTContext()), DC(dc), Options(options),
     Arena(dc->getASTContext(), Allocator),
     CG(*new ConstraintGraph(*this))
 {
-  if (expr) {
-    InputExprs.insert(expr);
-  }
-
   assert(DC && "context required");
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -528,6 +528,12 @@ static void extendDepthMap(
 
 Optional<std::pair<unsigned, Expr *>> ConstraintSystem::getExprDepthAndParent(
     Expr *expr) {
+  // Check whether the parent has this information.
+  if (baseCS && baseCS != this) {
+    if (auto known = baseCS->getExprDepthAndParent(expr))
+      return *known;
+  }
+
   // Bring the set of expression weights up to date.
   while (NumInputExprsInWeights < InputExprs.size()) {
     extendDepthMap(InputExprs[NumInputExprsInWeights], ExprWeights);
@@ -537,9 +543,6 @@ Optional<std::pair<unsigned, Expr *>> ConstraintSystem::getExprDepthAndParent(
   auto e = ExprWeights.find(expr);
   if (e != ExprWeights.end())
     return e->second;
-
-  if (baseCS && baseCS != this)
-    return baseCS->getExprDepthAndParent(expr);
 
   return None;
 }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1664,8 +1664,7 @@ public:
   };
 
   ConstraintSystem(DeclContext *dc,
-                   ConstraintSystemOptions options,
-                   Expr *expr = nullptr);
+                   ConstraintSystemOptions options);
   ~ConstraintSystem();
 
   /// Retrieve the type checker associated with this constraint system.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1024,6 +1024,12 @@ public:
   unsigned CountDisjunctions = 0;
 
 private:
+  /// The set of expressions for which we have generated constraints.
+  llvm::SetVector<Expr *> InputExprs;
+
+  /// The number of input expressions whose parents and depths have
+  /// been entered into \c ExprWeights.
+  unsigned NumInputExprsInWeights = 0;
 
   llvm::DenseMap<Expr *, std::pair<unsigned, Expr *>> ExprWeights;
 
@@ -1982,28 +1988,21 @@ public:
   getConstraintLocator(const ConstraintLocatorBuilder &builder);
 
   /// Lookup and return parent associated with given expression.
-  Expr *getParentExpr(Expr *expr) const {
-    auto e = ExprWeights.find(expr);
-    if (e != ExprWeights.end())
-      return e->second.second;
-
-    if (baseCS && baseCS != this)
-      return baseCS->getParentExpr(expr);
-
+  Expr *getParentExpr(Expr *expr) {
+    if (auto result = getExprDepthAndParent(expr))
+      return result->second;
     return nullptr;
   }
 
   /// Retrieve the depth of the given expression.
-  Optional<unsigned> getExprDepth(Expr *expr) const {
-    auto e = ExprWeights.find(expr);
-    if (e != ExprWeights.end())
-      return e->second.first;
-
-    if (baseCS && baseCS != this)
-      return baseCS->getExprDepth(expr);
-
+  Optional<unsigned> getExprDepth(Expr *expr) {
+    if (auto result = getExprDepthAndParent(expr))
+      return result->first;
     return None;
   }
+
+  /// Retrieve the depth and parent expression of the given expression.
+  Optional<std::pair<unsigned, Expr *>> getExprDepthAndParent(Expr *expr);
 
   /// Returns a locator describing the callee for the anchor of a given locator.
   ///

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2198,7 +2198,7 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   if (options.contains(TypeCheckExprFlags::SubExpressionDiagnostics))
     csOptions |= ConstraintSystemFlags::SubExpressionDiagnostics;
 
-  ConstraintSystem cs(dc, csOptions, expr);
+  ConstraintSystem cs(dc, csOptions);
   cs.baseCS = baseCS;
 
   // Verify that a purpose was specified if a convertType was.  Note that it is


### PR DESCRIPTION
Rather than setting up the constraint solver with a single expression
(that gets recorded for parents/depths), record each expression that
goes through constraint generation.