### PR TITLE
[AutoDiff] Deprecate method-style differential operators.

### DIFF
--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
@@ -297,35 +297,3 @@ public func valueWithDerivative<T: FloatingPoint, R>(
   let (y, differential) = valueWithDifferential(at: x, in: f)
   return (y, differential(1))
 }
-
-public extension Differentiable {
-  @inlinable
-  func gradient(
-    in f: @differentiable (Self) -> Tracked<Float>
-  ) -> TangentVector {
-    return self.pullback(in: f)(1)
-  }
-
-  @inlinable
-  func gradient<T : Differentiable>(
-    at x: T, in f: @differentiable (Self, T) -> Tracked<Float>
-  ) -> (TangentVector, T.TangentVector) {
-    return self.pullback(at: x, in: f)(1)
-  }
-
-  @inlinable
-  func valueWithGradient(
-    in f: @differentiable (Self) -> Tracked<Float>
-  ) -> (value: Tracked<Float>, gradient: TangentVector) {
-    let (y, pb) = self.valueWithPullback(in: f)
-    return (y, pb(1))
-  }
-
-  @inlinable
-  func valueWithGradient<T : Differentiable>(
-    at x: T, in f: @differentiable (Self, T) -> Tracked<Float>
-  ) -> (value: Tracked<Float>, gradient: (TangentVector, T.TangentVector)) {
-    let (y, pb) = self.valueWithPullback(at: x, in: f)
-    return (y, pb(1))
-  }
-}

--- a/stdlib/public/Differentiation/DifferentiationSupport.swift
+++ b/stdlib/public/Differentiation/DifferentiationSupport.swift
@@ -286,7 +286,9 @@ public extension Differentiable {
   internal func _vjp_withRecomputationInPullbacks<Result : Differentiable>(
     _ body: @escaping @differentiable (Self) -> Result
   ) -> (Result, (Result.TangentVector) -> TangentVector) {
-    return valueWithPullback(in: Swift.withRecomputationInPullbacks(body))
+    return Swift.valueWithPullback(
+      at: self, in: Swift.withRecomputationInPullbacks(body)
+    )
   }
 }
 
@@ -295,6 +297,10 @@ public extension Differentiable {
 //===----------------------------------------------------------------------===//
 
 public extension Differentiable {
+  @available(*, deprecated, message: """
+    Method-style differential operators are deprecated and will be removed; \
+    use top-level function 'Swift.valueWithPullback(at:in:)' instead
+    """)
   @inlinable
   func valueWithPullback<R>(
     in f: @differentiable (Self) -> R
@@ -302,6 +308,10 @@ public extension Differentiable {
     return Builtin.applyDerivative_vjp_arity1(f, self)
   }
 
+  @available(*, deprecated, message: """
+    Method-style differential operators are deprecated and will be removed; \
+    use top-level function 'Swift.pullback(at:in:)' instead
+    """)
   @inlinable
   func pullback<R>(
     in f: @differentiable (Self) -> R
@@ -309,23 +319,35 @@ public extension Differentiable {
     return Builtin.applyDerivative_vjp_arity1(f, self).1
   }
 
+  @available(*, deprecated, message: """
+    Method-style differential operators are deprecated and will be removed; \
+    use top-level function 'Swift.gradient(at:in:)' instead
+    """)
   @inlinable
   func gradient<R>(
     in f: @differentiable (Self) -> R
   ) -> TangentVector
     where R : FloatingPoint, R.TangentVector == R {
-    return self.pullback(in: f)(R(1))
+    return Swift.pullback(at: self, in: f)(R(1))
   }
 
+  @available(*, deprecated, message: """
+    Method-style differential operators are deprecated and will be removed; \
+    use top-level function 'Swift.valueWithGradient(at:in:)' instead
+    """)
   @inlinable
   func valueWithGradient<R>(
     in f: @differentiable (Self) -> R
   ) -> (value: R, gradient: TangentVector)
     where R : FloatingPoint, R.TangentVector == R {
-    let (y, pb) = self.valueWithPullback(in: f)
+    let (y, pb) = Swift.valueWithPullback(at: self, in: f)
     return (y, pb(R(1)))
   }
 
+  @available(*, deprecated, message: """
+    Method-style differential operators are deprecated and will be removed; \
+    use top-level function 'Swift.valueWithPullback(at:_:in:)' instead
+    """)
   @inlinable
   func valueWithPullback<T, R>(
     at x: T, in f: @differentiable (Self, T) -> R
@@ -334,6 +356,10 @@ public extension Differentiable {
     return Builtin.applyDerivative_vjp_arity2(f, self, x)
   }
 
+  @available(*, deprecated, message: """
+    Method-style differential operators are deprecated and will be removed; \
+    use top-level function 'Swift.pullback(at:_:in:)' instead
+    """)
   @inlinable
   func pullback<T, R>(
     at x: T, in f: @differentiable (Self, T) -> R
@@ -341,20 +367,28 @@ public extension Differentiable {
     return Builtin.applyDerivative_vjp_arity2(f, self, x).1
   }
 
+  @available(*, deprecated, message: """
+    Method-style differential operators are deprecated and will be removed; \
+    use top-level function 'Swift.gradient(at:_:in:)' instead
+    """)
   @inlinable
   func gradient<T, R>(
     at x: T, in f: @differentiable (Self, T) -> R
   ) -> (TangentVector, T.TangentVector)
     where R : FloatingPoint, R.TangentVector == R {
-    return self.pullback(at: x, in: f)(R(1))
+    return Swift.pullback(at: self, x, in: f)(R(1))
   }
 
+  @available(*, deprecated, message: """
+    Method-style differential operators are deprecated and will be removed; \
+    use top-level function 'Swift.valueWithGradient(at:_:in:)' instead
+    """)
   @inlinable
   func valueWithGradient<T, R>(
     at x: T, in f: @differentiable (Self, T) -> R
   ) -> (value: R, gradient: (TangentVector, T.TangentVector))
     where R : FloatingPoint, R.TangentVector == R {
-    let (y, pb) = self.valueWithPullback(at: x, in: f)
+    let (y, pb) = Swift.valueWithPullback(at: self, x, in: f)
     return (y, pb(R(1)))
   }
 }

--- a/test/AutoDiff/currying.swift
+++ b/test/AutoDiff/currying.swift
@@ -8,16 +8,17 @@ var CurryingAutodiffTests = TestSuite("CurryingAutodiff")
 CurryingAutodiffTests.testWithLeakChecking("StructMember") {
   struct A {
     @differentiable(wrt: (value))
-    func v(_ value: Tracked<Float>) -> Tracked<Float> { return value * value }
+    func instanceMethod(_ value: Tracked<Float>) -> Tracked<Float> { return value * value }
   }
 
   let a = A()
-  // This implicitly constructs a function (A) -> (Tracked<Float>) -> Tracked<Float>
-  // which gets called with a:
-  let g: @differentiable (Tracked<Float>) -> Tracked<Float> = a.v
+  // Referencing `a.instanceMethod` implicitly applies the curried function
+  // `A.instanceMethod` of type `(A) -> (Tracked<Float>) -> Tracked<Float>` to
+  // the value `a`, producing a `(Tracked<Float>) -> Tracked<Float>` value.
+  // This value is then converted to a `@differentiable` function-typed value.
+  let g: @differentiable (Tracked<Float>) -> Tracked<Float> = a.instanceMethod
 
-
-  expectEqual(6.0, Tracked<Float>(3.0).gradient(in: g))
+  expectEqual(6.0, gradient(at: 3, in: g))
 }
 
 runAllTests()

--- a/test/AutoDiff/existential.swift
+++ b/test/AutoDiff/existential.swift
@@ -10,14 +10,16 @@ protocol A {
   @differentiable(wrt: x)
   func a(_ x: Tracked<Float>) -> Tracked<Float>
 }
-func b(g: A) -> Tracked<Float> { return (3.0 as Tracked<Float>).gradient() { x in g.a(x) } }
+func b(g: A) -> Tracked<Float> {
+  return gradient(at: 3) { x in g.a(x) }
+}
 
 struct B : A {
   @differentiable(wrt: x)
-  func a(_ x: Tracked<Float>) -> Tracked<Float> { return x * 5.0 }
+  func a(_ x: Tracked<Float>) -> Tracked<Float> { return x * 5 }
 }
 
-ExistentialTests.testWithLeakChecking("vjp/adjoint constructed with existentials.") {
+ExistentialTests.testWithLeakChecking("Existential method VJP") {
   expectEqual(5.0, b(g: B()))
 }
 

--- a/test/AutoDiff/leakchecking.swift
+++ b/test/AutoDiff/leakchecking.swift
@@ -39,13 +39,13 @@ LeakCheckingTests.testWithLeakChecking("BasicLetLeakChecking") {
   do {
     let model = ExampleLeakModel()
     let x: Tracked<Float> = 1.0
-    _ = model.gradient(at: x) { m, x in m.applied(to: x) }
+    _ = gradient(at: model, x) { m, x in m.applied(to: x) }
   }
 
   do {
     let model = ExampleLeakModel()
     let x: Tracked<Float> = 1.0
-    _ = model.gradient(at: x) { m, x in
+    _ = gradient(at: model, x) { m, x -> Tracked<Float> in
       let (y0, y1) = (m.applied(to: x), m.applied(to: x))
       return y0 + y0 - y1
     }
@@ -95,7 +95,7 @@ LeakCheckingTests.testWithLeakChecking("TestProtocolDefaultDerivative") {
 
   let x = Tracked<Float>(1)
   let model = Foo()
-  _ = model.valueWithGradient { model in
+  _ = valueWithGradient(at: model) { model in
     // Call the protocol default implementation method.
     model.defaultImpl(x)
   }
@@ -130,7 +130,7 @@ LeakCheckingTests.testWithLeakChecking("ProtocolRequirements") {
   }
   let x = Tracked<Int>(1)
   let model = Model()
-  _ = model.valueWithGradient { model in
+  _ = valueWithGradient(at: model) { model in
     model(x)
   }
 }
@@ -140,7 +140,7 @@ LeakCheckingTests.testWithLeakChecking("LetStructs") {
     let z = Tracked(x)
     return z.value
   }
-  _ = Tracked<Float>(4).valueWithGradient(in: structConstructionWithOwnedParams)
+  _ = valueWithGradient(at: 4, in: structConstructionWithOwnedParams)
 }
 
 LeakCheckingTests.testWithLeakChecking("NestedVarStructs") {
@@ -154,7 +154,7 @@ LeakCheckingTests.testWithLeakChecking("NestedVarStructs") {
                                 z.first.value.second + y.first))
     return y.first + y.second - z.first.value.first + z.first.value.second
   }
-  expectEqual((8, 2), Tracked<Float>(4).valueWithGradient(in: nestedstruct_var))
+  expectEqual((8, 2), valueWithGradient(at: 4, in: nestedstruct_var))
 }
 
 LeakCheckingTests.testWithLeakChecking("NestedVarTuples") {
@@ -168,7 +168,7 @@ LeakCheckingTests.testWithLeakChecking("NestedVarTuples") {
     z.0.1 = z.0.1 + y.0
     return y.0 + y.1 - z.0.0 + z.0.1
   }
-  expectEqual((8, 2), Tracked<Float>(4).valueWithGradient(in: nestedtuple_var))
+  expectEqual((8, 2), valueWithGradient(at: 4, in: nestedtuple_var))
 }
 
 // Tests class method differentiation and JVP/VJP vtable entry thunks.
@@ -207,7 +207,7 @@ LeakCheckingTests.testWithLeakChecking("ClassMethods") {
   }
 
   func classValueWithGradient(_ c: Super) -> (Tracked<Float>, Tracked<Float>) {
-    return Tracked<Float>(1).valueWithGradient { c.f($0) }
+    return valueWithGradient(at: 1) { c.f($0) }
   }
   expectEqual((2, 2), classValueWithGradient(Super()))
   expectEqual((3, 3), classValueWithGradient(SubOverride()))
@@ -377,14 +377,15 @@ LeakCheckingTests.testWithLeakChecking("ParameterConventionMismatchLeakChecking"
   }
   let v = MyTrackedFloat<Any>.TangentVector(base: 10)
   expectEqual(10, pullback(at: Tracked<Float>(1)) { x in MyTrackedFloat(x, dummy: 1.0) }(v))
-  _ = Tracked<Float>(1).gradient { x in MyTrackedFloat<Any>(x, dummy: 1).ownedParameter(x) }
-  _ = Tracked<Float>(1).gradient { x in MyTrackedFloat<Any>(x, dummy: 1).sharedParameter(x) }
-  _ = Tracked<Float>(1).gradient { x in MyTrackedFloat<Any>(x, dummy: 1).ownedParameterGeneric(x) }
-  _ = Tracked<Float>(1).gradient { x in MyTrackedFloat<Any>(x, dummy: 1).sharedParameterGeneric(x) }
-  _ = Tracked<Float>(1).gradient { x in MyTrackedFloat<Any>(x, dummy: 1).consuming(x) }
-  _ = Tracked<Float>(1).gradient { x in MyTrackedFloat<Any>(x, dummy: 1).consumingGeneric(x) }
-  _ = Tracked<Float>(1).gradient { x in MyTrackedFloat<Any>(x, dummy: 1).nonconsuming(x) }
-  _ = Tracked<Float>(1).gradient { x in MyTrackedFloat<Any>(x, dummy: 1).nonconsumingGeneric(x) }
+  let x: Tracked<Float> = 1
+  _ = gradient(at: x) { x in MyTrackedFloat<Any>(x, dummy: 1).ownedParameter(x) }
+  _ = gradient(at: x) { x in MyTrackedFloat<Any>(x, dummy: 1).sharedParameter(x) }
+  _ = gradient(at: x) { x in MyTrackedFloat<Any>(x, dummy: 1).ownedParameterGeneric(x) }
+  _ = gradient(at: x) { x in MyTrackedFloat<Any>(x, dummy: 1).sharedParameterGeneric(x) }
+  _ = gradient(at: x) { x in MyTrackedFloat<Any>(x, dummy: 1).consuming(x) }
+  _ = gradient(at: x) { x in MyTrackedFloat<Any>(x, dummy: 1).consumingGeneric(x) }
+  _ = gradient(at: x) { x in MyTrackedFloat<Any>(x, dummy: 1).nonconsuming(x) }
+  _ = gradient(at: x) { x in MyTrackedFloat<Any>(x, dummy: 1).nonconsumingGeneric(x) }
 }
 
 LeakCheckingTests.testWithLeakChecking("ClosureCaptureLeakChecking") {
@@ -392,16 +393,16 @@ LeakCheckingTests.testWithLeakChecking("ClosureCaptureLeakChecking") {
     var model = ExampleLeakModel()
     let x: Tracked<Float> = 1.0
 
-    _ = model.gradient { m in m.applied(to: x) }
+    _ = gradient(at: model) { m in m.applied(to: x) }
     for _ in 0..<10 {
-      _ = model.gradient { m in m.applied(to: x) }
+      _ = gradient(at: model) { m in m.applied(to: x) }
     }
   }
 
   do {
     var model = ExampleLeakModel()
     var x: Tracked<Float> = 1.0
-    _ = model.gradient { m in
+    _ = gradient(at: model) { m -> Tracked<Float> in
       x = x + x
       var y = x + Tracked<Float>(x.value)
       return m.applied(to: y)
@@ -411,7 +412,7 @@ LeakCheckingTests.testWithLeakChecking("ClosureCaptureLeakChecking") {
   do {
     var model = ExampleLeakModel()
     let x: Tracked<Float> = 1.0
-    _ = model.gradient { m in
+    _ = gradient(at: model) { m -> Tracked<Float> in
       var model = m
       model.bias = x
       return model.applied(to: x)
@@ -423,7 +424,7 @@ LeakCheckingTests.testWithLeakChecking("ClosureCaptureLeakChecking") {
       let x: Tracked<Float> = .zero
       var y: Tracked<Float> = .zero
       mutating func differentiateSomethingThatCapturesSelf() {
-        _ = x.gradient { x in
+        _ = gradient(at: x) { x -> Tracked<Float> in
           self.y += .zero
           return .zero
         }
@@ -439,8 +440,7 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithTrivialUnconditionalMath"
     if true {}
     return x
   }
-  var x: Tracked<Float> = 1.0
-  _ = x.valueWithGradient(in: ControlFlowWithTrivialUnconditionalMath)
+  _ = valueWithGradient(at: 1, in: ControlFlowWithTrivialUnconditionalMath)
 }
 
 LeakCheckingTests.testWithLeakChecking("ControlFlowWithTrivialNestedIfElse") {
@@ -453,8 +453,7 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithTrivialNestedIfElse") {
       }
     }
   }
-  var x: Tracked<Float> = 1.0
-  _ = x.valueWithGradient(in: ControlFlowNestedWithTrivialIfElse)
+  _ = valueWithGradient(at: 1, in: ControlFlowNestedWithTrivialIfElse)
 }
 
 LeakCheckingTests.testWithLeakChecking("ControlFlowWithActiveCFCondition") {
@@ -467,13 +466,13 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithActiveCFCondition") {
       return x
     }
   }
-  _ = model.gradient(at: x, in: ControlFlowWithActiveCFCondition)
+  _ = gradient(at: model, x, in: ControlFlowWithActiveCFCondition)
 }
 
 LeakCheckingTests.testWithLeakChecking("ControlFlowWithIf") {
   var model = ExampleLeakModel()
   let x: Tracked<Float> = 1.0
-  _ = model.gradient(at: x) { m, x in
+  _ = gradient(at: model, x) { m, x -> Tracked<Float> in
     var result: Tracked<Float> = x
     if x > 0 {
       result = result + m.applied(to: x)
@@ -494,10 +493,12 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithIfInMethod") {
       return input * w1
     }
   }
+  let dense = Dense(w1: 4, w2: 5)
+  let denseNil = Dense(w1: 4, w2: nil)
   expectEqual((Dense.TangentVector(w1: 10), 20),
-              Dense(w1: 4, w2: 5).gradient(at: 2, in: { dense, x in dense(x) }))
+              gradient(at: dense, 2, in: { dense, x in dense(x) }))
   expectEqual((Dense.TangentVector(w1: 2), 4),
-              Dense(w1: 4, w2: nil).gradient(at: 2, in: { dense, x in dense(x) }))
+              gradient(at: denseNil, 2, in: { dense, x in dense(x) }))
 }
 
 
@@ -509,8 +510,8 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithLoop") {
     }
     return result
   }
-  expectEqual((8, 12), Tracked<Float>(2).valueWithGradient(in: for_loop))
-  expectEqual((27, 27), Tracked<Float>(3).valueWithGradient(in: for_loop))
+  expectEqual((8, 12), valueWithGradient(at: 2, in: for_loop))
+  expectEqual((27, 27), valueWithGradient(at: 3, in: for_loop))
 }
 
 LeakCheckingTests.testWithLeakChecking("ControlFlowWithNestedLoop") {
@@ -529,8 +530,8 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithNestedLoop") {
     }
     return outer
   }
-  expectEqual((0.5, -0.25), Tracked<Float>(2).valueWithGradient(in: nested_loop))
-  expectEqual((0.25, -0.0625), Tracked<Float>(4).valueWithGradient(in: nested_loop))
+  expectEqual((0.5, -0.25), valueWithGradient(at: 2, in: nested_loop))
+  expectEqual((0.25, -0.0625), valueWithGradient(at: 4, in: nested_loop))
 }
 
 LeakCheckingTests.testWithLeakChecking("ControlFlowWithNestedTuples") {
@@ -549,9 +550,9 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithNestedTuples") {
     }
     return y.0 + y.1 - z.0.0 + z.0.1
   }
-  expectEqual((8, 2), Tracked<Float>(4).valueWithGradient(in: cond_nestedtuple_var))
-  expectEqual((-20, 2), Tracked<Float>(-10).valueWithGradient(in: cond_nestedtuple_var))
-  expectEqual((-2674, 2), Tracked<Float>(-1337).valueWithGradient(in: cond_nestedtuple_var))
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_nestedtuple_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_nestedtuple_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_nestedtuple_var))
 }
 
 LeakCheckingTests.testWithLeakChecking("ControlFlowWithNestedStructs") {
@@ -570,9 +571,9 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithNestedStructs") {
     }
     return y.first + y.second - z.first.value.first + z.first.value.second
   }
-  expectEqual((8, 2), Tracked<Float>(4).valueWithGradient(in: cond_nestedstruct_var))
-  expectEqual((-20, 2), Tracked<Float>(-10).valueWithGradient(in: cond_nestedstruct_var))
-  expectEqual((-2674, 2), Tracked<Float>(-1337).valueWithGradient(in: cond_nestedstruct_var))
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_nestedstruct_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_nestedstruct_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_nestedstruct_var))
 }
 
 LeakCheckingTests.testWithLeakChecking("ControlFlowWithSwitchEnumWithPayload") {
@@ -598,10 +599,10 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithSwitchEnumWithPayload") {
     }
     return x + y
   }
-  expectEqual((8, 2), Tracked<Float>(4).valueWithGradient(in: { x in enum_notactive2(.a(10), x) }))
-  expectEqual((20, 2), Tracked<Float>(10).valueWithGradient(in: { x in enum_notactive2(.b(4, 5), x) }))
-  expectEqual((-20, 2), Tracked<Float>(-10).valueWithGradient(in: { x in enum_notactive2(.a(10), x) }))
-  expectEqual((-2674, 2), Tracked<Float>(-1337).valueWithGradient(in: { x in enum_notactive2(.b(4, 5), x) }))
+  expectEqual((8, 2), valueWithGradient(at: 4, in: { x in enum_notactive2(.a(10), x) }))
+  expectEqual((20, 2), valueWithGradient(at: 10, in: { x in enum_notactive2(.b(4, 5), x) }))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: { x in enum_notactive2(.a(10), x) }))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: { x in enum_notactive2(.b(4, 5), x) }))
 }
 
 LeakCheckingTests.testWithLeakChecking("ArrayLiteralInitialization") {

--- a/test/AutoDiff/simple_model.swift
+++ b/test/AutoDiff/simple_model.swift
@@ -90,7 +90,7 @@ SimpleModelTests.testWithLeakChecking("gradient") {
   let model = Model(l1: layer, l2: layer, l3: layer)
   let label: Tracked<Float> = 3
   let input: Tracked<Float> = 1
-  let gradModel = model.gradient { model -> Tracked<Float> in
+  let gradModel = gradient(at: model) { model -> Tracked<Float> in
     let pred = model.prediction(for: input)
     return model.loss(of: pred, from: label)
   }


### PR DESCRIPTION
Currently, there exist both top-level function differential operators and
method-style differential operators. Method-style differential operators apply
top-level function versions to `self`.

Method-style differential operators needlessly increase API surface area and
confuse users. Removing them will make the top-level versions canonical.
[Related mailing list thread.](https://groups.google.com/a/tensorflow.org/d/msg/swift/_lNgd9N5SM4/mBmKiNBxAgAJ)

Deprecate stdlib method-style differential operators.

Remove `DifferentiationUnittest` method-style differential operators and
update tests.

Resolves TF-1019.