### PR TITLE
[CMake] Fix find_package for libXml2 on case sensitive filesystems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -926,7 +926,7 @@ find_package(PythonInterp REQUIRED)
 #
 
 if(LLVM_ENABLE_LIBXML2)
-  find_package(Libxml2 REQUIRED)
+  find_package(LibXml2 REQUIRED)
 else()
   find_package(LibXml2)
 endif()


### PR DESCRIPTION
This fixes the find_package to work on a case sensitive file system when LLVM_ENABLE_LIBXML2 is true.  The cmake finder is FindLibXml2.cmake. Otherwise, if set, the build will fail with:

CMake Error at CMakeLists.txt:929 (find_package):
  By not providing "FindLibxml2.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Libxml2", but
  CMake did not find one.

  Could not find a package configuration file provided by "Libxml2" with any
  of the following names:

    Libxml2Config.cmake
    libxml2-config.cmake

@swift-ci Please smoke test