### PR TITLE
[AutoDiff] Fix unsilenceable `@noDerivative` warning.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4241,11 +4241,15 @@ void AttributeChecker::visitNoDerivativeAttr(NoDerivativeAttr *attr) {
         diag::noderivative_only_on_differentiable_struct_or_class_fields);
     return;
   }
-  if (!conformsToDifferentiable(
-          nominal->getDeclaredInterfaceType(),
-          nominal->getDeclContext())) {
-    diagnoseAndRemoveAttr(attr,
-        diag::noderivative_only_on_differentiable_struct_or_class_fields);
+  // Find any `Differentiable` conformance for the nominal type. If no such
+  // conformance exists, emit an error.
+  auto *diffProto =
+      nominal->getASTContext().getProtocol(KnownProtocolKind::Differentiable);
+  auto conf = nominal->getModuleContext()->lookupConformance(
+      nominal->getDeclaredInterfaceType(), diffProto);
+  if (!conf) {
+    diagnoseAndRemoveAttr(
+        attr, diag::noderivative_only_on_differentiable_struct_or_class_fields);
     return;
   }
 }

--- a/test/Sema/class_differentiable.swift
+++ b/test/Sema/class_differentiable.swift
@@ -525,6 +525,42 @@ class ImplicitNoDerivativeWithSeparateTangent : Differentiable {
   }
 }
 
+// TF-1018: verify that `@noDerivative` warnings are always silenceable, even
+// when the `Differentiable` conformance context is not the nominal type
+// declaration.
+
+class ExtensionDifferentiableNoDerivative<T> {
+  // expected-warning @+2 {{stored property 'x' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
+  // expected-warning @+1 {{stored property 'y' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
+  var x, y: T
+  // expected-warning @+1 {{stored property 'nondiff' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
+  var nondiff: Bool
+  init() { fatalError() }
+}
+extension ExtensionDifferentiableNoDerivative: Differentiable {}
+
+class ExtensionDifferentiableNoDerivativeFixed<T> {
+  @noDerivative var x, y: T
+  @noDerivative var nondiff: Bool
+  init() { fatalError() }
+}
+extension ExtensionDifferentiableNoDerivativeFixed: Differentiable {}
+
+class ConditionalDifferentiableNoDerivative<T> {
+  var x, y: T
+  // expected-warning @+1 {{stored property 'nondiff' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
+  var nondiff: Bool
+  init() { fatalError() }
+}
+extension ConditionalDifferentiableNoDerivative: Differentiable where T: Differentiable {}
+
+class ConditionalDifferentiableNoDerivativeFixed<T> {
+  var x, y: T
+  @noDerivative var nondiff: Bool
+  init() { fatalError() }
+}
+extension ConditionalDifferentiableNoDerivativeFixed: Differentiable where T: Differentiable {}
+
 // TF-265: Test invalid initializer (that uses a non-existent type).
 class InvalidInitializer : Differentiable {
   init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {} // expected-error {{use of undeclared type 'NonExistentType'}}

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -361,6 +361,38 @@ struct ImplicitNoDerivativeWithSeparateTangent : Differentiable {
   var b: Bool // expected-warning {{stored property 'b' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
 }
 
+// TF-1018: verify that `@noDerivative` warnings are always silenceable, even
+// when the `Differentiable` conformance context is not the nominal type
+// declaration.
+
+struct ExtensionDifferentiableNoDerivative<T> {
+  // expected-warning @+2 {{stored property 'x' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
+  // expected-warning @+1 {{stored property 'y' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
+  var x, y: T
+  // expected-warning @+1 {{stored property 'nondiff' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
+  var nondiff: Bool
+}
+extension ExtensionDifferentiableNoDerivative: Differentiable {}
+
+struct ExtensionDifferentiableNoDerivativeFixed<T> {
+  @noDerivative var x, y: T
+  @noDerivative var nondiff: Bool
+}
+extension ExtensionDifferentiableNoDerivativeFixed: Differentiable {}
+
+struct ConditionalDifferentiableNoDerivative<T> {
+  var x, y: T
+  // expected-warning @+1 {{stored property 'nondiff' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
+  var nondiff: Bool
+}
+extension ConditionalDifferentiableNoDerivative: Differentiable where T: Differentiable {}
+
+struct ConditionalDifferentiableNoDerivativeFixed<T> {
+  var x, y: T
+  @noDerivative var nondiff: Bool
+}
+extension ConditionalDifferentiableNoDerivativeFixed: Differentiable where T: Differentiable {}
+
 // TF-265: Test invalid initializer (that uses a non-existent type).
 struct InvalidInitializer : Differentiable {
   init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {} // expected-error {{use of undeclared type 'NonExistentType'}}


### PR DESCRIPTION
Previously, `@noDerivative` warnings were unsilenceable for `Differentiable`
conditional conformances: adding `@noDerivative` in the nominal type declaration
was rejected by `@noDerivative` attribute type-checking.

Now, such warnings can be silenced by adding an explicit `@noDerivative`
attribute. `@noDerivative` can always be added in the nominal type declaration,
because cross-file derived conformances are rejected.

Add `@noDerivative` tests for `Differentiable`-conforming structs/classes.

Resolves TF-1018.

---

```swift
struct Foo<T> {
  var x, y: T
  @noDerivative var u: Bool
}
extension Foo: Differentiable where T: Differentiable {}
```
Before:
```
noderiv.swift:3:3: error: '@noDerivative' is only allowed on stored properties in structure or class types that declare a conformance to 'Differentiable'
  @noDerivative var u: Bool
  ^~~~~~~~~~~~~~

noderiv.swift:3:3: warning: stored property 'u' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute
  @noDerivative var u: Bool
  ^
  @noDerivative
```
After: no error.

---

Pretty sure all `@noDerivative` warnings are silenceable now.