### PR TITLE
[SIL Optimization] Create new utilities for dead code elimination. 

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -641,8 +641,10 @@ BUILTIN_MISC_OPERATION(PoundAssert, "poundAssert", "", Special)
 
 /// globalStringTablePointer has type String -> Builtin.RawPointer.
 /// It returns an immortal, global string table pointer for strings constructed
-/// from string literals.
-BUILTIN_MISC_OPERATION_WITH_SILGEN(GlobalStringTablePointer, "globalStringTablePointer", "", Special)
+/// from string literals. We consider it effects as readnone meaning that it
+/// does not read any memory (note that even though it reads from a string, it
+/// is a pure value and therefore we can consider it as readnone).
+BUILTIN_MISC_OPERATION_WITH_SILGEN(GlobalStringTablePointer, "globalStringTablePointer", "n", Special)
 
 #undef BUILTIN_MISC_OPERATION_WITH_SILGEN
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -528,6 +528,9 @@ ERROR(oslog_non_constant_interpolation, none, "'OSLogInterpolation' instance "
 ERROR(oslog_property_not_constant, none, "'OSLogInterpolation.%0' is not a "
       "constant", (StringRef))
 
+ERROR(oslog_message_alive_after_opts, none, "OSLogMessage instance must not "
+      "be explicitly created and must be deletable", ())
+
 ERROR(global_string_pointer_on_non_constant, none, "globalStringTablePointer "
       "builtin must used only on string literals", ())
 

--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -207,6 +207,8 @@ public:
   void dumpState();
 };
 
+bool hasConstantEvaluableAnnotation(SILFunction *fun);
+
 bool isConstantEvaluable(SILFunction *fun);
 
 /// Return true if and only if the given function \p fun is specially modeled

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -56,8 +56,101 @@ NullablePtr<SILInstruction> createIncrementBefore(SILValue ptr,
 NullablePtr<SILInstruction> createDecrementBefore(SILValue ptr,
                                                   SILInstruction *insertpt);
 
+/// A utility for deleting one or more instructions belonging to a function, and
+/// cleaning up any dead code resulting from deleting those instructions. Use
+/// this utility instead of
+/// \c recursivelyDeleteTriviallyDeadInstruction.
+class InstructionDeleter {
+private:
+  // A set vector of instructions that are found to be dead. The ordering
+  // of instructions in this set is important as when a dead instruction is
+  // removed, new instructions will be generated to fix the lifetime of the
+  // instruction's operands. This has to be deterministic.
+  SmallSetVector<SILInstruction *, 8> deadInstructions;
+
+  void deleteInstruction(SILInstruction *inst,
+                         llvm::function_ref<void(SILInstruction *)> callback,
+                         bool fixOperandLifetimes);
+
+public:
+  InstructionDeleter() {}
+
+  /// If the instruction \p inst is dead, record it so that it can be cleaned
+  /// up.
+  void trackIfDead(SILInstruction *inst);
+
+  /// Delete the instruction \p inst and record instructions that may become
+  /// dead because of the removal of \c inst. This function will add necessary
+  /// ownership instructions to fix the lifetimes of the operands of \c inst to
+  /// compensate for its deletion. This function will not clean up dead code
+  /// resulting from the instruction's removal. To do so, invoke the method \c
+  /// cleanupDeadCode of this instance, once the SIL of the contaning function
+  /// is made consistent.
+  ///
+  /// \pre the function containing \c inst must be using ownership SIL.
+  /// \pre the instruction to be deleted must not have any use other than
+  /// incidental uses.
+  ///
+  /// \param callback a callback called whenever an instruction
+  /// is deleted.
+  void forceDeleteAndFixLifetimes(
+      SILInstruction *inst,
+      llvm::function_ref<void(SILInstruction *)> callback =
+          [](SILInstruction *) {});
+
+  /// Delete the instruction \p inst and record instructions that may become
+  /// dead because of the removal of \c inst. If in ownership SIL, use the
+  /// \c forceDeleteAndFixLifetimes function instead, unless under special
+  /// circumstances where the client must handle fixing lifetimes of the
+  /// operands of the deleted instructions. This function will not fix the
+  /// lifetimes of the operands of \c inst once it is deleted. This function
+  /// will not clean up dead code resulting from the instruction's removal. To
+  /// do so, invoke the method \c cleanupDeadCode of this instance, once the SIL
+  /// of the contaning function is made consistent.
+  ///
+  /// \pre the instruction to be deleted must not have any use other than
+  /// incidental uses.
+  ///
+  /// \param callback a callback called whenever an instruction
+  /// is deleted.
+  void forceDelete(
+      SILInstruction *inst,
+      llvm::function_ref<void(SILInstruction *)> callback =
+          [](SILInstruction *) {});
+
+  /// Clean up dead instructions that are tracked by this instance and all
+  /// instructions that transitively become dead.
+  ///
+  /// \pre the function contaning dead instructions must be consistent (i.e., no
+  /// under or over releases). Note that if \c forceDelete call leaves the
+  /// function body in an inconsistent state, it needs to be made consistent
+  /// before this method is invoked.
+  ///
+  /// \param callback a callback called whenever an instruction is deleted.
+  void
+  cleanUpDeadInstructions(llvm::function_ref<void(SILInstruction *)> callback =
+                              [](SILInstruction *) {});
+};
+
+/// If \c inst is dead, delete it and recursively eliminate all code that
+/// becomes dead because of that. If more than one instruction must
+/// be checked/deleted use the \c InstructionDeleter utility.
+///
+/// This function will add necessary compensation code to fix the lifetimes of
+/// the operands of the deleted instructions.
+///
+/// \pre the SIL function containing the instruction is assumed to be
+/// consistent, i.e., does not have under or over releases.
+///
+/// \param callback a callback called whenever an instruction is deleted.
+void eliminateDeadInstruction(
+    SILInstruction *inst, llvm::function_ref<void(SILInstruction *)> callback =
+                              [](SILInstruction *) {});
+
 /// For each of the given instructions, if they are dead delete them
-/// along with their dead operands.
+/// along with their dead operands. Note this utility must be phased out and
+/// replaced by \c eliminateDeadInstruction  and
+/// \c InstructionDeleter utilities.
 ///
 /// \param inst The ArrayRef of instructions to be deleted.
 /// \param force If Force is set, don't check if the top level instructions
@@ -69,7 +162,9 @@ void recursivelyDeleteTriviallyDeadInstructions(
     });
 
 /// If the given instruction is dead, delete it along with its dead
-/// operands.
+/// operands. Note this utility must be phased out and replaced by
+/// \c eliminateDeadInstruction and
+/// \c InstructionDeleter utilities.
 ///
 /// \param inst The instruction to be deleted.
 /// \param force If Force is set, don't check if the top level instruction is

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -991,7 +991,7 @@ void LoopTreeOptimization::hoistLoadsAndStores(SILValue addr, SILLoop *loop, Ins
   }
 
   // In case the value is only stored but never loaded in the loop.
-  recursivelyDeleteTriviallyDeadInstructions(initialLoad);
+  eliminateDeadInstruction(initialLoad);
 }
 
 bool LoopTreeOptimization::hoistAllLoadsAndStores(SILLoop *loop) {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2010,8 +2010,13 @@ void LifetimeChecker::deleteDeadRelease(unsigned ReleaseID) {
   SILInstruction *Release = Destroys[ReleaseID];
   if (isa<DestroyAddrInst>(Release)) {
     SILValue Addr = Release->getOperand(0);
-    if (auto *AddrI = Addr->getDefiningInstruction())
+    if (auto *AddrI = Addr->getDefiningInstruction()) {
+      // FIXME: AddrI will not be deleted (nor its operands) when Release is
+      // still using AddrI's result. Fix this, and migrate to using
+      // InstructionDeleter utility instead of
+      // recursivelyDeadTriviallyDeadInstructions.
       recursivelyDeleteTriviallyDeadInstructions(AddrI);
+    }
   }
   Release->eraseFromParent();
   Destroys[ReleaseID] = nullptr;

--- a/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
+++ b/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
@@ -56,12 +56,17 @@ static bool cleanFunction(SILFunction &fn) {
           LLVM_FALLTHROUGH;
         }
         case BuiltinValueKind::PoundAssert:
-        case BuiltinValueKind::StaticReport:
+        case BuiltinValueKind::StaticReport: {
           // The call to the builtin should get removed before we reach
           // IRGen.
-          recursivelyDeleteTriviallyDeadInstructions(bi, /* Force */ true);
+          InstructionDeleter deleter;
+          deleter.forceDelete(bi);
+          // StaticReport only takes trivial operands, and therefore doesn't
+          // require fixing the lifetime of its operands.
+          deleter.cleanUpDeadInstructions();
           madeChange = true;
           break;
+        }
         default:
           break;
       }

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -2118,7 +2118,7 @@ bool AllocOptimize::promoteLoadCopy(LoadInst *li) {
     SILValue addr = li->getOperand();
     li->eraseFromParent();
     if (auto *addrI = addr->getDefiningInstruction())
-      recursivelyDeleteTriviallyDeadInstructions(addrI);
+      eliminateDeadInstruction(addrI);
     return true;
   }
 
@@ -2139,7 +2139,7 @@ bool AllocOptimize::promoteLoadCopy(LoadInst *li) {
   SILValue addr = li->getOperand();
   li->eraseFromParent();
   if (auto *addrI = addr->getDefiningInstruction())
-    recursivelyDeleteTriviallyDeadInstructions(addrI);
+    eliminateDeadInstruction(addrI);
   return true;
 }
 
@@ -2242,7 +2242,7 @@ bool AllocOptimize::promoteLoadBorrow(LoadBorrowInst *lbi) {
   SILValue addr = lbi->getOperand();
   lbi->eraseFromParent();
   if (auto *addrI = addr->getDefiningInstruction())
-    recursivelyDeleteTriviallyDeadInstructions(addrI);
+    eliminateDeadInstruction(addrI);
   return true;
 }
 

--- a/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
+++ b/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
@@ -52,14 +52,12 @@ struct SILGenCanonicalize final : CanonicalizeInstruction {
       SILInstruction *deadOperInst = *deadOperands.begin();
       // Make sure at least the first instruction is removed from the set.
       deadOperands.erase(deadOperInst);
-      recursivelyDeleteTriviallyDeadInstructions(
-        deadOperInst, false,
-        [&](SILInstruction *deadInst) {
-          LLVM_DEBUG(llvm::dbgs() << "Trivially dead: " << *deadInst);
-          if (nextII == deadInst->getIterator())
-            ++nextII;
-          deadOperands.erase(deadInst);
-        });
+      eliminateDeadInstruction(deadOperInst, [&](SILInstruction *deadInst) {
+        LLVM_DEBUG(llvm::dbgs() << "Trivially dead: " << *deadInst);
+        if (nextII == deadInst->getIterator())
+          ++nextII;
+        deadOperands.erase(deadInst);
+      });
     }
     return nextII;
   }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -919,7 +919,11 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
     // apply. Since the apply was never rewritten, if they aren't removed here,
     // they will be removed later as dead when visited by SILCombine, causing
     // SILCombine to loop infinitely, creating and destroying the casts.
-    recursivelyDeleteTriviallyDeadInstructions(*Builder.getTrackingList());
+    InstructionDeleter deleter;
+    for (SILInstruction *inst : *Builder.getTrackingList()) {
+      deleter.trackIfDead(inst);
+    }
+    deleter.cleanUpDeadInstructions();
     Builder.getTrackingList()->clear();
     return nullptr;
   }

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -1261,7 +1261,7 @@ static bool sinkArgument(EnumCaseDataflowContext &Context, SILBasicBlock *BB, un
       TI->setOperand(ArgNum, CloneInst->getOperand(*DifferentOperandIndex));
       // Now delete the clone as we only needed it operand.
       if (CloneInst != FSI)
-        recursivelyDeleteTriviallyDeadInstructions(CloneInst);
+        eliminateDeadInstruction(CloneInst);
       ++CloneIt;
     }
     assert(CloneIt == Clones.end() && "Clone/pred mismatch");

--- a/lib/SILOptimizer/UtilityPasses/ConstantEvaluableSubsetChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ConstantEvaluableSubsetChecker.cpp
@@ -145,7 +145,8 @@ class ConstantEvaluableSubsetChecker : public SILModuleTransform {
       evaluatedFunctions.insert(callee);
 
       SILModule &calleeModule = callee->getModule();
-      if (callee->isAvailableExternally() && isConstantEvaluable(callee) &&
+      if (callee->isAvailableExternally() &&
+          hasConstantEvaluableAnnotation(callee) &&
           callee->getOptimizationMode() != OptimizationMode::NoOptimization) {
         diagnose(calleeModule.getASTContext(),
                  callee->getLocation().getSourceLoc(),
@@ -161,7 +162,7 @@ class ConstantEvaluableSubsetChecker : public SILModuleTransform {
 
     for (SILFunction &fun : *module) {
       // Record functions annotated as constant evaluable.
-      if (isConstantEvaluable(&fun)) {
+      if (hasConstantEvaluableAnnotation(&fun)) {
         constantEvaluableFunctions.insert(&fun);
         continue;
       }

--- a/lib/SILOptimizer/Utils/CFGOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/CFGOptUtils.cpp
@@ -86,7 +86,7 @@ deleteTriviallyDeadOperandsOfDeadArgument(MutableArrayRef<Operand> termOperands,
   if (!i)
     return;
   op.set(SILUndef::get(op.get()->getType(), *i->getFunction()));
-  recursivelyDeleteTriviallyDeadInstructions(i);
+  eliminateDeadInstruction(i);
 }
 
 // Our implementation assumes that our caller is attempting to remove a dead

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -2129,7 +2129,12 @@ bool swift::isKnownConstantEvaluableFunction(SILFunction *fun) {
   return classifyFunction(fun).hasValue();
 }
 
-bool swift::isConstantEvaluable(SILFunction *fun) {
+bool swift::hasConstantEvaluableAnnotation(SILFunction *fun) {
   assert(fun && "fun should not be nullptr");
   return fun->hasSemanticsAttr("constant_evaluable");
+}
+
+bool swift::isConstantEvaluable(SILFunction *fun) {
+  return hasConstantEvaluableAnnotation(fun) ||
+         isKnownConstantEvaluableFunction(fun);
 }

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -12,8 +12,8 @@
 
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/AST/GenericSignature.h"
-#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/SemanticAttrs.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/DynamicCasts.h"
@@ -27,6 +27,7 @@
 #include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
+#include "swift/SILOptimizer/Utils/ConstExpr.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -171,9 +172,283 @@ bool swift::isIntermediateRelease(SILInstruction *inst,
   return false;
 }
 
+static bool hasOnlyEndOfScopeOrDestroyUses(SILInstruction *inst) {
+  for (SILValue result : inst->getResults()) {
+    for (Operand *use : result->getUses()) {
+      SILInstruction *user = use->getUser();
+      bool isDebugUser = user->isDebugInstruction();
+      if (!isa<DestroyValueInst>(user) && !isEndOfScopeMarker(user) &&
+          !isDebugUser)
+        return false;
+      // Include debug uses only in Onone mode.
+      if (isDebugUser && inst->getFunction()->getEffectiveOptimizationMode() <=
+                             OptimizationMode::NoOptimization)
+        return false;
+    }
+  }
+  return true;
+}
+
+/// Return true iff the \p applySite calls a constant evaluable function and if
+/// it is read-only which implies the following:
+///   (1) The call does not write into any memory location.
+///   (2) The call may destroy owned parameters i.e., consume them.
+///   (3) The call does not throw or exit the program.
+static bool isReadOnlyConstantEvaluableCall(FullApplySite applySite) {
+  assert(applySite);
+  SILFunction *callee = applySite.getCalleeFunction();
+  if (!callee || !isConstantEvaluable(callee)) {
+    return false;
+  }
+  // Here all effects of the call is restricted to its indirect results, which
+  // must have value semantics. If there are no indirect results, the call must
+  // be read-only, except for consuming its operands.
+  return applySite.getNumIndirectSILResults() == 0;
+}
+
+/// A scope-affecting instruction is an instruction which may end the scope of
+/// its operand or may produce scoped results that require cleaning up. E.g.
+/// begin_borrow, begin_access, copy_value, a call that produces a owned value
+/// are scoped instructions. The scope of the results of the first two
+/// instructions end with an end_borrow/acess instruction, while those of the
+/// latter two end with a consuming operation like destroy_value instruction.
+/// These instruction may also end the scope of its operand e.g. a call could
+/// consume owned arguments thereby ending its scope. Dead-code eliminating a
+/// scope-affecting instruction requires fixing the lifetime of the non-trivial
+/// operands of the instruction and requires cleaning up the end-of-scope uses
+/// of non-trivial results.
+///
+/// \param inst instruction that checked for liveness.
+static bool isScopeAffectingInstructionDead(SILInstruction *inst) {
+  SILFunction *fun = inst->getFunction();
+  assert(fun && "Instruction has no function.");
+  // Only support ownership SIL for scoped instructions.
+  if (!fun->hasOwnership()) {
+    return false;
+  }
+  // If the instruction has any use other than end of scope use or destroy_value
+  // use, bail out.
+  if (!hasOnlyEndOfScopeOrDestroyUses(inst)) {
+    return false;
+  }
+  // If inst is a copy or beginning of scope, inst is dead, since we know that
+  // it is used only in a destroy_value or end-of-scope instruction.
+  if (getSingleValueCopyOrCast(inst))
+    return true;
+
+  switch (inst->getKind()) {
+  case SILInstructionKind::LoadBorrowInst: {
+    // A load_borrow only used in an end_borrow is dead.
+    return true;
+  }
+  case SILInstructionKind::LoadInst: {
+    LoadOwnershipQualifier loadOwnershipQual =
+        cast<LoadInst>(inst)->getOwnershipQualifier();
+    // If the load creates a copy, it is dead, since we know that if at all it
+    // is used, it is only in a destroy_value instruction.
+    return (loadOwnershipQual == LoadOwnershipQualifier::Copy ||
+            loadOwnershipQual == LoadOwnershipQualifier::Trivial);
+    // TODO: we can handle load [take] but we would have to know that the
+    // operand has been consumed. Note that OperandOwnershipKind map does not
+    // say this for load.
+  }
+  case SILInstructionKind::PartialApplyInst: {
+    // Partial applies that are only used in destroys cannot have any effect on
+    // the program state, provided the values they capture are explicitly
+    // destroyed.
+    return true;
+  }
+  case SILInstructionKind::StructInst:
+  case SILInstructionKind::EnumInst:
+  case SILInstructionKind::TupleInst:
+  case SILInstructionKind::ConvertFunctionInst:
+  case SILInstructionKind::DestructureStructInst:
+  case SILInstructionKind::DestructureTupleInst: {
+    // All these ownership forwarding instructions that are only used in
+    // destroys are dead provided the values they consume are destroyed
+    // explicitly.
+    return true;
+  }
+  case SILInstructionKind::ApplyInst: {
+    // Given a call to a function annotated as constant_evaluable, the call
+    // will be removed as long as the following holds:
+    // 1. If the call destroys its arguments: when removing the call, a destroy
+    // of each argument is added.
+    // 2. If the call returns a dead value i.e., a value that is only
+    // destroyed: both the call and corresponding destroy will be removed.
+    // Note that a value returned by a constant evaluable function must either
+    // contain constant pure values (trivial instances or array/string
+    // literals), or the arguments passed to the call. Given that its arguments
+    // will be destroyed explicitly, it is okay to remove the destroys of the
+    // return value of a constant evaluable function.
+    FullApplySite applySite(cast<ApplyInst>(inst));
+    return isReadOnlyConstantEvaluableCall(applySite);
+  }
+  default: {
+    return false;
+  }
+  }
+}
+
+void InstructionDeleter::trackIfDead(SILInstruction *inst) {
+  if (isInstructionTriviallyDead(inst) ||
+      isScopeAffectingInstructionDead(inst)) {
+    assert(!isIncidentalUse(inst) && !isa<DestroyValueInst>(inst) &&
+           "Incidental uses cannot be removed in isolation. "
+           "They would be removed iff the operand is dead");
+    deadInstructions.insert(inst);
+  }
+}
+
+/// Given an \p operand that belongs to an instruction that will be removed,
+/// destroy the operand just before the instruction, if the instruction consumes
+/// \p operand. This function will result in a double consume, which is expected
+/// to be resolved when the caller deletes the original instruction. This
+/// function works only on ownership SIL.
+static void destroyConsumedOperandOfDeadInst(Operand &operand) {
+  assert(operand.get() && operand.getUser());
+  SILInstruction *deadInst = operand.getUser();
+  SILFunction *fun = deadInst->getFunction();
+  assert(fun->hasOwnership());
+
+  SILValue operandValue = operand.get();
+  if (operandValue->getType().isTrivial(*fun))
+    return;
+  // A scope ending instruction cannot be deleted in isolation without removing
+  // the instruction defining its operand as well.
+  assert(!isEndOfScopeMarker(deadInst) && !isa<DestroyValueInst>(deadInst) &&
+         "lifetime ending instruction is deleted without its operand");
+  ValueOwnershipKind operandOwnershipKind = operandValue.getOwnershipKind();
+  UseLifetimeConstraint lifetimeConstraint =
+      operand.getOwnershipKindMap().getLifetimeConstraint(operandOwnershipKind);
+  if (lifetimeConstraint == UseLifetimeConstraint::MustBeInvalidated) {
+    // Since deadInst cannot be an end-of-scope instruction (asserted above),
+    // this must be a consuming use of an owned value.
+    assert(operandOwnershipKind == ValueOwnershipKind::Owned);
+    SILBuilderWithScope builder(deadInst);
+    builder.emitDestroyValueOperation(deadInst->getLoc(), operandValue);
+  }
+}
+
 namespace {
 using CallbackTy = llvm::function_ref<void(SILInstruction *)>;
-} // end anonymous namespace
+} // namespace
+
+void InstructionDeleter::deleteInstruction(SILInstruction *inst,
+                                           CallbackTy callback,
+                                           bool fixOperandLifetimes) {
+  // We cannot fix operand lifetimes in non-ownership SIL.
+  assert(!fixOperandLifetimes || inst->getFunction()->hasOwnership());
+  // Collect instruction and its immediate uses and check if they are all
+  // incidental uses. Also, invoke the callback on the instruction and its uses.
+  // Note that the Callback is invoked before deleting anything to ensure that
+  // the SIL is valid at the time of the callback.
+  SmallVector<SILInstruction *, 4> toDeleteInsts;
+  toDeleteInsts.push_back(inst);
+  callback(inst);
+  for (SILValue result : inst->getResults()) {
+    for (Operand *use : result->getUses()) {
+      SILInstruction *user = use->getUser();
+      assert(isIncidentalUse(user) || isa<DestroyValueInst>(user));
+      callback(user);
+      toDeleteInsts.push_back(user);
+    }
+  }
+  // Record definitions of instruction's operands. Also, in case an operand is
+  // consumed by inst, emit necessary compensation code.
+  SmallVector<SILInstruction *, 4> operandDefinitions;
+  for (Operand &operand : inst->getAllOperands()) {
+    SILValue operandValue = operand.get();
+    assert(operandValue &&
+           "Instruction's operand are deleted before the instruction");
+    SILInstruction *defInst = operandValue->getDefiningInstruction();
+    // If the operand has a defining instruction, it could be potentially
+    // dead. Therefore, record the definition.
+    if (defInst)
+      operandDefinitions.push_back(defInst);
+    // The scope of the operand could be ended by inst. Therefore, emit
+    // any compensating code needed to end the scope of the operand value
+    // once inst is deleted.
+    if (fixOperandLifetimes)
+      destroyConsumedOperandOfDeadInst(operand);
+  }
+  // First drop all references from all instructions to be deleted and then
+  // erase the instruction. Note that this is done in this order so that when an
+  // instruction is deleted, its uses would have dropped their references.
+  for (SILInstruction *inst : toDeleteInsts) {
+    inst->dropAllReferences();
+  }
+  for (SILInstruction *inst : toDeleteInsts) {
+    inst->eraseFromParent();
+  }
+  // Record operand definitions that become dead now.
+  for (SILInstruction *operandValInst : operandDefinitions) {
+    trackIfDead(operandValInst);
+  }
+}
+
+void InstructionDeleter::cleanUpDeadInstructions(CallbackTy callback) {
+  SILFunction *fun = nullptr;
+  if (!deadInstructions.empty())
+    fun = deadInstructions.front()->getFunction();
+  while (!deadInstructions.empty()) {
+    SmallVector<SILInstruction *, 8> currentDeadInsts(deadInstructions.begin(),
+                                                      deadInstructions.end());
+    // Though deadInstructions is cleared here, calls to deleteInstruction may
+    // append to deadInstructions. So we need to iterate until this it is empty.
+    deadInstructions.clear();
+    for (SILInstruction *deadInst : currentDeadInsts) {
+      // deadInst will not have been deleted in the previous iterations,
+      // because, by definition, deleteInstruction will only delete an earlier
+      // instruction and its incidental/destroy uses. The former cannot be
+      // deadInst as deadInstructions is a set vector, and the latter cannot be
+      // in deadInstructions as they are incidental uses which are never added
+      // to deadInstructions.
+      deleteInstruction(deadInst, callback, /*Fix lifetime of operands*/
+                        fun->hasOwnership());
+    }
+  }
+}
+
+static bool hasOnlyIncidentalUses(SILInstruction *inst,
+                                  bool disallowDebugUses = false) {
+  for (SILValue result : inst->getResults()) {
+    for (Operand *use : result->getUses()) {
+      SILInstruction *user = use->getUser();
+      if (!isIncidentalUse(user))
+        return false;
+      if (disallowDebugUses && user->isDebugInstruction())
+        return false;
+    }
+  }
+  return true;
+}
+
+void InstructionDeleter::forceDeleteAndFixLifetimes(SILInstruction *inst,
+                                                    CallbackTy callback) {
+  SILFunction *fun = inst->getFunction();
+  assert(fun->hasOwnership());
+  bool disallowDebugUses =
+      fun->getEffectiveOptimizationMode() <= OptimizationMode::NoOptimization;
+  assert(hasOnlyIncidentalUses(inst, disallowDebugUses));
+  deleteInstruction(inst, callback, /*Fix lifetime of operands*/ true);
+}
+
+void InstructionDeleter::forceDelete(SILInstruction *inst,
+                                     CallbackTy callback) {
+  bool disallowDebugUses =
+      inst->getFunction()->getEffectiveOptimizationMode() <=
+      OptimizationMode::NoOptimization;
+  assert(hasOnlyIncidentalUses(inst, disallowDebugUses));
+  deleteInstruction(inst, callback, /*Fix lifetime of operands*/ false);
+}
+
+void swift::eliminateDeadInstruction(SILInstruction *inst,
+                                     CallbackTy callback) {
+  InstructionDeleter deleter;
+  deleter.trackIfDead(inst);
+  deleter.cleanUpDeadInstructions(callback);
+}
 
 void swift::recursivelyDeleteTriviallyDeadInstructions(
     ArrayRef<SILInstruction *> ia, bool force, CallbackTy callback) {
@@ -205,8 +480,8 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
         // If the operand is an instruction that is only used by the instruction
         // being deleted, delete it.
         if (auto *operandValInst = operandVal->getDefiningInstruction())
-          if (!deadInsts.count(operandValInst)
-              && isInstructionTriviallyDead(operandValInst))
+          if (!deadInsts.count(operandValInst) &&
+              isInstructionTriviallyDead(operandValInst))
             nextInsts.insert(operandValInst);
       }
 

--- a/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
@@ -30,17 +30,15 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // expected-error @-2 {{globalStringTablePointer builtin must used only on string literals}}
   }
 
-  // FIXME: the following test should produce diagnostics and is a not
-  // valid uses of the log APIs. The string interpolation passed to the os log
-  // call must be apart of the log call, it cannot be constructed earlier.
-  // It nonetheless works fine, but should be rejected.
   func testNoninlinedOSLogMessage(h: Logger) {
     let logMessage: OSLogMessage = "Minimum integer value: \(Int.min)"
+      // expected-error @-1 {{OSLogMessage instance must not be explicitly created and must be deletable}}
     h.log(level: .debug, logMessage)
   }
 
   func testNoninlinedOSLogMessageComplex(h: Logger, b: Bool) {
     let logMessage: OSLogMessage = "Maximum integer value: \(Int.max)"
+      // expected-error @-1 {{OSLogMessage instance must not be explicitly created and must be deletable}}
     if !b {
       return;
     }

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.sil
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.sil
@@ -57,7 +57,6 @@ bb0:
   destroy_value %7 : $OSLogMessageStub
   %13 = tuple ()
   return %13 : $()
-    // CHECK-NOT: {{%.*}} = struct_extract {{%.*}} : $OSLogInterpolationStub, #OSLogInterpolationStub.formatString
     // CHECK-DAG: [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
     // CHECK-DAG: {{%.*}} = apply [[STRINGUSE]]([[BORROW:%[0-9]+]])
     // CHECK-DAG: [[BORROW]] = begin_borrow [[STRINGCONST:%[0-9]+]]
@@ -98,8 +97,6 @@ bb0:
   dealloc_stack %11 : $*String
   %15 = tuple ()
   return %15 : $()
-    // Skip the first literal.
-    // CHECK: {{%.*}} = string_literal utf8 "some long message: %llx"
     // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "some long message: %llx"
     // CHECK: [[STRINGINIT:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
     // CHECK: [[STRINGCONST:%[0-9]+]] = apply [[STRINGINIT]]([[LIT]], {{%.*}}, {{%.*}}, {{%.*}})
@@ -175,13 +172,12 @@ bb0:
   destroy_value %9 : $String
   %12 = tuple ()
   return %12 : $()
-    // CHECK-NOT: ({{%.*}}) = destructure_struct {{%.*}} : $OSLogInterpolationStub
-    // CHECK-DAG: [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
-    // CHECK-DAG: {{%.*}} = apply [[STRINGUSE]]([[STRINGCONST:%[0-9]+]])
-    // CHECK-DAG: [[STRINGCONST]] = apply [[STRINGINIT:%[0-9]+]]([[LIT:%[0-9]+]], {{%.*}}, {{%.*}}, {{%.*}})
-    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-DAG: [[LIT]] = string_literal utf8 "test message: %lld"
-    // CHECK-DAG: destroy_value [[STRINGCONST]] : $String
+    // CHECK-DAG [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
+    // CHECK-DAG {{%.*}} = apply [[STRINGUSE]]([[STRINGCONST:%[0-9]+]])
+    // CHECK-DAG [[STRINGCONST]] = apply [[STRINGINIT:%[0-9]+]]([[LIT:%[0-9]+]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-DAG [[LIT]] = string_literal utf8 "test message: %lld"
+    // CHECK-DAG destroy_value [[STRINGCONST]] : $String
 }
 
 // Test that the OSLogOptimization pass does not fold instructions that define
@@ -215,7 +211,6 @@ bb0:
   destroy_value %7 : $OSLogMessageStub
   %15 = tuple ()
   return %15 : $()
-    // CHECK-NOT: {{%.*}} = struct_extract {{%.*}} : $OSLogInterpolationStub, #OSLogInterpolationStub.formatString
     // CHECK-DAG: [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
     // CHECK-DAG: {{%.*}} = apply [[STRINGUSE]]([[BORROW:%[0-9]+]])
     // CHECK-DAG: [[BORROW]] = begin_borrow [[COPYVAL:%[0-9]+]]
@@ -275,8 +270,6 @@ bb5:
     // We must have all string literals at the beginning of the borrowed scope,
     // and destorys of the literals at the end of the borrow scope.
 
-    // Skip the first literal which is the original one.
-    // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "test message: %lld"
     // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "test message: %lld"
     // CHECK: [[STRINGINIT:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
     // CHECK: [[STRINGCONST:%[0-9]+]] = apply [[STRINGINIT]]([[LIT]], {{%.*}}, {{%.*}}, {{%.*}})
@@ -535,8 +528,7 @@ bb0:
   destroy_value %2 : $OSLogMessageStringArrayStub
   %8 = tuple ()
   return %8 : $()
-    // Skip the first instance of "ab".
-    // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "ab"
+    // The first instance of "ab" will be dead code eliminated.
     // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "ab"
     // CHECK: [[STRINGINIT:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
     // CHECK: [[STRINGCONST:%[0-9]+]] = apply [[STRINGINIT]]([[LIT]], {{%.*}}, {{%.*}}, {{%.*}})
@@ -741,7 +733,7 @@ bb0(%0 : @guaranteed $String):
   destroy_value %6 : $OSLogMessageStringCapture
   %18 = tuple ()
   return %18 : $()
-    // CHECK: [[FUNREFORIG:%[0-9]+]] = function_ref @idString
+    // The first instance of function_ref @idString will be dead code eliminated.
     // CHECK: [[ORIGCAPTURE:%[0-9]+]] = copy_value %0 : $String
     // CHECK: [[NEWCAPTURE:%[0-9]+]] = copy_value [[ORIGCAPTURE]] : $String
     // CHECK: [[FUNREF:%[0-9]+]] = function_ref @idString
@@ -795,10 +787,9 @@ bb0:
   dealloc_stack %1 : $*Int64
   %18 = tuple ()
   return %18 : $()
-    // CHECK: [[FUNREFORIG:%[0-9]+]] = function_ref @genericFunction
-    // CHECK: [[CLOSUREORIG:%[0-9]+]] = partial_apply [callee_guaranteed] [[FUNREFORIG]]<Int64, Bool>([[CAPTURE1:%[0-9]+]], [[CAPTURE2:%[0-9]+]])
+    // The first instance of function_ref @genericFunction will be dead-code eliminated.
     // CHECK: [[FUNREF:%[0-9]+]] = function_ref @genericFunction
-    // CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FUNREF]]<Int64, Bool>([[CAPTURE1]], [[CAPTURE2]])
+    // CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FUNREF]]<Int64, Bool>([[CAPTURE1:%[0-9]+]], [[CAPTURE2:%[0-9]+]])
     // CHECK: [[BORROW:%[0-9]+]] = begin_borrow [[CLOSURE]] : $@callee_guaranteed () -> Int32
     // CHECK: [[USE:%[0-9]+]] = function_ref @useClosure
     // CHECK: apply [[USE]]([[BORROW]])
@@ -871,4 +862,106 @@ bb0:
   destroy_value %2 : $OSLogMessageClosureArrayStub
   %8 = tuple ()
   return %8 : $()
+}
+
+// The following tests are for checking dead-code elimination performed by the
+// OSLogOptimization pass.
+
+struct OSLogInterpolationDCEStub {
+  var formatString: String
+}
+
+struct OSLogMessageDCEStub {
+  var interpolation: OSLogInterpolationDCEStub
+}
+
+sil [ossa] [Onone] [_semantics "constant_evaluable"] [_semantics "oslog.message.init_stub"] @oslogMessageDCEInit : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub {
+bb0(%0 : @owned $OSLogInterpolationDCEStub):
+  %1 = struct $OSLogMessageDCEStub (%0 : $OSLogInterpolationDCEStub)
+  return %1 : $OSLogMessageDCEStub
+}
+
+// CHECK-LABEL: @testDCEOfStructCreation
+sil [ossa] @testDCEOfStructCreation : $@convention(thin) () -> () {
+bb0:
+  %0 = string_literal utf8 "some message"
+  %1 = integer_literal $Builtin.Word, 12
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = metatype $@thin String.Type
+  // function_ref String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%0, %1, %2, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = struct $OSLogInterpolationDCEStub(%5 : $String)
+  %7 = copy_value %6 : $OSLogInterpolationDCEStub
+  %8 = function_ref @oslogMessageDCEInit : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %9 = apply %8(%7) : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %10 = begin_borrow %9 : $OSLogMessageDCEStub
+  end_borrow %10 : $OSLogMessageDCEStub
+  destroy_value %9 : $OSLogMessageDCEStub
+  destroy_value %6 : $OSLogInterpolationDCEStub
+  %13 = tuple ()
+  return %13 : $()
+    // CHECK: bb0
+    // CHECK-NEXT: [[EMPTYTUP:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[EMPTYTUP]]
+}
+
+sil [ossa] [Onone] [_semantics "constant_evaluable"] [_semantics "oslog.message.init_stub"] @oslogMessageGuaranteedInit : $@convention(thin) (@guaranteed OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub {
+bb0(%0 : @guaranteed $OSLogInterpolationDCEStub):
+  %2 = copy_value %0 : $OSLogInterpolationDCEStub
+  %3 = struct $OSLogMessageDCEStub (%2 : $OSLogInterpolationDCEStub)
+  return %3 : $OSLogMessageDCEStub
+}
+
+// CHECK-LABEL: @testDCEOfGuaranteedStructCreation
+sil [ossa] @testDCEOfGuaranteedStructCreation : $@convention(thin) () -> () {
+bb0:
+  %0 = string_literal utf8 "some message"
+  %1 = integer_literal $Builtin.Word, 12
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = metatype $@thin String.Type
+  // function_ref String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%0, %1, %2, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = struct $OSLogInterpolationDCEStub(%5 : $String)
+  %7 = begin_borrow %6 : $OSLogInterpolationDCEStub
+  %9 = function_ref @oslogMessageGuaranteedInit : $@convention(thin) (@guaranteed OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %10 = apply %9(%7) : $@convention(thin) (@guaranteed OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  destroy_value %10 : $OSLogMessageDCEStub
+  end_borrow %7 : $OSLogInterpolationDCEStub
+  destroy_value %6 : $OSLogInterpolationDCEStub
+  %13 = tuple ()
+  return %13 : $()
+    // CHECK: bb0
+    // CHECK-NEXT: [[EMPTYTUP:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[EMPTYTUP]]
+}
+
+// CHECK-LABEL: @testLifetimeAdjustmentOfDCE
+sil [ossa] @testLifetimeAdjustmentOfDCE : $@convention(thin) () -> () {
+bb0:
+  %0 = string_literal utf8 "some message"
+  %1 = integer_literal $Builtin.Word, 12
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = metatype $@thin String.Type
+  // function_ref String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%0, %1, %2, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = copy_value %5 : $String
+  %7 = struct $OSLogInterpolationDCEStub(%5 : $String)
+  %8 = function_ref @oslogMessageDCEInit : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %9 = apply %8(%7) : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  destroy_value %9 : $OSLogMessageDCEStub
+  %11 = function_ref @useFormatString : $@convention(thin) (@guaranteed String) -> ()
+  %12 = apply %11(%6) : $@convention(thin) (@guaranteed String) -> ()
+  destroy_value %6 : $String
+  %13 = tuple ()
+  return %13 : $()
+    // CHECK: [[STRINGINITREF:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK: [[STRING:%[0-9]+]] = apply [[STRINGINITREF]](
+    // CHECK-NEXT: [[COPY:%[0-9]+]]  = copy_value [[STRING]]
+    // CHECK-NEXT: destroy_value [[STRING]]
+    // CHECK-NOT: OSLogInterpolationDCEStub
+    // CHECK-NOT: OSLogMessageDCEStub
+    // CHECK: return
 }

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -460,5 +460,34 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
       // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
       // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 6
   }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest23testDeadCodeEliminationL_1h6number8num32bit6stringy0aB06LoggerV_Sis5Int32VSStF
+  func testDeadCodeElimination(
+    h: Logger,
+    number: Int,
+    num32bit: Int32,
+    string: String
+  ) {
+    h.log("A message with no data")
+    h.log("smallstring")
+    h.log(
+      level: .error,
+      """
+      A message with many interpolations \(number), \(num32bit), \(string), \
+      and a suffix
+      """)
+    h.log(
+      level: .info,
+      """
+      \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \
+      \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \
+      \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \
+      \(1) \(1) \(1) \(1) \(1) \(48) \(49)
+      """)
+    let concatString = string + ":" + String(number)
+    h.log("\(concatString)")
+      // CHECK-NOT: OSLogMessage
+      // CHECK-LABEL: end sil function '$s25OSLogPrototypeCompileTest23testDeadCodeEliminationL_1h6number8num32bit6stringy0aB06LoggerV_Sis5Int32VSStF'
+  }
 }
 

--- a/test/SILOptimizer/access_marker_mandatory.swift
+++ b/test/SILOptimizer/access_marker_mandatory.swift
@@ -49,8 +49,6 @@ func takeS(_ s: S) {}
 // CHECK: [[ADDRI:%.*]] = struct_element_addr [[WRITE]] : $*S, #S.i
 // CHECK: store %{{.*}} to [[ADDRI]] : $*Int
 // CHECK: end_access [[WRITE]]
-// CHECK: [[READ:%.*]] = begin_access [read] [static] [[STK]] : $*S
-// CHECK: end_access [[READ]]
 // CHECK: [[FTAKE:%.*]] = function_ref @$s23access_marker_mandatory5takeSyyAA1SVF : $@convention(thin) (@guaranteed S) -> ()
 // CHECK: apply [[FTAKE]](%{{.*}}) : $@convention(thin) (@guaranteed S) -> ()
 // CHECK-LABEL: } // end sil function '$s23access_marker_mandatory14modifyAndReadS1oyyXl_tF'

--- a/test/SILOptimizer/predictable_memopt_ownership.sil
+++ b/test/SILOptimizer/predictable_memopt_ownership.sil
@@ -428,7 +428,7 @@ bb0:
 // CHECK-LABEL: sil [ossa] @dead_allocation_1
 sil [ossa] @dead_allocation_1 : $@convention(thin) (@owned Optional<AnyObject>) -> () {
 bb0(%0 : @owned $Optional<AnyObject>):
-// CHECK: copy_value %0
+// CHECK-NOT: alloc_stack
   %1 = alloc_stack $Optional<AnyObject>
   %2 = alloc_stack $Optional<AnyObject>
   store %0 to [init] %2 : $*Optional<AnyObject>
@@ -438,6 +438,7 @@ bb0(%0 : @owned $Optional<AnyObject>):
   dealloc_stack %2 : $*Optional<AnyObject>
   destroy_addr %1 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
+// CHECK: destroy_value %0
   %3 = tuple ()
   return %3 : $()
 }
@@ -445,7 +446,6 @@ bb0(%0 : @owned $Optional<AnyObject>):
 // CHECK-LABEL: sil [ossa] @dead_allocation_2
 sil [ossa] @dead_allocation_2 : $@convention(thin) (@owned Optional<AnyObject>) -> () {
 bb0(%0 : @owned $Optional<AnyObject>):
-// CHECK: copy_value %0
 // CHECK-NOT: alloc_stack
   %1 = alloc_stack $Optional<AnyObject>
   %2 = alloc_stack $Optional<AnyObject>
@@ -457,6 +457,7 @@ bb0(%0 : @owned $Optional<AnyObject>):
   destroy_addr %1 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
   %3 = tuple ()
+// CHECK: destroy_value %0
   return %3 : $()
 }
 


### PR DESCRIPTION
The new utilities perform more aggressive dead code-elimination especially in ownership SIL and can replace `recursivelyDeleteTriviallyDeadInstructions` utility. The new utilitites consist of a function `eliminateDeadCode` and a class `InstructionDeleter`. The former should be used for non-force deletions and later for force deletions.

This patch also migrates most non-force-delete use cases of
`recursivelyDeleteTriviallyDeadInstructions` to the new `eliminateDeadCode` utility
and migrates one force-delete use case of `recursivelyDeleteTriviallyDeadInstructions`
(in IRGenPrepare) to use the `InstructionDeleter` utility.  Other force-delete 
use cases can be migrated similarly.

Most of the logic for dead code elimination is in file `lib/SILOptimizer/Utils/InstOptUtils.cpp/h`. The remaining changes in the patch is for updating the clients to use the new utility and some updates to the tests. 

The main motivation for creating these new utilities is for removing dead code resulting after  optimizing the new OSLog APIs. This is the first of the two patches. The second patch will improve  `PredicatableDeadAllocationElimination`. 