### PR TITLE
[CSDiagnostics] A couple of fixes for the "self." immutability fix-it

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3424,9 +3424,9 @@ ERROR(assignment_bang_has_immutable_subcomponent,none,
 NOTE(change_to_mutating,none,
      "mark %select{method|accessor}0 'mutating' to make 'self' mutable",
      (bool))
-NOTE(masked_instance_variable,none,
-     "add explicit 'self.' to refer to mutable property of %0",
-     (Type))
+NOTE(masked_mutable_property,none,
+     "add explicit '%0' to refer to mutable %1 of %2",
+     (StringRef, DescriptiveDeclKind, Type))
 
 ERROR(assignment_let_property_delegating_init,none,
       "'let' property %0 may not be initialized directly; use "

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1647,9 +1647,10 @@ bool AssignmentFailure::diagnoseAsError() {
         });
 
         if (foundProperty != results.end()) {
-          emitDiagnostic(Loc, diag::masked_instance_variable,
+          auto startLoc = immutableExpr->getStartLoc();
+          emitDiagnostic(startLoc, diag::masked_instance_variable,
                          typeContext->getSelfTypeInContext())
-              .fixItInsert(Loc, "self.");
+              .fixItInsert(startLoc, "self.");
         }
       }
 

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -701,3 +701,15 @@ extension JustAProtocol {
     name = "World" // expected-error {{cannot assign to property: 'self' is immutable}}
   }
 }
+
+struct S {
+  var x = 0
+
+  struct Nested {
+    func foo() {
+      // SR-11786: Make sure we don't offer the 'self.' fix-it here.
+      let x = 0 // expected-note {{change 'let' to 'var' to make it mutable}}
+      x += 1 // expected-error {{left side of mutating operator isn't mutable: 'x' is a 'let' constant}}
+    }
+  }
+}

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -704,6 +704,7 @@ extension JustAProtocol {
 
 struct S {
   var x = 0
+  static var y = 0
 
   struct Nested {
     func foo() {
@@ -724,5 +725,19 @@ struct S {
 
     x = 1 // expected-error {{cannot assign to value: 'x' is a 'let' constant}}
     // expected-note@-1 {{add explicit 'self.' to refer to mutable property of 'S'}} {{5-5=self.}}
+
+    // SR-11788: Insert "Type." for a static property.
+    let y = 0 // expected-note {{change 'let' to 'var' to make it mutable}}
+    y += 1 // expected-error {{left side of mutating operator isn't mutable: 'y' is a 'let' constant}}
+    // expected-note@-1 {{add explicit 'S.' to refer to mutable static property of 'S'}} {{5-5=S.}}
+  }
+}
+
+struct S2<T> {
+  static var y: Int { get { 0 } set {} }
+  func foo() {
+    let y = 0 // expected-note {{change 'let' to 'var' to make it mutable}}
+    y += 1 // expected-error {{left side of mutating operator isn't mutable: 'y' is a 'let' constant}}
+    // expected-note@-1 {{add explicit 'S2<T>.' to refer to mutable static property of 'S2<T>'}} {{5-5=S2<T>.}}
   }
 }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -712,4 +712,17 @@ struct S {
       x += 1 // expected-error {{left side of mutating operator isn't mutable: 'x' is a 'let' constant}}
     }
   }
+
+  func bar() {
+    // SR-11787: Make sure we insert "self." in the right location.
+    let x = 0 // expected-note 3{{change 'let' to 'var' to make it mutable}}
+    x += 1 // expected-error {{left side of mutating operator isn't mutable: 'x' is a 'let' constant}}
+    // expected-note@-1 {{add explicit 'self.' to refer to mutable property of 'S'}} {{5-5=self.}}
+
+    (try x) += 1 // expected-error {{left side of mutating operator isn't mutable: 'x' is a 'let' constant}}
+    // expected-note@-1 {{add explicit 'self.' to refer to mutable property of 'S'}} {{10-10=self.}}
+
+    x = 1 // expected-error {{cannot assign to value: 'x' is a 'let' constant}}
+    // expected-note@-1 {{add explicit 'self.' to refer to mutable property of 'S'}} {{5-5=self.}}
+  }
 }


### PR DESCRIPTION
This PR changes the `self.` fix-it logic for a shadowed mutable property such that it does a qualified lookup on the type which the method is a member of, which prevents it from finding unrelated results in a parent type. In addition, it adds support for shadowed static mutable properties by offering to insert `Type.`. Finally, it tweaks the insertion location such that it's at the start of the affected expression.

Resolves SR-11786, SR-11787, and SR-11788.