### PR TITLE
[CS] Coerce dynamic member strings to their param type

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4521,14 +4521,8 @@ namespace {
       auto subscript = cast<SubscriptDecl>(overload.choice.getDecl());
       assert(!subscript->isGetterMutating());
 
-      auto indexType = AnyFunctionType::composeInput(
-          cs.getASTContext(),
-          subscript->getInterfaceType()->castTo<AnyFunctionType>()->getParams(),
-          /*canonicalVararg=*/false);
-
       // Compute substitutions to refer to the member.
       auto ref = resolveConcreteDeclRef(subscript, locator);
-      indexType = indexType.subst(ref.getSubstitutions());
 
       // If this is a @dynamicMemberLookup reference to resolve a property
       // through the subscript(dynamicMember:) member, restore the

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -746,3 +746,10 @@ struct SR_10557_S1 {
     fatalError()
   }
 }
+
+@dynamicMemberLookup
+struct SR11877 {
+  subscript(dynamicMember member: Substring) -> Int { 0 }
+}
+
+_ = \SR11877.okay


### PR DESCRIPTION
Previously we were assuming that the string literal argument was always of type `String`, however any `ExpressibleByStringLiteral` parameter is allowed. This PR moves `buildDynamicMemberLookupIndexExpr` into ExprRewriter, and passes the string literal through `handleStringLiteralExpr` to properly handle its coercion to the parameter type.

Resolves SR-11877.