### PR TITLE
[Driver] Use correct designator for filelist for dynamic link job

### DIFF
--- a/include/swift/Driver/Util.h
+++ b/include/swift/Driver/Util.h
@@ -45,8 +45,9 @@ namespace driver {
   /// the Job this info is attached to.
   struct FilelistInfo {
     enum class WhichFiles : unsigned {
-      Input,
-      PrimaryInputs,
+      InputJobs,
+      SourceInputActions,
+      InputJobsAndSourceInputActions,
       Output,
       /// Batch mode frontend invocations may have so many supplementary
       /// outputs that they don't comfortably fit as command-line arguments.

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -230,14 +230,10 @@ toolchains::Darwin::addLinkerInputArgs(InvocationInfo &II,
   ArgStringList &Arguments = II.Arguments;
   if (context.shouldUseInputFileList()) {
     Arguments.push_back("-filelist");
-    const auto whichFiles = context.Inputs.empty()
-                                ? FilelistInfo::WhichFiles::PrimaryInputs
-                                : FilelistInfo::WhichFiles::Input;
     Arguments.push_back(context.getTemporaryFilePath("inputs", "LinkFileList"));
     II.FilelistInfos.push_back(
-        {Arguments.back(), file_types::TY_Object, whichFiles});
-    assert((context.Inputs.empty() || context.InputActions.empty()) &&
-           "If both are non-empty the filelist won't work");
+        {Arguments.back(), file_types::TY_Object,
+         FilelistInfo::WhichFiles::InputJobsAndSourceInputActions});
   } else {
     addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                            file_types::TY_Object);
@@ -648,7 +644,7 @@ toolchains::Darwin::constructInvocation(const StaticLinkJobAction &job,
     Arguments.push_back("-filelist");
     Arguments.push_back(context.getTemporaryFilePath("inputs", "LinkFileList"));
     II.FilelistInfos.push_back({Arguments.back(), file_types::TY_Object,
-                                FilelistInfo::WhichFiles::Input});
+                                FilelistInfo::WhichFiles::InputJobs});
   } else {
     addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                            file_types::TY_Object);

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -230,15 +230,20 @@ toolchains::Darwin::addLinkerInputArgs(InvocationInfo &II,
   ArgStringList &Arguments = II.Arguments;
   if (context.shouldUseInputFileList()) {
     Arguments.push_back("-filelist");
+    const auto whichFiles = context.Inputs.empty()
+                                ? FilelistInfo::WhichFiles::PrimaryInputs
+                                : FilelistInfo::WhichFiles::Input;
     Arguments.push_back(context.getTemporaryFilePath("inputs", "LinkFileList"));
-    II.FilelistInfos.push_back({Arguments.back(), file_types::TY_Object,
-                                FilelistInfo::WhichFiles::PrimaryInputs});
+    II.FilelistInfos.push_back(
+        {Arguments.back(), file_types::TY_Object, whichFiles});
+    assert((context.Inputs.empty() || context.InputActions.empty()) &&
+           "If both are non-empty the filelist won't work");
   } else {
     addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                            file_types::TY_Object);
+    addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
   }
 
-  addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
 
   if (context.OI.CompilerMode == OutputInfo::Mode::SingleCompile)
     addInputsOfType(Arguments, context.Inputs, context.Args,

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -232,7 +232,7 @@ toolchains::Darwin::addLinkerInputArgs(InvocationInfo &II,
     Arguments.push_back("-filelist");
     Arguments.push_back(context.getTemporaryFilePath("inputs", "LinkFileList"));
     II.FilelistInfos.push_back({Arguments.back(), file_types::TY_Object,
-                                FilelistInfo::WhichFiles::Input});
+                                FilelistInfo::WhichFiles::PrimaryInputs});
   } else {
     addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                            file_types::TY_Object);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -579,7 +579,7 @@ void ToolChain::JobContext::addFrontendInputAndOutputArguments(
     Arguments.push_back("-primary-filelist");
     Arguments.push_back(getTemporaryFilePath("primaryInputs", ""));
     FilelistInfos.push_back({Arguments.back(), file_types::TY_Swift,
-                             FilelistInfo::WhichFiles::PrimaryInputs});
+                             FilelistInfo::WhichFiles::SourceInputActions});
   }
   if (!UseFileList || !UsePrimaryFileList) {
     addFrontendCommandLineInputArguments(MayHavePrimaryInputs, UseFileList,
@@ -876,7 +876,7 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
     Arguments.push_back(context.getTemporaryFilePath("inputs", ""));
     II.FilelistInfos.push_back({Arguments.back(),
                                 file_types::TY_SwiftModuleFile,
-                                FilelistInfo::WhichFiles::Input});
+                                FilelistInfo::WhichFiles::InputJobs});
 
     addInputsOfType(Arguments, context.InputActions,
                     file_types::TY_SwiftModuleFile);


### PR DESCRIPTION
Fixes a bug, rdar://56946329, that happens when the driver decides to use filelists for linking.
The internal filelist object was pointing to the wrong set of inputs and nothing was written to the list.