### PR TITLE
[ConstraintSystem] Introduce notion of constraint system phase

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3851,6 +3851,10 @@ bool FailureDiagnosis::diagnoseExprFailure() {
 /// This is guaranteed to always emit an error message.
 ///
 void ConstraintSystem::diagnoseFailureForExpr(Expr *expr) {
+  setPhase(ConstraintSystemPhase::Diagnostics);
+
+  SWIFT_DEFER { setPhase(ConstraintSystemPhase::Finalization); };
+
   // Continue simplifying any active constraints left in the system.  We can end
   // up with them because the solver bails out as soon as it sees a Failure.  We
   // don't want to leave them around in the system because later diagnostics

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6049,7 +6049,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
     // subscript dispatch relies on presence of function application.
     if (result.ViableCandidates.size() == 1) {
       auto &choice = result.ViableCandidates.front();
-      if (!solverState && choice.isKeyPathDynamicMemberLookup() &&
+      if (Phase == ConstraintSystemPhase::ConstraintGeneration &&
+          choice.isKeyPathDynamicMemberLookup() &&
           member.getBaseName().isSubscript()) {
         // Let's move this constraint to the active
         // list so it could be picked up right after

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1298,6 +1298,10 @@ bool ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions,
 void ConstraintSystem::solveImpl(SmallVectorImpl<Solution> &solutions) {
   assert(solverState);
 
+  setPhase(ConstraintSystemPhase::Solving);
+
+  SWIFT_DEFER { setPhase(ConstraintSystemPhase::Finalization); };
+
   // If constraint system failed while trying to
   // genenerate constraints, let's stop right here.
   if (failedConstraint)
@@ -1449,7 +1453,7 @@ ConstraintSystem::filterDisjunction(
       // Early simplification of the "keypath dynamic member lookup" choice
       // is impossible because it requires constraints associated with
       // subscript index expression to be present.
-      if (!solverState)
+      if (Phase == ConstraintSystemPhase::ConstraintGeneration)
         return SolutionKind::Unsolved;
 
       for (auto *currentChoice : disjunction->getNestedConstraints()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2452,6 +2452,8 @@ SolutionResult ConstraintSystem::salvage() {
     log << "---Attempting to salvage and emit diagnostics---\n";
   }
 
+  setPhase(ConstraintSystemPhase::Diagnostics);
+
   // Attempt to solve again, capturing all states that come from our attempts to
   // select overloads or bind type variables.
   //

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -995,6 +995,13 @@ struct DynamicCallableMethods {
   }
 };
 
+enum class ConstraintSystemPhase {
+  ConstraintGeneration,
+  Solving,
+  Diagnostics,
+  Finalization
+};
+
 /// Describes a system of constraints on type variables, the
 /// solution of which assigns concrete types to each of the type variables.
 /// Constraint systems are typically generated given an (untyped) expression.
@@ -1038,6 +1045,9 @@ public:
   unsigned CountDisjunctions = 0;
 
 private:
+  /// Current phase of the constraint system lifetime.
+  ConstraintSystemPhase Phase = ConstraintSystemPhase::ConstraintGeneration;
+
   /// The set of expressions for which we have generated constraints.
   llvm::SetVector<Expr *> InputExprs;
 
@@ -1526,6 +1536,33 @@ private:
   };
 
 public:
+  /// Move constraint system to a new phase of its lifetime.
+  void setPhase(ConstraintSystemPhase newPhase) {
+#ifndef NDEBUG
+    switch (Phase) {
+    case ConstraintSystemPhase::ConstraintGeneration:
+      assert(newPhase == ConstraintSystemPhase::Solving);
+      break;
+
+    case ConstraintSystemPhase::Solving:
+      assert(newPhase == ConstraintSystemPhase::Diagnostics ||
+             newPhase == ConstraintSystemPhase::Finalization);
+      break;
+
+    case ConstraintSystemPhase::Diagnostics:
+      assert(newPhase == ConstraintSystemPhase::Solving ||
+             newPhase == ConstraintSystemPhase::Finalization);
+      break;
+
+    case ConstraintSystemPhase::Finalization:
+      assert(newPhase == ConstraintSystemPhase::Diagnostics);
+      break;
+    }
+#endif
+
+    Phase = newPhase;
+  }
+
   /// Cache the types of the given expression and all subexpressions.
   void cacheExprTypes(Expr *expr) {
     bool excludeRoot = false;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1536,8 +1536,13 @@ private:
   };
 
 public:
+  ConstraintSystemPhase getPhase() const { return Phase; }
+
   /// Move constraint system to a new phase of its lifetime.
   void setPhase(ConstraintSystemPhase newPhase) {
+    if (Phase == newPhase)
+      return;
+
 #ifndef NDEBUG
     switch (Phase) {
     case ConstraintSystemPhase::ConstraintGeneration:
@@ -1545,7 +1550,10 @@ public:
       break;
 
     case ConstraintSystemPhase::Solving:
-      assert(newPhase == ConstraintSystemPhase::Diagnostics ||
+      // We can come back to constraint generation phase while
+      // processing function builder body.
+      assert(newPhase == ConstraintSystemPhase::ConstraintGeneration ||
+             newPhase == ConstraintSystemPhase::Diagnostics ||
              newPhase == ConstraintSystemPhase::Finalization);
       break;
 

--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct ContentView : View {
+  @State var foo: [String] = Array(repeating: "", count: 5)
+
+  var body: some View {
+    VStack {
+      HStack { // expected-error {{ambiguous reference to member 'buildBlock()'}}
+        Text("")
+        TextFi // expected-error {{use of unresolved identifier 'TextFi'}}
+      }
+
+      ForEach(0 ... 4, id: \.self) { i in
+        HStack {
+          TextField("", text: self.$foo[i])
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Some constraint transformations require knowledge about what state
constraint system is currently in e.g. `constraint generation`,
`solving` or `diagnostics` to make a decision whether simplication
is possible. Notable example is `keypath dynamic member lookup`
which requires a presence of `applicable fn` constraint to retrieve
some contextual information.

Currently presence or absence of solver state is used to determine
whether constraint system is in `constraint generation` or `solving`
phase, but it's incorrect in case of `diagnoseFailureForExpr` which
tries to simplify leftover "active" constraints before it can attempt
type-check based diagnostics.

To make this more robust let's introduce (maybe temporarily until
type-check based diagnostics are completely obsoleted) a proper
notion of "phase" to constraint system so it is always clear what
transitions are allowed and what state constraint system is
currently in.

Resolves: rdar://problem/57201781
Resolves: rdar://problem/57129493
Resolves: rdar://problem/56798281
Resolves: rdar://problem/57318966
Resolves: rdar://problem/57253131

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
