### PR TITLE
[Constraint application] Stop optimizing casts in the AST.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3583,9 +3583,6 @@ namespace {
         return nullptr;
       case CheckedCastKind::Coercion:
       case CheckedCastKind::BridgingCoercion: {
-        if (SuppressDiagnostics)
-          return nullptr;
-
         if (cs.getType(sub)->isEqual(toType)) {
           ctx.Diags.diagnose(expr->getLoc(), diag::forced_downcast_noop, toType)
               .fixItRemove(SourceRange(
@@ -3599,14 +3596,9 @@ namespace {
                             "as");
         }
 
-        // Transmute the checked cast into a coercion expression.
-        auto *result =
-            new (ctx) CoerceExpr(sub, expr->getLoc(), expr->getCastTypeLoc());
-        cs.setType(result, toType);
-        cs.setType(result->getCastTypeLoc(), toType);
-        unsigned disjunctionChoice =
-          (castKind == CheckedCastKind::Coercion ? 0 : 1);
-        return visitCoerceExpr(result, disjunctionChoice);
+        expr->setCastKind(castKind);
+        cs.setType(expr, toType);
+        return expr;
       }
 
       // Valid casts.
@@ -3659,37 +3651,18 @@ namespace {
           fromType, toType, castContextKind, cs.DC, expr->getLoc(), sub,
           expr->getCastTypeLoc().getSourceRange());
       switch (castKind) {
-        /// Invalid cast.
+      // Invalid cast.
       case CheckedCastKind::Unresolved:
         expr->setCastKind(CheckedCastKind::ValueCast);
         break;
 
       case CheckedCastKind::Coercion:
       case CheckedCastKind::BridgingCoercion: {
-        if (SuppressDiagnostics)
-          return nullptr;
-
         ctx.Diags.diagnose(expr->getLoc(), diag::conditional_downcast_coercion,
                            cs.getType(sub), toType);
-
-        // Transmute the checked cast into a coercion expression.
-        auto *coerce =
-            new (ctx) CoerceExpr(sub, expr->getLoc(), expr->getCastTypeLoc());
-        cs.setType(coerce, toType);
-        cs.setType(coerce->getCastTypeLoc(), toType);
-        unsigned disjunctionChoice =
-          (castKind == CheckedCastKind::Coercion ? 0 : 1);
-        Expr *result = visitCoerceExpr(coerce, disjunctionChoice);
-        if (!result)
-          return nullptr;
-
-        // Wrap the result in an optional. Mark the optional injection as
-        // explicit, because the user did in fact write the '?' as part of
-        // 'as?', even though it wasn't necessary.
-        result =
-            new (ctx) InjectIntoOptionalExpr(result, OptionalType::get(toType));
-        result->setImplicit(false);
-        return cs.cacheType(result);
+        expr->setCastKind(castKind);
+        cs.setType(expr, OptionalType::get(toType));
+        return expr;
       }
 
       // Valid casts.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3530,12 +3530,9 @@ namespace {
         // Convert the subexpression.
         Expr *sub = expr->getSubExpr();
 
-        solution.setExprTypes(sub);
-
-        if (TypeChecker::convertToType(sub, toType, cs.DC))
+        sub = solution.coerceToType(sub, toType, cs.getConstraintLocator(sub));
+        if (!sub)
           return nullptr;
-          
-        cs.cacheExprTypes(sub);
 
         expr->setSubExpr(sub);
         cs.setType(expr, toType);

--- a/test/stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/stdlib/BridgeIdAsAny.swift.gyb
@@ -196,6 +196,11 @@ testCases = [
 ]
 }%
 
+/// Whether this can be safely casted to NSObject
+func isNSObject<T>(_ value: T) -> Bool {
+  return (value as? NSObject) != nil
+}
+
 % for testName, type, valueExpr, testFunc, conformsToError, conformsToHashable in testCases:
 BridgeAnything.test("${testName}") {
   autoreleasepool {
@@ -207,7 +212,7 @@ BridgeAnything.test("${testName}") {
     let xInArray = [x]
     ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInArray) as! [AnyObject])[0])
     ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInArray) as? [AnyObject])![0])
-    if (x as? NSObject) != nil {
+    if isNSObject(x) {
       ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInArray) as! [AnyObject])[0])
       ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInArray) as? [AnyObject])![0])
     }
@@ -216,7 +221,7 @@ BridgeAnything.test("${testName}") {
     let xInDictValue = ["key" : x]
     ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInDictValue) as! [String: AnyObject])["key"]!)
     ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInDictValue) as? [String: AnyObject])!["key"]!)
-    if (x as? NSObject) != nil {
+    if isNSObject(x) {
       ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInDictValue) as! [String: NSObject])["key"]!)
       ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInDictValue) as? [String: NSObject])!["key"]!)
     }
@@ -228,7 +233,7 @@ BridgeAnything.test("${testName}") {
     // The NSObject version below can't test class LifetimeTracked.
     // ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInDictKey) as! [(AnyObject & Hashable): String]).keys.first!)
     // ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInDictKey) as? [(AnyObject & Hashable): String])!.keys.first!)
-    if (x as? NSObject) != nil {
+    if isNSObject(x) {
       ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInDictKey) as! [NSObject: String]).keys.first!)
       ${testFunc}(original: x, bridged: (_bridgeAnythingToObjectiveC(xInDictKey) as? [NSObject: String])!.keys.first!)
     }


### PR DESCRIPTION
Constraint application was rewriting conditional casts (`as?`) and
forced casts (`as!`) into coercions (`as`) at the AST level when it
determined that there was a coercion. Stop doing that: it's the
optimizer's job to remove such casts.