### PR TITLE
Introduce LowLevel module with demangle function

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -60,6 +60,7 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(runtime)
   add_subdirectory(stubs)
   add_subdirectory(core)
+  add_subdirectory(LowLevel)
   add_subdirectory(SwiftOnoneSupport)
 endif()
 

--- a/stdlib/public/LowLevel/CMakeLists.txt
+++ b/stdlib/public/LowLevel/CMakeLists.txt
@@ -1,0 +1,22 @@
+#===--- CMakeLists.txt -----------------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===------------------------------------------------------------------------===#
+
+add_swift_target_library(swiftLowLevel ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  Demangle.swift
+
+  SWIFT_COMPILE_FLAGS
+    ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}
+  LINK_FLAGS
+    "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+  INSTALL_IN_COMPONENT
+    stdlib
+)

--- a/stdlib/public/LowLevel/Demangle.swift
+++ b/stdlib/public/LowLevel/Demangle.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftShims
+
+/// Given a mangled Swift symbol, demangle it into a human readable format.
+///
+/// Valid Swift symbols begin with the following prefixes:
+///   ┌─────────────────────╥────────┐
+///   │ Swift Version       ║ Prefix │
+///   ╞═════════════════════╬════════╡
+///   │ Swift 3 and below   ║   _T   │
+///   ├─────────────────────╫────────┤
+///   │ Swift 4             ║  _T0   │
+///   ├─────────────────────╫────────┤
+///   │ Swift 4.x           ║   $S   │
+///   ├─────────────────────╫────────┤
+///   │ Swift 5+            ║   $s   │
+///   └─────────────────────╨────────┘
+///
+/// - Parameters:
+///   - mangledName: A mangled Swift symbol.
+/// - Returns: A human readable demangled Swift symbol.
+public func demangle(
+  _ mangledName: String,
+  simplified: Bool = false
+) -> String? {
+  return mangledName.utf8CString.withUnsafeBufferPointer {
+    let demangledPtr = _swift_stdlib_demangle(
+      /* mangledName */ $0.baseAddress,
+      /* mangledNameLength */ $0.count - 1,
+      /* outputBuffer */ nil,
+      /* outputBufferSize */ nil,
+      /* flags */ simplified ? 0x2 : 0x1
+    )
+
+    guard demangledPtr != nil else {
+      return nil
+    }
+
+    let demangledName = String(cString: demangledPtr!)
+    _swift_stdlib_free(demangledPtr!)
+    return demangledName
+  }
+}

--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -59,6 +59,13 @@ int _swift_stdlib_putc_stderr(int C);
 SWIFT_RUNTIME_STDLIB_API
 __swift_size_t _swift_stdlib_getHardwareConcurrency(void);
 
+SWIFT_RUNTIME_STDLIB_API
+char *_swift_stdlib_demangle(const char *mangledName,
+                             __swift_size_t mangledNameLength,
+                             char *outputBuffer,
+                             __swift_size_t *outputBufferSize,
+                             __swift_uint32_t flags);
+
 /// Manually allocated memory is at least 16-byte aligned in Swift.
 ///
 /// When swift_slowAlloc is called with "default" alignment (alignMask ==

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -634,17 +634,14 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
   return nullptr;
 }
 
-// NB: This function is not used directly in the Swift codebase, but is
-// exported for Xcode support and is used by the sanitizers. Please coordinate
+// This function is exported for Xcode support, used by the sanitizers, and is
+// used by the demangle function in the LowLevel module. Please coordinate
 // before changing.
 char *swift_demangle(const char *mangledName,
                      size_t mangledNameLength,
                      char *outputBuffer,
                      size_t *outputBufferSize,
                      uint32_t flags) {
-  if (flags != 0) {
-    swift::fatalError(0, "Only 'flags' value of '0' is currently supported.");
-  }
   if (outputBuffer != nullptr && outputBufferSize == nullptr) {
     swift::fatalError(0, "'outputBuffer' is passed but the size is 'nullptr'.");
   }
@@ -654,9 +651,25 @@ char *swift_demangle(const char *mangledName,
   if (!Demangle::isSwiftSymbol(mangledName))
     return nullptr; // Not a mangled name
 
-  // Demangle the name.
   auto options = Demangle::DemangleOptions();
   options.DisplayDebuggerGeneratedModule = false;
+
+  // It's important that we use two bits here because we want to maintain
+  // compatibility with other clients that have been using this and passing
+  // 0 for the flag value.
+
+  // If the first bit is set, use swift-demangle's default options.
+  if (flags & 0x1) {
+    options.DisplayDebuggerGeneratedModule = true;
+    options.SynthesizeSugarOnTypes = true;
+  }
+
+  // If the second bit is set, use swift-demangle's simplified version.
+  if (flags & 0x2) {
+    options = Demangle::DemangleOptions::SimplifiedUIDemangleOptions();
+  }
+
+  // Demangle the name.
   auto result =
       Demangle::demangleSymbolAsString(mangledName,
                                        mangledNameLength,

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -76,6 +76,7 @@ static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
 #include <thread>
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
+#include "swift/Demangling/Demangle.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/SwiftDtoa.h"
 #include "swift/Basic/Lazy.h"
@@ -524,3 +525,11 @@ size_t swift::_swift_stdlib_getHardwareConcurrency() {
   return std::thread::hardware_concurrency();
 }
 
+char *swift::_swift_stdlib_demangle(const char *mangledName,
+                                    __swift_size_t mangledNameLength,
+                                    char *outputBuffer,
+                                    __swift_size_t *outputBufferSize,
+                                    __swift_uint32_t flags) {
+  return swift_demangle(mangledName, mangledNameLength, outputBuffer,
+                        outputBufferSize, flags);
+ }


### PR DESCRIPTION
This is the revised version for [SE-0262](https://github.com/apple/swift-evolution/blob/master/proposals/0262-demangle.md).

Changes this incorporates:
1. The removal of the unsafe variants of the demangle function
2. Addition of a new `LowLevel` (open 24/7 for bikeshedding) module where demangle and friend can reside in.
3. Support for `swift-demangle`'s default form and a `-simplified` form through the usage of the `simplified: Bool` parameter (defaults to false)