### PR TITLE
[AutoDiff] Fix variedness propagation for `apply` inout arguments.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2143,13 +2143,16 @@ public:
 private:
   /// Predicate used to filter InoutArgumentRange.
   struct OperandToInoutArgument {
-    const Impl &inst;
-    OperandToInoutArgument(const Impl &inst) : inst(inst) {}
+    ArrayRef<SILParameterInfo> paramInfos;
+    OperandValueArrayRef arguments;
+    OperandToInoutArgument(const Impl &inst)
+        : paramInfos(inst.getSubstCalleeConv().getParameters()),
+          arguments(inst.getArgumentsWithoutIndirectResults()) {
+      assert(paramInfos.size() == arguments.size());
+    }
     Optional<SILValue> operator()(unsigned long i) const {
-      auto paramInfo = inst.getSubstCalleeConv().getParameters()[i];
-      auto argument = inst.getArgumentsWithoutIndirectResults()[i];
-      if (paramInfo.isIndirectMutating())
-        return argument;
+      if (paramInfos[i].isIndirectMutating())
+        return arguments[i];
       return None;
     }
   };

--- a/lib/SILOptimizer/Mandatory/Differentiation.h
+++ b/lib/SILOptimizer/Mandatory/Differentiation.h
@@ -103,7 +103,6 @@ inline void createEntryArguments(SILFunction *f) {
     auto *decl = new (ctx) ParamDecl(loc, loc, Identifier(), loc,
                                      Identifier(), moduleDecl);
     decl->setSpecifier(ParamDecl::Specifier::Default);
-//    decl->setType(type.getASTType());
     entry->createFunctionArgument(type, decl);
   };
   for (auto indResTy : conv.getIndirectSILResultTypes())

--- a/test/AutoDiff/differentiation_transform_diagnostics.swift
+++ b/test/AutoDiff/differentiation_transform_diagnostics.swift
@@ -270,23 +270,68 @@ func roundingGivesError(x: Float) -> Float {
 // Inout arguments
 //===----------------------------------------------------------------------===//
 
-func activeInoutArg(_ x: Float) -> Float {
-  var a = x
-  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
-  a += x
-  return a
-}
 // expected-error @+1 {{function is not differentiable}}
-_ = pullback(at: .zero, in: activeInoutArg(_:))
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArg(_ x: Float) -> Float {
+  var result = x
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  result += x
+  return result
+}
 
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgNonactiveInitialResult(_ x: Float) -> Float {
+  var result: Float = 1
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  result += x
+  return result
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
 func activeInoutArgTuple(_ x: Float) -> Float {
   var tuple = (x, x)
   // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
   tuple.0 *= x
   return x * tuple.0
 }
+
 // expected-error @+1 {{function is not differentiable}}
-_ = pullback(at: .zero, in: activeInoutArgTuple(_:))
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgControlFlow(_ array: [Float]) -> Float {
+  var result: Float = 1
+  for i in withoutDerivative(at: array).indices {
+    // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+    result += array[i]
+  }
+  return result
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgControlFlowComplex(_ array: [Float], _ bool: Bool) -> Float {
+  var result: Float = 1
+  if bool {
+    if bool {}
+    for i in withoutDerivative(at: array).indices {
+      switch i % 2 {
+      case 0: continue
+      case 1: break
+      default: break
+      }
+      result = result + 1
+      // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+      result += array[i]
+    }
+  }
+  return result
+}
 
 //===----------------------------------------------------------------------===//
 // Non-varied results

--- a/test/AutoDiff/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/forward_mode_diagnostics.swift
@@ -53,23 +53,37 @@ func calls_diff_of_nested(_ x: Float) -> Float {
 // Inout arguments
 //===----------------------------------------------------------------------===//
 
-func activeInoutArg(_ x: Float) -> Float {
-  var a = x
-  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
-  a += x
-  return a
-}
 // expected-error @+1 {{function is not differentiable}}
-_ = differential(at: .zero, in: activeInoutArg(_:))
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgNonactiveInitialResult(_ x: Float) -> Float {
+  var result: Float = 1
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  result += x
+  return result
+}
 
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
 func activeInoutArgTuple(_ x: Float) -> Float {
   var tuple = (x, x)
   // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
   tuple.0 *= x
   return x * tuple.0
 }
+
 // expected-error @+1 {{function is not differentiable}}
-_ = differential(at: .zero, in: activeInoutArgTuple(_:))
+@differentiable
+// expected-note @+2 {{when differentiating this function definition}}
+// expected-note @+1 {{forward-mode differentiation does not yet support control flow}}
+func activeInoutArgControlFlow(_ array: [Float]) -> Float {
+  var result: Float = 1
+  for i in withoutDerivative(at: array).indices {
+    result += array[i]
+  }
+  return result
+}
 
 //===----------------------------------------------------------------------===//
 // Non-varied results


### PR DESCRIPTION
Propagate variedness from `apply` argument operands to `apply` inout arguments
(representing results). `apply` inout arguments are now correctly marked as
active, triggering non-differentiability errors.

Add `ApplyInstBase::getInoutArguments` for iterating over `@inout` and
`@inout_aliasable` arguments.

Add non-differentiability diagnostics and activity info tests.

Resolves TF-974.

---

Example:

```swift
@differentiable
func activeInoutArgNonactiveInitialResult(_ x: Float) -> Float {
  var result: Float = 1
  result += x // Active `inout` argument: `result`.
  return result
}
print(gradient(at: 3, in: activeInoutArgNonactiveInitialResult))

// Before: successful compilation. Prints 0.0.
// After: compile-time error.
//
//     tf-974.swift:1:2: error: function is not differentiable
//     @differentiable
//     ~^~~~~~~~~~~~~~
//     tf-974.swift:2:6: note: when differentiating this function definition
//     func activeInoutArgNonactiveInitialResult(_ x: Float) -> Float {
//          ^
//     tf-974.swift:4:10: note: cannot differentiate through 'inout' arguments
//       result += x // Active `inout` argument: `result`.
//              ^
```