### PR TITLE
[IDE] Enable 'IgnoreSwiftSourceInfo' in code completion

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -172,6 +172,10 @@ static bool swiftCodeCompleteImpl(
     return false;
   }
 
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+
   const char *Position = InputFile->getBufferStart() + CodeCompletionOffset;
   std::unique_ptr<llvm::WritableMemoryBuffer> NewBuffer =
       llvm::WritableMemoryBuffer::getNewUninitMemBuffer(

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -67,6 +67,10 @@ static bool swiftConformingMethodListImpl(
     return false;
   }
 
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+
   Invocation.setCodeCompletionPoint(newBuffer.get(), Offset);
 
   // Create a factory for code completion callbacks that will feed the

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -67,6 +67,10 @@ static bool swiftTypeContextInfoImpl(SwiftLangSupport &Lang,
     return false;
   }
 
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+
   Invocation.setCodeCompletionPoint(newBuffer.get(), Offset);
 
   // Create a factory for code completion callbacks that will feed the

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -740,6 +740,10 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
 
   CompilerInvocation Invocation(InitInvok);
 
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+
   Invocation.setCodeCompletionPoint(CleanFile.get(), Offset);
 
   // Create a CodeCompletionConsumer.
@@ -800,6 +804,10 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
                << " at offset " << Offset << "\n";
 
   CompilerInvocation Invocation(InitInvok);
+
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
 
   Invocation.setCodeCompletionPoint(CleanFile.get(), Offset);
 
@@ -869,6 +877,10 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
 
   Invocation.setCodeCompletionPoint(CleanFile.get(), CodeCompletionOffset);
+
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
 
   // Disable to build syntax tree because code-completion skips some portion of
   // source text. That breaks an invariant of syntax tree building.


### PR DESCRIPTION
Getting source locations from `.swiftsourceinfo` is currently expensive. Since they are not necessary for code completion, set `IgnoreSwiftSourceInfo` to `true`.

rdar://problem/57194358
https://bugs.swift.org/browse/SR-11767

(This reduces the testing time for `IDE/complete_value_expr.swift` from 29sec to 22sec).