### PR TITLE
[WIP] EscapeAnalysis: rewrite canEscapeToUsePoint.

### DIFF
--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -836,15 +836,6 @@ void EscapeAnalysis::ConnectionGraph::computeUsePoints() {
 #endif
   // First scan the whole function and add relevant instructions as use-points.
   for (auto &BB : *F) {
-    for (SILArgument *BBArg : BB.getArguments()) {
-      /// In addition to releasing instructions (see below) we also add block
-      /// arguments as use points. In case of loops, block arguments can
-      /// "extend" the liferange of a reference in upward direction.
-      if (CGNode *ArgNode = lookupNode(BBArg)) {
-        addUsePoint(ArgNode, BBArg);
-      }
-    }
-
     for (auto &I : BB) {
       switch (I.getKind()) {
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1655,3 +1655,50 @@ bb10(%arg3 : $C):
   %66 = tuple ()
   return %66 : $()
 }
+
+// Test canEscapeToUsePoint with defer edges between non-reference-type nodes.
+//
+// Unfortunately, the only way I can think of to create defer edges
+// between non-reference nodes is with address-type block arguments.
+// This will be banned soon, so the test will need to be disabled, but
+// this is still an important corner case in the EscapeAnalysis
+// logic. To keep the test working, and be able to test many more
+// important corner cases, we should introduce testing modes that
+// introduce spurious but predictable defer edges and node merges.
+//
+// Here, canEscape to us called on %bbarg (%5) whose node is not
+// marked escaping. But it does have a defer edge to the local address
+// (%0) which does cause the address to escape via the call site.
+//
+// CHECK-LABEL: CG of testDeferPointer
+// CHECK-NEXT:   Val %0 Esc: G, Succ: (%0.1)
+// CHECK-NEXT:  Con %0.1 Esc: G, Succ:
+// CHECK-NEXT:  Val %1 Esc: %5, Succ: (%0.1)
+// CHECK-NEXT:  Val %5 Esc: %5, Succ: %0, %1
+// CHECK-LABEL: End
+// CHECK: NoEscape: %5 = argument of bb3 : $*Builtin.Int32
+// CHECK-NEXT:  to   %{{.*}} = apply %{{.*}}(%0) : $@convention(thin) (@inout Builtin.Int32) -> ()
+sil @takeAdr : $@convention(thin) (@inout Builtin.Int32) -> ()
+
+sil hidden @testDeferPointer : $@convention(thin) () -> () {
+bb0:
+  %iadr1 = alloc_stack $Builtin.Int32
+  %iadr2 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%iadr1: $*Builtin.Int32)
+
+bb2:
+  br bb3(%iadr2: $*Builtin.Int32)
+
+bb3(%bbarg: $*Builtin.Int32):
+  %val = integer_literal $Builtin.Int32, 1
+  store %val to %bbarg : $*Builtin.Int32
+  %ftake = function_ref @takeAdr : $@convention(thin) (@inout Builtin.Int32) -> ()
+  %call = apply %ftake(%iadr1) : $@convention(thin) (@inout Builtin.Int32) -> ()
+  dealloc_stack %iadr2 : $*Builtin.Int32
+  dealloc_stack %iadr1 : $*Builtin.Int32
+  %z = tuple ()
+  return %z : $()
+}

--- a/test/SILOptimizer/escape_analysis_dead_store.sil
+++ b/test/SILOptimizer/escape_analysis_dead_store.sil
@@ -1,0 +1,142 @@
+// RUN: %target-sil-opt %s -dead-store-elim -enable-sil-verify-all | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+final class X {
+  @objc deinit
+  init()
+}
+
+public struct S {
+  @_hasStorage var x: X { get set }
+  @_hasStorage var i: Int { get set }
+  init(x: X, i: Int)
+}
+
+@_hasStorage @_hasInitialValue var gg: X { get set }
+
+@inline(never) func takex(_ x: X)
+
+sil [noinline] @takeX : $@convention(thin) (@guaranteed X) -> ()
+
+// Test that escape analysis does not consider an inout argument to
+// escape at a call site even though it's reference-type field does
+// escape. Dead store elimination asks MemoryBehaviorVisitor whether
+// the apply may read from the inout argument. This call into
+// canEscapeToUsePoint, which should return false because the inout
+// structure itself is not exposed to the call, only it's
+// reference-type field is.
+//
+// CHECK-LABEL: sil @testInoutNoEscape
+// CHECK-NOT: store
+// CHECK:     apply
+// CHECK:     store
+// CHECK-NOT: store
+// CHECK:    } // end sil function 'testInoutNoEscape'
+sil @testInoutNoEscape : $@convention(thin) (@inout S, @guaranteed S) -> () {
+bb0(%0 : $*S, %1 : $S):
+  %4 = struct_extract %1 : $S, #S.x
+  %5 = struct_element_addr %0 : $*S, #S.x
+  %6 = load %5 : $*X
+  strong_retain %4 : $X
+  strong_release %6 : $X
+  store %1 to %0 : $*S
+  %10 = function_ref @takeX : $@convention(thin) (@guaranteed X) -> ()
+  strong_retain %4 : $X
+  %12 = apply %10(%4) : $@convention(thin) (@guaranteed X) -> ()
+  release_value %1 : $S
+  store %1 to %0 : $*S
+  %15 = tuple ()
+  return %15 : $()
+}
+
+// =============================================================================
+// Test that a store writing back into a container is not eliminated
+// when the container's interior pointer later escapes into a function
+// that reads from the pointer.
+
+final internal class TestArrayContainer {
+  @_hasStorage @_hasInitialValue internal final var pointer: UnsafeMutablePointer<Int32> { get set }
+  @_hasStorage @_hasInitialValue internal final var storage: ContiguousArray<Int32> { get set }
+  @_optimize(none) @inline(never) internal final func append(_ arg: Int32)
+  internal final func va_list() -> UnsafeMutableRawPointer
+  init()
+  @objc deinit
+}
+
+// specialized UnsafeMutableRawPointer.load<A>(fromByteOffset:as:)
+sil @$sSv4load14fromByteOffset2asxSi_xmtlFSpys5Int32VGSg_Tg5Tf4ndn_n : $@convention(method) (Int, UnsafeMutableRawPointer) -> Optional<UnsafeMutablePointer<Int32>> // user: %5
+// ContiguousArray.append(_:)
+sil @$ss15ContiguousArrayV6appendyyxnF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout ContiguousArray<τ_0_0>) -> ()
+
+
+// Helper that reads from a raw pointer.
+sil hidden [noinline] @takeRawPtr : $@convention(thin) (UnsafeMutableRawPointer) -> Bool {
+bb0(%0 : $UnsafeMutableRawPointer):
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = struct $Int (%1 : $Builtin.Int64)
+  // function_ref specialized UnsafeMutableRawPointer.load<A>(fromByteOffset:as:)
+  %3 = function_ref @$sSv4load14fromByteOffset2asxSi_xmtlFSpys5Int32VGSg_Tg5Tf4ndn_n : $@convention(method) (Int, UnsafeMutableRawPointer) -> Optional<UnsafeMutablePointer<Int32>>
+  %4 = apply %3(%2, %0) : $@convention(method) (Int, UnsafeMutableRawPointer) -> Optional<UnsafeMutablePointer<Int32>> // users: %18, %6
+  %5 = integer_literal $Builtin.Int1, -1
+  %6 = struct $Bool (%5 : $Builtin.Int1)
+  return %6 : $Bool
+}
+
+// TestArrayContainer.append(_:)
+// Helper that produces a nonempty array.
+sil hidden [noinline] [Onone] @TestArrayContainer_append : $@convention(method) (Int32, @guaranteed TestArrayContainer) -> () {
+bb0(%0 : $Int32, %1 : $TestArrayContainer):
+  %2 = alloc_stack $Int32
+  store %0 to %2 : $*Int32
+  %4 = ref_element_addr %1 : $TestArrayContainer, #TestArrayContainer.storage
+  %5 = function_ref @$ss15ContiguousArrayV6appendyyxnF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout ContiguousArray<τ_0_0>) -> ()
+  %6 = apply %5<Int32>(%2, %4) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout ContiguousArray<τ_0_0>) -> ()
+  dealloc_stack %2 : $*Int32
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil [noinline] @testContainerPointer : $@convention(thin) () -> Bool {
+// CHECK: [[ALLOC:%.*]] = alloc_ref [stack] $TestArrayContainer
+// CHECK: [[PTR:%.*]] = ref_element_addr %0 : $TestArrayContainer, #TestArrayContainer.pointer
+// CHECK: [[LOAD:%.*]] = load %{{.*}} : $*__ContiguousArrayStorageBase
+// CHECK: [[ELTS:%.*]] = ref_tail_addr [[LOAD]] : $__ContiguousArrayStorageBase, $Int32
+// CHECK: [[ELTPTR:%.*]] = address_to_pointer [[ELTS]] : $*Int32 to $Builtin.RawPointer
+// CHECK: [[UMP:%.*]] = struct $UnsafeMutablePointer<Int32> ([[ELTPTR]] : $Builtin.RawPointer)
+// CHECK: store [[UMP]] to [[PTR]] : $*UnsafeMutablePointer<Int32>
+// CHECK: [[F:%.*]] = function_ref @takeRawPtr : $@convention(thin) (UnsafeMutableRawPointer) -> Bool
+// CHECK: apply [[F]](%{{.*}}) : $@convention(thin) (UnsafeMutableRawPointer) -> Bool
+// CHECK: fix_lifetime %0 : $TestArrayContainer
+// CHECK-LABEL: } // end sil function 'testContainerPointer'
+sil [noinline] @testContainerPointer : $@convention(thin) () -> Bool {
+bb0:
+  %0 = alloc_ref [stack] $TestArrayContainer
+  %1 = ref_element_addr %0 : $TestArrayContainer, #TestArrayContainer.pointer
+  %2 = ref_element_addr %0 : $TestArrayContainer, #TestArrayContainer.storage
+  %3 = integer_literal $Builtin.Int32, 42
+  %4 = struct $Int32 (%3 : $Builtin.Int32)
+  %5 = function_ref @TestArrayContainer_append : $@convention(method) (Int32, @guaranteed TestArrayContainer) -> ()
+  %6 = apply %5(%4, %0) : $@convention(method) (Int32, @guaranteed TestArrayContainer) -> ()
+  %7 = struct_element_addr %2 : $*ContiguousArray<Int32>, #ContiguousArray._buffer
+  %8 = struct_element_addr %7 : $*_ContiguousArrayBuffer<Int32>, #_ContiguousArrayBuffer._storage
+  %9 = load %8 : $*__ContiguousArrayStorageBase
+  %10 = ref_tail_addr %9 : $__ContiguousArrayStorageBase, $Int32
+  %11 = address_to_pointer %10 : $*Int32 to $Builtin.RawPointer
+  %12 = struct $UnsafeMutablePointer<Int32> (%11 : $Builtin.RawPointer)
+  store %12 to %1 : $*UnsafeMutablePointer<Int32>
+  %14 = address_to_pointer %1 : $*UnsafeMutablePointer<Int32> to $Builtin.RawPointer
+  %15 = struct $UnsafeMutableRawPointer (%14 : $Builtin.RawPointer)
+  %16 = function_ref @takeRawPtr : $@convention(thin) (UnsafeMutableRawPointer) -> Bool
+  %17 = apply %16(%15) : $@convention(thin) (UnsafeMutableRawPointer) -> Bool
+  fix_lifetime %0 : $TestArrayContainer
+  set_deallocating %0 : $TestArrayContainer
+  strong_release %9 : $__ContiguousArrayStorageBase
+  dealloc_ref %0 : $TestArrayContainer
+  dealloc_ref [stack] %0 : $TestArrayContainer
+  return %17 : $Bool
+}


### PR DESCRIPTION
Correctness: do not make any enforced assumptions about how the
connection graph is built (I don't think the previous assumption would
always hold if content nodes can be arbitrarily merged). Only make one
assumption about the client code: the access being checked must be to
some address within the provided value, not another object indirectly
reachable from that value.

Optimization: Allow escape analysis to prove that an addressable
object does not escape even when one of its reference-type fields
escapes.