### PR TITLE
[AutoDiff] simplify SILGen thunking and set correct thunk linkage

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -148,15 +148,6 @@ public:
                                CanSILFunctionType constantTy);
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Get or create an autodiff derivative function forwarding thunk for the
-  /// given derivative SILDeclRef, SILFunction, and function type.
-  /// The thunk simply forwards arguments and returns results: use this when no
-  /// reabstraction or self reordering is necessary.
-  SILFunction *getOrCreateAutoDiffDerivativeForwardingThunk(
-      SILDeclRef derivativeFnRef, SILFunction *derivativeFn,
-      CanSILFunctionType derivativeFnTy);
-
-  // SWIFT_ENABLE_TENSORFLOW
   /// Get or create an autodiff derivative function vtable entry thunk for the
   /// given SILDeclRef and derivative function type.
   SILFunction *
@@ -182,8 +173,15 @@ public:
                                            CanType dynamicSelfType);
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Get or create an autodiff derivative function thunk performing
-  /// reabstraction and/or self-reordering.
+  /// Given a user-specified custom derivative, get or create a thunk that calls
+  /// the custom derivative, and that haswith the abstraction pattern and
+  /// parameter ordering required for the SIL derivative of the given original
+  /// function.
+  ///
+  /// To achieve the required SIL derivative, the thunk may perform any subset
+  /// of:
+  /// - Self-reordering.
+  /// - Reabstraction.
   ///
   /// Self-reordering is done for canonicalizing the types of derivative
   /// functions for instance methods wrt self. We want users to define
@@ -223,12 +221,14 @@ public:
   /// ordering uniform for "wrt self instance method derivatives" and simplifies
   /// the transform rules.
   ///
-  /// If `reorderSelf` is true, reorder self so that it appears as:
+  /// If self must be reordered, reorder it so that it appears as:
   /// - The last parameter in the returned differential.
   /// - The last result in the returned pullback.
-  SILFunction *getOrCreateAutoDiffDerivativeReabstractionThunk(
-      SILFunction *original, AutoDiffConfig config, SILFunction *derivativeFn,
-      AutoDiffDerivativeFunctionKind derivativeFnKind, bool reorderSelf);
+  SILFunction *
+  getOrCreateCustomDerivativeThunk(
+      SILFunction *customDerivativeFn,
+      SILFunction *originalFn, const AutoDiffConfig &config,
+      AutoDiffDerivativeFunctionKind kind);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/test/AutoDiff/downstream/silgen_thunking/main.swift
+++ b/test/AutoDiff/downstream/silgen_thunking/main.swift
@@ -52,7 +52,7 @@ struct SelfReordering : Differentiable & AdditiveArithmetic {
     return (value, { v in (Self(1), Self(2), Self(3)) })
   }
 
-// CHECK-LABEL: sil hidden [always_inline] [ossa] @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__jvp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> @owned SelfReordering)
+// CHECK-LABEL: sil hidden [thunk] [always_inline] [ossa] @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__jvp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> @owned SelfReordering)
 // CHECK: bb0([[X:%.*]] : @guaranteed $SelfReordering, [[Y:%.*]] : @guaranteed $SelfReordering, [[SELF:%.*]] : @guaranteed $SelfReordering):
 // CHECK: [[JVP:%.*]] = function_ref @$s4main14SelfReorderingV23jvpThreeParameterMethodyAC5value_A2C_A2Ctc12differentialtAC_ACtF
 // CHECK: [[JVP_RESULT:%.*]] = apply [[JVP]]([[X]], [[Y]], [[SELF]])
@@ -67,7 +67,7 @@ struct SelfReordering : Differentiable & AdditiveArithmetic {
 // CHECK: [[DF_RESULT:%.*]] = apply [[DF]]([[DSELF]], [[DX]], [[DY]])
 // CHECK: return [[DF_RESULT]]
 
-// CHECK-LABEL: sil hidden [always_inline] [ossa] @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__vjp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering) -> (@owned SelfReordering, @owned SelfReordering, @owned SelfReordering))
+// CHECK-LABEL: sil hidden [thunk] [always_inline] [ossa] @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__vjp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering) -> (@owned SelfReordering, @owned SelfReordering, @owned SelfReordering))
 // CHECK: bb0([[X:%.*]] : @guaranteed $SelfReordering, [[Y:%.*]] : @guaranteed $SelfReordering, [[SELF:%.*]] : @guaranteed $SelfReordering):
 // CHECK: [[VJP:%.*]] = function_ref @$s4main14SelfReorderingV23vjpThreeParameterMethodyAC5value_AC_A2CtACc8pullbacktAC_ACtF
 // CHECK: [[VJP_RESULT:%.*]] = apply [[VJP]]([[X]], [[Y]], [[SELF]])
@@ -117,7 +117,7 @@ where Dummy: Differentiable & ExpressibleByIntegerLiteral {
     return (value, { v in (v, 2.0, 3.0) })
   }
 
-// CHECK-LABEL: sil hidden [always_inline] [ossa] @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__jvp_src_0_wrt_0_1_2{{.*}} : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed τ_1_0.TangentVector, @in_guaranteed τ_1_1.TangentVector, @in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> @out SelfReorderingGeneric<τ_0_0>.TangentVector) {
+// CHECK-LABEL: sil hidden [thunk] [always_inline] [ossa] @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__jvp_src_0_wrt_0_1_2{{.*}} : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed τ_1_0.TangentVector, @in_guaranteed τ_1_1.TangentVector, @in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> @out SelfReorderingGeneric<τ_0_0>.TangentVector) {
 // CHECK: bb0([[JVP_RESULT:%.*]] : $*SelfReorderingGeneric<τ_0_0>, [[X:%.*]] : $*τ_1_0, [[Y:%.*]] : $*τ_1_1, [[SELF:%.*]] : $*SelfReorderingGeneric<τ_0_0>):
 // CHECK: [[JVP:%.*]] = function_ref @$s4main21SelfReorderingGenericV23jvpThreeParameterMethodyACyxG5value_AC13TangentVectorVyx_GAI_AGQyd__AGQyd_0_tc12differentialtqd___qd_0_ts14DifferentiableRd__sAMRd_0_s25ExpressibleByFloatLiteralAJRQsAnKRQr0_lF
 // CHECK: [[DF:%.*]] = apply [[JVP]]<τ_0_0, τ_1_0, τ_1_1>([[JVP_RESULT]], [[X]], [[Y]], [[SELF]])
@@ -131,7 +131,7 @@ where Dummy: Differentiable & ExpressibleByIntegerLiteral {
 // CHECK: [[VOID:%.*]] = tuple ()
 // CHECK: return [[VOID]]
 
-// CHECK-LABEL: sil hidden [always_inline] [ossa] @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__vjp_src_0_wrt_0_1_2{{.*}} : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> (@out τ_1_0.TangentVector, @out τ_1_1.TangentVector, @out SelfReorderingGeneric<τ_0_0>.TangentVector)) {
+// CHECK-LABEL: sil hidden [thunk] [always_inline] [ossa] @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__vjp_src_0_wrt_0_1_2{{.*}} : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> (@out τ_1_0.TangentVector, @out τ_1_1.TangentVector, @out SelfReorderingGeneric<τ_0_0>.TangentVector)) {
 // CHECK: bb0([[VJP_RESULT:%.*]] : $*SelfReorderingGeneric<τ_0_0>, [[X:%.*]] : $*τ_1_0, [[Y:%.*]] : $*τ_1_1, [[SELF:%.*]] : $*SelfReorderingGeneric<τ_0_0>):
 // CHECK: [[VJP:%.*]] = function_ref @$s4main21SelfReorderingGenericV23vjpThreeParameterMethodyACyxG5value_AC13TangentVectorVyx_G_AGQyd__AGQyd_0_tAIc8pullbacktqd___qd_0_ts14DifferentiableRd__sAMRd_0_s25ExpressibleByFloatLiteralAJRQsAnKRQr0_lF
 // CHECK: [[PB:%.*]] = apply [[VJP]]<τ_0_0, τ_1_0, τ_1_1>([[VJP_RESULT]], [[X]], [[Y]], [[SELF]])
@@ -145,6 +145,35 @@ where Dummy: Differentiable & ExpressibleByIntegerLiteral {
 // CHECK: [[VOID:%.*]] = tuple ()
 // CHECK: return [[VOID]]
 }
+
+// Test thunk linkage.
+
+public func hasPrivateDerivative(_ x: Float) -> Float { x }
+
+@derivative(of: hasPrivateDerivative)
+fileprivate func privateDerivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  (x, { $0 })
+}
+
+// CHECK-LABEL: sil private [thunk] [always_inline] [ossa] @AD__$s4main20hasPrivateDerivativeyS2fF__vjp_src_0_wrt_0
+
+public func hasInternalDerivative(_ x: Float) -> Float { x }
+
+@derivative(of: hasInternalDerivative)
+internal func internalDerivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  (x, { $0 })
+}
+
+// CHECK-LABEL: sil hidden [thunk] [always_inline] [ossa] @AD__$s4main21hasInternalDerivativeyS2fF__vjp_src_0_wrt_0
+
+public func hasPublicDerivative(_ x: Float) -> Float { x }
+
+@derivative(of: hasPublicDerivative)
+public func publicDerivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  (x, { $0 })
+}
+
+// CHECK-LABEL: sil [thunk] [always_inline] [ossa] @AD__$s4main19hasPublicDerivativeyS2fF__vjp_src_0_wrt_0
 
 extension SelfReorderingGeneric.TangentVector : ExpressibleByFloatLiteral {}
 


### PR DESCRIPTION
Sets the SILGen'd AD thunk linkage to the same linkage as the custom derivative that they wrap, by doing two things:
* Use `customDerivativeFn->getLinkage()` for the linkage of the AD thunk.
* Use `ForDefinition` when getting the custom derivative functions. The `NotForDefinition` flag is for creating function declarations with external linkage, so if we use that then `customDerivativeFn->getLinkage()` is an external linkage, which is not right. (This code is probably going to be deleted very soon anyways, when we forbid custom derivatives in `@differentiable` attributes.)

Also it was initially hard for me to figure out what was going on, so I made some simplifications:
* Delete `getOrCreateAutoDiffDerivativeForwardingThunk` because we can just use the other thunking function, which has a superset of its functionality.
* Rename `getOrCreateAutoDiffDerivativeReabstractionThunk` -> `getOrCreateCustomDerivativeThunk` to clarify that it does all thunking necessary for custom derivatives, not just reabstraction.
* Make `getOrCreateCustomDerivativeThunk` determine whether self needs reordering, so that the caller does not have to worry about that.