### PR TITLE
[Diagnostics] Don't include @unknown default in the empty switch fix-it

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1207,6 +1207,12 @@ namespace {
             }
             if (!Context.LangOpts.EnableNonFrozenEnumExhaustivityDiagnostics)
               continue;
+
+            // This can occur if the switch is empty and the subject type is an
+            // enum. If decomposing the enum type yields an unknown space that
+            // is not required, don't suggest adding it in the fix-it.
+            if (flat.isAllowedButNotRequired())
+              continue;
           }
 
           process(flat, flats.size() == 1);

--- a/test/stmt/nonexhaustive_switch_stmt_editor.swift
+++ b/test/stmt/nonexhaustive_switch_stmt_editor.swift
@@ -19,6 +19,10 @@ public func testNonExhaustive(_ value: NonExhaustive) {
   case .b: break
   }
   
+  switch value { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{do you want to add missing cases?}} {{3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n@unknown default:\n<#code#>\n}}
+  }
+
   switch value {
   case .a: break
   case .b: break


### PR DESCRIPTION
Resolves SR-11672. This turned out to only affect the fix-it for empty switch statements, which is why the existing tests didn't catch it.