### PR TITLE
[AST] Handle visiting UnresolvedType in TypeMatcher

### DIFF
--- a/include/swift/AST/CanTypeVisitor.h
+++ b/include/swift/AST/CanTypeVisitor.h
@@ -31,15 +31,12 @@ class CanTypeVisitor {
 public:
   RetTy visit(CanType T, Args... args) {
     switch (T->getKind()) {
-#define UNCHECKED_TYPE(CLASS, PARENT) \
-    case TypeKind::CLASS:
 #define SUGARED_TYPE(CLASS, PARENT) \
     case TypeKind::CLASS:
 #define TYPE(CLASS, PARENT)
 #include "swift/AST/TypeNodes.def"
-      llvm_unreachable("non-canonical or unchecked type");
+      llvm_unreachable("non-canonical type");
 
-#define UNCHECKED_TYPE(CLASS, PARENT)
 #define SUGARED_TYPE(CLASS, PARENT)
 #define TYPE(CLASS, PARENT)                                  \
     case TypeKind::CLASS:                                    \
@@ -64,7 +61,12 @@ public:
 #define TYPE(CLASS, PARENT) ABSTRACT_TYPE(CLASS, PARENT)
 #define ABSTRACT_SUGARED_TYPE(CLASS, PARENT)
 #define SUGARED_TYPE(CLASS, PARENT)
-#define UNCHECKED_TYPE(CLASS, PARENT)
+  // Don't allow unchecked types by default, but allow visitors to opt-in to
+  // handling them.
+#define UNCHECKED_TYPE(CLASS, PARENT)                          \
+  RetTy visit##CLASS##Type(Can##CLASS##Type T, Args... args) { \
+     llvm_unreachable("unchecked type");                       \
+  }
 #include "swift/AST/TypeNodes.def"
 };
 

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -111,6 +111,13 @@ class TypeMatcher {
     TRIVIAL_CASE(BuiltinVectorType)
     TRIVIAL_CASE(SILTokenType)
 
+    bool visitUnresolvedType(CanUnresolvedType firstType, Type secondType,
+                             Type sugaredFirstType) {
+      // Unresolved types never match.
+      return mismatch(firstType.getPointer(), secondType,                \
+                      sugaredFirstType);                                 \
+    }
+
     bool visitTupleType(CanTupleType firstTuple, Type secondType,
                         Type sugaredFirstType) {
       if (auto secondTuple = secondType->getAs<TupleType>()) {
@@ -264,23 +271,6 @@ class TypeMatcher {
       return mismatch(firstInOut.getPointer(), secondType, sugaredFirstType);
     }
 
-    bool visitUnboundBoundGenericType(CanUnboundGenericType firstUBGT,
-                                      Type secondType, Type sugaredFirstType) {
-      if (auto secondUBGT = secondType->getAs<UnboundGenericType>()) {
-        if (firstUBGT->getDecl() != secondUBGT->getDecl())
-          return mismatch(firstUBGT.getPointer(), secondUBGT, sugaredFirstType);
-
-        if (firstUBGT.getParent())
-          return this->visit(firstUBGT.getParent(), secondUBGT->getParent(),
-                             sugaredFirstType->castTo<UnboundGenericType>()
-                               ->getParent());
-
-        return true;
-      }
-
-      return mismatch(firstUBGT.getPointer(), secondType, sugaredFirstType);
-    }
-
     bool visitBoundGenericType(CanBoundGenericType firstBGT,
                                Type secondType, Type sugaredFirstType) {
       auto _secondBGT = secondType->getCanonicalType();
@@ -308,8 +298,6 @@ class TypeMatcher {
 
       return mismatch(firstBGT.getPointer(), secondType, sugaredFirstType);
     }
-
-    TRIVIAL_CASE(TypeVariableType)
 
 #undef TRIVIAL_CASE
   };

--- a/test/IDE/complete_uninferred_generic.swift
+++ b/test/IDE/complete_uninferred_generic.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNINFERRED | %FileCheck %s -check-prefix=UNINFERRED
+
+struct S1<V0> {}
+protocol P1 {
+    associatedtype A1
+}
+extension P1 where A1 == S1<Int> {
+    subscript<T>(v0: T) -> Int  { fatalError() }
+    subscript<T>(v0: T) -> Undefined { fatalError() }
+}
+struct S2<T> : P1 {
+    typealias A1 = S1<T>
+}
+_ = S2()#^UNINFERRED^#
+
+// UNINFERRED: Decl[Subscript]/Super:     [{#(v0): T#}][#Int#]; name=[v0: T]
+// UNINFERRED: Decl[Subscript]/Super:     [{#(v0): T#}][#<<error type>>#]; name=[v0: T]
+// UNINFERRED: Keyword[self]/CurrNominal: .self[#S2<_>#]; name=self


### PR DESCRIPTION
This prevents code completion hitting llvm_unreachable("non-canonical or unchecked type") within the substitution logic.

Resolves rdar://problem/56726715

```
0   libsystem_kernel.dylib        	0x00007fff6735e2c6 __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff67419bf1 pthread_kill + 284
2   libsystem_c.dylib             	0x00007fff672c8745 __abort + 144
3   libsystem_c.dylib             	0x00007fff672c86b5 abort + 142
4   com.apple.SourceKitService.5.0.20191202101_osx	0x000000010c4ddc1e llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 462
5   com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a73577a swift::CanTypeVisitor<swift::TypeMatcher<swift::GenericSignatureBuilder::addSameTypeRequirementBetweenConcrete(swift::Type, swift::Type, swift::GenericSignatureBuilder::FloatingRequirementSource, llvm::function_ref<void (swift::Type, swift::Type)>)::ReqTypeMatcher>::MatchVisitor, bool, swift::Type, swift::Type>::visit(swift::CanType, swift::Type, swift::Type) + 3770
6   com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a736bcf swift::TypeMatcher<swift::GenericSignatureBuilder::addSameTypeRequirementBetweenConcrete(swift::Type, swift::Type, swift::GenericSignatureBuilder::FloatingRequirementSource, llvm::function_ref<void (swift::Type, swift::Type)>)::ReqTypeMatcher>::MatchVisitor::visitBoundGenericType(swift::CanTypeWrapper<swift::BoundGenericType>, swift::Type, swift::Type) + 463
7   com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a72095f swift::GenericSignatureBuilder::addSameTypeRequirementBetweenConcrete(swift::Type, swift::Type, swift::GenericSignatureBuilder::FloatingRequirementSource, llvm::function_ref<void (swift::Type, swift::Type)>) + 143
8   com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a71fa77 swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) + 247
9   com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a710b68 swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::RequirementRepr const*, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::SubstitutionMap const*, swift::ModuleDecl*) + 1704
10  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a72aa33 swift::AbstractGenericSignatureRequest::evaluate(swift::Evaluator&, swift::GenericSignatureImpl*, llvm::SmallVector<swift::GenericTypeParamType*, 2u>, llvm::SmallVector<swift::Requirement, 2u>) const + 787
11  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a3719fe llvm::Expected<swift::GenericSignature> swift::SimpleRequest<swift::AbstractGenericSignatureRequest, swift::GenericSignature (swift::GenericSignatureImpl*, llvm::SmallVector<swift::GenericTypeParamType*, 2u>, llvm::SmallVector<swift::Requirement, 2u>), (swift::CacheKind)1>::callDerived<0ul, 1ul, 2ul>(swift::Evaluator&, llvm::index_sequence<0ul, 1ul, 2ul>) const + 126
12  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a370f5e swift::SimpleRequest<swift::AbstractGenericSignatureRequest, swift::GenericSignature (swift::GenericSignatureImpl*, llvm::SmallVector<swift::GenericTypeParamType*, 2u>, llvm::SmallVector<swift::Requirement, 2u>), (swift::CacheKind)1>::evaluateRequest(swift::AbstractGenericSignatureRequest const&, swift::Evaluator&) + 14
13  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a796eef llvm::Expected<swift::AbstractGenericSignatureRequest::OutputType> swift::Evaluator::getResultUncached<swift::AbstractGenericSignatureRequest>(swift::AbstractGenericSignatureRequest const&) + 255
14  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a796aa8 llvm::Expected<swift::AbstractGenericSignatureRequest::OutputType> swift::Evaluator::getResultCached<swift::AbstractGenericSignatureRequest, (void*)0>(swift::AbstractGenericSignatureRequest const&) + 136
15  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a7949d6 llvm::Expected<swift::AbstractGenericSignatureRequest::OutputType> swift::Evaluator::operator()<swift::AbstractGenericSignatureRequest>(swift::AbstractGenericSignatureRequest const&) + 134
16  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a72af11 swift::AbstractGenericSignatureRequest::evaluate(swift::Evaluator&, swift::GenericSignatureImpl*, llvm::SmallVector<swift::GenericTypeParamType*, 2u>, llvm::SmallVector<swift::Requirement, 2u>) const + 2033
17  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a3719fe llvm::Expected<swift::GenericSignature> swift::SimpleRequest<swift::AbstractGenericSignatureRequest, swift::GenericSignature (swift::GenericSignatureImpl*, llvm::SmallVector<swift::GenericTypeParamType*, 2u>, llvm::SmallVector<swift::Requirement, 2u>), (swift::CacheKind)1>::callDerived<0ul, 1ul, 2ul>(swift::Evaluator&, llvm::index_sequence<0ul, 1ul, 2ul>) const + 126
18  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a370f5e swift::SimpleRequest<swift::AbstractGenericSignatureRequest, swift::GenericSignature (swift::GenericSignatureImpl*, llvm::SmallVector<swift::GenericTypeParamType*, 2u>, llvm::SmallVector<swift::Requirement, 2u>), (swift::CacheKind)1>::evaluateRequest(swift::AbstractGenericSignatureRequest const&, swift::Evaluator&) + 14
19  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a796eef llvm::Expected<swift::AbstractGenericSignatureRequest::OutputType> swift::Evaluator::getResultUncached<swift::AbstractGenericSignatureRequest>(swift::AbstractGenericSignatureRequest const&) + 255
20  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a796aa8 llvm::Expected<swift::AbstractGenericSignatureRequest::OutputType> swift::Evaluator::getResultCached<swift::AbstractGenericSignatureRequest, (void*)0>(swift::AbstractGenericSignatureRequest const&) + 136
21  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a7949d6 llvm::Expected<swift::AbstractGenericSignatureRequest::OutputType> swift::Evaluator::operator()<swift::AbstractGenericSignatureRequest>(swift::AbstractGenericSignatureRequest const&) + 134
22  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a79483b swift::AbstractGenericSignatureRequest::OutputType swift::evaluateOrDefault<swift::AbstractGenericSignatureRequest>(swift::Evaluator&, swift::AbstractGenericSignatureRequest, swift::AbstractGenericSignatureRequest::OutputType) + 27
23  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a78f4a3 substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<swift::ProtocolConformanceRef (swift::CanType, swift::Type, swift::ProtocolDecl*)>, swift::SubstOptions) + 2435
24  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a788cd6 swift::Type::subst(swift::SubstitutionMap, swift::SubstOptions) const + 118
25  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a284b12 lookupVisibleMemberDecls(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::GenericSignatureBuilder*) + 1314
26  com.apple.SourceKitService.5.0.20191202101_osx	0x0000000109ac69b3 (anonymous namespace)::CodeCompletionCallbacksImpl::doneParsing() + 9923
27  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a52bdf9 swift::Parser::performCodeCompletionSecondPassImpl(swift::PersistentParserState::CodeCompletionDelayedDeclState&) + 1513
28  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010a52b6ed swift::Parser::performCodeCompletionSecondPass(swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory&) + 269
29  com.apple.SourceKitService.5.0.20191202101_osx	0x0000000109aac11b swift::CompilerInstance::parseAndCheckTypesUpTo(swift::CompilerInstance::ImplicitImports const&, swift::SourceFile::ASTStage_t) + 699
30  com.apple.SourceKitService.5.0.20191202101_osx	0x0000000109aab86d swift::CompilerInstance::performSemaUpTo(swift::SourceFile::ASTStage_t) + 621
31  com.apple.SourceKitService.5.0.20191202101_osx	0x00000001099f45ec swiftCodeCompleteImpl(SourceKit::SwiftLangSupport&, llvm::MemoryBuffer*, unsigned int, (anonymous namespace)::SwiftCodeCompletionConsumer&, llvm::ArrayRef<char const*>, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) + 2828
32  com.apple.SourceKitService.5.0.20191202101_osx	0x00000001099f39a5 SourceKit::SwiftLangSupport::codeComplete(llvm::MemoryBuffer*, unsigned int, SourceKit::CodeCompletionConsumer&, llvm::ArrayRef<char const*>, llvm::Optional<SourceKit::VFSOptions>) + 293
33  com.apple.SourceKitService.5.0.20191202101_osx	0x0000000109a598d4 handleSemanticRequest(sourcekitd::RequestDict, std::__1::function<void (void*)>, sourcekitd_uid_s*, llvm::Optional<llvm::StringRef>, llvm::Optional<llvm::StringRef>, llvm::ArrayRef<char const*>, llvm::Optional<SourceKit::VFSOptions>) + 2228
34  com.apple.SourceKitService.5.0.20191202101_osx	0x0000000109a58f3a void SourceKit::WorkQueue::DispatchData::callAndDelete<handleRequestImpl(void*, std::__1::function<void (void*)>)::$_4>(void*) + 330
35  libdispatch.dylib             	0x00007fff671d663d _dispatch_client_callout + 8
36  libdispatch.dylib             	0x00007fff671d9374 _dispatch_block_invoke_direct + 256
37  com.apple.SourceKitService.5.0.20191202101_osx	0x000000010c199dcf executeBlock(void*) + 15
38  com.apple.SourceKitService.5.0.20191202101_osx	0x00000001099d4a3d ExecuteOnThread_Dispatch(void*) + 13
39  libsystem_pthread.dylib       	0x00007fff674172eb _pthread_body + 126
40  libsystem_pthread.dylib       	0x00007fff6741a249 _pthread_start + 66
41  libsystem_pthread.dylib       	0x00007fff6741640d thread_start + 13
```