### PR TITLE
[AutoDiff] Make `transpose(of:)` available.

### DIFF
--- a/stdlib/public/Differentiation/DifferentiationSupport.swift
+++ b/stdlib/public/Differentiation/DifferentiationSupport.swift
@@ -368,12 +368,13 @@ public extension Differentiable {
 
 // Transpose
 
-@available(*, unavailable)
 @inlinable
 public func transpose<T, R>(
-  of body: @escaping @differentiable/*(linear)*/ (T) -> R
-) -> @differentiable/*(linear)*/ (R) -> T {
-  fatalError()
+  of body: @escaping @differentiable(linear) (T) -> R
+) -> @differentiable(linear) (R) -> T {
+  let original = body as (T) -> R
+  let transpose = { x in Builtin.applyTranspose_arity1(body, x) }
+  return Builtin.linearFunction_arity1(transpose, original)
 }
 
 // Value with differential


### PR DESCRIPTION
Depends on #28469. Resolves SR-11845.