### PR TITLE
[sil] Use SILNodes.def to define ARGKIND##ArrayRef instead of hard co…

### DIFF
--- a/include/swift/SIL/SILArgumentArrayRef.h
+++ b/include/swift/SIL/SILArgumentArrayRef.h
@@ -26,15 +26,12 @@
 namespace swift {
 
 class SILArgument;
-class SILPhiArgument;
-class SILFunctionArgument;
 
-using PhiArgumentArrayRef =
-    TransformRange<ArrayRef<SILArgument *>, SILPhiArgument *(*)(SILArgument *)>;
-
-using FunctionArgumentArrayRef =
-    TransformRange<ArrayRef<SILArgument *>,
-                   SILFunctionArgument *(*)(SILArgument *)>;
+#define ARGUMENT(NAME, PARENT)                                                 \
+  class NAME;                                                                  \
+  using NAME##ArrayRef =                                                       \
+      TransformRange<ArrayRef<SILArgument *>, NAME *(*)(SILArgument *)>;
+#include "swift/SIL/SILNodes.def"
 
 } // namespace swift
 

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -26,8 +26,6 @@ namespace swift {
 
 class SILFunction;
 class SILArgument;
-class SILPhiArgument;
-class SILFunctionArgument;
 class SILPrintContext;
 
 class SILBasicBlock :
@@ -193,14 +191,10 @@ public:
 
   ArrayRef<SILArgument *> getArguments() const { return ArgumentList; }
 
-  /// Returns a transform array ref that performs llvm::cast<SILPhiArgument> on
+  /// Returns a transform array ref that performs llvm::cast<NAME>
   /// each argument and then returns the downcasted value.
-  PhiArgumentArrayRef getPhiArguments() const;
-
-  /// Returns a transform array ref that performs
-  /// llvm::cast<SILFunctionArgument> on each argument and then returns the
-  /// downcasted value.
-  FunctionArgumentArrayRef getFunctionArguments() const;
+#define ARGUMENT(NAME, PARENT) NAME##ArrayRef get##NAME##s() const;
+#include "swift/SIL/SILNodes.def"
 
   unsigned getNumArguments() const { return ArgumentList.size(); }
   const SILArgument *getArgument(unsigned i) const { return ArgumentList[i]; }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -646,7 +646,7 @@ void SILCloner<ImplClass>::clonePhiArgs(SILBasicBlock *oldBB) {
   auto *mappedBB = BBMap[oldBB];
 
   // Create new arguments for each of the original block's arguments.
-  for (auto *Arg : oldBB->getPhiArguments()) {
+  for (auto *Arg : oldBB->getSILPhiArguments()) {
     SILValue mappedArg = mappedBB->createPhiArgument(
       getOpType(Arg->getType()), Arg->getOwnershipKind());
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6989,8 +6989,8 @@ public:
   }
 
   using SuccessorBlockArgumentsListTy =
-      TransformRange<ConstSuccessorListTy,
-                     function_ref<PhiArgumentArrayRef(const SILSuccessor &)>>;
+      TransformRange<ConstSuccessorListTy, function_ref<SILPhiArgumentArrayRef(
+                                               const SILSuccessor &)>>;
 
   /// Return the range of Argument arrays for each successor of this
   /// block.

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -455,7 +455,7 @@ OperandOwnershipKindClassifier::visitSwitchEnumInst(SwitchEnumInst *sei) {
   // and merge them.
   auto mergedKind = ValueOwnershipKind::merge(makeTransformRange(
       sei->getSuccessorBlockArguments(),
-      [&](PhiArgumentArrayRef array) -> ValueOwnershipKind {
+      [&](SILPhiArgumentArrayRef array) -> ValueOwnershipKind {
         // If the array is empty, we have a non-payloaded case. Return any.
         if (array.empty())
           return ValueOwnershipKind::None;

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -129,14 +129,14 @@ void SILBasicBlock::cloneArgumentList(SILBasicBlock *Other) {
          "Expected to both blocks to be entries or not");
   if (isEntry()) {
     assert(args_empty() && "Expected to have no arguments");
-    for (auto *FuncArg : Other->getFunctionArguments()) {
+    for (auto *FuncArg : Other->getSILFunctionArguments()) {
       createFunctionArgument(FuncArg->getType(),
                              FuncArg->getDecl());
     }
     return;
   }
 
-  for (auto *PHIArg : Other->getPhiArguments()) {
+  for (auto *PHIArg : Other->getSILPhiArguments()) {
     createPhiArgument(PHIArg->getType(), PHIArg->getOwnershipKind(),
                       PHIArg->getDecl());
   }
@@ -359,18 +359,12 @@ bool SILBasicBlock::isEntry() const {
 }
 
 /// Declared out of line so we can have a declaration of SILArgument.
-PhiArgumentArrayRef SILBasicBlock::getPhiArguments() const {
-  return PhiArgumentArrayRef(getArguments(), [](SILArgument *arg) {
-    return cast<SILPhiArgument>(arg);
-  });
-}
-
-/// Declared out of line so we can have a declaration of SILArgument.
-FunctionArgumentArrayRef SILBasicBlock::getFunctionArguments() const {
-  return FunctionArgumentArrayRef(getArguments(), [](SILArgument *arg) {
-    return cast<SILFunctionArgument>(arg);
-  });
-}
+#define ARGUMENT(NAME, PARENT)                                                 \
+  NAME##ArrayRef SILBasicBlock::get##NAME##s() const {                         \
+    return NAME##ArrayRef(getArguments(),                                      \
+                          [](SILArgument *arg) { return cast<NAME>(arg); });   \
+  }
+#include "swift/SIL/SILNodes.def"
 
 /// Returns true if this block ends in an unreachable or an apply of a
 /// no-return apply or builtin.

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1223,9 +1223,9 @@ bool TermInst::isProgramTerminating() const {
 
 TermInst::SuccessorBlockArgumentsListTy
 TermInst::getSuccessorBlockArguments() const {
-  function_ref<PhiArgumentArrayRef(const SILSuccessor &)> op;
-  op = [](const SILSuccessor &succ) -> PhiArgumentArrayRef {
-    return succ.getBB()->getPhiArguments();
+  function_ref<SILPhiArgumentArrayRef(const SILSuccessor &)> op;
+  op = [](const SILSuccessor &succ) -> SILPhiArgumentArrayRef {
+    return succ.getBB()->getSILPhiArguments();
   };
   return SuccessorBlockArgumentsListTy(getSuccessors(), op);
 }

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -349,7 +349,7 @@ bool SILValueOwnershipChecker::gatherUsers(
       //
       // TODO: We could ignore this error and emit a more specific error on the
       // actual terminator.
-      for (auto *succArg : succBlock->getPhiArguments()) {
+      for (auto *succArg : succBlock->getSILPhiArguments()) {
         // *NOTE* We do not emit an error here since we want to allow for more
         // specific errors to be found during use_verification.
         //

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -843,7 +843,7 @@ void ConsumedArgToEpilogueReleaseMatcher::collectMatchingDestroyAddresses(
   SILFunction::iterator anotherEpilogueBB =
       (Kind == ExitKind::Return) ? F->findThrowBB() : F->findReturnBB();
 
-  for (auto *arg : F->begin()->getFunctionArguments()) {
+  for (auto *arg : F->begin()->getSILFunctionArguments()) {
     if (arg->isIndirectResult())
       continue;
     if (arg->getArgumentConvention() != SILArgumentConvention::Indirect_In)

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ArgumentExplosionTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ArgumentExplosionTransform.cpp
@@ -320,7 +320,7 @@ bool FunctionSignatureTransform::ArgumentExplosionAnalyzeParameters() {
   SILFunction *F = TransformDescriptor.OriginalFunction;
   // Did we decide we should optimize any parameter?
   bool SignatureOptimize = false;
-  auto Args = F->begin()->getFunctionArguments();
+  auto Args = F->begin()->getSILFunctionArguments();
   ConsumedArgToEpilogueReleaseMatcher ArgToReturnReleaseMap(
       RCIA->get(F), F, {SILArgumentConvention::Direct_Owned});
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/DeadArgumentTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/DeadArgumentTransform.cpp
@@ -29,7 +29,7 @@ bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
   // Did we decide we should optimize any parameter?
   SILFunction *F = TransformDescriptor.OriginalFunction;
   bool SignatureOptimize = false;
-  auto Args = F->begin()->getFunctionArguments();
+  auto Args = F->begin()->getSILFunctionArguments();
   auto OrigShouldModifySelfArgument =
       TransformDescriptor.shouldModifySelfArgument;
   // Analyze the argument information.

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -130,7 +130,7 @@ bool ExistentialSpecializer::canSpecializeExistentialArgsInFunction(
     llvm::SmallDenseMap<int, ExistentialTransformArgumentDescriptor>
         &ExistentialArgDescriptor) {
   auto *F = Apply.getReferencedFunctionOrNull();
-  auto CalleeArgs = F->begin()->getFunctionArguments();
+  auto CalleeArgs = F->begin()->getSILFunctionArguments();
   bool returnFlag = false;
 
   /// Analyze the argument for protocol conformance.  Iterator over the callee's
@@ -314,7 +314,7 @@ void ExistentialSpecializer::specializeExistentialArgsInAppliesWithinFunction(
       /// Save the arguments in a descriptor.
       llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> Allocator;
       llvm::SmallVector<ArgumentDescriptor, 4> ArgumentDescList;
-      auto Args = Callee->begin()->getFunctionArguments();
+      auto Args = Callee->begin()->getSILFunctionArguments();
       for (unsigned i : indices(Args)) {
         ArgumentDescList.emplace_back(Args[i], Allocator);
       }

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -538,7 +538,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   ArgumentExplosionFinalizeOptimizedFunction();
 
   // Update the ownership kinds of function entry BB arguments.
-  for (auto Arg : NewF->begin()->getFunctionArguments()) {
+  for (auto Arg : NewF->begin()->getSILFunctionArguments()) {
     SILType MappedTy = Arg->getType();
     auto Ownershipkind =
         ValueOwnershipKind(*NewF, MappedTy, Arg->getArgumentConvention());
@@ -826,7 +826,7 @@ public:
     llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> Allocator;
     llvm::SmallVector<ArgumentDescriptor, 4> ArgumentDescList;
     llvm::SmallVector<ResultDescriptor, 4> ResultDescList;
-    auto Args = F->begin()->getFunctionArguments();
+    auto Args = F->begin()->getSILFunctionArguments();
     for (unsigned i : indices(Args)) {
       ArgumentDescList.emplace_back(Args[i], Allocator);
     }

--- a/lib/SILOptimizer/FunctionSignatureTransforms/OwnedToGuaranteedTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/OwnedToGuaranteedTransform.cpp
@@ -56,7 +56,7 @@ static SILInstruction *findOnlyApply(SILFunction *F) {
 
 bool FunctionSignatureTransform::OwnedToGuaranteedAnalyzeParameters() {
   SILFunction *F = TransformDescriptor.OriginalFunction;
-  auto Args = F->begin()->getFunctionArguments();
+  auto Args = F->begin()->getSILFunctionArguments();
   // A map from consumed SILArguments to the release associated with an
   // argument.
   //

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -619,7 +619,7 @@ SILValue EagerDispatch::emitArgumentCast(CanSILFunctionType CalleeSubstFnTy,
 /// has a direct result.
 SILValue EagerDispatch::
 emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs) {
-  auto OrigArgs = GenericFunc->begin()->getFunctionArguments();
+  auto OrigArgs = GenericFunc->begin()->getSILFunctionArguments();
   assert(OrigArgs.size() == substConv.getNumSILArguments()
          && "signature mismatch");
   // Create a substituted callee type.

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -618,7 +618,7 @@ static void updateBasicBlockArgTypes(SILBasicBlock *BB,
                                      ArchetypeType *OldOpenedArchetype,
                                      ArchetypeType *NewOpenedArchetype) {
   // Check types of all BB arguments.
-  for (auto *Arg : BB->getPhiArguments()) {
+  for (auto *Arg : BB->getSILPhiArguments()) {
     if (!Arg->getType().hasOpenedExistential())
       continue;
     // Type of this BB argument uses an opened existential.

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -221,7 +221,7 @@ SILValue SILSSAUpdater::GetValueInMiddleOfBlock(SILBasicBlock *BB) {
   if (!BB->getArguments().empty()) {
     llvm::SmallDenseMap<SILBasicBlock *, SILValue, 8> ValueMap(PredVals.begin(),
                                                                PredVals.end());
-    for (auto *Arg : BB->getPhiArguments())
+    for (auto *Arg : BB->getSILPhiArguments())
       if (isEquivalentPHI(Arg, ValueMap))
         return Arg;
 


### PR DESCRIPTION
…ding names.

I also changed all of the places that vended these to use SILNodes.def as well
so that when new argument kinds are added, things just work.
