### PR TITLE
Cross-module-optimization: Mark stored class properties as usableFromInline if they are used in a ref_element_addr instruction.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3115,7 +3115,7 @@ static AccessLevel getAdjustedFormalAccess(const ValueDecl *VD,
     return getMaximallyOpenAccessFor(VD);
 
   if (treatUsableFromInlineAsPublic &&
-      (access == AccessLevel::Internal || access == AccessLevel::Private) &&
+      access <= AccessLevel::Internal &&
       VD->isUsableFromInline()) {
     return AccessLevel::Public;
   }

--- a/test/SILOptimizer/Inputs/cross-module-objc.swift
+++ b/test/SILOptimizer/Inputs/cross-module-objc.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+final class ObjcClass : NSObject {
+  fileprivate var ii: Int = 127
+}
+
+@inline(never)
+func returnObjcClassMember<T>(_ c: ObjcClass, _ t: T) -> Int {
+  return c.ii
+}
+
+@inline(never)
+public func callObjcClassMember<T>(_ t: T) -> Int {
+  let c = ObjcClass()
+  return returnObjcClassMember(c, t)
+}
+

--- a/test/SILOptimizer/cross-module-optimization-objc.swift
+++ b/test/SILOptimizer/cross-module-optimization-objc.swift
@@ -1,0 +1,32 @@
+// First test: functional correctness
+
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O -wmo -parse-as-library -cross-module-optimization -emit-module -emit-module-path=%t/Test.swiftmodule -module-name=Test -I%t %S/Inputs/cross-module-objc.swift -c -o %t/test.o
+// RUN: %target-build-swift -O -wmo -module-name=Main -I%t %s -c -o %t/main.o
+// RUN: %target-swiftc_driver %t/main.o %t/test.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// Check if it also works if the main module is compiled with -Onone:
+
+// RUN: %target-build-swift -Onone -wmo -module-name=Main -I%t %s -c -o %t/main-onone.o
+// RUN: %target-swiftc_driver %t/main-onone.o %t/test.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// Second test: check if CMO really imports the SIL of functions in other modules.
+
+// RUN: %target-build-swift -O -wmo -module-name=Main -I%t %s -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil | %FileCheck %s -check-prefix=CHECK-SIL
+
+
+import Test
+
+func testClass() {
+  // CHECK-OUTPUT: 127
+  // CHECK-SIL-DAG: sil shared [noinline] @$s4Test21returnObjcClassMemberySiAA0cD0C_xtlFSi_Tg5
+  print(callObjcClassMember(0))
+}
+
+testClass()
+


### PR DESCRIPTION
Fixes a wrong linkage for direct field offset variables.