### PR TITLE
[NFC] Reduce some duplication in IRGen code for method descriptors.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -148,20 +148,19 @@ public:
     if (method->getAttrs().hasAttribute<NSManagedAttr>())
       return;
 
-    llvm::Constant *name, *imp, *types;
-    emitObjCMethodDescriptorParts(IGM, method, /*concrete*/true,
-                                  name, types, imp);
+    auto descriptor = emitObjCMethodDescriptorParts(IGM, method,
+                                                    /*concrete*/true);
     
     // When generating JIT'd code, we need to call sel_registerName() to force
     // the runtime to unique the selector.
     llvm::Value *sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(),
-                                          name);
+                                          descriptor.selectorRef);
     
     llvm::Value *args[] = {
       method->isStatic() ? metaclassMetadata : classMetadata,
       sel,
-      imp,
-      types
+      descriptor.impl,
+      descriptor.typeEncoding
     };
     
     Builder.CreateCall(class_replaceMethod, args);
@@ -172,20 +171,19 @@ public:
 
   void visitConstructorDecl(ConstructorDecl *constructor) {
     if (!requiresObjCMethodDescriptor(constructor)) return;
-    llvm::Constant *name, *imp, *types;
-    emitObjCMethodDescriptorParts(IGM, constructor, /*concrete*/true,
-                                  name, types, imp);
+    auto descriptor = emitObjCMethodDescriptorParts(IGM, constructor,
+                                                    /*concrete*/true);
 
     // When generating JIT'd code, we need to call sel_registerName() to force
     // the runtime to unique the selector.
     llvm::Value *sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(),
-                                          name);
+                                          descriptor.selectorRef);
 
     llvm::Value *args[] = {
       classMetadata,
       sel,
-      imp,
-      types
+      descriptor.impl,
+      descriptor.typeEncoding
     };
 
     Builder.CreateCall(class_replaceMethod, args);
@@ -206,23 +204,22 @@ public:
     if (prop->getAttrs().hasAttribute<NSManagedAttr>())
       return;
 
-    llvm::Constant *name, *imp, *types;
-    emitObjCGetterDescriptorParts(IGM, prop,
-                                  name, types, imp);
+    auto descriptor = emitObjCGetterDescriptorParts(IGM, prop);
     // When generating JIT'd code, we need to call sel_registerName() to force
     // the runtime to unique the selector.
     llvm::Value *sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(),
-                                          name);
+                                          descriptor.selectorRef);
     auto theClass = prop->isStatic() ? metaclassMetadata : classMetadata;
-    llvm::Value *getterArgs[] = {theClass, sel, imp, types};
+    llvm::Value *getterArgs[] =
+      {theClass, sel, descriptor.impl, descriptor.typeEncoding};
     Builder.CreateCall(class_replaceMethod, getterArgs);
 
     if (prop->isSettable(prop->getDeclContext())) {
-      emitObjCSetterDescriptorParts(IGM, prop,
-                                    name, types, imp);
+      auto descriptor = emitObjCSetterDescriptorParts(IGM, prop);
       sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(),
-                               name);
-      llvm::Value *setterArgs[] = {theClass, sel, imp, types};
+                               descriptor.selectorRef);
+      llvm::Value *setterArgs[] =
+        {theClass, sel, descriptor.impl, descriptor.typeEncoding};
       
       Builder.CreateCall(class_replaceMethod, setterArgs);
     }
@@ -232,22 +229,21 @@ public:
     assert(!subscript->isStatic() && "objc doesn't support class subscripts");
     if (!requiresObjCSubscriptDescriptor(IGM, subscript)) return;
     
-    llvm::Constant *name, *imp, *types;
-    emitObjCGetterDescriptorParts(IGM, subscript,
-                                  name, types, imp);
+    auto descriptor = emitObjCGetterDescriptorParts(IGM, subscript);
     // When generating JIT'd code, we need to call sel_registerName() to force
     // the runtime to unique the selector.
     llvm::Value *sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(),
-                                          name);
-    llvm::Value *getterArgs[] = {classMetadata, sel, imp, types};
+                                          descriptor.selectorRef);
+    llvm::Value *getterArgs[] =
+      {classMetadata, sel, descriptor.impl, descriptor.typeEncoding};
     Builder.CreateCall(class_replaceMethod, getterArgs);
 
     if (subscript->supportsMutation()) {
-      emitObjCSetterDescriptorParts(IGM, subscript,
-                                    name, types, imp);
+      auto descriptor = emitObjCSetterDescriptorParts(IGM, subscript);
       sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(),
-                               name);
-      llvm::Value *setterArgs[] = {classMetadata, sel, imp, types};
+                               descriptor.selectorRef);
+      llvm::Value *setterArgs[] =
+        {classMetadata, sel, descriptor.impl, descriptor.typeEncoding};
       
       Builder.CreateCall(class_replaceMethod, setterArgs);
     }
@@ -353,16 +349,16 @@ public:
       return;
     }
 
-    llvm::Constant *name, *imp, *types;
-    emitObjCMethodDescriptorParts(IGM, method, /*concrete*/false,
-                                  name, types, imp);
+    auto descriptor = emitObjCMethodDescriptorParts(IGM, method,
+                                                    /*concrete*/false);
     
     // When generating JIT'd code, we need to call sel_registerName() to force
     // the runtime to unique the selector.
-    llvm::Value *sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(), name);
+    llvm::Value *sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(),
+                                          descriptor.selectorRef);
 
     llvm::Value *args[] = {
-      NewProto, sel, types,
+      NewProto, sel, descriptor.typeEncoding,
       // required?
       llvm::ConstantInt::get(IGM.ObjCBoolTy,
                              !method->getAttrs().hasAttribute<OptionalAttr>()),
@@ -381,14 +377,13 @@ public:
   void visitAbstractStorageDecl(AbstractStorageDecl *prop) {
     // TODO: Add properties to protocol.
     
-    llvm::Constant *name, *imp, *types;
-    emitObjCGetterDescriptorParts(IGM, prop,
-                                  name, types, imp);
+    auto descriptor = emitObjCGetterDescriptorParts(IGM, prop);
     // When generating JIT'd code, we need to call sel_registerName() to force
     // the runtime to unique the selector.
-    llvm::Value *sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(), name);
+    llvm::Value *sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(),
+                                          descriptor.selectorRef);
     llvm::Value *getterArgs[] = {
-      NewProto, sel, types,
+      NewProto, sel, descriptor.typeEncoding,
       // required?
       llvm::ConstantInt::get(IGM.ObjCBoolTy,
                              !prop->getAttrs().hasAttribute<OptionalAttr>()),
@@ -399,11 +394,11 @@ public:
     Builder.CreateCall(protocol_addMethodDescription, getterArgs);
     
     if (prop->isSettable(nullptr)) {
-      emitObjCSetterDescriptorParts(IGM, prop,
-                                    name, types, imp);
-      sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(), name);
+      auto descriptor = emitObjCSetterDescriptorParts(IGM, prop);
+      sel = Builder.CreateCall(IGM.getObjCSelRegisterNameFn(),
+                               descriptor.selectorRef);
       llvm::Value *setterArgs[] = {
-        NewProto, sel, types,
+        NewProto, sel, descriptor.typeEncoding,
         // required?
         llvm::ConstantInt::get(IGM.ObjCBoolTy,
                                !prop->getAttrs().hasAttribute<OptionalAttr>()),

--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -105,58 +105,51 @@ namespace irgen {
   llvm::Value *emitObjCAutoreleaseReturnValue(IRGenFunction &IGF,
                                               llvm::Value *value);
 
+  struct ObjCMethodDescriptor {
+    llvm::Constant *selectorRef = nullptr;
+    llvm::Constant *typeEncoding = nullptr;
+    llvm::Constant *impl = nullptr;
+    SILFunction *silFunction = nullptr;
+  };
+
   /// Build the components of an Objective-C method descriptor for the given
   /// method or constructor implementation.
-  SILFunction *emitObjCMethodDescriptorParts(IRGenModule &IGM,
-                                             AbstractFunctionDecl *method,
-                                             bool concrete,
-                                             llvm::Constant *&selectorRef,
-                                             llvm::Constant *&atEncoding,
-                                             llvm::Constant *&impl);
+  ObjCMethodDescriptor
+  emitObjCMethodDescriptorParts(IRGenModule &IGM,
+                                AbstractFunctionDecl *method,
+                                bool concrete);
 
   /// Build the components of an Objective-C method descriptor for the given
   /// property's method implementations.
-  SILFunction *emitObjCGetterDescriptorParts(IRGenModule &IGM,
-                                             VarDecl *property,
-                                             llvm::Constant *&selectorRef,
-                                             llvm::Constant *&atEncoding,
-                                             llvm::Constant *&impl);
+  ObjCMethodDescriptor emitObjCGetterDescriptorParts(IRGenModule &IGM,
+                                                     VarDecl *property);
 
   /// Build the components of an Objective-C method descriptor for the given
   /// subscript's method implementations.
-  SILFunction *emitObjCGetterDescriptorParts(IRGenModule &IGM,
-                                             SubscriptDecl *subscript,
-                                             llvm::Constant *&selectorRef,
-                                             llvm::Constant *&atEncoding,
-                                             llvm::Constant *&impl);
+  ObjCMethodDescriptor emitObjCGetterDescriptorParts(IRGenModule &IGM,
+                                                     SubscriptDecl *property);
 
-  SILFunction *emitObjCGetterDescriptorParts(IRGenModule &IGM,
-                                             AbstractStorageDecl *subscript,
-                                             llvm::Constant *&selectorRef,
-                                             llvm::Constant *&atEncoding,
-                                             llvm::Constant *&impl);
+  /// Build the components of an Objective-C method descriptor if the abstract
+  /// storage refers to a property or a subscript.
+  ObjCMethodDescriptor
+  emitObjCGetterDescriptorParts(IRGenModule &IGM,
+                                AbstractStorageDecl *subscript);
 
   /// Build the components of an Objective-C method descriptor for the given
   /// property's method implementations.
-  SILFunction *emitObjCSetterDescriptorParts(IRGenModule &IGM,
-                                             VarDecl *property,
-                                             llvm::Constant *&selectorRef,
-                                             llvm::Constant *&atEncoding,
-                                             llvm::Constant *&impl);
+  ObjCMethodDescriptor emitObjCSetterDescriptorParts(IRGenModule &IGM,
+                                                     VarDecl *property);
 
   /// Build the components of an Objective-C method descriptor for the given
   /// subscript's method implementations.
-  SILFunction *emitObjCSetterDescriptorParts(IRGenModule &IGM,
-                                             SubscriptDecl *subscript,
-                                             llvm::Constant *&selectorRef,
-                                             llvm::Constant *&atEncoding,
-                                             llvm::Constant *&impl);
+  ObjCMethodDescriptor emitObjCSetterDescriptorParts(IRGenModule &IGM,
+                                                     SubscriptDecl *property);
 
-  SILFunction *emitObjCSetterDescriptorParts(IRGenModule &IGM,
-                                             AbstractStorageDecl *subscript,
-                                             llvm::Constant *&selectorRef,
-                                             llvm::Constant *&atEncoding,
-                                             llvm::Constant *&impl);
+  /// Build the components of an Objective-C method descriptor if the abstract
+  /// storage refers to a property or a subscript.
+  ObjCMethodDescriptor
+  emitObjCSetterDescriptorParts(IRGenModule &IGM,
+                                AbstractStorageDecl *subscript);
 
   /// Build an Objective-C method descriptor for the given method,
   /// constructor, or destructor implementation.


### PR DESCRIPTION
It seems a bit tedious (and a tad confusing) to create pointers and pass them by reference. It should be ok if we return a 4-word struct instead.

I'm somewhat dissatisfied with one of the struct names `ObjCMethodRep`, but I don't have any bright ideas. Suggestions welcome. There is already a class `irgen::ObjCMethod` so I can't name it that.