### PR TITLE
Provide a custom diagnostic for conformance to NSObjectProtocol

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1734,6 +1734,10 @@ ERROR(type_does_not_conform,none,
 ERROR(cannot_use_nil_with_this_type,none,
       "'nil' cannot be used in context expecting type %0", (Type))
 
+ERROR(type_cannot_conform_to_nsobject,none,
+      "cannot declare conformance to 'NSObjectProtocol' in Swift; %0 should "
+      "inherit 'NSObject' instead", (Type))
+
 ERROR(use_of_equal_instead_of_equality,none,
       "use of '=' in a boolean context, did you mean '=='?", ())
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2758,7 +2758,7 @@ diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind) {
     auto FixitBufferId = SM.findBufferContainingLoc(FixitLocation);
     for (auto VD : MissingWitnesses) {
       // Don't ever emit a diagnostic for a requirement in the NSObject
-      // protocol. They'renot implementable.
+      // protocol. They're not implementable.
       if (isNSObjectProtocol(VD->getDeclContext()->getSelfProtocolDecl()))
         continue;
 

--- a/test/decl/protocol/conforms/nsobject.swift
+++ b/test/decl/protocol/conforms/nsobject.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+class A: NSObjectProtocol { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'A' should inherit 'NSObject' instead}}{{10-26=NSObject}}
+
+@objc protocol Other: NSObjectProtocol { }
+
+class B: Other { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'B' should inherit 'NSObject' instead}}
+
+class C { }
+
+class D: C, NSObjectProtocol { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'D' should inherit 'NSObject' instead}}
+
+class E { }
+
+extension E: NSObjectProtocol { } // expected-error{{cannot declare conformance to 'NSObjectProtocol' in Swift; 'E' should inherit 'NSObject' instead}}


### PR DESCRIPTION
Swift classes cannot meaningfully conform to NSObjectProtocol.
Inheriting from NSObject is the appropriate fix, so suggest that.
Fixes rdar://problem/32543753.

The diagnostic now looks like this:

```
proto.swift:3:7: error: cannot declare conformance to 'NSObjectProtocol' in Swift; 'Foo' should inherit 'NSObject' instead
class Foo: NSObjectProtocol { }
      ^    ~~~~~~~~~~~~~~~~
           NSObject
```