### PR TITLE
[windows] Adapt some Dependencies tests to Windows.

### DIFF
--- a/test/Driver/Dependencies/chained-private.swift
+++ b/test/Driver/Dependencies/chained-private.swift
@@ -16,8 +16,7 @@
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | cat > %t/outputToCheck
-
+// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v >%t/outputToCheck 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-THIRD %s < %t/outputToCheck
 
 // Driver now schedules jobs in the order the inputs were given, but

--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/only-skip-once/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>%t/stderr.txt | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL: Job finished: {compile: main.o <= main.swift}
 // CHECK-INITIAL: Job finished: {compile: file1.o <= file1.swift}
@@ -12,7 +12,7 @@
 // CHECK-INITIAL: Job finished: {link: main <= main.o file1.o file2.o}
 
 // RUN: touch -t 201401240006 %t/file2.swift
-// RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD %s
+// RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>%t/stderr.txt | %FileCheck -check-prefix=CHECK-REBUILD %s
 
 // We should skip the main and file1 rebuilds here, but we should only note skipping them _once_
 // CHECK-REBUILD: Job finished: {compile: file2.o <= file2.swift}

--- a/test/Driver/Dependencies/range-lifecycle.swift
+++ b/test/Driver/Dependencies/range-lifecycle.swift
@@ -277,8 +277,8 @@
 
 // RUN: %FileCheck -check-prefix=CHECK-ADD-NEW-FILE %s < %t/output7
 
-// CHECK-ADD-NEW-FILE-DAG: unable to load swift ranges file "./fileC.swiftranges", No such file or directory
-// CHECK-ADD-NEW-FILE-DAG: unable to determine when 'fileC.compiledsource' was last modified: No such file or directory
+// CHECK-ADD-NEW-FILE-DAG: unable to load swift ranges file "./fileC.swiftranges", {{N|n}}o such file or directory
+// CHECK-ADD-NEW-FILE-DAG: unable to determine when 'fileC.compiledsource' was last modified: {{N|n}}o such file or directory
 // CHECK-ADD-NEW-FILE-DAG: Queuing <Dependencies> (initial): {compile: fileC.o <= fileC.swift}
 // CHECK-ADD-NEW-FILE-DAG: Using dependencies: At least one input ('fileC.swift') lacks a supplementary output needed for the source range strategy.
 // CHECK-ADD-NEW-FILE-DAG: Queuing <Dependencies> because of dependencies discovered later: {compile: fileB.o <= fileB.swift}


### PR DESCRIPTION
It seems that redirecting the stderr and then the stdout in Lit might
not work like in Unix and the stderr might be redirected to the original
stdout instead. To avoid that, remove the usage of cat, and redirect the
stdout to a temporal file, and then the stderr there.

Also, Windows do not lock the access to the file descriptor for stdout,
so stdout and stderr redirected to the same place might overlap. To
avoid partial matches, redirect stderr of some failing test to a
temporal file, in order to match only over the output (which seems to be
the only thing trying to be match).

Finally, it seems that Windows libc, and Darwin/Linux libc do not match
in the capitalization of some error strings. Use a pattern to match both
lower case and upper case.

Introduced in #28164 and first seen in https://ci-external.swift.org/job/oss-swift-windows-x86_64/2065/.