### PR TITLE
[SILGEN] Inject "willThrow" hooks after foreign error propagation.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4609,9 +4609,6 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc, SILValue fn,
     SILValue error = errorBB->createPhiArgument(fnConv.getSILErrorType(),
                                                 ValueOwnershipKind::Owned);
 
-    B.createBuiltin(loc, SGM.getASTContext().getIdentifier("willThrow"),
-                    SGM.Types.getEmptyTupleType(), {}, {error});
-
     Cleanups.emitCleanupsForReturn(CleanupLocation::get(loc), IsForUnwind);
     B.createThrow(loc, error);
   }

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -279,7 +279,7 @@ void SILGenFunction::emitForeignErrorBlock(SILLocation loc,
 
   // Propagate.
   FullExpr throwScope(Cleanups, CleanupLocation::get(loc));
-  emitThrow(loc, error);
+  emitThrow(loc, error, true);
 }
 
 /// Perform a foreign error check by testing whether the call result is zero.

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -172,12 +172,6 @@ emitApplyWithRethrow(SILBuilder &Builder,
     SILValue Error = ErrorBB->createPhiArgument(fnConv.getSILErrorType(),
                                                 ValueOwnershipKind::Owned);
 
-    Builder.createBuiltin(Loc,
-                          Builder.getASTContext().getIdentifier("willThrow"),
-                          Builder.getModule().Types.getEmptyTupleType(),
-                          SubstitutionMap(),
-                          {Error});
-
     EmitCleanup(Builder, Loc);
     addThrowValue(ErrorBB, Error);
   }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -269,7 +269,6 @@ class HasThrowingInit {
 // CHECK:    bb1([[SELF:%.*]] : @owned $HasThrowingInit):
 // CHECK-NEXT: return [[SELF]]
 // CHECK:    bb2([[ERROR:%.*]] : @owned $Error):
-// CHECK-NEXT: builtin "willThrow"
 // CHECK-NEXT: throw [[ERROR]]
 
 // CHECK-LABEL: sil hidden [ossa] @$s6errors15HasThrowingInit{{.*}} : $@convention(method) (Int, @owned HasThrowingInit) -> (@owned HasThrowingInit, @error Error) {
@@ -320,7 +319,6 @@ protocol Doomed {
 // CHECK:      [[T0:%.*]] = tuple ()
 // CHECK:      return [[T0]] : $()
 // CHECK:    bb2([[T0:%.*]] : @owned $Error):
-// CHECK:      builtin "willThrow"([[T0]] : $Error)
 // CHECK:      throw [[T0]] : $Error
 struct DoomedStruct : Doomed {
   func check() throws {}
@@ -335,7 +333,6 @@ struct DoomedStruct : Doomed {
 // CHECK:      end_borrow [[BORROWED_SELF]]
 // CHECK:      return [[T0]] : $()
 // CHECK:    bb2([[T0:%.*]] : @owned $Error):
-// CHECK:      builtin "willThrow"([[T0]] : $Error)
 // CHECK:      end_borrow [[BORROWED_SELF]]
 // CHECK:      throw [[T0]] : $Error
 class DoomedClass : Doomed {
@@ -376,7 +373,6 @@ func testThunk(_ fn: () throws -> Int) throws -> Int {
 // CHECK:   [[T0:%.*]] = tuple ()
 // CHECK:   return [[T0]]
 // CHECK: bb2([[T0:%.*]] : @owned $Error):
-// CHECK:   builtin "willThrow"([[T0]] : $Error)
 // CHECK:   throw [[T0]] : $Error
 
 func createInt(_ fn: () -> Int) throws {}

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -51,6 +51,7 @@ func test0() throws {
   // CHECK: [[T0:%.*]] = load [take] [[ERR_TEMP0]]
   // CHECK: [[T1:%.*]] = function_ref @$s10Foundation22_convertNSErrorToErrorys0E0_pSo0C0CSgF : $@convention(thin) (@guaranteed Optional<NSError>) -> @owned Error
   // CHECK: [[T2:%.*]] = apply [[T1]]([[T0]])
+  // CHECK: "willThrow"([[T2]] : $Error)
   // CHECK: throw [[T2]] : $Error
 }
 
@@ -161,6 +162,7 @@ let fn = ErrorProne.fail
 // CHECK:      return
 // CHECK:      [[T0:%.*]] = load [take] [[TEMP]]
 // CHECK:      [[T1:%.*]] = apply {{%.*}}([[T0]])
+// CHECK:      "willThrow"([[T1]] : $Error)
 // CHECK:      throw [[T1]]
 
 func testArgs() throws {

--- a/test/SILGen/objc_factory_init.swift
+++ b/test/SILGen/objc_factory_init.swift
@@ -42,6 +42,40 @@ extension Hive {
   convenience init(otherQueen other: Bee) {
     self.init(queen: other)
   }
+
+  // CHECK-LABEL: sil hidden [ossa] @$sSo4HiveC17objc_factory_initE15otherFlakyQueenABSo3BeeC_tKcfC
+  // CHECK: bb0([[QUEEN:%.*]] : @owned $Bee, [[META:%.*]] : $@thick Hive.Type):
+  // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var Hive }, let, name "self"
+  // CHECK:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[MU]] : ${ var Hive }, 0
+  // CHECK:   [[FOREIGN_ERROR_STACK:%.*]] = alloc_stack $Optional<NSError>
+  // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
+  // CHECK:   [[BORROWED_QUEEN:%.*]] = begin_borrow [[QUEEN]]
+  // CHECK:   [[COPIED_BORROWED_QUEEN:%.*]] = copy_value [[BORROWED_QUEEN]]
+  // CHECK:   [[OPT_COPIED_BORROWED_QUEEN:%.*]] = enum $Optional<Bee>, #Optional.some!enumelt.1, [[COPIED_BORROWED_QUEEN]]
+  // CHECK:   [[FACTORY:%[0-9]+]] = objc_method [[OBJC_META]] : $@objc_metatype Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (Bee?) throws -> Hive, $@convention(objc_method) (Optional<Bee>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive> // user: %25
+  // CHECK:   [[ERROR_PTR_STACK:%.*]] = alloc_stack $AutoreleasingUnsafeMutablePointer<Optional<NSError>>
+  // CHECK:   [[ERROR_PTR:%.*]] = load [trivial] [[ERROR_PTR_STACK]]
+  // CHECK:   [[OPT_ERROR_PTR:%.*]] = enum $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, #Optional.some!enumelt.1, [[ERROR_PTR]]
+  // CHECK:   [[OPT_NEW_HIVE:%.*]] = apply [[FACTORY]]([[OPT_COPIED_BORROWED_QUEEN]], [[OPT_ERROR_PTR]], [[OBJC_META]]) : $@convention(objc_method) (Optional<Bee>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
+  // CHECK:   switch_enum [[OPT_NEW_HIVE]] : $Optional<Hive>, case #Optional.some!enumelt.1: [[NORMAL_BB:bb[0-9]+]], case #Optional.none!enumelt: [[ERROR_BB:bb[0-9]+]] // id: %34
+  //
+  // CHECK: bb1([[HIVE:%.*]] : @owned $Hive):
+  // CHECK:   assign [[HIVE]] to [[PB_BOX]]
+  // CHECK:   dealloc_stack [[FOREIGN_ERROR_STACK]]
+  // CHECK:   [[HIVE_COPY:%.*]] = load [copy] [[PB_BOX]]
+  // CHECK:   return [[HIVE_COPY]]
+  // CHECK: bb2:
+  // CHECK:   [[OPTIONAL_NSERROR:%.*]] = load [take] [[FOREIGN_ERROR_STACK]] : $*Optional<NSError>
+  // CHECK:   [[CONVERT_NSERROR_TO_ERROR_FUNC:%.*]] = function_ref @$s10Foundation22_convertNSErrorToErrorys0E0_pSo0C0CSgF : $@convention(thin) (@guaranteed Optional<NSError>) -> @owned Error
+  // CHECK:   [[ERROR:%.*]] = apply [[CONVERT_NSERROR_TO_ERROR_FUNC]]([[OPTIONAL_NSERROR]]) : $@convention(thin) (@guaranteed Optional<NSError>) -> @owned Error
+  // CHECK:   "willThrow"([[ERROR]] : $Error)
+  // CHECK:   dealloc_stack [[FOREIGN_ERROR_STACK]]
+  // CHECK:   throw [[ERROR]] : $Error
+  // CHECK: } // end sil function '$sSo4HiveC17objc_factory_initE15otherFlakyQueenABSo3BeeC_tKcfC'
+  convenience init(otherFlakyQueen other: Bee) throws {
+    try self.init(flakyQueen: other)
+  }
 }
 
 extension SomeClass {

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -228,7 +228,6 @@ bb2:
 // CHECK:   try_apply %{{.*}}(%{{.*}}, %{{.*}}) : $@convention(thin) (Int, Int) -> (Int, @error Error), normal bb8, error bb7
 
 // CHECK: bb7(%{{.*}} : $Error):
-// CHECK:   %{{.*}} = builtin "willThrow"(%{{.*}} : $Error) : $()
 // CHECK:   br bb3(%{{.*}} : $Error)
 
 // CHECK: bb8(%{{.*}} : $Int):


### PR DESCRIPTION
1. Don't inject "willThrow" hooks before rethrow propagation branches.
2. Inject "willThrow" hooks after foreign error propagation branches.
3. Updated tests

cc @jckarter
More information in ticket: https://bugs.swift.org/browse/SR-11803

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
