### PR TITLE
[Parse] Statement typo corrections

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -931,6 +931,8 @@ ERROR(statement_begins_with_closure,none,
       "top-level statement cannot begin with a closure expression", ())
 ERROR(statement_same_line_without_semi,none,
       "consecutive statements on a line must be separated by ';'", ())
+ERROR(statement_misspell,none,
+    "did you misspell '%0'", (StringRef))
 ERROR(invalid_label_on_stmt,none,
       "labels are only valid on loops, if, and switch statements", ())
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -931,8 +931,8 @@ ERROR(statement_begins_with_closure,none,
       "top-level statement cannot begin with a closure expression", ())
 ERROR(statement_same_line_without_semi,none,
       "consecutive statements on a line must be separated by ';'", ())
-ERROR(statement_misspell,none,
-    "did you misspell '%0'", (StringRef))
+NOTE(statement_misspell,none,
+    "did you misspell '%0'?", (StringRef))
 ERROR(invalid_label_on_stmt,none,
       "labels are only valid on loops, if, and switch statements", ())
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -871,8 +871,6 @@ public:
   }
   ParserResult<BraceStmt> parseBraceItemList(Diag<> ID);
 
-  Optional<tok> closestMatchingStmtTokenForIdentifier(StringRef identifier);
-
   //===--------------------------------------------------------------------===//
   // Decl Parsing
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -870,7 +870,9 @@ public:
                            IsFollowingGuard);
   }
   ParserResult<BraceStmt> parseBraceItemList(Diag<> ID);
-  
+
+  Optional<tok> closestMatchingStmtTokenForIdentifier(StringRef identifier);
+
   //===--------------------------------------------------------------------===//
   // Decl Parsing
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -344,10 +344,29 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
     const bool IsAtStartOfLineOrPreviousHadSemi =
         PreviousHadSemi || Tok.isAtStartOfLine();
     if (!IsAtStartOfLineOrPreviousHadSemi) {
-      SourceLoc EndOfPreviousLoc = getEndOfPreviousLoc();
-      diagnose(EndOfPreviousLoc, diag::statement_same_line_without_semi)
-        .fixItInsert(EndOfPreviousLoc, ";");
-      // FIXME: Add semicolon to the AST?
+      Token previousToken = Lexer::getTokenAtLocation(SourceMgr, PreviousLoc);
+      Optional<tok> stmtTokMatch = None;
+      if (previousToken.getKind() == tok::identifier) {
+        SourceLoc startOfLineLocation = L->getLocForStartOfLine(SourceMgr, previousToken.getLoc());
+        SourceLoc locationOfTokenAtStartOfLine = Lexer::getTokenAtLocation(SourceMgr, startOfLineLocation).getLoc();
+        if (previousToken.getLoc() == locationOfTokenAtStartOfLine) {
+          stmtTokMatch = closestMatchingStmtTokenForIdentifier(previousToken.getText());
+        }
+      }
+      if (stmtTokMatch) {
+        ParserPosition parserPosition = ParserPosition(L->getStateForBeginningOfToken(previousToken), PreviousLoc);
+        backtrackToPosition(parserPosition);
+        Tok.setKind(*stmtTokMatch);
+
+        StringRef stmtTokenText = getTokenText(*stmtTokMatch);
+        diagnose(PreviousLoc, diag::statement_misspell, stmtTokenText)
+          .fixItReplace(PreviousLoc, stmtTokenText);
+      } else {
+        SourceLoc EndOfPreviousLoc = getEndOfPreviousLoc();
+        diagnose(EndOfPreviousLoc, diag::statement_same_line_without_semi)
+          .fixItInsert(EndOfPreviousLoc, ";");
+        // FIXME: Add semicolon to the AST?
+      }
     }
 
     ParserPosition BeginParserPosition;
@@ -2531,4 +2550,67 @@ ParserResult<Stmt> Parser::parseStmtPoundAssert() {
 
   return makeParserResult<Stmt>(new (Context) PoundAssertStmt(
       SourceRange(startLoc, endLoc), conditionExprResult.get(), message));
+}
+
+//
+///// Produce a score (smaller is better) comparing a parameter name and
+///// potentially-typo'd argument name.
+/////
+///// \param identifier The name of the identifier.
+///// \param stmt The name of the argument.
+///// \param maxScore The maximum score permitted by this comparison, or
+///// 0 if there is no limit.
+/////
+///// \returns the score, if it is good enough to even consider this a match.
+///// Otherwise, an empty optional.
+/////
+static Optional<unsigned> scoreIdentifierAndStmtNameTypo(StringRef identifier,
+                                                          StringRef stmt,
+                                                          unsigned maxScore) {
+  // Compute the edit distance.
+  unsigned dist = stmt.edit_distance(identifier, /*AllowReplacements=*/true,
+                                        /*MaxEditDistance=*/maxScore);
+
+  // If the edit distance would be too long, we're done.
+  if (maxScore != 0 && dist > maxScore)
+    return None;
+
+  // The distance can be zero due to the "with" transformation above.
+  if (dist == 0)
+    return 1;
+
+  // If this is just a single character label on both sides,
+  // simply return distance.
+  if (identifier.size() == 1 && stmt.size() == 1)
+    return dist;
+
+  // Only allow about one typo for every two properly-typed characters, which
+  // prevents completely-wacky suggestions in many cases.
+  if (dist > (stmt.size() + 1) / 3)
+    return None;
+
+  return dist;
+}
+
+Optional<tok> Parser::closestMatchingStmtTokenForIdentifier(StringRef identifier) {
+  SmallVector<std::pair<StringRef, tok>, 19> stmtKeywords;
+  #define STMT_KEYWORD(kw) stmtKeywords.push_back({ #kw, tok::kw_##kw });
+  #include "swift/Syntax/TokenKinds.def"
+  unsigned bestScore = 0;
+  Optional<tok> best = None;
+  for (size_t i = 0; i < stmtKeywords.size(); ++i) {
+    std::pair<StringRef, tok> pair = stmtKeywords[i];
+    StringRef potentialStatement = pair.first;
+
+    if (auto score = scoreIdentifierAndStmtNameTypo(identifier,
+                                            potentialStatement,
+                                            bestScore)) {
+      if (*score < bestScore || bestScore == 0) {
+        bestScore = *score;
+        best = pair.second;
+      }
+    }
+  }
+
+  return best;
 }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -383,11 +383,13 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
           stmtTokMatch = closestMatchingStmtTokenForIdentifier(previousToken.getText());
         }
       }
-      if (stmtTokMatch && Tok.isAny(tok::kw_let, tok::kw_var)) {
+      if (stmtTokMatch) {
         StringRef stmtTokenText = getTokenText(*stmtTokMatch);
         diagnose(PreviousLoc, diag::statement_misspell, stmtTokenText)
           .fixItReplace(PreviousLoc, stmtTokenText);
-        consumeToken();
+        if (Tok.isAny(tok::kw_let, tok::kw_var)) {
+          consumeToken();
+        }
         skipUntilDeclStmtRBrace(tok::r_brace);
         continue;
       }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -383,15 +383,13 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
           stmtTokMatch = closestMatchingStmtTokenForIdentifier(previousToken.getText());
         }
       }
-      if (stmtTokMatch) {
-        Entries.pop_back();
-        ParserPosition parserPosition = ParserPosition(L->getStateForBeginningOfToken(previousToken), PreviousLoc);
-        backtrackToPosition(parserPosition);
-        Tok.setKind(*stmtTokMatch);
-
+      if (stmtTokMatch && Tok.isAny(tok::kw_let, tok::kw_var)) {
         StringRef stmtTokenText = getTokenText(*stmtTokMatch);
         diagnose(PreviousLoc, diag::statement_misspell, stmtTokenText)
           .fixItReplace(PreviousLoc, stmtTokenText);
+        consumeToken();
+        skipUntilDeclStmtRBrace(tok::r_brace);
+        continue;
       }
     }
 

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -18,13 +18,14 @@ func foo(_ n: Int) -> Int {
 // CHECK-AST-LABEL: (func_decl{{.*}}"bar()"
 func bar() {
   // CHECK: (brace_stmt
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
+  // CHECK:   (for_each_stmt
+  // CHECK-NEXT:   (pattern_named 'foo')
+  // CHECK-NEXT:   (pattern_named 'foo')
   // CHECK-AST: (brace_stmt
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
+  // CHECK-AST-NEXT: (declref_expr type='{{[^']+}}'
+  // CHECK-AST-NEXT:   (for_each_stmt
+  // CHECK-AST-NEXT:   (pattern_named type='{{[^']+}}' 'foo')
+  // CHECK-AST-NEXT:   (pattern_named type='{{[^']+}}' 'foo')
   foo foo foo
 }
 

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -22,7 +22,6 @@ func bar() {
   // CHECK-NEXT:   (pattern_named 'foo')
   // CHECK-NEXT:   (pattern_named 'foo')
   // CHECK-AST: (brace_stmt
-  // CHECK-AST-NEXT: (declref_expr type='{{[^']+}}'
   // CHECK-AST-NEXT:   (for_each_stmt
   // CHECK-AST-NEXT:   (pattern_named type='{{[^']+}}' 'foo')
   // CHECK-AST-NEXT:   (pattern_named type='{{[^']+}}' 'foo')

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -17,14 +17,10 @@ func foo(_ n: Int) -> Int {
 // CHECK-LABEL: (func_decl{{.*}}"bar()"
 // CHECK-AST-LABEL: (func_decl{{.*}}"bar()"
 func bar() {
-  // CHECK: (brace_stmt
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-AST: (brace_stmt
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
+  // CHECK-NEXT: (parameter_list 
+  // CHECK-NEXT: (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
+  // CHECK-AST-NEXT: (parameter_list 
+  // CHECK-AST-NEXT: (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
   foo foo foo
 }
 

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -18,13 +18,13 @@ func foo(_ n: Int) -> Int {
 // CHECK-AST-LABEL: (func_decl{{.*}}"bar()"
 func bar() {
   // CHECK: (brace_stmt
-  // CHECK:   (for_each_stmt
-  // CHECK-NEXT:   (pattern_named 'foo')
-  // CHECK-NEXT:   (pattern_named 'foo')
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
   // CHECK-AST: (brace_stmt
-  // CHECK-AST-NEXT:   (for_each_stmt
-  // CHECK-AST-NEXT:   (pattern_named type='{{[^']+}}' 'foo')
-  // CHECK-AST-NEXT:   (pattern_named type='{{[^']+}}' 'foo')
+  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
+  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
+  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
   foo foo foo
 }
 

--- a/test/Parse/statement_typo.swift
+++ b/test/Parse/statement_typo.swift
@@ -2,12 +2,20 @@
 
 func statementMisspelledAtTheBegginingOfTheLine() {
   let test = 5
-  gaurd test > 5 else { return } // expected-error {{did you misspell 'guard'}} {{3-8=guard}} expected-error {{use of unresolved identifier 'gaurd'}}
-  i test > 5 { return } // expected-error {{did you misspell 'if'}} {{3-4=if}} expected-error {{use of unresolved identifier 'i'}}
-  whle test > 5 { return } // expected-error {{did you misspell 'while'}} {{3-7=while}} expected-error {{use of unresolved identifier 'whle'}}
+  gaurd test > 5 else { return } // expected-error {{consecutive statements}} // expected-note {{did you misspell 'guard'}} {{3-8=guard}}
+  i test > 5 { return } // expected-error {{consecutive statements}} // expected-note {{did you misspell 'if'}} {{3-4=if}}
+  whle test > 5 { return } // expected-error {{consecutive statements}} // expected-note {{did you misspell 'while'}} {{3-7=while}}
 }
 
 func statementMisspelledNotAtTheBegginingOfTheLine() {
   let i = 5
   var x = i x=x+1 // expected-error {{consecutive statements}}
+}
+
+// SR-8510
+
+func foo() -> Int? { return 0 }
+func bar() {
+  gaurd let x = foo() else { return }  // expected-error {{consecutive statements}} // expected-note {{did you misspell 'guard'}} {{3-8=guard}}
+  print(x)
 }

--- a/test/Parse/statement_typo.swift
+++ b/test/Parse/statement_typo.swift
@@ -1,21 +1,36 @@
 // RUN: %target-typecheck-verify-swift
 
-func statementMisspelledAtTheBegginingOfTheLine() {
-  let test = 5
-  gaurd test > 5 else { return } // expected-error {{consecutive statements}} // expected-note {{did you misspell 'guard'}} {{3-8=guard}}
-  i test > 5 { return } // expected-error {{consecutive statements}} // expected-note {{did you misspell 'if'}} {{3-4=if}}
-  whle test > 5 { return } // expected-error {{consecutive statements}} // expected-note {{did you misspell 'while'}} {{3-7=while}}
-}
-
-func statementMisspelledNotAtTheBegginingOfTheLine() {
-  let i = 5
-  var x = i x=x+1 // expected-error {{consecutive statements}}
-}
-
 // SR-8510
 
 func foo() -> Int? { return 0 }
 func bar() {
-  gaurd let x = foo() else { return }  // expected-error {{consecutive statements}} // expected-note {{did you misspell 'guard'}} {{3-8=guard}}
+  gaurd let x = foo() else { return }  // expected-error {{consecutive statements}} 
+  // expected-note@-1 {{did you misspell 'guard'}} {{3-8=guard}}
+  // expected-error@-2 {{use of unresolved identifier 'gaurd'}}
   print(x)
+}
+
+func stmtMisspelledAtTheBegginingOfTheLineWithLet() {
+  gaurd let firstWithLet = foo() else { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'guard'}} {{3-8=guard}}
+  // expected-error@-2 {{use of unresolved identifier 'gaurd'}}
+  i let secondWithLet = foo() { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'if'}} {{3-4=if}}
+  whle let thirdWithLet = foo() { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'while'}} {{3-7=while}}
+}
+
+func stmtMisspelledAtTheBegginingOfTheLineWithVar() {
+  gaurd var firstWithLet = foo() else { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'guard'}} {{3-8=guard}}
+  // expected-error@-2 {{use of unresolved identifier 'gaurd'}}
+  i var secondWithLet = foo() { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'if'}} {{3-4=if}}
+  whle var thirdWithLet = foo() { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'while'}} {{3-7=while}}
+}
+
+func stmtMisspelledNotAtTheBegginingOfTheLine() {
+  let i = 5
+  var x = i x=x+1 // expected-error {{consecutive statements}}
 }

--- a/test/Parse/statement_typo.swift
+++ b/test/Parse/statement_typo.swift
@@ -10,17 +10,25 @@ func bar() {
   print(x)
 }
 
-func stmtMisspelledAtTheBegginingOfTheLineWithLet() {
+func stmtMisspelledAtTheBegginingOfTheLineWithLet1() {
   gaurd let firstWithLet = foo() else { return } // expected-error {{consecutive statements}}
   // expected-note@-1 {{did you misspell 'guard'}} {{3-8=guard}}
   // expected-error@-2 {{use of unresolved identifier 'gaurd'}}
-  i let secondWithLet = foo() { return } // expected-error {{consecutive statements}}
-  // expected-note@-1 {{did you misspell 'if'}} {{3-4=if}}
-  whle let thirdWithLet = foo() { return } // expected-error {{consecutive statements}}
-  // expected-note@-1 {{did you misspell 'while'}} {{3-7=while}}
 }
 
-func stmtMisspelledAtTheBegginingOfTheLineWithVar() {
+func stmtMisspelledAtTheBegginingOfTheLineWithLet2() {
+  i let secondWithLet = foo() { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'if'}} {{3-4=if}}
+  // expected-error@-2 {{use of unresolved identifier 'i'}}
+}
+
+func stmtMisspelledAtTheBegginingOfTheLineWithLet3() {
+  whle let thirdWithLet = foo() { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'while'}} {{3-7=while}}
+  // expected-error@-2 {{use of unresolved identifier 'whle'}}
+}
+
+func stmtMisspelledAtTheBegginingOfTheLineWithVar1() {
   gaurd var firstWithLet = foo() else { return } // expected-error {{consecutive statements}}
   // expected-note@-1 {{did you misspell 'guard'}} {{3-8=guard}}
   // expected-error@-2 {{use of unresolved identifier 'gaurd'}}
@@ -28,6 +36,18 @@ func stmtMisspelledAtTheBegginingOfTheLineWithVar() {
   // expected-note@-1 {{did you misspell 'if'}} {{3-4=if}}
   whle var thirdWithLet = foo() { return } // expected-error {{consecutive statements}}
   // expected-note@-1 {{did you misspell 'while'}} {{3-7=while}}
+}
+
+func stmtMisspelledAtTheBegginingOfTheLineWithVar2() {
+  i var secondWithLet = foo() { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'if'}} {{3-4=if}}
+  // expected-error@-2 {{use of unresolved identifier 'i'}}
+}
+
+func stmtMisspelledAtTheBegginingOfTheLineWithVar3() {
+  whle var thirdWithLet = foo() { return } // expected-error {{consecutive statements}}
+  // expected-note@-1 {{did you misspell 'while'}} {{3-7=while}}
+  // expected-error@-2 {{use of unresolved identifier 'whle'}}
 }
 
 func stmtMisspelledNotAtTheBegginingOfTheLine() {

--- a/test/Parse/statement_typo.swift
+++ b/test/Parse/statement_typo.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+func statementMisspelledAtTheBegginingOfTheLine() {
+  let test = 5
+  gaurd test > 5 else { return } // expected-error {{did you misspell 'guard'}} {{3-8=guard}} expected-error {{use of unresolved identifier 'gaurd'}}
+  i test > 5 { return } // expected-error {{did you misspell 'if'}} {{3-4=if}} expected-error {{use of unresolved identifier 'i'}}
+  whle test > 5 { return } // expected-error {{did you misspell 'while'}} {{3-7=while}} expected-error {{use of unresolved identifier 'whle'}}
+}
+
+func statementMisspelledNotAtTheBegginingOfTheLine() {
+  let i = 5
+  var x = i x=x+1 // expected-error {{consecutive statements}}
+}


### PR DESCRIPTION
Current implementation steps:
1. If consecutive statement error occurred we are getting previous identifier, then trying to typo correct it to one of the statements keywords.
2. Updated tests

Current implementation is limited to only identifiers that start from the beginning of the line. Like
``` swift
gaurd x>5 else { return }
```
The limitation exists because it is ambigous how to handle case where 
``` swift
x=1+i i=i+1
```
Should we correct it to `if` statement, or provide insert of `';'`.

https://bugs.swift.org/browse/SR-8510