### PR TITLE
[Type checker] Remove an unnecessary cycle break.

### DIFF
--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -167,13 +167,13 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
       if (!argumentParam)
         continue;
 
-      if (!argumentParam->hasInterfaceType())
-        continue;
-
       if (argumentParam->isInOut() || argumentParam->isVariadic())
         continue;
 
       auto paramType = argumentParam->getInterfaceType();
+      if (paramType->is<ErrorType>())
+        continue;
+
       if (argumentParam->isAutoClosure()) {
         if (auto *fnType = paramType->getAs<FunctionType>())
           paramType = fnType->getResult();

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -474,6 +474,34 @@ func testWrapperInitWithDefaultArg() {
   // CHECK-NEXT: Init
 }
 
+// rdar://problem/57350503 - DI failure due to an unnecessary cycle breaker
+public class Test57350503 {
+  @Synchronized
+  public private(set) var anchor: Int
+
+  public init(anchor: Int) {
+    self.anchor = anchor
+    printMe()
+  }
+
+  private func printMe() { }
+}
+
+@propertyWrapper
+public final class Synchronized<Value> {
+  private var value: Value
+
+  public var wrappedValue: Value {
+    get { value }
+    set { value = newValue }
+  }
+
+  public init(wrappedValue: Value) {
+    value = wrappedValue
+  }
+}
+
+
 testIntStruct()
 testIntClass()
 testRefStruct()


### PR DESCRIPTION
The `hasInterfaceType()` check should only be used for cycle breaking, and in
this case was preventing us from properly establishing the capabilities of
a property wrapper.

Fixes rdar://problem/57350503 and several dupes.
