### PR TITLE
Update checkout for tensorflow-swift-apis.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -267,7 +267,7 @@
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-11-11-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-11-11-a",
                 "tensorflow": "7c7d924821a8b1b20433c2f3f484bbd409873a84",
-                "tensorflow-swift-apis": "c09de96f739aa8bfce0c41e19213bd2d7fa9a4ba",
+                "tensorflow-swift-apis": "9548ea2fec10bb83ca8364ce8bcf82306dad9009",
                 "tensorflow-swift-quote": "4faabf7b04827b9c522eef15387eea3895eaf001"
             }
         }


### PR DESCRIPTION
https://github.com/tensorflow/swift-apis/commit/9548ea2fec10bb83ca8364ce8bcf82306dad9009

---

Notable change: rename `@differentiating` to `@derivative(of:)` to fix stdlib compilation warning. https://github.com/tensorflow/swift-apis/pull/569