### PR TITLE
[Linux] Build and install Foundation static libraries.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1847,6 +1847,9 @@ for host in "${ALL_HOSTS[@]}"; do
             tmp_product=libdispatch
             LIBDISPATCH_STATIC_CMAKE_OPTIONS=${LIBDISPATCH_CMAKE_OPTIONS[@]}
         fi
+        if [[ ${tmp_product} == "foundation_static" ]]; then
+            tmp_product=foundation
+        fi
         if ! [[ $(should_execute_action "${host}-${tmp_product}-build") ]]; then
             continue
         fi
@@ -3092,6 +3095,9 @@ for host in "${ALL_HOSTS[@]}"; do
         tmp_product=${product}
         if [[ ${tmp_product} == "libdispatch_static" ]]; then
             tmp_product=libdispatch
+        fi
+        if [[ ${tmp_product} == "foundation_static" ]]; then
+            tmp_product=foundation
         fi
         if ! [[ $(should_execute_action "${host}-${tmp_product}-install") ]]; then
             continue


### PR DESCRIPTION
- Builds libFoundation.a, libFoundationNetworking.a and
  libFoundationXML.a and installs them in usr/lib/swift_static/linux

- Note this does NOT make -static-stdlib work for Foundation at this time.

This is the equivalent PR to #25085 which built and installed libdispatch static libraries.
This PR relied on apple/swift-corelibs-foundation#2568.