### PR TITLE
Fix various problems with top-level 'guard' statements and captures

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -399,7 +399,7 @@ protected:
     HasSingleExpressionBody : 1
   );
 
-  SWIFT_INLINE_BITFIELD(FuncDecl, AbstractFunctionDecl, 1+1+2+1+1+2,
+  SWIFT_INLINE_BITFIELD(FuncDecl, AbstractFunctionDecl, 1+1+2+1+1+2+1,
     /// Whether we've computed the 'static' flag yet.
     IsStaticComputed : 1,
 
@@ -416,7 +416,12 @@ protected:
     SelfAccessComputed : 1,
 
     /// Backing bits for 'self' access kind.
-    SelfAccess : 2
+    SelfAccess : 2,
+
+    /// Whether this is a top-level function which should be treated
+    /// as if it were in local context for the purposes of capture
+    /// analysis.
+    HasTopLevelLocalContextCaptures : 1
   );
 
   SWIFT_INLINE_BITFIELD(AccessorDecl, FuncDecl, 4+1+1,
@@ -6078,6 +6083,7 @@ protected:
     Bits.FuncDecl.SelfAccessComputed = false;
     Bits.FuncDecl.IsStaticComputed = false;
     Bits.FuncDecl.IsStatic = false;
+    Bits.FuncDecl.HasTopLevelLocalContextCaptures = false;
   }
 
 private:
@@ -6235,6 +6241,12 @@ public:
   /// Perform basic checking to determine whether the @IBAction or
   /// @IBSegueAction attribute can be applied to this function.
   bool isPotentialIBActionTarget() const;
+
+  bool hasTopLevelLocalContextCaptures() const {
+    return Bits.FuncDecl.HasTopLevelLocalContextCaptures;
+  }
+
+  void setHasTopLevelLocalContextCaptures(bool hasCaptures=true);
 };
 
 /// This represents an accessor function, such as a getter or setter.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2713,6 +2713,10 @@ public:
   AccessSemantics getAccessSemanticsFromContext(const DeclContext *DC,
                                                 bool isAccessOnSelf) const;
 
+  /// Determines if a reference to this declaration from a nested function
+  /// should be treated like a capture of a local value.
+  bool isLocalCapture() const;
+
   /// Print a reference to the given declaration.
   std::string printRef() const;
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -869,7 +869,7 @@ public:
   /// Return true if parser is at the start of a decl or decl-import.
   bool isStartOfDecl();
 
-  bool parseTopLevel();
+  void parseTopLevel();
 
   /// Flags that control the parsing of declarations.
   enum ParseDeclFlags {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -857,10 +857,18 @@ public:
                            TopLevelCodeDecl *TLCD);
 
   ParserStatus parseBraceItems(SmallVectorImpl<ASTNode> &Decls,
+                               BraceItemListKind Kind,
+                               BraceItemListKind ConditionalBlockKind,
+                               bool &IsFollowingGuard);
+  ParserStatus parseBraceItems(SmallVectorImpl<ASTNode> &Decls,
                                BraceItemListKind Kind =
                                    BraceItemListKind::Brace,
                                BraceItemListKind ConditionalBlockKind =
-                                   BraceItemListKind::Brace);
+                                   BraceItemListKind::Brace) {
+    bool IsFollowingGuard = false;
+    return parseBraceItems(Decls, Kind, ConditionalBlockKind,
+                           IsFollowingGuard);
+  }
   ParserResult<BraceStmt> parseBraceItemList(Diag<> ID);
   
   //===--------------------------------------------------------------------===//

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -946,24 +946,6 @@ public:
   CaptureInfo getLoweredLocalCaptures(SILDeclRef fn);
   bool hasLoweredLocalCaptures(SILDeclRef fn);
 
-#ifndef NDEBUG
-  /// If \c false, \c childDC is in a context it cannot capture variables from,
-  /// so it is expected that Sema may not have computed its \c CaptureInfo.
-  ///
-  /// This call exists for use in assertions; do not use it to skip capture
-  /// processing.
-  static bool canCaptureFromParent(DeclContext *childDC) {
-    // This call was added because Sema leaves the captures of functions that
-    // cannot capture anything uncomputed.
-    // TODO: Make Sema set them to CaptureInfo::empty() instead.
-
-    if (childDC)
-      if (auto decl = childDC->getAsDecl())
-         return decl->getDeclContext()->isLocalContext();
-    return true;
-  }
-#endif
-
   enum class ABIDifference : uint8_t {
     // Types have compatible calling conventions and representations, so can
     // be trivially bitcast.

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -119,18 +119,14 @@ namespace swift {
   ///
   /// \param PersistentState if non-null the same PersistentState object can
   /// be used to resume parsing or parse delayed function bodies.
-  ///
-  /// \return true if the parser found code with side effects.
-  bool parseIntoSourceFile(SourceFile &SF, unsigned BufferID, bool *Done,
+  void parseIntoSourceFile(SourceFile &SF, unsigned BufferID, bool *Done,
                            SILParserState *SIL = nullptr,
                            PersistentParserState *PersistentState = nullptr,
                            bool DelayBodyParsing = true);
 
   /// Parse a single buffer into the given source file, until the full source
   /// contents are parsed.
-  ///
-  /// \return true if the parser found code with side effects.
-  bool parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
+  void parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
                                PersistentParserState *PersistentState = nullptr,
                                bool DelayBodyParsing = true);
 

--- a/lib/AST/CaptureInfo.cpp
+++ b/lib/AST/CaptureInfo.cpp
@@ -57,7 +57,7 @@ CaptureInfo CaptureInfo::empty() {
 
 bool CaptureInfo::hasLocalCaptures() const {
   for (auto capture : getCaptures())
-    if (capture.getDecl()->getDeclContext()->isLocalContext())
+    if (capture.getDecl()->isLocalCapture())
       return true;
   return false;
 }
@@ -71,7 +71,7 @@ getLocalCaptures(SmallVectorImpl<CapturedValue> &Result) const {
 
   // Filter out global variables.
   for (auto capture : getCaptures()) {
-    if (!capture.getDecl()->getDeclContext()->isLocalContext())
+    if (!capture.getDecl()->isLocalCapture())
       continue;
 
     Result.push_back(capture);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2866,6 +2866,16 @@ bool ValueDecl::isImplicitlyUnwrappedOptional() const {
     false);
 }
 
+bool ValueDecl::isLocalCapture() const {
+  auto *dc = getDeclContext();
+
+  if (auto *fd = dyn_cast<FuncDecl>(this))
+    if (isa<SourceFile>(dc))
+      return fd->hasTopLevelLocalContextCaptures();
+
+  return dc->isLocalContext();
+}
+
 ArrayRef<ValueDecl *>
 ValueDecl::getSatisfiedProtocolRequirements(bool Sorted) const {
   // Dig out the nominal type.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7669,6 +7669,12 @@ bool FuncDecl::isPotentialIBActionTarget() const {
     !isa<AccessorDecl>(this);
 }
 
+void FuncDecl::setHasTopLevelLocalContextCaptures(bool hasCaptures) {
+  assert(!hasCaptures || isa<SourceFile>(getDeclContext()));
+  
+  Bits.FuncDecl.HasTopLevelLocalContextCaptures = hasCaptures;
+}
+
 Type TypeBase::getSwiftNewtypeUnderlyingType() {
   auto structDecl = getStructOrBoundGenericStruct();
   if (!structDecl)

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -187,12 +187,10 @@ typeCheckREPLInput(ModuleDecl *MostRecentModule, StringRef Name,
     REPLInputFile.addImports(ImportsWithOptions);
   }
 
-  bool FoundAnySideEffects = false;
   bool Done;
   do {
-    FoundAnySideEffects |=
-        parseIntoSourceFile(REPLInputFile, BufferID, &Done, nullptr,
-                            &PersistentState);
+    parseIntoSourceFile(REPLInputFile, BufferID, &Done, nullptr,
+                        &PersistentState);
   } while (!Done);
   performTypeChecking(REPLInputFile);
   return REPLModule;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -189,7 +189,7 @@ namespace {
 ///     decl-sil       [[only in SIL mode]
 ///     decl-sil-stage [[only in SIL mode]
 /// \endverbatim
-bool Parser::parseTopLevel() {
+void Parser::parseTopLevel() {
   SF.ASTStage = SourceFile::Parsing;
 
   // Prime the lexer.
@@ -246,17 +246,6 @@ bool Parser::parseTopLevel() {
     consumeToken();
   }
 
-  // If this is a Main source file, determine if we found code that needs to be
-  // executed (this is used by the repl to know whether to compile and run the
-  // newly parsed stuff).
-  bool FoundTopLevelCodeToExecute = false;
-  if (allowTopLevelCode()) {
-    for (auto V : Items) {
-      if (isa<TopLevelCodeDecl>(V.get<Decl*>()))
-        FoundTopLevelCodeToExecute = true;
-    }
-  }
-
   // Add newly parsed decls to the module.
   for (auto Item : Items) {
     if (auto *D = Item.dyn_cast<Decl*>()) {
@@ -279,8 +268,6 @@ bool Parser::parseTopLevel() {
     SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
     TokReceiver->finalize();
   }
-
-  return FoundTopLevelCodeToExecute;
 }
 
 ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -112,13 +112,13 @@ void PrettyStackTraceParser::print(llvm::raw_ostream &out) const {
   out << '\n';
 }
 
-static bool parseIntoSourceFileImpl(SourceFile &SF,
-                                unsigned BufferID,
-                                bool *Done,
-                                SILParserState *SIL,
-                                PersistentParserState *PersistentState,
-                                bool FullParse,
-                                bool DelayBodyParsing) {
+static void parseIntoSourceFileImpl(SourceFile &SF,
+                                    unsigned BufferID,
+                                    bool *Done,
+                                    SILParserState *SIL,
+                                    PersistentParserState *PersistentState,
+                                    bool FullParse,
+                                    bool DelayBodyParsing) {
   assert((!FullParse || (SF.canBeParsedInFull() && !SIL)) &&
          "cannot parse in full with the given parameters!");
 
@@ -149,10 +149,8 @@ static bool parseIntoSourceFileImpl(SourceFile &SF,
   llvm::SaveAndRestore<bool> S(P.IsParsingInterfaceTokens,
                                SF.hasInterfaceHash());
 
-  bool FoundSideEffects = false;
   do {
-    bool hasSideEffects = P.parseTopLevel();
-    FoundSideEffects = FoundSideEffects || hasSideEffects;
+    P.parseTopLevel();
     *Done = P.Tok.is(tok::eof);
   } while (FullParse && !*Done);
 
@@ -160,29 +158,27 @@ static bool parseIntoSourceFileImpl(SourceFile &SF,
     auto rawNode = P.finalizeSyntaxTree();
     STreeCreator->acceptSyntaxRoot(rawNode, SF);
   }
-
-  return FoundSideEffects;
 }
 
-bool swift::parseIntoSourceFile(SourceFile &SF,
+void swift::parseIntoSourceFile(SourceFile &SF,
                                 unsigned BufferID,
                                 bool *Done,
                                 SILParserState *SIL,
                                 PersistentParserState *PersistentState,
                                 bool DelayBodyParsing) {
-  return parseIntoSourceFileImpl(SF, BufferID, Done, SIL,
-                                 PersistentState,
-                                 /*FullParse=*/SF.shouldBuildSyntaxTree(),
-                                 DelayBodyParsing);
+  parseIntoSourceFileImpl(SF, BufferID, Done, SIL,
+                          PersistentState,
+                          /*FullParse=*/SF.shouldBuildSyntaxTree(),
+                          DelayBodyParsing);
 }
 
-bool swift::parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
+void swift::parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
                                     PersistentParserState *PersistentState,
                                     bool DelayBodyParsing) {
   bool Done = false;
-  return parseIntoSourceFileImpl(SF, BufferID, &Done, /*SIL=*/nullptr,
-                                 PersistentState, /*FullParse=*/true,
-                                 DelayBodyParsing);
+  parseIntoSourceFileImpl(SF, BufferID, &Done, /*SIL=*/nullptr,
+                          PersistentState, /*FullParse=*/true,
+                          DelayBodyParsing);
 }
 
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2392,6 +2392,15 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
     resultingCaptures.push_back(*selfCapture);
   }
 
+  // It is an error for a member of a nominal type to have any captures
+  // at all. If we just clear them out here, SILGen will diagnose the
+  // problem.
+  if (fn.hasDecl()) {
+    auto *dc = fn.getDecl()->getDeclContext();
+    if (dc->isTypeContext())
+      resultingCaptures.clear();
+  }
+
   // Cache the uniqued set of transitive captures.
   CaptureInfo info{Context, resultingCaptures, capturesDynamicSelf,
                    capturesOpaqueValue, capturesGenericParams};

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -695,31 +695,6 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
   }
 }
 
-#ifndef NDEBUG
-/// If \c false, \c function is either a declaration that inherently cannot
-/// capture variables, or it is in a context it cannot capture variables from.
-/// In either case, it is expected that Sema may not have computed its
-/// \c CaptureInfo.
-///
-/// This call exists for use in assertions; do not use it to skip capture
-/// processing.
-static bool canCaptureFromParent(SILDeclRef function) {
-  switch (function.kind) {
-  case SILDeclRef::Kind::StoredPropertyInitializer:
-  case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
-    return false;
-
-  default:
-    if (function.hasDecl()) {
-      if (auto dc = dyn_cast<DeclContext>(function.getDecl())) {
-        return TypeConverter::canCaptureFromParent(dc);
-      }
-    }
-    return false;
-  }
-}
-#endif
-
 void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,
                                            bool EmitProfilerIncrement) {
   auto *dc = function.getDecl()->getInnermostDeclContext();
@@ -757,14 +732,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,
     params = ParameterList::create(ctx, SourceLoc(), {param}, SourceLoc());
   }
 
-  CaptureInfo captureInfo;
-  if (function.getAnyFunctionRef())
-    captureInfo = SGM.M.Types.getLoweredLocalCaptures(function);
-  else {
-    assert(!canCaptureFromParent(function));
-    captureInfo = CaptureInfo::empty();
-  }
-
+  auto captureInfo = SGM.M.Types.getLoweredLocalCaptures(function);
   auto interfaceType = value->getType()->mapTypeOutOfContext();
   emitProlog(captureInfo, params, /*selfParam=*/nullptr,
              dc, interfaceType, /*throws=*/false, SourceLoc());

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -445,8 +445,7 @@ void SILGenFunction::emitProlog(CaptureInfo captureInfo,
   
   // Emit the capture argument variables. These are placed last because they
   // become the first curry level of the SIL function.
-  assert((captureInfo.hasBeenComputed() ||
-          !TypeConverter::canCaptureFromParent(DC)) &&
+  assert(captureInfo.hasBeenComputed() &&
          "can't emit prolog of function with uncomputed captures");
   for (auto capture : captureInfo.getCaptures()) {
     if (capture.isDynamicSelfMetadata()) {

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -312,7 +312,7 @@ public:
 
     // Only capture var decls at global scope.  Other things can be captured
     // if they are local.
-    if (!isa<VarDecl>(D) && !DC->isLocalContext())
+    if (!isa<VarDecl>(D) && !D->isLocalCapture())
       return { false, DRE };
 
     // We're going to capture this, compute flags for the capture.

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/Basic/Defer.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -219,10 +220,14 @@ public:
     if (D->getBaseName() == Context.Id_dollarInterpolation)
       return { false, DRE };
 
+    // DC is the DeclContext where D was defined
+    // CurDC is the DeclContext where D was referenced
+    auto DC = D->getDeclContext();
+
     // Capture the generic parameters of the decl, unless it's a
     // local declaration in which case we will pick up generic
     // parameter references transitively.
-    if (!D->getDeclContext()->isLocalContext()) {
+    if (!DC->isLocalContext()) {
       if (!ObjC || !D->isObjC() || isa<ConstructorDecl>(D)) {
         if (auto subMap = DRE->getDeclRef().getSubstitutions()) {
           for (auto type : subMap.getReplacementTypes()) {
@@ -232,40 +237,57 @@ public:
       }
     }
 
-    // DC is the DeclContext where D was defined
-    // CurDC is the DeclContext where D was referenced
-    auto DC = D->getDeclContext();
+    // Don't "capture" type definitions at all.
+    if (isa<TypeDecl>(D))
+      return { false, DRE };
 
     // A local reference is not a capture.
-    if (CurDC == DC)
+    if (CurDC == DC || isa<TopLevelCodeDecl>(CurDC))
       return { false, DRE };
 
     auto TmpDC = CurDC;
+    while (TmpDC != nullptr) {
+      // Variables defined inside TopLevelCodeDecls are semantically
+      // local variables. If the reference is not from the top level,
+      // we have a capture.
+      if (isa<TopLevelCodeDecl>(DC) &&
+          (isa<SourceFile>(TmpDC) || isa<TopLevelCodeDecl>(TmpDC)))
+        break;
 
-    if (!isa<TopLevelCodeDecl>(DC)) {
-      while (TmpDC != nullptr) {
-        if (TmpDC == DC)
-          break;
+      if (TmpDC == DC)
+        break;
 
-        // The initializer of a lazy property will eventually get
-        // recontextualized into it, so treat it as if it's already there.
-        if (auto init = dyn_cast<PatternBindingInitializer>(TmpDC)) {
-          if (auto lazyVar = init->getInitializedLazyVar()) {
-            // If we have a getter with a body, we're already re-parented
-            // everything so pretend we're inside the getter.
-            if (auto getter = lazyVar->getAccessor(AccessorKind::Get)) {
-              if (getter->getBody(/*canSynthesize=*/false)) {
-                TmpDC = getter;
-                continue;
-              }
+      // The initializer of a lazy property will eventually get
+      // recontextualized into it, so treat it as if it's already there.
+      if (auto init = dyn_cast<PatternBindingInitializer>(TmpDC)) {
+        if (auto lazyVar = init->getInitializedLazyVar()) {
+          // If we have a getter with a body, we're already re-parented
+          // everything so pretend we're inside the getter.
+          if (auto getter = lazyVar->getAccessor(AccessorKind::Get)) {
+            if (getter->getBody(/*canSynthesize=*/false)) {
+              TmpDC = getter;
+              continue;
             }
           }
         }
+      }
 
-        // We have an intervening nominal type context that is not the
-        // declaration context, and the declaration context is not global.
-        // This is not supported since nominal types cannot capture values.
-        if (auto NTD = dyn_cast<NominalTypeDecl>(TmpDC)) {
+      // We have an intervening nominal type context that is not the
+      // declaration context, and the declaration context is not global.
+      // This is not supported since nominal types cannot capture values.
+      if (auto NTD = dyn_cast<NominalTypeDecl>(TmpDC)) {
+        // Allow references to local functions from inside methods of a
+        // local type, because if the local function has captures, we'll
+        // diagnose them in SILGen. It's a bit unfortunate that we can't
+        // ban this outright, but people rely on code like this working:
+        //
+        // do {
+        //   func local() {}
+        //   class C {
+        //     func method() { local() }
+        //   }
+        // }
+        if (!isa<FuncDecl>(D)) {
           if (DC->isLocalContext()) {
             Context.Diags.diagnose(DRE->getLoc(), diag::capture_across_type_decl,
                                    NTD->getDescriptiveKind(),
@@ -278,18 +300,14 @@ public:
             return { false, DRE };
           }
         }
-
-        TmpDC = TmpDC->getParent();
       }
 
-      // We walked all the way up to the root without finding the declaration,
-      // so this is not a capture.
-      if (TmpDC == nullptr)
-        return { false, DRE };
+      TmpDC = TmpDC->getParent();
     }
 
-    // Don't "capture" type definitions at all.
-    if (isa<TypeDecl>(D))
+    // We walked all the way up to the root without finding the declaration,
+    // so this is not a capture.
+    if (TmpDC == nullptr)
       return { false, DRE };
 
     // Only capture var decls at global scope.  Other things can be captured

--- a/test/Parse/confusables.swift
+++ b/test/Parse/confusables.swift
@@ -7,9 +7,9 @@
 let number⁚ Int // expected-note {{operator '⁚' contains possibly confused characters; did you mean to use ':'?}} {{11-14=:}}
 
 // expected-warning @+3 2 {{integer literal is unused}}
-// expected-error @+2 2 {{invalid character in source file}}
+// expected-error @+2 {{invalid character in source file}}
 // expected-error @+1 {{consecutive statements on a line must be separated by ';'}}
-5 ‒ 5 // expected-note 2 {{unicode character '‒' looks similar to '-'; did you mean to use '-'?}} {{3-6=-}}
+5 ‒ 5 // expected-note {{unicode character '‒' looks similar to '-'; did you mean to use '-'?}} {{3-6=-}}
 
 // expected-error @+2 {{use of unresolved identifier 'ꝸꝸꝸ'}}
 // expected-error @+1 {{expected ',' separator}}

--- a/test/Parse/identifiers.swift
+++ b/test/Parse/identifiers.swift
@@ -26,7 +26,7 @@ func s̈pin̈al_tap̈() {}
 () // expected-error{{invalid character in source file}} {{1-4= }}
 
 // Placeholders are recognized as identifiers but with error.
-func <#some name#>() {} // expected-error 2 {{editor placeholder in source file}}
+func <#some name#>() {} // expected-error {{editor placeholder in source file}}
 
 // Keywords as identifiers
 class switch {} // expected-error {{keyword 'switch' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{7-13=`switch`}}

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -754,7 +754,7 @@ let curlyQuotes2 = “hello world!"
 
 
 // <rdar://problem/21196171> compiler should recover better from "unicode Specials" characters
-let ￼tryx  = 123        // expected-error 2 {{invalid character in source file}}  {{5-8= }}
+let ￼tryx  = 123        // expected-error {{invalid character in source file}}  {{5-8= }}
 
 
 // <rdar://problem/21369926> Malformed Swift Enums crash playground service

--- a/test/SILGen/nested_types_referencing_nested_functions.swift
+++ b/test/SILGen/nested_types_referencing_nested_functions.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name nested_types_referencing_nested_functions %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -verify -module-name nested_types_referencing_nested_functions %s | %FileCheck %s
 
 do {
   func foo() { bar(2) }
@@ -31,4 +31,20 @@ do {
   _ = Foo.zang as (Foo) -> (Int) -> ()
   _ = x.zim
   _ = x.zang as (Int) -> ()
+}
+
+// Invalid case
+do {
+  var x = 123 // expected-note {{captured value declared here}}
+
+  func local() {
+    // expected-error@-1 {{closure captures 'x' before it is declared}}
+    _ = x // expected-note {{captured here}}
+  }
+
+  class Bar {
+    func zang() {
+      local()
+    }
+  }
 }

--- a/test/SILGen/top_level_captures.swift
+++ b/test/SILGen/top_level_captures.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+guard let x: Int = nil else { while true { } }
+
+// CHECK-LABEL: sil hidden [ossa] @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> () {
+func capturesX() {
+  _ = x
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s18top_level_captures17transitiveCaptureyyF : $@convention(thin) (Int) -> () {
+// CHECK: [[FUNC:%.*]] = function_ref @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> ()
+func transitiveCapture() {
+  capturesX()
+}

--- a/test/expr/capture/nested_class.swift
+++ b/test/expr/capture/nested_class.swift
@@ -36,3 +36,20 @@ struct StructWithInnerStruct {
     }
   }
 }
+
+// Types cannot close over top-level guard bindings
+guard let x: Int = nil else { fatalError() }
+// expected-note@-1 {{'x' declared here}}
+
+func getX() -> Int { return x }
+
+class ClosesOverGuard { // expected-note {{type declared here}}
+  func foo() {
+    _ = x
+    // expected-error@-1 {{class declaration cannot close over value 'x' defined in outer scope}}
+  }
+
+  func bar() {
+    _ = getX() // This is diagnosed by SILGen.
+  }
+}


### PR DESCRIPTION
- Methods of local types are normally not allowed to capture local bindings from the outer scope, however we did not diagnose this case if the local binding was itself part of a TopLevelCodeDecl, causing a crash on invalid; an example would be a `var` nested inside a top-level `do` statement. One case that used to work is where the local type referenced a local function that itself had no captures; this continues to work.

- Bindings established by a `guard` statement are visible outside of the TopLevelCodeDecl in which the GuardStmt and it's associated VarDecls appear, but the functions referencing them were not properly considered to be in local context, so we did not always expect them to have a capture list. These cases now work correctly.

Finally, clean up some the assertions that check for the presence of a capture list. We compute capture lists eagerly in Sema, so by the time we get to SILGen we must have all the capture lists that we need. However this was complicated by references to top-level functions defined in other files and similar, where no capture list was computed or necessary. By centralizing the check inside `getLoweredLocalCaptures()` we can just skip all of the work entirely if we know there won't be any local captures.

Fixed <rdar://problem/23051362> / <https://bugs.swift.org/browse/SR-3528>, and some related issues I discovered while working on those.