### PR TITLE
Inliner: fix condition to prevent inlining of functions with dynamic-self

### DIFF
--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -735,9 +735,9 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
     // Check if passed Self is the same as the Self of the caller.
     // In this case, it is safe to inline because both functions
     // use the same Self.
-    if (AI.hasSelfArgument() && Caller->hasSelfParam()) {
+    if (AI.hasSelfArgument() && Caller->hasSelfMetadataParam()) {
       auto CalleeSelf = stripCasts(AI.getSelfArgument());
-      auto CallerSelf = Caller->getSelfArgument();
+      auto CallerSelf = Caller->getSelfMetadataArgument();
       if (CalleeSelf != SILValue(CallerSelf))
         return nullptr;
     } else

--- a/test/SILOptimizer/performance_inliner.sil
+++ b/test/SILOptimizer/performance_inliner.sil
@@ -968,3 +968,29 @@ bb2(%7 : $Error):
 sil_vtable C {
   #C.callThrowing!1: @callThrowing
 }
+
+// Test that the inliner doesn't crash if a dynamic-self callee is called from a
+// non-dynamic-self caller. Currently we just prevent inlining in this case.
+// We could handle this at some time, but we must not crash.
+
+class X { }
+protocol PX : X { }
+
+sil @no_self_metadata : $@convention(method) <Self where Self : PX> (@thick Self.Type) -> () {
+bb0(%1 : $@thick Self.Type):
+  %4 = upcast %1 : $@thick Self.Type to $@thick X.Type
+  %5 = function_ref @has_self_metadata : $@convention(method) (@thick X.Type) -> @owned X
+  %6 = apply %5(%4) : $@convention(method) (@thick X.Type) -> @owned X
+  strong_release %6 : $X
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil [always_inline] @has_self_metadata : $@convention(method) (@thick X.Type) -> @owned X {
+bb0(%1 : $@thick X.Type):
+  %3 = unchecked_trivial_bit_cast %1 : $@thick X.Type to $@thick @dynamic_self X.Type
+  %27 = upcast %3 : $@thick @dynamic_self X.Type to $@thick X.Type
+  %30 = alloc_ref_dynamic %27 : $@thick X.Type, $X
+  return %30 : $X
+}
+

--- a/test/SILOptimizer/specialize_dynamic_self.swift
+++ b/test/SILOptimizer/specialize_dynamic_self.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -module-name specialize_dynamic_self -Xllvm -sil-inline-generics -emit-sil -O -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name specialize_dynamic_self -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil -O -primary-file %s | %FileCheck %s
 
 protocol P {}
 
@@ -10,12 +10,12 @@ extension P {
 }
 
 class C<T> : P {
-  // CHECK-LABEL: sil shared [always_inline] @$s23specialize_dynamic_self1CC11returnsSelfACyxGXDyFSi_Tg5 : $@convention(method) (@guaranteed C<Int>) -> @owned C<Int>
+  // CHECK-LABEL: sil shared [noinline] @$s23specialize_dynamic_self1CC11returnsSelfACyxGXDyFSi_Tg5 : $@convention(method) (@guaranteed C<Int>) -> @owned C<Int>
   // CHECK: [[RESULT:%.*]] = alloc_stack $C<Int>
   // CHECK: [[FN:%.*]] = function_ref @$s23specialize_dynamic_self1PPAAE7method1yyF : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
   // CHECK: apply [[FN]]<@dynamic_self C<Int>>([[RESULT]]) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
   // CHECK: return %0 : $C<Int>
-  @inline(__always)
+  @inline(never)
   final func returnsSelf() -> Self {
     method2()
     return self


### PR DESCRIPTION
Now the condition matches exactly what's checked in asserts in SILBuilder.

fixes an assert in the PerformanceInliner
https://bugs.swift.org/browse/SR-11817
rdar://problem/57369847
