### PR TITLE
[Diagnostics] Port/Improve diagnostics for `@dynamicCallable` and `callAsFunction`

### DIFF
--- a/docs/TypeChecker.rst
+++ b/docs/TypeChecker.rst
@@ -993,7 +993,6 @@ The things in the queue yet to be ported are:
 
 - Problems related to calls and operator applications e.g.
 
-  - ``@dynamicCallable`` related diagnostics
   - Missing explicit ``Self.`` and ``self.``
   - Logic related to overload candidate ranking (``CalleeCandidateInfo``)
   - ``diagnoseParameterErrors``

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -121,6 +121,12 @@ Expr *FailureDiagnostic::getBaseExprFor(Expr *anchor) const {
     return SE->getBase();
   else if (auto *MRE = dyn_cast<MemberRefExpr>(anchor))
     return MRE->getBase();
+  else if (auto *call = dyn_cast<CallExpr>(anchor)) {
+    auto fnType = getType(call->getFn());
+    if (fnType->isCallableNominalType(getDC())) {
+      return call->getFn();
+    }
+  }
 
   return nullptr;
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1148,6 +1148,12 @@ public:
   bool diagnoseAsError() override;
 
 private:
+  /// Tailored diagnostics for missing special `@dynamicCallable` methods
+  /// e.g. if caller expects `dynamicallyCall(withKeywordArguments:)`
+  /// overload to be present, but a class marked as `@dynamicCallable`
+  /// defines only `dynamicallyCall(withArguments:)` variant.
+  bool diagnoseForDynamicCallable() const;
+
   static DeclName findCorrectEnumCaseName(Type Ty,
                                           TypoCorrectionResults &corrections,
                                           DeclName memberName);

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -113,6 +113,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::KeyPathValue:
   case ConstraintLocator::KeyPathComponentResult:
   case ConstraintLocator::Condition:
+  case ConstraintLocator::DynamicCallable:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -452,6 +453,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
 
     case Condition:
       out << "condition expression";
+      break;
+
+    case DynamicCallable:
+      out << "implicit call to @dynamicCallable method";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -167,6 +167,8 @@ CUSTOM_LOCATOR_PATH_ELT(Witness)
 /// The condition associated with 'if' expression or ternary operator.
 SIMPLE_LOCATOR_PATH_ELT(Condition)
 
+SIMPLE_LOCATOR_PATH_ELT(DynamicCallable)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3066,6 +3066,11 @@ void constraints::simplifyLocator(Expr *&anchor,
       break;
     }
 
+    case ConstraintLocator::DynamicCallable: {
+      path = path.slice(1);
+      continue;
+    }
+
     case ConstraintLocator::ApplyFunction:
       // Extract application function.
       if (auto applyExpr = dyn_cast<ApplyExpr>(anchor)) {

--- a/test/Sema/call_as_function_simple.swift
+++ b/test/Sema/call_as_function_simple.swift
@@ -102,9 +102,7 @@ struct Mutating {
   }
 }
 func testMutating(_ x: Mutating, _ y: inout Mutating) {
-  // TODO(SR-11378): Improve this error to match the error using a direct `callAsFunction` member reference.
-  // expected-error @+2 {{cannot call value of non-function type 'Mutating'}}
-  // expected-error @+1 {{cannot invoke 'x' with no arguments}}
+  // expected-error @+1 {{cannot use mutating member on immutable value: 'x' is a 'let' constant}}
   _ = x()
   // expected-error @+1 {{cannot use mutating member on immutable value: 'x' is a 'let' constant}}
   _ = x.callAsFunction()

--- a/test/attr/attr_dynamic_callable.swift
+++ b/test/attr/attr_dynamic_callable.swift
@@ -52,10 +52,21 @@ func testCallable(
 func testCallableDiagnostics(
   a: Callable, b: DiscardableResult, c: Throwing, d: KeywordArgumentCallable
 ) {
-  a("hello", "world") // expected-error {{cannot invoke 'a' with an argument list of type '(String, String)'}}
-  b("hello", "world") // expected-error {{cannot invoke 'b' with an argument list of type '(String, String)'}}
-  try? c(1, 2, 3, 4) // expected-error {{cannot invoke 'c' with an argument list of type '(Int, Int, Int, Int)'}}
-  d(x1: "hello", x2: "world") // expected-error {{cannot invoke 'd' with an argument list of type '(x1: String, x2: String)'}}
+  a("hello", "world")
+  // expected-error@-1:5  {{cannot convert value of type 'String' to expected argument type 'Int'}}
+  // expected-error@-2:14 {{cannot convert value of type 'String' to expected argument type 'Int'}}
+  b("hello", "world")
+  // expected-error@-1:5  {{cannot convert value of type 'String' to expected argument type 'Double'}}
+  // expected-error@-2:14 {{cannot convert value of type 'String' to expected argument type 'Double'}}
+  try? c(1, 2, 3, 4)
+  // expected-error@-1:10 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  // expected-error@-2:13 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  // expected-error@-3:16 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+  // expected-error@-4:19 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+
+  d(x1: "hello", x2: "world")
+  // expected-error@-1:9  {{cannot convert value of type 'String' to expected argument type 'Float'}}
+  // expected-error@-2:22 {{cannot convert value of type 'String' to expected argument type 'Float'}}
 }
 
 func testIUO(


### PR DESCRIPTION
- Improve diagnostics for mutating `callAsFunction` used on r-value
- Align `@dynamicCallable` argument locators with regular calls
- Port tailored diagnostics for missing `dynamicallyCall` methods

Resolves: [SR-11378](https://bugs.swift.org/browse/SR-11378)
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
