### PR TITLE
[Constraint system] Apply fixes without relying on a root expression.

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1709,7 +1709,7 @@ private:
 
   /// Emit the fixes computed as part of the solution, returning true if we were
   /// able to emit an error message, or false if none of the fixits worked out.
-  bool applySolutionFixes(Expr *E, const Solution &solution);
+  bool applySolutionFixes(const Solution &solution);
 
   /// If there is more than one viable solution,
   /// attempt to pick the best solution and remove all of the rest.

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -198,14 +198,14 @@ func moreComplexUnwrapFixes() {
   // expected-note@-2{{force-unwrap using '!'}}{{12-12=!}}
 
   takeOpt(t.optS.value) // expected-error{{value of optional type 'T?' must be unwrapped to refer to member 'optS' of wrapped base type 'T'}}
-  // expected-note@-1{{chain the optional using '?'}}{{17-17=?}}
+  // expected-note@-1{{chain the optional using '?'}}{{12-12=?}}
   // expected-error@-2{{value of optional type 'S?' must be unwrapped to refer to member 'value' of wrapped base type 'S'}}
-  // expected-note@-3{{chain the optional using '?'}}{{12-12=?}}
+  // expected-note@-3{{chain the optional using '?'}}{{17-17=?}}
 
   takeNon(t.optS.value) // expected-error{{value of optional type 'T?' must be unwrapped to refer to member 'optS' of wrapped base type 'T'}}
-  // expected-note@-1{{chain the optional using '?'}}{{17-17=?}}
+  // expected-note@-1{{chain the optional using '?'}}{{12-12=?}}
   // expected-error@-2{{value of optional type 'S?' must be unwrapped to refer to member 'value' of wrapped base type 'S'}}
-  // expected-note@-3{{chain the optional using '?'}}{{12-12=?}}
+  // expected-note@-3{{chain the optional using '?'}}{{17-17=?}}
   // expected-note@-4{{force-unwrap using '!'}}{{17-17=!}}
 
   takeNon(os?.value) // expected-error{{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}


### PR DESCRIPTION
When applying the set of fixes introduced by a solution, don't rely on
a walk from the "root" expression of the constraint system to
attribute the fixes to expressions. Rather, collect the fixes and emit
diagnostics in source order of the expressions that pertain to.
