### PR TITLE
[sil] Cleanup SILArgument in preparation for adding new non-phi terminator argument kinds

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -62,29 +62,52 @@ struct SILArgumentKind {
 };
 
 class SILArgument : public ValueBase {
-  void operator=(const SILArgument &) = delete;
-  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED
+  friend class SILBasicBlock;
 
-  SILBasicBlock *ParentBB;
-  const ValueDecl *Decl;
+  SILBasicBlock *parentBlock;
+  const ValueDecl *decl;
+
+protected:
+  SILArgument(ValueKind subClassKind, SILBasicBlock *inputParentBlock,
+              SILType type, ValueOwnershipKind ownershipKind,
+              const ValueDecl *inputDecl = nullptr);
+
+  SILArgument(ValueKind subClassKind, SILBasicBlock *inputParentBlock,
+              SILBasicBlock::arg_iterator positionInArgumentArray, SILType type,
+              ValueOwnershipKind ownershipKind,
+              const ValueDecl *inputDecl = nullptr);
+
+  // A special constructor, only intended for use in
+  // SILBasicBlock::replacePHIArg and replaceFunctionArg.
+  explicit SILArgument(ValueKind subClassKind, SILType type,
+                       ValueOwnershipKind ownershipKind,
+                       const ValueDecl *inputDecl = nullptr)
+      : ValueBase(subClassKind, type, IsRepresentative::Yes),
+        parentBlock(nullptr), decl(inputDecl) {
+    Bits.SILArgument.VOKind = static_cast<unsigned>(ownershipKind);
+  }
 
 public:
+  void operator=(const SILArgument &) = delete;
+  void operator delete(void *, size_t) SWIFT_DELETE_OPERATOR_DELETED;
+
   ValueOwnershipKind getOwnershipKind() const {
     return static_cast<ValueOwnershipKind>(Bits.SILArgument.VOKind);
   }
-  void setOwnershipKind(ValueOwnershipKind NewKind) {
-    Bits.SILArgument.VOKind = static_cast<unsigned>(NewKind);
+
+  void setOwnershipKind(ValueOwnershipKind newKind) {
+    Bits.SILArgument.VOKind = static_cast<unsigned>(newKind);
   }
 
-  SILBasicBlock *getParent() { return ParentBB; }
-  const SILBasicBlock *getParent() const { return ParentBB; }
+  SILBasicBlock *getParent() { return parentBlock; }
+  const SILBasicBlock *getParent() const { return parentBlock; }
 
   SILFunction *getFunction();
   const SILFunction *getFunction() const;
 
   SILModule &getModule() const;
 
-  const ValueDecl *getDecl() const { return Decl; }
+  const ValueDecl *getDecl() const { return decl; }
 
   static bool classof(const SILInstruction *) = delete;
   static bool classof(const SILUndef *) = delete;
@@ -94,10 +117,11 @@ public:
   }
 
   unsigned getIndex() const {
-    ArrayRef<SILArgument *> Args = getParent()->getArguments();
-    for (unsigned i = 0, e = Args.size(); i != e; ++i)
-      if (Args[i] == this)
-        return i;
+    for (auto p : llvm::enumerate(getParent()->getArguments())) {
+      if (p.value() == this) {
+        return p.index();
+      }
+    }
     llvm_unreachable("SILArgument not argument of its parent BB");
   }
 
@@ -107,18 +131,18 @@ public:
 
   /// If this argument is a phi, return the incoming phi value for the given
   /// predecessor BB. If this argument is not a phi, return an invalid SILValue.
-  SILValue getIncomingPhiValue(SILBasicBlock *predBB);
+  SILValue getIncomingPhiValue(SILBasicBlock *predBlock);
 
   /// If this argument is a phi, populate `OutArray` with the incoming phi
   /// values for each predecessor BB. If this argument is not a phi, return
   /// false.
-  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &ReturnedPhiValues);
+  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &returnedPhiValues);
 
   /// If this argument is a phi, populate `OutArray` with each predecessor block
   /// and its incoming phi value. If this argument is not a phi, return false.
-  bool getIncomingPhiValues(
-      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-          &ReturnedPredAndPhiValuePairs);
+  bool
+  getIncomingPhiValues(SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+                           &returnedPredAndPhiValuePairs);
 
   /// Returns true if we were able to find a single terminator operand value for
   /// each predecessor of this arguments basic block. The found values are
@@ -127,7 +151,8 @@ public:
   /// Note: this peeks through any projections or cast implied by the
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
-  bool getSingleTerminatorOperands(SmallVectorImpl<SILValue> &OutArray);
+  bool getSingleTerminatorOperands(
+      SmallVectorImpl<SILValue> &returnedSingleTermOperands);
 
   /// Returns true if we were able to find single terminator operand values for
   /// each predecessor of this arguments basic block. The found values are
@@ -137,7 +162,8 @@ public:
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
   bool getSingleTerminatorOperands(
-      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
+      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+          &returnedSingleTermOperands);
 
   /// If this SILArgument's parent block has a single predecessor whose
   /// terminator has a single operand, return the incoming operand of the
@@ -153,29 +179,33 @@ public:
   }
 
 protected:
-  SILArgument(ValueKind SubClassKind, SILBasicBlock *ParentBB, SILType Ty,
-              ValueOwnershipKind OwnershipKind,
-              const ValueDecl *D = nullptr);
-  SILArgument(ValueKind SubClassKind, SILBasicBlock *ParentBB,
-              SILBasicBlock::arg_iterator Pos, SILType Ty,
-              ValueOwnershipKind OwnershipKind,
-              const ValueDecl *D = nullptr);
-
-  // A special constructor, only intended for use in
-  // SILBasicBlock::replacePHIArg and replaceFunctionArg.
-  explicit SILArgument(ValueKind SubClassKind, SILType Ty,
-                       ValueOwnershipKind OwnershipKind,
-                       const ValueDecl *D = nullptr)
-      : ValueBase(SubClassKind, Ty, IsRepresentative::Yes), ParentBB(nullptr),
-        Decl(D) {
-    Bits.SILArgument.VOKind = static_cast<unsigned>(OwnershipKind);
+  void setParent(SILBasicBlock *newParentBlock) {
+    parentBlock = newParentBlock;
   }
-  void setParent(SILBasicBlock *P) { ParentBB = P; }
-
-  friend SILBasicBlock;
 };
 
 class SILPhiArgument : public SILArgument {
+  friend class SILBasicBlock;
+
+  SILPhiArgument(SILBasicBlock *parentBlock, SILType type,
+                 ValueOwnershipKind ownershipKind,
+                 const ValueDecl *decl = nullptr)
+      : SILArgument(ValueKind::SILPhiArgument, parentBlock, type, ownershipKind,
+                    decl) {}
+
+  SILPhiArgument(SILBasicBlock *parentBlock,
+                 SILBasicBlock::arg_iterator argArrayInsertPt, SILType type,
+                 ValueOwnershipKind ownershipKind,
+                 const ValueDecl *decl = nullptr)
+      : SILArgument(ValueKind::SILPhiArgument, parentBlock, argArrayInsertPt,
+                    type, ownershipKind, decl) {}
+
+  // A special constructor, only intended for use in
+  // SILBasicBlock::replacePHIArg.
+  explicit SILPhiArgument(SILType type, ValueOwnershipKind ownershipKind,
+                          const ValueDecl *decl = nullptr)
+      : SILArgument(ValueKind::SILPhiArgument, type, ownershipKind, decl) {}
+
 public:
   /// Return true if this is block argument is actually a phi argument as
   /// opposed to a cast or projection.
@@ -186,7 +216,7 @@ public:
   ///
   /// FIXME: Once SILPhiArgument actually implies that it is a phi argument,
   /// this will be guaranteed to return a valid SILValue.
-  SILValue getIncomingPhiValue(SILBasicBlock *BB);
+  SILValue getIncomingPhiValue(SILBasicBlock *predBlock);
 
   /// If this argument is a phi, populate `OutArray` with the incoming phi
   /// values for each predecessor BB. If this argument is not a phi, return
@@ -194,15 +224,16 @@ public:
   ///
   /// FIXME: Once SILPhiArgument actually implies that it is a phi argument,
   /// this will always succeed.
-  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &OutArray);
+  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &returnedPhiValues);
 
   /// If this argument is a phi, populate `OutArray` with each predecessor block
   /// and its incoming phi value. If this argument is not a phi, return false.
   ///
   /// FIXME: Once SILPhiArgument actually implies that it is a phi argument,
   /// this will always succeed.
-  bool getIncomingPhiValues(
-      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
+  bool
+  getIncomingPhiValues(SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+                           &returnedPredAndPhiValuePairs);
 
   /// Returns true if we were able to find a single terminator operand value for
   /// each predecessor of this arguments basic block. The found values are
@@ -211,7 +242,8 @@ public:
   /// Note: this peeks through any projections or cast implied by the
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
-  bool getSingleTerminatorOperands(SmallVectorImpl<SILValue> &OutArray);
+  bool getSingleTerminatorOperands(
+      SmallVectorImpl<SILValue> &returnedSingleTermOperands);
 
   /// Returns true if we were able to find single terminator operand values for
   /// each predecessor of this arguments basic block. The found values are
@@ -221,7 +253,8 @@ public:
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
   bool getSingleTerminatorOperands(
-      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
+      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+          &returnedSingleTermOperands);
 
   /// If this SILArgument's parent block has a single predecessor whose
   /// terminator has a single operand, return the incoming operand of the
@@ -236,30 +269,35 @@ public:
   static bool classof(const SILNode *node) {
     return node->getKind() == SILNodeKind::SILPhiArgument;
   }
-
-private:
-  friend SILBasicBlock;
-  SILPhiArgument(SILBasicBlock *ParentBB, SILType Ty, ValueOwnershipKind OwnershipKind,
-                 const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPhiArgument, ParentBB, Ty, OwnershipKind, D) {}
-  SILPhiArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
-                 SILType Ty, ValueOwnershipKind OwnershipKind,
-                 const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPhiArgument, ParentBB, Pos, Ty, OwnershipKind, D) {}
-
-  // A special constructor, only intended for use in
-  // SILBasicBlock::replacePHIArg.
-  explicit SILPhiArgument(SILType Ty, ValueOwnershipKind OwnershipKind,
-                          const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILPhiArgument, Ty, OwnershipKind, D) {}
 };
 
 class SILFunctionArgument : public SILArgument {
+  friend class SILBasicBlock;
+
+  SILFunctionArgument(SILBasicBlock *parentBlock, SILType type,
+                      ValueOwnershipKind ownershipKind,
+                      const ValueDecl *decl = nullptr)
+      : SILArgument(ValueKind::SILFunctionArgument, parentBlock, type,
+                    ownershipKind, decl) {}
+  SILFunctionArgument(SILBasicBlock *parentBlock,
+                      SILBasicBlock::arg_iterator argArrayInsertPt,
+                      SILType type, ValueOwnershipKind ownershipKind,
+                      const ValueDecl *decl = nullptr)
+      : SILArgument(ValueKind::SILFunctionArgument, parentBlock,
+                    argArrayInsertPt, type, ownershipKind, decl) {}
+
+  // A special constructor, only intended for use in
+  // SILBasicBlock::replaceFunctionArg.
+  explicit SILFunctionArgument(SILType type, ValueOwnershipKind ownershipKind,
+                               const ValueDecl *decl = nullptr)
+      : SILArgument(ValueKind::SILFunctionArgument, type, ownershipKind, decl) {
+  }
+
 public:
   bool isIndirectResult() const {
     auto numIndirectResults =
         getFunction()->getConventions().getNumIndirectSILResults();
-    return (getIndex() < numIndirectResults);
+    return getIndex() < numIndirectResults;
   }
 
   SILArgumentConvention getArgumentConvention() const {
@@ -280,8 +318,8 @@ public:
   bool isSelf() const;
 
   /// Returns true if this SILArgument is passed via the given convention.
-  bool hasConvention(SILArgumentConvention P) const {
-    return getArgumentConvention() == P;
+  bool hasConvention(SILArgumentConvention convention) const {
+    return getArgumentConvention() == convention;
   }
 
   static bool classof(const SILInstruction *) = delete;
@@ -289,22 +327,6 @@ public:
   static bool classof(const SILNode *node) {
     return node->getKind() == SILNodeKind::SILFunctionArgument;
   }
-
-private:
-  friend SILBasicBlock;
-
-  SILFunctionArgument(SILBasicBlock *ParentBB, SILType Ty, ValueOwnershipKind OwnershipKind,
-                      const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Ty, OwnershipKind, D) {}
-  SILFunctionArgument(SILBasicBlock *ParentBB, SILBasicBlock::arg_iterator Pos,
-                      SILType Ty, ValueOwnershipKind OwnershipKind, const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILFunctionArgument, ParentBB, Pos, Ty, OwnershipKind, D) {}
-
-  // A special constructor, only intended for use in
-  // SILBasicBlock::replaceFunctionArg.
-  explicit SILFunctionArgument(SILType Ty, ValueOwnershipKind OwnershipKind,
-                               const ValueDecl *D = nullptr)
-      : SILArgument(ValueKind::SILFunctionArgument, Ty, OwnershipKind, D) {}
 };
 
 //===----------------------------------------------------------------------===//
@@ -318,38 +340,43 @@ inline bool SILArgument::isPhiArgument() {
   return false;
 }
 
-inline SILValue SILArgument::getIncomingPhiValue(SILBasicBlock *BB) {
+inline SILValue SILArgument::getIncomingPhiValue(SILBasicBlock *predBlock) {
   if (isa<SILFunctionArgument>(this))
     return SILValue();
-  return cast<SILPhiArgument>(this)->getIncomingPhiValue(BB);
-}
-
-inline bool
-SILArgument::getIncomingPhiValues(SmallVectorImpl<SILValue> &OutArray) {
-  if (isa<SILFunctionArgument>(this))
-    return false;
-  return cast<SILPhiArgument>(this)->getIncomingPhiValues(OutArray);
+  return cast<SILPhiArgument>(this)->getIncomingPhiValue(predBlock);
 }
 
 inline bool SILArgument::getIncomingPhiValues(
-    SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray) {
+    SmallVectorImpl<SILValue> &returnedPhiValues) {
   if (isa<SILFunctionArgument>(this))
     return false;
-  return cast<SILPhiArgument>(this)->getIncomingPhiValues(OutArray);
+  return cast<SILPhiArgument>(this)->getIncomingPhiValues(returnedPhiValues);
+}
+
+inline bool SILArgument::getIncomingPhiValues(
+    SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+        &returnedPredAndPhiValuePairs) {
+  if (isa<SILFunctionArgument>(this))
+    return false;
+  return cast<SILPhiArgument>(this)->getIncomingPhiValues(
+      returnedPredAndPhiValuePairs);
 }
 
 inline bool SILArgument::getSingleTerminatorOperands(
-    SmallVectorImpl<SILValue> &OutArray) {
+    SmallVectorImpl<SILValue> &returnedSingleTermOperands) {
   if (isa<SILFunctionArgument>(this))
     return false;
-  return cast<SILPhiArgument>(this)->getSingleTerminatorOperands(OutArray);
+  return cast<SILPhiArgument>(this)->getSingleTerminatorOperands(
+      returnedSingleTermOperands);
 }
 
 inline bool SILArgument::getSingleTerminatorOperands(
-    SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray) {
+    SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+        &returnedSingleTermOperands) {
   if (isa<SILFunctionArgument>(this))
     return false;
-  return cast<SILPhiArgument>(this)->getSingleTerminatorOperands(OutArray);
+  return cast<SILPhiArgument>(this)->getSingleTerminatorOperands(
+      returnedSingleTermOperands);
 }
 
 } // end swift namespace

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -127,22 +127,22 @@ public:
 
   /// Return true if this block argument is actually a phi argument as
   /// opposed to a cast or projection.
-  bool isPhiArgument();
+  bool isPhiArgument() const;
 
   /// If this argument is a phi, return the incoming phi value for the given
   /// predecessor BB. If this argument is not a phi, return an invalid SILValue.
-  SILValue getIncomingPhiValue(SILBasicBlock *predBlock);
+  SILValue getIncomingPhiValue(SILBasicBlock *predBlock) const;
 
   /// If this argument is a phi, populate `OutArray` with the incoming phi
   /// values for each predecessor BB. If this argument is not a phi, return
   /// false.
-  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &returnedPhiValues);
+  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &returnedPhiValues) const;
 
   /// If this argument is a phi, populate `OutArray` with each predecessor block
   /// and its incoming phi value. If this argument is not a phi, return false.
   bool
   getIncomingPhiValues(SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-                           &returnedPredAndPhiValuePairs);
+                           &returnedPredAndPhiValuePairs) const;
 
   /// Returns true if we were able to find a single terminator operand value for
   /// each predecessor of this arguments basic block. The found values are
@@ -152,7 +152,7 @@ public:
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
   bool getSingleTerminatorOperands(
-      SmallVectorImpl<SILValue> &returnedSingleTermOperands);
+      SmallVectorImpl<SILValue> &returnedSingleTermOperands) const;
 
   /// Returns true if we were able to find single terminator operand values for
   /// each predecessor of this arguments basic block. The found values are
@@ -163,7 +163,7 @@ public:
   /// the enum itself (the operand of the switch_enum).
   bool getSingleTerminatorOperands(
       SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-          &returnedSingleTermOperands);
+          &returnedSingleTermOperands) const;
 
   /// If this SILArgument's parent block has a single predecessor whose
   /// terminator has a single operand, return the incoming operand of the
@@ -209,14 +209,14 @@ class SILPhiArgument : public SILArgument {
 public:
   /// Return true if this is block argument is actually a phi argument as
   /// opposed to a cast or projection.
-  bool isPhiArgument();
+  bool isPhiArgument() const;
 
   /// If this argument is a phi, return the incoming phi value for the given
   /// predecessor BB. If this argument is not a phi, return an invalid SILValue.
   ///
   /// FIXME: Once SILPhiArgument actually implies that it is a phi argument,
   /// this will be guaranteed to return a valid SILValue.
-  SILValue getIncomingPhiValue(SILBasicBlock *predBlock);
+  SILValue getIncomingPhiValue(SILBasicBlock *predBlock) const;
 
   /// If this argument is a phi, populate `OutArray` with the incoming phi
   /// values for each predecessor BB. If this argument is not a phi, return
@@ -224,7 +224,7 @@ public:
   ///
   /// FIXME: Once SILPhiArgument actually implies that it is a phi argument,
   /// this will always succeed.
-  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &returnedPhiValues);
+  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &returnedPhiValues) const;
 
   /// If this argument is a phi, populate `OutArray` with each predecessor block
   /// and its incoming phi value. If this argument is not a phi, return false.
@@ -233,7 +233,7 @@ public:
   /// this will always succeed.
   bool
   getIncomingPhiValues(SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-                           &returnedPredAndPhiValuePairs);
+                           &returnedPredAndPhiValuePairs) const;
 
   /// Returns true if we were able to find a single terminator operand value for
   /// each predecessor of this arguments basic block. The found values are
@@ -243,7 +243,7 @@ public:
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
   bool getSingleTerminatorOperands(
-      SmallVectorImpl<SILValue> &returnedSingleTermOperands);
+      SmallVectorImpl<SILValue> &returnedSingleTermOperands) const;
 
   /// Returns true if we were able to find single terminator operand values for
   /// each predecessor of this arguments basic block. The found values are
@@ -254,7 +254,7 @@ public:
   /// the enum itself (the operand of the switch_enum).
   bool getSingleTerminatorOperands(
       SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-          &returnedSingleTermOperands);
+          &returnedSingleTermOperands) const;
 
   /// If this SILArgument's parent block has a single predecessor whose
   /// terminator has a single operand, return the incoming operand of the
@@ -333,21 +333,22 @@ public:
 // Out of line Definitions for SILArgument to avoid Forward Decl issues
 //===----------------------------------------------------------------------===//
 
-inline bool SILArgument::isPhiArgument() {
+inline bool SILArgument::isPhiArgument() const {
   if (auto *phiArg = dyn_cast<SILPhiArgument>(this))
     return phiArg->isPhiArgument();
 
   return false;
 }
 
-inline SILValue SILArgument::getIncomingPhiValue(SILBasicBlock *predBlock) {
+inline SILValue
+SILArgument::getIncomingPhiValue(SILBasicBlock *predBlock) const {
   if (isa<SILFunctionArgument>(this))
     return SILValue();
   return cast<SILPhiArgument>(this)->getIncomingPhiValue(predBlock);
 }
 
 inline bool SILArgument::getIncomingPhiValues(
-    SmallVectorImpl<SILValue> &returnedPhiValues) {
+    SmallVectorImpl<SILValue> &returnedPhiValues) const {
   if (isa<SILFunctionArgument>(this))
     return false;
   return cast<SILPhiArgument>(this)->getIncomingPhiValues(returnedPhiValues);
@@ -355,7 +356,7 @@ inline bool SILArgument::getIncomingPhiValues(
 
 inline bool SILArgument::getIncomingPhiValues(
     SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-        &returnedPredAndPhiValuePairs) {
+        &returnedPredAndPhiValuePairs) const {
   if (isa<SILFunctionArgument>(this))
     return false;
   return cast<SILPhiArgument>(this)->getIncomingPhiValues(
@@ -363,7 +364,7 @@ inline bool SILArgument::getIncomingPhiValues(
 }
 
 inline bool SILArgument::getSingleTerminatorOperands(
-    SmallVectorImpl<SILValue> &returnedSingleTermOperands) {
+    SmallVectorImpl<SILValue> &returnedSingleTermOperands) const {
   if (isa<SILFunctionArgument>(this))
     return false;
   return cast<SILPhiArgument>(this)->getSingleTerminatorOperands(
@@ -372,7 +373,7 @@ inline bool SILArgument::getSingleTerminatorOperands(
 
 inline bool SILArgument::getSingleTerminatorOperands(
     SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-        &returnedSingleTermOperands) {
+        &returnedSingleTermOperands) const {
   if (isa<SILFunctionArgument>(this))
     return false;
   return cast<SILPhiArgument>(this)->getSingleTerminatorOperands(

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -112,12 +112,12 @@ public:
   /// If this argument is a phi, populate `OutArray` with the incoming phi
   /// values for each predecessor BB. If this argument is not a phi, return
   /// false.
-  bool getIncomingPhiValues(llvm::SmallVectorImpl<SILValue> &ReturnedPhiValues);
+  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &ReturnedPhiValues);
 
   /// If this argument is a phi, populate `OutArray` with each predecessor block
   /// and its incoming phi value. If this argument is not a phi, return false.
   bool getIncomingPhiValues(
-      llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
           &ReturnedPredAndPhiValuePairs);
 
   /// Returns true if we were able to find a single terminator operand value for
@@ -127,7 +127,7 @@ public:
   /// Note: this peeks through any projections or cast implied by the
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
-  bool getSingleTerminatorOperands(llvm::SmallVectorImpl<SILValue> &OutArray);
+  bool getSingleTerminatorOperands(SmallVectorImpl<SILValue> &OutArray);
 
   /// Returns true if we were able to find single terminator operand values for
   /// each predecessor of this arguments basic block. The found values are
@@ -137,7 +137,7 @@ public:
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
   bool getSingleTerminatorOperands(
-      llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
+      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
 
   /// If this SILArgument's parent block has a single predecessor whose
   /// terminator has a single operand, return the incoming operand of the
@@ -194,7 +194,7 @@ public:
   ///
   /// FIXME: Once SILPhiArgument actually implies that it is a phi argument,
   /// this will always succeed.
-  bool getIncomingPhiValues(llvm::SmallVectorImpl<SILValue> &OutArray);
+  bool getIncomingPhiValues(SmallVectorImpl<SILValue> &OutArray);
 
   /// If this argument is a phi, populate `OutArray` with each predecessor block
   /// and its incoming phi value. If this argument is not a phi, return false.
@@ -202,7 +202,7 @@ public:
   /// FIXME: Once SILPhiArgument actually implies that it is a phi argument,
   /// this will always succeed.
   bool getIncomingPhiValues(
-      llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
+      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
 
   /// Returns true if we were able to find a single terminator operand value for
   /// each predecessor of this arguments basic block. The found values are
@@ -211,7 +211,7 @@ public:
   /// Note: this peeks through any projections or cast implied by the
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
-  bool getSingleTerminatorOperands(llvm::SmallVectorImpl<SILValue> &OutArray);
+  bool getSingleTerminatorOperands(SmallVectorImpl<SILValue> &OutArray);
 
   /// Returns true if we were able to find single terminator operand values for
   /// each predecessor of this arguments basic block. The found values are
@@ -221,7 +221,7 @@ public:
   /// terminator. e.g. the incoming value for a switch_enum payload argument is
   /// the enum itself (the operand of the switch_enum).
   bool getSingleTerminatorOperands(
-      llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
+      SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray);
 
   /// If this SILArgument's parent block has a single predecessor whose
   /// terminator has a single operand, return the incoming operand of the
@@ -325,28 +325,28 @@ inline SILValue SILArgument::getIncomingPhiValue(SILBasicBlock *BB) {
 }
 
 inline bool
-SILArgument::getIncomingPhiValues(llvm::SmallVectorImpl<SILValue> &OutArray) {
+SILArgument::getIncomingPhiValues(SmallVectorImpl<SILValue> &OutArray) {
   if (isa<SILFunctionArgument>(this))
     return false;
   return cast<SILPhiArgument>(this)->getIncomingPhiValues(OutArray);
 }
 
 inline bool SILArgument::getIncomingPhiValues(
-    llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray) {
+    SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray) {
   if (isa<SILFunctionArgument>(this))
     return false;
   return cast<SILPhiArgument>(this)->getIncomingPhiValues(OutArray);
 }
 
 inline bool SILArgument::getSingleTerminatorOperands(
-    llvm::SmallVectorImpl<SILValue> &OutArray) {
+    SmallVectorImpl<SILValue> &OutArray) {
   if (isa<SILFunctionArgument>(this))
     return false;
   return cast<SILPhiArgument>(this)->getSingleTerminatorOperands(OutArray);
 }
 
 inline bool SILArgument::getSingleTerminatorOperands(
-    llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray) {
+    SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray) {
   if (isa<SILFunctionArgument>(this))
     return false;
   return cast<SILPhiArgument>(this)->getSingleTerminatorOperands(OutArray);

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -72,7 +72,7 @@ SILModule &SILArgument::getModule() const {
 // expensive to call this helper instead of simply specifying phis with an
 // opcode. It results in repeated CFG traversals and repeated, unnecessary
 // switching over terminator opcodes.
-bool SILPhiArgument::isPhiArgument() {
+bool SILPhiArgument::isPhiArgument() const {
   // No predecessors indicates an unreachable block.
   if (getParent()->pred_empty())
     return false;
@@ -101,7 +101,7 @@ static SILValue getIncomingPhiValueForPred(const SILBasicBlock *parentBlock,
       ->getArgForDestBB(parentBlock, argIndex);
 }
 
-SILValue SILPhiArgument::getIncomingPhiValue(SILBasicBlock *predBlock) {
+SILValue SILPhiArgument::getIncomingPhiValue(SILBasicBlock *predBlock) const {
   if (!isPhiArgument())
     return SILValue();
 
@@ -118,7 +118,7 @@ SILValue SILPhiArgument::getIncomingPhiValue(SILBasicBlock *predBlock) {
 }
 
 bool SILPhiArgument::getIncomingPhiValues(
-    SmallVectorImpl<SILValue> &returnedPhiValues) {
+    SmallVectorImpl<SILValue> &returnedPhiValues) const {
   if (!isPhiArgument())
     return false;
 
@@ -137,7 +137,7 @@ bool SILPhiArgument::getIncomingPhiValues(
 
 bool SILPhiArgument::getIncomingPhiValues(
     SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-        &returnedPredBBAndPhiValuePairs) {
+        &returnedPredBBAndPhiValuePairs) const {
   if (!isPhiArgument())
     return false;
 
@@ -189,7 +189,7 @@ getSingleTerminatorOperandForPred(const SILBasicBlock *parentBlock,
 }
 
 bool SILPhiArgument::getSingleTerminatorOperands(
-    SmallVectorImpl<SILValue> &returnedSingleTermOperands) {
+    SmallVectorImpl<SILValue> &returnedSingleTermOperands) const {
   const auto *parentBlock = getParent();
 
   if (parentBlock->pred_empty())
@@ -209,7 +209,7 @@ bool SILPhiArgument::getSingleTerminatorOperands(
 
 bool SILPhiArgument::getSingleTerminatorOperands(
     SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-        &returnedSingleTermOperands) {
+        &returnedSingleTermOperands) const {
   const auto *parentBlock = getParent();
 
   if (parentBlock->pred_empty())

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -23,28 +23,30 @@ using namespace swift;
 // SILArgument Implementation
 //===----------------------------------------------------------------------===//
 
-SILArgument::SILArgument(ValueKind ChildKind, SILBasicBlock *ParentBB,
-                         SILType Ty, ValueOwnershipKind OwnershipKind,
-                         const ValueDecl *D)
-    : ValueBase(ChildKind, Ty, IsRepresentative::Yes), ParentBB(ParentBB),
-      Decl(D) {
-  Bits.SILArgument.VOKind = static_cast<unsigned>(OwnershipKind);
-  ParentBB->insertArgument(ParentBB->args_end(), this);
+SILArgument::SILArgument(ValueKind subClassKind,
+                         SILBasicBlock *inputParentBlock, SILType type,
+                         ValueOwnershipKind ownershipKind,
+                         const ValueDecl *inputDecl)
+    : ValueBase(subClassKind, type, IsRepresentative::Yes),
+      parentBlock(inputParentBlock), decl(inputDecl) {
+  Bits.SILArgument.VOKind = static_cast<unsigned>(ownershipKind);
+  inputParentBlock->insertArgument(inputParentBlock->args_end(), this);
 }
 
-SILArgument::SILArgument(ValueKind ChildKind, SILBasicBlock *ParentBB,
-                         SILBasicBlock::arg_iterator Pos, SILType Ty,
-                         ValueOwnershipKind OwnershipKind, const ValueDecl *D)
-    : ValueBase(ChildKind, Ty, IsRepresentative::Yes), ParentBB(ParentBB),
-      Decl(D) {
-  Bits.SILArgument.VOKind = static_cast<unsigned>(OwnershipKind);
+SILArgument::SILArgument(ValueKind subClassKind,
+                         SILBasicBlock *inputParentBlock,
+                         SILBasicBlock::arg_iterator argArrayInsertPt,
+                         SILType type, ValueOwnershipKind ownershipKind,
+                         const ValueDecl *inputDecl)
+    : ValueBase(subClassKind, type, IsRepresentative::Yes),
+      parentBlock(inputParentBlock), decl(inputDecl) {
+  Bits.SILArgument.VOKind = static_cast<unsigned>(ownershipKind);
   // Function arguments need to have a decl.
-  assert(
-    !ParentBB->getParent()->isBare() &&
-    ParentBB->getParent()->size() == 1
-          ? D != nullptr
-          : true);
-  ParentBB->insertArgument(Pos, this);
+  assert(!inputParentBlock->getParent()->isBare() &&
+                 inputParentBlock->getParent()->size() == 1
+             ? decl != nullptr
+             : true);
+  inputParentBlock->insertArgument(argArrayInsertPt, this);
 }
 
 
@@ -76,84 +78,89 @@ bool SILPhiArgument::isPhiArgument() {
     return false;
 
   // Multiple predecessors require phis.
-  auto *predBB = getParent()->getSinglePredecessorBlock();
-  if (!predBB)
+  auto *predBlock = getParent()->getSinglePredecessorBlock();
+  if (!predBlock)
     return true;
 
-  auto *TI = predBB->getTerminator();
-  return isa<BranchInst>(TI) || isa<CondBranchInst>(TI);
+  auto *termInst = predBlock->getTerminator();
+  return isa<BranchInst>(termInst) || isa<CondBranchInst>(termInst);
 }
 
-static SILValue getIncomingPhiValueForPred(const SILBasicBlock *BB,
-                                           const SILBasicBlock *Pred,
-                                           unsigned Index) {
-  const TermInst *TI = Pred->getTerminator();
-  if (auto *BI = dyn_cast<BranchInst>(TI))
-    return BI->getArg(Index);
+static SILValue getIncomingPhiValueForPred(const SILBasicBlock *parentBlock,
+                                           const SILBasicBlock *predBlock,
+                                           unsigned argIndex) {
+  const auto *predBlockTermInst = predBlock->getTerminator();
+  if (auto *bi = dyn_cast<BranchInst>(predBlockTermInst))
+    return bi->getArg(argIndex);
 
   // FIXME: Disallowing critical edges in SIL would enormously simplify phi and
   // branch handling and reduce expensive analysis invalidation. If that is
   // done, then only BranchInst will participate in phi operands, eliminating
   // the need to search for the appropriate CondBranchInst operand.
-  return cast<CondBranchInst>(TI)->getArgForDestBB(BB, Index);
+  return cast<CondBranchInst>(predBlockTermInst)
+      ->getArgForDestBB(parentBlock, argIndex);
 }
 
-SILValue SILPhiArgument::getIncomingPhiValue(SILBasicBlock *predBB) {
+SILValue SILPhiArgument::getIncomingPhiValue(SILBasicBlock *predBlock) {
   if (!isPhiArgument())
     return SILValue();
 
-  SILBasicBlock *Parent = getParent();
-  assert(!Parent->pred_empty());
+  const auto *parentBlock = getParent();
+  assert(!parentBlock->pred_empty());
 
-  unsigned Index = getIndex();
+  unsigned argIndex = getIndex();
 
-  assert(Parent->pred_end()
-         != std::find(Parent->pred_begin(), Parent->pred_end(), predBB));
+  assert(parentBlock->pred_end() != std::find(parentBlock->pred_begin(),
+                                              parentBlock->pred_end(),
+                                              predBlock));
 
-  return getIncomingPhiValueForPred(Parent, predBB, Index);
+  return getIncomingPhiValueForPred(parentBlock, predBlock, argIndex);
 }
 
 bool SILPhiArgument::getIncomingPhiValues(
-    llvm::SmallVectorImpl<SILValue> &ReturnedPhiValues) {
+    SmallVectorImpl<SILValue> &returnedPhiValues) {
   if (!isPhiArgument())
     return false;
 
-  SILBasicBlock *Parent = getParent();
-  assert(!Parent->pred_empty());
+  const auto *parentBlock = getParent();
+  assert(!parentBlock->pred_empty());
 
-  unsigned Index = getIndex();
-  for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
-    SILValue Value = getIncomingPhiValueForPred(Parent, Pred, Index);
-    assert(Value);
-    ReturnedPhiValues.push_back(Value);
+  unsigned argIndex = getIndex();
+  for (auto *predBlock : getParent()->getPredecessorBlocks()) {
+    SILValue incomingValue =
+        getIncomingPhiValueForPred(parentBlock, predBlock, argIndex);
+    assert(incomingValue);
+    returnedPhiValues.push_back(incomingValue);
   }
   return true;
 }
 
 bool SILPhiArgument::getIncomingPhiValues(
-    llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
-        &ReturnedPredBBAndPhiValuePairs) {
+    SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+        &returnedPredBBAndPhiValuePairs) {
   if (!isPhiArgument())
     return false;
 
-  SILBasicBlock *Parent = getParent();
-  assert(!Parent->pred_empty());
+  const auto *parentBlock = getParent();
+  assert(!parentBlock->pred_empty());
 
-  unsigned Index = getIndex();
-  for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
-    SILValue Value = getIncomingPhiValueForPred(Parent, Pred, Index);
-    assert(Value);
-    ReturnedPredBBAndPhiValuePairs.push_back({Pred, Value});
+  unsigned argIndex = getIndex();
+  for (auto *predBlock : getParent()->getPredecessorBlocks()) {
+    SILValue incomingValue =
+        getIncomingPhiValueForPred(parentBlock, predBlock, argIndex);
+    assert(incomingValue);
+    returnedPredBBAndPhiValuePairs.push_back({predBlock, incomingValue});
   }
   return true;
 }
 
-static SILValue getSingleTerminatorOperandForPred(const SILBasicBlock *BB,
-                                                  const SILBasicBlock *Pred,
-                                                  unsigned Index) {
-  const TermInst *TI = Pred->getTerminator();
+static SILValue
+getSingleTerminatorOperandForPred(const SILBasicBlock *parentBlock,
+                                  const SILBasicBlock *predBlock,
+                                  unsigned argIndex) {
+  const auto *predTermInst = predBlock->getTerminator();
 
-  switch (TI->getTermKind()) {
+  switch (predTermInst->getTermKind()) {
   case TermKind::UnreachableInst:
   case TermKind::ReturnInst:
   case TermKind::ThrowInst:
@@ -167,61 +174,65 @@ static SILValue getSingleTerminatorOperandForPred(const SILBasicBlock *BB,
   case TermKind::YieldInst:
     return SILValue();
   case TermKind::BranchInst:
-    return cast<const BranchInst>(TI)->getArg(Index);
+    return cast<const BranchInst>(predTermInst)->getArg(argIndex);
   case TermKind::CondBranchInst:
-    return cast<const CondBranchInst>(TI)->getArgForDestBB(BB, Index);
+    return cast<const CondBranchInst>(predTermInst)
+        ->getArgForDestBB(parentBlock, argIndex);
   case TermKind::CheckedCastBranchInst:
-    return cast<const CheckedCastBranchInst>(TI)->getOperand();
+    return cast<const CheckedCastBranchInst>(predTermInst)->getOperand();
   case TermKind::CheckedCastValueBranchInst:
-    return cast<const CheckedCastValueBranchInst>(TI)->getOperand();
+    return cast<const CheckedCastValueBranchInst>(predTermInst)->getOperand();
   case TermKind::SwitchEnumInst:
-    return cast<const SwitchEnumInst>(TI)->getOperand();
+    return cast<const SwitchEnumInst>(predTermInst)->getOperand();
   }
   llvm_unreachable("Unhandled TermKind?!");
 }
 
 bool SILPhiArgument::getSingleTerminatorOperands(
-    llvm::SmallVectorImpl<SILValue> &OutArray) {
-  SILBasicBlock *Parent = getParent();
+    SmallVectorImpl<SILValue> &returnedSingleTermOperands) {
+  const auto *parentBlock = getParent();
 
-  if (Parent->pred_empty())
+  if (parentBlock->pred_empty())
     return false;
 
-  unsigned Index = getIndex();
-  for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
-    SILValue Value = getSingleTerminatorOperandForPred(Parent, Pred, Index);
-    if (!Value)
+  unsigned argIndex = getIndex();
+  for (auto *predBlock : getParent()->getPredecessorBlocks()) {
+    SILValue incomingValue =
+        getSingleTerminatorOperandForPred(parentBlock, predBlock, argIndex);
+    if (!incomingValue)
       return false;
-    OutArray.push_back(Value);
+    returnedSingleTermOperands.push_back(incomingValue);
   }
 
   return true;
 }
 
 bool SILPhiArgument::getSingleTerminatorOperands(
-    llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray) {
-  SILBasicBlock *Parent = getParent();
+    SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+        &returnedSingleTermOperands) {
+  const auto *parentBlock = getParent();
 
-  if (Parent->pred_empty())
+  if (parentBlock->pred_empty())
     return false;
 
-  unsigned Index = getIndex();
-  for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
-    SILValue Value = getSingleTerminatorOperandForPred(Parent, Pred, Index);
-    if (!Value)
+  unsigned argIndex = getIndex();
+  for (auto *predBlock : getParent()->getPredecessorBlocks()) {
+    SILValue incomingValue =
+        getSingleTerminatorOperandForPred(parentBlock, predBlock, argIndex);
+    if (!incomingValue)
       return false;
-    OutArray.push_back({Pred, Value});
+    returnedSingleTermOperands.push_back({predBlock, incomingValue});
   }
 
   return true;
 }
 
 SILValue SILPhiArgument::getSingleTerminatorOperand() const {
-  const SILBasicBlock *Parent = getParent();
-  const SILBasicBlock *PredBB = Parent->getSinglePredecessorBlock();
-  if (!PredBB)
+  const auto *parentBlock = getParent();
+  const auto *predBlock = parentBlock->getSinglePredecessorBlock();
+  if (!predBlock)
     return SILValue();
-  return getSingleTerminatorOperandForPred(Parent, PredBB, getIndex());
+  return getSingleTerminatorOperandForPred(parentBlock, predBlock, getIndex());
 }
 
 const SILPhiArgument *BranchInst::getArgForOperand(const Operand *oper) const {


### PR DESCRIPTION
These are just some cleanups to modernize SILArgument in preparation for my adding new argument kinds (SwitchEnumResult, CheckedCastBranchResult, etc) so that SILPhiArgument is a true phi argument.