### PR TITLE
FIX: stdlib->public->core->String.swift  478

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -444,7 +444,7 @@ extension String {
   /// different `UInt8` arrays---the first with well-formed UTF-8 code unit
   /// sequences and the second with an ill-formed sequence at the end.
   ///
-  ///     let validUTF8: [UInt8] = [67, 97, 102, -61, -87, 0]
+  ///     let validUTF8: [Int8] = [67, 97, 102, -61, -87, 0]
   ///     let s = String(uninitializedCapacity: validUTF8.count,
   ///                    initializingUTF8With: { ptr in
   ///         ptr.initializeFrom(validUTF8)
@@ -452,7 +452,7 @@ extension String {
   ///     })
   ///     // Prints "Café"
   ///
-  ///     let invalidUTF8: [UInt8] = [67, 97, 102, -61, 0]
+  ///     let invalidUTF8: [Int8] = [67, 97, 102, -61, 0]
   ///     let s = String(uninitializedCapacity: invalidUTF8.count,
   ///                    initializingUTF8With: { ptr in
   ///         ptr.initializeFrom(invalidUTF8)
@@ -479,7 +479,7 @@ extension String {
   internal init(
     uninitializedCapacity capacity: Int,
     initializingUTF8With initializer: (
-      _ buffer: UnsafeMutableBufferPointer<UInt8>
+      _ buffer: UnsafeMutableBufferPointer<Int8>
     ) throws -> Int
   ) rethrows {
     if _fastPath(capacity <= _SmallString.capacity) {


### PR DESCRIPTION
  @inline(__always)
  internal init(
    uninitializedCapacity capacity: Int,
    initializingUTF8With initializer: (
      _ buffer: UnsafeMutableBufferPointer<UInt8>
    ) throws -> Int
  ) rethrows {
    if _fastPath(capacity <= _SmallString.capacity) {
      let smol = try _SmallString(initializingUTF8With: initializer)
      // Fast case where we fit in a _SmallString and don't need UTF8 validation
      if _fastPath(smol.isASCII) {
        self = String(_StringGuts(smol))
      } else {
        //We succeeded in making a _SmallString, but may need to repair UTF8
        self = smol.withUTF8 { String._fromUTF8Repairing($0).result }
      }
      return
    }
    
    self = try String._fromLargeUTF8Repairing(
      uninitializedCapacity: capacity,
      initializingWith: initializer)
  }

The instance used on the annotation document cannot be compiled by Xcode 👍 
let invalidUTF8: [UInt8] = [67, 97, 102, -61, 0]

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
