### PR TITLE
[ConstraintGraph] NFC: Adjustency list and equivalence class printing…

### DIFF
--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1350,7 +1350,7 @@ void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent,
              });
    for (auto adj : sortedAdjacencies) {
      out << ' ';
-     adj->print(out);
+     adj->print(out, PO);
 
      const auto info = AdjacencyInfo.lookup(adj);
      auto degree = info.NumConstraints;
@@ -1389,7 +1389,7 @@ void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent,
     out << "Equivalence class:";
     for (unsigned i = 1, n = EquivalenceClass.size(); i != n; ++i) {
       out << ' ';
-      EquivalenceClass[i]->print(out);
+      EquivalenceClass[i]->print(out, PO);
     }
     out << "\n";
   }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3540,7 +3540,7 @@ void Solution::dump(raw_ostream &out) const {
     out.indent(2);
     Type(typeVar).print(out, PO);
     out << " as ";
-    binding.second.print(out);
+    binding.second.print(out, PO);
     if (auto *locator = typeVar->getImpl().getLocator()) {
       out << " @ ";
       locator->dump(sm, out);


### PR DESCRIPTION
… should respect printing flags

This is a follow-up to https://github.com/apple/swift/pull/28336 which fixes a couple more places 
where `PrintOptions` haven't been properly propagated which leads to type variables being printed as `_`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
