### PR TITLE
[TypeChecker] User interface type while validating keypath dynamic su…

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1207,7 +1207,7 @@ bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
     return false;
 
   const auto *param = decl->getIndices()->get(0);
-  if (auto NTD = param->getType()->getAnyNominal()) {
+  if (auto NTD = param->getInterfaceType()->getAnyNominal()) {
     return NTD == ctx.getKeyPathDecl() ||
            NTD == ctx.getWritableKeyPathDecl() ||
            NTD == ctx.getReferenceWritableKeyPathDecl();


### PR DESCRIPTION
…bscript parameter

Avoid unnecessary parameter type substitutions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
