### PR TITLE
[CS] Fix key path dynamic member IUOs

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4253,7 +4253,7 @@ namespace {
         case KeyPathExpr::Component::Kind::UnresolvedProperty: {
           // If we couldn't resolve the component, leave it alone.
           if (!foundDecl) {
-            component = origComponent;
+            resolvedComponents.push_back(origComponent);
             break;
           }
 
@@ -4276,7 +4276,7 @@ namespace {
         case KeyPathExpr::Component::Kind::UnresolvedSubscript: {
           // Leave the component unresolved if the overload was not resolved.
           if (!foundDecl) {
-            component = origComponent;
+            resolvedComponents.push_back(origComponent);
             break;
           }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1550,6 +1550,7 @@ namespace {
                                        ctx.Id_dynamicMember, componentLoc,
                                        components);
         keyPath->resolveComponents(ctx, components);
+        cs.cacheExprTypes(keyPath);
         return keyPath;
       }
 
@@ -1640,10 +1641,9 @@ namespace {
       componentExpr->setType(ty);
       cs.cacheType(componentExpr);
 
-      cs.setType(keyPath, 0, ty);
-
       keyPath->setParsedPath(componentExpr);
       keyPath->resolveComponents(ctx, components);
+      cs.cacheExprTypes(keyPath);
       return keyPath;
     }
 


### PR DESCRIPTION
Previously we were only handling IUO unwrapping in `visitKeyPathExpr`, but not for callers that were building their own property and subscript components such as dynamic member lookup.

This PR moves the IUO unwrapping logic into `buildKeyPath[Property/Subscript]Component`, and adjusts their signatures to allow them to append multiple components. It also adds `buildKeyPathOptionalForceComponent` to allow more convenient adding of an optional force component.

Resolves SR-11893.