### PR TITLE
[silopt] Add a new SerializeSIL utility pipeline.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassPipeline.def
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.def
@@ -30,6 +30,7 @@ PASSPIPELINE(Onone, "Passes run at -Onone")
 PASSPIPELINE(InstCount, "Utility pipeline to just run the inst count pass")
 PASSPIPELINE(Lowering, "SIL Address Lowering")
 PASSPIPELINE(IRGenPrepare, "Pipeline to run during IRGen")
+PASSPIPELINE(SerializeSIL, "Utility pipeline that just runs SerializeSILPass ")
 
 #undef PASSPIPELINE_WITH_OPTIONS
 #undef PASSPIPELINE

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -685,6 +685,20 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
 }
 
 //===----------------------------------------------------------------------===//
+//                        Serialize SIL Pass Pipeline
+//===----------------------------------------------------------------------===//
+
+// Add to P a new pipeline that just serializes SIL. Meant to be used in
+// situations where perf optzns are disabled, but we may need to serialize.
+SILPassPipelinePlan
+SILPassPipelinePlan::getSerializeSILPassPipeline(const SILOptions &Options) {
+  SILPassPipelinePlan P(Options);
+  P.startPipeline("Serialize SIL");
+  P.addSerializeSILPass();
+  return P;
+}
+
+//===----------------------------------------------------------------------===//
 //                          Inst Count Pass Pipeline
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This pipeline just runs the Serialize SIL pass. The reason I am adding this is
that currently if one passes -disable-sil-perf-optzns or mess with
-sil-opt-pass-count, one can cause serialization to not occur, making it
difficult to bisect/turn off-on opts.
