### PR TITLE
[AutoDiff] Fix `@differentiable` attribute type-checking crash.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3364,6 +3364,9 @@ DifferentiableAttributeParameterIndicesRequest::evaluate(
     return nullptr;
   }
 
+  // If the original declaration has an error interface type, return.
+  if (original->getInterfaceType()->hasError())
+    return nullptr;
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
   bool isMethod = original->hasImplicitSelfDecl();
 

--- a/test/AutoDiff/compiler_crashers_fixed/tf1017-diff-attr-invalid-original-interface-type.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1017-diff-attr-invalid-original-interface-type.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -typecheck %s -verify
+// REQUIRES: asserts
+
+// TF-1017: `@differentiable` attribute type-checking crash when original
+// declaration has an error type.
+
+protocol P: Differentiable {
+  @differentiable
+  init(x: Float)
+}
+extension P {
+  @differentiable
+  // expected-error @+1 {{generic parameter 'U' is not used in function signature}}
+  init<U>(_ x: Float) {
+    self.init(x: x)
+  }
+}
+extension P where Self: FloatingPoint {
+  @differentiable
+  func hello(_ x: Float) -> Self {
+    .init(x)
+  }
+}
+
+// Assertion failed: (isa<X>(Val) && "cast<Ty>() argument of incompatible type!"), function cast, file llvm/include/llvm/Support/Casting.h, line 264.
+// Assertion failed: (D), function printDifferentiableAttrArguments, file swift/lib/AST/Attr.cpp, line 493.


### PR DESCRIPTION
Check that original declaration has a non-error interface type to avoid crash.

Resolves TF-1017.