### PR TITLE
[allocbox-to-stack] Add a new semantics attribute that says vars of a nominal type marked with _semantics("boxtostack.mustbeonstack") must be on the stack.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -541,6 +541,11 @@ ERROR(polymorphic_builtin_passed_type_without_static_overload, none, "Static"
       "overload implied by passing argument of type %2",
       (Identifier, StringRef, Type))
 
+ERROR(box_to_stack_cannot_promote_box_to_stack_due_to_escape_alloc, none,
+      "Can not promote value from heap to stack due to value escaping", ())
+NOTE(box_to_stack_cannot_promote_box_to_stack_due_to_escape_location, none,
+     "value escapes here", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "allocbox-to-stack"
+#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/SILArgument.h"
@@ -354,6 +355,12 @@ findUnexpectedBoxUse(SILValue Box, bool examinePartialApply,
   return nullptr;
 }
 
+template <typename... T, typename... U>
+static InFlightDiagnostic diagnose(ASTContext &Context, SourceLoc loc,
+                                   Diag<T...> diag, U &&... args) {
+  return Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
+
 /// canPromoteAllocBox - Can we promote this alloc_box to an alloc_stack?
 static bool canPromoteAllocBox(AllocBoxInst *ABI,
                                SmallVectorImpl<Operand *> &PromotedOperands) {
@@ -368,6 +375,21 @@ static bool canPromoteAllocBox(AllocBoxInst *ABI,
     LLVM_DEBUG(llvm::dbgs() << "*** Failed to promote alloc_box in @"
                << ABI->getFunction()->getName() << ": " << *ABI
                << "    Due to user: " << *User << "\n");
+
+    // Check if the vardecl has a "boxtostack.mustbeonstack" attribute. If so,
+    // emit a diagnostic.
+    if (auto *decl = ABI->getDecl()) {
+      if (decl->hasSemanticsAttr("boxtostack.mustbeonstack")) {
+        auto allocDiag =
+            diag::box_to_stack_cannot_promote_box_to_stack_due_to_escape_alloc;
+        diagnose(ABI->getModule().getASTContext(), ABI->getLoc().getSourceLoc(),
+                 allocDiag);
+        auto escapeNote = diag::
+            box_to_stack_cannot_promote_box_to_stack_due_to_escape_location;
+        diagnose(ABI->getModule().getASTContext(),
+                 User->getLoc().getSourceLoc(), escapeNote);
+      }
+    }
 
     return false;
   }

--- a/test/SILOptimizer/allocboxtostack_escape.swift
+++ b/test/SILOptimizer/allocboxtostack_escape.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend %s -o /dev/null -verify -emit-sil
+
+struct Box<T> {
+  var value: T
+}
+
+class Klass {}
+
+func myPrint(_ x: inout Box<Klass>) -> () { print(x) }
+
+func testError() -> (() -> ()) {
+  @_semantics("boxtostack.mustbeonstack")
+  var x = Box<Klass>(value: Klass()) // expected-error {{Can not promote value from heap to stack due to value escaping}}
+  let result = { // expected-note {{value escapes here}}
+    myPrint(&x)
+  }
+  return result
+}
+
+func main() {
+  testError()()
+}
+
+main()


### PR DESCRIPTION
This is just an experimental option I added for the swift-nio people to play with.