### PR TITLE
wasm: add support for `wasm32-unknown-wasi`

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -39,6 +39,7 @@ static const StringRef SupportedConditionalCompilationOSs[] = {
   "PS4",
   "Cygwin",
   "Haiku",
+  "WASI",
 };
 
 static const StringRef SupportedConditionalCompilationArches[] = {
@@ -48,7 +49,8 @@ static const StringRef SupportedConditionalCompilationArches[] = {
   "x86_64",
   "powerpc64",
   "powerpc64le",
-  "s390x"
+  "s390x",
+  "wasm32",
 };
 
 static const StringRef SupportedConditionalCompilationEndianness[] = {
@@ -246,6 +248,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   case llvm::Triple::Haiku:
     addPlatformConditionValue(PlatformConditionKind::OS, "Haiku");
     break;
+  case llvm::Triple::WASI:
+    addPlatformConditionValue(PlatformConditionKind::OS, "WASI");
+    break;
   default:
     UnsupportedOS = true;
     break;
@@ -277,6 +282,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   case llvm::Triple::ArchType::systemz:
     addPlatformConditionValue(PlatformConditionKind::Arch, "s390x");
     break;
+  case llvm::Triple::ArchType::wasm32:
+    addPlatformConditionValue(PlatformConditionKind::Arch, "wasm32");
+    break;
   default:
     UnsupportedArch = true;
   }
@@ -291,6 +299,7 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   case llvm::Triple::ArchType::thumb:
   case llvm::Triple::ArchType::aarch64:
   case llvm::Triple::ArchType::ppc64le:
+  case llvm::Triple::ArchType::wasm32:
   case llvm::Triple::ArchType::x86:
   case llvm::Triple::ArchType::x86_64:
     addPlatformConditionValue(PlatformConditionKind::Endianness, "little");

--- a/test/Parse/ConditionalCompilation/wasm32Target.swift
+++ b/test/Parse/ConditionalCompilation/wasm32Target.swift
@@ -1,0 +1,8 @@
+// RUN: %swift -typecheck %s -verify -target wasm32-unknown-wasi -disable-objc-interop -parse-stdlib
+// RUN: %swift-ide-test -test-input-complete -source-filename %s -target wasm32-unknown-wasi
+
+#if arch(wasm32) && os(WASI) && _runtime(_Native) && _endian(little)
+class C {}
+var x = C()
+#endif
+var y = x


### PR DESCRIPTION
This adds the initial conditional compilation support for the WASM32
"architecture" assuming that WASI is used as the "OS".  Support for
baremetal targets in Swift needs more work still, but this gives enough
infrastructure to start playing with WASM.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
