### PR TITLE
[AutoDiff] Fix differentiation of tuples with single differentiable e…

### DIFF
--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
@@ -259,25 +259,43 @@ extension Tracked where T : Differentiable & FloatingPoint, T == T.TangentVector
 
 // Differential operators for `Tracked<T>`.
 
-public func gradient<T, U>(
-  at x: T, in f: @differentiable (T) -> Tracked<U>
-) -> T.TangentVector
-where U : FloatingPoint, U.TangentVector == U {
-  return pullback(at: x, in: f)(Tracked<U>(1))
+public func gradient<T, R: FloatingPoint>(
+  at x: T, in f: @differentiable (T) -> Tracked<R>
+) -> T.TangentVector where R.TangentVector == R {
+  return pullback(at: x, in: f)(1)
 }
 
-public func gradient<T, U, R>(
+public func gradient<T, U, R: FloatingPoint>(
   at x: T, _ y: U, in f: @differentiable (T, U) -> Tracked<R>
-) -> (T.TangentVector, U.TangentVector)
-  where R : FloatingPoint, R.TangentVector == R {
-  return pullback(at: x, y, in: f)(Tracked<R>(1))
+) -> (T.TangentVector, U.TangentVector) where R.TangentVector == R {
+  return pullback(at: x, y, in: f)(1)
 }
 
-public func valueWithGradient<T, U : FloatingPoint>(
-  at x: T, in f: @differentiable (T) -> Tracked<U>
-) -> (value: Tracked<U>, gradient: T.TangentVector) {
+public func derivative<T: FloatingPoint, R>(
+  at x: Tracked<T>, in f: @differentiable (Tracked<T>) -> R
+) -> R.TangentVector where T.TangentVector == T {
+  return differential(at: x, in: f)(1)
+}
+
+public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+  at x: Tracked<T>, _ y: Tracked<U>,
+  in f: @differentiable (Tracked<T>, Tracked<U>) -> R
+) -> R.TangentVector where T.TangentVector == T, U.TangentVector == U {
+  return differential(at: x, y, in: f)(1, 1)
+}
+
+public func valueWithGradient<T, R: FloatingPoint>(
+  at x: T, in f: @differentiable (T) -> Tracked<R>
+) -> (value: Tracked<R>, gradient: T.TangentVector) {
   let (y, pullback) = valueWithPullback(at: x, in: f)
-  return (y, pullback(Tracked<U>(1)))
+  return (y, pullback(1))
+}
+
+public func valueWithDerivative<T: FloatingPoint, R>(
+  at x: Tracked<T>, in f: @differentiable (Tracked<T>) -> R
+) -> (value: R, derivative: R.TangentVector) {
+  let (y, differential) = valueWithDifferential(at: x, in: f)
+  return (y, differential(1))
 }
 
 public extension Differentiable {

--- a/test/AutoDiff/compiler_crashers/tf1011-differential-unset-tangent-buffer.swift
+++ b/test/AutoDiff/compiler_crashers/tf1011-differential-unset-tangent-buffer.swift
@@ -1,0 +1,33 @@
+// RUN: not --crash %target-swift-emit-sil -enable-experimental-forward-mode-differentiation %s -verify
+// REQUIRES: asserts
+
+// TF-1011: Differential generation crash due to unset tangent buffer.
+
+@differentiable
+func arrayLiteral(_ x: Float, _ y: Float) -> [Float] {
+  var result = [x * y, x * y]
+  return result
+}
+
+// [AD] Original bb0: To differentiate or not to differentiate?
+// [ ]   debug_value %0 : $Float, let, name "x", argno 1 // id: %2
+// [ ]   debug_value %1 : $Float, let, name "y", argno 2 // id: %3
+// [∂]   %4 = alloc_stack $Array<Float>, var, name "result" // users: %26, %25, %21, %22
+// [ ]   %5 = integer_literal $Builtin.Word, 2           // user: %7
+// [ ]   // function_ref _allocateUninitializedArray<A>(_:)
+//   %6 = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer) // user: %7
+// [∂]   %7 = apply %6<Float>(%5) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer) // user: %8
+// [∂]   (%8, %9) = destructure_tuple %7 : $(Array<Float>, Builtin.RawPointer) // users: %21, %10
+// [ ]   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*Float // users: %16, %14
+// [ ]   %11 = metatype $@thin Float.Type                // user: %13
+// [ ]   // function_ref static Float.* infix(_:_:)
+//   %12 = function_ref @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float // user: %13
+// [∂]   %13 = apply %12(%0, %1, %11) : $@convention(method) (Float, Float, @thin Float.Type) -> Float // user: %14
+// [∂]   store %13 to [trivial] %10 : $*Float            // id: %14
+// ...
+// [AD] JVPEmitter visited:
+// [ORIG]  store %13 to [trivial] %10 : $*Float            // id: %14
+// Assertion failed: (!insertion.second && "tangent buffer should already exist"), function getTangentBuffer, file swift/lib/SILOptimizer/Mandatory/Differentiation.cpp, line 4528.
+
+// `store %13 to [trivial] %10` is visited but `%10 = pointer_to_address %9` is
+// not. `%10` does not have a set tangent buffer.

--- a/test/AutoDiff/compiler_crashers/tf984-differential-unset-tangent-buffer.swift
+++ b/test/AutoDiff/compiler_crashers/tf984-differential-unset-tangent-buffer.swift
@@ -1,0 +1,32 @@
+// RUN: not --crash %target-swift-emit-sil -enable-experimental-forward-mode-differentiation %s -verify
+// REQUIRES: asserts
+
+// TF-984: Differential generation crash due to unset tangent buffer.
+
+struct Mut: Differentiable {}
+extension Mut {
+  mutating func mutatingMethodWrtMultipleResults(_ x: Mut) -> Mut {
+    return x
+  }
+}
+
+@differentiable(wrt: x)
+func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) -> Mut {
+  var result = nonactive
+  result = result.mutatingMethodWrtMultipleResults(x)
+  return result
+}
+
+// [AD] Original bb0: To differentiate or not to differentiate?
+// [ ]   debug_value_addr %0 : $*Mut, var, name "nonactive", argno 1 // id: %2
+// [ ]   debug_value %1 : $Mut, let, name "x", argno 2   // id: %3
+// [∂]   %4 = alloc_stack $Mut, var, name "result"       // users: %18, %6, %8, %12, %15
+// [ ]   %5 = begin_access [read] [static] %0 : $*Mut    // users: %7, %6
+// [∂]   copy_addr %5 to [initialization] %4 : $*Mut     // id: %6
+// ...
+// [AD] JVPEmitter visited:
+// [ORIG]  copy_addr %5 to [initialization] %4 : $*Mut     // id: %6
+// Assertion failed: (!insertion.second && "tangent buffer should already exist"), function getTangentBuffer, file swift/lib/SILOptimizer/Mandatory/Differentiation.cpp, line 4528.
+
+// `copy_addr %5 to [initialization] %4` is visited but `%5 = begin_access` is
+// not. `%5` does not have a set tangent buffer.

--- a/test/AutoDiff/compiler_crashers_fixed/tf964-pullback-tuple-nontuple-adjoint-value.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf964-pullback-tuple-nontuple-adjoint-value.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-emit-sil %s -verify
+// REQUIRES: asserts
+
+// TF-964: `PullbackEmitter::visitTupleInst` crash for `tuple` instructions with
+// non-tuple-typed adjoint values.
+
+@differentiable
+func TF_964(_ x: Float) -> Float {
+  let tuple = (x, 1)
+  return tuple.0
+}
+
+// Original crasher:
+// Assertion failed: (Operand->getType().is<TupleType>() && "Expected a tuple typed operand?!"), function create, file /Users/swiftninjas/s4tf/swift/lib/SIL/SILInstructions.cpp, line 2676.
+// Stack dump:
+// 0.	Program arguments: /Library/Developer/Toolchains/swift-tensorflow-RELEASE-0.6.xctoolchain/usr/bin/swift -frontend -interpret tf-964.swift -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -color-diagnostics -module-name main
+// 1.	Swift version 5.1.1-dev (Swift 7b97b0ced0)
+// 2.	While running pass #17 SILModuleTransform "Differentiation".
+// 3.	While processing `[differentiable source 0 wrt 0]` attribute on SIL function "@$s4main6TF_964yS2fF".
+//  for 'TF_964(_:)' (at tf-964.swift:2:1)
+// 4.	While generating VJP for SIL function "@$s4main6TF_964yS2fF".
+//  for 'TF_964(_:)' (at tf-964.swift:2:1)
+// 5.	While generating pullback for SIL function "@$s4main6TF_964yS2fF".
+//  for 'TF_964(_:)' (at tf-964.swift:2:1)


### PR DESCRIPTION
…lement.

Fix differentiation of tuples with single differentiable element, i.e.
non-tuple-typed tangent space:
- `JVPEmitter::emitTangentForTupleInst`
- `JVPEmitter::emitTangentForDestructureTupleInst`
- `PullbackEmitter::visitTupleInst`

These visitors now check when tuple values have non-tuple-typed tangent spaces.

Resolves TF-964. Add tests (using non-trivial values to test ownership).
Add forward-mode crasher tests: TF-984, TF-1011.
Remove duplicate tests from `test/AutoDiff/forward_mode_runtime.swift`.