### PR TITLE
[test] Redirect stderr to a different file to avoid mixing with stdout.

### DIFF
--- a/test/Frontend/ast-dump.swift
+++ b/test/Frontend/ast-dump.swift
@@ -4,9 +4,9 @@
 // RUN: echo 'public func main() {a(); b()}' >%t/main.swift
 
 // Test printing to stdout
-// RUN: %target-swift-frontend -dump-ast -primary-file %t/a.swift %t/b.swift %t/main.swift -module-name main -o - 2>&1 | %FileCheck -check-prefix A-AST %s
-// RUN: %target-swift-frontend -dump-ast %t/a.swift -primary-file %t/b.swift %t/main.swift -module-name main -o - 2>&1 | %FileCheck -check-prefix B-AST %s
-// RUN: %target-swift-frontend -dump-ast %t/a.swift %t/b.swift -primary-file %t/main.swift -module-name main -o - 2>&1 | %FileCheck -check-prefix MAIN-AST %s
+// RUN: %target-swift-frontend -dump-ast -primary-file %t/a.swift %t/b.swift %t/main.swift -module-name main -o - 2>%t/a.swift.stderr | %FileCheck -check-prefix A-AST %s
+// RUN: %target-swift-frontend -dump-ast %t/a.swift -primary-file %t/b.swift %t/main.swift -module-name main -o - 2>%t/b.swift.stderr | %FileCheck -check-prefix B-AST %s
+// RUN: %target-swift-frontend -dump-ast %t/a.swift %t/b.swift -primary-file %t/main.swift -module-name main -o - 2>%t/main.swift.stderr | %FileCheck -check-prefix MAIN-AST %s
 
 // Test printing to files
 // RUN: %target-swift-frontend -dump-ast -primary-file %t/a.swift %t/b.swift %t/main.swift -module-name main -o %t/a.ast


### PR DESCRIPTION
In Windows stdout and stderr are not line buffered, so the output of
stderr can be intermixed with the stdout, which will break the test when
checking with CHECK-NEXT and similar. Additionally it seems that stderr
always contains at least one new line.

Redirecting stderr to a file removes the problems with the mixing, and
since the stderr is not checked for this test, should not change
anything.
