### PR TITLE
Revert "[Runtime] Handle dynamic casting to NSObject via error bridging."

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -37,7 +37,6 @@
 #include "llvm/Support/Compiler.h"
 #if SWIFT_OBJC_INTEROP
 #include "swift/Runtime/ObjCBridge.h"
-#include "SwiftObject.h"
 #include "SwiftValue.h"
 #endif
 
@@ -2331,10 +2330,9 @@ static bool swift_dynamicCastImpl(OpaqueValue *dest, OpaqueValue *src,
   case MetadataKind::Class:
   case MetadataKind::ObjCClassWrapper:
 #if SWIFT_OBJC_INTEROP
-    // If the destination type is an NSError or NSObject, and the source type
-    // is an Error, then the cast can succeed by NSError bridging.
-    if (targetType == getNSErrorMetadata() ||
-        targetType == getNSObjectMetadata()) {
+    // If the destination type is an NSError, and the source type is an
+    // Error, then the cast can succeed by NSError bridging.
+    if (targetType == getNSErrorMetadata()) {
       // Don't rebridge if the source is already some kind of NSError.
       if (srcType->isAnyClass()
           && swift_dynamicCastObjCClass(*reinterpret_cast<id*>(src),

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -29,7 +29,6 @@
 
 
 #if SWIFT_OBJC_INTEROP
-#if __OBJC__
 
 // Source code: "SwiftObject"
 // Real class name: mangled "Swift._SwiftObject"
@@ -84,13 +83,5 @@ id getDescription(OpaqueValue *value, const Metadata *type);
 }
 
 #endif
-#endif
-
-namespace swift {
-
-/// Get the NSObject metadata.
-const Metadata *getNSObjectMetadata();
-
-}
 
 #endif

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1552,11 +1552,6 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
   free(nullTerminatedFilename);
 }
 
-const Metadata *swift::getNSObjectMetadata() {
-  return SWIFT_LAZY_CONSTANT(
-      swift_getObjCClassMetadata((const ClassMetadata *)[NSObject class]));
-}
-
 #endif
 
 const ClassMetadata *swift::getRootSuperclass() {

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -767,29 +767,4 @@ ErrorBridgingTests.test("@objc error domains for nested types") {
               String(reflecting: NonPrintAsObjCError.self))
 }
 
-@inline(never)
-@_optimize(none)
-func anyToAny<T, U>(_ a: T, _ : U.Type) -> U {
-  return a as! U
-}
-
-ErrorBridgingTests.test("error-to-NSObject casts") {
-  let error = MyCustomizedError(code: 12345)
-
-  // Unconditional cast
-  let nsErrorAsObject1 = unconditionalCast(error, to: NSObject.self)
-  let nsError1 = unconditionalCast(nsErrorAsObject1, to: NSError.self)
-  expectEqual("custom", nsError1.domain)
-  expectEqual(12345, nsError1.code)
-
-  // Conditional cast
-  let nsErrorAsObject2 = conditionalCast(error, to: NSObject.self)!
-  let nsError2 = unconditionalCast(nsErrorAsObject2, to: NSError.self)
-  expectEqual("custom", nsError2.domain)
-  expectEqual(12345, nsError2.code)
-
-  // "is" check
-  expectTrue(error is NSObject)
-}
-
 runAllTests()


### PR DESCRIPTION
Reverts apple/swift#28353 to fix Swift-in-the-OS bots (e.g. https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RA-test-simulator-swift-in-the-os/764).