### PR TITLE
[CodeCompletion] Stop using temporary Lexer in the second pass

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -74,7 +74,14 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
 
   case DeclContextKind::AbstractFunctionDecl: {
     auto *AFD = cast<AbstractFunctionDecl>(DC);
-    swift::typeCheckAbstractFunctionBodyUntil(AFD, Loc);
+    auto &SM = DC->getASTContext().SourceMgr;
+    auto bodyRange = AFD->getBodySourceRange();
+    if (SM.rangeContainsTokenLoc(bodyRange, Loc)) {
+      swift::typeCheckAbstractFunctionBodyUntil(AFD, Loc);
+    } else {
+      assert(bodyRange.isInvalid() && "The body should not be parsed if the "
+                                      "completion happens in the signature");
+    }
     break;
   }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -144,7 +144,6 @@ void Parser::performCodeCompletionSecondPassImpl(
   SyntaxContext->disable();
 
   auto BeginParserPosition = getParserPosition(info.BodyPos);
-  auto EndLexerState = L->getStateForEndOfTokenLoc(info.BodyEnd);
 
   // ParserPositionRAII needs a primed parser to restore to.
   if (Tok.is(tok::NUM_TOKENS))
@@ -152,12 +151,6 @@ void Parser::performCodeCompletionSecondPassImpl(
 
   // Ensure that we restore the parser state at exit.
   ParserPositionRAII PPR(*this);
-
-  // Create a lexer that cannot go past the end state.
-  Lexer LocalLex(*L, BeginParserPosition.LS, EndLexerState);
-
-  // Temporarily swap out the parser's current lexer with our new one.
-  llvm::SaveAndRestore<Lexer *> T(L, &LocalLex);
 
   // Rewind to the beginning of the top-level code.
   restoreParserPosition(BeginParserPosition);

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -143,17 +143,8 @@ void Parser::performCodeCompletionSecondPassImpl(
   // Disable libSyntax creation in the delayed parsing.
   SyntaxContext->disable();
 
-  auto BeginParserPosition = getParserPosition(info.BodyPos);
-
-  // ParserPositionRAII needs a primed parser to restore to.
-  if (Tok.is(tok::NUM_TOKENS))
-    consumeTokenWithoutFeedingReceiver();
-
-  // Ensure that we restore the parser state at exit.
-  ParserPositionRAII PPR(*this);
-
-  // Rewind to the beginning of the top-level code.
-  restoreParserPosition(BeginParserPosition);
+  // Set the parser position to the start of the delayed decl or the body.
+  restoreParserPosition(getParserPosition(info.BodyPos));
 
   // Do not delay parsing in the second pass.
   llvm::SaveAndRestore<bool> DisableDelayedBody(DelayBodyParsing, false);

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2121,15 +2121,11 @@ TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
                                                             builderType);
       if (!body)
         return true;
-    } else if (func->hasSingleExpressionBody()) {
-      auto resultTypeLoc = func->getBodyResultTypeLoc();
-      auto expr = func->getSingleExpressionBody();
-
-      if (resultTypeLoc.isNull() || resultTypeLoc.getType()->isVoid()) {
-        // The function returns void.  We don't need an explicit return, no matter
-        // what the type of the expression is.  Take the inserted return back out.
-        body->setFirstElement(expr);
-      }
+    } else if (func->hasSingleExpressionBody() &&
+               func->getResultInterfaceType()->isVoid()) {
+      // The function returns void.  We don't need an explicit return, no matter
+      // what the type of the expression is.  Take the inserted return back out.
+      body->setFirstElement(func->getSingleExpressionBody());
     }
   } else if (isa<ConstructorDecl>(AFD) &&
              (body->empty() ||

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -695,9 +695,6 @@ struct InitializerWithNameAndParam {
 struct InitializerWithLabels {
   init c d: Int {}
   // expected-error @-1 {{expected '(' for initializer parameters}}
-  // expected-error @-2 {{expected declaration}}
-  // expected-error @-3 {{consecutive declarations on a line must be separated by ';'}}
-  // expected-note @-5 {{in declaration of 'InitializerWithLabels'}}
 }
 
 // rdar://20337695


### PR DESCRIPTION
* Since we only call one parsing function (i.e. `parseBraceItemList`, `parseDecl`, or `parseExprOrStmt`), the parser stops at the end of the node anyways. It's not necessary to limit the Lexer to set an ArtificialEOF. As a ground work, modify the Parser to *not* parse the body if the completion happens in the signature
* Don't restore the parser position after the second pass because it's just not necessary. The parser here lives only for the single second pass.
* Use `getResultInterfaceType()` to get the result type in `TypeCheckFunctionBodyUntilRequest`. So we can type check the body without type checking the signature of the func decl. (This change is actually not needed but I think this is an improvement)