### PR TITLE
[AutoDiff] diff wit silgen: type simplification, getters

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -195,20 +195,9 @@ void TBDGenVisitor::addDifferentiabilityWitness(
       attr->getParameterIndices(),
       original->getInterfaceType()->castTo<AnyFunctionType>());
 
-  GenericSignature genericSignature = attr->getDerivativeGenericSignature();
-  if (auto *jvpDecl = attr->getJVPFunction()) {
-    assert(!genericSignature ||
-           jvpDecl->getGenericSignature()->isEqual(genericSignature));
-    genericSignature = jvpDecl->getGenericSignature();
-  }
-  if (auto *vjpDecl = attr->getVJPFunction()) {
-    assert(!genericSignature ||
-           vjpDecl->getGenericSignature()->isEqual(genericSignature));
-    genericSignature = vjpDecl->getGenericSignature();
-  }
-
   std::string originalMangledName = SILDeclRef(original).mangle();
-  AutoDiffConfig config{loweredParamIndices, resultIndices, genericSignature};
+  AutoDiffConfig config{loweredParamIndices, resultIndices,
+                        attr->getDerivativeGenericSignature()};
   SILDifferentiabilityWitnessKey key(originalMangledName, config);
 
   Mangle::ASTMangler mangle;

--- a/test/AutoDiff/sil_differentiability_witness_silgen.swift
+++ b/test/AutoDiff/sil_differentiability_witness_silgen.swift
@@ -74,6 +74,10 @@ func generic_vjp<T: Differentiable>(_ x: T, _ y: Float) -> (
 public struct Foo: Differentiable {
   public var x: Float
 
+// CHECK-LABEL: // differentiability witness for Foo.x.getter
+// CHECK-NEXT: sil_differentiability_witness [parameters 0] [results 0] @$s36sil_differentiability_witness_silgen3FooV1xSfvg : $@convention(method) (Foo) -> Float {
+// CHECK-NEXT: }
+
   @differentiable
   public init(_ x: Float) {
     self.x = x


### PR DESCRIPTION
1. There was some logic that occasionally sets the generic signature of the witness to be different from the generic signature of the attribute. This is causing a problem [1] for me, and tests don't fail when I delete the logic. So I deleted the logic.
2. SILGen was not generating witnesses for getters. Now it does.

[1] I'm trying to make the differentiation pass populate both attributes and witnesses, so that we can smoothly move it from attributes to witnesses in small pieces without breaking anything. But the mismatched generic signatures make it difficult to tell which attributes and witnesses correspond to each other.