### PR TITLE
[windows] Enable symbolic references in PE/COFF. 

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -119,19 +119,6 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
         }
       }
 
-      // TODO: ObjectMemoryReader for PE platforms still does not
-      // implement symbol relocations. For now, on non-Mach-O platforms,
-      // only symbolic reference things in the same module.
-      if (IGM.TargetInfo.OutputObjectFormat != llvm::Triple::MachO
-          && IGM.TargetInfo.OutputObjectFormat != llvm::Triple::ELF) {
-        auto formalAccessScope = type->getFormalAccessScope(nullptr, true);
-        if ((formalAccessScope.isPublic() || formalAccessScope.isInternal()) &&
-            (!IGM.CurSourceFile ||
-             IGM.CurSourceFile != type->getParentSourceFile())) {
-          return false;
-        }
-      }
-      
       return true;
     } else if (auto opaque = s.dyn_cast<const OpaqueTypeDecl *>()) {
       // Always symbolically reference opaque types.

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -1,3 +1,5 @@
+// XFAIL: OS=windows-msvc
+
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -I %S/Inputs

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1,4 +1,5 @@
 // REQUIRES: no_asan
+// XFAIL: OS=windows-msvc
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -19,7 +19,6 @@
 
 // RUN: %target-build-swift -O -wmo -module-name=Main -I%t %s -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil | %FileCheck %s -check-prefix=CHECK-SIL
 
-
 import Test
 
 


### PR DESCRIPTION
In order for the cross-module optimization to work, it needs to generate
symbolic references, which were disabled in PE/COFF. This commit enables
them and marks some Reflection tests with XFAIL since
swift-reflection-dump still doesn't handle symbolic references.

Introduced in #28407 and first seen in https://ci-external.swift.org/job/oss-swift-windows-x86_64/2104/