### PR TITLE
[Type checker] Fix crash with invalid overriding property.

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2770,7 +2770,8 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
 
   // Check if we have observers.
   } else if (hasWillSet || hasDidSet) {
-    if (storage->getAttrs().hasAttribute<OverrideAttr>()) {
+    if (storage->getAttrs().hasAttribute<OverrideAttr>() &&
+        storage->getDeclContext()->isTypeContext()) {
       readImpl = ReadImplKind::Inherited;
     } else {
       readImpl = ReadImplKind::Stored;

--- a/validation-test/compiler_crashers_2_fixed/rdar57040259.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar57040259.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend -typecheck %s
+class A { }
+class B: A {
+  func foo(_: () -> ()) {
+
+  override var prop: Any? {
+      didSet { }
+  }
+}


### PR DESCRIPTION
When an overriding property containing willSet or didSet is not within
a type, the type checker could crash due to a missing "self"
declaration. Check this condition. Fixes rdar://problem/57040259.
