### PR TITLE
build: relax SWIFT_PATH_TO_LIBDISPATCH_SOURCE requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,13 +464,15 @@ option(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB "Only build the Swift Syntax Parser libr
 option(SWIFT_BUILD_SOURCEKIT "Build SourceKit" TRUE)
 option(SWIFT_ENABLE_SOURCEKIT_TESTS "Enable running SourceKit tests" TRUE)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(NOT EXISTS "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}")
-    message(SEND_ERROR "SyntaxParserLib and SourceKit require libdispatch on non-Darwin hosts.  Please specify SWIFT_PATH_TO_LIBDISPATCH_SOURCE")
+if(SWIFT_BUILD_SYNTAXPARSERLIB OR SWIFT_BUILD_SOURCEKIT)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(SWIFT_NEED_EXPLICIT_LIBDISPATCH FALSE)
+  else()
+    set(SWIFT_NEED_EXPLICIT_LIBDISPATCH TRUE)
+    if(NOT EXISTS "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}")
+      message(SEND_ERROR "SyntaxParserLib and SourceKit require libdispatch on non-Darwin hosts.  Please specify SWIFT_PATH_TO_LIBDISPATCH_SOURCE")
+    endif()
   endif()
-  set(SWIFT_NEED_EXPLICIT_LIBDISPATCH TRUE)
-else()
-  set(SWIFT_NEED_EXPLICIT_LIBDISPATCH FALSE)
 endif()
 
 #


### PR DESCRIPTION
This is only needed for SourceKit or SyntaxParserLib.  Relax the check
with the condition that was accidentally dropped.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
