### PR TITLE
test: loosen the #file, #filePath tests for Windows

### DIFF
--- a/test/SILGen/magic_identifier_file.swift
+++ b/test/SILGen/magic_identifier_file.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -module-name Foo %s | %FileCheck --check-prefixes=BOTH,ABSOLUTE %s
-// RUN: %target-swift-emit-silgen -enable-experimental-concise-pound-file -DNEEDS_CONCISE -module-name Foo %s | %FileCheck --check-prefixes=BOTH,CONCISE %s
+// RUN: %target-swift-emit-silgen -module-name Foo %/s | %FileCheck --check-prefixes=BOTH,ABSOLUTE %s
+// RUN: %target-swift-emit-silgen -enable-experimental-concise-pound-file -DNEEDS_CONCISE -module-name Foo %/s | %FileCheck --check-prefixes=BOTH,CONCISE %s
 
 // FIXME: Once this feature becomes non-experimental, we should update existing
 // tests and delete this file.

--- a/test/SILGen/magic_identifier_filepath.swift
+++ b/test/SILGen/magic_identifier_filepath.swift
@@ -1,5 +1,5 @@
 // Check that we generate the right code with the flag.
-// RUN: %target-swift-emit-silgen -enable-experimental-concise-pound-file -module-name Foo %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-concise-pound-file -module-name Foo %/s | %FileCheck %s
 
 // Check that we give errors for use of #filePath if concise #file isn't enabled.
 // FIXME: Drop if we stop rejecting this.


### PR DESCRIPTION
Be more lenient about the path separator.  This repairs the tests on
Windows after #25656.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
