### PR TITLE
stdlib: two small Array improvements

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -765,6 +765,12 @@ extension Array: RandomAccessCollection, MutableCollection {
   public var count: Int {
     return _getCount()
   }
+  
+  @inlinable
+  @_alwaysEmitIntoClient
+  public var first: Element? {
+    _getCount() == 0 ? nil : _buffer[0]
+  }
 }
 
 extension Array: ExpressibleByArrayLiteral {

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -266,7 +266,7 @@ extension _ArrayBuffer {
   internal var count: Int {
     @inline(__always)
     get {
-      return _fastPath(_isNative) ? _native.count : _nonNative.count
+      return _fastPath(_isNative) ? _native.count : _nonNative.endIndex
     }
     set {
       _internalInvariant(_isNative, "attempting to update count of Cocoa array")

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -133,7 +133,7 @@ func testArchetypeReplacement1<FOO : Equatable>(_ a: [FOO]) {
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/CurrNominal:   append({#(newElement): Equatable#})[#Void#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/CurrNominal:   insert({#(newElement): Equatable#}, {#at: Int#})[#Void#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceVar]/Super:            isEmpty[#Bool#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceVar]/Super:            first[#Equatable?#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceVar]/CurrNominal:      first[#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/Super:         dropFirst({#(k): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/Super:         dropLast({#(k): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/Super:         prefix({#(maxLength): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
@@ -164,7 +164,7 @@ func testArchetypeReplacement3 (_ a : [Int]) {
 // PRIVATE_NOMINAL_MEMBERS_7: Begin completions
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/CurrNominal:   append({#(newElement): Int#})[#Void#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         removeLast()[#Int#]
-// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceVar]/Super:            first[#Int?#]
+// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceVar]/CurrNominal:      first[#Int?#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         map({#(transform): (Int) throws -> T##(Int) throws -> T#})[' rethrows'][#[T]#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         dropLast({#(k): Int#})[#ArraySlice<Int>#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         elementsEqual({#(other): Sequence#}, {#by: (Int, Sequence.Element) throws -> Bool##(Int, Sequence.Element) throws -> Bool#})[' rethrows'][#Bool#]; name=elementsEqual(other: Sequence, by: (Int, Sequence.Element) throws -> Bool) rethrows

--- a/test/IDE/complete_literal.swift
+++ b/test/IDE/complete_literal.swift
@@ -83,7 +83,7 @@ func testArray(f1: Float) {
   _ = [1, 2, f1] #^LITERAL8^#
 }
 // LITERAL8-DAG: Decl[InstanceVar]/CurrNominal:      .count[#Int#]; name=count
-// LITERAL8-DAG: Decl[InstanceVar]/Super:            .first[#Float?#]; name=first
+// LITERAL8-DAG: Decl[InstanceVar]/CurrNominal:      .first[#Float?#]; name=first
 
 func testDict(f1: Float) {
   _ = ["foo": f1, "bar": "baz"] #^LITERAL9^#

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -57,13 +57,13 @@ let _ = \Person.friends#^ARRAY_NODOT^#
 // ARRAY-NODOT: Begin completions
 // ARRAY-NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#(index): Int#}][#Person#]; name=[index: Int]
 // ARRAY-NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .count[#Int#]; name=count
-// ARRAY-NODOT-DAG: Decl[InstanceVar]/Super:            .first[#Person?#]; name=first
+// ARRAY-NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .first[#Person?#]; name=first
 
 let _ = \Person.friends.#^ARRAY_DOT^#
 // ARRAY-DOT: Begin completions
 // ARRAY-DOT-NOT: Decl[Subscript]/CurrNominal:        [{#(index): Int#}][#Element#]; name=[Int]
 // ARRAY-DOT-DAG: Decl[InstanceVar]/CurrNominal:      count[#Int#]; name=count
-// ARRAY-DOT-DAG: Decl[InstanceVar]/Super:            first[#Person?#]; name=first
+// ARRAY-DOT-DAG: Decl[InstanceVar]/CurrNominal:      first[#Person?#]; name=first
 // ARRAY-DOT-NOT: Decl[Subscript]/CurrNominal:        [{#(index): Int#}][#Element#]; name=[Int]
 
 let _ = \Person.friends[0]#^OBJ_NODOT^#
@@ -114,13 +114,13 @@ let _ = \[Person]#^ARRAYTYPE_NODOT^#
 // ARRAYTYPE-NODOT: Begin completions
 // ARRAYTYPE-NODOT-DAG: Decl[Subscript]/CurrNominal:        .[{#(index): Int#}][#Person#]; name=[index: Int]
 // ARRAYTYPE-NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .count[#Int#]; name=count
-// ARRAYTYPE-NODOT-DAG: Decl[InstanceVar]/Super:            .first[#Person?#]; name=first
+// ARRAYTYPE-NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .first[#Person?#]; name=first
 
 let _ = \[Person].#^ARRAYTYPE_DOT^#
 // ARRAYTYPE-DOT: Begin completions
 // ARRAYTYPE-DOT-DAG: Decl[Subscript]/CurrNominal:        [{#(index): Int#}][#Person#]; name=[index: Int]
 // ARRAYTYPE-DOT-DAG: Decl[InstanceVar]/CurrNominal:      count[#Int#]; name=count
-// ARRAYTYPE-DOT-DAG: Decl[InstanceVar]/Super:            first[#Person?#]; name=first
+// ARRAYTYPE-DOT-DAG: Decl[InstanceVar]/CurrNominal:      first[#Person?#]; name=first
 
 func test(_ p: Person) {
   let _ = p[keyPath: \Person.#^APPLY_TYPE_DOT^#]


### PR DESCRIPTION
* make the non-native Array.count smaller more efficient

Use _CocoaArrayWrapper.endIndex which returns the NSArray.count.
In the old version, "count" translated to RandomAccessCollection.count, which ended up in multiple calls to endIndex.

* Add custom .first to Array (copied from @airspeedswift's https://github.com/apple/swift/pull/28349)

Without this, Array.first compiled down to RandomAccessCollection.first, which ended up in pretty unefficient code.

rdar://problem/46291397
