### PR TITLE
Fix getDirectlyInheritedNominalTypeDecls

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -334,7 +334,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<ArrayRef<Requirement>> evaluate(Evaluator &evaluator, ProtocolDecl *proto) const;
+  llvm::Expected<ArrayRef<Requirement>> evaluate(Evaluator &evaluator,
+                                                 ProtocolDecl *proto) const;
 
 public:
   // Separate caching.

--- a/test/Interpreter/Inputs/dynamic_replacement_protocol_self_orig.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_protocol_self_orig.swift
@@ -1,0 +1,56 @@
+protocol View {
+  associatedtype Body: View
+
+  var body: Self.Body { get }
+}
+
+extension Never: View {
+  typealias Body = Never
+
+  var body: Self.Body { fatalError() }
+}
+
+struct AnyView: View {
+  var body: Never { fatalError() }
+}
+
+protocol ViewModelRenderable {
+  var view: AnyView { get }
+}
+
+extension ViewModelRenderable where Self: SectionModel {
+  static func view<Model, MyView: SectionViewModelView>(for model: Model, ofType: MyView.Type) -> AnyView where Model == MyView.BodyViewModel {
+    fatalError()
+  }
+}
+
+protocol SectionViewModelView where Self: View {
+  associatedtype BodyViewModel: SectionModel
+
+  init(bodyViewModel: BodyViewModel)
+}
+
+public protocol SectionModel: Codable {
+  var sectionName: String { get }
+}
+
+extension SectionModel {
+  public var sectionName: String {
+    "Hello world!"
+  }
+}
+
+struct NewUserModel: SectionModel {
+}
+
+extension NewUserModel: ViewModelRenderable {
+  var view: AnyView { Self.view(for: self, ofType: NewUserView.self) }
+}
+
+struct NewUserView: SectionViewModelView {
+  var bodyViewModel: NewUserModel = .init()
+
+  var body: Never {
+    fatalError()
+  }
+}

--- a/test/Interpreter/dynamic_replacement_protocol_self.swift
+++ b/test/Interpreter/dynamic_replacement_protocol_self.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(TestModuleLinking)) -module-name TestModuleLinking -emit-module -emit-module-path %t/TestModuleLinking.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_protocol_self_orig.swift -Xfrontend -enable-private-imports -Xfrontend -enable-implicit-dynamic
+// RUN: %target-build-swift -I%t -L%t -lTestModuleLinking -o %t/main %target-rpath(%t) %s -swift-version 5
+// RUN: %target-codesign %t/main %t/%target-library-name(TestModuleLinking)
+// RUN: %target-run %t/main %t/%target-library-name(TestModuleLinking) %t/%target-library-name(TestModuleLinking)
+
+// N.B. We're not actually executing anything here - all we care about is
+// if the linker is content.
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
+
+@_private(sourceFile: "dynamic_replacement_protocol_self_orig.swift") import TestModuleLinking
+
+extension NewUserModel {
+  @_dynamicReplacement(for: view) private var __preview__view: AnyView {
+    Self.view(for: self, ofType: NewUserView.self)
+  }
+}
+
+typealias NewUserModel = TestModuleLinking.NewUserModel


### PR DESCRIPTION
`getDirectlyInheritedNominalTypeDecls` looks for inherited protocols in two places: the actual inheritance clause of a declaration and the trailing where clause.  This works fine for normal declarations, but deserialized protocols that have Self constraints have no trailing where clause and appear to have no super-protocol bounds.  This means clients can potentially disagree about the structure of the protocol, and any symbols derived from it.

The test case demonstrates this problem directly: We build a hollowed-out SwiftUI preview provider then try to dynamically replace a requirement in a Self-constrained protocol extension.  The SwiftUI module sees the where clause, but when we go to deserialize the module in the "Preview" the protocol extension sees the wrong inheritance bounds and mis-mangles the call to `Self.view(for:ofType:)`.

The fix is to ask the requirement signature for Self requirements that would normally appear on a trailing where clause.

Resolves rdar://57150777