### PR TITLE
Use the same alignment for writing and reading .swift_ast section contents

### DIFF
--- a/lib/ASTSectionImporter/ASTSectionImporter.cpp
+++ b/lib/ASTSectionImporter/ASTSectionImporter.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/ASTSectionImporter/ASTSectionImporter.h"
+#include "../Serialization/ModuleFormat.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Serialization/Validation.h"
@@ -63,7 +64,8 @@ bool swift::parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
       return false;
     }
 
-    buf = buf.substr(info.bytes);
+    buf = buf.substr(
+      llvm::alignTo(info.bytes, swift::serialization::SWIFTMODULE_ALIGNMENT));
   }
 
   return true;

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -37,6 +37,7 @@
 #include "swift/SILOptimizer/PassManager/PassPipeline.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/Subsystems.h"
+#include "../Serialization/ModuleFormat.h"
 #include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Analysis/AliasAnalysis.h"
@@ -1330,7 +1331,7 @@ swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
     break;
   }
   ASTSym->setSection(Section);
-  ASTSym->setAlignment(8);
+  ASTSym->setAlignment(serialization::SWIFTMODULE_ALIGNMENT);
   ::performLLVM(Opts, &Ctx.Diags, nullptr, nullptr, IGM.getModule(),
                 IGM.TargetMachine.get(),
                 Ctx.LangOpts.EffectiveLanguageVersion,

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -375,8 +375,8 @@ ValidationInfo serialization::validateSerializedAST(
   ValidationInfo result;
 
   // Check 32-bit alignment.
-  if (data.size() % 4 != 0 ||
-      reinterpret_cast<uintptr_t>(data.data()) % 4 != 0)
+  if (data.size() % SWIFTMODULE_ALIGNMENT != 0 ||
+      reinterpret_cast<uintptr_t>(data.data()) % SWIFTMODULE_ALIGNMENT != 0)
     return result;
 
   llvm::BitstreamCursor cursor(data);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -39,6 +39,9 @@ using llvm::BCVBR;
 /// Magic number for serialized module files.
 const unsigned char SWIFTMODULE_SIGNATURE[] = { 0xE2, 0x9C, 0xA8, 0x0E };
 
+/// Alignment of each serialized modules inside a .swift_ast section.
+const unsigned char SWIFTMODULE_ALIGNMENT = 4;
+
 /// Serialized module format major version number.
 ///
 /// Always 0 for Swift 1.x - 4.x.

--- a/test/DebugInfo/ASTSection-multi.swift
+++ b/test/DebugInfo/ASTSection-multi.swift
@@ -1,0 +1,49 @@
+// REQUIRES: OS=linux-gnu
+// REQUIRES: executable_test
+// REQUIRES: swift_tools_extra
+
+// Test that concatenated .swift_ast sections of various sizes can be parsed.
+
+// RUN: %empty-directory(%t)
+
+// RUN: echo "public let a0 = 0"  >%t/a0.swift
+
+// RUN: echo "public let a1 = 0"  >%t/a1.swift
+// RUN: echo "public let b1 = 0" >>%t/a1.swift
+
+// RUN: echo "public let a2 = 0"  >%t/a2.swift
+// RUN: echo "public let b2 = 0" >>%t/a2.swift
+// RUN: echo "public let c2 = 0" >>%t/a2.swift
+
+// RUN: echo "public let a3 = 0"  >%t/a3.swift
+// RUN: echo "public let b3 = 0" >>%t/a3.swift
+// RUN: echo "public let c3 = 0" >>%t/a3.swift
+// RUN: echo "public let d3 = 0" >>%t/a3.swift
+
+// RUN: %target-build-swift %t/a0.swift -c -g -o %t/a0.o -parse-as-library
+// RUN: %target-build-swift %t/a1.swift -c -g -o %t/a1.o -parse-as-library
+// RUN: %target-build-swift %t/a2.swift -c -g -o %t/a2.o -parse-as-library
+// RUN: %target-build-swift %t/a3.swift -c -g -o %t/a3.o -parse-as-library
+
+// RUN: %target-build-swift %t/a0.swift -emit-module -emit-module-path %t/a0.swiftmodule
+// RUN: %target-build-swift %t/a1.swift -emit-module -emit-module-path %t/a1.swiftmodule
+// RUN: %target-build-swift %t/a2.swift -emit-module -emit-module-path %t/a2.swiftmodule
+// RUN: %target-build-swift %t/a3.swift -emit-module -emit-module-path %t/a3.swiftmodule
+
+// RUN: %target-swift-modulewrap %t/a0.swiftmodule -o %t/a0-mod.o
+// RUN: %target-swift-modulewrap %t/a1.swiftmodule -o %t/a1-mod.o
+// RUN: %target-swift-modulewrap %t/a2.swiftmodule -o %t/a2-mod.o
+// RUN: %target-swift-modulewrap %t/a3.swiftmodule -o %t/a3-mod.o
+
+// RUN: %target-build-swift -o %t/a.out %s \
+// RUN:                     %t/a0.o %t/a0-mod.o \
+// RUN:                     %t/a1.o %t/a1-mod.o \
+// RUN:                     %t/a2.o %t/a2-mod.o \
+// RUN:                     %t/a3.o %t/a3-mod.o
+
+// RUN: %lldb-moduleimport-test -verbose %t/a.out | %FileCheck %s
+// CHECK: Importing a0... ok!
+// CHECK: Importing a1... ok!
+// CHECK: Importing a2... ok!
+// CHECK: Importing a3... ok!
+


### PR DESCRIPTION
This fixes a bug that made it impossible to read any subsequent Swift modules
out of a .swift_ast section a previous section had a size divisible by 4.

https://bugs.swift.org/browse/SR-7932
rdar://problem/57110020
