### PR TITLE
[build] allow to skip build of clang-tools-extras

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -498,6 +498,8 @@ class BuildScriptInvocation(object):
             impl_args += ["--skip-build-watchos-simulator"]
         if not args.build_android:
             impl_args += ["--skip-build-android"]
+        if not args.build_clang_tools_extra:
+            impl_args += ["--skip-build-clang-tools-extra"]
 
         if not args.test and not args.long_test and not args.stress_test:
             impl_args += ["--skip-test-swift"]

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -125,6 +125,7 @@ KNOWN_SETTINGS=(
     skip-build-benchmarks       ""               "set to skip building Swift Benchmark Suite"
     skip-build-external-benchmarks "1"            "set to skip building the external Swift Benchmark Suite. (skipped by default)"
     skip-build-playgroundsupport ""              "set to skip building PlaygroundSupport"
+    skip-build-clang-tools-extra ""              "set to skip building clang-tools-extra as part of llvm"
     skip-local-build            ""               "set to skip building for the current host (useful when crosscompiling)"
     skip-test-cmark             ""               "set to skip testing CommonMark"
     skip-test-lldb              ""               "set to skip testing lldb"
@@ -1680,15 +1681,19 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${llvm_cmake_options[@]}"
                 )
 
-                if [[ "${SKIP_BUILD_COMPILER_RT}" ]]; then
-                    cmake_options+=(
-                    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;"
-                    )
-                else
-                    cmake_options+=(
-                    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;"
-                    )
+                llvm_enable_projects=("clang")
+
+                if [[ ! "${SKIP_BUILD_COMPILER_RT}" ]]; then
+                    llvm_enable_projects+=("compiler-rt")
                 fi
+
+                if [[ ! "${SKIP_BUILD_CLANG_TOOLS_EXTRA}" ]]; then
+                    llvm_enable_projects+=("clang-tools-extra")
+                fi
+
+                cmake_options+=(
+                    -DLLVM_ENABLE_PROJECTS="$(join ";" ${llvm_enable_projects[@]})"
+                )
 
                 cmake_options+=(
                   -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -615,6 +615,11 @@ def create_argument_parser():
     option(['--build-libparser-only'], store_true('build_libparser_only'),
            help='build only libParser for SwiftSyntax')
 
+    option('--skip-build-clang-tools-extra',
+           toggle_false('build_clang_tools_extra'),
+           default=True,
+           help='skip building clang-tools-extra as part of llvm')
+
     # -------------------------------------------------------------------------
     in_group('Extra actions to perform before or in addition to building')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -56,6 +56,7 @@ EXPECTED_DEFAULTS = {
     'build_android': False,
     'build_args': [],
     'build_benchmarks': True,
+    'build_clang_tools_extra': True,
     'build_cygwin': True,
     'build_external_benchmarks': False,
     'build_foundation': False,
@@ -553,6 +554,8 @@ EXPECTED_OPTIONS = [
     DisableOption('--skip-test-swiftevolve', dest='test_swiftevolve'),
     DisableOption('--skip-test-toolchain-benchmarks',
                   dest='test_toolchainbenchmarks'),
+    DisableOption('--skip-build-clang-tools-extra',
+                  dest='build_clang_tools_extra'),
 
     ChoicesOption('--android-ndk-gcc-version',
                   choices=['4.8', '4.9']),


### PR DESCRIPTION
Also at the same time refactor code that composes LLVM_ENABLE_PROJECTS

Supports rdar://problem/57432088