### PR TITLE
[AutoDiff] Clean up parsing and printing.

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -716,15 +716,6 @@ public:
     return Tok.is(tok::identifier) && Tok.getText() == value;
   }
 
-  /// Returns true if token is the identifier "wrt".
-  bool isWRTIdentifier(Token tok) { return isIdentifier(Tok, "wrt"); }
-
-  /// Returns true if token is the identifier "jvp".
-  bool isJVPIdentifier(Token Tok) { return isIdentifier(Tok, "jvp"); }
-
-  /// Returns true if token is the identifier "vjp".
-  bool isVJPIdentifier(Token Tok) { return isIdentifier(Tok, "vjp"); }
-
   /// Consume the starting '<' of the current token, which may either
   /// be a complete '<' token or some kind of operator token starting with '<',
   /// e.g., '<>'.

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -6976,8 +6976,7 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
   // Parse '[serialized]' flag (optional).
   bool isSerialized = false;
   SourceLoc serializedTokLoc;
-  if (P.Tok.is(tok::l_square) && P.peekToken().is(tok::identifier) &&
-      P.peekToken().getText() == "serialized") {
+  if (P.Tok.is(tok::l_square) && P.isIdentifier(P.peekToken(), "serialized")) {
     isSerialized = true;
     serializedTokLoc = P.Tok.getLoc();
     P.consumeToken(tok::l_square);
@@ -7023,7 +7022,7 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
     SourceLoc lBraceLoc;
     P.consumeIf(tok::l_brace, lBraceLoc);
     // Parse JVP (optional).
-    if (P.isJVPIdentifier(P.Tok)) {
+    if (P.isIdentifier(P.Tok, "jvp")) {
       P.consumeToken(tok::identifier);
       if (P.parseToken(tok::colon, diag::sil_diff_witness_expected_token, ":"))
         return true;
@@ -7032,7 +7031,7 @@ bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
         return true;
     }
     // Parse VJP (optional).
-    if (P.isVJPIdentifier(P.Tok)) {
+    if (P.isIdentifier(P.Tok, "vjp")) {
       P.consumeToken(tok::identifier);
       if (P.parseToken(tok::colon, diag::sil_diff_witness_expected_token, ":"))
         return true;


### PR DESCRIPTION
- Use general `Parser::isIdentifier(Token, StringRef)` function.
  - Remove specialized `isWRTIdentifier`, `isJVPIdentifier`, `isVJPIdentifier`
    functions from `Parser`.
- Clarify doc comments and parameter nullability for attribute printing code:
  - `getDifferentiationParametersClauseString`
  - `getTransposedParametersClauseString`
- Minor formatting and naming updates.