### PR TITLE
Cross-module-optimization: make sure that witness tables, which are used by serialized functions, get public linkage

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleSerializationSetup.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleSerializationSetup.cpp
@@ -191,6 +191,12 @@ makeSubstUsableFromInline(const SubstitutionMap &substs) {
   for (Type replType : substs.getReplacementTypes()) {
     makeTypeUsableFromInline(replType->getCanonicalType());
   }
+  for (ProtocolConformanceRef pref : substs.getConformances()) {
+    if (pref.isConcrete()) {
+      ProtocolConformance *concrete = pref.getConcrete();
+      makeDeclUsableFromInline(concrete->getProtocol(), M);
+    }
+  }
 }
 
 /// Decide whether to serialize a function.

--- a/test/SILOptimizer/Inputs/cross-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module.swift
@@ -152,6 +152,29 @@ public func callFoo_gen<T>(_ t: T) {
   printFooGeneric(1234)
 }
 
+fileprivate protocol PrivateProto {
+  func foo()
+}
+
+public class FooClass: PrivateProto {
+  func foo() {
+    print(321)
+  }
+}
+
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+fileprivate func callProtocolFoo<T: PrivateProto>(_ t: T) {
+  t.foo()
+}
+
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+public func callFooViaConformance<T>(_ t: T) {
+  let c = FooClass()
+  callProtocolFoo(c)
+}
+
 @inline(never)
 public func callGenericSubmoduleFunc<T>(_ t: T) {
   genericSubmoduleFunc(t)

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -83,6 +83,8 @@ func testProtocolsAndClasses() {
   callFoo_gen(27)
   // CHECK-OUTPUT: 55
   callClassMethod(55)
+  // CHECK-OUTPUT: 321
+  callFooViaConformance(0)
 }
 
 func testSubModule() {


### PR DESCRIPTION
Fixes an undefined-symbol error.
