### PR TITLE
[AutoDiff] Improve diagnostic for multiple active results.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -524,6 +524,8 @@ NOTE(autodiff_when_differentiating_function_definition,none,
      "when differentiating this function definition", ())
 NOTE(autodiff_cannot_differentiate_through_inout_arguments,none,
      "cannot differentiate through 'inout' arguments", ())
+NOTE(autodiff_cannot_differentiate_through_multiple_results,none,
+     "cannot differentiate through multiple results", ())
 NOTE(autodiff_class_member_not_supported,none,
      "differentiating class members is not yet supported", ())
 // TODO(TF-642): Remove when `partial_apply` works with `@differentiable`

--- a/test/AutoDiff/activity_analysis.swift
+++ b/test/AutoDiff/activity_analysis.swift
@@ -204,6 +204,106 @@ func TF_954(_ x: Float) -> Float {
 // CHECK: [ACTIVE]   %40 = begin_access [read] [static] %2 : $*Float
 // CHECK: [ACTIVE]   %41 = load [trivial] %40 : $*Float
 
+// Check `inout` argument activity.
+
+struct Mut: Differentiable {}
+extension Mut {
+  @differentiable(wrt: x)
+  mutating func mutatingMethod(_ x: Mut) -> Mut {
+    return x
+  }
+}
+
+// CHECK-LABEL: [AD] Activity info for $s17activity_analysis3MutV14mutatingMethodyA2CF at (source=0 parameters=(0))
+// CHECK: [ACTIVE] %0 = argument of bb0 : $Mut
+// CHECK: [NONE] %1 = argument of bb0 : $*Mut
+
+// TODO(TF-985): Find workaround to avoid marking non-wrt `inout` argument as
+// active.
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: x)
+// expected-note @+1 {{when differentiating this function definition}}
+func nonActiveInoutArg(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  return nonactive.mutatingMethod(x)
+}
+
+// CHECK-LABEL: [AD] Activity info for $s17activity_analysis17nonActiveInoutArgyAA3MutVADz_ADtF at (source=0 parameters=(1))
+// CHECK: [ACTIVE] %0 = argument of bb0 : $*Mut
+// CHECK: [ACTIVE] %1 = argument of bb0 : $Mut
+// CHECK: [ACTIVE]   %4 = begin_access [modify] [static] %0 : $*Mut
+// CHECK: [NONE]   // function_ref Mut.mutatingMethod(_:)
+// CHECK: [ACTIVE]   %6 = apply %5(%1, %4) : $@convention(method) (Mut, @inout Mut) -> Mut
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: x)
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgMutatingMethod(_ x: Mut) -> Mut {
+  var result = x
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  result = result.mutatingMethod(result)
+  return result
+}
+
+// CHECK-LABEL: [AD] Activity info for $s17activity_analysis28activeInoutArgMutatingMethodyAA3MutVADF at (source=0 parameters=(0))
+// CHECK: [ACTIVE] %0 = argument of bb0 : $Mut
+// CHECK: [ACTIVE]   %2 = alloc_stack $Mut, var, name "result"
+// CHECK: [ACTIVE]   %4 = begin_access [read] [static] %2 : $*Mut
+// CHECK: [ACTIVE]   %5 = load [trivial] %4 : $*Mut
+// CHECK: [ACTIVE]   %7 = begin_access [modify] [static] %2 : $*Mut
+// CHECK: [NONE]   // function_ref Mut.mutatingMethod(_:)
+// CHECK: [ACTIVE]   %9 = apply %8(%5, %7) : $@convention(method) (Mut, @inout Mut) -> Mut
+// CHECK: [ACTIVE]   %11 = begin_access [modify] [static] %2 : $*Mut
+// CHECK: [ACTIVE]   %14 = begin_access [read] [static] %2 : $*Mut
+// CHECK: [ACTIVE]   %15 = load [trivial] %14 : $*Mut
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: x)
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  var result = nonactive
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  result = result.mutatingMethod(x)
+  return result
+}
+
+// CHECK_LABEL: [AD] Activity info for $s17activity_analysis31activeInoutArgMutatingMethodVaryAA3MutVADz_ADtF at (source=0 parameters=(1))
+// CHECK: [USEFUL] %0 = argument of bb0 : $*Mut
+// CHECK: [ACTIVE] %1 = argument of bb0 : $Mut
+// CHECK: [ACTIVE]   %4 = alloc_stack $Mut, var, name "result"
+// CHECK: [USEFUL]   %5 = begin_access [read] [static] %0 : $*Mut
+// CHECK: [ACTIVE]   %8 = begin_access [modify] [static] %4 : $*Mut
+// CHECK: [NONE]   // function_ref Mut.mutatingMethod(_:)
+// CHECK: [ACTIVE]   %10 = apply %9(%1, %8) : $@convention(method) (Mut, @inout Mut) -> Mut
+// CHECK: [ACTIVE]   %12 = begin_access [modify] [static] %4 : $*Mut
+// CHECK: [ACTIVE]   %15 = begin_access [read] [static] %4 : $*Mut
+// CHECK: [ACTIVE]   %16 = load [trivial] %15 : $*Mut
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: x)
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgMutatingMethodTuple(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  var result = (nonactive, x)
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  let result2 = result.0.mutatingMethod(result.0)
+  return result2
+}
+
+// CHECK-LABEL: [AD] Activity info for $s17activity_analysis33activeInoutArgMutatingMethodTupleyAA3MutVADz_ADtF at (source=0 parameters=(1))
+// CHECK: [USEFUL] %0 = argument of bb0 : $*Mut
+// CHECK: [ACTIVE] %1 = argument of bb0 : $Mut
+// CHECK: [ACTIVE]   %4 = alloc_stack $(Mut, Mut), var, name "result"
+// CHECK: [ACTIVE]   %5 = tuple_element_addr %4 : $*(Mut, Mut), 0
+// CHECK: [ACTIVE]   %6 = tuple_element_addr %4 : $*(Mut, Mut), 1
+// CHECK: [USEFUL]   %7 = begin_access [read] [static] %0 : $*Mut
+// CHECK: [ACTIVE]   %11 = begin_access [read] [static] %4 : $*(Mut, Mut)
+// CHECK: [ACTIVE]   %12 = tuple_element_addr %11 : $*(Mut, Mut), 0
+// CHECK: [ACTIVE]   %13 = load [trivial] %12 : $*Mut
+// CHECK: [ACTIVE]   %15 = begin_access [modify] [static] %4 : $*(Mut, Mut)
+// CHECK: [ACTIVE]   %16 = tuple_element_addr %15 : $*(Mut, Mut), 0
+// CHECK: [NONE]   // function_ref Mut.mutatingMethod(_:)
+// CHECK: [ACTIVE]   %18 = apply %17(%13, %16) : $@convention(method) (Mut, @inout Mut) -> Mut
+
 //===----------------------------------------------------------------------===//
 // Non-differentiable functions
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/differentiation_transform_diagnostics.swift
+++ b/test/AutoDiff/differentiation_transform_diagnostics.swift
@@ -255,6 +255,22 @@ let no_return: @differentiable (Float) -> Float = { x in
 }
 
 //===----------------------------------------------------------------------===//
+// Multiple results
+//===----------------------------------------------------------------------===//
+
+func multipleResults(_ x: Float) -> (Float, Float) {
+  return (x, x)
+}
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func usesMultipleResults(_ x: Float) -> Float {
+  // expected-note @+1 {{cannot differentiate through multiple results}}
+  let tuple = multipleResults(x)
+  return tuple.0 + tuple.1
+}
+
+//===----------------------------------------------------------------------===//
 // Non-differentiable arguments and results
 //===----------------------------------------------------------------------===//
 
@@ -331,6 +347,54 @@ func activeInoutArgControlFlowComplex(_ array: [Float], _ bool: Bool) -> Float {
     }
   }
   return result
+}
+
+struct Mut: Differentiable {}
+extension Mut {
+  @differentiable(wrt: x)
+  mutating func mutatingMethod(_ x: Mut) -> Mut {
+    return x
+  }
+}
+
+// TODO(TF-985): Find workaround to avoid marking non-wrt `inout` argument as
+// active.
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: x)
+// expected-note @+1 {{when differentiating this function definition}}
+func nonActiveInoutArg(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  return nonactive.mutatingMethod(x)
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: x)
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgMutatingMethod(_ x: Mut) -> Mut {
+  var result = x
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  result = result.mutatingMethod(result)
+  return result
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: x)
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  var result = nonactive
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  result = result.mutatingMethod(x)
+  return result
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: x)
+// expected-note @+1 {{when differentiating this function definition}}
+func activeInoutArgMutatingMethodTuple(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  var result = (nonactive, x)
+  // expected-note @+1 {{cannot differentiate through 'inout' arguments}}
+  let result2 = result.0.mutatingMethod(result.0)
+  return result2
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/forward_mode_diagnostics.swift
@@ -50,6 +50,22 @@ func calls_diff_of_nested(_ x: Float) -> Float {
 }
 
 //===----------------------------------------------------------------------===//
+// Multiple results
+//===----------------------------------------------------------------------===//
+
+func multipleResults(_ x: Float) -> (Float, Float) {
+  return (x, x)
+}
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func usesMultipleResults(_ x: Float) -> Float {
+  // expected-note @+1 {{cannot differentiate through multiple results}}
+  let tuple = multipleResults(x)
+  return tuple.0 + tuple.1
+}
+
+//===----------------------------------------------------------------------===//
 // Inout arguments
 //===----------------------------------------------------------------------===//
 
@@ -84,6 +100,52 @@ func activeInoutArgControlFlow(_ array: [Float]) -> Float {
   }
   return result
 }
+
+struct Mut: Differentiable {}
+extension Mut {
+  @differentiable(wrt: x)
+  mutating func mutatingMethod(_ x: Mut) -> Mut {
+    return x
+  }
+}
+
+// FIXME(TF-985): Forward-mode crash due to unset tangent buffer.
+/*
+@differentiable(wrt: x)
+func nonActiveInoutArg(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  return nonactive.mutatingMethod(x)
+}
+*/
+
+// FIXME(TF-985): Forward-mode crash due to unset tangent buffer.
+/*
+@differentiable(wrt: x)
+func activeInoutArgMutatingMethod(_ x: Mut) -> Mut {
+  var result = x
+  result = result.mutatingMethod(result)
+  return result
+}
+*/
+
+// FIXME(TF-985): Forward-mode crash due to unset tangent buffer.
+/*
+@differentiable(wrt: x)
+func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  var result = nonactive
+  result = result.mutatingMethod(x)
+  return result
+}
+*/
+
+// FIXME(TF-985): Forward-mode crash due to unset tangent buffer.
+/*
+@differentiable(wrt: x)
+func activeInoutArgMutatingMethodTuple(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  var result = (nonactive, x)
+  let result2 = result.0.mutatingMethod(result.0)
+  return result2
+}
+*/
 
 //===----------------------------------------------------------------------===//
 // Non-varied results


### PR DESCRIPTION
Improve diagnostic message for multiple active results.
Add diagnostic tests for multiple active results and active `inout` arguments.

Exposes TF-984: forward-mode crash due to unset tangent buffer.
Exposes TF-985: no workaround to avoid marking non-wrt `inout` arguments as active.