### PR TITLE
Filter out invalid nested types from typealias override checking

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4102,6 +4102,10 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
         auto type = dyn_cast<TypeDecl>(found);
         if (!type || isa<AssociatedTypeDecl>(type)) continue;
 
+        // Ignore nominal types. They're always invalid declarations.
+        if (isa<NominalTypeDecl>(type))
+          continue;
+
         // ... from the same module as the protocol.
         if (type->getModuleContext() != proto->getModuleContext()) continue;
 

--- a/validation-test/compiler_crashers_2_fixed/rdar57003317.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar57003317.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+protocol Iteratee {
+  associatedtype Iterator
+}
+
+protocol BidirectionalAdvancingCollection: Iteratee {
+  struct Iterator<Elements> {}
+}


### PR DESCRIPTION
The lookupDirect means that we can see (nominal) type declarations nested inside of a protocol. If we do not filter these invalid declarations, we will offer a bogus fixit on top of a cycle diagnostic.  Remove these types from consideration entirely so we don't crash *and* don't offer bogus fixits.

Resolves rdar://57003317