### PR TITLE
[TF] Re-enable `-enable-ownership-stripping-after-serialization`.

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -237,12 +237,8 @@ function(_compile_swift_files
        NOT "${SWIFTFILE_MODULE_NAME}" STREQUAL "DifferentiationUnittest")
       list(APPEND swift_flags "-enable-library-evolution")
     endif()
-    # FIXME(SR-11336): `-enable-ownership-stripping-after-serialization` for
-    # swiftCore causes test/AutoDiff/array.swift to crash, related to
-    # Array and key paths.
-    # Disabling the flag for swiftCore requires disabling the flag for all
-    # other standard library modules.
-    # list(APPEND swift_flags "-Xfrontend" "-enable-ownership-stripping-after-serialization")
+    # SWIFT_ENABLE_TENSORFLOW END
+    list(APPEND swift_flags "-Xfrontend" "-enable-ownership-stripping-after-serialization")
   endif()
 
   if(SWIFT_STDLIB_USE_NONATOMIC_RC)

--- a/test/DebugInfo/LoadableByAddress.swift
+++ b/test/DebugInfo/LoadableByAddress.swift
@@ -1,4 +1,3 @@
-// SWIFT_ENABLE_TENSORFLOW
 // RUN: %target-swift-frontend %s -module-name A -emit-ir -g -o - | %FileCheck %s
 // REQUIRES: CPU=x86_64
 public struct Continuation<A> {

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -7,10 +7,6 @@
 // whether specific compile-time constants such as the format string,
 // the size of the byte buffer etc. are literals after the mandatory pipeline.
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 import OSLogPrototype
 
 if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {

--- a/test/SILOptimizer/constant_evaluable_subset_test.swift
+++ b/test/SILOptimizer/constant_evaluable_subset_test.swift
@@ -18,10 +18,6 @@
 //
 // RUN: %FileCheck %s < %t/error-output-mandatory
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 // Test Swift code snippets that are expected to be constant evaluable and those
 // that are not. If any of the test here fails, it indicates a change in the
 // output of SILGen or the mandatory passes that affects the constant

--- a/test/SILOptimizer/constant_propagation_diagnostics.swift
+++ b/test/SILOptimizer/constant_propagation_diagnostics.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -o /dev/null -verify
 // RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -emit-sil -sdk %S/../SILGen/Inputs %s -o /dev/null -verify
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 // <rdar://problem/18213320> enum with raw values that are too big are not diagnosed
 enum EnumWithTooLargeElements : UInt8 {
   case negativeOne = -1     // expected-error 2 {{negative integer '-1' overflows when stored into unsigned type 'UInt8'}}

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 // RUN: %target-swift-frontend -emit-sil -enable-ownership-stripping-after-serialization -primary-file %s -o /dev/null -verify
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 import Swift
 
 func markUsed<T>(_ t: T) {}

--- a/test/SILOptimizer/definite_init_diagnostics_objc.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_objc.swift
@@ -2,10 +2,6 @@
 // RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -I %S/../SILGen/Inputs -enable-source-import -parse-stdlib -o /dev/null -verify -enable-ownership-stripping-after-serialization
 // REQUIRES: objc_interop
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 import Swift
 import gizmo
 

--- a/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
 // RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s -enable-ownership-stripping-after-serialization
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 // High-level tests that DI rejects certain invalid idioms for early
 // return from initializers.
 

--- a/test/SILOptimizer/diagnostic_constant_propagation.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation.swift
@@ -9,10 +9,6 @@
 // References: <rdar://problem/29937936>,
 // <https://bugs.swift.org/browse/SR-5964>
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable RUN lines after SR-11336 is fixed.
-// XFAIL: *
-
 import StdlibUnittest
 
 func testArithmeticOverflow() {

--- a/test/SILOptimizer/diagnostic_constant_propagation_int_arch64.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_int_arch64.swift
@@ -13,10 +13,6 @@
 //
 // FIXME: <rdar://problem/39193272> A false negative that happens only in REPL
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 import StdlibUnittest
 
 func testArithmeticOverflow_Int_64bit() {

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
 // RUN: %target-swift-frontend -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 import Swift
 
 func takesTwoInouts<T>(_ p1: inout T, _ p2: inout T) { }

--- a/test/SILOptimizer/exclusivity_static_diagnostics_objc.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_objc.swift
@@ -2,10 +2,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/optional_closure_bridging.h -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 // REQUIRES: objc_interop
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 import Foundation
 
 class SomeClass {

--- a/test/SILOptimizer/generalized_accessors.swift
+++ b/test/SILOptimizer/generalized_accessors.swift
@@ -3,10 +3,6 @@
 //
 // Tests for yield-once diagnostics emitted for generalized accessors.
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 struct TestNoYield {
   var computed: Int {
     _read {

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify -enable-ownership-stripping-after-serialization
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 func a() {  // expected-warning {{all paths through this function will call itself}}
   a()
 }

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil %s -verify
 // RUN: %target-swift-frontend -emit-sil %s -verify -enable-ownership-stripping-after-serialization
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 func takesEscaping(_: @escaping () -> ()) {}
 
 func takesNonEscaping(_ fn: () -> ()) { fn() }

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -sil-verify-all -primary-file %s -emit-sil -o - -verify | %FileCheck %s
 // RUN: %target-swift-frontend -sil-verify-all -primary-file %s -emit-sil -o - -verify -enable-ownership-stripping-after-serialization
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 // These tests are deliberately shallow, because I do not want to depend on the
 // specifics of SIL generation, which might change for reasons unrelated to this
 // pass

--- a/test/SILOptimizer/noescape_param_exclusivity.swift
+++ b/test/SILOptimizer/noescape_param_exclusivity.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil %s -verify
 // RUN: %target-swift-frontend -emit-sil %s -verify -enable-ownership-stripping-after-serialization
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable test after SR-11336 is fixed.
-// XFAIL: *
-
 func test0(a: (() -> ()) -> (), b: () -> ()) {
   a(b) // expected-error {{passing a non-escaping function parameter 'b' to a call to a non-escaping function parameter can allow re-entrant modification of a variable}}
 }

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -2,10 +2,6 @@
 // RUN: %target-swift-frontend -enable-experimental-static-assert -enable-ownership-stripping-after-serialization -emit-sil %s -verify
 // REQUIRES: asserts
 
-// SWIFT_ENABLE_TENSORFLOW
-// TODO(TF-799): Re-enable RUN line after SR-11336 is fixed.
-// XFAIL: *
-
 //===----------------------------------------------------------------------===//
 // Basic function calls and control flow
 //===----------------------------------------------------------------------===//

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -250,7 +250,7 @@
         "tensorflow": {
             "aliases": ["tensorflow"],
             "repos": {
-                "llvm-project": "b3338d3f55b4eba6433be56c5e05f5c04f79dcd5",
+                "llvm-project": "6d186f86de6fe0e6da9ca1972386c064514703e6",
                 "swift": "tensorflow",
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2019-11-11-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2019-11-11-a",


### PR DESCRIPTION
SR-11336 was recently resolved, making it possible to re-enable the flag.
Re-enable previously disabled SILOptimizer tests.

Resolves TF-799.