### PR TITLE
[test] Adjust SwiftNativeNSBase conditions

### DIFF
--- a/validation-test/stdlib/SwiftNativeNSBase.swift
+++ b/validation-test/stdlib/SwiftNativeNSBase.swift
@@ -21,7 +21,12 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
-// REQUIRES: rdar55727144
+
+// The oldest ABI-stable stdlibs don't have a __SwiftNativeNSMutableArrayBase
+// class, so they can't run the UnwantedCdtors test.
+// FIXME: This should be based on a runtime library version check.
+// UNSUPPORTED: use_os_stdlib
+
 import Foundation
 import StdlibUnittest
 


### PR DESCRIPTION
Adjust the conditions on the SwiftNativeNSBase test so that it runs when testing with the stdlib built directly from this repository.

rdar://problem/50413373