### PR TITLE
Optimizer: Don't keep alwaysEmitIntoClient-functions alive after serialization

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -405,6 +405,11 @@ class SerializeSILPass : public SILModuleTransform {
         updateOpaqueArchetypes(F);
         invalidateAnalysis(&F, SILAnalysis::InvalidationKind::Everything);
       }
+
+      // After serialization we don't need to keep @alwaysEmitIntoClient
+      // functions alive, i.e. we don't need to treat them as public functions.
+      if (F.getLinkage() == SILLinkage::PublicNonABI && M.isWholeModule())
+        F.setLinkage(SILLinkage::Shared);
     }
 
     for (auto &WT : M.getWitnessTables()) {

--- a/test/SILOptimizer/alwaysemitintoclient.swift
+++ b/test/SILOptimizer/alwaysemitintoclient.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -DMODULE %s -O -emit-sil | %FileCheck %s
+
+// Also link to make sure we don't eliminate any needed symbols.
+
+// RUN: %target-swift-frontend -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -DMODULE %s -O -c -o module.o
+// RUN: %target-build-swift -DMAIN %s -I%t -O -o %t/a.out
+
+#if MODULE
+
+// Check if the optimizer eliminates testit() in Module.
+
+// CHECK-NOT: {{sil .*testit.*}}
+
+@_alwaysEmitIntoClient
+@inline(never)
+public func testit() {
+  print("hello")
+}
+
+#endif
+
+
+#if MAIN
+
+import Module
+
+public func caller() {
+  testit()
+}
+
+#endif
+


### PR DESCRIPTION
This enables dead-function elimination if such functions are not referenced with the module.
