### PR TITLE
[build] SR-11880 skip building compiler-rt with --xcode

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1677,9 +1677,18 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
                     -DLLVM_ENABLE_LTO:STRING="${LLVM_ENABLE_LTO}"
                     -DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON
-                    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;"
                     "${llvm_cmake_options[@]}"
                 )
+
+                if [[ "${SKIP_BUILD_COMPILER_RT}" ]]; then
+                    cmake_options+=(
+                    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;"
+                    )
+                else
+                    cmake_options+=(
+                    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;"
+                    )
+                fi
 
                 cmake_options+=(
                   -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE


### PR DESCRIPTION
After merging https://github.com/apple/swift/pull/28341/ ./utils/build-script build the `compiler-rt` even with `--xcode` parameter, which breaks a build. This PR resolves this issue by skipping `compiler-rt` in cases when it is not supported (build with Xcode generator and/or cross-compiling).

Resolves https://bugs.swift.org/browse/SR-11880.

@shahmishal 

@swift-ci Please test
