### PR TITLE
Run checkPatternBindingCaptures on Extensions

### DIFF
--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -45,13 +45,12 @@ class FindCapturedVars : public ASTWalker {
   bool NoEscape, ObjC, IsGenericFunction;
 
 public:
-  FindCapturedVars(ASTContext &Context,
-                   SourceLoc CaptureLoc,
+  FindCapturedVars(SourceLoc CaptureLoc,
                    DeclContext *CurDC,
                    bool NoEscape,
                    bool ObjC,
                    bool IsGenericFunction)
-      : Context(Context), CaptureLoc(CaptureLoc), CurDC(CurDC),
+      : Context(CurDC->getASTContext()), CaptureLoc(CaptureLoc), CurDC(CurDC),
         NoEscape(NoEscape), ObjC(ObjC), IsGenericFunction(IsGenericFunction) {}
 
   CaptureInfo getCaptureInfo() const {
@@ -595,8 +594,7 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
     isGeneric = (AFD->getGenericParams() != nullptr);
 
   auto &Context = AFR.getAsDeclContext()->getASTContext();
-  FindCapturedVars finder(Context,
-                          AFR.getLoc(),
+  FindCapturedVars finder(AFR.getLoc(),
                           AFR.getAsDeclContext(),
                           AFR.isKnownNoEscape(),
                           AFR.isObjC(),
@@ -613,8 +611,7 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   if (auto *AFD = AFR.getAbstractFunctionDecl()) {
     for (auto *P : *AFD->getParameters()) {
       if (auto E = P->getTypeCheckedDefaultExpr()) {
-        FindCapturedVars finder(Context,
-                                E->getLoc(),
+        FindCapturedVars finder(E->getLoc(),
                                 AFD,
                                 /*isNoEscape=*/false,
                                 /*isObjC=*/false,
@@ -680,14 +677,15 @@ void TypeChecker::checkPatternBindingCaptures(NominalTypeDecl *typeDecl) {
       if (init == nullptr)
         continue;
 
-      FindCapturedVars finder(ctx,
-                              init->getLoc(),
-                              PBD->getInitContext(i),
+      auto *DC = PBD->getInitContext(i);
+      FindCapturedVars finder(init->getLoc(),
+                              DC,
                               /*NoEscape=*/false,
                               /*ObjC=*/false,
                               /*IsGenericFunction*/false);
       init->walk(finder);
 
+      auto &ctx = DC->getASTContext();
       if (finder.getDynamicSelfCaptureLoc().isValid() && !isLazy(PBD)) {
         ctx.Diags.diagnose(finder.getDynamicSelfCaptureLoc(),
                            diag::dynamic_self_stored_property_init);

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -660,10 +660,8 @@ static bool isLazy(PatternBindingDecl *PBD) {
   return false;
 }
 
-void TypeChecker::checkPatternBindingCaptures(NominalTypeDecl *typeDecl) {
-  auto &ctx = typeDecl->getASTContext();
-
-  for (auto member : typeDecl->getMembers()) {
+void TypeChecker::checkPatternBindingCaptures(IterableDeclContext *DC) {
+  for (auto member : DC->getMembers()) {
     // Ignore everything other than PBDs.
     auto *PBD = dyn_cast<PatternBindingDecl>(member);
     if (!PBD) continue;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2265,6 +2265,8 @@ public:
     for (Decl *Member : ED->getMembers())
       visit(Member);
 
+    TypeChecker::checkPatternBindingCaptures(ED);
+
     TypeChecker::checkConformancesInContext(ED, ED);
 
     TypeChecker::checkDeclAttributes(ED);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1046,7 +1046,7 @@ public:
   static void computeCaptures(AnyFunctionRef AFR);
 
   /// Check for invalid captures from stored property initializers.
-  static void checkPatternBindingCaptures(NominalTypeDecl *typeDecl);
+  static void checkPatternBindingCaptures(IterableDeclContext *DC);
 
   /// Change the context of closures in the given initializer
   /// expression to the given context.

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -162,6 +162,13 @@ class C {
   }
 }
 
+extension C {
+  static var rdar57188331 = Self.staticFunc() // expected-error {{covariant 'Self' type cannot be referenced from a stored property initializer}} expected-error {{stored property cannot have covariant 'Self' type}}
+  static var rdar57188331Var = ""
+  static let rdar57188331Ref = UnsafeRawPointer(&Self.rdar57188331Var) // expected-error {{covariant 'Self' type cannot be referenced from a stored property initializer}}
+}
+
+
 struct S1 {
   typealias _SELF = Self
   let j = 99.1


### PR DESCRIPTION
Neglecting to emit a diagnostic here caused us to submit invalid ASTs to SILGen.  I'm really hoping this isn't source breaking...

Resolves rdar://57188331, rdar://56467142, and SR-11636