### PR TITLE
[SourceKit/swift-ide-test] Consolidate duplicated logics between completion like requests

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -543,6 +543,10 @@ public:
   /// Returns true if there was an error during setup.
   bool setup(const CompilerInvocation &Invocation);
 
+  const CompilerInvocation &getInvocation() {
+    return Invocation;
+  }
+
 private:
   /// Set up the file system by loading and validating all VFS overlay YAML
   /// files. If the process of validating VFS files failed, or the overlay

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -801,13 +801,15 @@ public:
   virtual void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf,
                                         unsigned Offset,
                                         ArrayRef<const char *> Args,
-                                        TypeContextInfoConsumer &Consumer) = 0;
+                                        TypeContextInfoConsumer &Consumer,
+                                        Optional<VFSOptions> vfsOptions) = 0;
 
   virtual void getConformingMethodList(llvm::MemoryBuffer *inputBuf,
                                        unsigned Offset,
                                        ArrayRef<const char *> Args,
                                        ArrayRef<const char *> ExpectedTypes,
-                                       ConformingMethodListConsumer &Consumer) = 0;
+                                       ConformingMethodListConsumer &Consumer,
+                                       Optional<VFSOptions> vfsOptions) = 0;
 
   virtual void getStatistics(StatisticsReceiver) = 0;
 };

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -58,7 +58,7 @@ class ImportDepth {
 
 public:
   ImportDepth() = default;
-  ImportDepth(ASTContext &context, CompilerInvocation &invocation);
+  ImportDepth(ASTContext &context, const CompilerInvocation &invocation);
 
   Optional<uint8_t> lookup(StringRef module) {
     auto I = depths.find(module);
@@ -320,7 +320,8 @@ CodeCompletionViewRef CodeCompletionOrganizer::takeResultsView() {
 // ImportDepth
 //===----------------------------------------------------------------------===//
 
-ImportDepth::ImportDepth(ASTContext &context, CompilerInvocation &invocation) {
+ImportDepth::ImportDepth(ASTContext &context,
+                         const CompilerInvocation &invocation) {
   llvm::DenseSet<ModuleDecl *> seen;
   std::deque<std::pair<ModuleDecl *, uint8_t>> worklist;
 

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -53,7 +53,7 @@ struct Options {
 
 struct SwiftCompletionInfo {
   swift::ASTContext *swiftASTContext = nullptr;
-  swift::CompilerInvocation *invocation = nullptr;
+  const swift::CompilerInvocation *invocation = nullptr;
   swift::ide::CodeCompletionContext *completionContext = nullptr;
 };
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -172,6 +172,10 @@ static bool swiftCodeCompleteImpl(
     return false;
   }
 
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+
   const char *Position = InputFile->getBufferStart() + CodeCompletionOffset;
   std::unique_ptr<llvm::WritableMemoryBuffer> NewBuffer =
       llvm::WritableMemoryBuffer::getNewUninitMemBuffer(

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -1178,7 +1178,8 @@ static void transformAndForwardResults(
 void SwiftLangSupport::codeCompleteOpen(
     StringRef name, llvm::MemoryBuffer *inputBuf, unsigned offset,
     OptionsDictionary *options, ArrayRef<FilterRule> rawFilterRules,
-    GroupedCodeCompletionConsumer &consumer, ArrayRef<const char *> args, Optional<VFSOptions> vfsOptions) {
+    GroupedCodeCompletionConsumer &consumer, ArrayRef<const char *> args,
+    Optional<VFSOptions> vfsOptions) {
   StringRef filterText;
   unsigned resultOffset = 0;
   unsigned maxResults = 0;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -129,15 +129,12 @@ static bool swiftCodeCompleteImpl(
   // Resolve symlinks for the input file; we resolve them for the input files
   // in the arguments as well.
   // FIXME: We need the Swift equivalent of Clang's FileEntry.
-  auto InputFile = llvm::MemoryBuffer::getMemBuffer(
-      UnresolvedInputFile->getBuffer(),
-      Lang.resolvePathSymlinks(UnresolvedInputFile->getBufferIdentifier()));
+  auto bufferIdentifier =
+      Lang.resolvePathSymlinks(UnresolvedInputFile->getBufferIdentifier());
 
-  auto origBuffSize = InputFile->getBufferSize();
-  unsigned CodeCompletionOffset = Offset;
-  if (CodeCompletionOffset > origBuffSize) {
-    CodeCompletionOffset = origBuffSize;
-  }
+  auto origOffset = Offset;
+  auto newBuffer = SwiftLangSupport::makeCodeCompletionMemoryBuffer(
+      UnresolvedInputFile, Offset, bufferIdentifier);
 
   CompilerInstance CI;
   // Display diagnostics to stderr.
@@ -149,24 +146,22 @@ static bool swiftCodeCompleteImpl(
   if (TracedOp.enabled()) {
     CI.addDiagnosticConsumer(&TraceDiags);
     trace::SwiftInvocation SwiftArgs;
-    trace::initTraceInfo(SwiftArgs, InputFile->getBufferIdentifier(), Args);
+    trace::initTraceInfo(SwiftArgs, bufferIdentifier, Args);
     TracedOp.setDiagnosticProvider(
         [&TraceDiags](SmallVectorImpl<DiagnosticEntryInfo> &diags) {
           TraceDiags.getAllDiagnostics(diags);
         });
-    TracedOp.start(SwiftArgs,
-                   {std::make_pair("OriginalOffset", std::to_string(Offset)),
-                    std::make_pair("Offset",
-                      std::to_string(CodeCompletionOffset))});
+    TracedOp.start(
+        SwiftArgs,
+        {std::make_pair("OriginalOffset", std::to_string(origOffset)),
+         std::make_pair("Offset", std::to_string(Offset))});
   }
 
   CompilerInvocation Invocation;
   bool Failed = Lang.getASTManager()->initCompilerInvocation(
-      Invocation, Args, CI.getDiags(), InputFile->getBufferIdentifier(),
-      FileSystem, Error);
-  if (Failed) {
+      Invocation, Args, CI.getDiags(), bufferIdentifier, FileSystem, Error);
+  if (Failed)
     return false;
-  }
   if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
     Error = "no input filenames specified";
     return false;
@@ -176,31 +171,17 @@ static bool swiftCodeCompleteImpl(
   // they are somewhat heavy operations and are not needed for completions.
   Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
 
-  const char *Position = InputFile->getBufferStart() + CodeCompletionOffset;
-  std::unique_ptr<llvm::WritableMemoryBuffer> NewBuffer =
-      llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
-                                              InputFile->getBufferSize() + 1,
-                                              InputFile->getBufferIdentifier());
-  char *NewBuf = NewBuffer->getBufferStart();
-  char *NewPos = std::copy(InputFile->getBufferStart(), Position, NewBuf);
-  *NewPos = '\0';
-  std::copy(Position, InputFile->getBufferEnd(), NewPos+1);
-
-  Invocation.setCodeCompletionPoint(NewBuffer.get(), CodeCompletionOffset);
-
-  auto swiftCache = Lang.getCodeCompletionCache(); // Pin the cache.
-  ide::CodeCompletionContext CompletionContext(swiftCache->getCache());
+  Invocation.setCodeCompletionPoint(newBuffer.get(), Offset);
 
   // Create a factory for code completion callbacks that will feed the
   // Consumer.
-  std::unique_ptr<CodeCompletionCallbacksFactory> CompletionCallbacksFactory(
-      ide::makeCodeCompletionCallbacksFactory(CompletionContext,
-                                              SwiftConsumer));
+  auto swiftCache = Lang.getCodeCompletionCache(); // Pin the cache.
+  ide::CodeCompletionContext CompletionContext(swiftCache->getCache());
 
-  Invocation.setCodeCompletionFactory(CompletionCallbacksFactory.get());
+  std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
+      ide::makeCodeCompletionCallbacksFactory(CompletionContext, SwiftConsumer));
 
-  // FIXME: We need to be passing the buffers from the open documents.
-  // It is not a huge problem in practice because Xcode auto-saves constantly.
+  Invocation.setCodeCompletionFactory(callbacksFactory.get());
 
   if (FileSystem != llvm::vfs::getRealFileSystem()) {
     CI.getSourceMgr().setFileSystem(FileSystem);

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -67,6 +67,10 @@ static bool swiftConformingMethodListImpl(
     return false;
   }
 
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+
   Invocation.setCodeCompletionPoint(newBuffer.get(), Offset);
 
   // Create a factory for code completion callbacks that will feed the

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -59,39 +59,18 @@ static bool swiftConformingMethodListImpl(
          std::make_pair("Offset", std::to_string(Offset))});
   }
 
-  CompilerInvocation Invocation;
-  bool Failed = Lang.getASTManager()->initCompilerInvocation(
-      Invocation, Args, CI.getDiags(), bufferIdentifier, FileSystem, Error);
-  if (Failed)
-    return false;
-  if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
-    Error = "no input filenames specified";
-    return false;
-  }
-
-  // Disable source location resolutions from .swiftsourceinfo file because
-  // they are somewhat heavy operations and are not needed for completions.
-  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
-
-  Invocation.setCodeCompletionPoint(newBuffer.get(), Offset);
-
   // Create a factory for code completion callbacks that will feed the
   // Consumer.
   std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
       ide::makeConformingMethodListCallbacksFactory(ExpectedTypeNames,
                                                     Consumer));
 
-  Invocation.setCodeCompletionFactory(callbacksFactory.get());
-
-  if (FileSystem != llvm::vfs::getRealFileSystem()) {
-    CI.getSourceMgr().setFileSystem(FileSystem);
+  if (!Lang.setupCompilerInstanceForCodeCompletion(CI, newBuffer.get(), Offset,
+                                                   Args, callbacksFactory.get(),
+                                                   FileSystem, Error)) {
+    return false;
   }
 
-  if (CI.setup(Invocation)) {
-    // FIXME: error?
-    return true;
-  }
-  registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performParseAndResolveImportsOnly();
 
   return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -585,12 +585,14 @@ public:
 
   void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf, unsigned Offset,
                                 ArrayRef<const char *> Args,
-                                TypeContextInfoConsumer &Consumer) override;
+                                TypeContextInfoConsumer &Consumer,
+                                Optional<VFSOptions> vfsOptions) override;
 
   void getConformingMethodList(llvm::MemoryBuffer *inputBuf, unsigned Offset,
                                ArrayRef<const char *> Args,
                                ArrayRef<const char *> ExpectedTypes,
-                               ConformingMethodListConsumer &Consumer) override;
+                               ConformingMethodListConsumer &Consumer,
+                               Optional<VFSOptions> vfsOptions) override;
 
   void getStatistics(StatisticsReceiver) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -349,6 +349,14 @@ public:
                                  unsigned &Offset,
                                  const std::string bufferIdentifier);
 
+  bool setupCompilerInstanceForCodeCompletion(
+      swift::CompilerInstance &CI,
+      llvm::MemoryBuffer *completionBuffer, unsigned Offset,
+      ArrayRef<const char *> Args,
+      swift::CodeCompletionCallbacksFactory *callbacksFactory,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+      std::string &Error);
+
   static SourceKit::UIdent getUIDForDecl(const swift::Decl *D,
                                          bool IsRef = false);
   static SourceKit::UIdent getUIDForExtensionOfDecl(const swift::Decl *D);

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -67,6 +67,10 @@ static bool swiftTypeContextInfoImpl(SwiftLangSupport &Lang,
     return false;
   }
 
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+
   Invocation.setCodeCompletionPoint(newBuffer.get(), Offset);
 
   // Create a factory for code completion callbacks that will feed the

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -710,11 +710,13 @@ removeCodeCompletionTokens(llvm::MemoryBuffer *Input,
                                            Input->getBufferIdentifier()));
 }
 
-static int doTypeContextInfo(const CompilerInvocation &InitInvok,
-                             StringRef SourceFilename,
-                             StringRef SecondSourceFileName,
-                             StringRef CodeCompletionToken,
-                             bool CodeCompletionDiagnostics) {
+static bool doCodeCompletionImpl(
+    CodeCompletionCallbacksFactory *callbacksFactory,
+    const CompilerInvocation &InitInvok,
+    StringRef SourceFilename,
+    StringRef SecondSourceFileName,
+    StringRef CodeCompletionToken,
+    bool CodeCompletionDiagnostics) {
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
       llvm::MemoryBuffer::getFile(SourceFilename);
   if (!FileBufOrErr) {
@@ -744,18 +746,13 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
   // they are somewhat heavy operations and are not needed for completions.
   Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
 
+  // Disable to build syntax tree because code-completion skips some portion of
+  // source text. That breaks an invariant of syntax tree building.
+  Invocation.getLangOptions().BuildSyntaxTree = false;
+
   Invocation.setCodeCompletionPoint(CleanFile.get(), Offset);
 
-  // Create a CodeCompletionConsumer.
-  std::unique_ptr<ide::TypeContextInfoConsumer> Consumer(
-      new ide::PrintingTypeContextInfoConsumer(llvm::outs()));
-
-  // Create a factory for code completion callbacks that will feed the
-  // Consumer.
-  std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
-      ide::makeTypeContextInfoCallbacksFactory(*Consumer));
-
-  Invocation.setCodeCompletionFactory(callbacksFactory.get());
+  Invocation.setCodeCompletionFactory(callbacksFactory);
   if (!SecondSourceFileName.empty()) {
     Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
         SecondSourceFileName);
@@ -774,43 +771,31 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
   return 0;
 }
 
+static int doTypeContextInfo(const CompilerInvocation &InitInvok,
+                             StringRef SourceFilename,
+                             StringRef SecondSourceFileName,
+                             StringRef CodeCompletionToken,
+                             bool CodeCompletionDiagnostics) {
+  // Create a CodeCompletionConsumer.
+  std::unique_ptr<ide::TypeContextInfoConsumer> Consumer(
+      new ide::PrintingTypeContextInfoConsumer(llvm::outs()));
+
+  // Create a factory for code completion callbacks that will feed the
+  // Consumer.
+  std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
+      ide::makeTypeContextInfoCallbacksFactory(*Consumer));
+
+  return doCodeCompletionImpl(callbacksFactory.get(), InitInvok, SourceFilename,
+                              SecondSourceFileName, CodeCompletionToken,
+                              CodeCompletionDiagnostics);
+}
+
 static int
 doConformingMethodList(const CompilerInvocation &InitInvok,
                        StringRef SourceFilename, StringRef SecondSourceFileName,
                        StringRef CodeCompletionToken,
                        bool CodeCompletionDiagnostics,
                        const std::vector<std::string> expectedTypeNames) {
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-      llvm::MemoryBuffer::getFile(SourceFilename);
-  if (!FileBufOrErr) {
-    llvm::errs() << "error opening input file: "
-                 << FileBufOrErr.getError().message() << '\n';
-    return 1;
-  }
-
-  unsigned Offset;
-
-  std::unique_ptr<llvm::MemoryBuffer> CleanFile(removeCodeCompletionTokens(
-      FileBufOrErr.get().get(), CodeCompletionToken, &Offset));
-
-  if (Offset == ~0U) {
-    llvm::errs() << "could not find code completion token \""
-                 << CodeCompletionToken << "\"\n";
-    return 1;
-  }
-  llvm::outs() << "found code completion token " << CodeCompletionToken
-               << " at offset " << Offset << "\n";
-  llvm::errs() << "found code completion token " << CodeCompletionToken
-               << " at offset " << Offset << "\n";
-
-  CompilerInvocation Invocation(InitInvok);
-
-  // Disable source location resolutions from .swiftsourceinfo file because
-  // they are somewhat heavy operations and are not needed for completions.
-  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
-
-  Invocation.setCodeCompletionPoint(CleanFile.get(), Offset);
-
   SmallVector<const char *, 4> typeNames;
   for (auto &name : expectedTypeNames)
     typeNames.push_back(name.c_str());
@@ -824,23 +809,9 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
   std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
       ide::makeConformingMethodListCallbacksFactory(typeNames, *Consumer));
 
-  Invocation.setCodeCompletionFactory(callbacksFactory.get());
-  if (!SecondSourceFileName.empty()) {
-    Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
-        SecondSourceFileName);
-  }
-  CompilerInstance CI;
-
-  PrintingDiagnosticConsumer PrintDiags;
-  if (CodeCompletionDiagnostics) {
-    // Display diagnostics to stderr.
-    CI.addDiagnosticConsumer(&PrintDiags);
-  }
-  if (CI.setup(Invocation))
-    return 1;
-  registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
-  return 0;
+  return doCodeCompletionImpl(callbacksFactory.get(), InitInvok, SourceFilename,
+                              SecondSourceFileName, CodeCompletionToken,
+                              CodeCompletionDiagnostics);
 }
 
 static int doCodeCompletion(const CompilerInvocation &InitInvok,
@@ -850,42 +821,6 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
                             bool CodeCompletionDiagnostics,
                             bool CodeCompletionKeywords,
                             bool CodeCompletionComments) {
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-    llvm::MemoryBuffer::getFile(SourceFilename);
-  if (!FileBufOrErr) {
-    llvm::errs() << "error opening input file: "
-                 << FileBufOrErr.getError().message() << '\n';
-    return 1;
-  }
-
-  unsigned CodeCompletionOffset;
-
-  std::unique_ptr<llvm::MemoryBuffer> CleanFile(
-      removeCodeCompletionTokens(FileBufOrErr.get().get(), CodeCompletionToken,
-                                 &CodeCompletionOffset));
-
-  if (CodeCompletionOffset == ~0U) {
-    llvm::errs() << "could not find code completion token \""
-                 << CodeCompletionToken << "\"\n";
-    return 1;
-  }
-  llvm::outs() << "found code completion token " << CodeCompletionToken
-               << " at offset " << CodeCompletionOffset << "\n";
-  llvm::errs() << "found code completion token " << CodeCompletionToken
-               << " at offset " << CodeCompletionOffset << "\n";
-
-  CompilerInvocation Invocation(InitInvok);
-
-  Invocation.setCodeCompletionPoint(CleanFile.get(), CodeCompletionOffset);
-
-  // Disable source location resolutions from .swiftsourceinfo file because
-  // they are somewhat heavy operations and are not needed for completions.
-  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
-
-  // Disable to build syntax tree because code-completion skips some portion of
-  // source text. That breaks an invariant of syntax tree building.
-  Invocation.getLangOptions().BuildSyntaxTree = false;
-
   std::unique_ptr<ide::OnDiskCodeCompletionCache> OnDiskCache;
   if (!options::CompletionCachePath.empty()) {
     OnDiskCache = llvm::make_unique<ide::OnDiskCodeCompletionCache>(
@@ -901,27 +836,12 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
 
   // Create a factory for code completion callbacks that will feed the
   // Consumer.
-  std::unique_ptr<CodeCompletionCallbacksFactory> CompletionCallbacksFactory(
-      ide::makeCodeCompletionCallbacksFactory(CompletionContext,
-                                              *Consumer));
+  std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
+      ide::makeCodeCompletionCallbacksFactory(CompletionContext, *Consumer));
 
-  Invocation.setCodeCompletionFactory(CompletionCallbacksFactory.get());
-  if (!SecondSourceFileName.empty()) {
-    Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
-        SecondSourceFileName);
-  }
-  CompilerInstance CI;
-
-  PrintingDiagnosticConsumer PrintDiags;
-  if (CodeCompletionDiagnostics) {
-    // Display diagnostics to stderr.
-    CI.addDiagnosticConsumer(&PrintDiags);
-  }
-  if (CI.setup(Invocation))
-    return 1;
-  registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
-  return 0;
+  return doCodeCompletionImpl(callbacksFactory.get(), InitInvok, SourceFilename,
+                              SecondSourceFileName, CodeCompletionToken,
+                              CodeCompletionDiagnostics);
 }
 
 static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -740,6 +740,10 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
 
   CompilerInvocation Invocation(InitInvok);
 
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+
   Invocation.setCodeCompletionPoint(CleanFile.get(), Offset);
 
   // Create a CodeCompletionConsumer.
@@ -800,6 +804,10 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
                << " at offset " << Offset << "\n";
 
   CompilerInvocation Invocation(InitInvok);
+
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
 
   Invocation.setCodeCompletionPoint(CleanFile.get(), Offset);
 
@@ -869,6 +877,10 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
 
   Invocation.setCodeCompletionPoint(CleanFile.get(), CodeCompletionOffset);
+
+  // Disable source location resolutions from .swiftsourceinfo file because
+  // they are somewhat heavy operations and are not needed for completions.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
 
   // Disable to build syntax tree because code-completion skips some portion of
   // source text. That breaks an invariant of syntax tree building.


### PR DESCRIPTION
(based on #28282 I'll rebase this after that PR is merged)

Consolidate duplicated logics between completion like requests: code completion, type context info, and conforming method list.

- Support VFS in `typecontextinfo` and `conformingmethods` requests too.
- For SourceKit, implement `SwiftLangSupport::setupCompilerInstanceForCodeCompletion()`
- For swift-ide-test, implement `doCodeCompletionImpl()`