### PR TITLE
[Serialization & ClangImporter] Filter decl to deserialize by their `@objc` attributes

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -159,9 +159,10 @@ public:
   ///
   /// \param Results Vector collecting the decls.
   ///
-  /// \param matchAttributes Check on the attributes of a decl to
-  /// filter which decls to fully deserialize. Only decls with accepted
-  /// attributes are deserialized and added to Results.
+  /// \param matchAttributes Check on the attributes of a decl to keep only
+  /// decls with matching attributes. The subclass SerializedASTFile checks the
+  /// attributes first to only deserialize decls with accepted attributes,
+  /// limiting deserialization work.
   virtual void
   getTopLevelDeclsWhereAttributesMatch(
               SmallVectorImpl<Decl*> &Results,

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -152,6 +152,20 @@ public:
   /// The order of the results is not guaranteed to be meaningful.
   virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {}
 
+  /// Finds top-level decls in this file filtered by their attributes.
+  ///
+  /// This does a simple local lookup, not recursively looking through imports.
+  /// The order of the results is not guaranteed to be meaningful.
+  ///
+  /// \param Results Vector collecting the decls.
+  ///
+  /// \param matchAttributes Check on the attributes of a decl to
+  /// filter which decls to fully deserialize. Only decls with accepted
+  /// attributes are deserialized and added to Results.
+  virtual void
+  getTopLevelDeclsWhereAttributesMatch(
+              SmallVectorImpl<Decl*> &Results,
+              llvm::function_ref<bool(DeclAttributes)> matchAttributes) const;
 
   /// Finds all precedence group decls in this file.
   ///

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -476,6 +476,20 @@ public:
   /// The order of the results is not guaranteed to be meaningful.
   void getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const;
 
+  /// Finds top-level decls of this module filtered by their attributes.
+  ///
+  /// This does a simple local lookup, not recursively looking through imports.
+  /// The order of the results is not guaranteed to be meaningful.
+  ///
+  /// \param Results Vector collecting the decls.
+  ///
+  /// \param matchAttributes Check on the attributes of a decl to
+  /// filter which decls to fully deserialize. Only decls with accepted
+  /// attributes are deserialized and added to Results.
+  void getTopLevelDeclsWhereAttributesMatch(
+               SmallVectorImpl<Decl*> &Results,
+               llvm::function_ref<bool(DeclAttributes)> matchAttributes) const;
+
   /// Finds all local type decls of this module.
   ///
   /// This does a simple local lookup, not recursively looking through imports.

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -352,6 +352,11 @@ public:
   virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
 
   virtual void
+  getTopLevelDeclsWhereAttributesMatch(
+      SmallVectorImpl<Decl*> &Results,
+      llvm::function_ref<bool(DeclAttributes)> matchAttributes) const override;
+
+  virtual void
   getPrecedenceGroups(SmallVectorImpl<PrecedenceGroupDecl*> &Results) const override;
 
   virtual void

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -136,6 +136,8 @@ const char TypeError::ID = '\0';
 void TypeError::anchor() {}
 const char ExtensionError::ID = '\0';
 void ExtensionError::anchor() {}
+const char DeclAttributesDidNotMatch::ID = '\0';
+void DeclAttributesDidNotMatch::anchor() {}
 
 /// Skips a single record in the bitstream.
 ///
@@ -2280,7 +2282,8 @@ public:
   /// passing each one to AddAttribute.
   llvm::Error deserializeDeclAttributes();
 
-  Expected<Decl *> getDeclCheckedImpl();
+  Expected<Decl *> getDeclCheckedImpl(
+    llvm::function_ref<bool(DeclAttributes)> matchAttributes = nullptr);
 
   Expected<Decl *> deserializeTypeAlias(ArrayRef<uint64_t> scratch,
                                         StringRef blobData) {
@@ -3855,7 +3858,9 @@ public:
 };
 
 Expected<Decl *>
-ModuleFile::getDeclChecked(DeclID DID) {
+ModuleFile::getDeclChecked(
+    DeclID DID,
+    llvm::function_ref<bool(DeclAttributes)> matchAttributes) {
   if (DID == 0)
     return nullptr;
 
@@ -3868,9 +3873,14 @@ ModuleFile::getDeclChecked(DeclID DID) {
     fatalIfNotSuccess(DeclTypeCursor.JumpToBit(declOrOffset));
 
     Expected<Decl *> deserialized =
-      DeclDeserializer(*this, declOrOffset).getDeclCheckedImpl();
+      DeclDeserializer(*this, declOrOffset).getDeclCheckedImpl(
+        matchAttributes);
     if (!deserialized)
       return deserialized;
+  } else if (matchAttributes) {
+    // Decl was cached but we may need to filter it
+    if (!matchAttributes(declOrOffset.get()->getAttrs()))
+      return llvm::make_error<DeclAttributesDidNotMatch>();
   }
 
   // Tag every deserialized ValueDecl coming out of getDeclChecked with its ID.
@@ -4181,13 +4191,23 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
 }
 
 Expected<Decl *>
-DeclDeserializer::getDeclCheckedImpl() {
-  if (auto s = ctx.Stats)
-    s->getFrontendCounters().NumDeclsDeserialized++;
+DeclDeserializer::getDeclCheckedImpl(
+  llvm::function_ref<bool(DeclAttributes)> matchAttributes) {
 
   auto attrError = deserializeDeclAttributes();
   if (attrError)
     return std::move(attrError);
+
+  if (matchAttributes) {
+    // Deserialize the full decl only if matchAttributes finds a match.
+    DeclAttributes attrs = DeclAttributes();
+    attrs.setRawAttributeChain(DAttrs);
+    if (!matchAttributes(attrs))
+      return llvm::make_error<DeclAttributesDidNotMatch>();
+  }
+
+  if (auto s = ctx.Stats)
+    s->getFrontendCounters().NumDeclsDeserialized++;
 
   // FIXME: @_dynamicReplacement(for:) includes a reference to another decl,
   // usually in the same type, and that can result in this decl being

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -411,6 +411,26 @@ public:
   }
 };
 
+// Decl was not deserialized because its attributes did not match the filter.
+//
+// \sa getDeclChecked
+class DeclAttributesDidNotMatch : public llvm::ErrorInfo<DeclAttributesDidNotMatch> {
+  friend ErrorInfo;
+  static const char ID;
+  void anchor() override;
+
+public:
+  DeclAttributesDidNotMatch() {}
+
+  void log(raw_ostream &OS) const override {
+    OS << "Decl attributes did not match filter";
+  }
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+
 LLVM_NODISCARD
 static inline std::unique_ptr<llvm::ErrorInfoBase>
 takeErrorInfo(llvm::Error error) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -786,7 +786,15 @@ public:
   void collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const;
 
   /// Adds all top-level decls to the given vector.
-  void getTopLevelDecls(SmallVectorImpl<Decl*> &Results);
+  ///
+  /// \param Results Vector collecting the decls.
+  ///
+  /// \param matchAttributes Optional check on the attributes of a decl to
+  /// filter which decls to fully deserialize. Only decls with accepted
+  /// attributes are deserialized and added to Results.
+  void getTopLevelDecls(
+         SmallVectorImpl<Decl*> &Results,
+         llvm::function_ref<bool(DeclAttributes)> matchAttributes = nullptr);
 
   /// Adds all precedence groups to the given vector.
   void getPrecedenceGroups(SmallVectorImpl<PrecedenceGroupDecl*> &Results);
@@ -888,8 +896,15 @@ public:
   /// Returns the decl with the given ID, deserializing it if needed.
   ///
   /// \param DID The ID for the decl within this module.
+  ///
+  /// \param matchAttributes Optional check on the attributes of the decl to
+  /// determine if it should be fully deserialized and returned. If the
+  /// attributes fail the check, the decl is not deserialized and
+  /// \c DeclAttributesDidNotMatch is returned.
   llvm::Expected<Decl *>
-  getDeclChecked(serialization::DeclID DID);
+  getDeclChecked(
+    serialization::DeclID DID,
+    llvm::function_ref<bool(DeclAttributes)> matchAttributes = nullptr);
 
   /// Returns the decl context with the given ID, deserializing it if needed.
   DeclContext *getDeclContext(serialization::DeclContextID DID);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1120,6 +1120,12 @@ SerializedASTFile::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
   File.getTopLevelDecls(results);
 }
 
+void SerializedASTFile::getTopLevelDeclsWhereAttributesMatch(
+              SmallVectorImpl<Decl*> &results,
+              llvm::function_ref<bool(DeclAttributes)> matchAttributes) const {
+  File.getTopLevelDecls(results, matchAttributes);
+}
+
 void SerializedASTFile::getPrecedenceGroups(
        SmallVectorImpl<PrecedenceGroupDecl*> &results) const {
   File.getPrecedenceGroups(results);


### PR DESCRIPTION
Add an alternative to getTopLevelDecls and getDeclChecked to limit which decls are deserialized by first looking at their attributes. If the attributes are accepted by a function passed as argument the decl is fully deserialized, otherwise it is ignored.

The filter is included in the signature of existing functions in the Serilalization services, but I’ve added new methods for it in FileUnit and its subclasses to leave existing implementations untouched.

This filter could be useful to address two issues:
- Included in this PR is a fix for a cycle where a general access to all top level decls lead the deserialization to call ClangImporter which triggered more deserialization. It crashed the compiler in a complex case so only limiting what is deserialized should be enough to fix this for now. rdar://problem/57118844
- Crashes in deserialization of modules using @_implementationOnly imports, most of these fail on the indexing phase trying to deserialize private decls which could be skipped if we filter by their attributes.

There are other instances of decl filtering after a call to getTopLevelDecls that are mainly filtering by Decl type. This could also be integrated in the filter functions to cover those cases and it would be worth investigating a possible performance gain.