### PR TITLE
build: remove `SWIFT_NEEDS_EXPLICIT_LIBDISPATCH`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,10 +465,7 @@ option(SWIFT_BUILD_SOURCEKIT "Build SourceKit" TRUE)
 option(SWIFT_ENABLE_SOURCEKIT_TESTS "Enable running SourceKit tests" ${SWIFT_BUILD_SOURCEKIT})
 
 if(SWIFT_BUILD_SYNTAXPARSERLIB OR SWIFT_BUILD_SOURCEKIT)
-  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    set(SWIFT_NEED_EXPLICIT_LIBDISPATCH FALSE)
-  else()
-    set(SWIFT_NEED_EXPLICIT_LIBDISPATCH TRUE)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     if(NOT EXISTS "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}")
       message(SEND_ERROR "SyntaxParserLib and SourceKit require libdispatch on non-Darwin hosts.  Please specify SWIFT_PATH_TO_LIBDISPATCH_SOURCE")
     endif()
@@ -954,122 +951,124 @@ if (LLVM_ENABLE_DOXYGEN)
   message(STATUS "Doxygen: enabled")
 endif()
 
-if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
-  if(CMAKE_C_COMPILER_ID STREQUAL Clang AND
-     CMAKE_C_COMPILER_VERSION VERSION_GREATER 3.8
-     OR LLVM_USE_SANITIZER)
-    set(SWIFT_LIBDISPATCH_C_COMPILER ${CMAKE_C_COMPILER})
-    set(SWIFT_LIBDISPATCH_CXX_COMPILER ${CMAKE_CXX_COMPILER})
-  elseif(${CMAKE_SYSTEM_NAME} STREQUAL ${CMAKE_HOST_SYSTEM_NAME})
-    if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-      set(SWIFT_LIBDISPATCH_C_COMPILER
-          $<TARGET_FILE_DIR:clang>/clang-cl${CMAKE_EXECUTABLE_SUFFIX})
-      set(SWIFT_LIBDISPATCH_CXX_COMPILER
-          $<TARGET_FILE_DIR:clang>/clang-cl${CMAKE_EXECUTABLE_SUFFIX})
+if(SWIFT_BUILD_SYNTAXPARSERLIB OR SWIFT_BUILD_SOURCEKIT)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    if(CMAKE_C_COMPILER_ID STREQUAL Clang AND
+       CMAKE_C_COMPILER_VERSION VERSION_GREATER 3.8
+       OR LLVM_USE_SANITIZER)
+      set(SWIFT_LIBDISPATCH_C_COMPILER ${CMAKE_C_COMPILER})
+      set(SWIFT_LIBDISPATCH_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+    elseif(${CMAKE_SYSTEM_NAME} STREQUAL ${CMAKE_HOST_SYSTEM_NAME})
+      if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+        set(SWIFT_LIBDISPATCH_C_COMPILER
+            $<TARGET_FILE_DIR:clang>/clang-cl${CMAKE_EXECUTABLE_SUFFIX})
+        set(SWIFT_LIBDISPATCH_CXX_COMPILER
+            $<TARGET_FILE_DIR:clang>/clang-cl${CMAKE_EXECUTABLE_SUFFIX})
+      else()
+        set(SWIFT_LIBDISPATCH_C_COMPILER $<TARGET_FILE_DIR:clang>/clang)
+        set(SWIFT_LIBDISPATCH_CXX_COMPILER $<TARGET_FILE_DIR:clang>/clang++)
+      endif()
     else()
-      set(SWIFT_LIBDISPATCH_C_COMPILER $<TARGET_FILE_DIR:clang>/clang)
-      set(SWIFT_LIBDISPATCH_CXX_COMPILER $<TARGET_FILE_DIR:clang>/clang++)
+      message(SEND_ERROR "libdispatch requires a newer clang compiler (${CMAKE_C_COMPILER_VERSION} < 3.9)")
     endif()
-  else()
-    message(SEND_ERROR "libdispatch requires a newer clang compiler (${CMAKE_C_COMPILER_VERSION} < 3.9)")
-  endif()
 
-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
-    set(SOURCEKIT_LIBDISPATCH_RUNTIME_DIR bin)
-  else()
-    set(SOURCEKIT_LIBDISPATCH_RUNTIME_DIR lib)
-  endif()
+    if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
+      set(SOURCEKIT_LIBDISPATCH_RUNTIME_DIR bin)
+    else()
+      set(SOURCEKIT_LIBDISPATCH_RUNTIME_DIR lib)
+    endif()
 
-  include(ExternalProject)
-  ExternalProject_Add(libdispatch
-                      SOURCE_DIR
-                        "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}"
-                      CMAKE_ARGS
-                        -DCMAKE_AR=${CMAKE_AR}
-                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                        -DCMAKE_C_COMPILER=${SWIFT_LIBDISPATCH_C_COMPILER}
-                        -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-                        -DCMAKE_CXX_COMPILER=${SWIFT_LIBDISPATCH_CXX_COMPILER}
-                        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-                        -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
-                        -DCMAKE_INSTALL_LIBDIR=lib
-                        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                        -DCMAKE_LINKER=${CMAKE_LINKER}
-                        -DCMAKE_RANLIB=${CMAKE_RANLIB}
-                        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-                        -DBUILD_SHARED_LIBS=YES
-                        -DENABLE_SWIFT=NO
-                        -DENABLE_TESTING=NO
-                      INSTALL_COMMAND
-                        # NOTE(compnerd) provide a custom install command to
-                        # ensure that we strip out the DESTDIR environment
-                        # from the sub-build
-                        ${CMAKE_COMMAND} -E env --unset=DESTDIR ${CMAKE_COMMAND} --build . --target install
-                      STEP_TARGETS
-                        install
-                      BUILD_BYPRODUCTS
-                        <INSTALL_DIR>/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
-                        <INSTALL_DIR>/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}dispatch${CMAKE_IMPORT_LIBRARY_SUFFIX}
-                        <INSTALL_DIR>/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
-                        <INSTALL_DIR>/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}BlocksRuntime${CMAKE_IMPORT_LIBRARY_SUFFIX}
-                      BUILD_ALWAYS
-                        1)
+    include(ExternalProject)
+    ExternalProject_Add(libdispatch
+                        SOURCE_DIR
+                          "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}"
+                        CMAKE_ARGS
+                          -DCMAKE_AR=${CMAKE_AR}
+                          -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                          -DCMAKE_C_COMPILER=${SWIFT_LIBDISPATCH_C_COMPILER}
+                          -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                          -DCMAKE_CXX_COMPILER=${SWIFT_LIBDISPATCH_CXX_COMPILER}
+                          -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                          -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+                          -DCMAKE_INSTALL_LIBDIR=lib
+                          -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                          -DCMAKE_LINKER=${CMAKE_LINKER}
+                          -DCMAKE_RANLIB=${CMAKE_RANLIB}
+                          -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+                          -DBUILD_SHARED_LIBS=YES
+                          -DENABLE_SWIFT=NO
+                          -DENABLE_TESTING=NO
+                        INSTALL_COMMAND
+                          # NOTE(compnerd) provide a custom install command to
+                          # ensure that we strip out the DESTDIR environment
+                          # from the sub-build
+                          ${CMAKE_COMMAND} -E env --unset=DESTDIR ${CMAKE_COMMAND} --build . --target install
+                        STEP_TARGETS
+                          install
+                        BUILD_BYPRODUCTS
+                          <INSTALL_DIR>/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
+                          <INSTALL_DIR>/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}dispatch${CMAKE_IMPORT_LIBRARY_SUFFIX}
+                          <INSTALL_DIR>/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
+                          <INSTALL_DIR>/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}BlocksRuntime${CMAKE_IMPORT_LIBRARY_SUFFIX}
+                        BUILD_ALWAYS
+                          1)
 
-  ExternalProject_Get_Property(libdispatch install_dir)
+    ExternalProject_Get_Property(libdispatch install_dir)
 
-  # CMake does not like the addition of INTERFACE_INCLUDE_DIRECTORIES without
-  # the directory existing.  Just create the location which will be populated
-  # during the installation.
-  file(MAKE_DIRECTORY ${install_dir}/include)
+    # CMake does not like the addition of INTERFACE_INCLUDE_DIRECTORIES without
+    # the directory existing.  Just create the location which will be populated
+    # during the installation.
+    file(MAKE_DIRECTORY ${install_dir}/include)
 
-  add_library(dispatch SHARED IMPORTED)
-  set_target_properties(dispatch
-                        PROPERTIES
-                          IMPORTED_LOCATION
-                            ${install_dir}/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
-                          IMPORTED_IMPLIB
-                            ${install_dir}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}dispatch${CMAKE_IMPORT_LIBRARY_SUFFIX}
-                          INTERFACE_INCLUDE_DIRECTORIES
-                            ${install_dir}/include)
+    add_library(dispatch SHARED IMPORTED)
+    set_target_properties(dispatch
+                          PROPERTIES
+                            IMPORTED_LOCATION
+                              ${install_dir}/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
+                            IMPORTED_IMPLIB
+                              ${install_dir}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}dispatch${CMAKE_IMPORT_LIBRARY_SUFFIX}
+                            INTERFACE_INCLUDE_DIRECTORIES
+                              ${install_dir}/include)
 
-  add_library(BlocksRuntime SHARED IMPORTED)
-  set_target_properties(BlocksRuntime
-                        PROPERTIES
-                          IMPORTED_LOCATION
-                            ${install_dir}/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
-                          IMPORTED_IMPLIB
-                            ${install_dir}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}BlocksRuntime${CMAKE_IMPORT_LIBRARY_SUFFIX}
-                          INTERFACE_INCLUDE_DIRECTORIES
-                            ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
+    add_library(BlocksRuntime SHARED IMPORTED)
+    set_target_properties(BlocksRuntime
+                          PROPERTIES
+                            IMPORTED_LOCATION
+                              ${install_dir}/${SOURCEKIT_LIBDISPATCH_RUNTIME_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
+                            IMPORTED_IMPLIB
+                              ${install_dir}/lib/${CMAKE_IMPORT_LIBRARY_PREFIX}BlocksRuntime${CMAKE_IMPORT_LIBRARY_SUFFIX}
+                            INTERFACE_INCLUDE_DIRECTORIES
+                              ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
 
-  add_dependencies(dispatch libdispatch-install)
-  add_dependencies(BlocksRuntime libdispatch-install)
+    add_dependencies(dispatch libdispatch-install)
+    add_dependencies(BlocksRuntime libdispatch-install)
 
-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
-    set(SOURCEKIT_RUNTIME_DIR bin)
-  else()
-    set(SOURCEKIT_RUNTIME_DIR lib)
-  endif()
-  add_dependencies(sourcekit-inproc BlocksRuntime dispatch)
-  swift_install_in_component(FILES
-                               $<TARGET_FILE:dispatch>
-                               $<TARGET_FILE:BlocksRuntime>
-                             DESTINATION ${SOURCEKIT_RUNTIME_DIR}
-                             COMPONENT sourcekit-inproc)
-  if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
+    if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
+      set(SOURCEKIT_RUNTIME_DIR bin)
+    else()
+      set(SOURCEKIT_RUNTIME_DIR lib)
+    endif()
+    add_dependencies(sourcekit-inproc BlocksRuntime dispatch)
     swift_install_in_component(FILES
-                                 $<TARGET_LINKER_FILE:dispatch>
-                                 $<TARGET_LINKER_FILE:BlocksRuntime>
-                               DESTINATION lib
+                                 $<TARGET_FILE:dispatch>
+                                 $<TARGET_FILE:BlocksRuntime>
+                               DESTINATION ${SOURCEKIT_RUNTIME_DIR}
                                COMPONENT sourcekit-inproc)
+    if(SWIFT_HOST_VARIANT_SDK STREQUAL WINDOWS)
+      swift_install_in_component(FILES
+                                   $<TARGET_LINKER_FILE:dispatch>
+                                   $<TARGET_LINKER_FILE:BlocksRuntime>
+                                 DESTINATION lib
+                                 COMPONENT sourcekit-inproc)
+    endif()
+
+
+    # FIXME(compnerd) this should be taken care of by the
+    # INTERFACE_INCLUDE_DIRECTORIES above
+    include_directories(AFTER
+                          ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime
+                          ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
   endif()
-
-
-  # FIXME(compnerd) this should be taken care of by the
-  # INTERFACE_INCLUDE_DIRECTORIES above
-  include_directories(AFTER
-                        ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime
-                        ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
 endif()
 
 # Add all of the subdirectories, where we actually do work.

--- a/tools/SourceKit/lib/Support/CMakeLists.txt
+++ b/tools/SourceKit/lib/Support/CMakeLists.txt
@@ -11,7 +11,9 @@ target_link_libraries(SourceKitSupport PRIVATE
   swiftSyntax
   clangBasic
   clangRewrite)
-if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
-  target_link_libraries(SourceKitSupport INTERFACE dispatch BlocksRuntime)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(SourceKitSupport INTERFACE
+    dispatch
+    BlocksRuntime)
 endif()
 

--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
@@ -7,8 +7,10 @@ if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
 else()
   target_link_libraries(complete-test PRIVATE sourcekitd)
 endif()
-if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
-  target_link_libraries(complete-test PRIVATE dispatch BlocksRuntime)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(complete-test PRIVATE
+    dispatch
+    BlocksRuntime)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -12,8 +12,10 @@ if(HAVE_UNICODE_LIBEDIT)
   else()
     target_link_libraries(sourcekitd-repl PRIVATE sourcekitd)
   endif()
-  if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
-    target_link_libraries(sourcekitd-repl PRIVATE dispatch BlocksRuntime)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    target_link_libraries(sourcekitd-repl PRIVATE
+      dispatch
+      BlocksRuntime)
   endif()
 
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -17,8 +17,10 @@ if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
 else()
   target_link_libraries(sourcekitd-test PRIVATE sourcekitd)
 endif()
-if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
-  target_link_libraries(sourcekitd-test PRIVATE dispatch BlocksRuntime)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(sourcekitd-test PRIVATE
+    dispatch
+    BlocksRuntime)
 endif()
 
 add_dependencies(sourcekitd-test sourcekitdTestOptionsTableGen)

--- a/tools/libSwiftSyntaxParser/CMakeLists.txt
+++ b/tools/libSwiftSyntaxParser/CMakeLists.txt
@@ -45,8 +45,9 @@ endif()
 
 set_property(TARGET libSwiftSyntaxParser APPEND_STRING PROPERTY
   COMPILE_FLAGS " -fblocks")
-if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
-  target_link_libraries(libSwiftSyntaxParser PRIVATE BlocksRuntime)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(libSwiftSyntaxParser PRIVATE
+    BlocksRuntime)
 endif()
 
 add_dependencies(parser-lib libSwiftSyntaxParser)

--- a/tools/swift-syntax-parser-test/CMakeLists.txt
+++ b/tools/swift-syntax-parser-test/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 
 set_property(TARGET swift-syntax-parser-test APPEND_STRING PROPERTY
   COMPILE_FLAGS " -fblocks")
-if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
-  target_link_libraries(swift-syntax-parser-test PRIVATE BlocksRuntime)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(swift-syntax-parser-test PRIVATE
+    BlocksRuntime)
 endif()

--- a/unittests/SyntaxParser/CMakeLists.txt
+++ b/unittests/SyntaxParser/CMakeLists.txt
@@ -24,6 +24,6 @@ endif()
 
 set_property(TARGET SwiftSyntaxParserTests APPEND_STRING PROPERTY
   COMPILE_FLAGS " -fblocks")
-if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(SwiftSyntaxParserTests PRIVATE BlocksRuntime)
 endif()


### PR DESCRIPTION
Restore the previous commit which somehow passed the buildbot given a
missing condition on the sub-configure for libdispatch.  This makes it
more explicit as to what the desire is; the variable was being used to
serve as a proxy for whether the build is not on a Darwin target.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
