### PR TITLE
[NFC] Refactor @_dynamicReplacement Checking

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4774,8 +4774,6 @@ public:
 
   bool hasAnyNativeDynamicAccessors() const;
 
-  bool hasAnyDynamicReplacementAccessors() const;
-
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_AbstractStorageDecl &&

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2389,6 +2389,7 @@ class ValueDecl : public Decl {
     unsigned isIUO : 1;
   } LazySemanticInfo = { };
 
+  friend class DynamicallyReplacedDeclRequest;
   friend class OverriddenDeclsRequest;
   friend class IsObjCRequest;
   friend class IsFinalRequest;
@@ -2749,6 +2750,11 @@ public:
   /// Retrieve the @functionBuilder type attached to this declaration,
   /// if there is one.
   Type getFunctionBuilderType() const;
+
+  /// If this value or its backing storage is annotated
+  /// @_dynamicReplacement(for: ...), compute the original declaration
+  /// that this declaration dynamically replaces.
+  ValueDecl *getDynamicallyReplacedDecl() const;
 };
 
 /// This is a common base class for declarations which declare a type.

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -103,6 +103,11 @@ public:
   virtual void
   loadRequirementSignature(const ProtocolDecl *proto, uint64_t contextData,
                            SmallVectorImpl<Requirement> &requirements) = 0;
+
+  /// Returns the replaced decl for a given @_dynamicReplacement(for:) attribute.
+  virtual ValueDecl *
+  loadDynamicallyReplacedFunctionDecl(const DynamicReplacementAttr *DRA,
+                                      uint64_t contextData) = 0;
 };
 
 /// A class that can lazily load conformances from a serialized format.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1930,6 +1930,24 @@ public:
   bool isCached() const { return true; }
 };
 
+class DynamicallyReplacedDeclRequest
+    : public SimpleRequest<DynamicallyReplacedDeclRequest,
+                           ValueDecl *(ValueDecl *), CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<ValueDecl *> evaluate(Evaluator &evaluator,
+                                       ValueDecl *VD) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -43,6 +43,9 @@ SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,
 SWIFT_REQUEST(TypeChecker, DefaultTypeRequest,
               Type(KnownProtocolKind, const DeclContext *), SeparatelyCached,
               NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DynamicallyReplacedDeclRequest,
+              ValueDecl *(ValueDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, EmittedMembersRequest, DeclRange(ClassDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, EnumRawValuesRequest,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -22,14 +22,14 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IndexSubset.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/AST/Types.h"
-#include "swift/AST/ParameterList.h"
 #include "swift/Basic/Defer.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
 using namespace swift;
 
 #define DECL_ATTR(_, Id, ...) \
@@ -1148,7 +1148,7 @@ DynamicReplacementAttr::DynamicReplacementAttr(SourceLoc atLoc,
                                                SourceRange parenRange)
     : DeclAttribute(DAK_DynamicReplacement, atLoc, baseRange,
                     /*Implicit=*/false),
-      ReplacedFunctionName(name), ReplacedFunction(nullptr) {
+      ReplacedFunctionName(name) {
   Bits.DynamicReplacementAttr.HasTrailingLocationInfo = true;
   getTrailingLocations()[0] = parenRange.Start;
   getTrailingLocations()[1] = parenRange.End;
@@ -1165,17 +1165,16 @@ DynamicReplacementAttr::create(ASTContext &Ctx, SourceLoc AtLoc,
       SourceRange(LParenLoc, RParenLoc));
 }
 
-DynamicReplacementAttr *DynamicReplacementAttr::create(ASTContext &Ctx,
-                                                       DeclName name) {
-  return new (Ctx) DynamicReplacementAttr(name);
+DynamicReplacementAttr *
+DynamicReplacementAttr::create(ASTContext &Ctx, DeclName name,
+                               AbstractFunctionDecl *f) {
+  return new (Ctx) DynamicReplacementAttr(name, f);
 }
 
 DynamicReplacementAttr *
 DynamicReplacementAttr::create(ASTContext &Ctx, DeclName name,
-                               AbstractFunctionDecl *f) {
-  auto res = new (Ctx) DynamicReplacementAttr(name);
-  res->setReplacedFunction(f);
-  return res;
+                               LazyMemberLoader *Resolver, uint64_t Data) {
+  return new (Ctx) DynamicReplacementAttr(name, Resolver, Data);
 }
 
 SourceLoc DynamicReplacementAttr::getLParenLoc() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4979,13 +4979,6 @@ bool AbstractStorageDecl::hasAnyNativeDynamicAccessors() const {
   return false;
 }
 
-bool AbstractStorageDecl::hasAnyDynamicReplacementAccessors() const {
-  for (auto accessor : getAllAccessors()) {
-    if (accessor->getAttrs().hasAttribute<DynamicReplacementAttr>())
-      return true;
-  }
-  return false;
-}
 void AbstractStorageDecl::setAccessors(SourceLoc lbraceLoc,
                                        ArrayRef<AccessorDecl *> accessors,
                                        SourceLoc rbraceLoc) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2833,6 +2833,13 @@ void ValueDecl::setIsDynamic(bool value) {
   LazySemanticInfo.isDynamic = value;
 }
 
+ValueDecl *ValueDecl::getDynamicallyReplacedDecl() const {
+  return evaluateOrDefault(getASTContext().evaluator,
+                           DynamicallyReplacedDeclRequest{
+                               const_cast<ValueDecl *>(this)},
+                           nullptr);
+}
+
 bool ValueDecl::canBeAccessedByDynamicLookup() const {
   if (!hasName())
     return false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4965,9 +4965,9 @@ bool AbstractStorageDecl::hasPrivateAccessor() const {
 
 bool AbstractStorageDecl::hasDidSetOrWillSetDynamicReplacement() const {
   if (auto *func = getParsedAccessor(AccessorKind::DidSet))
-    return func->getAttrs().hasAttribute<DynamicReplacementAttr>();
+    return (bool)func->getDynamicallyReplacedDecl();
   if (auto *func = getParsedAccessor(AccessorKind::WillSet))
-    return func->getAttrs().hasAttribute<DynamicReplacementAttr>();
+    return (bool)func->getDynamicallyReplacedDecl();
   return false;
 }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1230,6 +1230,12 @@ public:
     llvm_unreachable("unimplemented for ClangImporter");
   }
 
+  ValueDecl *
+  loadDynamicallyReplacedFunctionDecl(const DynamicReplacementAttr *DRA,
+                                      uint64_t contextData) override {
+    llvm_unreachable("unimplemented for ClangImporter");
+  }
+
   void loadRequirementSignature(const ProtocolDecl *decl, uint64_t contextData,
                                 SmallVectorImpl<Requirement> &reqs) override {
     llvm_unreachable("unimplemented for ClangImporter");

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -452,21 +452,18 @@ withOpaqueTypeGenericArgs(IRGenFunction &IGF,
 
 bool shouldUseOpaqueTypeDescriptorAccessor(OpaqueTypeDecl *opaque) {
   auto *namingDecl = opaque->getNamingDecl();
-  auto *abstractStorage = dyn_cast<AbstractStorageDecl>(namingDecl);
 
   // Don't emit accessors for abstract storage that is not dynamic or a dynamic
   // replacement.
-  if (abstractStorage) {
+  if (auto *abstractStorage = dyn_cast<AbstractStorageDecl>(namingDecl)) {
     return abstractStorage->hasAnyNativeDynamicAccessors() ||
-           abstractStorage->hasAnyDynamicReplacementAccessors();
+           abstractStorage->getDynamicallyReplacedDecl();
   }
 
   // Don't emit accessors for functions that are not dynamic or dynamic
   // replacements.
-  return opaque->getNamingDecl()->isNativeDynamic() ||
-         opaque->getNamingDecl()
-             ->getAttrs()
-             .hasAttribute<DynamicReplacementAttr>();
+  return namingDecl->isNativeDynamic() ||
+         (bool)namingDecl->getDynamicallyReplacedDecl();
 }
 
 static llvm::Value *

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2369,7 +2369,7 @@ static void emitDynamicallyReplaceableThunk(IRGenModule &IGM,
 void IRGenModule::emitOpaqueTypeDescriptorAccessor(OpaqueTypeDecl *opaque) {
   auto *namingDecl = opaque->getNamingDecl();
   auto *abstractStorage = dyn_cast<AbstractStorageDecl>(namingDecl);
-  
+
   bool isNativeDynamic = false;
   const bool isDynamicReplacement = namingDecl->getDynamicallyReplacedDecl();
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2369,15 +2369,14 @@ static void emitDynamicallyReplaceableThunk(IRGenModule &IGM,
 void IRGenModule::emitOpaqueTypeDescriptorAccessor(OpaqueTypeDecl *opaque) {
   auto *namingDecl = opaque->getNamingDecl();
   auto *abstractStorage = dyn_cast<AbstractStorageDecl>(namingDecl);
-
+  
   bool isNativeDynamic = false;
-  bool isDynamicReplacement = false;
+  const bool isDynamicReplacement = namingDecl->getDynamicallyReplacedDecl();
 
   // Don't emit accessors for abstract storage that is not dynamic or a dynamic
   // replacement.
   if (abstractStorage) {
     isNativeDynamic = abstractStorage->hasAnyNativeDynamicAccessors();
-    isDynamicReplacement = abstractStorage->hasAnyDynamicReplacementAccessors();
     if (!isNativeDynamic && !isDynamicReplacement)
       return;
   }
@@ -2385,10 +2384,7 @@ void IRGenModule::emitOpaqueTypeDescriptorAccessor(OpaqueTypeDecl *opaque) {
   // Don't emit accessors for functions that are not dynamic or dynamic
   // replacements.
   if (!abstractStorage) {
-    isNativeDynamic = opaque->getNamingDecl()->isNativeDynamic();
-    isDynamicReplacement = opaque->getNamingDecl()
-                               ->getAttrs()
-                               .hasAttribute<DynamicReplacementAttr>();
+    isNativeDynamic = namingDecl->isNativeDynamic();
     if (!isNativeDynamic && !isDynamicReplacement)
       return;
   }

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -76,12 +76,12 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
           SILFunctionTypeRepresentation::ObjCMethod)
     return;
 
-  auto *replacedFuncAttr = Attrs.getAttribute<DynamicReplacementAttr>();
-  if (!replacedFuncAttr)
+  // Only assign replacements when the thing being replaced is function-like and
+  // explicitly declared.  
+  auto *origDecl = decl->getDynamicallyReplacedDecl();
+  auto *replacedDecl = dyn_cast_or_null<AbstractFunctionDecl>(origDecl);
+  if (!replacedDecl)
     return;
-
-  auto *replacedDecl = replacedFuncAttr->getReplacedFunction();
-  assert(replacedDecl);
 
   if (decl->isObjC()) {
     F->setObjCReplacement(replacedDecl);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -789,8 +789,7 @@ bool isCallToReplacedInDynamicReplacement(SILGenFunction &SGF,
                                           bool &isObjCReplacementSelfCall) {
   if (auto *func =
           dyn_cast_or_null<AbstractFunctionDecl>(SGF.FunctionDC->getAsDecl())) {
-    auto *repl = func->getAttrs().getAttribute<DynamicReplacementAttr>();
-    if (repl && repl->getReplacedFunction() == afd) {
+    if (func->getDynamicallyReplacedDecl() == afd) {
       isObjCReplacementSelfCall = afd->isObjC();
       return true;
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2072,10 +2072,10 @@ void AttributeChecker::visitDiscardableResultAttr(DiscardableResultAttr *attr) {
 }
 
 /// Lookup the replaced decl in the replacments scope.
-void lookupReplacedDecl(DeclName replacedDeclName,
-                        const DynamicReplacementAttr *attr,
-                        const ValueDecl *replacement,
-                        SmallVectorImpl<ValueDecl *> &results) {
+static void lookupReplacedDecl(DeclName replacedDeclName,
+                               const DynamicReplacementAttr *attr,
+                               const ValueDecl *replacement,
+                               SmallVectorImpl<ValueDecl *> &results) {
   auto *declCtxt = replacement->getDeclContext();
 
   // Look at the accessors' storage's context.
@@ -2232,11 +2232,12 @@ findReplacedFunction(DeclName replacedFunctionName,
     // Check for static/instance mismatch.
     if (result->isStatic() != replacement->isStatic())
       continue;
-    
+
+    auto resultTy = result->getInterfaceType();
+    auto replaceTy = replacement->getInterfaceType();
     TypeMatchOptions matchMode = TypeMatchFlags::AllowABICompatible;
     matchMode |= TypeMatchFlags::AllowCompatibleOpaqueTypeArchetypes;
-    if (result->getInterfaceType()->getCanonicalType()->matches(
-            replacement->getInterfaceType()->getCanonicalType(), matchMode)) {
+    if (resultTy->matches(replaceTy, matchMode)) {
       if (!result->isDynamic()) {
         if (Diags) {
           Diags->diagnose(attr->getLocation(),
@@ -2286,9 +2287,11 @@ findReplacedStorageDecl(DeclName replacedFunctionName,
     // Check for static/instance mismatch.
     if (result->isStatic() != replacement->isStatic())
       continue;
-    if (result->getInterfaceType()->getCanonicalType()->matches(
-            replacement->getInterfaceType()->getCanonicalType(),
-            TypeMatchFlags::AllowABICompatible)) {
+    auto resultTy = result->getInterfaceType();
+    auto replaceTy = replacement->getInterfaceType();
+    TypeMatchOptions matchMode = TypeMatchFlags::AllowABICompatible;
+    matchMode |= TypeMatchFlags::AllowCompatibleOpaqueTypeArchetypes;
+    if (resultTy->matches(replaceTy, matchMode)) {
       if (!result->isDynamic()) {
         return nullptr;
       }
@@ -2298,113 +2301,48 @@ findReplacedStorageDecl(DeclName replacedFunctionName,
   return nullptr;
 }
 
-ValueDecl *TypeChecker::findReplacedDynamicFunction(const ValueDecl *vd) {
-  assert(isa<AbstractFunctionDecl>(vd) || isa<AbstractStorageDecl>(vd));
-  if (isa<AccessorDecl>(vd))
-    return nullptr;
-
-  auto *attr = vd->getAttrs().getAttribute<DynamicReplacementAttr>();
-  if (!attr)
-    return nullptr;
-
-  auto *afd = dyn_cast<AbstractFunctionDecl>(vd);
-  if (afd) {
-    // When we pass nullptr as the type checker argument attr is truely const.
-    return findReplacedFunction(attr->getReplacedFunctionName(), afd,
-                                const_cast<DynamicReplacementAttr *>(attr),
-                                nullptr);
-  }
-  auto *storageDecl = dyn_cast<AbstractStorageDecl>(vd);
-  if (!storageDecl)
-    return nullptr;
-  return findReplacedStorageDecl(attr->getReplacedFunctionName(), storageDecl, attr);
-}
-
 void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr) {
   assert(isa<AbstractFunctionDecl>(D) || isa<AbstractStorageDecl>(D));
-  auto *VD = cast<ValueDecl>(D);
+  auto *replacement = cast<ValueDecl>(D);
 
-  if (!isa<ExtensionDecl>(VD->getDeclContext()) &&
-      !VD->getDeclContext()->isModuleScopeContext()) {
+  if (!isa<ExtensionDecl>(replacement->getDeclContext()) &&
+      !replacement->getDeclContext()->isModuleScopeContext()) {
     diagnose(attr->getLocation(), diag::dynamic_replacement_not_in_extension,
-             VD->getBaseName());
+             replacement->getBaseName());
     attr->setInvalid();
     return;
   }
 
-  if (VD->isNativeDynamic()) {
+  if (replacement->isNativeDynamic()) {
     diagnose(attr->getLocation(), diag::dynamic_replacement_must_not_be_dynamic,
-             VD->getBaseName());
+             replacement->getBaseName());
     attr->setInvalid();
     return;
   }
 
-  // Don't process a declaration twice. This will happen to accessor decls after
-  // we have processed their var decls.
-  if (attr->getReplacedFunction())
+  auto *original = replacement->getDynamicallyReplacedDecl();
+  if (!original) {
+    attr->setInvalid();
     return;
-
-  SmallVector<AbstractFunctionDecl *, 4> replacements;
-  SmallVector<AbstractFunctionDecl *, 4> origs;
-
-  // Collect the accessor replacement mapping if this is an abstract storage.
-  if (auto *var = dyn_cast<AbstractStorageDecl>(VD)) {
-    var->visitParsedAccessors([&](AccessorDecl *accessor) {
-      if (attr->isInvalid())
-        return;
-
-       auto *orig = findReplacedAccessor(attr->getReplacedFunctionName(),
-                                         accessor, attr, Ctx);
-       if (!orig)
-         return;
-
-       origs.push_back(orig);
-       replacements.push_back(accessor);
-     });
-  } else {
-    // Otherwise, find the matching function.
-    auto *fun = cast<AbstractFunctionDecl>(VD);
-    if (auto *orig = findReplacedFunction(attr->getReplacedFunctionName(), fun,
-                                          attr, &Ctx.Diags)) {
-      origs.push_back(orig);
-      replacements.push_back(fun);
-    } else
-      return;
   }
 
-  // Annotate the replacement with the original func decl.
-  for (auto index : indices(replacements)) {
-    if (auto *attr = replacements[index]
-                         ->getAttrs()
-                         .getAttribute<DynamicReplacementAttr>()) {
-      auto *replacedFun = origs[index];
-      auto *replacement = replacements[index];
-      if (replacedFun->isObjC() && !replacement->isObjC()) {
-        diagnose(attr->getLocation(),
-                 diag::dynamic_replacement_replacement_not_objc_dynamic,
-                 attr->getReplacedFunctionName());
-        attr->setInvalid();
-        return;
-      }
-      if (!replacedFun->isObjC() && replacement->isObjC()) {
-        diagnose(attr->getLocation(),
-                 diag::dynamic_replacement_replaced_not_objc_dynamic,
-                 attr->getReplacedFunctionName());
-        attr->setInvalid();
-        return;
-      }
-      attr->setReplacedFunction(replacedFun);
-      continue;
-    }
-    auto *newAttr = DynamicReplacementAttr::create(
-        VD->getASTContext(), attr->getReplacedFunctionName(), origs[index]);
-    DeclAttributes &attrs = replacements[index]->getAttrs();
-    attrs.add(newAttr);
+  if (original->isObjC() && !replacement->isObjC()) {
+    diagnose(attr->getLocation(),
+             diag::dynamic_replacement_replacement_not_objc_dynamic,
+             attr->getReplacedFunctionName());
+    attr->setInvalid();
   }
-  if (auto *CD = dyn_cast<ConstructorDecl>(VD)) {
+  if (!original->isObjC() && replacement->isObjC()) {
+    diagnose(attr->getLocation(),
+             diag::dynamic_replacement_replaced_not_objc_dynamic,
+             attr->getReplacedFunctionName());
+    attr->setInvalid();
+  }
+
+  if (auto *CD = dyn_cast<ConstructorDecl>(replacement)) {
     auto *attr = CD->getAttrs().getAttribute<DynamicReplacementAttr>();
     auto replacedIsConvenienceInit =
-        cast<ConstructorDecl>(attr->getReplacedFunction())->isConvenienceInit();
+        cast<ConstructorDecl>(original)->isConvenienceInit();
     if (replacedIsConvenienceInit &&!CD->isConvenienceInit()) {
       diagnose(attr->getLocation(),
                diag::dynamic_replacement_replaced_constructor_is_convenience,
@@ -2416,13 +2354,6 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
           attr->getReplacedFunctionName());
     }
   }
-
-
-  // Remove the attribute on the abstract storage (we have moved it to the
-  // accessor decl).
-  if (!isa<AbstractStorageDecl>(VD))
-    return;
-  D->getAttrs().removeAttribute(attr);
 }
 
 void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
@@ -2910,4 +2841,54 @@ void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
     auto attr = new (D->getASTContext()) DynamicAttr(/*implicit=*/true);
     D->getAttrs().add(attr);
   }
+}
+
+llvm::Expected<ValueDecl *>
+DynamicallyReplacedDeclRequest::evaluate(Evaluator &evaluator,
+                                         ValueDecl *VD) const {
+  // Dynamic replacements must be explicit.
+  if (VD->isImplicit())
+    return nullptr;
+
+  auto *attr = VD->getAttrs().getAttribute<DynamicReplacementAttr>();
+  if (!attr) {
+    // It's likely that the accessor isn't annotated but its storage is.
+    if (auto *AD = dyn_cast<AccessorDecl>(VD)) {
+      // Try to grab the attribute from the storage.
+      attr = AD->getStorage()->getAttrs().getAttribute<DynamicReplacementAttr>();
+    }
+
+    if (!attr) {
+      // Otherwise, it's not dynamically replacing anything.
+      return nullptr;
+    }
+  }
+
+  // If the attribute is invalid, bail.
+  if (attr->isInvalid())
+    return nullptr;
+
+  // If we can lazily resolve the function, do so now.
+  if (auto *LazyResolver = attr->Resolver) {
+    auto decl = attr->Resolver->loadDynamicallyReplacedFunctionDecl(
+        attr, attr->ResolverContextData);
+    attr->Resolver = nullptr;
+    return decl;
+  }
+
+  auto &Ctx = VD->getASTContext();
+  if (auto *AD = dyn_cast<AccessorDecl>(VD)) {
+    return findReplacedAccessor(attr->getReplacedFunctionName(), AD, attr, Ctx);
+  }
+
+  if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
+    return findReplacedFunction(attr->getReplacedFunctionName(), AFD,
+                                attr, &Ctx.Diags);
+  }
+
+  if (auto *SD = dyn_cast<AbstractStorageDecl>(VD)) {
+    return findReplacedStorageDecl(attr->getReplacedFunctionName(), SD, attr);
+  }
+
+  return nullptr;
 }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1045,11 +1045,10 @@ Optional<ObjCReason> shouldMarkAsObjC(const ValueDecl *VD, bool allowImplicit) {
   if (isa<AbstractFunctionDecl>(VD) || isa<AbstractStorageDecl>(VD))
     if (auto *replacementAttr =
             VD->getAttrs().getAttribute<DynamicReplacementAttr>()) {
-      if (auto *replaced = replacementAttr->getReplacedFunction()) {
+      if (auto *replaced = VD->getDynamicallyReplacedDecl()) {
         if (replaced->isObjC())
           return ObjCReason(ObjCReason::ImplicitlyObjC);
-      } else if (auto *replaced =
-                     TypeChecker::findReplacedDynamicFunction(VD)) {
+      } else if (auto *replaced = VD->getDynamicallyReplacedDecl()) {
         if (replaced->isObjC())
           return ObjCReason(ObjCReason::ImplicitlyObjC);
       }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1048,9 +1048,6 @@ Optional<ObjCReason> shouldMarkAsObjC(const ValueDecl *VD, bool allowImplicit) {
       if (auto *replaced = VD->getDynamicallyReplacedDecl()) {
         if (replaced->isObjC())
           return ObjCReason(ObjCReason::ImplicitlyObjC);
-      } else if (auto *replaced = VD->getDynamicallyReplacedDecl()) {
-        if (replaced->isObjC())
-          return ObjCReason(ObjCReason::ImplicitlyObjC);
       }
     }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2056,7 +2056,8 @@ public:
     // Force these requests in case they emit diagnostics.
     (void) FD->getInterfaceType();
     (void) FD->getOperatorDecl();
-
+    (void) FD->getDynamicallyReplacedDecl();
+    
     if (!FD->isInvalid()) {
       checkGenericParams(FD);
       TypeChecker::checkReferencedGenericParams(FD);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -723,7 +723,6 @@ public:
   static void addImplicitDynamicAttribute(Decl *D);
   static void checkDeclAttributes(Decl *D);
   static void checkParameterAttributes(ParameterList *params);
-  static ValueDecl *findReplacedDynamicFunction(const ValueDecl *d);
 
   static Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
                                           ReferenceOwnershipAttr *attr);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5457,6 +5457,11 @@ ModuleFile::loadAssociatedTypeDefault(const swift::AssociatedTypeDecl *ATD,
   return getType(contextData);
 }
 
+ValueDecl *ModuleFile::loadDynamicallyReplacedFunctionDecl(
+    const DynamicReplacementAttr *DRA, uint64_t contextData) {
+  return cast<ValueDecl>(getDecl(contextData));
+}
+
 void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
                                          uint64_t contextData) {
   using namespace decls_block;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4114,9 +4114,6 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         serialization::decls_block::DynamicReplacementDeclAttrLayout::
             readRecord(scratch, isImplicit, replacedFunID, numArgs, rawPieceIDs);
 
-        auto replacedFunDecl = MF.getDeclChecked(replacedFunID);
-        if (!replacedFunDecl)
-          return replacedFunDecl.takeError();
         auto baseName = MF.getDeclBaseName(rawPieceIDs[0]);
         SmallVector<Identifier, 4> pieces;
         for (auto pieceID : rawPieceIDs.slice(1))
@@ -4125,8 +4122,8 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         assert(numArgs != 0);
         assert(!isImplicit && "Need to update for implicit");
         Attr = DynamicReplacementAttr::create(
-            ctx, DeclName(ctx, baseName, ArrayRef<Identifier>(pieces)),
-            cast<AbstractFunctionDecl>(*replacedFunDecl));
+            ctx, DeclName(ctx, baseName, ArrayRef<Identifier>(pieces)), &MF,
+            replacedFunID);
         break;
       }
 

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -839,6 +839,10 @@ public:
   virtual Type loadAssociatedTypeDefault(const AssociatedTypeDecl *ATD,
                                          uint64_t contextData) override;
 
+  virtual ValueDecl *
+  loadDynamicallyReplacedFunctionDecl(const DynamicReplacementAttr *DRA,
+                                      uint64_t contextData) override;
+
   virtual void finishNormalConformance(NormalProtocolConformance *conformance,
                                        uint64_t contextData) override;
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 525; // target formal type for casts
+const uint16_t SWIFTMODULE_VERSION_MINOR = 526; // @_dynamicReplacement adjustments
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2069,7 +2069,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     didVerifyAttrs = true;
   }
 
-  void writeDeclAttribute(const DeclAttribute *DA) {
+  void writeDeclAttribute(const Decl *D, const DeclAttribute *DA) {
     using namespace decls_block;
 
     // Completely ignore attributes that aren't serialized.
@@ -2261,10 +2261,11 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       pieces.push_back(S.addDeclBaseNameRef(replacedFun.getBaseName()));
       for (auto argName : replacedFun.getArgumentNames())
         pieces.push_back(S.addDeclBaseNameRef(argName));
-      assert(theAttr->getReplacedFunction());
+      auto *afd = cast<ValueDecl>(D)->getDynamicallyReplacedDecl();
+      assert(afd && "Missing replaced decl!");
       DynamicReplacementDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode, false, /*implicit flag*/
-          S.addDeclRef(theAttr->getReplacedFunction()), pieces.size(), pieces);
+          S.addDeclRef(afd), pieces.size(), pieces);
       return;
     }
 
@@ -2673,7 +2674,7 @@ public:
   void visit(const Decl *D) {
     // Emit attributes (if any).
     for (auto Attr : D->getAttrs())
-      writeDeclAttribute(Attr);
+      writeDeclAttribute(D, Attr);
 
     if (auto *value = dyn_cast<ValueDecl>(D))
       writeDiscriminatorsIfNeeded(value);

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -226,7 +226,7 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
     addSymbol(
         LinkEntity::forDynamicallyReplaceableFunctionKey(AFD, useAllocator));
   }
-  if (AFD->getAttrs().hasAttribute<DynamicReplacementAttr>()) {
+  if (AFD->getDynamicallyReplacedDecl()) {
     bool useAllocator = shouldUseAllocatorMangling(AFD);
     addSymbol(LinkEntity::forDynamicallyReplaceableFunctionVariable(
         AFD, useAllocator));
@@ -254,7 +254,7 @@ void TBDGenVisitor::visitFuncDecl(FuncDecl *FD) {
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessorKey(opaqueResult));
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessorVar(opaqueResult));
     }
-    if (FD->getAttrs().hasAttribute<DynamicReplacementAttr>()) {
+    if (FD->getDynamicallyReplacedDecl()) {
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessor(opaqueResult));
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessorVar(opaqueResult));
     }
@@ -282,7 +282,7 @@ void TBDGenVisitor::visitAbstractStorageDecl(AbstractStorageDecl *ASD) {
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessorKey(opaqueResult));
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessorVar(opaqueResult));
     }
-    if (ASD->hasAnyDynamicReplacementAccessors()) {
+    if (ASD->getDynamicallyReplacedDecl()) {
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessor(opaqueResult));
       addSymbol(LinkEntity::forOpaqueTypeDescriptorAccessorVar(opaqueResult));
     }


### PR DESCRIPTION
Refactor the way the compiler deals with `@_dynamicReplacement`.  This started as an effort to just lazy-load the member instead of forcing the cross-reference in deserialization - this caused a cycle in name lookup.

It wound up being... a lot more.

Add a request for the original decl behind a `@_dynamicReplacement` attribute.  The request absorbs the lazy member loading logic, the previous logic in the type checker for validating this attribute, and the logic for handling accessors.  There is also a change to the way we validate and check this attribute. Rather than strip it from VarDecls and place it back onto their accessors, leave it where it is.  The accessors can use the attribute attached to their storage to recover the replaced decl they need by lookup and type match.  This also means we can simplify and remove some predicates that were used by IRGen and SILGen that required fanning out and iterating over all the accessors just to see if they had `@_dynamicReplacement` reparented onto them.

This also changes the decls we serialize this attributes for - we're no longer serializing all the accessors' replacements, and we're now serializing all the VarDecl's replacements - so bump the module format version.