### PR TITLE
[build] Build compiler-rt for all Darwin platform in llvm-only preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -610,6 +610,12 @@ build-ninja
 skip-build-swift
 skip-build-cmark
 
+# These are needed to trigger the compilation of compiler-rt
+# for all Darwin platforms
+ios
+watchos
+tvos
+
 #===------------------------------------------------------------------------===#
 # A setting to run a buildbot that passes extra swift args when compiling
 # modules that match regexp.


### PR DESCRIPTION
When building llvm-only for Darwin, we need to ensure that we build
compiler-rt for all Darwin platforms, as some scenarios require those to
be present

Addresses rdar://problem/57671343