### PR TITLE
[ConstraintSystem] Fix a case of too eager force optional unwrap with…

### DIFF
--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -402,3 +402,21 @@ func sr_11104() {
   bar(["hello"].first)
   // expected-error@-1 {{cannot convert value of type 'String?' to expected argument type 'Int'}}
 }
+
+// rdar://problem/57668873 - Too eager force optional unwrap fix
+
+@objc class Window {}
+
+@objc protocol WindowDelegate {
+  @objc optional var window: Window? { get set }
+}
+
+func test_force_unwrap_not_being_too_eager() {
+  struct WindowContainer {
+    unowned(unsafe) var delegate: WindowDelegate? = nil
+  }
+
+  let obj: WindowContainer = WindowContainer()
+  if let _ = obj.delegate?.window { // Ok
+  }
+}


### PR DESCRIPTION
… optional contextual type

If return of optional chaining is assigned to an optional type
or discarded there should be no force optional unwrap attempt
on it because type variable associated with context can be
bound to optional of any depth.

Resolves: rdar://problem/57668763

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
