### PR TITLE
[AutoDiff upstream] fix TF-971

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2233,9 +2233,10 @@ static bool parseDifferentiableAttributeArgument(Parser &P,
     return false;
   }
 
-  // If the next token is an arrow, then the matched '( <identifier> )' is
-  // actually the parameter type list, not an argument to '@differentiable'.
-  if (P.Tok.is(tok::arrow))
+  // If the next token is not a `(`, `@`, or an identifier, then the
+  // matched '( <identifier> )' is actually the parameter type list,
+  // not an argument to '@differentiable'.
+  if (P.Tok.isNot(tok::l_paren, tok::at_sign, tok::identifier))
     return false;
 
   backtrack.cancelBacktrack();

--- a/test/AutoDiff/Parse/differentiable_func_type.swift
+++ b/test/AutoDiff/Parse/differentiable_func_type.swift
@@ -8,6 +8,14 @@ let b: @differentiable(linear) (Float) -> Float // okay
 // CHECK: (pattern_named 'b'
 // CHECK-NEXT: (type_attributed attrs=@differentiable(linear)
 
+let c: @differentiable (Float) throws -> Float // okay
+// CHECK: (pattern_named 'c'
+// CHECK-NEXT: (type_attributed attrs=@differentiable{{[^(]}}
+
+let d: @differentiable(linear) (Float) throws -> Float // okay
+// CHECK: (pattern_named 'd'
+// CHECK-NEXT: (type_attributed attrs=@differentiable(linear)
+
 // Generic type test.
 struct A<T> {
   func foo() {


### PR DESCRIPTION
Upstreaming `@differentiable` function type parsing introduced a bug: The parser can't parse `@differentiable` functions with `throws`. The bug wasn't caught by the parsing tests in the upstreaming PR.

This fixes the bug and adds parsing tests.

Resolves TF-971.

