### PR TITLE
Revert "Sema: Look for generic parameters first when inferring an associated type"

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3502,29 +3502,12 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
                        AssociatedTypeDecl *assocType) {
   // Conformances constructed by the ClangImporter should have explicit type
   // witnesses already.
-  if (isa<ClangModuleUnit>(DC->getModuleScopeContext())) {
+  if (isa<ClangModuleUnit>(Conformance->getDeclContext()->getModuleScopeContext())) {
     llvm::errs() << "Cannot look up associated type for imported conformance:\n";
     Conformance->getType().dump(llvm::errs());
     assocType->dump(llvm::errs());
     abort();
   }
-
-  // If we fail to find a witness via lookup, check for a generic parameter.
-  auto checkForGenericParameter = [&]() {
-    // If there is a generic parameter of the named type, use that.
-    if (auto genericSig = DC->getGenericSignatureOfContext()) {
-      for (auto gp : genericSig->getInnermostGenericParams()) {
-        if (gp->getName() == assocType->getName()) {
-          if (!checkTypeWitness(DC, Proto, assocType, gp)) {
-            recordTypeWitness(assocType, gp, nullptr);
-            return ResolveWitnessResult::Success;
-          }
-        }
-      }
-    }
-
-    return ResolveWitnessResult::Missing;
-  };
 
   // Look for a member type with the same name as the associated type.
   auto candidates = TypeChecker::lookupMemberType(
@@ -3532,7 +3515,7 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
 
   // If there aren't any candidates, we're done.
   if (!candidates) {
-    return checkForGenericParameter();
+    return ResolveWitnessResult::Missing;
   }
 
   // Determine which of the candidates is viable.
@@ -3566,7 +3549,7 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
                      return x.first->getDeclContext()
                         ->getSelfProtocolDecl() == nullptr;
                    }) == nonViable.end())
-    return checkForGenericParameter();
+    return ResolveWitnessResult::Missing;
 
   // If there is a single viable candidate, form a substitution for it.
   if (viable.size() == 1) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -918,6 +918,14 @@ AssociatedTypeInference::computeAbstractTypeWitness(
       return derivedType;
   }
 
+  // If there is a generic parameter of the named type, use that.
+  if (auto genericSig = dc->getGenericSignatureOfContext()) {
+    for (auto gp : genericSig->getInnermostGenericParams()) {
+      if (gp->getName() == assocType->getName())
+        return dc->mapTypeIntoContext(gp);
+    }
+  }
+
   return Type();
 }
 

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -283,9 +283,6 @@ extension _NativeSet {
 
 extension _NativeSet: _SetBuffer {
   @usableFromInline
-  internal typealias Element = Element
-
-  @usableFromInline
   internal typealias Index = Set<Element>.Index
 
   @inlinable

--- a/test/decl/protocol/req/associated_type_inference_valid.swift
+++ b/test/decl/protocol/req/associated_type_inference_valid.swift
@@ -22,35 +22,3 @@ struct R : P {
   let x: Y? = nil
   func foo(_: Y) {}
 }
-
-// SR-8813
-protocol BaseProtocol {
-  associatedtype Value
-  typealias Closure = () -> Value
-
-  init(closure: Closure)
-}
-
-struct Base<Value>: BaseProtocol {
-  private var closure: Closure?
-
-  init(closure: Closure) {
-    withoutActuallyEscaping(closure) { new in
-      self.closure = new
-    }
-  }
-}
-
-// SR-11407
-protocol _Drivable: AnyObject {
-  typealias Driver = Self
-}
-protocol Configurator {
-  associatedtype Drivable: _Drivable
-  typealias Driver = Drivable.Driver
-  func configure(driver: Driver)
-}
-struct AnyConfigurator<Drivable: _Drivable>: Configurator {
-  private let thing: Driver?
-  func configure(driver: AnyConfigurator.Driver) {}
-}

--- a/test/decl/protocol/typealias_inference.swift
+++ b/test/decl/protocol/typealias_inference.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+// SR-8813
+// By itself in this file because this particular expected error is omitted if there have been any other diagnostics.
+protocol BaseProtocol {
+  associatedtype Value
+  typealias Closure = () -> Value
+
+  init(closure: Closure)
+}
+
+struct Base<Value>: BaseProtocol {
+  private let closure: Closure
+
+  init(closure: Closure) { //expected-error {{reference to invalid type alias 'Closure' of type 'Base<Value>'}}
+    self.closure = closure
+  }
+}


### PR DESCRIPTION
This breaks source compatibility a little bit more than we'd like, so
reverting it for now.

Fixes <rdar://problem/57213598>.

This reverts commit 04fbcc01490646699883637abbda00546534a72c.