### PR TITLE
[msvc] std::move the pointer for the method that requires an rvalue.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2049,7 +2049,7 @@ DefaultArgumentInitContextRequest::evaluate(Evaluator &eval,
     if (param == otherParam)
       result = initDC;
     else
-      eval.cacheOutput(DefaultArgumentInitContextRequest{otherParam}, initDC);
+      eval.cacheOutput(DefaultArgumentInitContextRequest{otherParam}, std::move(initDC));
   }
   assert(result && "Didn't create init context?");
   return result;


### PR DESCRIPTION
MSVC was chocking with the given syntax, saying that
'swift::DefaultArgumentInitializer *' wasn't the expected 'swift::Initializer *&&'.

Introduced in #27756 and started failing in https://ci-external.swift.org/job/oss-swift-windows-x86_64/1967