### PR TITLE
Revert "Eagerly TypeCheck Synthesized Decls"

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -147,6 +147,11 @@ public:
   /// A set of synthesized declarations that need to be type checked.
   llvm::SmallVector<Decl *, 8> SynthesizedDecls;
 
+  /// We might perform type checking on the same source file more than once,
+  /// if its the main file or a REPL instance, so keep track of the last
+  /// checked synthesized declaration to avoid duplicating work.
+  unsigned LastCheckedSynthesizedDecl = 0;
+
   /// A mapping from Objective-C selectors to the methods that have
   /// those selectors.
   llvm::DenseMap<ObjCSelector, llvm::TinyPtrVector<AbstractFunctionDecl *>>

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1251,10 +1251,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
       C, StaticSpellingKind::None, hashValuePat, /*InitExpr*/ nullptr,
       parentDC);
 
-  // If any of the members we synthesized didn't typecheck, bail out.
-  if (derived.addMembersToConformanceContext({hashValueDecl, patDecl})) {
-    return nullptr;
-  }
+  derived.addMembersToConformanceContext({hashValueDecl, patDecl});
 
   return hashValueDecl;
 }

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -46,10 +46,7 @@ public:
   DeclContext *getConformanceContext() const;
 
   /// Add \c children as members of the context that declares the conformance.
-  ///
-  /// \returns True if any of the added members were found to be invalid after type
-  /// checking.
-  bool addMembersToConformanceContext(ArrayRef<Decl *> children);
+  void addMembersToConformanceContext(ArrayRef<Decl *> children);
 
   /// Get the declared type of the protocol that this is conformance is for.
   Type getProtocolType() const;
@@ -200,7 +197,12 @@ public:
   /// Add a getter to a derived property.  The property becomes read-only.
   static AccessorDecl *
   addGetterToReadOnlyDerivedProperty(VarDecl *property,
-                                            Type propertyContextType);
+                                     Type propertyContextType);
+
+  /// Declare a getter for a derived property.
+  /// The getter will not be added to the property yet.
+  static AccessorDecl *declareDerivedPropertyGetter(VarDecl *property,
+                                                    Type propertyContextType);
 
   /// Build a reference to the 'self' decl of a derived function.
   static DeclRefExpr *createSelfDeclRef(AbstractFunctionDecl *fn);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1550,7 +1550,6 @@ bool TypeChecker::isAvailabilitySafeForConformance(
 // Returns 'nullptr' if this is the setter's 'newValue' parameter;
 // otherwise, returns the corresponding parameter of the subscript
 // declaration.
-
 static ParamDecl *getOriginalParamFromAccessor(AbstractStorageDecl *storage,
                                                AccessorDecl *accessor,
                                                ParamDecl *param) {

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -61,7 +61,7 @@ func customHashable() {
 enum InvalidCustomHashable {
   case A, B
 
-  var hashValue: String { return "" } // expected-note 2 {{previously declared here}}
+  var hashValue: String { return "" } // expected-note {{previously declared here}}
 }
 func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String {
   return ""
@@ -72,7 +72,7 @@ func invalidCustomHashable() {
   s = InvalidCustomHashable.A.hashValue
   _ = s
   var _: Int = InvalidCustomHashable.A.hashValue
-  InvalidCustomHashable.A.hash(into: &hasher) // expected-error {{value of type 'InvalidCustomHashable' has no member 'hash'}}
+  InvalidCustomHashable.A.hash(into: &hasher)
 }
 
 // Check use of an enum's synthesized members before the enum is actually declared.


### PR DESCRIPTION
This reverts commit cab4e9f011590d900d70f879202aa121606295a8.

We need to do a bit more refactoring here; until then revert this so that we're not calling typeCheckDecl() on declarations in secondary files.