### PR TITLE
[FrondEnd] Wrap RunInmediately() in a stack trace to indicate running user code

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1376,6 +1376,12 @@ static bool processCommandLineAndRunImmediately(CompilerInvocation &Invocation,
       ProcessCmdLine(opts.ImmediateArgv.begin(), opts.ImmediateArgv.end());
   Instance.setSILModule(std::move(SM));
 
+
+  PrettyStackTraceStringAction trace(
+      "running user code",
+      MSF.is<SourceFile *>() ? MSF.get<SourceFile *>()->getFilename()
+                     : MSF.get<ModuleDecl *>()->getModuleFilename());
+
   ReturnValue =
       RunImmediately(Instance, CmdLine, IRGenOpts, Invocation.getSILOptions());
   return Instance.getASTContext().hadError();

--- a/test/Frontend/crash-in-user-code.swift
+++ b/test/Frontend/crash-in-user-code.swift
@@ -1,0 +1,19 @@
+
+// RUN: echo %s > %t.filelist.txt
+// RUN: not --crash %target-swift-frontend -interpret -filelist %t.filelist.txt 2>&1 | %FileCheck %s
+
+// UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=tvos
+// UNSUPPORTED: OS=watchos
+
+// CHECK: Stack dump:
+// CHECK-NEXT: Program arguments:
+// CHECK-NEXT: Swift version
+// CHECK-NEXT: Contents of {{.*}}.filelist.txt:
+// CHECK-NEXT: ---
+// CHECK-NEXT: crash-in-user-code.swift
+// CHECK-NEXT: ---
+// CHECK-NEXT: While running user code "{{.*}}crash-in-user-code.swift"
+
+let x: Int? = nil
+x!


### PR DESCRIPTION


<!-- What's in this pull request? -->
We tried merging this change earlier in  #28284 but was reverted since it caused CI failures [here](https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RD_test-simulator/2612/console). As a fix, I have added `UNSUPPORTED`  for iOS, watchOS, and tvOS. 

I am not sure why, but the test just crashes with the following error in those situations:
```
error: Illegal instruction: 4
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-11765.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
