### PR TITLE
[AutoDiff] Fix activity analysis use-after-free crash.

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/tf945-activity-analysis-tuple-element-addr.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf945-activity-analysis-tuple-element-addr.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-sil %s
+// REQUIRES: asserts
+
+// TF-945: Activity analysis crash because
+// `DifferentiableActivityInfo::getLookupConformanceFunction` returned a
+// `LookupConformanceFn` (type alias for `llvm::function_ref`), which does not
+// own the underlying callable.
+
+@differentiable
+func TF_945(_ x: Float) -> Float {
+  var result = (x, 1)
+  let (x, y) = result
+  return x
+}


### PR DESCRIPTION
Remove `DifferentiableActivityInfo::getLookupConformanceFunction`, which
returned a `LookupConformanceFn` (type alias for `LookupConformanceFn`),
which does not own the underlying callable.

Add a `DifferentiableActivityInfo::hasTangentSpace` helper, which is easier
to use and avoids the issue.

Resolves TF-945.