### PR TITLE
Fix memory violation when build record is bad.

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -79,6 +79,7 @@ using CommandSet = llvm::SmallPtrSet<const Job *, 16>;
 class Compilation {
 public:
   class IncrementalSchemeComparator {
+    const bool EnableIncrementalBuildWhenConstructed;
     const bool &EnableIncrementalBuild;
     const bool EnableSourceRangeDependencies;
     const bool &UseSourceRangeDependencies;
@@ -108,7 +109,8 @@ public:
                                 const StringRef CompareIncrementalSchemesPath,
                                 unsigned SwiftInputCount,
                                 DiagnosticEngine &Diags)
-        : EnableIncrementalBuild(EnableIncrementalBuild),
+        : EnableIncrementalBuildWhenConstructed(EnableIncrementalBuild),
+          EnableIncrementalBuild(EnableIncrementalBuild),
           EnableSourceRangeDependencies(EnableSourceRangeDependencies),
           UseSourceRangeDependencies(UseSourceRangeDependencies),
           CompareIncrementalSchemesPath(CompareIncrementalSchemesPath),

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -2003,6 +2003,10 @@ void Compilation::IncrementalSchemeComparator::outputComparison() const {
 
 void Compilation::IncrementalSchemeComparator::outputComparison(
     llvm::raw_ostream &out) const {
+  if (!EnableIncrementalBuildWhenConstructed) {
+    out << "*** Incremental build was not enabled in the command line ***\n";
+    return;
+  }
   if (!EnableIncrementalBuild) {
     // No stats will have been gathered
     assert(!WhyIncrementalWasDisabled.empty() && "Must be a reason");

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -375,7 +375,7 @@ static bool getCompilationRecordPath(std::string &buildRecordPath,
   return false;
 }
 
-static StringRef failedToReadOutOfDateMap(bool ShowIncrementalBuildDecisions,
+static std::string failedToReadOutOfDateMap(bool ShowIncrementalBuildDecisions,
                                           StringRef buildRecordPath,
                                           StringRef reason = "") {
   std::string why = "malformed build record file";
@@ -398,7 +398,7 @@ static void dealWithRemovedInputs(ArrayRef<StringRef> removedInputs,
                                   bool ShowIncrementalBuildDecisions);
 
 /// Returns why ignore incrementality
-static StringRef
+static std::string
 populateOutOfDateMap(InputInfoMap &map, llvm::sys::TimePoint<> &LastBuildTime,
                      StringRef argsHashStr, const InputFileList &inputs,
                      StringRef buildRecordPath,
@@ -893,7 +893,7 @@ Driver::buildCompilation(const ToolChain &TC,
   computeArgsHash(ArgsHash, *TranslatedArgList);
   llvm::sys::TimePoint<> LastBuildTime = llvm::sys::TimePoint<>::min();
   InputInfoMap outOfDateMap;
-  StringRef whyIgnoreIncrementallity =
+  std::string whyIgnoreIncrementallity =
       !Incremental
           ? ""
           : buildRecordPath.empty()
@@ -1027,7 +1027,7 @@ Driver::buildCompilation(const ToolChain &TC,
   // This has to happen after building jobs, because otherwise we won't even
   // emit .swiftdeps files for the next build.
   if (!whyIgnoreIncrementallity.empty())
-    C->disableIncrementalBuild(whyIgnoreIncrementallity.str());
+    C->disableIncrementalBuild(whyIgnoreIncrementallity);
 
   if (Diags.hadAnyError())
     return nullptr;


### PR DESCRIPTION
Return a string instead of a StringRef for why incrementality is being disabled.
rdar://57437165 & rdar://57540981