### PR TITLE
[Sanitizers] Add Scudo support

### DIFF
--- a/include/swift/Basic/Sanitizers.def
+++ b/include/swift/Basic/Sanitizers.def
@@ -24,5 +24,6 @@ SANITIZER(0, Address,   address,    asan)
 SANITIZER(1, Thread,    thread,     tsan)
 SANITIZER(2, Undefined, undefined,  ubsan)
 SANITIZER(3, Fuzzer,    fuzzer,     fuzzer)
+SANITIZER(4, Scudo,     scudo,      scudo)
 
 #undef SANITIZER

--- a/test/Driver/sanitize_scudo.swift
+++ b/test/Driver/sanitize_scudo.swift
@@ -1,0 +1,40 @@
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-unknown-linux-gnu %s | %FileCheck -check-prefix=SCUDO_LINUX %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target arm64-apple-ios7.1 %s 2>&1 | %FileCheck -check-prefix=SCUDO_IOS %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target arm64-apple-tvos9.0 %s 2>&1 | %FileCheck -check-prefix=SCUDO_tvOS %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target armv7k-apple-watchos2.0 %s 2>&1 | %FileCheck -check-prefix=SCUDO_watchOS %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target i386-apple-watchos2.0 %s 2>&1 | %FileCheck -check-prefix=SCUDO_watchOS_SIM %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target i386-apple-macosx10.9 %s 2>&1 | %FileCheck -check-prefix=SCUDO_OSX_32 %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-apple-ios7.1 %s 2>&1 | %FileCheck -check-prefix=SCUDO_IOSSIM %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-apple-macosx10.9 %s 2>&1 | %FileCheck -check-prefix=SCUDO_OSX_64 %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-apple-tvos9.0 %s 2>&1 | %FileCheck -check-prefix=SCUDO_tvOS_SIM %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo -target x86_64-unknown-windows-msvc %s 2>&1 | %FileCheck -check-prefix=SCUDO_WINDOWS %s
+
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo,address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=SCUDO_ASAN %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo,thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=SCUDO_TSAN %s
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo,undefined -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=SCUDO_UBSAN_LINUX %s
+
+
+/*
+ * Make sure we don't accidentally add the sanitizer library path when building libraries or modules
+ */
+// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -emit-library -sanitize=scudo -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=SCUDO_LIBRARY_LINUX %s
+
+// SCUDO_LINUX: bin/clang
+// SCUDO_LINUX-SAME: -pie
+// SCUDO_LINUX-SAME: -fsanitize=scudo
+// SCUDO_OSX_32: unsupported option '-sanitize=scudo' for target 'i386-apple-macosx10.9'
+// SCUDO_OSX_64: unsupported option '-sanitize=scudo' for target 'x86_64-apple-macosx10.9'
+// SCUDO_IOSSIM: unsupported option '-sanitize=scudo' for target 'x86_64-apple-ios7.1'
+// SCUDO_IOS: unsupported option '-sanitize=scudo' for target 'arm64-apple-ios7.1'
+// SCUDO_tvOS_SIM: unsupported option '-sanitize=scudo' for target 'x86_64-apple-tvos9.0'
+// SCUDO_tvOS: unsupported option '-sanitize=scudo' for target 'arm64-apple-tvos9.0'
+// SCUDO_watchOS_SIM: unsupported option '-sanitize=scudo' for target 'i386-apple-watchos2.0'
+// SCUDO_watchOS: unsupported option '-sanitize=scudo' for target 'armv7k-apple-watchos2.0'
+// SCUDO_WINDOWS: unsupported option '-sanitize=scudo' for target 'x86_64-unknown-windows-msvc'
+
+// SCUDO_ASAN: argument '-sanitize=scudo' is not allowed with '-sanitize=address'
+// SCUDO_TSAN: argument '-sanitize=scudo' is not allowed with '-sanitize=thread'
+// SCUDO_UBSAN_LINUX: -fsanitize=undefined,scudo
+// SCUDO_LIBRARY_LINUX: bin/clang
+// SCUDO_LIBRARY_LINUX-NOT: -fsanitize=scudo
+

--- a/test/Sanitizers/scudo.swift
+++ b/test/Sanitizers/scudo.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=scudo -o %t_scudo-binary
+// RUN: not %target-run %t_scudo-binary 2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: OS=linux-gnu
+
+let allocated = UnsafeMutableRawPointer.allocate(byteCount: 128, alignment: 1)
+allocated.deallocate()
+allocated.deallocate()
+
+// CHECK: ERROR: invalid chunk state


### PR DESCRIPTION
LLVM ships a hardened memory allocator called Scudo:
https://llvm.org/docs/ScudoHardenedAllocator.html. This allocator
provides additional mitigations against heap-based vulnerabilities, but
retains sufficient performance to be safely run in production
applications.

While ideal Swift applications are obviously written in pure Swift, in
practice most applications contain some amount of code written in
less-safe languages. Additionally, plenty of Swift programs themselves
contain unsafe code, particularly when attempting to implement
high-performance data structures. These sources of unsafety introduce
the risk of memory issues, and having the option to use the Scudo
allocator is a useful defense-in-depth tool.

This patch enables `-sanitize=scudo` as an extra `swiftc` flag. This
sanitizer is only supported on Linux, so no further work is required to
enable it on Windows or Apple platforms. As this "sanitizer" is only a
runtime component, we do not require any wider changes to instrument
code.

The result of this patch matches the API of clang, which supports
`-fsanitize=scudo`.

- - - 

I do have one question: currently this patch contains no regression tests. I was fundamentally unsure of where to place these regression tests, but I think we should have them, so please do as part of your review suggest a location and form for the regression tests.