### PR TITLE
[AutoDiff] Add builtin differentiable/linear function consturctors.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -352,11 +352,18 @@ IndexSubset *getLoweredParameterIndices(IndexSubset *indices,
                                         AnyFunctionType *type);
 
 /// Retrieve config from the function name of a variant of
-/// `Builtin.autodiffApply`, e.g. `Builtin.autodiffApply_jvp_arity2_order1`.
+/// `Builtin.autodiffApply`, e.g. `Builtin.autodiffApply_jvp_arity2`.
 /// Returns true if the function name is parsed successfully.
 bool getBuiltinAutoDiffApplyConfig(StringRef operationName,
                                    AutoDiffDerivativeFunctionKind &kind,
                                    unsigned &arity, bool &rethrows);
+
+/// Retrieve config from the function name of a variant of
+/// `Builtin.differentiableFunction` or `Builtin.linearFunction`, e.g.
+/// `Builtin.differentiableFunction_arity1_throws`.
+/// Returns true if the function name is parsed successfully.
+bool getBuiltinDifferentiableOrLinearFunctionConfig(
+    StringRef operationName, unsigned &arity, bool &throws);
 
 /// Computes the correct linkage for a derivative function given the linkage of
 /// the original function. If the original linkage is not external and

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -448,6 +448,12 @@ BUILTIN_SIL_OPERATION(ProjectTailElems, "projectTailElems", Special)
 /// autodiffApply
 BUILTIN_SIL_OPERATION(AutoDiffApply, "autodiffApply", Special)
 
+/// differentiableFunction
+BUILTIN_SIL_OPERATION(DifferentiableFunction, "differentiableFunction", Special)
+
+/// linearFunction
+BUILTIN_SIL_OPERATION(LinearFunction, "linearFunction", Special)
+
 #undef BUILTIN_SIL_OPERATION
 
 // BUILTIN_RUNTIME_CALL - A call into a runtime function.

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -130,6 +130,9 @@ IDENTIFIER(withKeywordArguments)
 IDENTIFIER(wrapped)
 IDENTIFIER(wrappedValue)
 IDENTIFIER(wrapperValue)
+// SWIFT_ENABLE_TENSORFLOW
+IDENTIFIER(differential)
+IDENTIFIER(pullback)
 
 // SWIFT_ENABLE_TENSORFLOW
 IDENTIFIER(TensorFlow)

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -312,6 +312,10 @@ const BuiltinInfo &SILModule::getBuiltinInfo(Identifier ID) {
   // SWIFT_ENABLE_TENSORFLOW
   else if (OperationName.startswith("autodiffApply_"))
     Info.ID = BuiltinValueKind::AutoDiffApply;
+  else if (OperationName.startswith("differentiableFunction_"))
+    Info.ID = BuiltinValueKind::DifferentiableFunction;
+  else if (OperationName.startswith("linearFunction_"))
+    Info.ID = BuiltinValueKind::LinearFunction;
   else
     Info.ID = llvm::StringSwitch<BuiltinValueKind>(OperationName)
 #define BUILTIN(id, name, attrs) .Case(name, BuiltinValueKind::id)

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -8961,11 +8961,15 @@ void Differentiation::run() {
       for (SILInstruction &i : bb) {
         if (auto *dfi = dyn_cast<DifferentiableFunctionInst>(&i))
           context.getDifferentiableFunctionInsts().push_back(dfi);
+        // Reject uncanonical `linear_function` instructions.
+        // FIXME(SR-11850): Add support for linear map transposition.
         else if (auto *lfi = dyn_cast<LinearFunctionInst>(&i)) {
-          astCtx.Diags.diagnose(
-              lfi->getLoc().getSourceLoc(),
-              diag::autodiff_conversion_to_linear_function_not_supported);
-          errorOccurred = true;
+          if (!lfi->hasTransposeFunction()) {
+            astCtx.Diags.diagnose(
+                lfi->getLoc().getSourceLoc(),
+                diag::autodiff_conversion_to_linear_function_not_supported);
+            errorOccurred = true;
+          }
         }
       }
     }

--- a/test/AutoDiff/builtin_differentiable_function_constructor.swift
+++ b/test/AutoDiff/builtin_differentiable_function_constructor.swift
@@ -1,0 +1,73 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-stdlib -o %t/Builtins
+// RUN: %target-codesign %t/Builtins
+// RUN: %target-run %t/Builtins
+// REQUIRES: executable_test
+
+import Swift
+import StdlibUnittest
+
+var BuiltinDifferentiableFunctionConstructorTests =
+  TestSuite("BuiltinDifferentiableFunctionConstructor")
+
+BuiltinDifferentiableFunctionConstructorTests.test("UnaryDifferentiable") {
+  func foo(_ x: Float) -> Float {
+    return x * x
+  }
+  func foo_jvp(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+    return (foo(x), { v in 2 * x * v })
+  }
+  func foo_vjp(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (foo(x), { v in 2 * x * v })
+  }
+  let diff_foo = Builtin.differentiableFunction_arity1(foo, foo_jvp, foo_vjp)
+  let (y, pb) = valueWithPullback(at: 4, in: diff_foo)
+  expectEqual(16, y)
+  expectEqual(0, pb(0))
+  expectEqual(8, pb(1))
+}
+
+BuiltinDifferentiableFunctionConstructorTests.test("BinaryDifferentiable") {
+  func foo(_ x: Float, _ y: Float) -> Float {
+    return x * y
+  }
+  func foo_jvp(_ x: Float, _ y: Float) -> (value: Float, differential: (Float, Float) -> Float) {
+    return (foo(x, y), { v1, v2 in y * v1 + x * v2 })
+  }
+  func foo_vjp(_ x: Float, _ y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
+    return (foo(x, y), { v in (y * v, x * v) })
+  }
+  let diff_foo = Builtin.differentiableFunction_arity2(foo, foo_jvp, foo_vjp)
+  let (y, pb) = valueWithPullback(at: 4, 6, in: diff_foo)
+  expectEqual(24, y)
+  expectEqual((0, 0), pb(0))
+  expectEqual((6, 4), pb(1))
+}
+
+BuiltinDifferentiableFunctionConstructorTests.test("UnaryLinear") {
+  func foo(_ x: Float) -> Float {
+    return 2 * x
+  }
+  func foo_transpose(_ v: Float) -> Float {
+    return v
+  }
+  let lin_foo = Builtin.linearFunction_arity1(foo, foo_transpose)
+  // TODO(SR-11845): Uncomment the following once `transpose(of:)` is available.
+  // let trans_foo = transpose(of: lin_foo)
+  // expectEqual(2, trans_foo(2))
+}
+
+BuiltinDifferentiableFunctionConstructorTests.test("UnaryLinear") {
+  func foo(_ x: Float, _ y: Float) -> Float {
+    return x + y
+  }
+  func foo_transpose(_ v: Float) -> (Float, Float) {
+    return (v, v)
+  }
+  let lin_foo = Builtin.linearFunction_arity2(foo, foo_transpose)
+  // TODO(SR-11845): Uncomment the following once `transpose(of:)` is available.
+  // let trans_foo = transpose(of: lin_foo)
+  // expectEqual((1, 1), trans_foo(1))
+}
+
+runAllTests()


### PR DESCRIPTION
Add builtin functions that construct a `@differentiable` or `@differentiable(linear)` function from component functons.

* `Builtin.differentiableFunction_*`

  Takes an original function, a JVP function and a VJP function and returns a `@differentiable` function.

  Pseudo-declaration:
  ```swift
  func differentiableFunction_arity{arity}[_throws]?{throws}<T...{arity}, U>(
      _ original: __owned @escaping (T...{arity}) {throws}? -> U,
      _ jvp: __owned @escaping (T...{arity}) {throws}? -> (value: U, differential: (T.TangentVector...{arity}) -> U.TangentVector),
      _ vjp: __owned @escaping (T...{arity}) {throws}? -> (value: U, pullback: (U.TangentVector) -> (T.TangentVector...{arity}))
  ) -> @differentiable (T...{arity}) {throws}? -> U
      where T...{arity} : Differentiable, U : Differentiable
  ```

* `Builtin.linearFunction_*`

  Takes an original function and a transpose function and returns a `@differentiable` function.

  Pseudo-declaration:
  ```swift
  func linearFunction_arity{arity}[_throws]?{throws}<T...{arity}, U>(
      _ original: __owned @escaping (T...{arity}) {throws}? -> U,
      _ transpose: __owned @escaping (U.TangentVector) {throws}? -> (T.TangentVector...{arity})
  ) -> @differentiable (T...{arity}) {throws}? -> U
      where T...{arity} : Differentiable & AdditiveArithmetic, U : Differentiable & AdditiveArithmetic
  ```

These builtins will be used to write unit tests for `@differentiable` and `@differentiable(linear)` function types that do not necessarily depend on the differentiation transform.

TODO:
- SR-11848: For robustness, we need SIL FileCheck tests for all AD builtins. These have not been added for `Builtin.autodiffApply*`, so I'm leaving this as a future task.
- SR-11847: Update `differentiableFunction(from:)` to use `Builtin.differentiableFunction*` in its implementation.
- SR-11849: Disallow non-top-level derivative registration.

Resolves SR-11846.