### PR TITLE
Lock down the access to the member variables in ADContext.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -885,12 +885,12 @@ public:
 
   /// Returns the result index for `dfi` if found in this context. Otherwise,
   /// sets the result index to zero and returns it.
-  unsigned getResultIndex(DifferentiableFunctionInst* dfi) {
+  unsigned getResultIndex(DifferentiableFunctionInst *dfi) {
     return resultIndices[dfi];
   }
 
   /// Sets the result index for `dfi`.
-  void setResultIndex(DifferentiableFunctionInst* dfi, unsigned index) {
+  void setResultIndex(DifferentiableFunctionInst *dfi, unsigned index) {
     resultIndices[dfi] = index;
   }
 
@@ -898,7 +898,7 @@ public:
     return nestedApplyInfo;
   }
 
-  void recordGeneratedFunction(SILFunction* function) {
+  void recordGeneratedFunction(SILFunction *function) {
     generatedFunctions.push_back(function);
   }
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -883,10 +883,10 @@ public:
     invokers.insert({witness, DifferentiationInvoker(witness)});
   }
 
-  /// Returns the result index for `dfi`, which should be already set.
+  /// Returns the result index for `dfi` if found in this context. Otherwise,
+  /// sets the result index to zero and returns it.
   unsigned getResultIndex(DifferentiableFunctionInst* dfi) {
-    assert(resultIndices.count(dfi) && "No result index set");
-    return resultIndices.lookup(dfi);
+    return resultIndices[dfi];
   }
 
   /// Sets the result index for `dfi`.


### PR DESCRIPTION
This PR locks down the internals of ADContext via appropriate API interface. This would be important to hide the details of ADContext when we move this out to a separate file. 

(This PR is a part of https://bugs.swift.org/browse/TF-993)