### PR TITLE
EscapeAnalysis: eliminate dangling pointers.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -252,16 +252,18 @@ public:
   /// pointer points to (see NodeType).
   class CGNode {
 
-    /// The associated value in the function. This is always valid for Argument
-    /// and Value nodes, and always nullptr for Return nodes. For Content nodes,
-    /// i is only used for debug printing. A Content's value 'V' is unreliable
-    /// because it can change as a result of the order the the graph is
-    /// constructed and summary graphs are merged. Sometimes it is derived from
-    /// the instructions that access the content, other times, it's simply
-    /// inherited from its parent. There may be multiple nodes associated to the
-    /// same value, e.g. a Content node has the same V as its points-to
-    /// predecessor.
-    ValueBase *V;
+    /// The associated value in the function. This is only valid for nodes that
+    /// are mapped to a value in the graph's Values2Nodes map. Multiple values
+    /// may be mapped to the same node, but only one value is associated with
+    /// the node via 'mappedValue'. Setting 'mappedValue' to a valid SILValue
+    /// for an unmapped node would result in a dangling pointer when the
+    /// SILValue is deleted.
+    ///
+    /// Argument and Value nodes are always initially mapped, but may become
+    /// unmapped when their SILValue is deleted. Content nodes are conditionally
+    /// mapped, only if they are associated with an explicit dereference in the
+    /// code (which has not been deleted). Return nodes are never mapped.
+    ValueBase *mappedValue;
 
     /// The outgoing points-to edge (if any) to a Content node. See also:
     /// pointsToIsEdge.
@@ -317,7 +319,7 @@ public:
     
     /// The constructor.
     CGNode(ValueBase *V, NodeType Type, bool hasRC)
-        : V(V), UsePoints(0), hasRC(hasRC), Type(Type) {
+        : mappedValue(V), UsePoints(0), hasRC(hasRC), Type(Type) {
       switch (Type) {
       case NodeType::Argument:
       case NodeType::Value:
@@ -332,6 +334,11 @@ public:
         break;
       }
     }
+
+    /// Get the representative node that maps to a SILValue and depth in the
+    /// pointsTo graph.
+    std::pair<const CGNode *, unsigned>
+    getRepNode(SmallPtrSetImpl<const CGNode *> &visited) const;
 
     /// Merges the use points from another node and returns true if there are
     /// any changes.
@@ -417,16 +424,20 @@ public:
     friend struct CGNodeWorklist;
 
   public:
-    SILValue getValue() const {
-      assert(Type == NodeType::Argument || Type == NodeType::Value);
-      return V;
-    }
-    SILValue getValueOrNull() const { return V; }
+    struct RepValue {
+      // May only be an invalid SILValue for Return nodes or deleted values.
+      llvm::PointerIntPair<SILValue, 1, bool> valueAndIsReturn;
+      unsigned depth;
 
-    void updateValue(SILValue newValue) {
-      assert(isContent());
-      V = newValue;
-    }
+      SILValue getValue() const { return valueAndIsReturn.getPointer(); }
+      bool isReturn() const { return valueAndIsReturn.getInt(); }
+      void
+      print(llvm::raw_ostream &stream,
+            const llvm::DenseMap<const SILNode *, unsigned> &instToIDMap) const;
+    };
+    // Get the representative SILValue for this node its depth relative to the
+    // node that is mapped to this value.
+    RepValue getRepValue() const;
 
     /// Return true if this node represents content.
     bool isContent() const { return Type == NodeType::Content; }
@@ -434,7 +445,7 @@ public:
     /// Return true if this node represents an entire reference counted object.
     bool hasRefCount() const { return hasRC; }
 
-    void setRefCount() { hasRC = true; }
+    void setRefCount(bool rc) { hasRC = rc; }
 
     /// Returns the escape state.
     EscapeState getEscapeState() const { return State; }
@@ -465,9 +476,8 @@ public:
     /// Note that in the false-case the node's value can still escape via
     /// the return instruction.
     ///
-    /// \p nodeValue is often the same as 'this->V', but is sometimes a more
-    /// refined value. For content nodes, 'this->V' is only a placeholder that
-    /// does not necessarilly represent the node's memory.
+    /// \p nodeValue is often the same as 'this->getRepValue().getValue()', but
+    /// is sometimes a more refined value specific to a content nodes.
     bool escapesInsideFunction(SILValue nodeValue) const {
       switch (getEscapeState()) {
         case EscapeState::None:
@@ -478,7 +488,6 @@ public:
         case EscapeState::Global:
           return true;
       }
-
       llvm_unreachable("Unhandled EscapeState in switch.");
     }
 
@@ -644,10 +653,9 @@ public:
     /// Returns null, if V is not a "pointer".
     CGNode *getNode(ValueBase *V, bool createIfNeeded = true);
 
-    /// Helper to create a content node and update the pointsTo graph. \p
-    /// addrNode will point to the new content node. The new content node is
-    /// directly initialized with the remaining function arguments.
-    CGNode *createContentNode(CGNode *addrNode, SILValue addrVal, bool hasRC);
+    /// Helper to create and return a content node with the given \p hasRC
+    /// flag. \p addrNode will gain a points-to edge to the new content node.
+    CGNode *createContentNode(CGNode *addrNode, bool hasRC);
 
     /// Create a new content node based on an existing content node to support
     /// graph merging.
@@ -687,6 +695,8 @@ public:
     void setNode(ValueBase *V, CGNode *Node) {
       assert(Values2Nodes.find(V) == Values2Nodes.end());
       Values2Nodes[V] = Node;
+      if (!Node->mappedValue)
+        Node->mappedValue = V;
     }
 
     /// Adds an argument/instruction in which the node's value is used.
@@ -707,7 +717,7 @@ public:
     void escapeContentsOf(CGNode *Node) {
       CGNode *escapedContent = Node->getContentNodeOrNull();
       if (!escapedContent) {
-        escapedContent = createContentNode(Node, Node->V, /*hasRC=*/false);
+        escapedContent = createContentNode(Node, /*hasRC=*/false);
       }
       escapedContent->markEscaping();
     }
@@ -736,10 +746,10 @@ public:
     /// Propagates the escape states through the graph.
     void propagateEscapeStates();
 
-    /// Removes a value from the graph.
-    /// It does not delete its node but makes sure that the value cannot be
-    /// lookup-up with getNode() anymore.
-    void removeFromGraph(ValueBase *V) { Values2Nodes.erase(V); }
+    /// Remove a value from the graph. Do not delete the mapped node, but reset
+    /// mappedValue if it is set to this value, and make sure that the node
+    /// cannot be looked up with getNode().
+    void removeFromGraph(ValueBase *V);
 
     enum class Traversal { Follow, Backtrack, Halt };
 
@@ -821,7 +831,7 @@ public:
 
     /// Just verifies the graph structure. This function can also be called
     /// during the graph is modified, e.g. in mergeAllScheduledNodes().
-    void verifyStructure() const;
+    void verifyStructure(bool allowMerge = false) const;
 
     friend struct ::CGForDotView;
     friend class EscapeAnalysis;

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -95,12 +95,12 @@ bb0(%0 : $Int):
 // Sanity check with a simple function.
 
 // CHECK-LABEL: CG of test_simple
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: %2
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%5)
 // CHECK-NEXT:    Arg %1 Esc: G, Succ:
-// CHECK-NEXT:    Val %2 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: A, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: G, Succ: %1
+// CHECK-NEXT:    Val %2 Esc: A, Succ: ([rc] %3)
+// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%3.1)
+// CHECK-NEXT:    Con %3.1 Esc: G, Succ: %1
+// CHECK-NEXT:    Con %5 Esc: A, Succ: %2
 // CHECK-NEXT:  End
 sil @test_simple : $@convention(thin) (@inout Y, @owned X) -> () {
 bb0(%0 : $*Y, %1 : $X):
@@ -117,12 +117,12 @@ bb0(%0 : $*Y, %1 : $X):
 // Test if a deferring edge is created for a block argument.
 
 // CHECK-LABEL: CG of deferringEdge
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%3.1)
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %4)
 // CHECK-NEXT:    Arg %1 Esc: A, Succ:
-// CHECK-NEXT:    Val %3 Esc: %3, Succ: (%3.1), %0
-// CHECK-NEXT:    Con %3.1 Esc: A, Succ: (%4)
-// CHECK-NEXT:    Con %4 Esc: A, Succ: %1
-// CHECK-NEXT:    Ret Esc: R, Succ: %0
+// CHECK-NEXT:    Val %3 Esc: %3, Succ: ([rc] %4), %0
+// CHECK-NEXT:    Con [rc] %4 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Con %4.1 Esc: A, Succ: %1
+// CHECK-NEXT:    Ret return Esc: R, Succ: %0
 // CHECK-NEXT:  End
 sil @deferringEdge : $@convention(thin) (@owned LinkedNode, @owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode, %1 : $LinkedNode):
@@ -138,7 +138,7 @@ bb1(%3 : $LinkedNode):
 
 // CHECK-LABEL: CG of escapes_via_return
 // CHECK-NEXT:    Val %0 Esc: R, Succ:
-// CHECK-NEXT:    Ret Esc: R, Succ: %0
+// CHECK-NEXT:    Ret return Esc: R, Succ: %0
 // CHECK-NEXT:  End
 sil @escapes_via_return : $@convention(thin) () -> @owned X {
 bb0:
@@ -149,14 +149,14 @@ bb0:
 // A linear chain of assignments is collapsed to a single node.
 
 // CHECK-LABEL: CG of test_linked_list
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Val %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: A, Succ: %0, %1, %4
-// CHECK-NEXT:    Val %4 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Val %7 Esc: %11, Succ: (%1.1)
-// CHECK-NEXT:    Val %11 Esc: %11, Succ: (%1.1), %2, %7
-// CHECK-NEXT:    Ret Esc: R, Succ: %2
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %2)
+// CHECK-NEXT:    Val %1 Esc: A, Succ: ([rc] %2)
+// CHECK-NEXT:    Con [rc] %2 Esc: A, Succ: (%13)
+// CHECK-NEXT:    Val %4 Esc: A, Succ: ([rc] %2)
+// CHECK-NEXT:    Val %7 Esc: %11, Succ: ([rc] %2)
+// CHECK-NEXT:    Val %11 Esc: %11, Succ: ([rc] %2), %7, %13
+// CHECK-NEXT:    Con %13 Esc: A, Succ: %0, %1, %4
+// CHECK-NEXT:    Ret return Esc: R, Succ: %13
 // CHECK-NEXT:  End
 sil @test_linked_list : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -184,14 +184,14 @@ bb2:
 // The same example as above but distributed over two functions.
 
 // CHECK-LABEL: CG of create_chain
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%7.1)
-// CHECK-NEXT:    Val %1 Esc: A, Succ: (%7.1)
-// CHECK-NEXT:    Val %4 Esc: A, Succ: (%7.1)
-// CHECK-NEXT:    Val %7 Esc: %11, Succ: (%7.1)
-// CHECK-NEXT:    Con %7.1 Esc: A, Succ: (%8)
-// CHECK-NEXT:    Con %8 Esc: A, Succ: %0, %1, %4
-// CHECK-NEXT:    Val %11 Esc: R, Succ: (%7.1), %8
-// CHECK-NEXT:    Ret Esc: R, Succ: %11
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %8)
+// CHECK-NEXT:    Val %1 Esc: A, Succ: ([rc] %8)
+// CHECK-NEXT:    Val %4 Esc: A, Succ: ([rc] %8)
+// CHECK-NEXT:    Val %7 Esc: %11, Succ: ([rc] %8)
+// CHECK-NEXT:    Con [rc] %8 Esc: A, Succ: (%8.1)
+// CHECK-NEXT:    Con %8.1 Esc: A, Succ: %0, %1, %4
+// CHECK-NEXT:    Val %11 Esc: R, Succ: ([rc] %8), %8.1
+// CHECK-NEXT:    Ret return Esc: R, Succ: %11
 // CHECK-NEXT:  End
 sil @create_chain : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -211,11 +211,11 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of loadNext
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Val %2 Esc: %2, Succ: (%2.1), %0, %3
-// CHECK-NEXT:    Con %2.1 Esc: A, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Ret Esc: R, Succ: %3
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %3)
+// CHECK-NEXT:    Val %2 Esc: %2, Succ: ([rc] %3), %0, %4
+// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con %4 Esc: A, Succ: ([rc] %3)
+// CHECK-NEXT:    Ret return Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @loadNext : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -233,15 +233,15 @@ bb2:
 // Content nodes in the callee are duplicated in the caller.
 
 // CHECK-LABEL: CG of call_load_next3
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.3)
-// CHECK-NEXT:    Con %0.3 Esc: A, Succ: (%0.4)
-// CHECK-NEXT:    Con %0.4 Esc: A, Succ: (%0.5)
-// CHECK-NEXT:    Con %0.5 Esc: A, Succ: (%0.6)
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %0.1)
+// CHECK-NEXT:    Con [rc] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: ([rc] %0.3)
+// CHECK-NEXT:    Con [rc] %0.3 Esc: A, Succ: (%0.4)
+// CHECK-NEXT:    Con %0.4 Esc: A, Succ: ([rc] %0.5)
+// CHECK-NEXT:    Con [rc] %0.5 Esc: A, Succ: (%0.6)
 // CHECK-NEXT:    Con %0.6 Esc: A, Succ:
 // CHECK-NEXT:    Val %2 Esc: R, Succ: %0.6
-// CHECK-NEXT:    Ret Esc: R, Succ: %2
+// CHECK-NEXT:    Ret return Esc: R, Succ: %2
 // CHECK-NEXT:  End
 sil @call_load_next3 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -251,14 +251,14 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of load_next3
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%1)
-// CHECK-NEXT:    Con %1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: A, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: A, Succ: (%4)
-// CHECK-NEXT:    Con %4 Esc: A, Succ: (%5)
-// CHECK-NEXT:    Con %5 Esc: A, Succ:
-// CHECK-NEXT:    Ret Esc: R, Succ: %5
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
+// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: A, Succ: ([rc] %3)
+// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con %4 Esc: A, Succ: ([rc] %5)
+// CHECK-NEXT:    Con [rc] %5 Esc: A, Succ: (%6)
+// CHECK-NEXT:    Con %6 Esc: A, Succ:
+// CHECK-NEXT:    Ret return Esc: R, Succ: %6
 // CHECK-NEXT:  End
 sil @load_next3 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -277,10 +277,10 @@ sil_global @global_x : $X
 // The argument escapes because it is stored to a global variable in the callee.
 
 // CHECK-LABEL: CG of call_store_pointer
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ: (%5)
-// CHECK-NEXT:    Con %5 Esc: G, Succ:
-// CHECK-NEXT:    Ret Esc: R, Succ: %5
+// CHECK-NEXT:    Arg %0 Esc: G, Succ: ([rc] %5)
+// CHECK-NEXT:    Con [rc] %5 Esc: G, Succ: (%6)
+// CHECK-NEXT:    Con %6 Esc: G, Succ:
+// CHECK-NEXT:    Ret return Esc: R, Succ: %6
 // CHECK-NEXT:  End
 sil @call_store_pointer : $@convention(thin) (@owned Pointer) -> @owned X {
 bb0(%0 : $Pointer):
@@ -310,11 +310,11 @@ bb0(%0 : $Pointer):
 // global variable in the callee.
 
 // CHECK-LABEL: CG of store_content
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %3)
 // CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ: %3
-// CHECK-NEXT:    Con %3 Esc: G, Succ:
+// CHECK-NEXT:    Con %1.1 Esc: G, Succ: %4
+// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con %4 Esc: G, Succ:
 // CHECK-NEXT:  End
 sil  @store_content : $@convention(thin) (@owned Pointer) -> () {
 bb0(%0 : $Pointer):
@@ -328,10 +328,10 @@ bb0(%0 : $Pointer):
 }
 
 // CHECK-LABEL: CG of call_store_content
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%4)
-// CHECK-NEXT:    Con %4 Esc: G, Succ:
-// CHECK-NEXT:    Ret Esc: R, Succ: %4
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %4)
+// CHECK-NEXT:    Con [rc] %4 Esc: A, Succ: (%5)
+// CHECK-NEXT:    Con %5 Esc: G, Succ:
+// CHECK-NEXT:    Ret return Esc: R, Succ: %5
 // CHECK-NEXT:  End
 sil @call_store_content : $@convention(thin) (@owned Pointer) -> @owned X {
 bb0(%0 : $Pointer):
@@ -405,12 +405,12 @@ sil @call_copy_addr_content : $@convention(thin) () -> () {
 
 // CHECK-LABEL: CG of test_partial_apply
 // CHECK-NEXT:    Arg %1 Esc: G, Succ:
-// CHECK-NEXT:    Arg %2 Esc: A, Succ: (%7.1)
-// CHECK-NEXT:    Val %3 Esc: %14,%15,%17, Succ: (%6.1)
-// CHECK-NEXT:    Val %6 Esc: %14,%15,%16, Succ: (%6.1)
-// CHECK-NEXT:    Con %6.1 Esc: %14,%15,%16,%17, Succ: (%7)
-// CHECK-NEXT:    Con %7 Esc: %14,%15,%16,%17, Succ: %2
-// CHECK-NEXT:    Con %7.1 Esc: G, Succ:
+// CHECK-NEXT:    Arg %2 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:    Con %2.1 Esc: G, Succ:
+// CHECK-NEXT:    Val %3 Esc: %14,%15,%17, Succ: ([rc] %7)
+// CHECK-NEXT:    Val %6 Esc: %14,%15,%16, Succ: ([rc] %7)
+// CHECK-NEXT:    Con [rc] %7 Esc: %14,%15,%16,%17, Succ: (%7.1)
+// CHECK-NEXT:    Con %7.1 Esc: %14,%15,%16,%17, Succ: %2
 // CHECK-NEXT:    Val %12 Esc: %14,%15, Succ: %3, %6
 // CHECK-NEXT:  End
 sil @test_partial_apply : $@convention(thin) (Int64, @owned X, @owned Y) -> Int64 {
@@ -435,14 +435,14 @@ bb0(%0 : $Int64, %1 : $X, %2 : $Y):
 
 // CHECK-LABEL: CG of closure1
 // CHECK-NEXT:    Arg %0 Esc: G, Succ:
-// CHECK-NEXT:    Arg %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: A, Succ: (%1.3)
-// CHECK-NEXT:    Con %1.3 Esc: G, Succ:
-// CHECK-NEXT:    Arg %2 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: A, Succ: (%2.2)
-// CHECK-NEXT:    Con %2.2 Esc: A, Succ: (%2.3)
-// CHECK-NEXT:    Con %2.3 Esc: G, Succ:
+// CHECK-NEXT:    Arg %1 Esc: A, Succ: ([rc] %3)
+// CHECK-NEXT:    Arg %2 Esc: A, Succ: ([rc] %4)
+// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%3.1)
+// CHECK-NEXT:    Con %3.1 Esc: A, Succ: (%3.2)
+// CHECK-NEXT:    Con %3.2 Esc: G, Succ:
+// CHECK-NEXT:    Con [rc] %4 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Con %4.1 Esc: A, Succ: ([rc] %4.2)
+// CHECK-NEXT:    Con [rc] %4.2 Esc: G, Succ:
 // CHECK-NEXT:    Val %7 Esc: %8, Succ: %2
 // CHECK-NEXT:  End
 sil @closure1 : $@convention(thin) (@owned X, @owned <τ_0_0> { var τ_0_0 } <Int64>, @owned <τ_0_0> { var τ_0_0 } <Y>) -> Int64 {
@@ -459,11 +459,11 @@ bb0(%0 : $X, %1 : $<τ_0_0> { var τ_0_0 } <Int64>, %2 : $<τ_0_0> { var τ_0_0 
 
 // CHECK-LABEL: CG of closure2
 // CHECK-NEXT:    Arg %0 Esc: G, Succ:
-// CHECK-NEXT:    Arg %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: A, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: G, Succ: (%4)
-// CHECK-NEXT:    Con %4 Esc: G, Succ: %0
+// CHECK-NEXT:    Arg %1 Esc: A, Succ: ([rc] %2)
+// CHECK-NEXT:    Con [rc] %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: A, Succ: ([rc] %4)
+// CHECK-NEXT:    Con [rc] %4 Esc: G, Succ: (%4.1)
+// CHECK-NEXT:    Con %4.1 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @closure2 : $@convention(thin) (@owned X, @owned <τ_0_0> { var τ_0_0 } <Y>) -> () {
 bb0(%0 : $X, %1 : $<τ_0_0> { var τ_0_0 } <Y>):
@@ -479,10 +479,10 @@ bb0(%0 : $X, %1 : $<τ_0_0> { var τ_0_0 } <Y>):
 // Test partial_apply. The box escapes in the callee.
 
 // CHECK-LABEL: CG of test_escaped_box
-// CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: G, Succ: (%1.3)
-// CHECK-NEXT:    Con %1.3 Esc: G, Succ:
+// CHECK-NEXT:    Val %1 Esc: G, Succ: ([rc] %2)
+// CHECK-NEXT:    Con [rc] %2 Esc: G, Succ: (%2.1)
+// CHECK-NEXT:    Con %2.1 Esc: G, Succ: (%2.2)
+// CHECK-NEXT:    Con %2.2 Esc: G, Succ:
 // CHECK-NEXT:    Val %6 Esc: G, Succ: %1
 // CHECK-NEXT:  End
 sil @test_escaped_box : $@convention(thin) (Int64) -> Int64 {
@@ -502,10 +502,10 @@ bb0(%0 : $Int64):
 }
 
 // CHECK-LABEL: CG of let_box_escape
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ: (%0.3)
-// CHECK-NEXT:    Con %0.3 Esc: G, Succ:
+// CHECK-NEXT:    Arg %0 Esc: G, Succ: ([rc] %1)
+// CHECK-NEXT:    Con [rc] %1 Esc: G, Succ: (%1.1)
+// CHECK-NEXT:    Con %1.1 Esc: G, Succ: (%1.2)
+// CHECK-NEXT:    Con %1.2 Esc: G, Succ:
 // CHECK-NEXT:  End
 sil @let_box_escape : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int64>) -> Int64 {
 bb0(%0 : $<τ_0_0> { var τ_0_0 } <Int64>):
@@ -524,8 +524,8 @@ sil @takebox :  $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int64>) -> (
 // The partial_apply itself escapes and therefore also the box escapes.
 
 // CHECK-LABEL: CG of test_escaped_partial_apply
-// CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ:
+// CHECK-NEXT:    Val %1 Esc: G, Succ: ([rc] %2)
+// CHECK-NEXT:    Con [rc] %2 Esc: G, Succ:
 // CHECK-NEXT:    Val %6 Esc: G, Succ: %1
 // CHECK-NEXT:  End
 sil @test_escaped_partial_apply : $@convention(thin) (Int64) -> () {
@@ -544,10 +544,10 @@ bb0(%0 : $Int64):
 }
 
 // CHECK-LABEL: CG of closure3
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.3)
-// CHECK-NEXT:    Con %0.3 Esc: G, Succ:
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
+// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%1.1)
+// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%1.2)
+// CHECK-NEXT:    Con %1.2 Esc: G, Succ:
 // CHECK-NEXT:  End
 sil @closure3 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int64>) -> Int64 {
 bb0(%0 : $<τ_0_0> { var τ_0_0 } <Int64>):
@@ -564,11 +564,11 @@ sil @take_partial_apply : $@convention(thin) (@owned @callee_owned () -> Int64) 
 sil_global @global_ln : $LinkedNode
 
 // CHECK-LABEL: CG of load_next_recursive
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%1)
-// CHECK-NEXT:    Con %1 Esc: G, Succ:
-// CHECK-NEXT:    Val %4 Esc: G, Succ: %1
-// CHECK-NEXT:    Ret Esc: R, Succ: %4
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
+// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: G, Succ:
+// CHECK-NEXT:    Val %4 Esc: G, Succ: %2
+// CHECK-NEXT:    Ret return Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @load_next_recursive : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -580,12 +580,12 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of let_escape
-// CHECK-NEXT:    Arg %0 Esc: G, Succ:
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ: 
+// CHECK-NEXT:    Arg %0 Esc: G, Succ: ([rc] %0.1)
+// CHECK-NEXT:    Con [rc] %0.1 Esc: G, Succ:
 // CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
 // CHECK-NEXT:    Con %1.1 Esc: G, Succ: %0
 // CHECK-NEXT:    Val %4 Esc: G, Succ: %0
-// CHECK-NEXT:    Ret Esc: R, Succ: %4
+// CHECK-NEXT:    Ret return Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @let_escape : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -597,12 +597,12 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of return_same
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Val %3 Esc: G, Succ: (%0.1), %0.2
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %3.1)
+// CHECK-NEXT:    Val %3 Esc: G, Succ: ([rc] %3.1), %3.2
+// CHECK-NEXT:    Con [rc] %3.1 Esc: G, Succ: (%3.2)
+// CHECK-NEXT:    Con %3.2 Esc: G, Succ: ([rc] %3.1)
 // CHECK-NEXT:    Val %5 Esc: R, Succ: %0, %3
-// CHECK-NEXT:    Ret Esc: R, Succ: %5
+// CHECK-NEXT:    Ret return Esc: R, Succ: %5
 // CHECK-NEXT:  End
 sil @return_same : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -620,15 +620,15 @@ bb2(%5 : $LinkedNode):
 // Another recursion test.
 
 // CHECK-LABEL: CG of loadNext2
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%1)
-// CHECK-NEXT:    Con %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: A, Succ: (%4.1)
-// CHECK-NEXT:    Val %4 Esc: R, Succ: %1.2, %4.2
-// CHECK-NEXT:    Con %4.1 Esc: A, Succ: (%4.2)
-// CHECK-NEXT:    Con %4.2 Esc: A, Succ: (%4.1)
-// CHECK-NEXT:    Ret Esc: R, Succ: %4
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
+// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: A, Succ: ([rc] %2.1)
+// CHECK-NEXT:    Con [rc] %2.1 Esc: A, Succ: (%2.2)
+// CHECK-NEXT:    Con %2.2 Esc: A, Succ: ([rc] %2.3)
+// CHECK-NEXT:    Con [rc] %2.3 Esc: A, Succ: (%2.4)
+// CHECK-NEXT:    Con %2.4 Esc: A, Succ: ([rc] %2.3)
+// CHECK-NEXT:    Val %4 Esc: R, Succ: %2.2, %2.4
+// CHECK-NEXT:    Ret return Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @loadNext2 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -640,14 +640,14 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of returnNext2
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%5)
-// CHECK-NEXT:    Val %3 Esc: R, Succ: (%5.1), %5.2
-// CHECK-NEXT:    Con %5 Esc: A, Succ: (%5.1)
-// CHECK-NEXT:    Con %5.1 Esc: A, Succ: (%5.2)
-// CHECK-NEXT:    Con %5.2 Esc: A, Succ: (%5.1)
-// CHECK-NEXT:    Val %8 Esc: R, Succ: %3, %5
-// CHECK-NEXT:    Ret Esc: R, Succ: %8
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %5)
+// CHECK-NEXT:    Val %3 Esc: R, Succ: ([rc] %3.1), %3.2
+// CHECK-NEXT:    Con [rc] %3.1 Esc: A, Succ: (%3.2)
+// CHECK-NEXT:    Con %3.2 Esc: A, Succ: ([rc] %3.1)
+// CHECK-NEXT:    Con [rc] %5 Esc: A, Succ: (%6)
+// CHECK-NEXT:    Con %6 Esc: A, Succ: ([rc] %3.1)
+// CHECK-NEXT:    Val %8 Esc: R, Succ: %3, %6
+// CHECK-NEXT:    Ret return Esc: R, Succ: %8
 // CHECK-NEXT:  End
 sil @returnNext2 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -670,12 +670,12 @@ bb3(%8 : $LinkedNode):
 // A single-cycle recursion test.
 
 // CHECK-LABEL: CG of single_cycle_recursion
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Con %2 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Val %5 Esc: R, Succ: (%2.1), %2
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %2)
+// CHECK-NEXT:    Con [rc] %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: A, Succ: ([rc] %2)
+// CHECK-NEXT:    Val %5 Esc: R, Succ: ([rc] %2), %3
 // CHECK-NEXT:    Val %7 Esc: R, Succ: %0, %5
-// CHECK-NEXT:    Ret  Esc: R, Succ: %7
+// CHECK-NEXT:    Ret return Esc: R, Succ: %7
 // CHECK-NEXT:  End
 sil @single_cycle_recursion : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -697,7 +697,7 @@ bb2(%5 : $LinkedNode):
 // CHECK-LABEL: CG of call_throwing_func
 // CHECK-NEXT:    Arg %0 Esc: A, Succ:
 // CHECK-NEXT:    Val %3 Esc: R, Succ: %0
-// CHECK-NEXT:    Ret Esc: R, Succ: %3
+// CHECK-NEXT:    Ret return Esc: R, Succ: %3
 // CHECK-NEXT:  End
 sil @call_throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error Error) {
 bb0(%0 : $X):
@@ -715,7 +715,7 @@ bb2(%5 : $Error):
 // CHECK-NEXT:    Arg %0 Esc: A, Succ:
 // CHECK-NEXT:    Val %3 Esc: G, Succ: (%3.1)
 // CHECK-NEXT:    Con %3.1 Esc: G, Succ:
-// CHECK-NEXT:    Ret  Esc: R, Succ: %0
+// CHECK-NEXT:    Ret return Esc: R, Succ: %0
 // CHECK-NEXT:  End
 sil @throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error Error) {
 bb0(%0 : $X):
@@ -735,11 +735,11 @@ bb2:
 // Test if a try_apply to an unknown function is handled correctly.
 
 // CHECK-LABEL: CG of call_unknown_throwing_func
-// CHECK-NEXT:    Arg %0 Esc: G, Succ:
+// CHECK-NEXT:    Arg %0 Esc: G, Succ: (%0.1)
 // CHECK-NEXT:    Con %0.1 Esc: G, Succ:
-// CHECK-NEXT:    Val %3 Esc: G, Succ:
+// CHECK-NEXT:    Val %3 Esc: G, Succ: (%3.1)
 // CHECK-NEXT:    Con %3.1 Esc: G, Succ:
-// CHECK-NEXT:    Ret Esc: R, Succ: %3
+// CHECK-NEXT:    Ret return Esc: R, Succ: %3
 // CHECK-NEXT:  End
 sil @call_unknown_throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error Error) {
 bb0(%0 : $X):
@@ -758,11 +758,11 @@ sil @unknown_throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error 
 // Test that the deinit of a box itself does not capture anything.
 
 // CHECK-LABEL: CG of test_release_of_partial_apply_with_box
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Val %1 Esc: %6, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: %6, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: %6, Succ: %0
-// CHECK-NEXT:    Con %2.1 Esc: G, Succ:
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con %0.1 Esc: G, Succ:
+// CHECK-NEXT:    Val %1 Esc: %6, Succ: ([rc] %2)
+// CHECK-NEXT:    Con [rc] %2 Esc: %6, Succ: (%2.1)
+// CHECK-NEXT:    Con %2.1 Esc: %6, Succ: %0
 // CHECK-NEXT:    Val %5 Esc: %6, Succ: %1
 // CHECK-NEXT:  End
 sil @test_release_of_partial_apply_with_box : $@convention(thin) (@owned Y) -> () {
@@ -783,9 +783,9 @@ sil @take_y_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Y>) -> ()
 
 // CHECK-LABEL: CG of store_to_unknown_reference
 // CHECK-NEXT:    Arg %0 Esc: G, Succ:
-// CHECK-NEXT:    Val %2 Esc: G, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: G, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: G, Succ: %0
+// CHECK-NEXT:    Val %2 Esc: G, Succ: ([rc] %3)
+// CHECK-NEXT:    Con [rc] %3 Esc: G, Succ: (%3.1)
+// CHECK-NEXT:    Con %3.1 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @store_to_unknown_reference : $@convention(thin) (@owned X) -> () {
 bb0(%0 : $X):
@@ -800,7 +800,7 @@ bb0(%0 : $X):
 // CHECK-LABEL: CG of get_reference
 // CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
 // CHECK-NEXT:    Con %1.1 Esc: G, Succ:
-// CHECK-NEXT:    Ret Esc: R, Succ: %1
+// CHECK-NEXT:    Ret return Esc: R, Succ: %1
 // CHECK-NEXT:  End
 sil @get_reference : $@convention(thin) () -> @owned Y {
 bb0:
@@ -816,9 +816,9 @@ sil @unknown_get_reference : $@convention(thin) () -> @owned Y
 sil @unknown_set_y : $@convention(thin) () -> @out Y
 
 // CHECK-LABEL: CG of get_y
-// CHECK-NEXT:    Val %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ:
-// CHECK-NEXT:    Ret  Esc: R, Succ: %0.1
+// CHECK-NEXT:    Val %0 Esc: G, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: G, Succ:
+// CHECK-NEXT:    Ret return Esc: R, Succ: %3
 // CHECK-NEXT:  End
 sil @get_y : $@convention(thin) () -> @owned Y {
 bb0:
@@ -831,10 +831,10 @@ bb0:
 }
 
 // CHECK-LABEL: CG of create_and_store_x
-// CHECK-NEXT:    Val %0 Esc: G, Succ:
-// CHECK-NEXT:    Val %2 Esc: G, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: G, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: G, Succ: %0
+// CHECK-NEXT:    Val %0 Esc: G, Succ: 
+// CHECK-NEXT:    Val %2 Esc: G, Succ: ([rc] %3)
+// CHECK-NEXT:    Con [rc] %3 Esc: G, Succ: (%3.1)
+// CHECK-NEXT:    Con %3.1 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @create_and_store_x : $@convention(thin) () -> () {
 bb0:
@@ -850,11 +850,11 @@ bb0:
 // Test types which are considered as pointers.
 
 // CHECK-LABEL: CG of pointer_types
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Arg %1 Esc: A, Succ:
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: 
+// CHECK-NEXT:    Arg %1 Esc: A, Succ: 
 // CHECK-NEXT:    Val %4 Esc: R, Succ: %0, %1
 // CHECK-NEXT:    Val %7 Esc: R, Succ: %4
-// CHECK-NEXT:    Ret Esc: R, Succ: %7
+// CHECK-NEXT:    Ret return Esc: R, Succ: %7
 // CHECK-NEXT:  End
 sil @pointer_types : $@convention(thin) (@owned Y, @owned Y) -> @owned Y {
 bb0(%0 : $Y, %1 : $Y):
@@ -871,12 +871,12 @@ bb1(%7 : $(Pointer, Pointer)):
 }
 
 // CHECK-LABEL: CG of defer_edge_cycle
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: (%2), %1.1
-// CHECK-NEXT:    Arg %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: %0.1
-// CHECK-NEXT:    Con %2 Esc: A, Succ: (%6)
-// CHECK-NEXT:    Con %6 Esc: A, Succ:
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Arg %1 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con %2 Esc: A, Succ: ([rc] %6), %4
+// CHECK-NEXT:    Con %4 Esc: A, Succ: %2
+// CHECK-NEXT:    Con [rc] %6 Esc: A, Succ: (%7)
+// CHECK-NEXT:    Con %7 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @defer_edge_cycle : $@convention(thin) (@inout Y, @inout Y) -> () {
 entry(%0 : $*Y, %1 : $*Y):
@@ -892,8 +892,8 @@ entry(%0 : $*Y, %1 : $*Y):
 
 // CHECK-LABEL: CG of take_c_func
 // CHECK-NEXT:    Arg %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ:
-// CHECK-NEXT:    Ret  Esc: R, Succ: %0
+// CHECK-NEXT:    Con %0.1 Esc: G, Succ: 
+// CHECK-NEXT:    Ret return Esc: R, Succ: %0
 // CHECK-NEXT:  End
 sil @take_c_func : $@convention(thin) (@convention(c) () -> ()) -> @convention(c) () -> () {
 bb0(%0 : $@convention(c) () -> ()):
@@ -929,7 +929,7 @@ bb0:
 // CHECK-NEXT:    Arg %2 Esc: A, Succ:
 // CHECK-NEXT:    Arg %3 Esc: A, Succ:
 // CHECK-NEXT:    Val %4 Esc: R, Succ: %1, %2, %3
-// CHECK-NEXT:    Ret  Esc: R, Succ: %4
+// CHECK-NEXT:    Ret return Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @test_select_enum : $@convention(thin) (PointerEnum2, @owned X, @owned X, @owned X) -> @owned X {
 bb0(%0 : $PointerEnum2, %1 : $X, %2 : $X, %3 : $X):
@@ -943,7 +943,7 @@ bb0(%0 : $PointerEnum2, %1 : $X, %2 : $X, %3 : $X):
 // CHECK-NEXT:    Arg %2 Esc: A, Succ:
 // CHECK-NEXT:    Arg %3 Esc: A, Succ:
 // CHECK-NEXT:    Val %4 Esc: R, Succ: %1, %2, %3
-// CHECK-NEXT:    Ret  Esc: R, Succ: %4
+// CHECK-NEXT:    Ret return Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @test_select_enum_addr : $@convention(thin) (@in PointerEnum2, @owned X, @owned X, @owned X) -> @owned X {
 bb0(%0 : $*PointerEnum2, %1 : $X, %2 : $X, %3 : $X):
@@ -956,7 +956,7 @@ bb0(%0 : $*PointerEnum2, %1 : $X, %2 : $X, %3 : $X):
 // CHECK-NEXT:    Arg %2 Esc: A, Succ:
 // CHECK-NEXT:    Arg %3 Esc: A, Succ:
 // CHECK-NEXT:    Val %6 Esc: R, Succ: %1, %2, %3
-// CHECK-NEXT:    Ret  Esc: R, Succ: %6
+// CHECK-NEXT:    Ret return Esc: R, Succ: %6
 // CHECK-NEXT:  End
 sil @test_select_value : $@convention(thin) (Builtin.Int64, @owned X, @owned X, @owned X) -> @owned X {
 bb0(%0 : $Builtin.Int64, %1 : $X, %2 : $X, %3 : $X):
@@ -967,10 +967,10 @@ bb0(%0 : $Builtin.Int64, %1 : $X, %2 : $X, %3 : $X):
 }
 
 // CHECK-LABEL: CG of test_existential_addr
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: , Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: , Succ: %0
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: 
+// CHECK-NEXT:    Val %1 Esc: , Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: , Succ: (%2.1)
+// CHECK-NEXT:    Con %2.1 Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @test_existential_addr : $@convention(thin) (@owned Pointer) -> () {
 bb0(%0 : $Pointer):
@@ -1015,7 +1015,7 @@ bb0(%0 : $ErrorClass):
 
 // CHECK-LABEL: CG of test_raw_pointer_to_ref
 // CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Ret  Esc: R, Succ: %0
+// CHECK-NEXT:    Ret return Esc: R, Succ: %0
 // CHECK-NEXT:  End
 sil @test_raw_pointer_to_ref : $@convention(thin) (@owned X) -> @owned X {
 bb0(%0 : $X):
@@ -1026,7 +1026,7 @@ bb0(%0 : $X):
 
 // CHECK-LABEL: CG of test_bridge_object_to_ref
 // CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Ret  Esc: R, Succ: %0
+// CHECK-NEXT:    Ret return Esc: R, Succ: %0
 // CHECK-NEXT:  End
 sil @test_bridge_object_to_ref : $@convention(thin) (@owned X, Builtin.Word) -> @owned X {
 bb0(%0 : $X, %1 : $Builtin.Word):
@@ -1051,7 +1051,7 @@ bb0(%0 : $*X, %1 : $X):
 
 // CHECK-LABEL: CG of test_casts
 // CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Ret  Esc: R, Succ: %0
+// CHECK-NEXT:    Ret return Esc: R, Succ: %0
 // CHECK-NEXT:  End
 sil @test_casts : $@convention(thin) (@owned AnyObject) -> @owned X {
 bb0(%0 : $AnyObject):
@@ -1074,11 +1074,11 @@ bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
 sil_global @global_y : $SomeData
 
 // CHECK-LABEL: CG of test_node_merge_during_struct_inst
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%4.1)
-// CHECK-NEXT:    Val %1 Esc: G, Succ: (%4.1)
-// CHECK-NEXT:    Val %4 Esc: , Succ: (%4.1)
-// CHECK-NEXT:    Con %4.1 Esc: G, Succ: (%4.1), %1
-// CHECK-NEXT:    Val %10 Esc: , Succ: %0, %4, %4.1
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%8)
+// CHECK-NEXT:    Val %1 Esc: G, Succ: (%8)
+// CHECK-NEXT:    Val %4 Esc: , Succ: (%8)
+// CHECK-NEXT:    Con %8 Esc: G, Succ: (%8), %1
+// CHECK-NEXT:    Val %10 Esc: , Succ: %0, %4, %8
 // CHECK-NEXT:  End
 sil @test_node_merge_during_struct_inst : $@convention(thin) (Y) -> () {
 bb0(%0 : $Y):
@@ -1150,9 +1150,9 @@ bb0(%0 : $Array<X>):
 // CHECK-LABEL: CG of arraysemantics_get_element
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
 // CHECK-NEXT:    Con %0.1 Esc: A, Succ: %1.2
-// CHECK-NEXT:    Arg %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: A, Succ:
+// CHECK-NEXT:    Arg %1 Esc: A, Succ: ([rc] %1.1)
+// CHECK-NEXT:    Con [rc] %1.1 Esc: A, Succ: (%1.2)
+// CHECK-NEXT:    Con %1.2 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @arraysemantics_get_element : $@convention(thin) (Array<X>) -> @out X {
 bb0(%io : $*X, %1 : $Array<X>):
@@ -1181,9 +1181,9 @@ bb0(%0 : $*Array<X>):
 }
 
 // CHECK-LABEL: CG of arraysemantics_get_element_address
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ:
-// CHECK-NEXT:    Val %4 Esc: , Succ: %0.1
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %0.1)
+// CHECK-NEXT:    Con [rc] %0.1 Esc: A, Succ: 
+// CHECK-NEXT:    Val %4 Esc: , Succ: [rc] %0.1
 // CHECK-NEXT:  End
 sil @arraysemantics_get_element_address : $@convention(thin) (Array<X>) -> () {
 bb0(%0 : $Array<X>):
@@ -1224,13 +1224,13 @@ bb0(%0 : $Array<X>):
 }
 
 // CHECK-LABEL: CG of arraysemantics_withUnsafeMutableBufferPointer
-// CHECK-NEXT:   Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:   Con %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:   Con %0.2 Esc: A, Succ: (%0.3)
-// CHECK-NEXT:   Con %0.3 Esc: G, Succ:
-// CHECK-NEXT:   Arg %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:   Con %1.1 Esc: G, Succ:
-// CHECK-NEXT:   Val %3 Esc: %4, Succ:
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con %0.1 Esc: A, Succ: ([rc] %0.2)
+// CHECK-NEXT:    Con [rc] %0.2 Esc: A, Succ: (%0.3)
+// CHECK-NEXT:    Con %0.3 Esc: G, Succ: 
+// CHECK-NEXT:    Arg %1 Esc: G, Succ: (%1.1)
+// CHECK-NEXT:    Con %1.1 Esc: G, Succ: 
+// CHECK-NEXT:    Val %3 Esc: %4, Succ: 
 // CHECK-NEXT: End
 sil @arraysemantics_withUnsafeMutableBufferPointer : $@convention(thin) (@inout Array<X>, @owned @callee_owned (@inout X) -> (@out (), @error Error)) -> () {
 bb(%0 : $*Array<X>, %1 : $@callee_owned (@inout X) -> (@out (), @error Error)):
@@ -1245,12 +1245,12 @@ bb(%0 : $*Array<X>, %1 : $@callee_owned (@inout X) -> (@out (), @error Error)):
 }
 
 // CHECK-LABEL: CG of arraysemantics_createUninitialized
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Val %2 Esc: R, Succ: (%6)
-// CHECK-NEXT:    Val %4 Esc: R, Succ: (%4.1)
-// CHECK-NEXT:    Con %4.1 Esc: R, Succ: %2
-// CHECK-NEXT:    Con %6 Esc: R, Succ: %0
-// CHECK-NEXT:    Ret  Esc: R, Succ: %4
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: 
+// CHECK-NEXT:    Val %2 Esc: R, Succ: (%2.1)
+// CHECK-NEXT:    Con %2.1 Esc: R, Succ: %0
+// CHECK-NEXT:    Val %4 Esc: R, Succ: ([rc] %6)
+// CHECK-NEXT:    Con [rc] %6 Esc: R, Succ: %2
+// CHECK-NEXT:    Ret return Esc: R, Succ: %4
 // CHECK-NEXT:  End
 sil @arraysemantics_createUninitialized : $@convention(thin) (@owned X) -> @owned Array<X> {
 bb0(%0 : $X):
@@ -1370,9 +1370,9 @@ bb0:
 // happen due to strong_release and figure out that the object will
 // globally escape.
 // CHECK-LABEL: CG of check_escaping_implicit_destructor_invocation_via_strong_release
-// CHECK-NEXT:   Val %0 Esc: %1, Succ: (%0.1)
-// CHECK-NEXT:   Con %0.1 Esc: %1, Succ: (%0.2)
-// CHECK-NEXT:   Con %0.2 Esc: G, Succ:
+// CHECK-NEXT:    Val %0 Esc: %1, Succ: ([rc] %0.1)
+// CHECK-NEXT:    Con [rc] %0.1 Esc: %1, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
 // CHECK-NEXT:  End
 sil @check_escaping_implicit_destructor_invocation_via_strong_release : $@convention(thin) () -> () {
 bb0:
@@ -1387,9 +1387,9 @@ bb0:
 // happen due to strong_release and figure out that the object will
 // globally escape.
 // CHECK-LABEL: CG of check_escaping_implicit_destructor_invocation_via_release_value
-// CHECK-NEXT:   Val %0 Esc: %1, Succ: (%0.1)
-// CHECK-NEXT:   Con %0.1 Esc: %1, Succ: (%0.2)
-// CHECK-NEXT:   Con %0.2 Esc: G, Succ:
+// CHECK-NEXT:    Val %0 Esc: %1, Succ: ([rc] %0.1)
+// CHECK-NEXT:    Con [rc] %0.1 Esc: %1, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
 // CHECK-NEXT:  End
 sil @check_escaping_implicit_destructor_invocation_via_release_value : $@convention(thin) () -> () {
 bb0:
@@ -1441,8 +1441,8 @@ bb0(%0 : $@convention(thin) () -> ()):
 
 // X.deinit
 // CHECK-LABEL: CG of $s4main1XCfD
-// CHECK:        Arg %0 Esc: A, Succ:
-// CHECK:      End
+// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:  End
 sil @$s4main1XCfD: $@convention(method) (@owned X) -> () {
 bb0(%0 : $X):
   fix_lifetime %0 : $X
@@ -1452,12 +1452,12 @@ bb0(%0 : $X):
 
 // Z.deinit
 // CHECK-LABEL: CG of $s4main1ZCfD
-// CHECK:        Arg %0 Esc: A, Succ: (%0.1)
-// CHECK:        Con %0.1 Esc: A, Succ: (%1)
-// CHECK:        Con %1 Esc: G, Succ:
-// CHECK:        Val %3 Esc: G, Succ: (%3.1)
-// CHECK:        Con %3.1 Esc: G, Succ: %1
-// CHECK:      End
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
+// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: G, Succ: 
+// CHECK-NEXT:    Val %3 Esc: G, Succ: (%3.1)
+// CHECK-NEXT:    Con %3.1 Esc: G, Succ: %2
+// CHECK-NEXT:  End
 sil @$s4main1ZCfD: $@convention(method) (@owned Z) -> () {
 bb0(%0 : $Z):
   %1 = ref_element_addr %0 : $Z, #Z.x
@@ -1485,9 +1485,9 @@ bb0(%0 : $X):
 }
 
 // CHECK-LABEL: CG of call_public_external_func
-// CHECK:        Val %0 Esc: G, Succ: (%0.1)
-// CHECK:        Con %0.1 Esc: G, Succ: 
-// CHECK:      End
+// CHECK-NEXT:    Val %0 Esc: G, Succ: (%0.1)
+// CHECK-NEXT:    Con %0.1 Esc: G, Succ: 
+// CHECK-NEXT:  End
 sil @call_public_external_func : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_ref $X
@@ -1515,13 +1515,13 @@ bb2:
 // begin_apply result) is just marked as escaping.
 
 // CHECK-LABEL: CG of call_coroutine
-// CHECK:         Val %0 Esc: G, Succ: (%0.1)
-// CHECK:         Con %0.1 Esc: G, Succ: (%0.2)
-// CHECK:         Con %0.2 Esc: G, Succ: 
-// CHECK:         Val %2 Esc: G, Succ: (%2.1)
-// CHECK:         Con %2.1 Esc: G, Succ: %4
-// CHECK:         Val %4 Esc: G, Succ: 
-// CHECK:       End
+// CHECK-NEXT:    Val %0 Esc: G, Succ: (%0.1)
+// CHECK-NEXT:    Con %0.1 Esc: G, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
+// CHECK-NEXT:    Val %2 Esc: G, Succ: (%2.1)
+// CHECK-NEXT:    Con %2.1 Esc: G, Succ: %4
+// CHECK-NEXT:    Val %4 Esc: G, Succ: 
+// CHECK-NEXT:  End
 sil @call_coroutine : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_ref $Y
@@ -1537,15 +1537,15 @@ bb0:
 
 // Test the absence of redundant pointsTo edges
 // CHECK-LABEL: CG of testInitializePointsToLeaf
-// CHECK:   Arg %0 Esc: A, Succ: (%0.1)
-// CHECK:   Con %0.1 Esc: A, Succ: (%0.2) [rc]
-// CHECK:   Con %0.2 Esc: A, Succ: (%12.1)
-// CHECK:   Val %2 Esc: %4, Succ: %0.2
-// CHECK:   Val %4 Esc: %4, Succ: %2
-// CHECK:   Val %7 Esc: %12, Succ: (%12.1), %0.2
-// CHECK:   Val %12 Esc: %12, Succ: (%12.1), %7
-// CHECK:   Con %12.1 Esc: A, Succ: (%13) [rc]
-// CHECK:   Con %13 Esc: A, Succ:
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %0.1)
+// CHECK-NEXT:    Con [rc] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: ([rc] %13)
+// CHECK-NEXT:    Val %2 Esc: %4, Succ: %0.2
+// CHECK-NEXT:    Val %4 Esc: %4, Succ: %2
+// CHECK-NEXT:    Val %7 Esc: %12, Succ: ([rc] %13), %0.2
+// CHECK-NEXT:    Val %12 Esc: %12, Succ: ([rc] %13), %7
+// CHECK-NEXT:    Con [rc] %13 Esc: A, Succ: (%14)
+// CHECK-NEXT:    Con %14 Esc: A, Succ: 
 // CHECK-LABEL: End
 class C {
   var c: C
@@ -1593,14 +1593,14 @@ bb10(%arg2 : $LinkedNode):
 // a defer edge from a node with uninitialized pointsTo to a node with
 // already-initialized pointsTo.
 // CHECK-LABEL: CG of testInitializePointsToRedundant
-// CHECK:   Arg %0 Esc: A, Succ: (%0.1)
-// CHECK:   Con %0.1 Esc: A, Succ: (%2) [rc]
-// CHECK:   Arg %1 Esc: A, Succ: (%0.1)
-// CHECK:   Con %2 Esc: A, Succ:
-// CHECK:   Val %7 Esc: %7,%18, Succ: %0
-// CHECK:   Val %12 Esc: %12,%14,%18, Succ: %1
-// CHECK:   Val %14 Esc: %18, Succ: (%0.1), %1, %12
-// CHECK:   Val %18 Esc: %18, Succ: %7, %14
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %2)
+// CHECK-NEXT:    Arg %1 Esc: A, Succ: ([rc] %2)
+// CHECK-NEXT:    Con [rc] %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: A, Succ: 
+// CHECK-NEXT:    Val %7 Esc: %7,%18, Succ: %0
+// CHECK-NEXT:    Val %12 Esc: %12,%14,%18, Succ: %1
+// CHECK-NEXT:    Val %14 Esc: %18, Succ: ([rc] %2), %1, %12
+// CHECK-NEXT:    Val %18 Esc: %18, Succ: %7, %14
 // CHECK-LABEL: End
 sil @testInitializePointsToMerge : $@convention(method) (@guaranteed C, @guaranteed C) -> C {
 bb0(%0: $C, %1 : $C):

--- a/test/SILOptimizer/escape_analysis_invalidate.sil
+++ b/test/SILOptimizer/escape_analysis_invalidate.sil
@@ -1,0 +1,84 @@
+// RUN: %target-sil-opt %s -temp-rvalue-opt -enable-sil-verify-all | %FileCheck %s
+//
+// TempRValue iteratively uses EscapeAnalysis and deletes
+// instructions. Make sure that the connection graph remains valid
+// <rdar://57290845>.
+
+import Swift
+
+sil_stage canonical
+
+protocol SomeProtocol {
+  func foo()
+}
+struct SomeInstance : SomeProtocol {
+  func foo()
+}
+class SomeClass {
+  var someProperty: SomeProtocol
+}
+struct SomeStruct {
+  var someRef: SomeClass
+}
+
+// CHECK-LABEL: sil @testTempRvalueEscapeAnalysisUpdate : $@convention(thin) (@in_guaranteed SomeProtocol, @guaranteed SomeClass) -> () {
+// CHECK: bb0(%0 : $*SomeProtocol, %1 : $SomeClass):
+// CHECK: alloc_ref $SomeClass
+// CHECK: alloc_stack $SomeStruct
+// CHECK-NOT: alloc_stack $SomeProtocol
+// CHECK-NOT: copy_addr
+// CHECK: init_existential_addr %{{.*}} : $*SomeProtocol, $SomeInstance
+// CHECK: [[OPEN1:%.*]] = open_existential_addr immutable_access %0 : $*SomeProtocol to $*@opened("6419340C-0B14-11EA-9897-ACDE48001122") SomeProtocol
+// CHECK: apply %{{.*}}<@opened("6419340C-0B14-11EA-9897-ACDE48001122") SomeProtocol>([[OPEN1]]) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+// CHECK-NOT: destroy_addr
+// CHECK-NOT: alloc_stack $SomeProtocol
+// CHECK-NOT: copy_addr
+// CHECK: [[OPEN2:%.*]] = open_existential_addr immutable_access %{{.*}} : $*SomeProtocol to $*@opened("6419340C-0B14-11EA-9897-ACDE48001123") SomeProtocol
+// CHECK: apply %{{.*}}<@opened("6419340C-0B14-11EA-9897-ACDE48001123") SomeProtocol>([[OPEN2]]) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+// CHECK-NOT: destroy_addr
+// CHECK-LABEL: } // end sil function 'testTempRvalueEscapeAnalysisUpdate'
+sil @testTempRvalueEscapeAnalysisUpdate : $@convention(thin) (@in_guaranteed SomeProtocol, @guaranteed SomeClass) -> () {
+bb0(%0 : $*SomeProtocol, %1 : $SomeClass):
+  // First create a uniquely identified protocol value. This way
+  // EscapeAnalysis canPointToSameMemory will kick in later. It can't
+  // be an exclusive argument, or AliasAnalysis will filter it before
+  // querying EscapeAnalysis.
+  %localRef = alloc_ref $SomeClass
+  %localPropAdr = ref_element_addr %localRef : $SomeClass, #SomeClass.someProperty
+  copy_addr %0 to [initialization] %localPropAdr : $*SomeProtocol
+  %stk0 = alloc_stack $SomeStruct
+  %stk0Ref = struct_element_addr %stk0 : $*SomeStruct, #SomeStruct.someRef
+  store %localRef to %stk0Ref : $*SomeClass
+  %indirectRef = load %stk0Ref : $*SomeClass
+  %indirectLocalPropAdr = ref_element_addr %indirectRef : $SomeClass, #SomeClass.someProperty
+  
+  %propAdr1 = ref_element_addr %1 : $SomeClass, #SomeClass.someProperty
+  // TempRValue tries to kick in on this copy, but there is an
+  // interfering write that can't be handled by AliasAnlysis without
+  // consulting EscapingAnalysis. MemoryBehavior drops down to
+  // EscapeAnalysis for only a few special instructions, like
+  // init_existential_addr.
+  %stkAdr1 = alloc_stack $SomeProtocol
+  copy_addr %0 to [initialization] %stkAdr1 : $*SomeProtocol
+  %instanceAdr = init_existential_addr %indirectLocalPropAdr : $*SomeProtocol, $SomeInstance
+  %openadr1 = open_existential_addr immutable_access %stkAdr1 : $*SomeProtocol to $*@opened("6419340C-0B14-11EA-9897-ACDE48001122") SomeProtocol
+  %witness1 = witness_method $@opened("6419340C-0B14-11EA-9897-ACDE48001122") SomeProtocol, #SomeProtocol.foo!1 : <Self where Self : SomeProtocol> (Self) -> () -> (), %openadr1 : $*@opened("6419340C-0B14-11EA-9897-ACDE48001122") SomeProtocol : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+  %call1 = apply %witness1<@opened("6419340C-0B14-11EA-9897-ACDE48001122") SomeProtocol>(%openadr1) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %stkAdr1 : $*SomeProtocol
+
+  // TempRValue optimization kicks in here. The open_existential_addr
+  // ceates a content node that refers back to the dead stack
+  // location.
+  %stkAdr2 = alloc_stack $SomeProtocol
+  copy_addr %propAdr1 to [initialization] %stkAdr2 : $*SomeProtocol
+  %openadr2 = open_existential_addr immutable_access %stkAdr2 : $*SomeProtocol to $*@opened("6419340C-0B14-11EA-9897-ACDE48001123") SomeProtocol
+  %witness2 = witness_method $@opened("6419340C-0B14-11EA-9897-ACDE48001123") SomeProtocol, #SomeProtocol.foo!1 : <Self where Self : SomeProtocol> (Self) -> () -> (), %openadr2 : $*@opened("6419340C-0B14-11EA-9897-ACDE48001123") SomeProtocol : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+  %call2 = apply %witness2<@opened("6419340C-0B14-11EA-9897-ACDE48001123") SomeProtocol>(%openadr2) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %stkAdr2 : $*SomeProtocol
+
+  dealloc_stack %stkAdr2 : $*SomeProtocol
+  dealloc_stack %stkAdr1 : $*SomeProtocol
+  dealloc_stack %stk0 : $*SomeStruct
+  %v = tuple ()
+  return %v : $()
+}


### PR DESCRIPTION
Avoid dangling pointers in the connection graph when SILValues are
deleted. This didn't show up in normal compilation because the values
were only used for printing the graph. But now we have more assertions
that check for well-formed graph. These could hit the dangling
pointers.

To guarantee this can't happen, establish a strict invariant that the
mappedValue is only used for nodes that exist in the value-to-node
map. Then clear out mappedValue whenever a value is deleted.

This completely changes the way that a node values are set and used
which in turn makes it *much* easier to debug the graph and associate
the nodes with the SIL function. For example, it's normal to view or
dump the graph at a key point. When the nodes are printed, the
associated SILValues are now more precise and consistent. However,
it's also normal to call CGNode::dump() from tracing code or within a
debugger. Previously, there was no way to assocate the output of
CGNode::dump() with the printed or displayed connection graph. Now
both forms of output have identical node IDs!

While we're at it, make sure the hasRC flag is always merged
conservatively in a couple more places.