### PR TITLE
[Diagnostics] Don't apply the single parameter tuple splat fix if the parameter type is a generic parameter.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3580,8 +3580,6 @@ ERROR(single_tuple_parameter_mismatch_special,none,
 ERROR(single_tuple_parameter_mismatch_normal,none,
       "%0 %1 expects a single parameter of type %2%3",
       (DescriptiveDeclKind, DeclBaseName, Type, StringRef))
-NOTE(note_maybe_forgot_to_form_tuple,none,
-     "did you mean to pass a tuple?", ())
 ERROR(unknown_single_tuple_parameter_mismatch,none,
       "single parameter of type %0 is expected in call", (Type))
 ERROR(cannot_convert_single_tuple_into_multiple_arguments,none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5171,23 +5171,9 @@ bool InvalidTupleSplatWithSingleParameterFailure::diagnoseAsError() {
     }
   }
 
-  // If the parameter is a generic parameter, it's hard to say
-  // whether use of a tuple is really intended here, so let's
-  // attach a fix-it to a note instead of the diagnostic message
-  // to indicate that it's not the only right solution possible.
-  if (auto *typeVar = ParamType->getAs<TypeVariableType>()) {
-    if (typeVar->getImpl().getGenericParameter()) {
-      diagnostic.flush();
-
-      emitDiagnostic(argExpr->getLoc(), diag::note_maybe_forgot_to_form_tuple)
-          .fixItInsertAfter(newLeftParenLoc, "(")
-          .fixItInsert(argExpr->getEndLoc(), ")");
-    }
-  } else {
-    diagnostic.highlight(argExpr->getSourceRange())
-        .fixItInsertAfter(newLeftParenLoc, "(")
-        .fixItInsert(argExpr->getEndLoc(), ")");
-  }
+  diagnostic.highlight(argExpr->getSourceRange())
+      .fixItInsertAfter(newLeftParenLoc, "(")
+      .fixItInsert(argExpr->getEndLoc(), ")");
 
   return true;
 }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -779,8 +779,7 @@ bool AllowTupleSplatForSingleParameter::attempt(
   // Parameter type has to be either a tuple (with the same arity as
   // argument list), or a type variable.
   if (!(paramTy->is<TupleType>() &&
-        paramTy->castTo<TupleType>()->getNumElements() == args.size()) &&
-      !paramTy->is<TypeVariableType>())
+        paramTy->castTo<TupleType>()->getNumElements() == args.size()))
     return true;
 
   SmallVector<TupleTypeElt, 4> argElts;
@@ -792,9 +791,9 @@ bool AllowTupleSplatForSingleParameter::attempt(
     auto flags = arg.getParameterFlags();
 
     // In situations where there is a single labeled parameter
-    // we need to form a tuple with omits first label e.g.
+    // we need to form a tuple which omits the label e.g.
     //
-    // func foo<T>(x: T) {}
+    // func foo<T>(x: (T, T)) {}
     // foo(x: 0, 1)
     //
     // We'd want to suggest argument list to be `x: (0, 1)` instead

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -96,15 +96,17 @@ foo(Foo.a, Foo.b) // Ok in Swift 4 because we strip labels from the arguments
 
 // rdar://problem/32551313 - Useless SE-0110 diagnostic
 
-enum E_32551313<L, R> {
+enum E_32551313<L, R> { // expected-note {{'R' declared as parameter to type 'E_32551313'}}
   case Left(L)
   case Right(R)
 }
 
 struct Foo_32551313 {
+  // FIXME(diagnostics): We should be able to figure out L and R from contextual type
   static func bar() -> E_32551313<(String, Foo_32551313?), (String, String)>? {
-    return E_32551313.Left("", Foo_32551313()) // expected-error {{enum case 'Left' expects a single parameter of type 'L' [with L = (String, Foo_32551313?)]}}
-    // expected-note@-1 {{did you mean to pass a tuple?}} {{28-28=(}} {{46-46=)}}
+    return E_32551313.Left("", Foo_32551313()) // expected-error {{extra argument in call}}
+    // expected-error@-1 {{generic parameter 'R' could not be inferred}} expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
+    // expected-error@-2 {{cannot convert return expression of type 'E_32551313<String, R>' to return type 'E_32551313<(String, Foo_32551313?), (String, String)>?'}}
   }
 }
 

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -214,3 +214,14 @@ func erroneousSR11350(x: Int) {
     }).domap(0) // expected-error{{value of type 'Optional<()>' has no member 'domap'}}
   }
 }
+
+func extraArg() {
+  tuplify(true) { _ in
+    1
+    2
+    3
+    4
+    5
+    6 // expected-error {{extra argument in call}}
+  }
+}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -69,12 +69,12 @@ func genericTuple<T, U>(_ x: (T, U)) {}
 
 do {
   generic(3)
-  generic(3, 4) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{11-11=(}} {{15-15=)}}
+  generic(3, 4) // expected-error {{extra argument in call}}
   generic((3))
   generic((3, 4))
 
   genericLabeled(x: 3)
-  genericLabeled(x: 3, 4) // expected-error {{global function 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{20-20=(}} {{25-25=)}}
+  genericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
   genericLabeled(x: (3))
   genericLabeled(x: (3, 4))
 
@@ -92,7 +92,7 @@ do {
   let d = (a, b)
 
   generic(a)
-  generic(a, b) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{11-11=(}} {{15-15=)}}
+  generic(a, b) // expected-error {{extra argument in call}}
   generic((a))
   generic(c)
   generic((a, b))
@@ -114,7 +114,7 @@ do {
   var d = (a, b)
 
   generic(a)
-  generic(a, b) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{11-11=(}} {{15-15=)}}
+  generic(a, b) // expected-error {{extra argument in call}}
   generic((a))
   generic(c)
   generic((a, b))
@@ -256,12 +256,12 @@ do {
   let s = Concrete()
 
   s.generic(3)
-  s.generic(3, 4) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{13-13=(}} {{17-17=)}}
+  s.generic(3, 4) // expected-error {{extra argument in call}}
   s.generic((3))
   s.generic((3, 4))
 
   s.genericLabeled(x: 3)
-  s.genericLabeled(x: 3, 4) // expected-error {{instance method 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{22-22=(}} {{27-27=)}}
+  s.genericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
   s.genericLabeled(x: (3))
   s.genericLabeled(x: (3, 4))
 
@@ -281,7 +281,7 @@ do {
   let d = (a, b)
 
   s.generic(a)
-  s.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{13-13=(}} {{17-17=)}}
+  s.generic(a, b) // expected-error {{extra argument in call}}
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -304,7 +304,7 @@ do {
   var d = (a, b)
 
   s.generic(a)
-  s.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{13-13=(}} {{17-17=)}}
+  s.generic(a, b) // expected-error {{extra argument in call}}
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -390,12 +390,12 @@ do {
   var s = Concrete()
 
   s.mutatingGeneric(3)
-  s.mutatingGeneric(3, 4) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{21-21=(}} {{25-25=)}}
+  s.mutatingGeneric(3, 4) // expected-error {{extra argument in call}}
   s.mutatingGeneric((3))
   s.mutatingGeneric((3, 4))
 
   s.mutatingGenericLabeled(x: 3)
-  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{instance method 'mutatingGenericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{30-30=(}} {{35-35=)}}
+  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
   s.mutatingGenericLabeled(x: (3))
   s.mutatingGenericLabeled(x: (3, 4))
 
@@ -415,7 +415,7 @@ do {
   let d = (a, b)
 
   s.mutatingGeneric(a)
-  s.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{21-21=(}} {{25-25=)}}
+  s.mutatingGeneric(a, b) // expected-error {{extra argument in call}}
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -438,7 +438,7 @@ do {
   var d = (a, b)
 
   s.mutatingGeneric(a)
-  s.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{21-21=(}} {{25-25=)}}
+  s.mutatingGeneric(a, b) // expected-error {{extra argument in call}}
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -929,10 +929,10 @@ struct GenericInitLabeledTuple<T> {
 }
 
 do {
-  _ = GenericInit(3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{19-19=(}} {{23-23=)}}
+  _ = GenericInit(3, 4) // expected-error {{extra argument in call}}
   _ = GenericInit((3, 4))
 
-  _ = GenericInitLabeled(x: 3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{28-28=(}} {{33-33=)}}
+  _ = GenericInitLabeled(x: 3, 4) // expected-error {{extra argument in call}}
   _ = GenericInitLabeled(x: (3, 4))
 
   _ = GenericInitTwo(3, 4)
@@ -967,7 +967,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericInit(a, b) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{19-19=(}} {{23-23=)}}
+  _ = GenericInit(a, b) // expected-error {{extra argument in call}}
   _ = GenericInit((a, b))
   _ = GenericInit(c)
 
@@ -1003,7 +1003,7 @@ do {
   var b = 4
   var c = (a, b)
 
-  _ = GenericInit(a, b) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{19-19=(}} {{23-23=)}}
+  _ = GenericInit(a, b) // expected-error {{extra argument in call}}
   _ = GenericInit((a, b))
   _ = GenericInit(c)
 
@@ -1127,12 +1127,12 @@ enum GenericEnum<T> {
 }
 
 do {
-  _ = GenericEnum.one(3, 4) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{23-23=(}} {{27-27=)}}
+  _ = GenericEnum.one(3, 4) // expected-error {{extra argument in call}}
   _ = GenericEnum.one((3, 4))
 
-  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{29-29=(}} {{34-34=)}}
+  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{extra argument in call}}
   _ = GenericEnum.labeled(x: (3, 4))
-  _ = GenericEnum.labeled(3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{27-27=(}} {{31-31=)}}
+  _ = GenericEnum.labeled(3, 4) // expected-error {{extra argument in call}}
   _ = GenericEnum.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
 
   _ = GenericEnum.two(3, 4)
@@ -1163,7 +1163,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericEnum.one(a, b) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{23-23=(}} {{27-27=)}}
+  _ = GenericEnum.one(a, b) // expected-error {{extra argument in call}}
   _ = GenericEnum.one((a, b))
   _ = GenericEnum.one(c)
 
@@ -1199,7 +1199,7 @@ do {
   var b = 4
   var c = (a, b)
 
-  _ = GenericEnum.one(a, b) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{23-23=(}} {{27-27=)}}
+  _ = GenericEnum.one(a, b) // expected-error {{extra argument in call}}
   _ = GenericEnum.one((a, b))
   _ = GenericEnum.one(c)
 


### PR DESCRIPTION
This effectively reverts #27584

rdar://problem/44877804
rdar://problem/55560957