### PR TITLE
[AutoDiff] fix TF-961 LoadableByAddress crash

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/tf961-protocol-req-loadable-by-address.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf961-protocol-req-loadable-by-address.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir %s
 // REQUIRES: asserts
 
 public protocol Protocol00023: Differentiable {


### PR DESCRIPTION
TF-961 occurs because LoadableByAddress does not handle the case where the differentiable function conversion instructions are operating on generic functions. This PR adds handling for this case.