### PR TITLE
[windows] Replace SourceKit cleaning regexes for Python script.

### DIFF
--- a/test/SourceKit/Inputs/sourcekitd_path_sanitize.py
+++ b/test/SourceKit/Inputs/sourcekitd_path_sanitize.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# sourcekitd_path_sanitize.py - Cleans up paths from sourcekitd-test output
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import re
+import sys
+
+SWIFTMODULE_BUNDLE_RE = re.compile(
+    r'key.filepath: ".*[/\\](.*)\.swiftmodule[/\\].*\.swiftmodule"')
+SWIFTMODULE_RE = re.compile(r'key.filepath: ".*[/\\](.*)\.swiftmodule"')
+SWIFT_RE = re.compile(r'key.filepath: ".*[/\\](.*)\.swift"')
+PCM_RE = re.compile(r'key.filepath: ".*[/\\](.*)-[0-9A-Z]*\.pcm"')
+HEADER_RE = re.compile(r' file=\\".*[/\\](.*)\.h\\"')
+
+try:
+    for line in sys.stdin.readlines():
+        line = re.sub(SWIFTMODULE_BUNDLE_RE,
+                      r'key.filepath: \1.swiftmodule', line)
+        line = re.sub(SWIFTMODULE_RE, r'key.filepath: \1.swiftmodule', line)
+        line = re.sub(SWIFT_RE, r'key.filepath: \1.swift', line)
+        line = re.sub(PCM_RE, r'key.filepath: \1.pcm', line)
+        line = re.sub(HEADER_RE, r' file=\1.h', line)
+        sys.stdout.write(line)
+except KeyboardInterrupt:
+    sys.stdout.flush()

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -1,3 +1,6 @@
+import os
+
+
 if 'sourcekit' not in config.available_features:
     config.unsupported = True
 
@@ -9,13 +12,10 @@ elif 'swift_evolve' in config.available_features:
     config.unsupported = True
 
 else:
-    sed_clean = r"sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule[/\\\\].*\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"
-    sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"
-    sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swift\"/key.filepath: \\1.swift/g'"
-    sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)-[0-9A-Z]*\\.pcm\"/key.filepath: \\1.pcm/g'"
-    sed_clean += r" | sed -e 's/ file=\\\\\".*[/\\\\]\\(.*\\)\\.h\\\\\"/ file=\\1.h/g'"
+    sk_path_sanitize = os.path.join(os.path.dirname(__file__), 'Inputs', 'sourcekitd_path_sanitize.py')
 
     config.substitutions.append( ('%sourcekitd-test', config.sourcekitd_test) )
     config.substitutions.append( ('%complete-test', config.complete_test) )
     config.substitutions.append( ('%swiftlib_dir', config.swiftlib_dir) )
-    config.substitutions.append( ('%sed_clean', sed_clean) )
+    config.substitutions.append( ('%sed_clean', '%s %s' % (sys.executable, sk_path_sanitize) )
+)


### PR DESCRIPTION
The quoting of the sed commands was creating problems in my Windows
installation. I am unsure if the implementation of sed.exe is different
or the cmd.exe is different.

In order to avoid problems in different machines, replace the piped sed
commands into only one python script. This should be multiplatform and
should execute the same in any of them. It also remove a lot of the
extra quoting and escaping, and avoids 5 processes for only just one.

