### PR TITLE
cherry-pick TF-965 fix to v0.6

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -250,7 +250,7 @@
         "tensorflow": {
             "aliases": ["tensorflow"],
             "repos": {
-                "llvm-project": "981e86a63172005c3f82f6edb3f843ee019ed48e",
+                "llvm-project": "71442b9e488f0c8a1f200f34cb0c6e464fa91725",
                 "swift": "tensorflow",
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2019-10-31-a",


### PR DESCRIPTION
I created https://github.com/apple/llvm-project/tree/swift/tensorflow-0.6 and cherry-picked the TF-965 fix to that branch (https://github.com/apple/llvm-project/commit/71442b9e488f0c8a1f200f34cb0c6e464fa91725).

This PR points the s4tf v0.6 swift branch at the resulting commit, so that v0.6 builds get the fix.