### PR TITLE
[AutoDiff] Update API/ABI status for attributes.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -510,7 +510,7 @@ DECL_ATTR(differentiable, Differentiable,
   90)
 DECL_ATTR(differentiating, Differentiating,
   OnFunc | LongAttribute | AllowMultipleAttributes |
-  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove |
+  ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove |
   NotSerialized, 91)
 SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
   OnAccessor | OnFunc | OnConstructor | OnSubscript |
@@ -518,11 +518,11 @@ SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
   NotSerialized, 92)
 SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
   OnVar |
-  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   93)
 DECL_ATTR(transposing, Transposing,
   OnFunc | LongAttribute | AllowMultipleAttributes |
-  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove |
+  ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove |
   NotSerialized, 94)
 
 SIMPLE_DECL_ATTR(IBSegueAction, IBSegueAction,


### PR DESCRIPTION
`@differentiating` and `@transposing` are:
- API/ABI stable to add. (The declaration is unaffected.)
- API/ABI breaking to remove.

`@noDerivative` is API/ABI breaking to add/remove.
Adding/removing the attribute changes derivative code behavior.