### PR TITLE
Driver: flip the flag of whether tracking system dependencies

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -466,6 +466,9 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back("-runtime-compatibility-version");
     Arguments.push_back(arg->getValue());
   }
+  if (context.Args.hasArg(options::OPT_track_system_dependencies)) {
+    Arguments.push_back("-track-system-dependencies");
+  }
 
   context.Args.AddLastArg(
       Arguments,

--- a/test/Driver/emit-dependencies.swift
+++ b/test/Driver/emit-dependencies.swift
@@ -1,0 +1,5 @@
+// RUN: %swiftc_driver_plain -emit-executable %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -emit-objc-header-path %t.h -serialize-diagnostics -emit-dependencies -parseable-output -driver-skip-execution 2>&1 | %FileCheck %s --check-prefix=CHECK-OFF
+// RUN: %swiftc_driver_plain -emit-executable %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -emit-objc-header-path %t.h -serialize-diagnostics -emit-dependencies -parseable-output -track-system-dependencies -driver-skip-execution 2>&1 | %FileCheck %s --check-prefix=CHECK-ON
+
+// CHECK-OFF-NOT: -track-system-dependencies
+// CHECK-ON: -track-system-dependencies


### PR DESCRIPTION
Tracking system dependencies should be the default setting so we always rebuild after
headers from SDK changes. We should also provide a way to opt-out so builders could reduce
the size of .d files if they are certain SDKs are stable.

 rdar://57361722
