### PR TITLE
SIL: Plumb abstraction patterns through type lowering.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -872,7 +872,19 @@ public:
   /// True if this type contains archetypes that could be substituted with
   /// concrete types to form the argument type.
   bool isBindableTo(Type ty);
+  
+  /// Visit this type and the argument type in parallel, invoking the callback
+  /// function with each archetype-to-substituted-type binding. The callback
+  /// may return a new type to substitute into the result type, or return
+  /// CanType() to error out of the operation.
+  ///
+  /// Returns the substituted type, or a null CanType() if this type
+  /// is not bindable to the substituted type, or the callback returns
+  /// CanType().
+  CanType substituteBindingsTo(Type ty,
+         llvm::function_ref<CanType(ArchetypeType*, CanType)> substFn);
 
+  
   /// Determines whether this type is similar to \p other as defined by
   /// \p matchOptions.
   bool matches(Type other, TypeMatchOptions matchOptions);
@@ -4274,6 +4286,10 @@ public:
   SILType substInterfaceType(SILModule &M,
                              SILType interfaceType) const;
 
+  /// Return the unsubstituted function type equivalent to this type; that is, the type that has the same
+  /// argument and result types as `this` type after substitutions, if any.
+  CanSILFunctionType getUnsubstitutedType(SILModule &M) const;
+                                    
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, getSubstGenericSignature(), getExtInfo(), getCoroutineKind(),
             getCalleeConvention(), getParameters(), getYields(), getResults(),

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -242,7 +242,8 @@ public:
   ///
   /// This is equivalent to, but possibly faster than, calling
   /// tc.getTypeLowering(type).isAddressOnly().
-  static bool isAddressOnly(CanType type, Lowering::TypeConverter &tc,
+  static bool isAddressOnly(CanType type,
+                            Lowering::TypeConverter &tc,
                             CanGenericSignature sig,
                             TypeExpansionContext expansion);
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1544,33 +1544,41 @@ bool TypeBase::isExactSuperclassOf(Type ty) {
   return false;
 }
 
-/// Returns true if type `a` has archetypes that can be bound to form `b`.
-bool TypeBase::isBindableTo(Type b) {
-  class IsBindableVisitor : public TypeVisitor<IsBindableVisitor, bool, CanType>
-  {
-    llvm::DenseMap<ArchetypeType *, CanType> Bindings;
-
-  public:
-    IsBindableVisitor() {}
+namespace {
+class IsBindableVisitor
+  : public TypeVisitor<IsBindableVisitor, CanType, CanType>
+{
+public:
+  llvm::function_ref<CanType (ArchetypeType *, CanType)> VisitBinding;
+  llvm::DenseMap<ArchetypeType *, CanType> Bindings;
   
-    bool visitArchetypeType(ArchetypeType *orig, CanType subst) {
-      // If we already bound this archetype, make sure the new binding candidate
-      // is the same type.
-      auto bound = Bindings.find(orig);
-      if (bound != Bindings.end()) {
-        return bound->second->isEqual(subst);
-      }
+  IsBindableVisitor(
+          llvm::function_ref<CanType (ArchetypeType *, CanType)> VisitBinding)
+    : VisitBinding(VisitBinding)
+  {}
 
+  CanType visitArchetypeType(ArchetypeType *orig, CanType subst) {
+    // If we already bound this archetype, make sure the new binding candidate
+    // is the same type.
+    auto bound = Bindings.find(orig);
+    if (bound != Bindings.end()) {
+      if (!bound->second->isEqual(subst))
+        return CanType();
+      
+      return VisitBinding(orig, subst);
+    }
+
+    if (!subst->isTypeParameter()) {
       // Check that the archetype isn't constrained in a way that makes the
       // binding impossible.
       // For instance, if the archetype is class-constrained, and the binding
       // is not a class, it can never be bound.
       if (orig->requiresClass() && !subst->satisfiesClassConstraint())
-        return false;
+        return CanType();
 
       if (auto superclass = orig->getSuperclass())
         if (!superclass->isBindableToSuperclassOf(subst))
-          return false;
+          return CanType();
 
       // TODO: If the archetype has a superclass constraint, check that the
       // substitution is a subclass.
@@ -1580,207 +1588,302 @@ bool TypeBase::isBindableTo(Type b) {
       
       // Otherwise, there may be an external retroactive conformance that
       // allows the binding.
-      
-      // Remember the binding, and succeed.
-      Bindings.insert({orig, subst});
-      return true;
     }
-    
-    bool visitType(TypeBase *orig, CanType subst) {
-      if (CanType(orig) == subst)
-        return true;
-      
-      return false;
-    }
-    
-    bool visitNominalType(NominalType *nom, CanType subst) {
-      if (auto substNom = dyn_cast<NominalType>(subst)) {
-        if (nom->getDecl() != substNom->getDecl())
-          return false;
-        
-        if (nom->getDecl()->isInvalid())
-          return false;
-        
-        // Same decl should always either have or not have a parent.
-        assert((bool)nom->getParent() == (bool)substNom->getParent());
-        
-        if (nom->getParent())
-          return visit(nom->getParent()->getCanonicalType(),
-                       substNom->getParent()->getCanonicalType());
-        return true;
-      }
-      return false;
-    }
-    
-    bool visitAnyMetatypeType(AnyMetatypeType *meta, CanType subst) {
-      if (auto substMeta = dyn_cast<AnyMetatypeType>(subst)) {
-        if (substMeta->getKind() != meta->getKind())
-          return false;
-        return visit(meta->getInstanceType()->getCanonicalType(),
-                     substMeta->getInstanceType()->getCanonicalType());
-      }
-      return false;
-    }
-    
-    bool visitTupleType(TupleType *tuple, CanType subst) {
-      if (auto substTuple = dyn_cast<TupleType>(subst)) {
-        // Tuple elements must match.
-        if (tuple->getNumElements() != substTuple->getNumElements())
-          return false;
-        // TODO: Label reordering?
-        for (unsigned i : indices(tuple->getElements())) {
-          auto elt = tuple->getElements()[i],
-               substElt = substTuple->getElements()[i];
-          if (elt.getName() != substElt.getName())
-            return false;
-          if (!visit(elt.getType(), substElt.getType()->getCanonicalType()))
-            return false;
-        }
-        return true;
-      }
-      return false;
-    }
-    
-    bool visitDependentMemberType(DependentMemberType *dt, CanType subst) {
-      return true;
-    }
-    bool visitGenericTypeParamType(GenericTypeParamType *dt, CanType subst) {
-      return true;
-    }
-    
-    bool visitFunctionType(FunctionType *func, CanType subst) {
-      if (auto substFunc = dyn_cast<FunctionType>(subst)) {
-        if (func->getExtInfo() != substFunc->getExtInfo())
-          return false;
-        
-        if (func->getParams().size() != substFunc->getParams().size())
-          return false;
-
-        for (unsigned i : indices(func->getParams())) {
-          if (!visit(func->getParams()[i].getOldType(),
-                     substFunc.getParams()[i].getOldType()))
-            return false;
-        }
-        
-        return visit(func->getResult()->getCanonicalType(),
-                     substFunc->getResult()->getCanonicalType());
-      }
-      return false;
-    }
-    
-    bool visitSILFunctionType(SILFunctionType *func,
-                              CanType subst) {
-      if (auto substFunc = dyn_cast<SILFunctionType>(subst)) {
-        if (func->getExtInfo() != substFunc->getExtInfo())
-          return false;
-        
-        // Compare substituted function types.
-        if (func->getSubstGenericSignature()
-            || substFunc->getSubstGenericSignature()) {
-          if (func->getSubstGenericSignature()
-                != substFunc->getSubstGenericSignature())
-            return false;
-          
-          auto sig = func->getSubstGenericSignature();
-          
-          auto origSubs = func->getSubstitutions();
-          auto substSubs = substFunc->getSubstitutions();
-          
-          if (!origSubs || !substSubs)
-            return false;
-          
-          for (unsigned i : indices(origSubs.getReplacementTypes())) {
-            if (!visit(origSubs.getReplacementTypes()[i]->getCanonicalType(sig),
-                     substSubs.getReplacementTypes()[i]->getCanonicalType(sig)))
-              return false;
-          }
-          
-          return true;
-        }
-        
-        if (func->getParameters().size() != substFunc->getParameters().size())
-          return false;
-        if (func->getResults().size() != substFunc->getResults().size())
-          return false;
-        
-        for (unsigned i : indices(func->getParameters())) {
-          if (func->getParameters()[i].getConvention()
-                != substFunc->getParameters()[i].getConvention())
-            return false;
-          if (!visit(func->getParameters()[i].getInterfaceType(),
-                     substFunc->getParameters()[i].getInterfaceType()))
-            return false;
-        }
-
-        for (unsigned i : indices(func->getResults())) {
-          if (func->getResults()[i].getConvention()
-              != substFunc->getResults()[i].getConvention())
-            return false;
-
-          if (!visit(func->getResults()[i].getInterfaceType(),
-                     substFunc->getResults()[i].getInterfaceType()))
-            return false;
-        }
-        
-        return true;
-      }
-      
-      return false;
-    }
-    
-    bool visitBoundGenericType(BoundGenericType *bgt, CanType subst) {
-      if (auto substBGT = dyn_cast<BoundGenericType>(subst)) {
-        if (bgt->getDecl() != substBGT->getDecl())
-          return false;
-
-        auto *decl = bgt->getDecl();
-        if (decl->isInvalid())
-          return false;
-
-        auto *moduleDecl = decl->getParentModule();
-        auto origSubMap = bgt->getContextSubstitutionMap(
-            moduleDecl, decl, decl->getGenericEnvironment());
-        auto substSubMap = substBGT->getContextSubstitutionMap(
-            moduleDecl, decl, decl->getGenericEnvironment());
-
-        auto genericSig = decl->getGenericSignature();
-        for (auto gp : genericSig->getGenericParams()) {
-          auto orig = Type(gp).subst(origSubMap)->getCanonicalType();
-          auto subst = Type(gp).subst(substSubMap)->getCanonicalType();
-          if (!visit(orig, subst))
-            return false;
-        }
-
-        for (const auto &req : genericSig->getRequirements()) {
-          if (req.getKind() != RequirementKind::Conformance) continue;
-
-          auto canTy = req.getFirstType()->getCanonicalType();
-          auto *proto = req.getSecondType()->castTo<ProtocolType>()->getDecl();
-          auto origConf = origSubMap.lookupConformance(canTy, proto);
-          auto substConf = substSubMap.lookupConformance(canTy, proto);
-
-          if (origConf.isConcrete()) {
-            if (!substConf.isConcrete())
-              return false;
-            if (origConf.getConcrete()->getRootConformance()
-                  != substConf.getConcrete()->getRootConformance())
-              return false;
-          }
-        }
-
-        // Same decl should always either have or not have a parent.
-        assert((bool)bgt->getParent() == (bool)substBGT->getParent());
-        if (bgt->getParent())
-          return visit(bgt->getParent()->getCanonicalType(),
-                       substBGT->getParent()->getCanonicalType());
-        return true;
-      }
-      return false;
-    }
-  };
+    // Remember the binding, and succeed.
+    Bindings.insert({orig, subst});
+    return VisitBinding(orig, subst);
+  }
   
-  return IsBindableVisitor().visit(getCanonicalType(),
-                                   b->getCanonicalType());
+  CanType visitType(TypeBase *orig, CanType subst) {
+    if (CanType(orig) == subst)
+      return subst;
+    
+    return CanType();
+  }
+  
+  CanType visitNominalType(NominalType *nom, CanType subst) {
+    if (auto substNom = dyn_cast<NominalType>(subst)) {
+      if (nom->getDecl() != substNom->getDecl())
+        return CanType();
+      
+      if (nom->getDecl()->isInvalid())
+        return CanType();
+      
+      // Same decl should always either have or not have a parent.
+      assert((bool)nom->getParent() == (bool)substNom->getParent());
+      
+      if (nom->getParent()) {
+        auto substParent = visit(nom->getParent()->getCanonicalType(),
+                                 substNom->getParent()->getCanonicalType());
+        if (substParent == substNom.getParent())
+          return subst;
+        return NominalType::get(nom->getDecl(), substParent,
+                                nom->getASTContext())
+          ->getCanonicalType();
+      }
+      return subst;
+    }
+    return CanType();
+  }
+  
+  CanType visitAnyMetatypeType(AnyMetatypeType *meta, CanType subst) {
+    if (auto substMeta = dyn_cast<AnyMetatypeType>(subst)) {
+      if (substMeta->getKind() != meta->getKind())
+        return CanType();
+      
+      auto substInstance = visit(meta->getInstanceType()->getCanonicalType(),
+                             substMeta->getInstanceType()->getCanonicalType());
+      if (!substInstance)
+        return CanType();
+      
+      if (substInstance == substMeta.getInstanceType())
+        return subst;
+      
+      return isa<ExistentialMetatypeType>(substMeta)
+        ? CanType(CanExistentialMetatypeType::get(substInstance))
+        : CanType(CanMetatypeType::get(substInstance));
+    }
+    return CanType();
+  }
+  
+  CanType visitTupleType(TupleType *tuple, CanType subst) {
+    if (auto substTuple = dyn_cast<TupleType>(subst)) {
+      // Tuple elements must match.
+      if (tuple->getNumElements() != substTuple->getNumElements())
+        return CanType();
+      // TODO: Label reordering?
+      SmallVector<TupleTypeElt, 4> newElements;
+      bool didChange = false;
+      for (unsigned i : indices(tuple->getElements())) {
+        auto elt = tuple->getElements()[i],
+             substElt = substTuple->getElements()[i];
+        if (elt.getName() != substElt.getName())
+          return CanType();
+        auto newElt = visit(elt.getType(),
+                            substElt.getType()->getCanonicalType());
+        if (!newElt)
+          return CanType();
+        newElements.push_back(substElt.getWithType(newElt));
+        didChange = didChange | (newElt != CanType(substElt.getType()));
+      }
+      if (!didChange)
+        return subst;
+      return TupleType::get(newElements, subst->getASTContext())
+        ->getCanonicalType();
+    }
+    return CanType();
+  }
+  
+  CanType visitDependentMemberType(DependentMemberType *dt, CanType subst) {
+    return subst;
+  }
+  CanType visitGenericTypeParamType(GenericTypeParamType *dt, CanType subst) {
+    return subst;
+  }
+  
+  CanType visitFunctionType(FunctionType *func, CanType subst) {
+    if (auto substFunc = dyn_cast<FunctionType>(subst)) {
+      if (func->getExtInfo() != substFunc->getExtInfo())
+        return CanType();
+      
+      if (func->getParams().size() != substFunc->getParams().size())
+        return CanType();
+
+      SmallVector<AnyFunctionType::Param, 4> newParams;
+      bool didChange = false;
+      for (unsigned i : indices(func->getParams())) {
+        auto param = func->getParams()[i];
+        auto substParam = substFunc.getParams()[i];
+        if (param.getParameterFlags() != substParam.getParameterFlags())
+          return CanType();
+        
+        auto newParamTy =
+          visit(param.getPlainType(), substParam.getPlainType());
+        if (!newParamTy)
+          return CanType();
+        
+        newParams.push_back(substParam.withType(newParamTy));
+        didChange = didChange | (newParamTy != substParam.getPlainType());
+      }
+      
+      auto newReturn = visit(func->getResult()->getCanonicalType(),
+                             substFunc->getResult()->getCanonicalType());
+      if (!newReturn)
+        return CanType();
+      if (!didChange && newReturn == substFunc.getResult())
+        return subst;
+      return FunctionType::get(newParams, newReturn)
+        ->getCanonicalType();
+    }
+    return CanType();
+  }
+  
+  CanType visitSILFunctionType(SILFunctionType *func,
+                            CanType subst) {
+    if (auto substFunc = dyn_cast<SILFunctionType>(subst)) {
+      if (func->getExtInfo() != substFunc->getExtInfo())
+        return CanType();
+      
+      // Compare substituted function types.
+      if (func->getSubstGenericSignature()
+          || substFunc->getSubstGenericSignature()) {
+        if (func->getSubstGenericSignature()
+              != substFunc->getSubstGenericSignature())
+          return CanType();
+        
+        auto sig = func->getSubstGenericSignature();
+        
+        auto origSubs = func->getSubstitutions();
+        auto substSubs = substFunc->getSubstitutions();
+        
+        if (!origSubs || !substSubs)
+          return CanType();
+        
+        for (unsigned i : indices(origSubs.getReplacementTypes())) {
+          auto origType =
+            origSubs.getReplacementTypes()[i]->getCanonicalType(sig);
+          auto substType =
+            substSubs.getReplacementTypes()[i]->getCanonicalType(sig);
+          
+          auto newType = visit(origType, substType);
+          
+          if (!newType)
+            return CanType();
+          
+          // We can test SILFunctionTypes for bindability, but we can't
+          // transform them.
+          assert(newType == substType
+                 && "cannot transform SILFunctionTypes");
+        }
+        
+        return subst;
+      }
+      
+      if (func->getParameters().size() != substFunc->getParameters().size())
+        return CanType();
+      if (func->getResults().size() != substFunc->getResults().size())
+        return CanType();
+      
+      for (unsigned i : indices(func->getParameters())) {
+        if (func->getParameters()[i].getConvention()
+              != substFunc->getParameters()[i].getConvention())
+          return CanType();
+        
+        auto origParam = func->getParameters()[i].getInterfaceType();
+        auto substParam = substFunc->getParameters()[i].getInterfaceType();
+        auto newParam = visit(origParam, substParam);
+        if (!newParam)
+          return CanType();
+        
+        // We can test SILFunctionTypes for bindability, but we can't
+        // transform them.
+        assert(newParam == substParam
+               && "cannot transform SILFunctionTypes");
+      }
+
+      for (unsigned i : indices(func->getResults())) {
+        if (func->getResults()[i].getConvention()
+            != substFunc->getResults()[i].getConvention())
+          return CanType();
+
+        auto origResult = func->getResults()[i].getInterfaceType();
+        auto substResult = substFunc->getResults()[i].getInterfaceType();
+        auto newResult = visit(origResult, substResult);
+        if (!newResult)
+          return CanType();
+
+        // We can test SILFunctionTypes for bindability, but we can't
+        // transform them.
+        assert(newResult == substResult
+               && "cannot transform SILFunctionTypes");
+      }
+      
+      return subst;
+    }
+    
+    return CanType();
+  }
+  
+  CanType visitBoundGenericType(BoundGenericType *bgt, CanType subst) {
+    if (auto substBGT = dyn_cast<BoundGenericType>(subst)) {
+      if (bgt->getDecl() != substBGT->getDecl())
+        return CanType();
+
+      auto *decl = bgt->getDecl();
+      if (decl->isInvalid())
+        return CanType();
+
+      auto *moduleDecl = decl->getParentModule();
+      auto origSubMap = bgt->getContextSubstitutionMap(
+          moduleDecl, decl, decl->getGenericEnvironment());
+      auto substSubMap = substBGT->getContextSubstitutionMap(
+          moduleDecl, decl, decl->getGenericEnvironment());
+
+      auto genericSig = decl->getGenericSignature();
+      
+      SmallVector<Type, 4> newParams;
+      bool didChange = false;
+      for (auto gp : genericSig->getGenericParams()) {
+        auto orig = Type(gp).subst(origSubMap)->getCanonicalType();
+        auto subst = Type(gp).subst(substSubMap)->getCanonicalType();
+        
+        auto newParam = visit(orig, subst);
+        if (!newParam)
+          return CanType();
+        
+        newParams.push_back(newParam);
+        didChange = didChange | (newParam != subst);
+      }
+
+      for (const auto &req : genericSig->getRequirements()) {
+        if (req.getKind() != RequirementKind::Conformance) continue;
+
+        auto canTy = req.getFirstType()->getCanonicalType();
+        auto *proto = req.getSecondType()->castTo<ProtocolType>()->getDecl();
+        auto origConf = origSubMap.lookupConformance(canTy, proto);
+        auto substConf = substSubMap.lookupConformance(canTy, proto);
+
+        if (origConf.isConcrete()) {
+          if (!substConf.isConcrete())
+            return CanType();
+          if (origConf.getConcrete()->getRootConformance()
+                != substConf.getConcrete()->getRootConformance())
+            return CanType();
+        }
+      }
+
+      // Same decl should always either have or not have a parent.
+      assert((bool)bgt->getParent() == (bool)substBGT->getParent());
+      CanType newParent;
+      if (bgt->getParent()) {
+        newParent = visit(bgt->getParent()->getCanonicalType(),
+                          substBGT->getParent()->getCanonicalType());
+      }
+      
+      if (!didChange && newParent == substBGT.getParent())
+        return subst;
+      
+      return BoundGenericType::get(substBGT->getDecl(),
+                                   newParent, newParams)
+        ->getCanonicalType();
+    }
+    return CanType();
+  }
+};
+}
+
+CanType TypeBase::substituteBindingsTo(Type ty,
+                llvm::function_ref<CanType(ArchetypeType*, CanType)> substFn) {
+  return IsBindableVisitor(substFn)
+    .visit(getCanonicalType(), ty->getCanonicalType());
+}
+
+bool TypeBase::isBindableTo(Type ty) {
+  return !substituteBindingsTo(ty,
+    [&](ArchetypeType *archetype, CanType binding) -> CanType {
+      return binding;
+    })
+    .isNull();
 }
 
 bool TypeBase::isBindableToSuperclassOf(Type ty) {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1262,13 +1262,11 @@ TypeConverter::~TypeConverter() {
   }
 }
 
-void TypeConverter::pushGenericContext(CanGenericSignature signature) {
+void TypeConverter::setGenericContext(CanGenericSignature signature) {
   if (!signature)
     return;
   
-  // Push the generic context down to the SIL TypeConverter, so we can share
-  // archetypes with SIL.
-  IGM.getSILTypes().pushGenericContext(signature);
+  CurGenericSignature = signature;
 
   // Clear the dependent type info cache since we have a new active signature
   // now.
@@ -1277,21 +1275,12 @@ void TypeConverter::pushGenericContext(CanGenericSignature signature) {
   Types.getCacheFor(/*isDependent*/ true, Mode::CompletelyFragile).clear();
 }
 
-void TypeConverter::popGenericContext(CanGenericSignature signature) {
-  if (!signature)
-    return;
-
-  // Pop the SIL TypeConverter's generic context too.
-  IGM.getSILTypes().popGenericContext(signature);
-  
-  Types.getCacheFor(/*isDependent*/ true, Mode::Normal).clear();
-  Types.getCacheFor(/*isDependent*/ true, Mode::Legacy).clear();
-  Types.getCacheFor(/*isDependent*/ true, Mode::CompletelyFragile).clear();
+CanGenericSignature IRGenModule::getCurGenericContext() {
+  return Types.getCurGenericContext();
 }
 
 GenericEnvironment *TypeConverter::getGenericEnvironment() {
-  auto genericSig = IGM.getSILTypes().getCurGenericContext();
-  return genericSig->getCanonicalSignature()->getGenericEnvironment();
+  return CurGenericSignature->getGenericEnvironment();
 }
 
 GenericEnvironment *IRGenModule::getGenericEnvironment() {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -841,7 +841,7 @@ private:
                    llvm::DINode::DIFlags Flags, unsigned &SizeInBits) {
     SmallVector<llvm::Metadata *, 16> Elements;
     unsigned OffsetInBits = 0;
-    auto genericSig = IGM.getSILTypes().getCurGenericContext();
+    auto genericSig = IGM.getCurGenericContext();
     for (auto ElemTy : TupleTy->getElementTypes()) {
       auto &elemTI = IGM.getTypeInfoForUnlowered(
           AbstractionPattern(genericSig, ElemTy->getCanonicalType()), ElemTy);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -858,7 +858,7 @@ public:
 
 private:
   TypeConverter &Types;
-  friend class TypeConverter;
+  friend TypeConverter;
 
   const clang::ASTContext *ClangASTContext;
   ClangTypeConverter *ClangTypes;
@@ -1423,6 +1423,10 @@ public:
 
   Address getAddrOfObjCISAMask();
 
+  /// Retrieve the generic signature for the current generic context, or null if no
+  /// generic environment is active.
+  CanGenericSignature getCurGenericContext();
+  
   /// Retrieve the generic environment for the current generic context.
   ///
   /// Fails if there is no generic context.

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -3175,9 +3175,6 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SmallVector<SILValue, 4> operands;
     
     if (P.consumeIf(tok::l_paren)) {
-      Lowering::GenericContextScope scope(SILMod.Types,
-        patternEnv ? patternEnv->getGenericSignature()->getCanonicalSignature()
-                   : nullptr);
       while (true) {
         SILValue v;
         

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -258,7 +258,7 @@ SILType SILFunction::getLoweredLoadableType(Type t) const {
 }
 
 const TypeLowering &SILFunction::getTypeLowering(SILType type) const {
-  return getModule().Types.getTypeLowering(type, TypeExpansionContext(*this));
+  return getModule().Types.getTypeLowering(type, *this);
 }
 
 SILType SILFunction::getLoweredType(SILType t) const {

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -81,7 +81,9 @@ SILType SILType::getSILTokenType(const ASTContext &C) {
 }
 
 bool SILType::isTrivial(const SILFunction &F) const {
-  return F.getTypeLowering(*this).isTrivial();
+  auto contextType = hasTypeParameter() ? F.mapTypeIntoContext(*this) : *this;
+  
+  return F.getTypeLowering(contextType).isTrivial();
 }
 
 bool SILType::isReferenceCounted(SILModule &M) const {
@@ -195,7 +197,9 @@ bool SILType::isLoadableOrOpaque(const SILFunction &F) const {
 }
 
 bool SILType::isAddressOnly(const SILFunction &F) const {
-  return F.getTypeLowering(*this).isAddressOnly();
+  auto contextType = hasTypeParameter() ? F.mapTypeIntoContext(*this) : *this;
+    
+  return F.getTypeLowering(contextType).isAddressOnly();
 }
 
 SILType SILType::substGenericArgs(SILModule &M, SubstitutionMap SubMap,
@@ -393,20 +397,24 @@ SILType SILType::mapTypeOutOfContext() const {
 CanType swift::getSILBoxFieldLoweredType(TypeExpansionContext context,
                                          SILBoxType *type, TypeConverter &TC,
                                          unsigned index) {
-  auto fieldTy = type->getLayout()->getFields()[index].getLoweredType();
+  auto fieldTy = SILType::getPrimitiveObjectType(
+    type->getLayout()->getFields()[index].getLoweredType());
+  
+  // Map the type into the new expansion context, which might substitute opaque
+  // types.
+  auto sig = type->getLayout()->getGenericSignature();
+  fieldTy = TC.getTypeLowering(fieldTy, context, sig)
+              .getLoweredType();
   
   // Apply generic arguments if the layout is generic.
   if (auto subMap = type->getSubstitutions()) {
-    auto sig = type->getLayout()->getGenericSignature();
-    fieldTy = SILType::getPrimitiveObjectType(fieldTy)
-      .subst(TC,
-             QuerySubstitutionMap{subMap},
-             LookUpConformanceInSubstitutionMap(subMap),
-             sig)
-      .getASTType();
+    fieldTy = fieldTy.subst(TC,
+                            QuerySubstitutionMap{subMap},
+                            LookUpConformanceInSubstitutionMap(subMap),
+                            sig);
   }
-  fieldTy = TC.getLoweredType(fieldTy, context).getASTType();
-  return fieldTy;
+  
+  return fieldTy.getASTType();
 }
 
 ValueOwnershipKind

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -422,7 +422,6 @@ SILResultInfo::getOwnershipKind(SILFunction &F) const {
   auto &M = F.getModule();
   auto FTy = F.getLoweredFunctionType();
   auto sig = FTy->getInvocationGenericSignature();
-  GenericContextScope GCS(M.Types, sig);
 
   bool IsTrivial = getSILStorageType(M, FTy).isTrivial(F);
   switch (getConvention()) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4478,9 +4478,6 @@ public:
             "keypath value type should match value type of keypath pattern");
     
     {
-      Lowering::GenericContextScope scope(F.getModule().Types,
-                                          pattern->getGenericSignature());
-      
       for (auto &component : pattern->getComponents()) {
         bool hasIndices;
         switch (component.getKind()) {
@@ -5130,7 +5127,6 @@ void SILProperty::verify(const SILModule &M) const {
   }
 
   auto canSig = sig ? sig->getCanonicalSignature() : nullptr;
-  Lowering::GenericContextScope scope(M.Types, canSig);
 
   auto require = [&](bool reqt, StringRef message) {
       if (!reqt) {

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -135,22 +135,22 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
 using RecursiveProperties = TypeLowering::RecursiveProperties;
 
 static RecursiveProperties
-classifyType(CanType type, TypeConverter &TC, CanGenericSignature sig,
-             TypeExpansionContext expansion);
+classifyType(AbstractionPattern origType, CanType type,
+             TypeConverter &TC, TypeExpansionContext expansion);
 
 namespace {
   /// A CRTP helper class for doing things that depends on type
   /// classification.
   template <class Impl, class RetTy>
-  class TypeClassifierBase : public CanTypeVisitor<Impl, RetTy> {
+  class TypeClassifierBase
+    : public CanTypeVisitor<Impl, RetTy, AbstractionPattern>
+  {
     Impl &asImpl() { return *static_cast<Impl*>(this); }
   protected:
     TypeConverter &TC;
-    CanGenericSignature Sig;
     TypeExpansionContext Expansion;
-    TypeClassifierBase(TypeConverter &TC, CanGenericSignature Sig,
-                       TypeExpansionContext Expansion)
-      : TC(TC), Sig(Sig), Expansion(Expansion) {}
+    TypeClassifierBase(TypeConverter &TC, TypeExpansionContext Expansion)
+      : TC(TC), Expansion(Expansion) {}
 
   public:
     // The subclass should implement:
@@ -189,9 +189,9 @@ namespace {
       return asImpl().handle(type, RecursiveProperties::forReference());
     }
 
-#define IMPL(TYPE, LOWERING)                            \
-    RetTy visit##TYPE##Type(Can##TYPE##Type type) {     \
-      return asImpl().handle##LOWERING(type);        \
+#define IMPL(TYPE, LOWERING)                                                 \
+    RetTy visit##TYPE##Type(Can##TYPE##Type type, AbstractionPattern orig) { \
+      return asImpl().handle##LOWERING(type);                                \
     }
 
     IMPL(BuiltinInteger, Trivial)
@@ -210,12 +210,14 @@ namespace {
 #undef IMPL
 
     RetTy visitBuiltinUnsafeValueBufferType(
-                                         CanBuiltinUnsafeValueBufferType type) {
+                                         CanBuiltinUnsafeValueBufferType type,
+                                         AbstractionPattern origType) {
       return asImpl().handleAddressOnly(type, {IsNotTrivial, IsFixedABI,
                                                IsAddressOnly, IsNotResilient});
     }
 
-    RetTy visitAnyFunctionType(CanAnyFunctionType type) {
+    RetTy visitAnyFunctionType(CanAnyFunctionType type,
+                               AbstractionPattern origType) {
       switch (type->getRepresentation()) {
       case AnyFunctionType::Representation::Swift:
       case AnyFunctionType::Representation::Block:
@@ -227,7 +229,8 @@ namespace {
       llvm_unreachable("bad function representation");
     }
     
-    RetTy visitSILFunctionType(CanSILFunctionType type) {
+    RetTy visitSILFunctionType(CanSILFunctionType type,
+                               AbstractionPattern origType) {
       // Only escaping closures are references.
       bool isSwiftEscaping = type->getExtInfo().isNoEscape() &&
                              type->getExtInfo().getRepresentation() ==
@@ -238,67 +241,52 @@ namespace {
       return asImpl().handleTrivial(type);
     }
 
-    RetTy visitLValueType(CanLValueType type) {
+    RetTy visitLValueType(CanLValueType type,
+                          AbstractionPattern origType) {
       llvm_unreachable("shouldn't get an l-value type here");
     }
-    RetTy visitInOutType(CanInOutType type) {
+    RetTy visitInOutType(CanInOutType type,
+                         AbstractionPattern origType) {
       llvm_unreachable("shouldn't get an inout type here");
     }
-    RetTy visitErrorType(CanErrorType type) {
+    RetTy visitErrorType(CanErrorType type,
+                         AbstractionPattern origType) {
       return asImpl().handleTrivial(type);
     }
 
-    // Dependent types should be contextualized before visiting.
+    // Dependent types can be lowered according to their corresponding
+    // abstraction pattern.
 
-    CanGenericSignature getGenericSignature() {
-      if (Sig)
-        return Sig;
-      return TC.getCurGenericContext();
-    }
-
-    RetTy visitAbstractTypeParamType(CanType type) {
-      if (auto genericSig = getGenericSignature()) {
-        if (genericSig->requiresClass(type)) {
+    RetTy visitAbstractTypeParamType(CanType type,
+                                     AbstractionPattern origType) {
+      if (origType.isTypeParameterOrOpaqueArchetype()) {
+        if (origType.requiresClass()) {
           return asImpl().handleReference(type);
-        } else if (genericSig->isConcreteType(type)) {
-          return asImpl().visit(genericSig->getConcreteType(type)
-                                    ->getCanonicalType());
         } else {
           return asImpl().handleAddressOnly(type,
                                             RecursiveProperties::forOpaque());
         }
+      } else {
+        // If the abstraction pattern provides a concrete type, lower as that
+        // type. This can occur if the abstraction pattern provides a more
+        // constrained generic signature with more same-type constraints than
+        // the original declaration whose type we're lowering.
+        return asImpl().visit(origType.getType(), origType);
       }
-      llvm_unreachable("should have substituted dependent type into context");
-
     }
 
-    RetTy visitGenericTypeParamType(CanGenericTypeParamType type) {
-      return visitAbstractTypeParamType(type);
+    RetTy visitGenericTypeParamType(CanGenericTypeParamType type,
+                                    AbstractionPattern origType) {
+      return visitAbstractTypeParamType(type, origType);
     }
 
-    RetTy visitDependentMemberType(CanDependentMemberType type) {
-      return visitAbstractTypeParamType(type);
+    RetTy visitDependentMemberType(CanDependentMemberType type,
+                                   AbstractionPattern origType) {
+      return visitAbstractTypeParamType(type, origType);
     }
 
     Type getConcreteReferenceStorageReferent(Type type) {
       if (type->isTypeParameter()) {
-        auto signature = getGenericSignature();
-        assert(signature && "dependent type without generic signature?!");
-
-        if (auto concreteType = signature->getConcreteType(type))
-          return concreteType->getCanonicalType();
-
-        assert(signature->requiresClass(type));
-
-        // If we have a superclass bound, recurse on that.  This should
-        // always terminate: even if we allow
-        //   <T, U: T, V: U, ...>
-        // at some point the type-checker should prove acyclic-ness.
-        auto bound = signature->getSuperclassBound(type);
-        if (bound) {
-          return getConcreteReferenceStorageReferent(bound->getCanonicalType());
-        }
-
         return TC.Context.getAnyObjectType();
       }
 
@@ -306,50 +294,58 @@ namespace {
     }
 
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-    RetTy visit##Name##StorageType(Can##Name##StorageType type) { \
+    RetTy visit##Name##StorageType(Can##Name##StorageType type, \
+                                   AbstractionPattern origType) { \
       return asImpl().handleAddressOnly(type, {IsNotTrivial, \
                                                IsFixedABI, \
                                                IsAddressOnly, \
                                                IsNotResilient}); \
     }
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-    RetTy visit##Name##StorageType(Can##Name##StorageType type) { \
+    RetTy visit##Name##StorageType(Can##Name##StorageType type, \
+                                   AbstractionPattern origType) { \
       return asImpl().handleReference(type); \
     }
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-    RetTy visitLoadable##Name##StorageType(Can##Name##StorageType type) { \
+    RetTy visitLoadable##Name##StorageType(Can##Name##StorageType type, \
+                                           AbstractionPattern origType) { \
       return asImpl().handleReference(type); \
     } \
-    RetTy visitAddressOnly##Name##StorageType(Can##Name##StorageType type) { \
+    RetTy visitAddressOnly##Name##StorageType(Can##Name##StorageType type, \
+                                              AbstractionPattern origType) { \
       return asImpl().handleAddressOnly(type, {IsNotTrivial, \
                                                IsFixedABI, \
                                                IsAddressOnly, \
                                                IsNotResilient}); \
     } \
-    RetTy visit##Name##StorageType(Can##Name##StorageType type) { \
+    RetTy visit##Name##StorageType(Can##Name##StorageType type, \
+                                   AbstractionPattern origType) { \
       auto referentType = type->getReferentType(); \
       auto concreteType = getConcreteReferenceStorageReferent(referentType); \
       if (Name##StorageType::get(concreteType, TC.Context) \
             ->isLoadable(Expansion.getResilienceExpansion())) { \
-        return asImpl().visitLoadable##Name##StorageType(type); \
+        return asImpl().visitLoadable##Name##StorageType(type, origType); \
       } else { \
-        return asImpl().visitAddressOnly##Name##StorageType(type); \
+        return asImpl().visitAddressOnly##Name##StorageType(type, origType); \
       } \
     }
 #define UNCHECKED_REF_STORAGE(Name, ...) \
-    RetTy visit##Name##StorageType(Can##Name##StorageType type) { \
+    RetTy visit##Name##StorageType(Can##Name##StorageType type, \
+                                   AbstractionPattern origType) { \
       return asImpl().handleTrivial(type); \
     }
 #include "swift/AST/ReferenceStorage.def"
 
-    RetTy visitOpaqueTypeArchetypeType(CanOpaqueTypeArchetypeType ty) {
+    RetTy visitOpaqueTypeArchetypeType(CanOpaqueTypeArchetypeType ty,
+                                       AbstractionPattern origType) {
       auto replacedTy = substOpaqueTypesWithUnderlyingTypes(ty, Expansion);
       if (replacedTy == ty)
-        return visitArchetypeType(ty);
-      return this->visit(replacedTy);
+        return visitArchetypeType(ty, origType);
+      return this->visit(replacedTy, origType);
     }
 
-    RetTy visitArchetypeType(CanArchetypeType type) {
+    RetTy visitArchetypeType(CanArchetypeType type,
+                             AbstractionPattern origType) {
       if (type->requiresClass()) {
         return asImpl().handleReference(type);
       }
@@ -372,7 +368,8 @@ namespace {
       return asImpl().handleAddressOnly(type, RecursiveProperties::forOpaque());
     }
 
-    RetTy visitExistentialType(CanType type) {
+    RetTy visitExistentialType(CanType type,
+                               AbstractionPattern origType) {
       switch (SILType::getPrimitiveObjectType(type)
                 .getPreferredExistentialRepresentation()) {
       case ExistentialRepresentation::None:
@@ -394,43 +391,54 @@ namespace {
 
       llvm_unreachable("Unhandled ExistentialRepresentation in switch.");
     }
-    RetTy visitProtocolType(CanProtocolType type) {
-      return visitExistentialType(type);
+    RetTy visitProtocolType(CanProtocolType type,
+                            AbstractionPattern origType) {
+      return visitExistentialType(type, origType);
     }
-    RetTy visitProtocolCompositionType(CanProtocolCompositionType type) {
-      return visitExistentialType(type);
+    RetTy visitProtocolCompositionType(CanProtocolCompositionType type,
+                                       AbstractionPattern origType) {
+      return visitExistentialType(type, origType);
     }
 
     // Enums depend on their enumerators.
-    RetTy visitEnumType(CanEnumType type) {
-      return asImpl().visitAnyEnumType(type, type->getDecl());
+    RetTy visitEnumType(CanEnumType type,
+                        AbstractionPattern origType) {
+      return asImpl().visitAnyEnumType(type, origType, type->getDecl());
     }
-    RetTy visitBoundGenericEnumType(CanBoundGenericEnumType type) {
-      return asImpl().visitAnyEnumType(type, type->getDecl());
+    RetTy visitBoundGenericEnumType(CanBoundGenericEnumType type,
+                                    AbstractionPattern origType) {
+      return asImpl().visitAnyEnumType(type, origType, type->getDecl());
     }
     
     // Structs depend on their physical fields.
-    RetTy visitStructType(CanStructType type) {
-      return asImpl().visitAnyStructType(type, type->getDecl());
+    RetTy visitStructType(CanStructType type,
+                          AbstractionPattern origType) {
+      return asImpl().visitAnyStructType(type, origType, type->getDecl());
     }
-    RetTy visitBoundGenericStructType(CanBoundGenericStructType type) {
-      return asImpl().visitAnyStructType(type, type->getDecl());
+    RetTy visitBoundGenericStructType(CanBoundGenericStructType type,
+                                      AbstractionPattern origType) {
+      return asImpl().visitAnyStructType(type, origType, type->getDecl());
     }
 
     // Tuples depend on their elements.
-    RetTy visitTupleType(CanTupleType type) {
+    RetTy visitTupleType(CanTupleType type,
+                         AbstractionPattern origType) {
       RecursiveProperties props;
-      for (auto eltType : type.getElementTypes()) {
-        props.addSubobject(classifyType(eltType, TC, Sig, Expansion));
+      for (unsigned i = 0, e = type->getNumElements(); i < e; ++i) {
+        props.addSubobject(classifyType(origType.getTupleElementType(i),
+                                        type.getElementType(i),
+                                        TC, Expansion));
       }
       return asImpl().handleAggregateByProperties(type, props);
     }
 
-    RetTy visitDynamicSelfType(CanDynamicSelfType type) {
-      return this->visit(type.getSelfType());
+    RetTy visitDynamicSelfType(CanDynamicSelfType type,
+                               AbstractionPattern origType) {
+      return this->visit(type.getSelfType(), origType);
     }
     
-    RetTy visitSILBlockStorageType(CanSILBlockStorageType type) {
+    RetTy visitSILBlockStorageType(CanSILBlockStorageType type,
+                                   AbstractionPattern origType) {
       // Should not be loaded.
       return asImpl().handleAddressOnly(type, {IsNotTrivial,
                                                IsFixedABI,
@@ -438,7 +446,8 @@ namespace {
                                                IsNotResilient});
     }
 
-    RetTy visitSILBoxType(CanSILBoxType type) {
+    RetTy visitSILBoxType(CanSILBoxType type,
+                          AbstractionPattern origType) {
       // Should not be loaded.
       return asImpl().handleReference(type);
     }
@@ -458,52 +467,39 @@ namespace {
   class TypeClassifier :
       public TypeClassifierBase<TypeClassifier, RecursiveProperties> {
   public:
-    TypeClassifier(TypeConverter &TC, CanGenericSignature Sig,
+    TypeClassifier(TypeConverter &TC,
                    TypeExpansionContext Expansion)
-        : TypeClassifierBase(TC, Sig, Expansion) {}
+        : TypeClassifierBase(TC, Expansion) {}
 
     RecursiveProperties handle(CanType type, RecursiveProperties properties) {
       return properties;
     }
 
-    RecursiveProperties visitAnyEnumType(CanType type, EnumDecl *D) {
+    RecursiveProperties visitAnyEnumType(CanType type,
+                                         AbstractionPattern origType,
+                                         EnumDecl *D) {
       // We have to look through optionals here without grabbing the
       // type lowering because the way that optionals are reabstracted
       // can trip recursion checks if we try to build a lowered type.
       if (D->isOptionalDecl()) {
-        return visit(type.getOptionalObjectType());
+        return visit(type.getOptionalObjectType(),
+                     origType.getOptionalObjectType());
       }
 
       // Consult the type lowering.
-      type = getSubstitutedTypeForTypeLowering(type);
-      auto &lowering = TC.getTypeLowering(type, Expansion);
+      auto &lowering = TC.getTypeLowering(origType, type, Expansion);
       return handleClassificationFromLowering(type, lowering);
     }
 
-    RecursiveProperties visitAnyStructType(CanType type, StructDecl *D) {
+    RecursiveProperties visitAnyStructType(CanType type,
+                                           AbstractionPattern origType,
+                                           StructDecl *D) {
       // Consult the type lowering.
-      type = getSubstitutedTypeForTypeLowering(type);
-      auto &lowering = TC.getTypeLowering(type, Expansion);
+      auto &lowering = TC.getTypeLowering(origType, type, Expansion);
       return handleClassificationFromLowering(type, lowering);
     }
 
   private:
-    CanType getSubstitutedTypeForTypeLowering(CanType type) {
-      // If we're using a generic signature different from
-      // TC.getCurGenericContext(), we have to map the
-      // type into context before asking for a type lowering
-      // because the rest of type lowering doesn't have a generic
-      // signature plumbed through.
-      if (Sig && type->hasTypeParameter()) {
-        type = Sig->getCanonicalSignature()
-          ->getGenericEnvironment()
-          ->mapTypeIntoContext(type)
-          ->getCanonicalType();
-      }
-
-      return type;
-    }
-
     RecursiveProperties handleClassificationFromLowering(CanType type,
                                            const TypeLowering &lowering) {
       return handle(type, lowering.getRecursiveProperties());
@@ -511,19 +507,22 @@ namespace {
   };
 } // end anonymous namespace
 
-static RecursiveProperties classifyType(CanType type, TypeConverter &tc,
-                                        CanGenericSignature sig,
+static RecursiveProperties classifyType(AbstractionPattern origType,
+                                        CanType type,
+                                        TypeConverter &tc,
                                         TypeExpansionContext expansion) {
-  return TypeClassifier(tc, sig, expansion).visit(type);
+  return TypeClassifier(tc, expansion).visit(type, origType);
 }
 
 /// True if the type, or the referenced type of an address
 /// type, is address-only.  For example, it could be a resilient struct or
 /// something of unknown size.
-bool SILType::isAddressOnly(CanType type, TypeConverter &tc,
+bool SILType::isAddressOnly(CanType type,
+                            TypeConverter &tc,
                             CanGenericSignature sig,
                             TypeExpansionContext expansion) {
-  return classifyType(type, tc, sig, expansion).isAddressOnly();
+  return classifyType(AbstractionPattern(sig, type),
+                      type, tc, expansion).isAddressOnly();
 }
 
 namespace {
@@ -737,9 +736,7 @@ namespace {
       if (Children.data() == nullptr) {
         SmallVector<Child, 4> children;
         lowerChildren(TC, children);
-        auto isDependent = IsDependent_t(getLoweredType().hasTypeParameter());
-        auto buf = operator new(sizeof(Child) * children.size(), TC,
-                                isDependent);
+        auto buf = operator new(sizeof(Child) * children.size(), TC);
         memcpy(buf, children.data(), sizeof(Child) * children.size());
         Children = {reinterpret_cast<Child*>(buf), children.size()};
       }
@@ -1177,11 +1174,9 @@ namespace {
   class LowerType
     : public TypeClassifierBase<LowerType, TypeLowering *>
   {
-    IsDependent_t Dependent;
   public:
-    LowerType(TypeConverter &TC, CanGenericSignature Sig,
-              TypeExpansionContext Expansion, IsDependent_t Dependent)
-      : TypeClassifierBase(TC, Sig, Expansion), Dependent(Dependent) {}
+    LowerType(TypeConverter &TC, TypeExpansionContext Expansion)
+      : TypeClassifierBase(TC, Expansion) {}
 
     TypeLowering *handleTrivial(CanType type) {
       return handleTrivial(type, RecursiveProperties::forTrivial());
@@ -1190,54 +1185,57 @@ namespace {
     TypeLowering *handleTrivial(CanType type,
                                 RecursiveProperties properties) {
       auto silType = SILType::getPrimitiveObjectType(type);
-      return new (TC, Dependent) TrivialTypeLowering(silType, properties,
-                                                     Expansion);
+      return new (TC) TrivialTypeLowering(silType, properties, Expansion);
     }
 
     TypeLowering *handleReference(CanType type) {
       auto silType = SILType::getPrimitiveObjectType(type);
-      return new (TC, Dependent) ReferenceTypeLowering(silType, Expansion);
+      return new (TC) ReferenceTypeLowering(silType, Expansion);
     }
 
     TypeLowering *handleAddressOnly(CanType type,
                                     RecursiveProperties properties) {
       if (!TC.Context.LangOpts.EnableSILOpaqueValues) {
         auto silType = SILType::getPrimitiveAddressType(type);
-        return new (TC, Dependent) AddressOnlyTypeLowering(silType, properties,
+        return new (TC) AddressOnlyTypeLowering(silType, properties,
                                                            Expansion);
       }
       auto silType = SILType::getPrimitiveObjectType(type);
-      return new (TC, Dependent) OpaqueValueTypeLowering(silType, properties,
-                                                         Expansion);
+      return new (TC) OpaqueValueTypeLowering(silType, properties, Expansion);
     }
 
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
     TypeLowering * \
-    visit##Name##StorageType(Can##Name##StorageType type) { \
-      return new (TC, Dependent) Loadable##Name##TypeLowering( \
+    visit##Name##StorageType(Can##Name##StorageType type, \
+                             AbstractionPattern origType) { \
+      return new (TC) Loadable##Name##TypeLowering( \
                                   SILType::getPrimitiveObjectType(type), \
                                   Expansion); \
     }
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
     TypeLowering * \
-    visitLoadable##Name##StorageType(Can##Name##StorageType type) { \
-      return new (TC, Dependent) Loadable##Name##TypeLowering( \
+    visitLoadable##Name##StorageType(Can##Name##StorageType type, \
+                                     AbstractionPattern origType) { \
+      return new (TC) Loadable##Name##TypeLowering( \
                                   SILType::getPrimitiveObjectType(type), \
                                   Expansion); \
     }
 #include "swift/AST/ReferenceStorage.def"
 
     TypeLowering *
-    visitBuiltinUnsafeValueBufferType(CanBuiltinUnsafeValueBufferType type) {
+    visitBuiltinUnsafeValueBufferType(CanBuiltinUnsafeValueBufferType type,
+                                      AbstractionPattern origType) {
       auto silType = SILType::getPrimitiveAddressType(type);
-      return new (TC, Dependent) UnsafeValueBufferTypeLowering(silType,
-                                                               Expansion);
+      return new (TC) UnsafeValueBufferTypeLowering(silType, Expansion);
     }
 
-    TypeLowering *visitTupleType(CanTupleType tupleType) {
+    TypeLowering *visitTupleType(CanTupleType tupleType,
+                                 AbstractionPattern origType) {
       RecursiveProperties properties;
-      for (auto eltType : tupleType.getElementTypes()) {
-        auto &lowering = TC.getTypeLowering(eltType, Expansion);
+      for (unsigned i = 0, e = tupleType->getNumElements(); i < e; ++i) {
+        auto eltType = tupleType.getElementType(i);
+        auto origEltType = origType.getTupleElementType(i);
+        auto &lowering = TC.getTypeLowering(origEltType, eltType, Expansion);
         properties.addSubobject(lowering.getRecursiveProperties());
       }
 
@@ -1270,7 +1268,9 @@ namespace {
       return false;
     }
 
-    TypeLowering *visitAnyStructType(CanType structType, StructDecl *D) {
+    TypeLowering *visitAnyStructType(CanType structType,
+                                     AbstractionPattern origType,
+                                     StructDecl *D) {
       RecursiveProperties properties;
 
       if (handleResilience(structType, D, properties))
@@ -1281,17 +1281,27 @@ namespace {
       // Classify the type according to its stored properties.
       for (auto field : D->getStoredProperties()) {
         auto substFieldType =
-          field->getInterfaceType().subst(subMap)->getCanonicalType();
-
-        properties.addSubobject(classifyType(substFieldType->getCanonicalType(),
-                                             TC, Sig, Expansion));
+          field->getInterfaceType().subst(subMap)
+               ->getCanonicalType(D->getGenericSignature());
+        
+        // We are determining the recursive properties of the struct here,
+        // not the lowered types of the fields, so instead of lowering the
+        // field type against the declaration's interface type as we normally
+        // would, we use the substituted field type in order to accurately
+        // preserve the properties of the aggregate.
+        auto origFieldType = origType.unsafeGetSubstFieldType(field);
+        
+        properties.addSubobject(classifyType(origFieldType, substFieldType,
+                                             TC, Expansion));
       }
 
       return handleAggregateByProperties<LoadableStructTypeLowering>(structType,
                                                                     properties);
     }
         
-    TypeLowering *visitAnyEnumType(CanType enumType, EnumDecl *D) {
+    TypeLowering *visitAnyEnumType(CanType enumType,
+                                   AbstractionPattern origType,
+                                   EnumDecl *D) {
       RecursiveProperties properties;
 
       if (handleResilience(enumType, D, properties))
@@ -1305,8 +1315,8 @@ namespace {
       // may be added resiliently later.
       if (D->isIndirect()) {
         properties.setNonTrivial();
-        return new (TC, Dependent) LoadableEnumTypeLowering(enumType, properties,
-                                                            Expansion);
+        return new (TC) LoadableEnumTypeLowering(enumType, properties,
+                                                 Expansion);
       }
 
       auto subMap = enumType->getContextSubstitutionMap(&TC.M, D);
@@ -1324,9 +1334,14 @@ namespace {
         }
         
         auto substEltType =
-          elt->getArgumentInterfaceType().subst(subMap)->getCanonicalType();
+          elt->getArgumentInterfaceType().subst(subMap)
+             ->getCanonicalType(D->getGenericSignature());
         
-        properties.addSubobject(classifyType(substEltType, TC, Sig, Expansion));
+        auto origEltType = origType.unsafeGetSubstFieldType(elt,
+                              elt->getArgumentInterfaceType()
+                                 ->getCanonicalType(D->getGenericSignature()));
+        properties.addSubobject(classifyType(origEltType, substEltType,
+                                             TC, Expansion));
       }
 
       return handleAggregateByProperties<LoadableEnumTypeLowering>(enumType,
@@ -1343,7 +1358,7 @@ namespace {
       if (props.isTrivial()) {
         return handleTrivial(type, props);
       }
-      return new (TC, Dependent) LoadableLoweringClass(type, props, Expansion);
+      return new (TC) LoadableLoweringClass(type, props, Expansion);
     }
   };
 } // end anonymous namespace
@@ -1355,7 +1370,7 @@ TypeConverter::TypeConverter(ModuleDecl &m)
 TypeConverter::~TypeConverter() {
   // The bump pointer allocator destructor will deallocate but not destroy all
   // our independent TypeLowerings.
-  for (auto &ti : IndependentTypes) {
+  for (auto &ti : LoweredTypes) {
     // Destroy only the unique entries.
     CanType srcType = ti.first.OrigType;
     if (!srcType) continue;
@@ -1365,30 +1380,16 @@ TypeConverter::~TypeConverter() {
   }
 }
 
-void *TypeLowering::operator new(size_t size, TypeConverter &tc,
-                                 IsDependent_t dependent) {
-  if (dependent) {
-    auto &state = tc.DependentTypes.back();
-    return state.BPA.Allocate(size, alignof(TypeLowering&));
-  }
-  return tc.IndependentBPA.Allocate(size, alignof(TypeLowering&));
+void *TypeLowering::operator new(size_t size, TypeConverter &tc) {
+  return tc.TypeLoweringBPA.Allocate(size, alignof(TypeLowering&));
 }
 
 const TypeLowering *TypeConverter::find(TypeKey k) {
   if (!k.isCacheable()) return nullptr;
 
   auto ck = k.getCachingKey();
-
-  llvm::DenseMap<CachingTypeKey, const TypeLowering *> *types;
-  if (k.isDependent()) {
-    auto &state = DependentTypes.back();
-    types = &state.Map;
-  } else {
-    types = &IndependentTypes;
-  }
-
-  auto found = types->find(ck);
-  if (found == types->end())
+  auto found = LoweredTypes.find(ck);
+  if (found == LoweredTypes.end())
     return nullptr;
 
   assert((found->second || k.expansionContext.isMinimal()) &&
@@ -1403,33 +1404,18 @@ void TypeConverter::removeNullEntry(TypeKey k) {
 
   auto ck = k.getCachingKey();
 
-  llvm::DenseMap<CachingTypeKey, const TypeLowering *> *types;
-  if (k.isDependent()) {
-    auto &state = DependentTypes.back();
-    types = &state.Map;
-  } else {
-    types = &IndependentTypes;
-  }
-
-  auto found = types->find(ck);
-  if (found == types->end() || found->second != nullptr)
+  auto found = LoweredTypes.find(ck);
+  if (found == LoweredTypes.end() || found->second != nullptr)
     return;
 
-  types->erase(ck);
+  LoweredTypes.erase(ck);
 }
 #endif
 
 void TypeConverter::insert(TypeKey k, const TypeLowering *tl) {
   if (!k.isCacheable()) return;
 
-  llvm::DenseMap<CachingTypeKey, const TypeLowering *> *types;
-  if (k.isDependent()) {
-    auto &state = DependentTypes.back();
-    types = &state.Map;
-  } else {
-    types = &IndependentTypes;
-  }
-  (*types)[k.getCachingKey()] = tl;
+  LoweredTypes[k.getCachingKey()] = tl;
 }
 
 /// Lower each of the elements of the substituted type according to
@@ -1543,8 +1529,6 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
   auto origHadOpaqueTypeArchetype =
       hasOpaqueArchetypeOrPropertiesOrCases(origSubstType->getCanonicalType());
   auto key = getTypeKey(origType, substType, forExpansion);
-  assert((!key.isDependent() || getCurGenericContext())
-         && "dependent type outside of generic context?!");
   assert(!substType->is<InOutType>());
 
   auto *candidateLowering = find(key.getKeyForMinimalExpansion());
@@ -1567,28 +1551,22 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
   // point in re-checking the table, so just construct a type lowering
   // and cache it.
   if (loweredSubstType == substType && key.isCacheable()) {
-    lowering = LowerType(*this,
-                         CanGenericSignature(),
-                         forExpansion,
-                         key.isDependent()).visit(key.SubstType);
+    lowering = LowerType(*this, forExpansion)
+      .visit(key.SubstType, key.OrigType);
 
   // Otherwise, check the table at a key that would be used by the
   // SILType-based lookup path for the type we just lowered to, then cache
   // that same result at this key if possible.
   } else {
-    AbstractionPattern origTypeForCaching =
-      AbstractionPattern(getCurGenericContext(), loweredSubstType);
-    auto loweredKey =
-        getTypeKey(origTypeForCaching, loweredSubstType, forExpansion);
-
-    lowering = &getTypeLoweringForLoweredType(loweredKey,
+    lowering = &getTypeLoweringForLoweredType(origType,
+                                              loweredSubstType,
                                               forExpansion,
                                               origHadOpaqueTypeArchetype);
   }
 
-  if (!lowering->isResilient() && !origHadOpaqueTypeArchetype)
+  if (!lowering->isResilient() && !origHadOpaqueTypeArchetype) {
     insert(key.getKeyForMinimalExpansion(), lowering);
-  else {
+  } else {
     insert(key, lowering);
 #ifndef NDEBUG
     removeNullEntry(key.getKeyForMinimalExpansion());
@@ -1627,7 +1605,7 @@ TypeConverter::computeLoweredRValueType(TypeExpansionContext forExpansion,
       substFnType = bridgedFnType;
 
       // Also rewrite the type of the abstraction pattern.
-      auto signature = getCurGenericContext();
+      auto signature = origType.getGenericSignatureOrNull();
       if (origType.isTypeParameter()) {
         origType = AbstractionPattern(signature, bridgedFnType);
       } else {
@@ -1640,7 +1618,7 @@ TypeConverter::computeLoweredRValueType(TypeExpansionContext forExpansion,
 
   // Ignore dynamic self types.
   if (auto selfType = dyn_cast<DynamicSelfType>(substType)) {
-    return getLoweredRValueType(forExpansion, selfType.getSelfType());
+    return getLoweredRValueType(forExpansion, origType, selfType.getSelfType());
   }
 
   // Static metatypes are unitary and can optimized to a "thin" empty
@@ -1719,14 +1697,10 @@ TypeConverter::computeLoweredRValueType(TypeExpansionContext forExpansion,
       substOpaqueTypesWithUnderlyingTypes(substType, forExpansion,
                                           /*allowLoweredTypes*/ true);
   if (underlyingTy != substType) {
-    if (auto underlyingFnTy = dyn_cast<AnyFunctionType>(underlyingTy)) {
-      underlyingTy = computeLoweredRValueType(
-          forExpansion, AbstractionPattern::getOpaque(), underlyingTy);
-    } else
-      underlyingTy = computeLoweredRValueType(
-          forExpansion,
-          AbstractionPattern(getCurGenericContext(), underlyingTy),
-          underlyingTy);
+    underlyingTy = computeLoweredRValueType(
+        forExpansion,
+        origType,
+        underlyingTy);
   }
 
   return underlyingTy;
@@ -1734,25 +1708,42 @@ TypeConverter::computeLoweredRValueType(TypeExpansionContext forExpansion,
 
 const TypeLowering &
 TypeConverter::getTypeLowering(SILType type,
-                               TypeExpansionContext forExpansion) {
+                               TypeExpansionContext forExpansion,
+                               CanGenericSignature sig) {
+  // The type lowering for a type parameter relies on its context.
+  assert(sig || !type.getASTType()->hasTypeParameter());
   auto loweredType = type.getASTType();
-  auto key = getTypeKey(AbstractionPattern(getCurGenericContext(), loweredType),
-                        loweredType, forExpansion);
-
   auto origHadOpaqueTypeArchetype =
       hasOpaqueArchetypeOrPropertiesOrCases(loweredType);
 
-  return getTypeLoweringForLoweredType(key, forExpansion,
-                                       origHadOpaqueTypeArchetype);
+  return getTypeLoweringForLoweredType(
+                       AbstractionPattern(sig, loweredType),
+                       loweredType, forExpansion,
+                       origHadOpaqueTypeArchetype);
 }
 
 const TypeLowering &
-TypeConverter::getTypeLoweringForLoweredType(TypeKey key,
+TypeConverter::getTypeLowering(SILType t, SILFunction &F) {
+  return getTypeLowering(t, TypeExpansionContext(F),
+                       F.getLoweredFunctionType()->getSubstGenericSignature());
+}
+
+const TypeLowering &
+TypeConverter::getTypeLoweringForLoweredType(AbstractionPattern origType,
+                                             CanType loweredType,
                                              TypeExpansionContext forExpansion,
                                              bool origHadOpaqueTypeArchetype) {
-  auto type = key.SubstType;
-  assert(type->isLegalSILType() && "type is not lowered!");
-  (void)type;
+  assert(loweredType->isLegalSILType() && "type is not lowered!");
+  (void)loweredType;
+  
+  // Cache the lowered type record for a contextualized type independent of the
+  // abstraction pattern. Lowered type parameters can't be cached or looked up
+  // without context. (TODO: We could if they match the out-of-context
+  // abstraction pattern.)
+  AbstractionPattern origTypeForCaching = loweredType->hasTypeParameter()
+      ? AbstractionPattern::getInvalid()
+      : AbstractionPattern(loweredType);
+  auto key = getTypeKey(origTypeForCaching, loweredType, forExpansion);
 
   auto *candidateLowering = find(key.getKeyForMinimalExpansion());
   auto *lowering = getTypeLoweringForExpansion(
@@ -1767,14 +1758,14 @@ TypeConverter::getTypeLoweringForLoweredType(TypeKey key,
 #endif
 
   if (forExpansion.shouldLookThroughOpaqueTypeArchetypes() &&
-      type->hasOpaqueArchetype()) {
-    type = computeLoweredRValueType(
-        forExpansion, AbstractionPattern(getCurGenericContext(), type), type);
+      loweredType->hasOpaqueArchetype()) {
+    loweredType = computeLoweredRValueType(
+        forExpansion, origType, loweredType);
   }
 
   lowering =
-      LowerType(*this, CanGenericSignature(), forExpansion, key.isDependent())
-          .visit(type);
+      LowerType(*this, forExpansion)
+        .visit(loweredType, origType);
 
   if (!lowering->isResilient() && !origHadOpaqueTypeArchetype)
     insert(key.getKeyForMinimalExpansion(), lowering);
@@ -2170,19 +2161,6 @@ void TypeConverter::popGenericContext(CanGenericSignature sig) {
   DependentTypeState &state = DependentTypes.back();
   assert(state.Sig == sig && "unpaired push/pop");
   
-  // Erase our cached TypeLowering objects and associated mappings for dependent
-  // types.
-  // Resetting the DependentBPA will deallocate but not run the destructor of
-  // the dependent TypeLowerings.
-  for (auto &ti : state.Map) {
-    // Destroy only the unique entries.
-    CanType srcType = ti.first.OrigType;
-    if (!srcType) continue;
-    CanType mappedType = ti.second->getLoweredType().getASTType();
-    if (srcType == mappedType)
-      ti.second->~TypeLowering();
-  }
-
   DependentTypes.pop_back();
 }
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -229,7 +229,6 @@ emitBridgeObjectiveCToNative(SILGenFunction &SGF,
   auto subs = witness.getSubstitutions();
 
   // Set up the generic signature, since formalResultTy is an interface type.
-  GenericContextScope genericContextScope(SGF.SGM.Types, genericSig);
   CalleeTypeInfo calleeTypeInfo(
       witnessFnTy,
       AbstractionPattern(genericSig, formalResultTy),

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2659,15 +2659,12 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
 
   // Build the signature of the thunk as expected by the keypath runtime.
   CanType loweredBaseTy, loweredPropTy;
-  {
-    GenericContextScope scope(SGM.Types, genericSig);
-    AbstractionPattern opaque = AbstractionPattern::getOpaque();
+  AbstractionPattern opaque = AbstractionPattern::getOpaque();
 
-    loweredBaseTy = SGM.Types.getLoweredRValueType(
-        TypeExpansionContext::minimal(), opaque, baseType);
-    loweredPropTy = SGM.Types.getLoweredRValueType(
-        TypeExpansionContext::minimal(), opaque, propertyType);
-  }
+  loweredBaseTy = SGM.Types.getLoweredRValueType(
+      TypeExpansionContext::minimal(), opaque, baseType);
+  loweredPropTy = SGM.Types.getLoweredRValueType(
+      TypeExpansionContext::minimal(), opaque, propertyType);
   
   auto paramConvention = ParameterConvention::Indirect_In_Guaranteed;
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2796,7 +2796,6 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
   // Build the signature of the thunk as expected by the keypath runtime.
   CanType loweredBaseTy, loweredPropTy;
   {
-    GenericContextScope scope(SGM.Types, genericSig);
     AbstractionPattern opaque = AbstractionPattern::getOpaque();
 
     loweredBaseTy = SGM.Types.getLoweredRValueType(

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2992,8 +2992,10 @@ CanSILFunctionType SILGenFunction::buildThunkType(
     SubstitutionMap &interfaceSubs,
     CanType &dynamicSelfType,
     bool withoutActuallyEscaping) {
-  assert(!expectedType->isPolymorphic());
-  assert(!sourceType->isPolymorphic());
+  // We shouldn't be thunking generic types here, and substituted function types
+  // ought to have their substitutions applied before we get here.
+  assert(!expectedType->isPolymorphic() && !expectedType->getSubstitutions());
+  assert(!sourceType->isPolymorphic() && !sourceType->getSubstitutions());
 
   // Can't build a thunk without context, so we require ownership semantics
   // on the result type.
@@ -3187,8 +3189,22 @@ static ManagedValue createThunk(SILGenFunction &SGF,
                                 AbstractionPattern outputOrigType,
                                 CanAnyFunctionType outputSubstType,
                                 const TypeLowering &expectedTL) {
-  auto sourceType = fn.getType().castTo<SILFunctionType>();
-  auto expectedType = expectedTL.getLoweredType().castTo<SILFunctionType>();
+  auto substSourceType = fn.getType().castTo<SILFunctionType>();
+  auto substExpectedType = expectedTL.getLoweredType().castTo<SILFunctionType>();
+  
+  // Apply substitutions in the source and destination types, since the thunk
+  // doesn't change because of different function representations.
+  CanSILFunctionType sourceType;
+  if (substSourceType->getSubstitutions()) {
+    sourceType = substSourceType->getUnsubstitutedType(SGF.SGM.M);
+    fn = SGF.B.createConvertFunction(loc, fn,
+                                   SILType::getPrimitiveObjectType(sourceType));
+  } else {
+    sourceType = substSourceType;
+  }
+  
+  auto expectedType = substExpectedType
+    ->getUnsubstitutedType(SGF.SGM.M);
 
   // We can't do bridging here.
   assert(expectedType->getLanguage() ==
@@ -3231,14 +3247,22 @@ static ManagedValue createThunk(SILGenFunction &SGF,
     createPartialApplyOfThunk(SGF, loc, thunk, interfaceSubs, dynamicSelfType,
                               toType, fn.ensurePlusOne(SGF, loc));
 
-  if (!expectedType->isNoEscape()) {
+  // Convert to the substituted result type.
+  if (expectedType != substExpectedType) {
+    auto substEscapingExpectedType = substExpectedType
+      ->getWithExtInfo(substExpectedType->getExtInfo().withNoEscape(false));
+    thunkedFn = SGF.B.createConvertFunction(loc, thunkedFn,
+                    SILType::getPrimitiveObjectType(substEscapingExpectedType));
+  }
+  
+  if (!substExpectedType->isNoEscape()) {
     return thunkedFn;
   }
 
   // Handle the escaping to noescape conversion.
-  assert(expectedType->isNoEscape());
+  assert(substExpectedType->isNoEscape());
   return SGF.B.createConvertEscapeToNoEscape(
-      loc, thunkedFn, SILType::getPrimitiveObjectType(expectedType));
+      loc, thunkedFn, SILType::getPrimitiveObjectType(substExpectedType));
 }
 
 static CanSILFunctionType buildWithoutActuallyEscapingThunkType(

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -337,10 +337,7 @@ computeNewArgInterfaceTypes(SILFunction *F, IndicesSet &PromotableIndices,
 
   LLVM_DEBUG(llvm::dbgs() << "Preparing New Args!\n");
 
-  auto fnTy = F->getLoweredFunctionType();
-
   auto &Types = F->getModule().Types;
-  Lowering::GenericContextScope scope(Types, fnTy->getInvocationGenericSignature());
 
   // For each parameter in the old function...
   for (unsigned Index : indices(Parameters)) {

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -371,8 +371,7 @@ computeNewArgInterfaceTypes(SILFunction *F, IndicesSet &PromotableIndices,
     auto paramBoxedTy =
         getSILBoxFieldType(TypeExpansionContext(*F), paramBoxTy, Types, 0);
     assert(expansion == F->getResilienceExpansion());
-    auto &paramTL =
-        Types.getTypeLowering(paramBoxedTy, TypeExpansionContext(*F));
+    auto &paramTL = Types.getTypeLowering(paramBoxedTy, *F);
     ParameterConvention convention;
     if (paramTL.isAddressOnly()) {
       convention = ParameterConvention::Indirect_In;

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -388,15 +388,6 @@ protected:
 
 /// Top-level entry point: allocate storage for all opaque/resilient values.
 void OpaqueStorageAllocation::allocateOpaqueStorage() {
-  // TODO: I think we need a GenericContextScope for mapTypeIntoContext, but all
-  // tests are currently passing without it.
-#if 0
-  auto canFnType = pass.F->getLoweredFunctionType();
-
-  // Setup a generic context for argument and result types.
-  swift::Lowering::GenericContextScope scope(pass.F->getModule().Types,
-                                             canFnType->getGenericSignature());
-#endif
   // Fixup this function's argument types with temporary loads.
   convertIndirectFunctionArgs();
 

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -584,8 +584,6 @@ SILFunction *PromotedParamCloner::initCloned(SILOptFunctionBuilder &FuncBuilder,
       SILType paramTy;
       {
         auto &TC = Orig->getModule().Types;
-        Lowering::GenericContextScope scope(TC,
-                                      OrigFTI->getSubstGenericSignature());
         paramTy = getSILBoxFieldType(TypeExpansionContext(*Orig), boxTy, TC, 0);
       }
       auto promotedParam = SILParameterInfo(paramTy.getASTType(),

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -676,7 +676,6 @@ void ReabstractionInfo::createSubstitutedAndSpecializedTypes() {
   CanGenericSignature CanSig;
   if (SpecializedGenericSig)
     CanSig = SpecializedGenericSig->getCanonicalSignature();
-  Lowering::GenericContextScope GenericScope(M.Types, CanSig);
 
   SILFunctionConventions substConv(SubstitutedType, M);
 
@@ -759,8 +758,6 @@ ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
   // First substitute concrete types into the existing function type.
   CanSILFunctionType FnTy;
   {
-    Lowering::GenericContextScope GenericScope(M.Types,
-                                               CanSpecializedGenericSig);
     FnTy = OrigF->getLoweredFunctionType()->substGenericArgs(
         M, SubstMap, getResilienceExpansion());
     // FIXME: Some of the added new requirements may not have been taken into
@@ -2091,11 +2088,6 @@ SILFunction *ReabstractionThunkGenerator::createThunk() {
     return Thunk;
 
   Thunk->setGenericEnvironment(ReInfo.getSpecializedGenericEnvironment());
-
-  // Set proper generic context scope for the type lowering.
-  CanSILFunctionType SpecType = SpecializedFunc->getLoweredFunctionType();
-  Lowering::GenericContextScope GenericScope(M.Types,
-                                     SpecType->getInvocationGenericSignature());
 
   SILBasicBlock *EntryBB = Thunk->createBasicBlock();
   SILBuilder Builder(EntryBB);


### PR DESCRIPTION
Lowering a SIL type should be a pure function of the formal type of a value and the
abstraction pattern it's being lowered against, but we historically did not carry
enough information in abstraction patterns to lower generic parameter types, so we
relied on a generic context signature that would be pushed and popped before lowering
interface types. This patch largely eliminates the necessity for that, by making it
so that `TypeClassifierBase` and its subclasses now take an `AbstractionPattern`
all the way down, and fixing up the visitor logic so that it derives appropriate
abstraction patterns for tuple elements, function arguments, and aggregate fields too.
This makes it so that type lowering is independent of the current generic context.
(Unfortunately, there are still places scattered across the code where we use the
current generic context in order to build abstraction patterns that we then feed
into type lowering, so we can't yet completely eliminate the concept.)

This then enables us to integrate substituted function type construction into type
lowering as well, since we can now lower a generic parameter type against an
abstraction pattern without that generic parameter having to be tied to the same
generic signature (or any generic signature at all, which in the case of a
substituted function type hasn't necessarily even been finalized yet.)