### PR TITLE
[LazyFilterSequence] Preserve order of predicates

### DIFF
--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -339,7 +339,7 @@ extension LazyFilterSequence {
     _ isIncluded: @escaping (Element) -> Bool
   ) -> LazyFilterSequence<Base> {
     return LazyFilterSequence(_base: _base) {
-      isIncluded($0) && self._predicate($0)
+      self._predicate($0) && isIncluded($0)
     }
   }
 }

--- a/test/stdlib/Filter.swift
+++ b/test/stdlib/Filter.swift
@@ -79,7 +79,7 @@ FilterTests.test("chained filter order") {
   let lazyFilter = array.lazy
     .filter { _ in false }
     .filter { _ in
-      expectationFailure("Executed second filter before first")
+      expectUnreachable("Executed second filter before first")
       return true
     }
   let lazyResult = Array(lazyFilter)
@@ -87,7 +87,7 @@ FilterTests.test("chained filter order") {
   let result = array
     .filter { _ in false }
     .filter { _ in
-      expectationFailure("Executed second filter before first")
+      expectUnreachable("Executed second filter before first")
       return true
     }
   

--- a/test/stdlib/Filter.swift
+++ b/test/stdlib/Filter.swift
@@ -73,4 +73,26 @@ FilterTests.test("single-count") {
   expectEqual(30, count)
 }
 
+FilterTests.test("chained filter order") {
+  let array = [1]
+  
+  let lazyFilter = array.lazy
+    .filter { _ in false }
+    .filter { _ in
+      expectationFailure("Executed second filter before first")
+      return true
+    }
+  let lazyResult = Array(lazyFilter)
+  
+  let result = array
+    .filter { _ in false }
+    .filter { _ in
+      expectationFailure("Executed second filter before first")
+      return true
+    }
+  
+  expectEqual(lazyResult.count, 0)
+  expectEqual(result.count, 0)
+}
+
 runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
The current behaviour leads to unexpected order of execution (reverse) and given a cheaper filter being applied before more expensive ones, an increase in performance cost for end users.

This fixes it by preserving the input order of the predicates

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-11841](https://bugs.swift.org/browse/SR-11841).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
