### PR TITLE
build: require libdispatch on non-Darwin targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,28 +459,15 @@ if(CMAKE_C_COMPILER_ID MATCHES Clang)
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror=gnu>)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL Darwin OR
-    EXISTS "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}")
-  set(SWIFT_BUILD_SYNTAXPARSERLIB_default TRUE)
-  set(SWIFT_BUILD_SOURCEKIT_default TRUE)
-else()
-  set(SWIFT_BUILD_SYNTAXPARSERLIB_default FALSE)
-  set(SWIFT_BUILD_SOURCEKIT_default FALSE)
-endif()
-option(SWIFT_BUILD_SYNTAXPARSERLIB
-    "Build the Swift Syntax Parser library"
-    ${SWIFT_BUILD_SYNTAXPARSERLIB_default})
-option(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
-    "Only build the Swift Syntax Parser library" FALSE)
-option(SWIFT_BUILD_SOURCEKIT
-    "Build SourceKit"
-    ${SWIFT_BUILD_SOURCEKIT_default})
-option(SWIFT_ENABLE_SOURCEKIT_TESTS
-    "Enable running SourceKit tests"
-    ${SWIFT_BUILD_SOURCEKIT_default})
+option(SWIFT_BUILD_SYNTAXPARSERLIB "Build the Swift Syntax Parser library" TRUE)
+option(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB "Only build the Swift Syntax Parser library" FALSE)
+option(SWIFT_BUILD_SOURCEKIT "Build SourceKit" TRUE)
+option(SWIFT_ENABLE_SOURCEKIT_TESTS "Enable running SourceKit tests" TRUE)
 
-if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND
-  (SWIFT_BUILD_SYNTAXPARSERLIB OR SWIFT_BUILD_SOURCEKIT))
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  if(NOT EXISTS "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}")
+    message(SEND_ERROR "SyntaxParserLib and SourceKit require libdispatch on non-Darwin hosts.  Please specify SWIFT_PATH_TO_LIBDISPATCH_SOURCE")
+  endif()
   set(SWIFT_NEED_EXPLICIT_LIBDISPATCH TRUE)
 else()
   set(SWIFT_NEED_EXPLICIT_LIBDISPATCH FALSE)


### PR DESCRIPTION
libdispatch is already required for Foundation.  At this point
libdispatch is available on all the supported platforms.  We simply
enable SyntaxParserLib and SourceKit on all targets, allowing users to
disable them.  If enabled on non-Darwin platforms, the user must specify
`SWIFT_PATH_TO_LIBDISPATCH_SOURCE` to indicate where to find
libdispatch.  This is done implicitly by build-script, resulting in no
change for users.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
