### PR TITLE
[ConstraintSystem] Guard against infinite recursion in key path dynam…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2029,11 +2029,18 @@ std::pair<Type, bool> ConstraintSystem::adjustTypeOfOverloadReference(
     DeclName memberName =
         isSubscriptRef ? DeclBaseName::createSubscript() : choice.getName();
 
-    addValueMemberConstraint(LValueType::get(rootTy), memberName, memberTy,
-                             useDC,
-                             isSubscriptRef ? FunctionRefKind::DoubleApply
-                                            : FunctionRefKind::Unapplied,
-                             /*outerAlternatives=*/{}, keyPathLoc);
+    auto *memberRef = Constraint::createMember(
+        *this, ConstraintKind::ValueMember, LValueType::get(rootTy), memberTy,
+        memberName, useDC,
+        isSubscriptRef ? FunctionRefKind::DoubleApply
+                       : FunctionRefKind::Unapplied,
+        keyPathLoc);
+
+    // Delay simplication of this constraint until after the overload choice
+    // has been bound for this key path dynamic member. This helps to identify
+    // recursive calls with the same base.
+    addUnsolvedConstraint(memberRef);
+    activateConstraint(memberRef);
 
     // In case of subscript things are more compicated comparing to "dot"
     // syntax, because we have to get "applicable function" constraint

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -753,3 +753,15 @@ struct SR11877 {
 }
 
 _ = \SR11877.okay
+
+func test_infinite_self_recursion() {
+  @dynamicMemberLookup
+  struct Recurse<T> {
+    subscript<U>(dynamicMember member: KeyPath<Recurse<T>, U>) -> Int {
+      return 1
+    }
+  }
+
+  _ = Recurse<Int>().foo
+  // expected-error@-1 {{value of type 'Recurse<Int>' has no dynamic member 'foo' using key path from root type 'Recurse<Int>'}}
+}

--- a/validation-test/Sema/SwiftUI/rdar57410798.swift
+++ b/validation-test/Sema/SwiftUI/rdar57410798.swift
@@ -1,0 +1,43 @@
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+enum ColorScheme: CaseIterable, Hashable, Equatable, Identifiable {
+// expected-error@-1 {{type 'ColorScheme' does not conform to protocol 'Identifiable'}}
+  case `default`
+  case pink
+
+  var foreground: Color {
+    switch self {
+    case .default:
+      return .primary
+    case .pink:
+      return .pink
+    }
+  }
+}
+
+struct IconPicker : View {
+  var body: some View {
+    Text("hello")
+  }
+}
+
+struct CountdownEditor : View {
+  @State var symbol: String = "timer"
+  @State var selectedColor: ColorScheme = ColorScheme.pink
+
+  var body: some View {
+    NavigationLink(destination: IconPicker()) {
+      Text("Icon")
+      Spacer()
+      Image(systemName: symbol)
+        .foregroundColor(selectedColor.color)
+        // expected-error@-1 {{cannot convert value of type 'Binding<Subject>' to expected argument type 'Color?'}}
+        // expected-error@-2 {{referencing subscript 'subscript(dynamicMember:)' requires wrapper 'Binding<ColorScheme>'}}
+        // expected-error@-3 {{value of type 'ColorScheme' has no dynamic member 'color' using key path from root type 'ColorScheme'}}
+    }
+  }
+}


### PR DESCRIPTION
…ic member lookup

It's possible to construct subscript member responsible for key path
dynamic member lookup in a way which is going to be self-recursive
and an attempt to lookup any non-existent member is going to trigger
infine recursion.

Let's guard against that by making sure that the base type of the
member lookup is different from root type of the key path.

Resolves: rdar://problem/50420029
Resolves: rdar://problem/57410798

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
