### PR TITLE
Add regression test for rdar://57265336

### DIFF
--- a/test/multifile/Inputs/finalize-nested-types-other.swift
+++ b/test/multifile/Inputs/finalize-nested-types-other.swift
@@ -1,0 +1,7 @@
+public class Foo {}
+
+extension Foo {
+  public struct Nested {
+    public init() {}
+  }
+}

--- a/test/multifile/finalize-nested-types.swift
+++ b/test/multifile/finalize-nested-types.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/finalize-nested-types-other.swift -module-name other -emit-module-path %t/other.swiftmodule
+// RUN: %target-swift-frontend -typecheck %s -I %t
+
+import other
+
+let t = Foo.self
+let n = t.Nested()


### PR DESCRIPTION
There was a logic error causing us to place nominal types on the
DeclsToFinalize list in the specific case where they were members
of an extension of a class.

Of course this kind of thing is indicative of bad design, and now,
the whole DeclsToFinalize list is gone. Let's add a regression
test for posterity.