### PR TITLE
[Type checker] Fold more for-each type checking into the constraint solver

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -489,6 +489,9 @@ public:
   /// Get the '+' function on two String.
   FuncDecl *getPlusFunctionOnString() const;
 
+  /// Get Sequence.makeIterator().
+  FuncDecl *getSequenceMakeIterator() const;
+
   /// Check whether the standard library provides all the correct
   /// intrinsic support for Optional<T>.
   ///

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3924,6 +3924,10 @@ public:
   /// value to be specified later.
   bool isPlaceholder() const { return Bits.OpaqueValueExpr.IsPlaceholder; }
 
+  void setIsPlaceholder(bool value) {
+    Bits.OpaqueValueExpr.IsPlaceholder = value;
+  }
+
   SourceRange getSourceRange() const { return Range; }
 
   static bool classof(const Expr *E) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -196,6 +196,9 @@ struct ASTContext::Implementation {
   /// The declaration of '+' function for two String.
   FuncDecl *PlusFunctionOnString = nullptr;
 
+  /// The declaration of 'Sequence.makeIterator()'.
+  FuncDecl *MakeIterator = nullptr;
+
   /// The declaration of Swift.Optional<T>.Some.
   EnumElementDecl *OptionalSomeDecl = nullptr;
 
@@ -708,6 +711,31 @@ FuncDecl *ASTContext::getPlusFunctionOnString() const {
     }
   }
   return getImpl().PlusFunctionOnString;
+}
+
+FuncDecl *ASTContext::getSequenceMakeIterator() const {
+  if (getImpl().MakeIterator) {
+    return getImpl().MakeIterator;
+  }
+
+  auto proto = getProtocol(KnownProtocolKind::Sequence);
+  if (!proto)
+    return nullptr;
+
+  for (auto result : proto->lookupDirect(Id_makeIterator)) {
+    if (result->getDeclContext() != proto)
+      continue;
+
+    if (auto func = dyn_cast<FuncDecl>(result)) {
+      if (func->getParameters()->size() != 0)
+        continue;
+
+      getImpl().MakeIterator = func;
+      return func;
+    }
+  }
+
+  return nullptr;
 }
 
 #define KNOWN_STDLIB_TYPE_DECL(NAME, DECL_CLASS, NUM_GENERIC_PARAMS) \

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -610,6 +610,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
 
     case ConstraintKind::ValueMember:
     case ConstraintKind::UnresolvedValueMember:
+    case ConstraintKind::ValueWitness:
       // If our type variable shows up in the base type, there's
       // nothing to do.
       // FIXME: Can we avoid simplification here?

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1670,6 +1670,7 @@ void ConstraintSystem::ArgumentInfoCollector::walk(Type argType) {
 
       case ConstraintKind::BindToPointerType:
       case ConstraintKind::ValueMember:
+      case ConstraintKind::ValueWitness:
       case ConstraintKind::UnresolvedValueMember:
       case ConstraintKind::Disjunction:
       case ConstraintKind::CheckedCast:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2367,6 +2367,26 @@ public:
     }
   }
 
+  /// Add a value witness constraint to the constraint system.
+  void addValueWitnessConstraint(
+      Type baseTy, ValueDecl *requirement, Type memberTy, DeclContext *useDC,
+      FunctionRefKind functionRefKind, ConstraintLocatorBuilder locator) {
+    assert(baseTy);
+    assert(memberTy);
+    assert(requirement);
+    assert(useDC);
+    switch (simplifyValueWitnessConstraint(
+        ConstraintKind::ValueWitness, baseTy, requirement, memberTy, useDC,
+        functionRefKind, TMF_GenerateConstraints, locator)) {
+    case SolutionKind::Unsolved:
+      llvm_unreachable("Unsolved result when generating constraints!");
+
+    case SolutionKind::Solved:
+    case SolutionKind::Error:
+      break;
+    }
+  }
+
   /// Add an explicit conversion constraint (e.g., \c 'x as T').
   void addExplicitConversionConstraint(Type fromType, Type toType,
                                        bool allowFixes,
@@ -3267,6 +3287,12 @@ private:
       DeclContext *useDC, FunctionRefKind functionRefKind,
       ArrayRef<OverloadChoice> outerAlternatives, TypeMatchOptions flags,
       ConstraintLocatorBuilder locator);
+
+  /// Attempt to simplify the given value witness constraint.
+  SolutionKind simplifyValueWitnessConstraint(
+      ConstraintKind kind, Type baseType, ValueDecl *member, Type memberType,
+      DeclContext *useDC, FunctionRefKind functionRefKind,
+      TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify the optional object constraint.
   SolutionKind simplifyOptionalObjectConstraint(

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2991,14 +2991,12 @@ auto TypeChecker::typeCheckForEachBinding(
       }
 
       // Reference the makeIterator witness.
-      // FIXME: Not tied to the actual witness.
       ASTContext &ctx = cs.getASTContext();
-      DeclName makeIteratorName(ctx, ctx.Id_makeIterator,
-                                ArrayRef<Identifier>());
+      FuncDecl *makeIterator = ctx.getSequenceMakeIterator();
       MakeIteratorType = cs.createTypeVariable(Locator, TVO_CanBindToNoEscape);
-      cs.addValueMemberConstraint(
-          LValueType::get(SequenceType), DeclNameRef(makeIteratorName),
-          MakeIteratorType, cs.DC, FunctionRefKind::Compound, { },
+      cs.addValueWitnessConstraint(
+          LValueType::get(SequenceType), makeIterator,
+          MakeIteratorType, cs.DC, FunctionRefKind::Compound,
           ContextualLocator);
 
       Stmt->setSequence(expr);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1032,8 +1032,20 @@ public:
   static bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC);
   static bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber);
 
+  /// Information about a type-checked for-each binding.
+  struct ForEachBinding {
+    Type sequenceType;
+    ProtocolConformanceRef sequenceConformance;
+    Type iteratorType;
+    ProtocolConformanceRef iteratorConformance;
+    Type elementType;
+  };
+
   /// Type-check a for-each loop's pattern binding and sequence together.
-  static bool typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt);
+  ///
+  /// \returns the binding, if successful.
+  static Optional<ForEachBinding> typeCheckForEachBinding(
+      DeclContext *dc, ForEachStmt *stmt);
 
   /// Compute the set of captures for the given function or closure.
   static void computeCaptures(AnyFunctionRef AFR);
@@ -1100,17 +1112,6 @@ public:
   /// \returns the default type, or null if there is no default type for
   /// this protocol.
   static Type getDefaultType(ProtocolDecl *protocol, DeclContext *dc);
-
-  /// Convert the given expression to the given type.
-  ///
-  /// \param expr The expression, which will be updated in place.
-  /// \param type The type to convert to.
-  /// \param typeFromPattern Optionally, the caller can specify the pattern
-  ///   from where the toType is derived, so that we can deliver better fixit.
-  ///
-  /// \returns true if an error occurred, false otherwise.
-  static bool convertToType(Expr *&expr, Type type, DeclContext *dc,
-                            Optional<Pattern*> typeFromPattern = None);
 
   /// Coerce the given expression to materializable type, if it
   /// isn't already.

--- a/test/Constraints/generic_protocol_witness.swift
+++ b/test/Constraints/generic_protocol_witness.swift
@@ -59,5 +59,6 @@ func usesAGenericMethod<U : NeedsAGenericMethod>(_ x: U) {
 struct L<T>: Sequence {} // expected-error {{type 'L<T>' does not conform to protocol 'Sequence'}}
 
 func z(_ x: L<Int>) {
-  for xx in x {} // expected-warning {{immutable value 'xx' was never used; consider replacing with '_' or removing it}}
+  for xx in x {}
+  // expected-error@-1{{for-in loop requires 'L<Int>' to conform to 'Sequence'}}
 }

--- a/test/Constraints/generic_protocol_witness.swift
+++ b/test/Constraints/generic_protocol_witness.swift
@@ -60,5 +60,6 @@ struct L<T>: Sequence {} // expected-error {{type 'L<T>' does not conform to pro
 
 func z(_ x: L<Int>) {
   for xx in x {}
-  // expected-error@-1{{for-in loop requires 'L<Int>' to conform to 'Sequence'}}
+  // expected-warning@-1{{immutable value 'xx' was never used; consider replacing with '_' or removing it}}
+  // expected-error@-2{{type 'L<Int>.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -215,7 +215,7 @@ public func testGetFunc() {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$s22big_types_corner_cases7TestBigC5test2yyF"(%T22big_types_corner_cases7TestBigC* swiftself)
 // CHECK: [[CALL1:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSaySS2ID_y22big_types_corner_cases9BigStructVcSg7handlertGMD"
 // CHECK: [[CALL2:%.*]] = call i8** @"$sSaySS2ID_y22big_types_corner_cases9BigStructVcSg7handlertGSayxGSlsWl"
-// CHECK: call swiftcc void @"$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF"(%Ts16IndexingIteratorV* noalias nocapture sret {{.*}}, %swift.type* [[CALL1]], i8** [[CALL2]], %swift.opaque* noalias nocapture swiftself {{.*}})
+// CHECK: call swiftcc void @"$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF"(%Ts16IndexingIteratorV{{.*}}* noalias nocapture sret {{.*}}, %swift.type* [[CALL1]], i8** [[CALL2]], %swift.opaque* noalias nocapture swiftself {{.*}})
 // CHECK: ret void
 class TestBig {
     typealias Handler = (BigStruct) -> Void

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -108,8 +108,8 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<Int>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<Int>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<Int>, #Sequence.makeIterator!1 : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[Int]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
@@ -208,8 +208,8 @@ func existentialBreak(_ xx: [P]) {
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<P>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<P>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<P>, #Sequence.makeIterator!1 : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[P]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<P>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
@@ -368,8 +368,8 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<GenericStruct<T>>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<GenericStruct<T>>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<GenericStruct<T>>, #Sequence.makeIterator!1 : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[GenericStruct<T>]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<GenericStruct<T>>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -15,6 +15,7 @@ struct BadContainer2 : Sequence { // expected-error{{type 'BadContainer2' does n
 func bad_containers_2(bc: BadContainer2) {
   for e in bc { }
   // expected-warning@-1 {{immutable value 'e' was never used; consider replacing with '_' or removing it}}
+  // expected-error@-2{{type 'BadContainer2.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }
 
 struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does not conform to protocol 'Sequence'}}
@@ -24,6 +25,7 @@ struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does n
 func bad_containers_3(bc: BadContainer3) {
   for e in bc { }
   // expected-warning@-1 {{immutable value 'e' was never used; consider replacing with '_' or removing it}}
+  // expected-error@-2{{type 'BadContainer3.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }
 
 struct BadIterator1 {}
@@ -36,6 +38,7 @@ struct BadContainer4 : Sequence { // expected-error{{type 'BadContainer4' does n
 func bad_containers_4(bc: BadContainer4) {
   for e in bc { }
   // expected-warning@-1 {{immutable value 'e' was never used; consider replacing with '_' or removing it}}
+  // expected-error@-2{{type 'BadContainer4.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }
 
 // Pattern type-checking


### PR DESCRIPTION
The type checking of the for-each loop is split between the constraint
solver (which does most of the work) and the statement checker (which
updates the for-each loop AST). Move more of the work into the constraint
solver proper, so that the AST updates can happen in one place, making use
of the solution produced by the solver. This allows a few things, some of
which are short-term gains and others that are more future-facing:

* `TypeChecker::convertToType` has been removed, because we can now either
use the more general `typeCheckExpression` entry point or perform the
appropriate operation within the constraint system.
* Solving the constraint system ensures that everything related to the
for-each loop fulyl checks out
* Additional refactoring will make it easier for the for-each loop to be
checked as part of a larger constraint system, e.g., for processing entire
closures or function bodies (that’s the futurist bit).

Use this to get some diagnostic improvements, specifically an improved
“did you mean to unwrap an optional” diagnostic. If you try to loop
over an `[Int]?`, the diagnostic will now be:

    error: for-in loop over optional type '[Int]?' must be unwrapped to a value of type '[Int]'

with the normal set of notes with Fix-Its to suggest reasonable actions:

    note: coalesce using '??' to provide a default when the optional value contains 'nil'
    note: force-unwrap using '!' to abort execution if the optional value contains 'nil'

It also introduces the notion of a "value witness" constraint, which better describes the
operation of looking for a value witness within a particular conformance. If the
conformance itself is ill-formed, then the right-hand-side of the constraint (the member
type) can be filled in with holes to suppress further diagnostics. This also ensures that the
AST records `makeIterator` calls through conformance rather than devirtualizing in the type
checker.