### PR TITLE
[build] Remove build-script-impl logic to set up project symlinks

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1185,22 +1185,6 @@ if [[ ! "${SKIP_BUILD_PLAYGROUNDSUPPORT}" && ! -d ${PLAYGROUNDSUPPORT_SOURCE_DIR
     exit 1
 fi
 
-# Symlink clang into the llvm tree.
-CLANG_SOURCE_DIR="${LLVM_SOURCE_DIR}/tools/clang"
-if [ ! -d "${CLANG_SOURCE_DIR}" ] ; then
-    make_relative_symlink "${WORKSPACE}/llvm-project/clang" "${CLANG_SOURCE_DIR}"
-fi
-
-# Don't symlink clang-tools-extra into the tree as the 'clang' symlink prevents
-# make_relative_symlink from working correctly.
-CLANG_TOOLS_EXTRA_SOURCE_DIR="${WORKSPACE}/llvm-project/clang-tools-extra"
-
-# Symlink compiler-rt into the llvm tree, if it exists.
-COMPILER_RT_SOURCE_DIR="${LLVM_SOURCE_DIR}/projects/compiler-rt"
-if [ ! -d "${COMPILER_RT_SOURCE_DIR}" ] ; then
-    make_relative_symlink "${WORKSPACE}/llvm-project/compiler-rt" "${COMPILER_RT_SOURCE_DIR}"
-fi
-
 PRODUCTS=(cmark llvm)
 if [[ ! "${SKIP_BUILD_LIBCXX}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" libcxx)
@@ -1693,15 +1677,12 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
                     -DLLVM_ENABLE_LTO:STRING="${LLVM_ENABLE_LTO}"
                     -DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON
+                    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;"
                     "${llvm_cmake_options[@]}"
                 )
 
                 cmake_options+=(
                   -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE
-                )
-
-                cmake_options+=(
-                  -DLLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR="${CLANG_TOOLS_EXTRA_SOURCE_DIR}"
                 )
 
                 if [[ "${BUILD_TOOLCHAIN_ONLY}" ]]; then


### PR DESCRIPTION
Instead of manually setting up symlinks in the project, it would be easier and
cleaner to use LLVM_ENABLE_PROJECT.

@shahmishal @compnerd @Rostepher 