### PR TITLE
[AutoDiff] populate diff witnesses during differentiation

### DIFF
--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2821,8 +2821,8 @@ static void printSILDifferentiabilityWitnesses(
     [] (const SILDifferentiabilityWitness *w1,
         const SILDifferentiabilityWitness *w2) -> bool {
       // TODO(TF-893): Sort based on more criteria for deterministic ordering.
-      return w1->getOriginalFunction()->getName()
-          .compare(w2->getOriginalFunction()->getName());
+      return w1->getOriginalFunction()->getName().compare(
+                 w2->getOriginalFunction()->getName()) == -1;
     }
   );
   for (auto *dw : sortedDiffWitnesses)

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -5405,6 +5405,11 @@ void SILDifferentiabilityWitness::verify(const SILModule &M) const {
   if (!M.getOptions().VerifyAll)
     return;
 #endif
+  // Skip lowered SIL: LoadableByAddress changes parameter/result conventions.
+  // TODO: Check that derivative function types match excluding
+  // parameter/result conventions in lowered SIL.
+  if (M.getStage() == SILStage::Lowered)
+    return;
   auto origFnType = getOriginalFunction()->getLoweredFunctionType();
   CanGenericSignature derivativeCanGenSig;
   if (auto derivativeGenSig = getDerivativeGenericSignature())

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -356,9 +356,10 @@ findDifferentiabilityWitness(SILModule &module, SILDifferentiableAttr *attr) {
 /// Sets the differentiability witness JVP and VJP to the JVP and VJP in `attr`.
 ///
 /// `attr` must have a JVP and VJP.
-static void fillDifferentiabilityWitness(SILModule &module,
-                                         const SILDifferentiableAttr *attr,
-                                         SILDifferentiabilityWitness *witness) {
+static void
+canonicalizeDifferentiabilityWitness(SILModule &module,
+                                     const SILDifferentiableAttr *attr,
+                                     SILDifferentiabilityWitness *witness) {
   auto jvpName = attr->getJVPName();
   assert(!jvpName.empty() && "Expected JVP name");
   auto *jvpFn = module.lookUpFunction(attr->getJVPName());
@@ -388,7 +389,7 @@ createDifferentiabilityWitness(SILModule &module, SILLinkage linkage,
       module, linkage, attr->getOriginal(), attr->getIndices().parameters,
       resultIndices, attr->getDerivativeGenericSignature(), /*jvp*/ nullptr,
       /*vjp*/ nullptr, /*isSerialized*/ false);
-  fillDifferentiabilityWitness(module, attr, witness);
+  canonicalizeDifferentiabilityWitness(module, attr, witness);
   return witness;
 }
 
@@ -9013,7 +9014,7 @@ void Differentiation::run() {
         witness &&
         "SILGen should create a witness for every [differentiable] attribute");
     assert(witness->isDefinition());
-    fillDifferentiabilityWitness(module, attr, witness);
+    canonicalizeDifferentiabilityWitness(module, attr, witness);
   }
 
   // Iteratively process `differentiable_function` instruction worklist.

--- a/test/AutoDiff/differentiable_function_inst_irgen.sil
+++ b/test/AutoDiff/differentiable_function_inst_irgen.sil
@@ -5,6 +5,10 @@ sil_stage raw
 import Swift
 import Builtin
 
+sil_differentiability_witness hidden [parameters 0] [results 0] @foo : $@convention(thin) (Float) -> Float {
+  vjp: @foo_vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+}
+
 // The adjoint function emitted by the compiler. Parameters are a vector, as in
 // vector-Jacobian products, and pullback struct value. The function is not
 // itself a pullback, but to be partially applied to form a pullback, which

--- a/test/AutoDiff/pass_creates_differentiability_witnesses.swift
+++ b/test/AutoDiff/pass_creates_differentiability_witnesses.swift
@@ -1,0 +1,78 @@
+// RUN: %target-swift-frontend -emit-sil -emit-sorted-sil %s | %FileCheck %s
+
+// MARK: - Public functions
+
+@differentiable
+@_silgen_name("f000_invokedDirectlyByDifferentiableAttrPublic")
+public func f000_invokedDirectlyByDifferentiableAttrPublic(_ x: Float) -> Float {
+  return f001_invokedIndirectlyByDifferentiableAttrPublic(x)
+}
+// CHECK-LABEL: sil_differentiability_witness [parameters 0] [results 0] @f000_invokedDirectlyByDifferentiableAttrPublic
+// CHECK-NEXT: jvp
+// CHECK-NEXT: vjp
+
+@_silgen_name("f001_invokedIndirectlyByDifferentiableAttrPublic")
+public func f001_invokedIndirectlyByDifferentiableAttrPublic(_ x: Float) -> Float {
+  return x
+}
+// CHECK-LABEL: sil_differentiability_witness hidden [parameters 0] [results 0] @f001_invokedIndirectlyByDifferentiableAttrPublic
+// CHECK-NEXT: jvp
+// CHECK-NEXT: vjp
+
+@_silgen_name("f002_invokedDirectlyByConversionPublic")
+public func f002_invokedDirectlyByConversionPublic(_ x: Float) -> Float {
+  return f003_invokedIndirectlyByConversionPublic(x)
+}
+// CHECK-LABEL: sil_differentiability_witness hidden [parameters 0] [results 0] @f002_invokedDirectlyByConversionPublic
+// CHECK-NEXT: jvp
+// CHECK-NEXT: vjp
+
+@_silgen_name("f003_invokedIndirectlyByConversionPublic")
+public func f003_invokedIndirectlyByConversionPublic(_ x: Float) -> Float {
+  return x
+}
+// CHECK-LABEL: sil_differentiability_witness hidden [parameters 0] [results 0] @f003_invokedIndirectlyByConversionPublic
+// CHECK-NEXT: jvp
+// CHECK-NEXT: vjp
+
+// MARK: - Internal functions
+
+@differentiable
+@_silgen_name("f004_invokedDirectlyByDifferentiableAttrInternal")
+internal func f004_invokedDirectlyByDifferentiableAttrInternal(_ x: Float) -> Float {
+  return f005_invokedIndirectlyByDifferentiableAttrInternal(x)
+}
+// CHECK-LABEL: sil_differentiability_witness hidden [parameters 0] [results 0] @f004_invokedDirectlyByDifferentiableAttrInternal
+// CHECK-NEXT: jvp
+// CHECK-NEXT: vjp
+
+@_silgen_name("f005_invokedIndirectlyByDifferentiableAttrInternal")
+internal func f005_invokedIndirectlyByDifferentiableAttrInternal(_ x: Float) -> Float {
+  return x
+}
+// CHECK-LABEL: sil_differentiability_witness hidden [parameters 0] [results 0] @f005_invokedIndirectlyByDifferentiableAttrInternal
+// CHECK-NEXT: jvp
+// CHECK-NEXT: vjp
+
+@_silgen_name("f006_invokedDirectlyByConversionInternal")
+internal func f006_invokedDirectlyByConversionInternal(_ x: Float) -> Float {
+  return f007_invokedIndirectlyByConversionInternal(x)
+}
+// CHECK-LABEL: sil_differentiability_witness hidden [parameters 0] [results 0] @f006_invokedDirectlyByConversionInternal
+// CHECK-NEXT: jvp
+// CHECK-NEXT: vjp
+
+@_silgen_name("f007_invokedIndirectlyByConversionInternal")
+internal func f007_invokedIndirectlyByConversionInternal(_ x: Float) -> Float {
+  return x
+}
+// CHECK-LABEL: sil_differentiability_witness hidden [parameters 0] [results 0] @f007_invokedIndirectlyByConversionInternal
+// CHECK-NEXT: jvp
+// CHECK-NEXT: vjp
+
+func invokesByConversion() -> Float {
+  var result: Float = 0
+  result += gradient(at: 0, in: f002_invokedDirectlyByConversionPublic)
+  result += gradient(at: 0, in: f006_invokedDirectlyByConversionInternal)
+  return result
+}

--- a/test/AutoDiff/subset_parameters_thunk.swift
+++ b/test/AutoDiff/subset_parameters_thunk.swift
@@ -14,7 +14,8 @@ func differentiate_foo_wrt_0(_ x: Float) -> Float {
   foo(x, 1)
 }
 
-// CHECK-LABEL: @{{.*}}differentiate_foo_wrt_0{{.*}}__vjp
+// Intentional "//" in the label so that this doesn't match a [differentiable] attr pointing at the vjp.
+// CHECK-LABEL: // {{.*}}differentiate_foo_wrt_0{{.*}}__vjp
 // CHECK: bb0
 // CHECK:   [[FOO_ORIG:%.*]] = function_ref @{{.*}}foo{{.*}} : $@convention(thin) <τ_0_0 where τ_0_0 : Numeric> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
 // CHECK:   [[FOO_FLOAT:%.*]] = partial_apply [callee_guaranteed] [[FOO_ORIG]]<Float>() : $@convention(thin) <τ_0_0 where τ_0_0 : Numeric> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0


### PR DESCRIPTION
The main point of this PR is to populate differentiability witnesses during the differentiation pass, while still using attributes for everything, so that we can incrementally switch everything over to using witnesses.

A few adjustments in other things were necessary to get this to work:
1. Extend the parameter indices in the attribute to handle the capture case. This code is copied from similar code for handling the same case for witnesses, in SILGen.cpp.
2. SIL sorting for witnesses was broken.
3. SILVerifier adjusted to work when witnesses point at things touched by LoadableByAddress.

I'm going to run a toolchain build and swift-apis tests on this before merging, because I'm not super confident that all the assertions I added will always pass.