### PR TITLE
Remove another unicode character in debug message.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -5851,7 +5851,7 @@ public:
           << ": To differentiate or not to differentiate?\n";
       for (auto &inst : llvm::reverse(*bb)) {
         s << (getPullbackInfo().shouldDifferentiateInstruction(&inst)
-                  ? "[∂] " : "[ ] ")
+                  ? "[x] " : "[ ] ")
           << inst;
       }
     });


### PR DESCRIPTION
This causes encoding errors in the emacs editor.