### PR TITLE
isCanonical should take the Clang function type into account only if UseClangFunctionTypes is enabled.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3008,8 +3008,12 @@ FunctionType *FunctionType::get(ArrayRef<AnyFunctionType::Param> params,
   void *mem = ctx.Allocate(allocSize, alignof(FunctionType), arena);
 
   bool isCanonical = isFunctionTypeCanonical(params, result);
-  if (uncommon.hasValue())
-    isCanonical &= uncommon->ClangFunctionType->isCanonicalUnqualified();
+  if (uncommon.hasValue()) {
+    if (ctx.LangOpts.UseClangFunctionTypes)
+      isCanonical &= uncommon->ClangFunctionType->isCanonicalUnqualified();
+    else
+      isCanonical = false;
+  }
 
   auto funcTy = new (mem) FunctionType(params, result, info,
                                        isCanonical ? &ctx : nullptr,

--- a/test/Sema/clang_types_in_ast.swift
+++ b/test/Sema/clang_types_in_ast.swift
@@ -4,6 +4,8 @@
 // RUN: %target-swift-frontend %s -typecheck -DNOCRASH2 -sdk %clang-importer-sdk
 // RUN: %target-swift-frontend %s -typecheck -DNOCRASH2 -sdk %clang-importer-sdk -use-clang-function-types
 // RUN: %target-swift-frontend %s -DAUXMODULE -module-name Foo -emit-module -o %t
+// FIXME: rdar://problem/57644243 : We shouldn't crash if -use-clang-function-types is not enabled.
+// RUN: not --crash %target-swift-frontend %s -typecheck -DNOCRASH3 -I %t
 
 // FIXME: [clang-function-type-serialization] This should stop crashing once we
 // start serializing clang function types.
@@ -25,12 +27,38 @@ func f() {
 #endif
 
 #if AUXMODULE
-public var DUMMY_SIGNAL : Optional<@convention(c) (Int32) -> Void> = .none
+public var DUMMY_SIGNAL1 : Optional<@convention(c) (Int32) -> ()> = .none
+public var DUMMY_SIGNAL2 : Optional<@convention(c) (Int32) -> Void> = .none
+#endif
+
+#if NOCRASH3
+import Foo
+public func my_signal1() -> Optional<@convention(c) (Int32) -> ()> {
+  return Foo.DUMMY_SIGNAL1
+}
+public func my_signal2() -> Optional<@convention(c) (Int32) -> Void> {
+  return Foo.DUMMY_SIGNAL1
+}
+public func my_signal3() -> Optional<@convention(c) (Int32) -> ()> {
+  return Foo.DUMMY_SIGNAL2
+}
+public func my_signal4() -> Optional<@convention(c) (Int32) -> Void> {
+  return Foo.DUMMY_SIGNAL2
+}
 #endif
 
 #if CRASH
 import Foo
-public func my_signal() -> Optional<@convention(c) (Int32) -> Void> {
-  return Foo.DUMMY_SIGNAL
+public func my_signal1() -> Optional<@convention(c) (Int32) -> ()> {
+  return Foo.DUMMY_SIGNAL1
+}
+public func my_signal2() -> Optional<@convention(c) (Int32) -> Void> {
+  return Foo.DUMMY_SIGNAL1
+}
+public func my_signal3() -> Optional<@convention(c) (Int32) -> ()> {
+  return Foo.DUMMY_SIGNAL2
+}
+public func my_signal4() -> Optional<@convention(c) (Int32) -> Void> {
+  return Foo.DUMMY_SIGNAL2
 }
 #endif

--- a/test/Sema/clang_types_in_ast.swift
+++ b/test/Sema/clang_types_in_ast.swift
@@ -4,8 +4,9 @@
 // RUN: %target-swift-frontend %s -typecheck -DNOCRASH2 -sdk %clang-importer-sdk
 // RUN: %target-swift-frontend %s -typecheck -DNOCRASH2 -sdk %clang-importer-sdk -use-clang-function-types
 // RUN: %target-swift-frontend %s -DAUXMODULE -module-name Foo -emit-module -o %t
-// FIXME: rdar://problem/57644243 : We shouldn't crash if -use-clang-function-types is not enabled.
-// RUN: not --crash %target-swift-frontend %s -typecheck -DNOCRASH3 -I %t
+
+// rdar://problem/57644243 : We shouldn't crash if -use-clang-function-types is not enabled.
+// RUN: %target-swift-frontend %s -typecheck -DNOCRASH3 -I %t
 
 // FIXME: [clang-function-type-serialization] This should stop crashing once we
 // start serializing clang function types.


### PR DESCRIPTION
Fixes rdar://problem/57644243.