### PR TITLE
[ASTMangler] Don't verify the USR mangling for invalid decls

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -518,8 +518,10 @@ std::string ASTMangler::mangleDeclAsUSR(const ValueDecl *Decl,
     appendEntity(Decl);
   }
 
-  // We have a custom prefix, so finalize() won't verify for us. Do it manually.
-  verify(Storage.str().drop_front(USRPrefix.size()));
+  // We have a custom prefix, so finalize() won't verify for us. If we're not
+  // in invalid code (coming from an IDE caller) verify manually.
+  if (!Decl->isInvalid())
+    verify(Storage.str().drop_front(USRPrefix.size()));
   return finalize();
 }
 

--- a/test/SourceKit/CursorInfo/cursor_invalid.swift
+++ b/test/SourceKit/CursorInfo/cursor_invalid.swift
@@ -24,6 +24,10 @@ func resyncParser2() {}
 
 Swift(label: 3)
 
+enum Outer {
+  case Inner(IDontExist)
+}
+
 // RUN: %sourcekitd-test -req=cursor -pos=4:13 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: source.lang.swift.decl.var.local (4:13-4:14)
 // CHECK1: c
@@ -63,3 +67,7 @@ Swift(label: 3)
 // EQEQ3: <decl.function.operator.infix><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>== </decl.name>(<decl.var.parameter><decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr="s:14cursor_invalid1CC">C</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>y</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr="s:14cursor_invalid1CC">C</ref.class></decl.var.parameter.type></decl.var.parameter>)</decl.function.operator.infix>
 
 // RUN: %sourcekitd-test -req=cursor -pos=25:7 %s -- %s | %FileCheck -check-prefix=DIAG %s
+
+// RUN: %sourcekitd-test -req=cursor -pos=28:8 %s -- %s | %FileCheck -check-prefix=INVALID_ENUM %s
+// INVALID_ENUM: source.lang.swift.decl.enumelement (28:8-28:13)
+// INVALID_ENUM: Inner(_:)


### PR DESCRIPTION
USRs generated for the index store and IDE requests for invalid decls are best-effort. They're just serving as a mostly-unique id for use when talking to the indexer in this case, so we don't need to guarantee they can be de- or re-mangled.

We were hitting some of these cases in the projects and crash traces mentioned in https://github.com/apple/swift/pull/28051