### PR TITLE
[Docs] Update TypeChecker.rst with a list of not-yet-ported diagnostics

### DIFF
--- a/docs/TypeChecker.rst
+++ b/docs/TypeChecker.rst
@@ -971,3 +971,34 @@ well-typed suggestions.
   meets and joins, so the solver continues until it runs out of
   supertypes to enumerate.
 
+New Diagnostic Architecture
+---------------------------
+
+We are currently working on porting type-check based diagnostics over
+to the new diagnostic framework, which is described in detail in this
+`blog post
+<https://swift.org/blog/new-diagnostic-arch-overview/>`_.
+
+The things in the queue yet to be ported are:
+
+- ``visitTupleExpr``: Diagnostics related to label/type mismatches
+  associated with tuple conversions.
+
+- Diagnostics related to member references: ``diagnoseMemberFailures``.
+  Most of the associated diagnostics have been ported and fixes are
+  located in ``ConstraintSystem::simplifyMemberConstraint``.
+
+- Closure expression diagnostics: ``diagnoseClosureExpr``.
+
+- Diagnostics related to ``if`` statement - "conditional" type mismatch
+  and, in case of ternary operator, type mismatches between branches.
+
+- Problems related to calls and operator applications e.g.
+
+  - ``@dynamicallyCallable`` related diagnostics
+  - Missing explicit ``Self.`` and ``self.``
+  - Logic related to overload candidate ranking (``CalleeCandidateInfo``)
+  - ``diagnoseParameterErrors``
+  - ``diagnoseSimpleErrors``
+
+- Diagnostics related to array/dictionary literals: ``visit{Array, Dictionary}Expr``.

--- a/docs/TypeChecker.rst
+++ b/docs/TypeChecker.rst
@@ -995,7 +995,7 @@ The things in the queue yet to be ported are:
 
 - Problems related to calls and operator applications e.g.
 
-  - ``@dynamicallyCallable`` related diagnostics
+  - ``@dynamicCallable`` related diagnostics
   - Missing explicit ``Self.`` and ``self.``
   - Logic related to overload candidate ranking (``CalleeCandidateInfo``)
   - ``diagnoseParameterErrors``


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
