### PR TITLE
[NFCi] Adding inttypes.h to Errors.cpp due to llvm.org change in STLExtras.h.

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -62,6 +62,8 @@
 #include <unwind.h>
 #endif
 
+#include <inttypes.h>
+
 namespace FatalErrorFlags {
 enum: uint32_t {
   ReportBacktrace = 1 << 0


### PR DESCRIPTION
In Errors.cpp, PRIxPTR is used in a format string:

constexpr const char *format = "%-4u %-34s 0x%0.16" PRIxPTR " %s + %td\n";

This fails to build because of upstream changes in STLExtras:

llvm/llvm-project@049043b#diff-43fc25e3af55e1ae97f17ef051d68aa4

This patch merely adds the include for the needed PRIxPTR define.

Replacing #28482