### PR TITLE
[Diagnostics] Port diagnostics related to ambiguities and constraints

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -69,6 +69,9 @@ ERROR(no_overloads_match_exactly_in_call_no_labels,none,
 ERROR(no_overloads_match_exactly_in_call_special,none,
       "no exact matches in call to %0",
       (DescriptiveDeclKind))
+ERROR(no_overloads_match_exactly_in_assignment,none,
+      "no exact matches in assignment to %0",
+      (DeclBaseName))
 
 ERROR(ambiguous_subscript,none,
       "ambiguous subscript with base type %0 and index type %1",
@@ -3400,6 +3403,10 @@ ERROR(assignment_dynamic_property_has_immutable_base,none,
       "cannot assign through dynamic lookup property: %0", (StringRef))
 ERROR(assignment_bang_has_immutable_subcomponent,none,
       "cannot assign through '!': %0", (StringRef))
+
+NOTE(candidate_is_not_assignable,none,
+     "candidate is not assignable: %0 %1",
+     (DescriptiveDeclKind, DeclName))
 
 NOTE(change_to_mutating,none,
      "mark %select{method|accessor}0 'mutating' to make 'self' mutable",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3044,6 +3044,8 @@ ERROR(collection_literal_empty,none,
 ERROR(unresolved_member_no_inference,none,
       "reference to member %0 cannot be resolved without a contextual type",
       (DeclName))
+ERROR(cannot_infer_base_of_unresolved_member,none,
+      "cannot infer contextual base in reference to member %0", (DeclName))
 ERROR(unresolved_collection_literal,none,
       "cannot infer type for empty collection literal without a "
       "contextual type", ())

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -738,6 +738,13 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
   if (shouldAttemptFixes() && result.Bindings.empty() &&
       typeVar->getImpl().canBindToHole()) {
     result.IsHole = true;
+    // If the base of the unresolved member reference like `.foo`
+    // couldn't be resolved we'd want to bind it to a hole at the
+    // very last moment possible, just like generic parameters.
+    auto *locator = typeVar->getImpl().getLocator();
+    if (locator->isLastElement<LocatorPathElt::MemberRefBase>())
+      result.PotentiallyIncomplete = true;
+
     result.addPotentialBinding({getASTContext().TheUnresolvedType,
         AllowedBindingKind::Exact, ConstraintKind::Defaultable, nullptr,
         typeVar->getImpl().getLocator()});

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -120,10 +120,6 @@ public:
     return CS.getASTContext().Diags.diagnose(std::forward<ArgTypes>(Args)...);
   }
 
-  /// Attempt to diagnose a failure without taking into account the specific
-  /// kind of expression that could not be type checked.
-  bool diagnoseConstraintFailure();
-
   /// Unless we've already done this, retypecheck the specified child of the
   /// current expression on its own, without including any contextual
   /// constraints or the parent expr nodes.  This is more likely to succeed than
@@ -239,24 +235,12 @@ private:
   /// true.
   bool diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure);
 
-  /// Produce a diagnostic for a general member-lookup failure (irrespective of
-  /// the exact expression kind).
-  bool diagnoseGeneralMemberFailure(Constraint *constraint);
-
   /// Given a result of name lookup that had no viable results, diagnose the
   /// unviable ones.
   void diagnoseUnviableLookupResults(MemberLookupResult &lookupResults,
                                      Expr *expr, Type baseObjTy, Expr *baseExpr,
                                      DeclName memberName, DeclNameLoc nameLoc,
                                      SourceLoc loc);
-
-  /// Produce a diagnostic for a general overload resolution failure
-  /// (irrespective of the exact expression kind).
-  bool diagnoseGeneralOverloadFailure(Constraint *constraint);
-  
-  /// Produce a diagnostic for a general conversion failure (irrespective of the
-  /// exact expression kind).
-  bool diagnoseGeneralConversionFailure(Constraint *constraint);
 
   bool diagnoseMemberFailures(
       Expr *E, Expr *baseEpxr, ConstraintKind lookupKind, DeclName memberName,
@@ -292,178 +276,6 @@ private:
   bool visitClosureExpr(ClosureExpr *CE);
 };
 } // end anonymous namespace
-
-
-
-static bool isMemberConstraint(Constraint *C) {
-  return C->getClassification() == ConstraintClassification::Member;
-}
-
-static bool isOverloadConstraint(Constraint *C) {
-  if (C->getKind() == ConstraintKind::BindOverload)
-    return true;
-
-  if (C->getKind() != ConstraintKind::Disjunction)
-    return false;
-  
-  return C->getNestedConstraints().front()->getKind() ==
-    ConstraintKind::BindOverload;
-}
-
-/// Return true if this constraint is a conversion or requirement between two
-/// types.
-static bool isConversionConstraint(const Constraint *C) {
-  return C->getClassification() == ConstraintClassification::Relational;
-}
-
-/// Attempt to diagnose a failure without taking into account the specific
-/// kind of expression that could not be type checked.
-bool FailureDiagnosis::diagnoseConstraintFailure() {
-  // This is the priority order in which we handle constraints.  Things earlier
-  // in the list are considered to have higher specificity (and thus, higher
-  // priority) than things lower in the list.
-  enum ConstraintRanking {
-    CR_MemberConstraint,
-    CR_ConversionConstraint,
-    CR_OverloadConstraint,
-    CR_OtherConstraint
-  };
-
-  // Start out by classifying all the constraints.
-  using RCElt = std::pair<Constraint *, ConstraintRanking>;
-  std::vector<RCElt> rankedConstraints;
-
-  // This is a predicate that classifies constraints according to our
-  // priorities.
-  std::function<void (Constraint*)> classifyConstraint = [&](Constraint *C) {
-    if (isMemberConstraint(C))
-      return rankedConstraints.push_back({C, CR_MemberConstraint});
-
-    if (isOverloadConstraint(C))
-      return rankedConstraints.push_back({C, CR_OverloadConstraint});
-
-    if (isConversionConstraint(C))
-      return rankedConstraints.push_back({C, CR_ConversionConstraint});
-
-    // We occasionally end up with disjunction constraints containing an
-    // original constraint along with one considered with a fix.  If we find
-    // this situation, add the original one to our list for diagnosis.
-    if (C->getKind() == ConstraintKind::Disjunction) {
-      Constraint *Orig = nullptr;
-      bool AllOthersHaveFixes = true;
-      for (auto DC : C->getNestedConstraints()) {
-        // If this is a constraint inside of the disjunction with a fix, ignore
-        // it.
-        if (DC->getFix())
-          continue;
-
-        // If we already found a candidate without a fix, we can't do this.
-        if (Orig) {
-          AllOthersHaveFixes = false;
-          break;
-        }
-
-        // Remember this as the exemplar to use.
-        Orig = DC;
-      }
-
-      if (Orig && AllOthersHaveFixes)
-        return classifyConstraint(Orig);
-      
-      // If we got all the way down to a truly ambiguous disjunction constraint
-      // with a conversion in it, the problem could be that none of the options
-      // in the disjunction worked.
-      //
-      // We don't have a lot of great options here, so (if all else fails),
-      // we'll attempt to diagnose the issue as though the first option was the
-      // problem.
-      rankedConstraints.push_back({
-        C->getNestedConstraints()[0],
-        CR_OtherConstraint
-      });
-      return;
-    }
-
-    return rankedConstraints.push_back({C, CR_OtherConstraint});
-  };
-  
-  // Look at the failed constraint and the general constraint list.  Processing
-  // the failed constraint first slightly biases it in the ranking ahead of
-  // other failed constraints at the same level.
-  if (CS.failedConstraint)
-    classifyConstraint(CS.failedConstraint);
-  for (auto &C : CS.getConstraints())
-    classifyConstraint(&C);
-
-  // Okay, now that we've classified all the constraints, sort them by their
-  // priority and privilege the favored constraints.
-  std::stable_sort(rankedConstraints.begin(), rankedConstraints.end(),
-                   [&] (RCElt LHS, RCElt RHS) {
-    // Rank things by their kind as the highest priority.
-    if (LHS.second < RHS.second)
-      return true;
-    if (LHS.second > RHS.second)
-      return false;
-    // Next priority is favored constraints.
-    if (LHS.first->isFavored() != RHS.first->isFavored())
-      return LHS.first->isFavored();
-    return false;
-  });
- 
-  // Now that we have a sorted precedence of constraints to diagnose, charge
-  // through them.
-  for (auto elt : rankedConstraints) {
-    auto C = elt.first;
-    if (isMemberConstraint(C) && diagnoseGeneralMemberFailure(C))
-      return true;
-
-    if (isConversionConstraint(C) && diagnoseGeneralConversionFailure(C))
-      return true;
-
-    if (isOverloadConstraint(C) && diagnoseGeneralOverloadFailure(C))
-      return true;
-    
-
-    // TODO: There can be constraints that aren't handled here!  When this
-    // happens, we end up diagnosing them as ambiguities that don't make sense.
-    // This isn't as bad as it seems though, because most of these will be
-    // diagnosed by expr diagnostics.
-  }
-  
-  // Otherwise, all the constraints look ok, diagnose this as an ambiguous
-  // expression.
-  return false;
-}
-
-
-bool FailureDiagnosis::diagnoseGeneralMemberFailure(Constraint *constraint) {
-  assert(isMemberConstraint(constraint));
-
-  // Get the referenced base expression from the failed constraint, along with
-  // the SourceRange for the member ref.  In "x.y", this returns the expr for x
-  // and the source range for y.
-  auto anchor = expr;
-  SourceRange memberRange = anchor->getSourceRange();
-  auto locator = constraint->getLocator();
-  if (locator) {
-    locator = simplifyLocator(CS, locator, memberRange);
-    if (locator->getAnchor())
-      anchor = locator->getAnchor();
-  }
-
-  // Check to see if this is a locator referring to something we cannot or do
-  // here: in this case, we ignore paths that end on archetypes witnesses, or
-  // associated types of the expression.
-  if (locator && !locator->getPath().empty()) {
-    // TODO: This should only ignore *unresolved* archetypes.  For resolved
-    // archetypes
-    return false;
-  }
-
-  return diagnoseMemberFailures(expr, anchor, constraint->getKind(),
-                                constraint->getMember(),
-                                constraint->getFunctionRefKind(), locator);
-}
 
 /// Given a result of name lookup that had no viable results, diagnose the
 /// unviable ones.
@@ -582,263 +394,6 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
              baseObjTy, memberName)
     .highlight(baseRange).highlight(nameLoc.getSourceRange());
   return;
-}
-
-// In the absence of a better conversion constraint failure, point out the
-// inability to find an appropriate overload.
-bool FailureDiagnosis::diagnoseGeneralOverloadFailure(Constraint *constraint) {
-  Constraint *bindOverload = constraint;
-  if (constraint->getKind() == ConstraintKind::Disjunction)
-    bindOverload = constraint->getNestedConstraints().front();
-
-  auto overloadChoice = bindOverload->getOverloadChoice();
-  auto overloadName = overloadChoice.getName();
-
-  // Get the referenced expression from the failed constraint.
-  auto anchor = expr;
-  if (auto locator = bindOverload->getLocator()) {
-    anchor = simplifyLocatorToAnchor(locator);
-    if (!anchor)
-      return false;
-  }
-
-  // The anchor for the constraint is almost always an OverloadedDeclRefExpr or
-  // UnresolvedDotExpr.  Look at the parent node in the AST to find the Apply to
-  // give a better diagnostic.
-  Expr *call = expr->getParentMap()[anchor];
-  // We look through some simple things that get in between the overload set
-  // and the apply.
-  while (call &&
-         (isa<IdentityExpr>(call) ||
-          isa<TryExpr>(call) || isa<ForceTryExpr>(call))) {
-    call = expr->getParentMap()[call];
-  }
-  
-  // FIXME: This is only needed because binops don't respect contextual types.
-  if (call && isa<ApplyExpr>(call))
-    return false;
-
-  // This happens, for example, with ambiguous OverloadedDeclRefExprs. We should
-  // just implement visitOverloadedDeclRefExprs and nuke this.
-
-  // If we couldn't resolve an argument, then produce a generic "ambiguity"
-  // diagnostic.
-  diagnose(anchor->getLoc(), diag::ambiguous_member_overload_set,
-           overloadName)
-    .highlight(anchor->getSourceRange());
-
-  if (constraint->getKind() == ConstraintKind::Disjunction) {
-    for (auto elt : constraint->getNestedConstraints()) {
-      if (elt->getKind() != ConstraintKind::BindOverload) continue;
-      if (auto *candidate = elt->getOverloadChoice().getDeclOrNull())
-        diagnose(candidate, diag::found_candidate);
-    }
-  }
-
-  return true;
-}
-
-bool FailureDiagnosis::diagnoseGeneralConversionFailure(Constraint *constraint){
-  auto anchor = expr;
-  bool resolvedAnchorToExpr = false;
-  
-  if (auto locator = constraint->getLocator()) {
-    anchor = simplifyLocatorToAnchor(locator);
-    if (anchor)
-      resolvedAnchorToExpr = true;
-    else
-      anchor = locator->getAnchor();    
-  }
-
-  Type fromType = CS.simplifyType(constraint->getFirstType());
-
-  if (fromType->hasTypeVariable() && resolvedAnchorToExpr) {
-    TCCOptions options;
-    
-    // If we know we're removing a contextual constraint, then we can force a
-    // type check of the subexpr because we know we're eliminating that
-    // constraint.
-    if (CS.getContextualTypePurpose() != CTP_Unused)
-      options |= TCC_ForceRecheck;
-
-    auto sub = typeCheckChildIndependently(anchor, options);
-    if (!sub) return true;
-    fromType = CS.getType(sub);
-  }
-
-  // Bail on constraints that don't relate two types.
-  if (constraint->getKind() == ConstraintKind::Disjunction
-      || constraint->getKind() == ConstraintKind::BindOverload)
-    return false;
-
-  fromType = fromType->getRValueType();
-  auto toType = CS.simplifyType(constraint->getSecondType());
-
-  // Try to simplify irrelevant details of function types.  For example, if
-  // someone passes a "() -> Float" function to a "() throws -> Int"
-  // parameter, then uttering the "throws" may confuse them into thinking that
-  // that is the problem, even though there is a clear subtype relation.
-  if (auto srcFT = fromType->getAs<FunctionType>())
-    if (auto destFT = toType->getAs<FunctionType>()) {
-      auto destExtInfo = destFT->getExtInfo();
-
-      if (!srcFT->isNoEscape()) destExtInfo = destExtInfo.withNoEscape(false);
-      if (!srcFT->throws()) destExtInfo = destExtInfo.withThrows(false);
-      if (destExtInfo != destFT->getExtInfo())
-        toType = FunctionType::get(destFT->getParams(), destFT->getResult(),
-                                   destExtInfo);
-
-      // If this is a function conversion that discards throwability or
-      // noescape, emit a specific diagnostic about that.
-      if (srcFT->throws() && !destFT->throws()) {
-        diagnose(expr->getLoc(), diag::throws_functiontype_mismatch,
-                 fromType, toType)
-        .highlight(expr->getSourceRange());
-        return true;
-      }
-
-      auto destPurpose = CTP_Unused;
-      if (constraint->getKind() == ConstraintKind::ArgumentConversion ||
-          constraint->getKind() == ConstraintKind::OperatorArgumentConversion)
-        destPurpose = CTP_CallArgument;
-    }
-
-  // If this is a callee that mismatches an expected return type, we can emit a
-  // very nice and specific error.  In this case, what we'll generally see is
-  // a failed conversion constraint of "A -> B" to "_ -> C", where the error is
-  // that B isn't convertible to C.
-  if (CS.getContextualTypePurpose() == CTP_CalleeResult) {
-    auto destFT = toType->getAs<FunctionType>();
-    auto srcFT = fromType->getAs<FunctionType>();
-    if (destFT && srcFT && !isUnresolvedOrTypeVarType(srcFT->getResult())) {
-      // Otherwise, the error is that the result types mismatch.
-      diagnose(expr->getLoc(), diag::invalid_callee_result_type,
-               srcFT->getResult(), destFT->getResult())
-        .highlight(expr->getSourceRange());
-      return true;
-    }
-  }
-  
-  
-  // If simplification has turned this into the same types, then this isn't the
-  // broken constraint that we're looking for.
-  if (fromType->isEqual(toType) &&
-      constraint->getKind() != ConstraintKind::ConformsTo &&
-      constraint->getKind() != ConstraintKind::LiteralConformsTo)
-    return false;
-  
-  
-  // If we have two tuples with mismatching types, produce a tailored
-  // diagnostic.
-  if (auto fromTT = fromType->getAs<TupleType>())
-    if (auto toTT = toType->getAs<TupleType>()) {
-      if (fromTT->getNumElements() != toTT->getNumElements()) {
-        auto failure = TupleContextualFailure(CS, fromTT, toTT,
-                                              CS.getConstraintLocator(expr));
-        return failure.diagnoseAsError();
-      }
-     
-      SmallVector<TupleTypeElt, 4> FromElts;
-      auto voidTy = CS.getASTContext().TheUnresolvedType;
-
-      for (unsigned i = 0, e = fromTT->getNumElements(); i != e; ++i)
-        FromElts.push_back({ voidTy, fromTT->getElement(i).getName() });
-      auto TEType = TupleType::get(FromElts, CS.getASTContext());
-
-      SmallVector<unsigned, 4> sources;
-      
-      // If the shuffle conversion is invalid (e.g. incorrect element labels),
-      // then we have a type error.
-      if (computeTupleShuffle(TEType->castTo<TupleType>()->getElements(),
-                              toTT->getElements(), sources)) {
-        auto failure = TupleContextualFailure(CS, fromTT, toTT,
-                                              CS.getConstraintLocator(expr));
-        return failure.diagnoseAsError();
-      }
-    }
-  
-  
-  // If the second type is a type variable, the expression itself is
-  // ambiguous.  Bail out so the general ambiguity diagnosing logic can handle
-  // it.
-  if (fromType->hasUnresolvedType() || fromType->hasTypeVariable() ||
-      toType->hasUnresolvedType() || toType->hasTypeVariable() ||
-      // FIXME: Why reject unbound generic types here?
-      fromType->is<UnboundGenericType>())
-    return false;
-
-  
-  // Check for various issues converting to Bool.
-  ContextualFailure failure(CS, fromType, toType,
-                            constraint->getLocator());
-  if (failure.diagnoseConversionToBool())
-    return true;
-
-  if (auto PT = toType->getAs<ProtocolType>()) {
-    if (isa<NilLiteralExpr>(expr->getValueProvidingExpr())) {
-      diagnose(expr->getLoc(), diag::cannot_use_nil_with_this_type, toType)
-        .highlight(expr->getSourceRange());
-      return true;
-    }
-
-    // Emit a conformance error through conformsToProtocol.
-    auto conformance = TypeChecker::conformsToProtocol(
-        fromType, PT->getDecl(), CS.DC, ConformanceCheckFlags::InExpression,
-        expr->getLoc());
-    if (conformance) {
-      if (conformance.isAbstract() || !conformance.getConcrete()->isInvalid())
-        return false;
-    }
-
-    return true;
-  }
-
-  // Due to migration reasons, types used to conform to BooleanType, which
-  // contain a member var 'boolValue', now does not convert to Bool. This block
-  // tries to add a specific diagnosis/fixit to explicitly invoke 'boolValue'.
-  if (toType->isBool() &&
-      fromType->mayHaveMembers()) {
-    auto LookupResult = TypeChecker::lookupMember(
-        CS.DC, fromType,
-        DeclName(CS.getASTContext().getIdentifier("boolValue")));
-    if (!LookupResult.empty()) {
-      if (isa<VarDecl>(LookupResult.begin()->getValueDecl())) {
-        if (anchor->canAppendPostfixExpression())
-          diagnose(anchor->getLoc(), diag::types_not_convertible_use_bool_value,
-                   fromType, toType).fixItInsertAfter(anchor->getEndLoc(),
-                                                      ".boolValue");
-        else
-          diagnose(anchor->getLoc(), diag::types_not_convertible_use_bool_value,
-            fromType, toType).fixItInsert(anchor->getStartLoc(), "(").
-              fixItInsertAfter(anchor->getEndLoc(), ").boolValue");
-        return true;
-      }
-    }
-  }
-
-  diagnose(anchor->getLoc(), diag::types_not_convertible,
-           constraint->getKind() == ConstraintKind::Subtype,
-           fromType, toType)
-    .highlight(anchor->getSourceRange());
-
-  // Check to see if this constraint came from a cast instruction. If so,
-  // and if this conversion constraint is different than the types being cast,
-  // produce a note that talks about the overall expression.
-  //
-  // TODO: Using parentMap would be more general, rather than requiring the
-  // issue to be related to the root of the expr under study.
-  if (auto ECE = dyn_cast<ExplicitCastExpr>(expr))
-    if (constraint->getLocator() &&
-        constraint->getLocator()->getAnchor() == ECE->getSubExpr()) {
-      if (!toType->isEqual(ECE->getCastTypeLoc().getType()))
-        diagnose(expr->getLoc(), diag::in_cast_expr_types,
-                 CS.getType(ECE->getSubExpr())->getRValueType(),
-                 ECE->getCastTypeLoc().getType()->getRValueType())
-            .highlight(ECE->getSubExpr()->getSourceRange())
-            .highlight(ECE->getCastTypeLoc().getSourceRange());
-  }
-
-  return true;
 }
 
 namespace {
@@ -1172,91 +727,13 @@ DeclContext *FailureDiagnosis::findDeclContext(Expr *subExpr) const {
   return finder.DC;
 }
 
-/// For an expression being type checked with a CTP_CalleeResult contextual
-/// type, try to diagnose a problem.
-bool FailureDiagnosis::diagnoseCalleeResultContextualConversionError() {
-  // Try to dig out the conversion constraint in question to find the contextual
-  // result type being specified.
-  Type contextualResultType;
-  for (auto &c : CS.getConstraints()) {
-    if (!isConversionConstraint(&c) || !c.getLocator() ||
-        c.getLocator()->getAnchor() != expr)
-      continue;
-    
-    // If we found our contextual type, then we know we have a conversion to
-    // some function type, and that the result type is concrete.  If not,
-    // ignore it.
-    auto toType = CS.simplifyType(c.getSecondType());
-    if (auto *FT = toType->getAs<AnyFunctionType>())
-      if (!isUnresolvedOrTypeVarType(FT->getResult())) {
-        contextualResultType = FT->getResult();
-        break;
-      }
-  }
-  if (!contextualResultType)
-    return false;
-
-  // Retypecheck the callee expression without a contextual type to resolve
-  // whatever we can in it.
-  auto callee = typeCheckChildIndependently(expr, TCC_ForceRecheck);
-  if (!callee)
-    return true;
-  
-  // Based on that, compute an overload set.
-  CalleeCandidateInfo calleeInfo(callee, /*hasTrailingClosure*/false, CS);
-
-  switch (calleeInfo.size()) {
-  case 0:
-    // If we found no overloads, then there is something else going on here.
-    return false;
-      
-  case 1:
-    // If the callee isn't of function type, then something else has gone wrong.
-    if (!calleeInfo[0].getResultType())
-      return false;
-      
-    diagnose(expr->getLoc(), diag::candidates_no_match_result_type,
-             calleeInfo.declName, calleeInfo[0].getResultType(),
-             contextualResultType);
-    return true;
-  default:
-    // Check to see if all of the viable candidates produce the same result,
-    // this happens for things like "==" and "&&" operators.
-    if (auto resultTy = calleeInfo[0].getResultType()) {
-      for (unsigned i = 1, e = calleeInfo.size(); i != e; ++i)
-        if (auto ty = calleeInfo[i].getResultType())
-          if (!resultTy->isEqual(ty)) {
-            resultTy = Type();
-            break;
-          }
-      if (resultTy) {
-        diagnose(expr->getLoc(), diag::candidates_no_match_result_type,
-                 calleeInfo.declName, calleeInfo[0].getResultType(),
-                 contextualResultType);
-        return true;
-      }
-    }
-
-    // Otherwise, produce a candidate set.
-    diagnose(expr->getLoc(), diag::no_candidates_match_result_type,
-             calleeInfo.declName, contextualResultType);
-    calleeInfo.suggestPotentialOverloads(expr->getLoc(), /*isResult*/true);
-    return true;
-  }
-}
-
 bool FailureDiagnosis::diagnoseContextualConversionError(
     Expr *expr, Type contextualType, ContextualTypePurpose CTP,
     Type suggestedType) {
   // If the constraint system has a contextual type, then we can test to see if
   // this is the problem that prevents us from solving the system.
-  if (!contextualType) {
-    // This contextual conversion constraint doesn't install an actual type.
-    if (CTP == CTP_CalleeResult)
-      return diagnoseCalleeResultContextualConversionError();
- 
+  if (!contextualType)
     return false;
-  }
 
   // Try re-type-checking the expression without the contextual type to see if
   // it can work without it.  If so, the contextual type is the problem.  We
@@ -2206,15 +1683,6 @@ namespace {
   };
 } // end anonymous namespace
 
-/// Return true if this function name is a comparison operator.  This is a
-/// simple heuristic used to guide comparison related diagnostics.
-static bool isNameOfStandardComparisonOperator(StringRef opName) {
-  return opName == "=="  || opName == "!=" ||
-         opName == "===" || opName == "!==" ||
-         opName == "<"   || opName == ">" ||
-         opName == "<="  || opName == ">=";
-}
-
 static bool diagnoseClosureExplicitParameterMismatch(
     ConstraintSystem &CS, SourceLoc loc,
     ArrayRef<AnyFunctionType::Param> params,
@@ -2899,18 +2367,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
       .highlight(rhsExpr->getSourceRange());
     }
 
-    if (lhsType->isEqual(rhsType) &&
-        isNameOfStandardComparisonOperator(overloadName) &&
-        lhsType->is<EnumType>() &&
-        !lhsType->getAs<EnumType>()->getDecl()
-          ->hasOnlyCasesWithoutAssociatedValues()) {
-      diagnose(callExpr->getLoc(),
-               diag::no_binary_op_overload_for_enum_with_payload,
-               overloadName);
-    } else {
-      calleeInfo.suggestPotentialOverloads(callExpr->getLoc());
-    }
-
+    calleeInfo.suggestPotentialOverloads(callExpr->getLoc());
     return true;
   }
 
@@ -3852,13 +3309,6 @@ void ConstraintSystem::diagnoseFailureForExpr(Expr *expr) {
 
   SWIFT_DEFER { setPhase(ConstraintSystemPhase::Finalization); };
 
-  // Continue simplifying any active constraints left in the system.  We can end
-  // up with them because the solver bails out as soon as it sees a Failure.  We
-  // don't want to leave them around in the system because later diagnostics
-  // will assume they are unsolvable and may otherwise leave the system in an
-  // inconsistent state.
-  simplify(/*ContinueAfterFailures*/true);
-
   // Look through RebindSelfInConstructorExpr to avoid weird Sema issues.
   if (auto *RB = dyn_cast<RebindSelfInConstructorExpr>(expr))
     expr = RB->getSubExpr();
@@ -3872,11 +3322,6 @@ void ConstraintSystem::diagnoseFailureForExpr(Expr *expr) {
   // If this is a contextual conversion problem, dig out some information.
   if (diagnosis.diagnoseContextualConversionError(expr, getContextualType(),
                                                   getContextualTypePurpose()))
-    return;
-
-  // If we can diagnose a problem based on the constraints left laying around in
-  // the system, do so now.
-  if (diagnosis.diagnoseConstraintFailure())
     return;
 
   // If no one could find a problem with this expression or constraint system,
@@ -4143,7 +3588,7 @@ void FailureDiagnosis::diagnoseAmbiguity(Expr *E) {
       return;
     }
   }
-  
+
   // Diagnose empty collection literals that lack context specifically.
   if (auto CE = dyn_cast<CollectionExpr>(E->getSemanticsProvidingExpr())) {
     if (CE->getNumElements() == 0) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2152,6 +2152,16 @@ bool ContextualFailure::diagnoseAsError() {
   return true;
 }
 
+bool ContextualFailure::diagnoseAsNote() {
+  auto overload = getChoiceFor(getLocator());
+  if (!(overload && overload->choice.isDecl()))
+    return false;
+
+  auto *decl = overload->choice.getDecl();
+  emitDiagnostic(decl, diag::found_candidate_type, getFromType());
+  return true;
+}
+
 static Optional<Diag<Type>>
 getContextualNilDiagnostic(ContextualTypePurpose CTP) {
   switch (CTP) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1440,6 +1440,17 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
   return failure.diagnose();
 }
 
+bool RValueTreatedAsLValueFailure::diagnoseAsNote() {
+  auto overload = getChoiceFor(getLocator());
+  if (!(overload && overload->choice.isDecl()))
+    return false;
+
+  auto *decl = overload->choice.getDecl();
+  emitDiagnostic(decl, diag::candidate_is_not_assignable,
+                 decl->getDescriptiveKind(), decl->getFullName());
+  return true;
+}
+
 static Decl *findSimpleReferencedDecl(const Expr *E) {
   if (auto *LE = dyn_cast<LoadExpr>(E))
     E = LE->getSubExpr();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -722,6 +722,8 @@ public:
 
   bool diagnoseAsError() override;
 
+  bool diagnoseAsNote() override;
+
   /// If we're trying to convert something to `nil`.
   bool diagnoseConversionToNil() const;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2010,7 +2010,7 @@ private:
   /// valid for the duration of the call, and suggests an alternative to use.
   void emitSuggestionNotes() const;
 };
-	
+
 class AssignmentTypeMismatchFailure final : public ContextualFailure {
 public:
   AssignmentTypeMismatchFailure(ConstraintSystem &cs,
@@ -2023,6 +2023,17 @@ public:
 
 private:
   bool diagnoseMissingConformance() const;
+};
+
+class MissingContextualBaseInMemberRefFailure final : public FailureDiagnostic {
+  DeclName MemberName;
+
+public:
+  MissingContextualBaseInMemberRefFailure(ConstraintSystem &cs, DeclName member,
+                                          ConstraintLocator *locator)
+      : FailureDiagnostic(cs, locator), MemberName(member) {}
+
+  bool diagnoseAsError();
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -638,6 +638,7 @@ public:
       : FailureDiagnostic(cs, locator) {}
 
   bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
 };
 
 class TrailingClosureAmbiguityFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1050,7 +1050,9 @@ std::string TreatEphemeralAsNonEphemeral::getName() const {
 }
 
 bool SpecifyBaseTypeForContextualMember::diagnose(bool asNote) const {
-  return false;
+  auto &cs = getConstraintSystem();
+  MissingContextualBaseInMemberRefFailure failure(cs, MemberName, getLocator());
+  return failure.diagnose(asNote);
 }
 
 SpecifyBaseTypeForContextualMember *SpecifyBaseTypeForContextualMember::create(

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -929,25 +929,29 @@ static bool isValueOfRawRepresentable(ConstraintSystem &cs,
 ExpandArrayIntoVarargs *
 ExpandArrayIntoVarargs::attempt(ConstraintSystem &cs, Type argType,
                                 Type paramType,
-                                ConstraintLocatorBuilder locator) {
-  auto constraintLocator = cs.getConstraintLocator(locator);
-  auto elementType = cs.isArrayType(argType);
-  if (elementType &&
-      constraintLocator->getLastElementAs<LocatorPathElt::ApplyArgToParam>()
-          ->getParameterFlags()
-          .isVariadic()) {
-    auto options = ConstraintSystem::TypeMatchOptions(
-        ConstraintSystem::TypeMatchFlags::TMF_ApplyingFix |
-        ConstraintSystem::TypeMatchFlags::TMF_GenerateConstraints);
-    auto result =
-        cs.matchTypes(*elementType, paramType,
-                      ConstraintKind::ArgumentConversion, options, locator);
-    if (result.isSuccess())
-      return new (cs.getAllocator())
-          ExpandArrayIntoVarargs(cs, argType, paramType, constraintLocator);
-  }
+                                ConstraintLocatorBuilder builder) {
+  auto *locator = cs.getConstraintLocator(builder);
 
-  return nullptr;
+  auto argLoc = locator->getLastElementAs<LocatorPathElt::ApplyArgToParam>();
+  if (!(argLoc && argLoc->getParameterFlags().isVariadic()))
+    return nullptr;
+
+  auto elementType = cs.isArrayType(argType);
+  if (!elementType)
+    return nullptr;
+
+  ConstraintSystem::TypeMatchOptions options;
+  options |= ConstraintSystem::TypeMatchFlags::TMF_ApplyingFix;
+  options |= ConstraintSystem::TypeMatchFlags::TMF_GenerateConstraints;
+
+  auto result = cs.matchTypes(*elementType, paramType, ConstraintKind::Subtype,
+                              options, builder);
+
+  if (result.isFailure())
+    return nullptr;
+
+  return new (cs.getAllocator())
+      ExpandArrayIntoVarargs(cs, argType, paramType, locator);
 }
 
 bool ExpandArrayIntoVarargs::diagnose(bool asNote) const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1048,3 +1048,13 @@ std::string TreatEphemeralAsNonEphemeral::getName() const {
   name += ::getName(ConversionKind);
   return name;
 }
+
+bool SpecifyBaseTypeForContextualMember::diagnose(bool asNote) const {
+  return false;
+}
+
+SpecifyBaseTypeForContextualMember *SpecifyBaseTypeForContextualMember::create(
+    ConstraintSystem &cs, DeclName member, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      SpecifyBaseTypeForContextualMember(cs, member, locator);
+}

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -223,6 +223,10 @@ enum class FixKind : uint8_t {
   /// Allow an ephemeral argument conversion for a parameter marked as being
   /// non-ephemeral.
   TreatEphemeralAsNonEphemeral,
+
+  /// Base type in reference to the contextual member e.g. `.foo` couldn't be
+  /// inferred and has to be specified explicitly.
+  SpecifyBaseTypeForContextualMember,
 };
 
 class ConstraintFix {
@@ -1533,6 +1537,27 @@ public:
   create(ConstraintSystem &cs, ConstraintLocator *locator, Type srcType,
          Type dstType, ConversionRestrictionKind conversionKind,
          bool downgradeToWarning);
+};
+
+class SpecifyBaseTypeForContextualMember final : public ConstraintFix {
+  DeclName MemberName;
+
+  SpecifyBaseTypeForContextualMember(ConstraintSystem &cs, DeclName member,
+                                     ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::SpecifyBaseTypeForContextualMember, locator),
+        MemberName(member) {}
+
+public:
+  std::string getName() const {
+    const auto baseName = MemberName.getBaseName();
+    return "specify base type in reference to member '" +
+           baseName.userFacingName().str() + "'";
+  }
+
+  bool diagnose(bool asNote = false) const;
+
+  static SpecifyBaseTypeForContextualMember *
+  create(ConstraintSystem &cs, DeclName member, ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1507,10 +1507,13 @@ namespace {
 
       auto memberLocator
         = CS.getConstraintLocator(expr, ConstraintLocator::UnresolvedMember);
-      auto baseTy = CS.createTypeVariable(baseLocator, TVO_CanBindToNoEscape);
-      auto memberTy = CS.createTypeVariable(memberLocator,
-                                            TVO_CanBindToLValue |
-                                            TVO_CanBindToNoEscape);
+
+      // Since base type in this case is completely dependent on context it
+      // should be marked as a potential hole.
+      auto baseTy = CS.createTypeVariable(baseLocator, TVO_CanBindToNoEscape |
+                                                           TVO_CanBindToHole);
+      auto memberTy = CS.createTypeVariable(
+          memberLocator, TVO_CanBindToLValue | TVO_CanBindToNoEscape);
 
       // An unresolved member expression '.member' is modeled as a value member
       // constraint

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2846,6 +2846,22 @@ bool ConstraintSystem::repairFailures(
       }
     }
 
+    if (auto *OEE = dyn_cast<OptionalEvaluationExpr>(anchor)) {
+      // If concrete type of the sub-expression can't be converted to the
+      // type associated with optional evaluation result it could only be
+      // contextual mismatch where type of the top-level expression
+      // comes from contextual type or its parent expression.
+      //
+      // Because result type of the optional evaluation is supposed to
+      // represent the type of its sub-expression with added level of
+      // optionality if needed.
+      if (!lhs->getOptionalObjectType() && !lhs->hasTypeVariable()) {
+        conversionsOrFixes.push_back(IgnoreContextualType::create(
+            *this, lhs, rhs, getConstraintLocator(OEE->getSubExpr())));
+        return true;
+      }
+    }
+
     if (auto *AE = dyn_cast<AssignExpr>(anchor)) {
       if (repairByInsertingExplicitCall(lhs, rhs))
         return true;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2815,6 +2815,14 @@ bool ConstraintSystem::repairFailures(
       return true;
     }
 
+    if (auto *ODRE = dyn_cast<OverloadedDeclRefExpr>(anchor)) {
+      if (lhs->is<LValueType>()) {
+        conversionsOrFixes.push_back(
+            TreatRValueAsLValue::create(*this, getConstraintLocator(locator)));
+        return true;
+      }
+    }
+
     if (auto *AE = dyn_cast<AssignExpr>(anchor)) {
       if (repairByInsertingExplicitCall(lhs, rhs))
         return true;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2583,10 +2583,10 @@ static void diagnoseOperatorAmbiguity(ConstraintSystem &cs,
   if (!applyExpr)
     return;
 
-  auto isNameOfStandardComparisonOperator = [](StringRef opName) -> bool {
-    return opName == "==" || opName == "!=" || opName == "===" ||
-           opName == "!==" || opName == "<" || opName == ">" ||
-           opName == "<=" || opName == ">=";
+  auto isNameOfStandardComparisonOperator = [](Identifier opName) -> bool {
+    return opName.is("==") || opName.is("!=") || opName.is("===") ||
+           opName.is("!==") || opName.is("<") || opName.is(">") ||
+           opName.is("<=") || opName.is(">=");
   };
 
   auto isEnumWithAssociatedValues = [](Type type) -> bool {
@@ -2609,7 +2609,7 @@ static void diagnoseOperatorAmbiguity(ConstraintSystem &cs,
           .highlight(lhs->getSourceRange())
           .highlight(rhs->getSourceRange());
 
-      if (isNameOfStandardComparisonOperator(operatorName.str()) &&
+      if (isNameOfStandardComparisonOperator(operatorName) &&
           isEnumWithAssociatedValues(lhsType)) {
         DE.diagnose(applyExpr->getLoc(),
                     diag::no_binary_op_overload_for_enum_with_payload,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2701,6 +2701,10 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
       DE.diagnose(commonAnchor->getLoc(),
                   diag::could_not_find_subscript_member_did_you_mean,
                   getType(UDE->getBase()));
+    } else if (fix->getKind() == FixKind::TreatRValueAsLValue) {
+      DE.diagnose(commonAnchor->getLoc(),
+                  diag::no_overloads_match_exactly_in_assignment,
+                  decl->getBaseName());
     } else {
       auto name = decl->getFullName();
       // Three choices here:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2147,7 +2147,7 @@ public:
   void diagnoseFailureForExpr(Expr *expr);
 
   bool diagnoseAmbiguity(ArrayRef<Solution> solutions);
-  bool diagnoseAmbiguityWithFixes(ArrayRef<Solution> solutions);
+  bool diagnoseAmbiguityWithFixes(SmallVectorImpl<Solution> &solutions);
 
   /// Give the deprecation warning for referring to a global function
   /// when there's a method from a conditional conformance in a smaller/closer

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -717,7 +717,7 @@ func rdar37790062() {
 }
 
 // <rdar://problem/39489003>
-typealias KeyedItem<K, T> = (key: K, value: T) // expected-note {{'T' declared as parameter to type 'KeyedItem'}}
+typealias KeyedItem<K, T> = (key: K, value: T)
 
 protocol Node {
   associatedtype T
@@ -731,7 +731,7 @@ extension Node {
   func getChild(for key:K)->(key: K, value: T) {
     return children.first(where: { (item:KeyedItem) -> Bool in
         return item.key == key
-        // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+        // expected-error@-1 {{binary operator '==' cannot be applied to two 'Self.K' operands}}
       })!
   }
 }

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -60,6 +60,7 @@ Optional<Int>(1) // expected-warning{{unused}}
 Optional(1) // expected-warning{{unused}}
 _ = .none as Optional<Int>
 Optional(.none) // expected-error{{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{9-9=<Any>}}
+// expected-error@-1 {{cannot infer contextual base in reference to member 'none'}}
 
 // Interpolation
 _ = "\(hello), \(world) #\(i)!"

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1288,7 +1288,7 @@ func badTypes() {
 // rdar://34357545
 func unresolvedTypeExistential() -> Bool {
   return (Int.self==_{})
-  // expected-error@-1 {{ambiguous reference to member '=='}}
+  // expected-error@-1 {{expression type 'Bool' is ambiguous without more context}}
 }
 
 func rdar43525641(_ a: Int, _ b: Int = 0, c: Int = 0, _ d: Int) {}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -498,8 +498,8 @@ enum Color {
   static var svar: Color { return .Red }
 }
 
-// FIXME: This used to be better: "'map' produces '[T]', not the expected contextual result type '(Int, Color)'"
-let _: (Int, Color) = [1,2].map({ ($0, .Unknown("")) }) // expected-error {{expression type '((Int) throws -> _) throws -> Array<_>' is ambiguous without more context}}
+let _: (Int, Color) = [1,2].map({ ($0, .Unknown("")) }) // expected-error {{cannot convert value of type 'Array<(Int, _)>' to specified type '(Int, Color)'}}
+// expected-error@-1 {{cannot infer contextual base in reference to member 'Unknown'}}
 
 let _: [(Int, Color)] = [1,2].map({ ($0, .Unknown("")) })// expected-error {{missing argument label 'description:' in call}}
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -920,13 +920,13 @@ class NSCache<K, V> {
 }
 
 class CacheValue {
-  func value(x: Int) -> Int {} // expected-note {{found this candidate}}
-  func value(y: String) -> String {} // expected-note {{found this candidate}}
+  func value(x: Int) -> Int {} // expected-note {{found candidate with type '(Int) -> Int'}}
+  func value(y: String) -> String {} // expected-note {{found candidate with type '(String) -> String'}}
 }
 
 func valueForKey<K>(_ key: K) -> CacheValue? {
   let cache = NSCache<K, CacheValue>()
-  return cache.object(forKey: key)?.value // expected-error {{ambiguous reference to member 'value(x:)'}}
+  return cache.object(forKey: key)?.value // expected-error {{no exact matches in call to instance method 'value'}}
 }
 
 // SR-2242: poor diagnostic when argument label is omitted

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -325,6 +325,7 @@ enum r23942743 {
   case Tomato(cloud: String)
 }
 let _ = .Tomato(cloud: .none)  // expected-error {{reference to member 'Tomato' cannot be resolved without a contextual type}}
+// expected-error@-1 {{cannot infer contextual base in reference to member 'none'}}
 
 
 

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -275,7 +275,9 @@ struct StaticMembers: Equatable {
   static var optProp: Optional = StaticMembers()
 
   static func method(_: Int) -> StaticMembers { return prop }
+  // expected-note@-1 {{found candidate with type '(Int) -> StaticMembers'}}
   static func method(withLabel: Int) -> StaticMembers { return prop }
+  // expected-note@-1 {{found candidate with type '(Int) -> StaticMembers'}}
   static func optMethod(_: Int) -> StaticMembers? { return optProp }
 
   static func ==(x: StaticMembers, y: StaticMembers) -> Bool { return true }
@@ -300,7 +302,7 @@ switch staticMembers {
   // TODO: repeated error message
   case .optProp: break // expected-error* {{not unwrapped}}
 
-  case .method: break // expected-error{{cannot match}}
+  case .method: break // expected-error{{no exact matches in call to static method 'method'}}
   case .method(0): break
   case .method(_): break // expected-error{{'_' can only appear in a pattern}}
   case .method(let x): break // expected-error{{cannot appear in an expression}}
@@ -379,10 +381,10 @@ func test8347() -> String {
       return ""
     }
 
-    func h() -> String { // expected-note {{found this candidate}}
+    func h() -> String {
       return ""
     }
-    func h() -> Double { // expected-note {{found this candidate}}
+    func h() -> Double {
       return 3.0
     }
     func h() -> Int? { //expected-note{{found this candidate}}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1657,14 +1657,14 @@ public extension Optional {
 // https://bugs.swift.org/browse/SR-6837
 
 // FIXME: Can't overlaod local functions so these must be top-level
-func takePairOverload(_ pair: (Int, Int?)) {} // expected-note {{found this candidate}}
-func takePairOverload(_: () -> ()) {} // expected-note {{found this candidate}}
+func takePairOverload(_ pair: (Int, Int?)) {}
+func takePairOverload(_: () -> ()) {}
 
 do {
   func takeFn(fn: (_ i: Int, _ j: Int?) -> ()) {}
   func takePair(_ pair: (Int, Int?)) {}
   takeFn(fn: takePair) // expected-error {{cannot convert value of type '((Int, Int?)) -> ()' to expected argument type '(Int, Int?) -> ()'}}
-  takeFn(fn: takePairOverload) // expected-error {{ambiguous reference to member 'takePairOverload'}}
+  takeFn(fn: takePairOverload) // expected-error {{cannot convert value of type '((Int, Int?)) -> ()' to expected argument type '(Int, Int?) -> ()'}}
   takeFn(fn: { (pair: (Int, Int?)) in } ) // Disallow for -swift-version 4 and later
   // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
   takeFn { (pair: (Int, Int?)) in } // Disallow for -swift-version 4 and later

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -7,7 +7,7 @@
 func identity<T>(_ value: T) -> T { return value }
 
 func identity2<T>(_ value: T) -> T { return value }
-// expected-note@-1 {{candidate expects value of type 'X' for parameter #1}}
+// expected-note@-1 {{'identity2' produces 'Y', not the expected contextual result type 'X'}}
 func identity2<T>(_ value: T) -> Int { return 0 }
 // expected-note@-1 {{'identity2' produces 'Int', not the expected contextual result type 'X'}}
 

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -78,9 +78,9 @@ protocol Overload {
   func f1(_: B) -> B // expected-note {{candidate expects value of type 'OtherOvl.B' for parameter #1}}
   func f2(_: Int) -> A // expected-note{{found this candidate}}
   func f2(_: Int) -> B // expected-note{{found this candidate}}
-  func f3(_: Int) -> Int // expected-note {{found this candidate}}
-  func f3(_: Float) -> Float // expected-note {{found this candidate}}
-  func f3(_: Self) -> Self // expected-note {{found this candidate}}
+  func f3(_: Int) -> Int // expected-note {{found candidate with type '(Int) -> Int'}}
+  func f3(_: Float) -> Float // expected-note {{found candidate with type '(Float) -> Float'}}
+  func f3(_: Self) -> Self // expected-note {{found candidate with type '(OtherOvl) -> OtherOvl'}}
 
   var prop : Self { get }
 }
@@ -112,7 +112,7 @@ func testOverload<Ovl : Overload, OtherOvl : Overload>(_ ovl: Ovl, ovl2: Ovl,
   var f3f : (Float) -> Float = ovl.f3
   var f3ovl_1 : (Ovl) -> Ovl = ovl.f3
   var f3ovl_2 : (Ovl) -> Ovl = ovl2.f3
-  var f3ovl_3 : (Ovl) -> Ovl = other.f3 // expected-error{{ambiguous reference to member 'f3'}}
+  var f3ovl_3 : (Ovl) -> Ovl = other.f3 // expected-error{{no 'f3' candidates produce the expected contextual result type '(Ovl) -> Ovl'}}
 
   var f3i_unbound : (Ovl) -> (Int) -> Int = Ovl.f3
   var f3f_unbound : (Ovl) -> (Float) -> Float = Ovl.f3

--- a/test/Interpreter/SDK/misc_osx.swift
+++ b/test/Interpreter/SDK/misc_osx.swift
@@ -7,8 +7,7 @@ import CoreServices
 func testFSEventStreamRef(stream: FSEventStreamRef) {
   // FIXME: These should be distinct types, constructible from one another.
   _ = stream as ConstFSEventStreamRef // works by coincidence because both are currently OpaquePointer
-  _ = ConstFSEventStreamRef(stream) // expected-error {{cannot invoke initializer for type 'ConstFSEventStreamRef' with an argument list of type '(FSEventStreamRef)'}}
-  // expected-note @-1 {{overloads for 'ConstFSEventStreamRef' exist with these partially matching parameter lists:}}
+  _ = ConstFSEventStreamRef(stream) // expected-error {{no exact matches in call to initializer}}
 
   // This is not a CF object.
   FSEventStreamRetain(stream) // no-warning

--- a/test/NameBinding/import-resolution-overload.swift
+++ b/test/NameBinding/import-resolution-overload.swift
@@ -46,7 +46,7 @@ scopedFunction = 42
 // FIXME: Should be an error -- a type name and a function cannot overload.
 var _ : Int = TypeNameWins(42)
 
-TypeNameWins = 42 // expected-error {{ambiguous reference to member 'TypeNameWins'}}
+TypeNameWins = 42 // expected-error {{no exact matches in assignment to 'TypeNameWins'}}
 var _ : TypeNameWins // no-warning
 
 // rdar://problem/21739333

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -26,10 +26,10 @@ struct S {
     f({x in x}, 2) // expected-error {{generic parameter 'T' could not be inferred}}
   }
   
-  func g<T>(_ a: T, _ b: Int) -> Void {} // expected-note {{in call to function 'g'}}
+  func g<T>(_ a: T, _ b: Int) -> Void {}
   func g(_ a: String) -> Void {}
   func test2() -> Void {
-    g(.notAThing, 7) // expected-error {{generic parameter 'T' could not be inferred}}
+    g(.notAThing, 7) // expected-error {{cannot infer contextual base in reference to member 'notAThing'}}
   }
   
   func h(_ a: Int, _ b: Int) -> Void {}

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -115,7 +115,6 @@ struct StructWithoutExplicitConformance {
 
 func structWithoutExplicitConformance() {
   if StructWithoutExplicitConformance(a: 1, b: "b") == StructWithoutExplicitConformance(a: 2, b: "a") { } // expected-error{{binary operator '==' cannot be applied to two 'StructWithoutExplicitConformance' operands}}
-  // expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists: }}
 }
 
 // Structs with non-hashable/equatable stored properties don't derive conformance.

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -100,7 +100,8 @@ func test3a(_ a: ZeroOneTwoThree) {
   // Overload resolution can resolve this to the right constructor.
   var h = ZeroOneTwoThree(1)
   
-  var i = 0 > 3 ? .none : .some(3) // expected-error {{reference to member 'none' cannot be resolved without a contextual type}}
+  var i = 0 > 3 ? .none : .some(3) // expected-error {{cannot infer contextual base in reference to member 'none'}}
+  // expected-error@-1 {{cannot infer contextual base in reference to member 'some'}}
   
   test3a;  // expected-error {{unused function}}
   .Zero   // expected-error {{reference to member 'Zero' cannot be resolved without a contextual type}}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -349,9 +349,9 @@ func testUnresolvedMemberSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
 struct SubscriptTest1 {
   subscript(keyword:String) -> Bool { return true }
-  // expected-note@-1 4 {{found this candidate}}
+  // expected-note@-1 3 {{found this candidate}} expected-note@-1 {{found candidate with type 'Bool'}}
   subscript(keyword:String) -> String? {return nil }
-  // expected-note@-1 4 {{found this candidate}}
+  // expected-note@-1 3 {{found this candidate}} expected-note@-1 {{found candidate with type 'String?'}}
 
   subscript(arg: SubClass) -> Bool { return true } // expected-note {{declared here}}
   subscript(arg: Protocol) -> Bool { return true } // expected-note 2 {{declared here}}
@@ -361,7 +361,7 @@ struct SubscriptTest1 {
 }
 
 func testSubscript1(_ s1 : SubscriptTest1) {
-  let _ : Int = s1["hello"]  // expected-error {{ambiguous subscript with base type 'SubscriptTest1' and index type 'String'}}
+  let _ : Int = s1["hello"]  // expected-error {{no 'subscript' candidates produce the expected contextual result type 'Int'}}
 
   if s1["hello"] {}
 

--- a/test/expr/closure/anonymous.swift
+++ b/test/expr/closure/anonymous.swift
@@ -27,17 +27,17 @@ func variadic() {
   let _: (Int...) -> () = {let _: [Int] = $0}
   // expected-error@-1 {{cannot convert value of type '(_) -> ()' to specified type '(Int...) -> ()'}}
 
-  // FIXME: Make the rest work
   takesVariadicInt({takesIntArray($0)})
-  // expected-error@-1 {{cannot convert value of type '([Int]) -> ()' to expected argument type '(Int...) -> ()'}}
+  // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
 
   let _: (Int...) -> () = {takesIntArray($0)}
-  // expected-error@-1 {{cannot convert value of type '([Int]) -> ()' to specified type '(Int...) -> ()'}}
+  // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
 
-  // TODO(diagnostics): This requires special handling - variadic vs. array
   takesVariadicGeneric({takesIntArray($0)})
-  // expected-error@-1 {{cannot convert value of type 'Array<_>' to expected argument type '[Int]'}}
-  // expected-note@-2 {{arguments to generic parameter 'Element' ('_' and 'Int') are expected to be equal}}
+  // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
+
+  // FIXME(diagnostics): Problems here are related to multi-statement closure bodies not being type-checked together with
+  // enclosing context.
 
   takesVariadicGeneric({let _: [Int] = $0})
   // expected-error@-1 {{cannot convert value of type '(_) -> ()' to expected argument type '(_...) -> ()'}}

--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -8,8 +8,8 @@ struct ContentView : View {
   @State var foo: [String] = Array(repeating: "", count: 5)
 
   var body: some View {
-    VStack {
-      HStack { // expected-error {{ambiguous reference to member 'buildBlock()'}}
+    VStack { // expected-error {{unable to infer complex closure return type; add explicit type to disambiguate}}
+      HStack {
         Text("")
         TextFi // expected-error {{use of unresolved identifier 'TextFi'}}
       }

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -3,13 +3,13 @@
 // RUN: %line-directive %t/main.swift -- %target-swift-frontend -typecheck -verify -swift-version 4.2 %t/main.swift
 
 func testUnaryMinusInUnsigned() {
-  var a: UInt8 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt8'}} expected-note * {{}} expected-warning * {{}}
+  var a: UInt8 = -(1) // expected-error {{no '-' candidates produce the expected contextual result type 'UInt8'}} expected-note * {{}} expected-warning * {{}}
 
-  var b: UInt16 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt16'}} expected-note * {{}} expected-warning * {{}}
+  var b: UInt16 = -(1) // expected-error {{no '-' candidates produce the expected contextual result type 'UInt16'}} expected-note * {{}} expected-warning * {{}}
 
-  var c: UInt32 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt32'}} expected-note * {{}} expected-warning * {{}}
+  var c: UInt32 = -(1) // expected-error {{no '-' candidates produce the expected contextual result type 'UInt32'}} expected-note * {{}} expected-warning * {{}}
 
-  var d: UInt64 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt64'}} expected-note * {{}} expected-warning * {{}}
+  var d: UInt64 = -(1) // expected-error {{no '-' candidates produce the expected contextual result type 'UInt64'}} expected-note * {{}} expected-warning * {{}}
 }
 
 // Int and UInt are not identical to any fixed-size integer type


### PR DESCRIPTION
Port and obsolete CSDiag logic related to diagnosing constraint failures - `diagnoseGeneral*Failures`.

- Fix single tuple vs. N arguments in function conversions
- Diagnose an attempt to assign a value to an overloaded name
- Diagnose ambiguities related to contextual type mismatch
- Detect passing array to variadic argument in function conversions
- Improve handling of ambiguities related to fixes
- Detect contextual type mismatches associated with optional evaluation
- Fix inability to infer contextual base type for member ref

Resolves: rdar://problem/56559847
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
