### PR TITLE
Remove the "-resolve-imports" frontend mode.

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -606,7 +606,7 @@ public:
   ///
   /// Like a parse-only invocation, a single file is required. Unlike a
   /// parse-only invocation, module imports will be processed.
-  void performParseAndResolveImportsOnly();
+  void performParseAndNameBinding();
 
   /// Performs mandatory, diagnostic, and optimization passes over the SIL.
   /// \param silModule The SIL module that was generated during SILGen.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -88,7 +88,6 @@ public:
   enum class ActionType {
     NoneAction,        ///< No specific action
     Parse,             ///< Parse only
-    ResolveImports,    ///< Parse and resolve imports only
     Typecheck,         ///< Parse and type-check only
     DumpParse,         ///< Parse only and dump AST
     DumpInterfaceHash, ///< Parse and dump the interface token hash.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -790,9 +790,6 @@ def fixit_all : Flag<["-"], "fixit-all">,
 def parse: Flag<["-"], "parse">,
   HelpText<"Parse input file(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
-def resolve_imports : Flag<["-"], "resolve-imports">,
-  HelpText<"Parse and resolve imports in input file(s)">, ModeOpt,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def typecheck : Flag<["-"], "typecheck">,
   HelpText<"Parse and type-check input file(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1480,7 +1480,6 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       break;
 
     case options::OPT_parse:
-    case options::OPT_resolve_imports:
     case options::OPT_typecheck:
     case options::OPT_dump_parse:
     case options::OPT_emit_syntax:

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -339,8 +339,6 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::EmitImportedModules;
   if (Opt.matches(OPT_parse))
     return FrontendOptions::ActionType::Parse;
-  if (Opt.matches(OPT_resolve_imports))
-    return FrontendOptions::ActionType::ResolveImports;
   if (Opt.matches(OPT_typecheck))
     return FrontendOptions::ActionType::Typecheck;
   if (Opt.matches(OPT_dump_parse))

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -681,7 +681,7 @@ shouldImplicityImportSwiftOnoneSupportModule(CompilerInvocation &Invocation) {
       || FrontendOptions::doesActionGenerateSIL(options.RequestedAction);
 }
 
-void CompilerInstance::performParseAndResolveImportsOnly() {
+void CompilerInstance::performParseAndNameBinding() {
   performSemaUpTo(SourceFile::NameBound);
 }
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -31,7 +31,6 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -70,7 +69,6 @@ bool FrontendOptions::isActionImmediate(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -148,7 +146,6 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
     return TY_Nothing;
 
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -224,7 +221,6 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::REPL:
   case ActionType::DumpPCM:
     return false;
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -248,7 +244,6 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -293,7 +288,6 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -344,7 +338,6 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
     return false;
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -367,7 +360,6 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -408,7 +400,6 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -444,7 +435,6 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
 bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   switch (action) {
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -496,7 +486,6 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
     return false;
 
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -521,7 +510,6 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -568,7 +556,6 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
   case ActionType::Typecheck:
-  case ActionType::ResolveImports:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::EmitPCH:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1215,8 +1215,6 @@ static bool performCompile(CompilerInstance &Instance,
     Instance.performParseOnly(/*EvaluateConditionals*/
                     Action == FrontendOptions::ActionType::EmitImportedModules,
                               ParseDelayedDeclListsOnEnd);
-  } else if (Action == FrontendOptions::ActionType::ResolveImports) {
-    Instance.performParseAndResolveImportsOnly();
   } else {
     Instance.performSema();
   }
@@ -1227,9 +1225,6 @@ static bool performCompile(CompilerInstance &Instance,
 
   (void)emitMakeDependenciesIfNeeded(Context.Diags,
                                      Instance.getDependencyTracker(), opts);
-
-  if (Action == FrontendOptions::ActionType::ResolveImports)
-    return Context.hadError();
 
   if (observer)
     observer->performedSemanticAnalysis(Instance);

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-dependencies-path - -resolve-imports "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC %s
+// RUN: %target-swift-frontend -emit-dependencies-path - -typecheck "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC %s
 // RUN: %target-swift-frontend -emit-reference-dependencies-path - -typecheck -primary-file "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC-YAML %s
 
 // RUN: %target-swift-frontend -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file "%S/../Inputs/empty file.swift"
@@ -39,8 +39,8 @@
 // CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
 // CHECK-MULTIPLE-OUTPUTS-NOT: {{ }}:{{ }}
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 // CHECK-IMPORT-LABEL: - :

--- a/test/Frontend/supplementary-output-support.swift
+++ b/test/Frontend/supplementary-output-support.swift
@@ -14,15 +14,11 @@
 // PARSE_NO_REFERENCE_DEPS: error: this mode does not support emitting reference dependency files{{$}}
 // RUN: not %target-swift-frontend -dump-ast -emit-reference-dependencies %s 2>&1 | %FileCheck -check-prefix=DUMP_NO_REFERENCE_DEPS %s
 // DUMP_NO_REFERENCE_DEPS: error: this mode does not support emitting reference dependency files{{$}}
-// RUN: not %target-swift-frontend -resolve-imports -emit-reference-dependencies %s 2>&1 | %FileCheck -check-prefix=RESOLVE_IMPORTS_NO_REFERENCE_DEPS %s
-// RESOLVE_IMPORTS_NO_REFERENCE_DEPS: error: this mode does not support emitting reference dependency files{{$}}
 
 // RUN: not %target-swift-frontend -parse -emit-objc-header %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_OBJC_HEADER %s
 // PARSE_NO_OBJC_HEADER: error: this mode does not support emitting Objective-C headers{{$}}
 // RUN: not %target-swift-frontend -dump-ast -emit-objc-header %s 2>&1 | %FileCheck -check-prefix=DUMP_NO_OBJC_HEADER %s
 // DUMP_NO_OBJC_HEADER: error: this mode does not support emitting Objective-C headers{{$}}
-// RUN: not %target-swift-frontend -resolve-imports -emit-objc-header %s 2>&1 | %FileCheck -check-prefix=RESOLVE_IMPORTS_NO_OBJC_HEADER %s
-// RESOLVE_IMPORTS_NO_OBJC_HEADER: error: this mode does not support emitting Objective-C headers{{$}}
 
 // RUN: not %target-swift-frontend -parse -emit-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_INTERFACE %s
 // PARSE_NO_INTERFACE: error: this mode does not support emitting module interface files{{$}}

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -216,7 +216,7 @@ static bool swiftCodeCompleteImpl(
   SwiftConsumer.setContext(&CI.getASTContext(), &Invocation,
                            &CompletionContext);
   registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
+  CI.performParseAndNameBinding();
   SwiftConsumer.clearContext();
 
   return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -86,7 +86,7 @@ static bool swiftConformingMethodListImpl(
     return true;
   }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
+  CI.performParseAndNameBinding();
 
   return true;
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -85,7 +85,7 @@ static bool swiftTypeContextInfoImpl(SwiftLangSupport &Lang,
     return true;
   }
   registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
+  CI.performParseAndNameBinding();
 
   return true;
 }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -771,7 +771,7 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
+  CI.performParseAndNameBinding();
   return 0;
 }
 
@@ -840,7 +840,7 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
+  CI.performParseAndNameBinding();
   return 0;
 }
 
@@ -921,7 +921,7 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
   if (CI.setup(Invocation))
     return 1;
   registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
+  CI.performParseAndNameBinding();
   return 0;
 }
 


### PR DESCRIPTION
The "resolve imports" frontend mode was only ever partially baked. It
avoided type checking, but still did a lot of work to perform
resolution of imports, which included (e.g.) building .swiftmodules
from .swiftinterfaces and creating Clang modules. It will be
supplanted by the fast dependency scanning work.
