### PR TITLE
Fix ExistentialSpecializer: inherited conformance

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -866,9 +866,9 @@ public:
   CanGenericSignature getSingleGenericParameterSignature() const;
 
   /// Retrieve a generic signature with a single type parameter conforming
-  /// to the given existential type.
-  CanGenericSignature getExistentialSignature(CanType existential,
-                                              ModuleDecl *mod);
+  /// to the given opened archetype.
+  CanGenericSignature getOpenedArchetypeSignature(CanType existential,
+                                                  ModuleDecl *mod);
 
   GenericSignature getOverrideGenericSignature(const ValueDecl *base,
                                                const ValueDecl *derived);

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -16,6 +16,7 @@
 
 #define DEBUG_TYPE "sil-existential-transform"
 #include "ExistentialTransform.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/SIL/OptimizationRemark.h"
@@ -114,11 +115,29 @@ void ExistentialSpecializerCloner::cloneAndPopulateFunction() {
   }
 }
 
+// Gather the conformances needed for an existential value based on an opened
+// archetype. This adds any conformances inherited from superclass constraints.
+static ArrayRef<ProtocolConformanceRef>
+collectExistentialConformances(ModuleDecl *M, CanType openedType,
+                               CanType existentialType) {
+  assert(!openedType.isAnyExistentialType());
+
+  auto layout = existentialType.getExistentialLayout();
+  auto protocols = layout.getProtocols();
+
+  SmallVector<ProtocolConformanceRef, 4> conformances;
+  for (auto proto : protocols) {
+    auto conformance = M->lookupConformance(openedType, proto->getDecl());
+    assert(conformance);
+    conformances.push_back(conformance);
+  }
+  return M->getASTContext().AllocateCopy(conformances);
+}
+
 // Create the entry basic block with the function arguments.
 void ExistentialSpecializerCloner::cloneArguments(
     SmallVectorImpl<SILValue> &entryArgs) {
   auto &M = OrigF->getModule();
-  auto &Ctx = M.getASTContext();
 
   // Create the new entry block.
   SILFunction &NewF = getBuilder().getFunction();
@@ -164,14 +183,10 @@ void ExistentialSpecializerCloner::cloneArguments(
     NewArg->setOwnershipKind(ValueOwnershipKind(
         NewF, GenericSILType, ArgDesc.Arg->getArgumentConvention()));
     // Determine the Conformances.
-    SmallVector<ProtocolConformanceRef, 1> NewConformances;
-    auto ContextTy = NewF.mapTypeIntoContext(GenericParam);
-    auto OpenedArchetype = ContextTy->castTo<ArchetypeType>();
-    for (auto proto : OpenedArchetype->getConformsTo()) {
-      NewConformances.push_back(ProtocolConformanceRef(proto));
-    }
-    ArrayRef<ProtocolConformanceRef> Conformances =
-        Ctx.AllocateCopy(NewConformances);
+    SILType ExistentialType = ArgDesc.Arg->getType().getObjectType();
+    CanType OpenedType = NewArg->getType().getASTType();
+    auto Conformances = collectExistentialConformances(
+        M.getSwiftModule(), OpenedType, ExistentialType.getASTType());
     auto ExistentialRepr =
         ArgDesc.Arg->getType().getPreferredExistentialRepresentation();
     auto &EAD = ExistentialArgDescriptor[ArgDesc.Index];

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -243,11 +243,34 @@ void ConcreteExistentialInfo::initializeSubstitutionMap(
 
   // Construct a single-generic-parameter substitution map directly to the
   // ConcreteType with this existential's full list of conformances.
+  //
+  // NOTE: getOpenedArchetypeSignature() generates the signature for passing an
+  // opened existential as a generic parameter. No opened archetypes are
+  // actually involved here--the API is only used as a convenient way to create
+  // a substitution map. Since opened archetypes have different conformances
+  // than their corresponding existential, ExistentialConformances needs to be
+  // filtered when using it with this (phony) generic signature.
   CanGenericSignature ExistentialSig =
-      M->getASTContext().getExistentialSignature(ExistentialType,
-                                                 M->getSwiftModule());
-  ExistentialSubs = SubstitutionMap::get(ExistentialSig, {ConcreteType},
-                                         ExistentialConformances);
+      M->getASTContext().getOpenedArchetypeSignature(ExistentialType,
+                                                     M->getSwiftModule());
+  ExistentialSubs = SubstitutionMap::get(
+      ExistentialSig, [&](SubstitutableType *type) { return ConcreteType; },
+      [&](CanType /*depType*/, Type /*replaceType*/,
+          ProtocolDecl *proto) -> ProtocolConformanceRef {
+        // Directly providing ExistentialConformances to the SubstitionMap will
+        // fail because of the mismatch between opened archetype conformance and
+        // existential value conformance. Instead, provide a conformance lookup
+        // function that pulls only the necessary conformances out of
+        // ExistentialConformances. This assumes that existential conformances
+        // are a superset of opened archetype conformances.
+        auto iter =
+            llvm::find_if(ExistentialConformances,
+                          [&](const ProtocolConformanceRef &conformance) {
+                            return conformance.getRequirement() == proto;
+                          });
+        assert(iter != ExistentialConformances.end() && "missing conformance");
+        return *iter;
+      });
   assert(isValid());
 }
 

--- a/test/SILOptimizer/existential_transform_extras.sil
+++ b/test/SILOptimizer/existential_transform_extras.sil
@@ -203,3 +203,61 @@ sil_witness_table hidden Klass1: P module dealloc {
 sil_witness_table hidden Klass2: P module dealloc {
   method #P.foo!1: <Self where Self : P> (Self) -> () -> Int32 : nil
 }
+
+// -----------------------------------------------------------------------------
+// Test composite conformances with superclass constraints where one of
+// the protocol constraints is satisfied by the superclass constraint.
+//
+// <rdar://problem/57025861> "Assertion failed: (conformances.size()
+// == numConformanceRequirements)" in ExistentialSpecializer on
+protocol Plotable {}
+
+class PlotLayer : Plotable {
+  init()
+}
+
+protocol InView {}
+
+class PlotLayerInView : PlotLayer & InView {
+  override init()
+}
+
+class PlotView {
+  @_hasStorage @_hasInitialValue var layers: Container<PlotLayer & Plotable & InView> { get set }
+  public func resolveLayers()
+  init()
+}
+
+struct Container<T> {
+  @_hasStorage @_hasInitialValue var val: T { get set }
+}
+
+// Check that the init_existential instruction was created with all
+// three requirements (the generic parameter only has two
+// requirements).  Relies on assertions during specialization and on
+// the SILVerifier to catch other inconsistencies.
+//
+// CHECK-LABEL: sil shared @$s40testExistentialSpecializeCompositeHelperTf4en_n : $@convention(thin) <τ_0_0 where τ_0_0 : PlotLayer, τ_0_0 : InView> (@owned τ_0_0, @inout Container<PlotLayer & InView & Plotable>) -> () {
+// CHECK: bb0(%0 : $τ_0_0, %1 : $*Container<PlotLayer & InView & Plotable>):
+// CHECK:   init_existential_ref %0 : $τ_0_0 : $τ_0_0, $PlotLayer & InView & Plotable
+// CHECK-LABEL: } // end sil function '$s40testExistentialSpecializeCompositeHelperTf4en_n'
+sil shared @testExistentialSpecializeCompositeHelper : $@convention(method) (@owned PlotLayer & Plotable & InView, @inout Container<PlotLayer & Plotable & InView>) -> () {
+bb0(%0 : $PlotLayer & Plotable & InView, %1 : $*Container<PlotLayer & Plotable & InView>):
+  %adr = struct_element_addr %1 : $*Container<PlotLayer & Plotable & InView>, #Container.val
+  store %0 to %adr : $*PlotLayer & Plotable & InView
+  %v = tuple ()
+  return %v : $()
+}
+
+sil @testExistentialSpecializeComposite : $@convention(method) (@guaranteed PlotView) -> () {
+bb0(%0 : $PlotView):
+  %ref = alloc_ref $PlotLayerInView
+  strong_retain %ref : $PlotLayerInView
+  %exis = init_existential_ref %ref : $PlotLayerInView : $PlotLayerInView, $PlotLayer & Plotable & InView
+  %array = ref_element_addr %0 : $PlotView, #PlotView.layers
+  %f = function_ref @testExistentialSpecializeCompositeHelper : $@convention(method) (@owned PlotLayer & Plotable & InView, @inout Container<PlotLayer & Plotable & InView>) -> ()
+  %call = apply %f(%exis, %array) : $@convention(method) (@owned PlotLayer & Plotable & InView, @inout Container<PlotLayer & Plotable & InView>) -> ()
+  strong_release %ref : $PlotLayerInView
+  %v = tuple ()
+  return %v : $()
+}


### PR DESCRIPTION
The ExistentialSpecializer incorrectly assumed that an existential's conformances match an opened archetype. They don't. Opened archetypes strip inherited conformances per the ABI for generic argument passing. Existential values retain those inherited conformances (for some inexplicable reason).

- Rename ASTContext::getExistentialSignature() to
  getOpenedArchetypeSiganture() because it was doing exactly the wrong
  thing for existentials.

- Fix ConcreteExistentialInfo to produce the correct SubstitutionMap.

- Fix ExistentialSpecializer to generate the correct conformances for
  init_existential by adding a collectExistentialConformances() helper.

Fixes <rdar://problem/57025861> "Assertion failed: (conformances.size() == numConformanceRequirements)" in ExistentialSpecializer on inlined code

