### PR TITLE
[update-checkout] Remove the symlink from update-checkout because we …

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -37,6 +37,16 @@ class Product(object):
         It provides a customization point for Product subclasses. It is set to
         the value of product_name() by default for this reason.
         """
+
+        llvm_projects = ['clang',
+                         'clang-tools-extra',
+                         'compiler-rt',
+                         'libcxx',
+                         'lldb',
+                         'llvm']
+
+        if cls.product_name() in llvm_projects:
+            return "llvm-project/{}".format(cls.product_name())
         return cls.product_name()
 
     @classmethod

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -11,7 +11,6 @@
 from __future__ import print_function
 
 import argparse
-import errno
 import json
 import os
 import platform

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -400,53 +400,6 @@ def skip_list_for_platform(config):
     return skip_list
 
 
-# Python 2.7 in Windows doesn't support os.symlink
-os_symlink = getattr(os, "symlink", None)
-if callable(os_symlink):
-    pass
-else:
-    def symlink_ms(source, link_name):
-        source = os.path.normpath(source)
-        link_name = os.path.normpath(link_name)
-        if os.path.isdir(link_name):
-            os.rmdir(link_name)
-        elif os.exists(link_name):
-            os.remove(link_name)
-        import ctypes
-        csl = ctypes.windll.kernel32.CreateSymbolicLinkW
-        csl.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
-        csl.restype = ctypes.c_ubyte
-        flags = 1 if os.path.isdir(source) else 0
-        if csl(link_name, source, flags) == 0:
-            raise ctypes.WinError()
-    os.symlink = symlink_ms
-
-
-def symlink_llvm_monorepo(args):
-    print("Create symlink for LLVM Project")
-    llvm_projects = ['clang',
-                     'llvm',
-                     'lldb',
-                     'compiler-rt',
-                     'libcxx',
-                     'clang-tools-extra']
-    for project in llvm_projects:
-        src_path = os.path.join(args.source_root,
-                                'llvm-project',
-                                project)
-        dst_path = os.path.join(args.source_root, project)
-        if not os.path.islink(dst_path):
-            try:
-                os.symlink(src_path, dst_path)
-            except OSError as e:
-                if e.errno == errno.EEXIST:
-                    print("File '%s' already exists. Remove it, so "
-                          "update-checkout can create the symlink to the "
-                          "llvm-monorepo." % dst_path)
-                else:
-                    raise e
-
-
 def main():
     freeze_support()
     parser = argparse.ArgumentParser(
@@ -599,7 +552,6 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
     if fail_count > 0:
         print("update-checkout failed, fix errors and try again")
     else:
-        symlink_llvm_monorepo(args)
         print("update-checkout succeeded")
         print_repo_hashes(args, config)
     sys.exit(fail_count)


### PR DESCRIPTION
…are using llvm projects directly
