### PR TITLE
Mark `IntRange::iterator::operator{==,!=}` as const.

### DIFF
--- a/include/swift/Basic/Range.h
+++ b/include/swift/Basic/Range.h
@@ -126,8 +126,8 @@ public:
       *this -= 1;
       return copy;
     }
-    bool operator==(iterator rhs) { return Value == rhs.Value; }
-    bool operator!=(iterator rhs) { return Value != rhs.Value; }
+    bool operator==(iterator rhs) const { return Value == rhs.Value; }
+    bool operator!=(iterator rhs) const { return Value != rhs.Value; }
 
     iterator &operator+=(difference_type i) {
       Value = Traits::addOffset(Value, i);


### PR DESCRIPTION
`IntRange::iterator::operator==` must be marked as `const` in order to use
`OptionalTransformRange<IntRange<...>, ...>::empty` under specific conditions.

---

Example error before this patch:

```
swift-dev/swift/include/swift/Basic/STLExtras.h:501:37: error: invalid operands to binary expression ('const swift::IntRange<unsigned long, swift::IntRangeTraits<unsigned long, false> >::iterator' and 'const swift::IntRange<unsigned long, swift::IntRangeTraits<unsigned long, false> >::iterator')
  bool empty() const { return First == Last; }
                              ~~~~~ ^  ~~~~
swift-dev/swift/lib/SILOptimizer/Mandatory/Differentiation.cpp:1595:32: note: in instantiation of member function 'swift::OptionalTransformRange<swift::IntRange<unsigned long, swift::IntRangeTraits<unsigned long, false> >, swift::ApplyInstBase<swift::ApplyInst, swift::SingleValueInstruction, true>::OperandToInoutArgument, swift::IntRange<unsigned long, swift::IntRangeTraits<unsigned long, false> >::iterator>::empty' requested here
  if (!ai->getInoutArguments().empty()) {
                               ^
swift-dev/swift/include/swift/Basic/Range.h:129:10: note: candidate function not viable: 'this' argument has type 'const swift::IntRange<unsigned long, swift::IntRangeTraits<unsigned long, false> >::iterator', but method is not marked const
    bool operator==(iterator rhs) { return Value == rhs.Value; }
         ^
```

`ApplyInstBase<...>::getInoutArguments()` was added to `tensorflow` branch in https://github.com/apple/swift/pull/28352. The change is yet to be upstreamed to `master`, feedback is welcome.

I'm not sure how to add a test on `master`, perhaps we can skip adding a test.