### PR TITLE
Drop the requirement that nested types be clang::TypeDecls

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2906,12 +2906,11 @@ ClangModuleUnit::lookupNestedType(Identifier name,
     // If the entry is not visible, skip it.
     if (!isVisibleClangEntry(clangCtx, entry)) continue;
 
-    auto clangDecl = entry.dyn_cast<clang::NamedDecl *>();
-    auto clangTypeDecl = dyn_cast_or_null<clang::TypeDecl>(clangDecl);
-    if (!clangTypeDecl)
+    auto *clangDecl = entry.dyn_cast<clang::NamedDecl *>();
+    if (!clangDecl)
       continue;
 
-    clangTypeDecl = cast<clang::TypeDecl>(clangTypeDecl->getMostRecentDecl());
+    const auto *clangTypeDecl = clangDecl->getMostRecentDecl();
 
     bool anyMatching = false;
     TypeDecl *originalDecl = nullptr;


### PR DESCRIPTION
The nested types table contains more than just nested typedefs and aggregate decls, it also contains classes that we've imported under nested names.  We were previously falling back to direct lookup to resolve (cross) references to these entities.  Instead, relax the preconditions for searching the table.

This breaks a few cycles involving re-entrant calls to lookupDirect/lookupQualified through the ClangImporter.

Should be NFC, but we'll see.