### PR TITLE
[stdlib] Add custom .first to Array

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -765,6 +765,12 @@ extension Array: RandomAccessCollection, MutableCollection {
   public var count: Int {
     return _getCount()
   }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  public var first: Element? {
+    _getCount() == 0 ? nil : _buffer[0]
+  }
 }
 
 extension Array: ExpressibleByArrayLiteral {


### PR DESCRIPTION
A bit brute force but it avoids double bounds checks that aren't getting optimized away.