### PR TITLE
[NFC] Refactor Overload Resolution a Bit

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2674,6 +2674,19 @@ public:
                           const DeclRefExpr *base = nullptr,
                           OpenedTypeMap *replacements = nullptr);
 
+private:
+  /// Adjust the constraint system to accomodate the given selected overload, and
+  /// recompute the type of the referenced declaration.
+  ///
+  /// \returns a pair containing the adjusted opened type of a reference to
+  /// this member and a bit indicating whether or not a bind constraint was added.
+  std::pair<Type, bool> adjustTypeOfOverloadReference(
+      const OverloadChoice &choice, ConstraintLocator *locator, Type boundType,
+      Type refType, DeclContext *useDC,
+      llvm::function_ref<void(unsigned int, Type, ConstraintLocator *)>
+          verifyThatArgumentIsHashable);
+
+public:
   /// Attempt to simplify the set of overloads corresponding to a given
   /// function application constraint.
   ///


### PR DESCRIPTION
The first commit pulls the out-parameters in `resolveOverloadForDeclWithSpecialTypeCheckingSemantics` out as its return type and adjusts the caller in `ConstraintSystem::resolveOverload` to have a bit of a simpler structure. 

The second commit further clarifies the structure of `ConstraintSystem::resolveOverload` by pulling out the parts that readjust the constraint system and the type of the reference to the selected overload into their own private helper function.  It also readjusts its structure from a branch-tree on the overload kind to a switch.