### PR TITLE
Use precondition instead of fatalError in DateInterval initializer

### DIFF
--- a/stdlib/public/Darwin/Foundation/DateInterval.swift
+++ b/stdlib/public/Darwin/Foundation/DateInterval.swift
@@ -54,10 +54,7 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable, Codable
     ///
     /// - precondition: `end >= start`
     public init(start: Date, end: Date) {
-        if end < start {
-            fatalError("Reverse intervals are not allowed")
-        }
-        
+        precondition(end >= start, "Reverse intervals are not allowed")
         self.start = start
         duration = end.timeIntervalSince(start)
     }


### PR DESCRIPTION
Supersedes #12743