### PR TITLE
[silgen] When emitting a tuple, ignore values with .none ownership, not just trivial values.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -767,14 +767,15 @@ ManagedValue SILGenBuilder::createTuple(SILLocation loc, SILType type,
     return ManagedValue::forUnmanaged(result);
   }
 
-  // We need to look for the first non-trivial value and use that as our cleanup
-  // cloner value.
+  // We need to look for the first value without .none ownership and use that as
+  // our cleanup cloner value.
   auto iter = find_if(elements, [&](ManagedValue mv) -> bool {
-    return !mv.getType().isTrivial(getFunction());
+    return mv.getOwnershipKind() != ValueOwnershipKind::None;
   });
 
   llvm::SmallVector<SILValue, 8> forwardedValues;
-  // If we have all trivial values, then just create the tuple and return. No
+
+  // If we have all .none values, then just create the tuple and return. No
   // cleanups need to be cloned.
   if (iter == elements.end()) {
     llvm::transform(elements, std::back_inserter(forwardedValues),

--- a/test/SILGen/silgenbuilder_tuple_ownership.swift
+++ b/test/SILGen/silgenbuilder_tuple_ownership.swift
@@ -1,0 +1,49 @@
+// RUN: %target-swift-emit-silgen %s
+//
+// Just make sure that we do not trigger the ownership verifier on this code. We
+// were previously not emitting a destroy_value for (nil, error) since we were
+// seeing the .none for [String: Any]? and propagating that values ownership
+// rather than the error.
+
+public enum Outcome<T> {
+    case success(T)
+    case error(T?, Error)
+}
+
+public protocol RequestContentRepresentable {
+}
+
+public class HttpClient {
+    public func fetch(requestContent: RequestContentRepresentable, completionHandler: @escaping (Outcome<[String: Any]>) -> Void) throws {
+      fatalError()
+    }
+}
+
+public final class Future <ResultType> {
+  @discardableResult
+  public func finish(result: ResultType) -> Bool {
+    fatalError()
+  }
+}
+
+class Controller {
+  internal func test() {
+    let content2: RequestContentRepresentable? = nil
+    let content = content2!
+    let httpClient2: HttpClient? = nil
+    let httpClient: HttpClient = httpClient2!
+    
+    // Create a Future to encapsulate the response handler.
+    // This allows us to guarantee we only call it once.
+    // We set the handler in the success block and we fail the future if we should no longer be allowed to call the completion
+    let futureResponseHandler = Future<([String: Any]?, Error?)>()
+  
+    do {
+      try httpClient.fetch(requestContent: content) { (outcome) in
+      }
+    } catch let error {
+      // This is calling the future's success handler with a tuple.
+      futureResponseHandler.finish(result: (nil, error))
+    }
+  }
+}


### PR DESCRIPTION
Otherwise, if we have a tuple whose first parameter is a .none ownership
non-trivial enum, we will leak the other parameters due to us not providing a
cleanup on the created tuple.

rdar://56806959
