### PR TITLE
[AutoDiff] Move dumpActivityInfo to DifferentiableActivityInfo class

### DIFF
--- a/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
@@ -208,14 +208,12 @@ public:
   Activity getActivity(SILValue value, const SILAutoDiffIndices &indices) const;
 
   /// Prints activity information for the `indices` of the given `value`.
-  void dumpActivityInfo(SILValue value,
-                        const SILAutoDiffIndices &indices,
-                        llvm::raw_ostream &s = llvm::dbgs()) const;
+  void dump(SILValue value, const SILAutoDiffIndices &indices,
+            llvm::raw_ostream &s = llvm::dbgs()) const;
 
   /// Prints activity information for the `indices` of the given `fn`.
-  void dumpActivityInfo(SILFunction &fn, SILAutoDiffIndices indices,
-                             llvm::raw_ostream &s = llvm::dbgs()) const;
-
+  void dump(SILFunction &fn, SILAutoDiffIndices indices,
+            llvm::raw_ostream &s = llvm::dbgs()) const;
 };
 
 class DifferentiableActivityCollection {

--- a/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
@@ -131,7 +131,7 @@ private:
   SmallVector<SmallDenseSet<SILValue>, 4> usefulValueSets;
 
   /// The original function.
-  SILFunction &getFunction();
+  SILFunction &getFunction() const;
 
   /// Returns true if the given SILValue has a tangent space.
   bool hasTangentSpace(SILValue value) {
@@ -211,8 +211,8 @@ public:
   void dump(SILValue value, const SILAutoDiffIndices &indices,
             llvm::raw_ostream &s = llvm::dbgs()) const;
 
-  /// Prints activity information for the `indices` of the given `fn`.
-  void dump(SILFunction &fn, SILAutoDiffIndices indices,
+  /// Prints activity information for the given `indices`.
+  void dump(SILAutoDiffIndices indices,
             llvm::raw_ostream &s = llvm::dbgs()) const;
 };
 

--- a/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
@@ -206,6 +206,16 @@ public:
   /// Returns the activity of the given value for the given `SILAutoDiffIndices`
   /// (parameter indices and result index).
   Activity getActivity(SILValue value, const SILAutoDiffIndices &indices) const;
+
+  /// Prints activity information for the `indices` of the given `value`.
+  void dumpActivityInfo(SILValue value,
+                        const SILAutoDiffIndices &indices,
+                        llvm::raw_ostream &s = llvm::dbgs()) const;
+
+  /// Prints activity information for the `indices` of the given `fn`.
+  void dumpActivityInfo(SILFunction &fn, SILAutoDiffIndices indices,
+                             llvm::raw_ostream &s = llvm::dbgs()) const;
+
 };
 
 class DifferentiableActivityCollection {

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -59,7 +59,7 @@ DifferentiableActivityInfo::DifferentiableActivityInfo(
   analyze(parent.domInfo, parent.postDomInfo);
 }
 
-SILFunction &DifferentiableActivityInfo::getFunction() {
+SILFunction &DifferentiableActivityInfo::getFunction() const {
   return parent.function;
 }
 
@@ -436,9 +436,9 @@ void DifferentiableActivityInfo::dump(SILValue value,
   s << "] " << value;
 }
 
-void DifferentiableActivityInfo::dump(SILFunction &fn,
-                                      SILAutoDiffIndices indices,
+void DifferentiableActivityInfo::dump(SILAutoDiffIndices indices,
                                       llvm::raw_ostream &s) const {
+  SILFunction &fn = getFunction();
   s << "Activity info for " << fn.getName() << " at " << indices << '\n';
   for (auto &bb : fn) {
     s << "bb" << bb.getDebugID() << ":\n";

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -422,9 +422,9 @@ Activity DifferentiableActivityInfo::getActivity(
   return activity;
 }
 
-void DifferentiableActivityInfo::dumpActivityInfo(
-    SILValue value, const SILAutoDiffIndices &indices,
-    llvm::raw_ostream &s) const {
+void DifferentiableActivityInfo::dump(SILValue value,
+                                      const SILAutoDiffIndices &indices,
+                                      llvm::raw_ostream &s) const {
   s << '[';
   auto activity = getActivity(value, indices);
   switch (activity.toRaw()) {
@@ -436,17 +436,17 @@ void DifferentiableActivityInfo::dumpActivityInfo(
   s << "] " << value;
 }
 
-void DifferentiableActivityInfo::dumpActivityInfo(SILFunction &fn,
-                                                  SILAutoDiffIndices indices,
-                                                  llvm::raw_ostream &s) const {
+void DifferentiableActivityInfo::dump(SILFunction &fn,
+                                      SILAutoDiffIndices indices,
+                                      llvm::raw_ostream &s) const {
   s << "Activity info for " << fn.getName() << " at " << indices << '\n';
   for (auto &bb : fn) {
     s << "bb" << bb.getDebugID() << ":\n";
     for (auto *arg : bb.getArguments())
-      dumpActivityInfo(arg, indices, s);
+      dump(arg, indices, s);
     for (auto &inst : bb)
       for (auto res : inst.getResults())
-        dumpActivityInfo(res, indices, s);
+        dump(res, indices, s);
     s << '\n';
   }
 }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1344,7 +1344,7 @@ private:
         vjp->getLoweredFunctionType()->getSubstGenericSignature(),
         AutoDiffDerivativeFunctionKind::VJP);
     LLVM_DEBUG(
-        activityInfo.dumpActivityInfo(*original, indices, getADDebugStream()));
+        activityInfo.dump(*original, indices, getADDebugStream()));
     return activityInfo;
   }
 
@@ -2098,7 +2098,7 @@ private:
         jvp->getLoweredFunctionType()->getSubstGenericSignature(),
         AutoDiffDerivativeFunctionKind::JVP);
     LLVM_DEBUG(
-        activityInfo.dumpActivityInfo(*original, indices, getADDebugStream()));
+        activityInfo.dump(*original, indices, getADDebugStream()));
     return activityInfo;
   }
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1343,8 +1343,7 @@ private:
     auto &activityInfo = activityCollection.getActivityInfo(
         vjp->getLoweredFunctionType()->getSubstGenericSignature(),
         AutoDiffDerivativeFunctionKind::VJP);
-    LLVM_DEBUG(
-        activityInfo.dump(*original, indices, getADDebugStream()));
+    LLVM_DEBUG(activityInfo.dump(indices, getADDebugStream()));
     return activityInfo;
   }
 
@@ -2097,8 +2096,7 @@ private:
     auto &activityInfo = activityCollection.getActivityInfo(
         jvp->getLoweredFunctionType()->getSubstGenericSignature(),
         AutoDiffDerivativeFunctionKind::JVP);
-    LLVM_DEBUG(
-        activityInfo.dump(*original, indices, getADDebugStream()));
+    LLVM_DEBUG(activityInfo.dump(indices, getADDebugStream()));
     return activityInfo;
   }
 


### PR DESCRIPTION
Minor refactoring as part of https://bugs.swift.org/browse/TF-993