### PR TITLE
[build] amend search path for Cmake modules

### DIFF
--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -10,7 +10,7 @@ endif()
 
 
 list(APPEND CMAKE_MODULE_PATH
-  "${SWIFT_SOURCE_ROOT}/llvm/cmake/modules"
+  "${SWIFT_SOURCE_ROOT}/llvm-project/llvm/cmake/modules"
   "${PROJECT_SOURCE_DIR}/../../../../cmake/modules"
   "${PROJECT_SOURCE_DIR}/../../../cmake/modules")
 


### PR DESCRIPTION
Since we are not using symlinks anymore, we need to point to the correct
directory with LLVM cmake modules.

Fixes rdar://problem/57294763