### PR TITLE
Move mandatory inlining cleanup to mandatory combine

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -32,6 +32,7 @@
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/raw_ostream.h"
@@ -279,9 +280,42 @@ namespace {
 class MandatoryCombine final : public SILFunctionTransform {
 
   SmallVector<SILInstruction *, 64> createdInstructions;
+  
+  // If the function can be removed, remove it and return true.
+  // Otherwise, return false.
+  bool tryRemoveUnusedFunction(SILFunction *function) {
+    SILOptFunctionBuilder funcBuilder(*this);
+    
+    if (function->getRefCount() != 0) return false;
+
+    // Leave non-transparent functions alone.
+    if (!function->isTransparent())
+     return false;
+
+    // We discard functions that don't have external linkage,
+    // e.g. deserialized functions, internal functions, and thunks.
+    // Being marked transparent controls this.
+    if (function->isPossiblyUsedExternally()) return false;
+
+    // ObjC functions are called through the runtime and are therefore alive
+    // even if not referenced inside SIL.
+    if (function->getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod)
+     return false;
+
+    // Okay, just erase the function from the module.
+    funcBuilder.eraseFunction(function);
+    return true;
+  }
 
   void run() override {
     auto *function = getFunction();
+    
+    // If the function can be removed, remove it and
+    // don't do all the extra work below.
+    if (tryRemoveUnusedFunction(function)) {
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
+      return;
+    }
 
     // If this function is an external declaration, bail. We only want to visit
     // functions with bodies.

--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -280,42 +280,9 @@ namespace {
 class MandatoryCombine final : public SILFunctionTransform {
 
   SmallVector<SILInstruction *, 64> createdInstructions;
-  
-  // If the function can be removed, remove it and return true.
-  // Otherwise, return false.
-  bool tryRemoveUnusedFunction(SILFunction *function) {
-    SILOptFunctionBuilder funcBuilder(*this);
-    
-    if (function->getRefCount() != 0) return false;
-
-    // Leave non-transparent functions alone.
-    if (!function->isTransparent())
-     return false;
-
-    // We discard functions that don't have external linkage,
-    // e.g. deserialized functions, internal functions, and thunks.
-    // Being marked transparent controls this.
-    if (function->isPossiblyUsedExternally()) return false;
-
-    // ObjC functions are called through the runtime and are therefore alive
-    // even if not referenced inside SIL.
-    if (function->getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod)
-     return false;
-
-    // Okay, just erase the function from the module.
-    funcBuilder.eraseFunction(function);
-    return true;
-  }
 
   void run() override {
     auto *function = getFunction();
-    
-    // If the function can be removed, remove it and
-    // don't do all the extra work below.
-//    if (tryRemoveUnusedFunction(function)) {
-//      invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
-//      return;
-//    }
 
     // If this function is an external declaration, bail. We only want to visit
     // functions with bodies.

--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -312,10 +312,10 @@ class MandatoryCombine final : public SILFunctionTransform {
     
     // If the function can be removed, remove it and
     // don't do all the extra work below.
-    if (tryRemoveUnusedFunction(function)) {
-      invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
-      return;
-    }
+//    if (tryRemoveUnusedFunction(function)) {
+//      invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
+//      return;
+//    }
 
     // If this function is an external declaration, bail. We only want to visit
     // functions with bodies.

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -764,9 +764,9 @@ static SILInstruction *tryDevirtualizeApplyHelper(FullApplySite InnerAI,
   return newApplyAI;
 }
 
-static size_t collectApplies(SILFunction *F, ClassHierarchyAnalysis *CHA,
+static bool collectApplies(SILFunction *F, ClassHierarchyAnalysis *CHA,
                              DominanceAnalysis *DA,
-                             SmallVector<FullApplySite, 8> &collection) {
+                             SmallVectorImpl<FullApplySite> &collection) {
   DominanceInfo *DT = DA->get(F);
   DominanceOrder domOrder(&F->front(), DT, F->size());
 
@@ -794,7 +794,7 @@ static size_t collectApplies(SILFunction *F, ClassHierarchyAnalysis *CHA,
     collection.push_back(apply);
   }
 
-  return collection.size();
+  return !collection.empty();
 }
 
 //===----------------------------------------------------------------------===//
@@ -806,7 +806,7 @@ namespace {
 class MandatoryInlining : public SILFunctionTransform {
   /// If possible, inlines each apply instruction in \param collection.
   bool inlineFunction(SILOptFunctionBuilder &funcBuilder, SILFunction *F,
-                      SmallVector<FullApplySite, 8> &collection) {
+                      SmallVectorImpl<FullApplySite> &collection) {
     bool madeChange = false;
     bool needUpdateStackNesting = false;
     SmallVector<ParameterConvention, 16> capturedArgConventions;

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -967,7 +967,6 @@ class MandatoryInlining : public SILFunctionTransform {
   void run() override {
     SILFunction *F = getFunction();
     ClassHierarchyAnalysis *CHA = getAnalysis<ClassHierarchyAnalysis>();
-    bool ShouldCleanup = !getOptions().DebugSerialization;
     bool SILVerifyAll = getOptions().VerifyAll;
     DenseFunctionSet FullyInlinedSet;
     ImmutableFunctionSet::Factory SetFactory;
@@ -997,35 +996,10 @@ class MandatoryInlining : public SILFunctionTransform {
       F->verify();
     }
 
-    if (!ShouldCleanup)
-      return;
-
-    // Now that we've inlined some functions, clean up.  If there are any
-    // transparent functions that are deserialized from another module that are
-    // now unused, just remove them from the module.
-    //
-    // We do this with a simple linear scan, because transparent functions that
-    // reference each other have already been flattened.
     invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
 
-    if (F->getRefCount() != 0) return;
-
-    // Leave non-transparent functions alone.
-    if (!F->isTransparent())
-     return;
-
-    // We discard functions that don't have external linkage,
-    // e.g. deserialized functions, internal functions, and thunks.
-    // Being marked transparent controls this.
-    if (F->isPossiblyUsedExternally()) return;
-
-    // ObjC functions are called through the runtime and are therefore alive
-    // even if not referenced inside SIL.
-    if (F->getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod)
-     return;
-
-    // Okay, just erase the function from the module.
-    FuncBuilder.eraseFunction(F);
+    // If there are any transparent functions that are deserialized from
+    // another module that are now unused, MandatoryCombine will remove them.
   }
 
 };

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -117,7 +117,6 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   if (!Options.StripOwnershipAfterSerialization)
     P.addOwnershipModelEliminator();
   P.addMandatoryInlining();
-  P.addMandatoryCombine();
   P.addMandatorySILLinker();
 
   // Promote loads as necessary to ensure we have enough SSA formation to emit
@@ -607,7 +606,6 @@ SILPassPipelinePlan::getSILOptPreparePassPipeline(const SILOptions &Options) {
   }
 
   P.startPipeline("SILOpt Prepare Passes");
-  P.addMandatoryInlining();
   P.addMandatoryCombine();
   P.addAccessMarkerElimination();
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -607,6 +607,7 @@ SILPassPipelinePlan::getSILOptPreparePassPipeline(const SILOptions &Options) {
   }
 
   P.startPipeline("SILOpt Prepare Passes");
+  P.addMandatoryInlining();
   P.addMandatoryCombine();
   P.addAccessMarkerElimination();
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -117,6 +117,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   if (!Options.StripOwnershipAfterSerialization)
     P.addOwnershipModelEliminator();
   P.addMandatoryInlining();
+  P.addMandatoryCombine();
   P.addMandatorySILLinker();
 
   // Promote loads as necessary to ensure we have enough SSA formation to emit

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -666,6 +666,7 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   SILPassPipelinePlan P(Options);
 
   P.startPipeline("Mandatory Combines");
+  P.addMandatoryInlining();
   P.addMandatoryCombine();
 
   // First serialize the SIL if we are asked to.

--- a/test/SILOptimizer/mandatory_inlining_circular.swift
+++ b/test/SILOptimizer/mandatory_inlining_circular.swift
@@ -2,10 +2,9 @@
 // RUN: %target-swift-frontend -sil-verify-all -emit-sil %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 
 @_transparent func waldo(_ x: Double) -> Double {
-  return fred(x); // expected-error {{inlining 'transparent' functions forms circular loop}} expected-note 1 {{while inlining here}}
+  return fred(x);
 }
 
-@_transparent func fred(_ x: Double) -> Double {
-  return waldo(x); // expected-error {{inlining 'transparent' functions forms circular loop}} expected-note 1 {{while inlining here}}
+@_transparent func fred(_ x: Double) -> Double { // expected-warning {{all paths through this function will call itself}}
+  return waldo(x); // expected-error {{inlining 'transparent' functions forms circular loop}}
 }
-


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch makes `MandatoryInlining` a `SILModuleTransform` instead of a `SILFunctionTransform`. It also moves the function removal cleanup to `MandatoryCombine` so that it will be run on every function. This is better because then we don't have to iterate over every function in a module twice in `MandatoryInlining`. And now, both can remain a `SILFunctionTransform`. It also has the benefit of allowing `MandatoryCombine` to exit early sometimes. 

The successor to #28394.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

cc @gottesmm 