### PR TITLE
[build] prefer picking up sqlite3 from Darwin SDK for llbuild

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2090,13 +2090,17 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DFoundation_DIR:PATH=$(build_directory ${host} foundation)/cmake/modules
                 )
 
-                # Ensure on Darwin platforms that we prefer the SQLite from the SDK
-                # instead of picking one found elsewhere (e.g. in /usr/include )
+                # Ensure on Darwin platforms that we consider only the SQLite headers
+                # from the SDK instead of picking ones found elsewhere
+                # (e.g. in /usr/include )
+                # Also consider only the SQLite dylib shipped with the OS
+                # to avoid mismatch with the headers
                 if [[ "$(uname -s)" = "Darwin" ]]; then
                     cmake_options=(
                         "${cmake_options[@]}"
 
-                        -DSQLite3_ROOT:="$(xcrun -sdk macosx -show-sdk-path)/usr/include"
+                        -DSQLite3_INCLUDE_DIR:PATH="$(xcrun -sdk macosx -show-sdk-path)/usr/include"
+                        -DSQLite3_LIBRARY:PATH="/usr/lib/libsqlite3.dylib"
                     )
                 fi
                 ;;

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2096,7 +2096,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     cmake_options=(
                         "${cmake_options[@]}"
 
-                        -DSQLite3_INCLUDE_DIR:PATH=$(xcrun -sdk macosx -show-sdk-path)/usr/include
+                        -DSQLite3_ROOT:="$(xcrun -sdk macosx -show-sdk-path)/usr/include"
                     )
                 fi
                 ;;

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2089,6 +2089,16 @@ for host in "${ALL_HOSTS[@]}"; do
                     -Ddispatch_DIR:PATH=$(build_directory ${host} libdispatch)/cmake/modules
                     -DFoundation_DIR:PATH=$(build_directory ${host} foundation)/cmake/modules
                 )
+
+                # Ensure on Darwin platforms that we prefer the SQLite from the SDK
+                # instead of picking one found elsewhere (e.g. in /usr/include )
+                if [[ "$(uname -s)" = "Darwin" ]]; then
+                    cmake_options=(
+                        "${cmake_options[@]}"
+
+                        -DSQLite3_INCLUDE_DIR:PATH=$(xcrun -sdk macosx -show-sdk-path)/usr/include
+                    )
+                fi
                 ;;
             xctest)
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"


### PR DESCRIPTION
When building llbuild on Darwin platforms, ensure that we prefer the SQLite from the SDK
instead of picking one found elsewhere (e.g. in /usr/include )

Addresses rdar://problem/57300418