### PR TITLE
[CS] A couple of fixes for implicit callAsFunction

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1910,6 +1910,26 @@ public:
   void cacheResult(Expr *expr) const;
 };
 
+/// Computes whether this is a type that supports being called through the
+/// implementation of a \c callAsFunction method.
+class IsCallableNominalTypeRequest
+    : public SimpleRequest<IsCallableNominalTypeRequest,
+                           bool(CanType, DeclContext *), CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<bool> evaluate(Evaluator &evaluator, CanType ty,
+                                DeclContext *dc) const;
+
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -88,6 +88,8 @@ SWIFT_REQUEST(TypeChecker, InterfaceTypeRequest,
               Type(ValueDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsAccessorTransparentRequest, bool(AccessorDecl *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsCallableNominalTypeRequest,
+              bool(CanType, DeclContext *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDynamicRequest, bool(ValueDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsFinalRequest, bool(ValueDecl *), SeparatelyCached,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -818,6 +818,10 @@ public:
             getAnyNominal());
   }
 
+  /// Checks whether this is a type that supports being called through the
+  /// implementation of a \c callAsFunction method.
+  bool isCallableNominalType(DeclContext *dc);
+
   /// Retrieve the superclass of this type.
   ///
   /// \param useArchetypes Whether to use context archetypes for outer generic

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -819,7 +819,8 @@ public:
   }
 
   /// Checks whether this is a type that supports being called through the
-  /// implementation of a \c callAsFunction method.
+  /// implementation of a \c callAsFunction method. Note that this does not
+  /// check access control.
   bool isCallableNominalType(DeclContext *dc);
 
   /// Retrieve the superclass of this type.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1480,6 +1480,17 @@ bool TypeBase::satisfiesClassConstraint() {
   return mayHaveSuperclass() || isObjCExistentialType();
 }
 
+bool TypeBase::isCallableNominalType(DeclContext *dc) {
+  // If the type cannot have members, we're done.
+  if (!mayHaveMembers())
+    return false;
+
+  auto canTy = getCanonicalType();
+  auto &ctx = canTy->getASTContext();
+  return evaluateOrDefault(ctx.evaluator,
+                           IsCallableNominalTypeRequest{canTy, dc}, false);
+}
+
 Type TypeBase::getSuperclass(bool useArchetypes) {
   auto *nominalDecl = getAnyNominal();
   auto *classDecl = dyn_cast_or_null<ClassDecl>(nominalDecl);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1481,6 +1481,10 @@ bool TypeBase::satisfiesClassConstraint() {
 }
 
 bool TypeBase::isCallableNominalType(DeclContext *dc) {
+  // Don't allow callAsFunction to be used with dynamic lookup.
+  if (isAnyObject())
+    return false;
+
   // If the type cannot have members, we're done.
   if (!mayHaveMembers())
     return false;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2616,13 +2616,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
     auto isDynamicCallable =
         CS.DynamicCallableCache[fnType->getCanonicalType()].isValid();
 
-    // Note: Consider caching `hasCallAsFunctionMethods` in `NominalTypeDecl`.
-    auto *nominal = fnType->getAnyNominal();
-    auto hasCallAsFunctionMethods = nominal &&
-      llvm::any_of(nominal->getMembers(), [](Decl *member) {
-          auto funcDecl = dyn_cast<FuncDecl>(member);
-          return funcDecl && funcDecl->isCallAsFunctionMethod();
-        });
+    auto hasCallAsFunctionMethods = fnType->isCallableNominalType(CS.DC);
 
     // Diagnose specific @dynamicCallable errors.
     if (isDynamicCallable) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7334,13 +7334,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
   // Handle applications of types with `callAsFunction` methods.
   // Do this before stripping optional types below, when `shouldAttemptFixes()`
   // is true.
-  auto hasCallAsFunctionMethods =
-      desugar2->mayHaveMembers() &&
-      llvm::any_of(lookupMember(desugar2, DeclName(ctx.Id_callAsFunction)),
-                   [](LookupResultEntry entry) {
-                     return isa<FuncDecl>(entry.getValueDecl());
-                   });
-  if (hasCallAsFunctionMethods) {
+  if (desugar2->isCallableNominalType(DC)) {
     auto memberLoc = getConstraintLocator(
         outerLocator.withPathElement(ConstraintLocator::Member));
     // Add a `callAsFunction` member constraint, binding the member type to a

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7342,6 +7342,8 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     auto memberTy = createTypeVariable(memberLoc, /*options=*/0);
     // TODO: Revisit this if `static func callAsFunction` is to be supported.
     // Static member constraint requires `FunctionRefKind::DoubleApply`.
+    // TODO: Use a custom locator element to identify this member constraint
+    // instead of just pointing to the function expr.
     addValueMemberConstraint(origLValueType2, DeclName(ctx.Id_callAsFunction),
                              memberTy, DC, FunctionRefKind::SingleApply,
                              /*outerAlternatives*/ {}, locator);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -4575,6 +4575,7 @@ llvm::Expected<bool>
 IsCallableNominalTypeRequest::evaluate(Evaluator &evaluator, CanType ty,
                                        DeclContext *dc) const {
   auto options = defaultMemberLookupOptions;
+  options |= NameLookupFlags::IgnoreAccessControl;
   if (isa<AbstractFunctionDecl>(dc))
     options |= NameLookupFlags::KnownPrivate;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -36,6 +36,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/TypeCheckerDebugConsumer.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Parse/Confusables.h"
 #include "swift/Parse/Lexer.h"
@@ -4568,4 +4569,22 @@ ForcedCheckedCastExpr *swift::findForcedDowncast(ASTContext &ctx, Expr *expr) {
   }
 
   return nullptr;
+}
+
+llvm::Expected<bool>
+IsCallableNominalTypeRequest::evaluate(Evaluator &evaluator, CanType ty,
+                                       DeclContext *dc) const {
+  auto options = defaultMemberLookupOptions;
+  if (isa<AbstractFunctionDecl>(dc))
+    options |= NameLookupFlags::KnownPrivate;
+
+  // Look for a callAsFunction method.
+  auto &ctx = ty->getASTContext();
+  auto results =
+      TypeChecker::lookupMember(dc, ty, ctx.Id_callAsFunction, options);
+  return llvm::any_of(results, [](LookupResultEntry entry) -> bool {
+    if (auto *fd = dyn_cast<FuncDecl>(entry.getValueDecl()))
+      return fd->isCallAsFunctionMethod();
+    return false;
+  });
 }

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -398,3 +398,13 @@ class HasMethodWithDefault {
 func testAnyObjectWithDefault(_ x: AnyObject) {
   x.hasDefaultParam()
 }
+
+// SR-11829: Don't perform dynamic lookup for callAsFunction.
+class ClassWithObjcCallAsFunction {
+  @objc func callAsFunction() {}
+}
+
+func testCallAsFunctionAnyObject(_ x: AnyObject) {
+  x() // expected-error {{cannot call value of non-function type 'AnyObject'}}
+  x.callAsFunction() // Okay.
+}

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -408,3 +408,26 @@ func genericMagic<T : ExpressibleByStringLiteral>(x: T = #file) -> T {
 }
 
 let _: String = genericMagic()
+
+// SR-11778
+struct CallableWithDefault {
+  func callAsFunction(x: Int = 4) {}
+  func callAsFunction(y: Int, z: String = #function) {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s17default_arguments23testCallableWithDefaultyyAA0deF0VF : $@convention(thin) (CallableWithDefault) -> ()
+func testCallableWithDefault(_ x: CallableWithDefault) {
+  // CHECK: [[DEF_FN:%[0-9]+]] = function_ref @$s17default_arguments19CallableWithDefaultV14callAsFunction1xySi_tFfA_ : $@convention(thin) () -> Int
+  // CHECK: [[DEF:%[0-9]+]] = apply [[DEF_FN]]() : $@convention(thin) () -> Int
+  // CHECK: [[CALL_AS_FN:%[0-9]+]] = function_ref @$s17default_arguments19CallableWithDefaultV14callAsFunction1xySi_tF : $@convention(method) (Int, CallableWithDefault) -> ()
+  // CHECK: apply [[CALL_AS_FN]]([[DEF]], {{%[0-9]+}})
+  x()
+
+  // CHECK: [[RAW_I:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 5
+  // CHECK: [[I:%[0-9]+]] = apply {{%[0-9]+}}([[RAW_I]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+  // CHECK: [[RAW_STR:%[0-9]+]] = string_literal utf8 "testCallableWithDefault(_:)"
+  // CHECK: [[STR:%[0-9]+]] = apply {{%[0-9]+}}([[RAW_STR]], {{%[0-9]+}}, {{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  // CHECK: [[CALL_AS_FN:%[0-9]+]] = function_ref @$s17default_arguments19CallableWithDefaultV14callAsFunction1y1zySi_SStF : $@convention(method) (Int, @guaranteed String, CallableWithDefault) -> ()
+  // CHECK: apply [[CALL_AS_FN]]([[I]], [[STR]], {{%[0-9]+}})
+  x(y: 5)
+}

--- a/test/Sema/call_as_function_generic.swift
+++ b/test/Sema/call_as_function_generic.swift
@@ -41,3 +41,19 @@ let genericString = GenericType<[String]>(collection: ["Hello", "world", "!"])
 _ = genericString("Hello")
 let genericInt = GenericType<Set<Int>>(collection: [1, 2, 3])
 _ = genericInt(initialValue: 1)
+
+// SR-11386
+class C<T> {}
+protocol P1 {}
+extension C where T : P1 { // expected-note {{where 'T' = 'Int'}}
+  func callAsFunction(t: T) {}
+}
+
+struct S0 : P1 {}
+
+func testCallAsFunctionWithWhereClause(_ c1: C<Int>, _ c2: C<S0>, _ s0: S0) {
+  c1(42) // expected-error {{referencing instance method 'callAsFunction(t:)' on 'C' requires that 'Int' conform to 'P1'}}
+  // expected-error@-1 {{missing argument label 't:' in call}}
+
+  c2(t: s0) // Okay.
+}

--- a/test/Sema/call_as_function_simple.swift
+++ b/test/Sema/call_as_function_simple.swift
@@ -204,3 +204,18 @@ func testDefaults(_ x: DoubleANumber) {
   x(5)
   x(5, completion: { _ in })
 }
+
+// SR-11881
+struct IUOCallable {
+  static var callable: IUOCallable { IUOCallable() }
+  func callAsFunction(_ x: Int) -> IUOCallable! { nil }
+}
+
+func testIUOCallAsFunction(_ x: IUOCallable) {
+  let _: IUOCallable = x(5)
+  let _: IUOCallable? = x(5)
+  let _ = x(5)
+
+  let _: IUOCallable = .callable(5)
+  let _: IUOCallable? = .callable(5)
+}

--- a/test/Sema/call_as_function_simple.swift
+++ b/test/Sema/call_as_function_simple.swift
@@ -192,3 +192,15 @@ func testIUO(a: SimpleCallable!, b: MultipleArgsCallable!, c: Extended!,
   _ = try? h()
   _ = try? h { throw DummyError() }
 }
+
+// SR-11778
+struct DoubleANumber {
+  func callAsFunction(_ x: Int, completion: (Int) -> Void = { _ in }) {
+    completion(x + x)
+  }
+}
+
+func testDefaults(_ x: DoubleANumber) {
+  x(5)
+  x(5, completion: { _ in })
+}

--- a/test/Sema/call_as_function_simple.swift
+++ b/test/Sema/call_as_function_simple.swift
@@ -219,3 +219,12 @@ func testIUOCallAsFunction(_ x: IUOCallable) {
   let _: IUOCallable = .callable(5)
   let _: IUOCallable? = .callable(5)
 }
+
+// Test access control.
+struct PrivateCallable {
+  private func callAsFunction(_ x: Int) {} // expected-note {{'callAsFunction' declared here}}
+}
+
+func testAccessControl(_ x: PrivateCallable) {
+  x(5) // expected-error {{'callAsFunction' is inaccessible due to 'private' protection level}}
+}


### PR DESCRIPTION
Start resolving callees for an implicit call to `callAsFunction` by adding a case for it in `getCalleeLocator`, which allows it to be used with default arguments and diagnosed with things like requirement failures.

In addition, prevent callables from being used with `AnyObject` lookup, previously this hit an assert in CSApply, now we'll reject it with an error.

Finally, tweak the CSApply logic for `callAsFunction` such that we apply all of `finishApply`'s transforms to it, which handles things like IUO unwraps.

Resolves SR-11386, SR-11778, SR-11829, and SR-11881.