### PR TITLE
SILGen: Fix crash when referencing dynamic Self from @convention(c) closure

### DIFF
--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -170,7 +170,7 @@ public:
 
   ArrayRef<CapturedValue> getCaptures() const {
     // FIXME: Ideally, everywhere that synthesizes a function should include
-    // its capture info.
+    // its capture info.
     if (!hasBeenComputed())
       return None;
     return StorageAndFlags.getPointer()->getCaptures();
@@ -188,7 +188,7 @@ public:
   /// \returns true if the function captures any generic type parameters.
   bool hasGenericParamCaptures() const {
     // FIXME: Ideally, everywhere that synthesizes a function should include
-    // its capture info.
+    // its capture info.
     if (!hasBeenComputed())
       return false;
     return StorageAndFlags.getInt().contains(Flags::HasGenericParamCaptures);
@@ -202,7 +202,7 @@ public:
   /// \returns the captured dynamic Self type, if any.
   DynamicSelfType *getDynamicSelfType() const {
     // FIXME: Ideally, everywhere that synthesizes a function should include
-    // its capture info.
+    // its capture info.
     if (!hasBeenComputed())
       return nullptr;
     return StorageAndFlags.getPointer()->getDynamicSelfType();
@@ -214,7 +214,7 @@ public:
 
   OpaqueValueExpr *getOpaqueValue() const {
     // FIXME: Ideally, everywhere that synthesizes a function should include
-    // its capture info.
+    // its capture info.
     if (!hasBeenComputed())
       return nullptr;
     return StorageAndFlags.getPointer()->getOpaqueValue();

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -116,7 +116,7 @@ ERROR(unsupported_c_function_pointer_conversion,none,
 ERROR(c_function_pointer_from_function_with_context,none,
       "a C function pointer cannot be formed from a "
       "%select{local function|closure}0 that captures "
-      "%select{context|generic parameters|dynamic Self type|<<error>}1",
+      "%select{context|generic parameters|dynamic Self type}1",
       (bool, unsigned))
 
 ERROR(objc_selector_malformed,none,"the type ObjectiveC.Selector is malformed",

--- a/test/IDE/print_swift_module.swift
+++ b/test/IDE/print_swift_module.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/print_swift_module.swiftmodule -emit-module-doc -emit-module-doc-path %t/print_swift_module.swiftdoc %s
 // RUN: %target-swift-ide-test -print-module -print-interface -no-empty-line-between-members -module-to-print=print_swift_module -I %t -source-filename=%s > %t.syn.txt
+// RUN: %target-swift-ide-test -print-module -access-filter-internal -no-empty-line-between-members -module-to-print=print_swift_module -I %t -source-filename=%s > %t.syn.internal.txt
 // RUN: %FileCheck %s -check-prefix=CHECK1 < %t.syn.txt
+// RUN: %FileCheck %s -check-prefix=CHECK2 < %t.syn.internal.txt
 
 public protocol P1 {
   /// foo1 comment from P1
@@ -53,3 +55,14 @@ public struct City {
 
 // CHECK1:      /// returnsAlias() comment
 // CHECK1-NEXT: func returnsAlias() -> print_swift_module.Alias<Int>
+
+// CHECK2: struct Event {
+public struct Event {
+  public var start: Int
+  public var end: Int?
+  public var repeating: ((), Int?)
+  public var name = "untitled event"
+
+  // CHECK2: init(start: Int, end: Int? = nil, repeating: ((), Int?) = ((), nil), name: String = "untitled event")
+}
+// CHECK2: }

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -105,3 +105,10 @@ func pointers_to_nested_local_functions_in_generics<T>(x: T) -> Int{
 func capture_list_no_captures(x: Int) {
   calls({ [x] in $0 }, 0) // expected-warning {{capture 'x' was never used}}
 }
+
+class Selfless {
+  func capture_dynamic_self() {
+    calls_no_args { _ = Self.self; return 0 }
+    // expected-error@-1 {{a C function pointer cannot be formed from a closure that captures dynamic Self type}}
+  }
+}


### PR DESCRIPTION
Fixes <rdar://problem/57510056>.