### PR TITLE
[DiagnosticVerifier] Make DiagnosticVerifier a DiagnosticConsumer

### DIFF
--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -18,30 +18,87 @@
 #ifndef SWIFT_FRONTEND_DIAGNOSTIC_VERIFIER_H
 #define SWIFT_FRONTEND_DIAGNOSTIC_VERIFIER_H
 
+#include "swift/AST/DiagnosticConsumer.h"
 #include "swift/Basic/LLVM.h"
 
 namespace swift {
-  class DependencyTracker;
-  class FileUnit;
-  class SourceManager;
-  class SourceFile;
+class DependencyTracker;
+class FileUnit;
+class SourceManager;
+class SourceFile;
 
-  /// Set up the specified source manager so that diagnostics are captured
-  /// instead of being printed.
-  void enableDiagnosticVerifier(SourceManager &SM);
+// MARK: - DependencyVerifier
+bool verifyDependencies(SourceManager &SM, const DependencyTracker &DT,
+                        ArrayRef<FileUnit *> SFs);
+bool verifyDependencies(SourceManager &SM, const DependencyTracker &DT,
+                        ArrayRef<SourceFile *> SFs);
 
-  /// Verify that captured diagnostics meet with the expectations of the source
-  /// files corresponding to the specified \p BufferIDs and tear down our
-  /// support for capturing and verifying diagnostics.
-  ///
-  /// This returns true if there are any mismatches found.
-  bool verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
-                         bool autoApplyFixes, bool ignoreUnknown);
+// MARK: - DiagnosticVerifier
+struct ExpectedFixIt;
 
-  bool verifyDependencies(SourceManager &SM, const DependencyTracker &DT,
-                          ArrayRef<FileUnit *> SFs);
-  bool verifyDependencies(SourceManager &SM, const DependencyTracker &DT,
-                          ArrayRef<SourceFile *> SFs);
+struct CapturedDiagnosticInfo {
+  llvm::SmallString<128> Message;
+  llvm::SmallString<32> FileName;
+  DiagnosticKind Classification;
+  SourceLoc Loc;
+  unsigned Line;
+  unsigned Column;
+  SmallVector<DiagnosticInfo::FixIt, 2> FixIts;
+
+  CapturedDiagnosticInfo(llvm::SmallString<128> Message,
+                         llvm::SmallString<32> FileName,
+                         DiagnosticKind Classification, SourceLoc Loc,
+                         unsigned Line, unsigned Column,
+                         SmallVector<DiagnosticInfo::FixIt, 2> FixIts)
+      : Message(Message), FileName(FileName), Classification(Classification),
+        Loc(Loc), Line(Line), Column(Column), FixIts(FixIts) {}
+};
+/// This class implements support for -verify mode in the compiler.  It
+/// buffers up diagnostics produced during compilation, then checks them
+/// against expected-error markers in the source file.
+class DiagnosticVerifier : public DiagnosticConsumer {
+  SourceManager &SM;
+  std::vector<CapturedDiagnosticInfo> CapturedDiagnostics;
+  ArrayRef<unsigned> BufferIDs;
+  bool AutoApplyFixes;
+  bool IgnoreUnknown;
+
+public:
+  explicit DiagnosticVerifier(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
+                              bool AutoApplyFixes, bool IgnoreUnknown)
+      : SM(SM), BufferIDs(BufferIDs), AutoApplyFixes(AutoApplyFixes),
+        IgnoreUnknown(IgnoreUnknown) {}
+
+  virtual void handleDiagnostic(SourceManager &SM,
+                                const DiagnosticInfo &Info) override;
+
+  virtual bool finishProcessing() override;
+
+private:
+  /// Result of verifying a file.
+  struct Result {
+    /// Were there any errors? All of the following are considered errors:
+    /// - Expected diagnostics that were not present
+    /// - Unexpected diagnostics that were present
+    /// - Errors in the definition of expected diagnostics
+    bool HadError;
+    bool HadUnexpectedDiag;
+  };
+
+  /// verifyFile - After the file has been processed, check to see if we
+  /// got all of the expected diagnostics and check to see if there were any
+  /// unexpected ones.
+  Result verifyFile(unsigned BufferID);
+
+  bool checkForFixIt(const ExpectedFixIt &Expected,
+                     const CapturedDiagnosticInfo &D, StringRef buffer);
+
+  // Render the verifier syntax for a given set of fix-its.
+  std::string renderFixits(ArrayRef<DiagnosticInfo::FixIt> fixits,
+                           StringRef InputFile);
+
+  void printRemainingDiagnostics() const;
+};
 }
 
 #endif

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -31,6 +31,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterOptions.h"
+#include "swift/Frontend/DiagnosticVerifier.h"
 #include "swift/Frontend/FrontendOptions.h"
 #include "swift/Frontend/ModuleInterfaceSupport.h"
 #include "swift/Migrator/MigratorOptions.h"
@@ -405,6 +406,7 @@ class CompilerInstance {
   std::unique_ptr<ASTContext> Context;
   std::unique_ptr<Lowering::TypeConverter> TheSILTypes;
   std::unique_ptr<SILModule> TheSILModule;
+  std::unique_ptr<DiagnosticVerifier> DiagVerifier;
 
   /// Null if no tracker.
   std::unique_ptr<DependencyTracker> DepTracker;
@@ -585,6 +587,7 @@ private:
   bool setUpInputs();
   bool setUpASTContextIfNeeded();
   void setupStatsReporter();
+  void setupDiagnosticVerifierIfNeeded();
   Optional<unsigned> setUpCodeCompletionBuffer();
 
   /// Set up all state in the CompilerInstance to process the given input file.

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -40,6 +40,7 @@ class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   // Educational notes which are buffered until the consumer is finished
   // constructing a snippet.
   SmallVector<std::string, 1> BufferedEducationalNotes;
+  bool SuppressOutput = false;
 
 public:
   PrintingDiagnosticConsumer(llvm::raw_ostream &stream = llvm::errs());
@@ -63,6 +64,10 @@ public:
 
   bool didErrorOccur() {
     return DidErrorOccur;
+  }
+
+  void setSuppressOutput(bool suppressOutput) {
+    SuppressOutput = suppressOutput;
   }
 
 private:

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -293,6 +293,17 @@ void CompilerInstance::setupStatsReporter() {
   Stats = std::move(Reporter);
 }
 
+void CompilerInstance::setupDiagnosticVerifierIfNeeded() {
+  auto &diagOpts = Invocation.getDiagnosticOptions();
+  if (diagOpts.VerifyMode != DiagnosticOptions::NoVerify) {
+    DiagVerifier = std::make_unique<DiagnosticVerifier>(
+        SourceMgr, InputSourceCodeBufferIDs,
+        diagOpts.VerifyMode == DiagnosticOptions::VerifyAndApplyFixes,
+        diagOpts.VerifyIgnoreUnknown);
+    addDiagnosticConsumer(DiagVerifier.get());
+  }
+}
+
 bool CompilerInstance::setup(const CompilerInvocation &Invok) {
   Invocation = Invok;
 
@@ -337,6 +348,7 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     return true;
 
   setupStatsReporter();
+  setupDiagnosticVerifierIfNeeded();
 
   return false;
 }

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -883,6 +883,9 @@ void PrintingDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
     DidErrorOccur = true;
   }
 
+  if (SuppressOutput)
+    return;
+
   if (Info.IsChildNote)
     return;
 

--- a/test/diagnostics/sil-opt-verifier.sil
+++ b/test/diagnostics/sil-opt-verifier.sil
@@ -1,0 +1,14 @@
+// RUN: not %target-sil-opt -enable-sil-verify-all %s -definite-init -verify 2>&1 | %FileCheck %s
+
+import Builtin
+import Swift
+
+// main
+sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  return %4 : $Int32 // expected-error {{use of undefined value '%5'}}
+  // CHECK-NOT: error: use of undefined value '%4'
+  // CHECK: incorrect message found
+}

--- a/test/diagnostics/verifier.swift
+++ b/test/diagnostics/verifier.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck -verify -serialize-diagnostics-path %t/serialized.dia -emit-fixits-path %t/fixits %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -verify -warnings-as-errors %s 2>&1 | %FileCheck %s -check-prefix CHECK-WARNINGS-AS-ERRORS
+// RUN: %FileCheck %s -check-prefix CHECK-SERIALIZED <%t/serialized.dia
+// RUN: %FileCheck %s -check-prefix CHECK-FIXITS <%t/fixits
+
+// Wrong message
+let x: Int = "hello, world!" // expected-error {{foo bar baz}}
+// CHECK-NOT: error: cannot convert value of type 'String' to specified type 'Int'
+// CHECK: error: incorrect message found
+
+// Wrong column
+let y: Int = "hello, world!" // expected-error@:49 {{cannot convert value of type}}
+// CHECK: message found at column 14 but was expected to appear at column 49
+
+// Wrong fix-it
+let z: Int = "hello, world!" as Any
+// expected-error@-1 {{cannot convert value of type}} {{3-3=foobarbaz}}
+// CHECK: expected fix-it not seen; actual fix-its: {{[{][{]}}36-36= as! Int{{[}][}]}}
+
+// Expected no fix-it
+let a: Bool = "hello, world!" as Any
+// expected-error@-1 {{cannot convert value of type}} {{none}}
+// CHECK: expected no fix-its; actual fix-it seen: {{[{][{]}}37-37= as! Bool{{[}][}]}}
+
+// Unexpected error
+_ = foo()
+// CHECK: unexpected error produced: use of unresolved identifier 'foo'
+
+func b() {
+  let c = 2
+}
+// CHECK: unexpected warning produced: initialization of immutable value 'c' was never used
+// CHECK-WARNINGS-AS-ERRORS: unexpected error produced: initialization of immutable value 'c' was never used
+
+// Verify the serialized diags have the right magic at the top.
+// CHECK-SERIALIZED: DIA
+
+// Ensure the verifier doesn't interfere with -emit-fixits-path.
+// CHECK-FIXITS: {
+// CHECK-FIXITS: "file":
+// CHECK-FIXITS: "offset":
+// CHECK-FIXITS: "text": " as! Int",
+// CHECK-FIXITS: },

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -349,6 +349,9 @@ int main(int argc, char **argv) {
   Invocation.getLangOptions().EnableExperimentalDifferentiableProgramming =
       EnableExperimentalDifferentiableProgramming;
 
+  Invocation.getDiagnosticOptions().VerifyMode =
+      VerifyMode ? DiagnosticOptions::Verify : DiagnosticOptions::NoVerify;
+
   // Setup the SIL Options.
   SILOptions &SILOpts = Invocation.getSILOptions();
   SILOpts.InlineThreshold = SILInlineThreshold;
@@ -404,15 +407,40 @@ int main(int argc, char **argv) {
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 
+  if (VerifyMode)
+    PrintDiags.setSuppressOutput(true);
+
+  struct FinishDiagProcessingCheckRAII {
+    bool CalledFinishDiagProcessing = false;
+    ~FinishDiagProcessingCheckRAII() {
+      assert(CalledFinishDiagProcessing &&
+             "returned from the function "
+             "without calling finishDiagProcessing");
+    }
+  } FinishDiagProcessingCheckRAII;
+
+  auto finishDiagProcessing = [&](int retValue) -> int {
+    FinishDiagProcessingCheckRAII.CalledFinishDiagProcessing = true;
+    PrintDiags.setSuppressOutput(false);
+    bool diagnosticsError = CI.getDiags().finishProcessing();
+    // If the verifier is enabled and did not encounter any verification errors,
+    // return 0 even if the compile failed. This behavior isn't ideal, but large
+    // parts of the test suite are reliant on it.
+    if (VerifyMode && !diagnosticsError) {
+      return 0;
+    }
+    return retValue ? retValue : diagnosticsError;
+  };
+
   if (CI.setup(Invocation))
-    return 1;
+    return finishDiagProcessing(1);
 
   CI.performSema();
 
   // If parsing produced an error, don't run any passes.
   bool HadError = CI.getASTContext().hadError();
   if (HadError)
-    return 1;
+    return finishDiagProcessing(1);
 
   // Load the SIL if we have a module. We have to do this after SILParse
   // creating the unfortunate double if statement.
@@ -428,11 +456,6 @@ int main(int argc, char **argv) {
     else
       SL->getAll();
   }
-
-  // If we're in verify mode, install a custom diagnostic handling for
-  // SourceMgr.
-  if (VerifyMode)
-    enableDiagnosticVerifier(CI.getSourceMgr());
 
   if (CI.getSILModule())
     CI.getSILModule()->setSerializeSILAction([]{});
@@ -511,7 +534,7 @@ int main(int argc, char **argv) {
       if (EC) {
         llvm::errs() << "while opening '" << OutputFile << "': "
                      << EC.message() << '\n';
-        return 1;
+        return finishDiagProcessing(1);
       }
       CI.getSILModule()->print(OS, CI.getMainModule(), SILOpts,
                                !DisableASTDump);
@@ -520,12 +543,7 @@ int main(int argc, char **argv) {
 
   HadError |= CI.getASTContext().hadError();
 
-  // If we're in -verify mode, we've buffered up all of the generated
-  // diagnostics.  Check now to ensure that they meet our expectations.
   if (VerifyMode) {
-    HadError = verifyDiagnostics(CI.getSourceMgr(), CI.getInputBufferIDs(),
-                                 /*autoApplyFixes*/false,
-                                 /*ignoreUnknown*/false);
     DiagnosticEngine &diags = CI.getDiags();
     if (diags.hasFatalErrorOccurred() &&
         !Invocation.getDiagnosticOptions().ShowDiagnosticsAfterFatalError) {
@@ -535,5 +553,5 @@ int main(int argc, char **argv) {
     }
   }
 
-  return HadError;
+  return finishDiagProcessing(HadError);
 }


### PR DESCRIPTION
Previously, `DiagnosticVerifier` hooked emission of `llvm::SMDiagnostic` to capture diagnostics for verification. This change makes `DiagnosticVerifier` a subclass of `DiagnosticConsumer` instead. This means that instead of checking expected diagnostics against the `llvm::SMDiagnostic`s emitted by `PrintedDiagnosticConsumer`, it checks them directly against the `DiagnosticInfo`s it receives from the `DiagnosticEngine`.

This is desirable for a couple reasons:
- It allows us to verify information about diagnostics that's lost when a `DiagnosticInfo` is translated to an `SMDiagnostic`. This will allow adding verifier support for educational notes in a follow-up
- It begins to reduce dependencies on `SMDiagnostic`. The current diagnostic pipeline looks like `Diagnostic -> DiagnosticInfo -> SMDiagnostic -> Text Output` when using the `PrintingDiagnosticConsumer`. Eventually I'd like to reduce that to just `Diagnostic -> DiagnosticInfo -> Text Output`. In addition to simplifying the diagnostics subsystem, this will make improving multi-byte character support in diagnostics much easier, and enable smaller QoL enhancements like https://bugs.swift.org/browse/SR-6024. (Edit: This will also allow running tests with -enable-experimental-diagnostic-formatting)

The downside of making this change now is that we lose test coverage of `PrintingDiagnosticConsumer` itself. Under the old system every test which used the verifier relied on it.