### PR TITLE
[Driver] Change `markTransitive` and `markExternal` to return values

### DIFF
--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -304,8 +304,7 @@ public:
   /// 2. Jobs not previously known to need dependencies reexamined after they
   /// are recompiled. Such jobs are added to the \ref cascadingJobs set, and
   /// accessed via \ref isMarked.
-  void markTransitive(
-      SmallVectorImpl<const driver::Job *> &consequentJobsToRecompile,
+  std::vector<const driver::Job*> markTransitive(
       const driver::Job *jobToBeRecompiled, const void *ignored = nullptr);
 
   /// "Mark" this node only.
@@ -316,8 +315,7 @@ public:
 
   std::vector<StringRef> getExternalDependencies() const;
 
-  void markExternal(SmallVectorImpl<const driver::Job *> &uses,
-                    StringRef externalDependency);
+  std::vector<const driver::Job*> markExternal(StringRef externalDependency);
 
   void forEachUnmarkedJobDirectlyDependentOnExternalSwiftdeps(
       StringRef externalDependency, function_ref<void(const driver::Job *)> fn);
@@ -436,8 +434,7 @@ private:
       std::unordered_set<const ModuleDepGraphNode *> &foundDependents,
       const ModuleDepGraphNode *definition);
 
-  void computeUniqueJobsFromNodes(
-      SmallVectorImpl<const driver::Job *> &uniqueJobs,
+  std::vector<const driver::Job*> computeUniqueJobsFromNodes(
       const std::unordered_set<const ModuleDepGraphNode *> &nodes);
 
   /// Record a visit to this node for later dependency printing

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -437,11 +437,9 @@ namespace driver {
     /// invalidated by any new dependency edges introduced by it. If reloading
     /// fails, this can cause deferred jobs to be immediately scheduled.
 
-    template <unsigned N>
-    void reloadAndRemarkDeps(const Job *FinishedCmd, int ReturnCode,
-                             SmallVector<const Job *, N> &Dependents,
+    std::vector<const Job*>
+    reloadAndRemarkDeps(const Job *FinishedCmd, int ReturnCode,
                              const bool forRanges) {
-
       const CommandOutput &Output = FinishedCmd->getOutput();
       StringRef DependenciesFile =
           Output.getAdditionalOutputForType(file_types::TY_SwiftDeps);
@@ -454,7 +452,7 @@ namespace driver {
         // not using either of those right now, and this logic should probably
         // be revisited when we are.
         assert(FinishedCmd->getCondition() == Job::Condition::Always);
-        return;
+        return {};
       }
       // If we have a dependency file /and/ the frontend task exited normally,
       // we can be discerning about what downstream files to rebuild.
@@ -470,61 +468,61 @@ namespace driver {
 
         switch (loadDepGraphFromPath(FinishedCmd, DependenciesFile,
                                      Comp.getDiags(), forRanges)) {
-        case CoarseGrainedDependencyGraphImpl::LoadResult::HadError:
-          if (ReturnCode == EXIT_SUCCESS) {
-            dependencyLoadFailed(DependenciesFile);
-            // Better try compiling whatever was waiting on more info.
-            for (const Job *Cmd : DeferredCommands)
-              scheduleCommandIfNecessaryAndPossible(Cmd);
-            DeferredCommands.clear();
-            Dependents.clear();
-          } // else, let the next build handle it.
+        case CoarseGrainedDependencyGraph::LoadResult::HadError:
+          if (ReturnCode != EXIT_SUCCESS)
+            // let the next build handle it.
+            break;
+          dependencyLoadFailed(DependenciesFile);
+          // Better try compiling whatever was waiting on more info.
+          for (const Job *Cmd : DeferredCommands)
+            scheduleCommandIfNecessaryAndPossible(Cmd);
+          DeferredCommands.clear();
           break;
-        case CoarseGrainedDependencyGraphImpl::LoadResult::UpToDate:
+
+        case CoarseGrainedDependencyGraph::LoadResult::UpToDate:
           if (!wasCascading)
             break;
           LLVM_FALLTHROUGH;
-        case CoarseGrainedDependencyGraphImpl::LoadResult::AffectsDownstream:
-          markTransitiveInDepGraph(Dependents, FinishedCmd, forRanges,
+        case CoarseGrainedDependencyGraph::LoadResult::AffectsDownstream:
+          return markTransitiveInDepGraph(FinishedCmd, forRanges,
                                    IncrementalTracer);
+        }
+        return {};
+        }
+        // If there's an abnormal exit (a crash), assume the worst.
+        switch (FinishedCmd->getCondition()) {
+        case Job::Condition::NewlyAdded:
+          // The job won't be treated as newly added next time. Conservatively
+          // mark it as affecting other jobs, because some of them may have
+          // completed already.
+          return markTransitiveInDepGraph(FinishedCmd, forRanges,
+                                   IncrementalTracer);
+        case Job::Condition::Always:
+          // Any incremental task that shows up here has already been marked;
+          // we didn't need to wait for it to finish to start downstream
+          // tasks.
+          assert(isMarkedInDepGraph(FinishedCmd, forRanges));
+          break;
+        case Job::Condition::RunWithoutCascading:
+          // If this file changed, it might have been a non-cascading change
+          // and it might not. Unfortunately, the interface hash has been
+          // updated or compromised, so we don't actually know anymore; we
+          // have to conservatively assume the changes could affect other
+          // files.
+          return markTransitiveInDepGraph(FinishedCmd, forRanges,
+                                   IncrementalTracer);
+
+        case Job::Condition::CheckDependencies:
+          // If the only reason we're running this is because something else
+          // changed, then we can trust the dependency graph as to whether
+          // it's a cascading or non-cascading change. That is, if whatever
+          // /caused/ the error isn't supposed to affect other files, and
+          // whatever /fixes/ the error isn't supposed to affect other files,
+          // then there's no need to recompile any other inputs. If either of
+          // those are false, we /do/ need to recompile other inputs.
           break;
         }
-        } else {
-          // If there's an abnormal exit (a crash), assume the worst.
-          switch (FinishedCmd->getCondition()) {
-          case Job::Condition::NewlyAdded:
-            // The job won't be treated as newly added next time. Conservatively
-            // mark it as affecting other jobs, because some of them may have
-            // completed already.
-            markTransitiveInDepGraph(Dependents, FinishedCmd, forRanges,
-                                     IncrementalTracer);
-            break;
-          case Job::Condition::Always:
-            // Any incremental task that shows up here has already been marked;
-            // we didn't need to wait for it to finish to start downstream
-            // tasks.
-            assert(isMarkedInDepGraph(FinishedCmd, forRanges));
-            break;
-          case Job::Condition::RunWithoutCascading:
-            // If this file changed, it might have been a non-cascading change
-            // and it might not. Unfortunately, the interface hash has been
-            // updated or compromised, so we don't actually know anymore; we
-            // have to conservatively assume the changes could affect other
-            // files.
-            markTransitiveInDepGraph(Dependents, FinishedCmd, forRanges,
-                                     IncrementalTracer);
-            break;
-          case Job::Condition::CheckDependencies:
-            // If the only reason we're running this is because something else
-            // changed, then we can trust the dependency graph as to whether
-            // it's a cascading or non-cascading change. That is, if whatever
-            // /caused/ the error isn't supposed to affect other files, and
-            // whatever /fixes/ the error isn't supposed to affect other files,
-            // then there's no need to recompile any other inputs. If either of
-            // those are false, we /do/ need to recompile other inputs.
-            break;
-          }
-        }
+      return {};
     }
 
     /// Check to see if a job produced a zero-length serialized diagnostics
@@ -744,8 +742,7 @@ namespace driver {
                                     const bool forRanges) {
       if (!Comp.getIncrementalBuildEnabled())
         return {};
-      SmallVector<const Job *, 16> Dependents;
-      reloadAndRemarkDeps(FinishedCmd, ReturnCode, Dependents, forRanges);
+      auto Dependents = reloadAndRemarkDeps(FinishedCmd, ReturnCode, forRanges);
       CommandSet DepSet;
       for (const Job *Cmd : Dependents)
         DepSet.insert(Cmd);
@@ -1035,12 +1032,12 @@ namespace driver {
       const auto loadResult = loadDepGraphFromPath(Cmd, DependenciesFile,
                                                    Comp.getDiags(), forRanges);
       switch (loadResult) {
-      case CoarseGrainedDependencyGraphImpl::LoadResult::HadError:
+      case CoarseGrainedDependencyGraph::LoadResult::HadError:
         dependencyLoadFailed(DependenciesFile, /*Warn=*/true);
         return None;
-      case CoarseGrainedDependencyGraphImpl::LoadResult::UpToDate:
+      case CoarseGrainedDependencyGraph::LoadResult::UpToDate:
         return std::make_pair(Cmd->getCondition(), true);
-      case CoarseGrainedDependencyGraphImpl::LoadResult::AffectsDownstream:
+      case CoarseGrainedDependencyGraph::LoadResult::AffectsDownstream:
         if (Comp.getEnableFineGrainedDependencies()) {
           // The fine-grained graph reports a change, since it lumps new
           // files together with new "Provides".
@@ -1106,15 +1103,16 @@ namespace driver {
       }
     }
 
-    SmallVector<const Job *, 16> collectCascadedJobsFromDependencyGraph(
+    CommandSet collectCascadedJobsFromDependencyGraph(
         const CommandSet &InitialCascadingCommands, const bool forRanges) {
-      SmallVector<const Job *, 16> CascadedJobs;
+      CommandSet CascadedJobs;
       // We scheduled all of the files that have actually changed. Now add the
       // files that haven't changed, so that they'll get built in parallel if
       // possible and after the first set of files if it's not.
       for (auto *Cmd : InitialCascadingCommands) {
-        markTransitiveInDepGraph(CascadedJobs, Cmd, forRanges,
-                                 IncrementalTracer);
+        for (const auto *transitiveCmd: markTransitiveInDepGraph(Cmd, forRanges,
+                                 IncrementalTracer))
+          CascadedJobs.insert(transitiveCmd);
       }
       for (auto *transitiveCmd : CascadedJobs)
         noteBuilding(transitiveCmd, /*willBeBuilding=*/true,
@@ -1133,7 +1131,8 @@ namespace driver {
         // If the dependency has been modified since the oldest built file,
         // or if we can't stat it for some reason (perhaps it's been
         // deleted?), trigger rebuilds through the dependency graph.
-        markExternalInDepGraph(ExternallyDependentJobs, dependency, forRanges);
+        for (const Job * marked: markExternalInDepGraph(dependency, forRanges))
+          ExternallyDependentJobs.push_back(marked);
       });
       for (auto *externalCmd : ExternallyDependentJobs) {
         noteBuilding(externalCmd, /*willBeBuilding=*/true,
@@ -1574,15 +1573,12 @@ namespace driver {
       return Dependencies;
     }
 
-    template <unsigned N>
-    void markExternalInDepGraph(SmallVector<const driver::Job *, N> &uses,
-                                StringRef externalDependency,
+    std::vector<const Job*>
+    markExternalInDepGraph(StringRef externalDependency,
                                 const bool forRanges) {
-      if (Comp.getEnableFineGrainedDependencies())
-        getFineGrainedDepGraph(forRanges).markExternal(uses,
-                                                       externalDependency);
-      else
-        getDepGraph(forRanges).markExternal(uses, externalDependency);
+      return Comp.getEnableFineGrainedDependencies()
+        ? getFineGrainedDepGraph(forRanges).markExternal(externalDependency)
+        : getDepGraph(forRanges).markExternal(externalDependency);
     }
 
     bool markIntransitiveInDepGraph(const Job *Cmd, const bool forRanges) {
@@ -1600,15 +1596,13 @@ namespace driver {
                  : getDepGraph(forRanges).loadFromPath(Cmd, path, diags);
     }
 
-    template <unsigned N>
-    void markTransitiveInDepGraph(
-        SmallVector<const Job *, N> &visited, const Job *Cmd,
+    std::vector<const Job*> markTransitiveInDepGraph(
+        const Job *Cmd,
         const bool forRanges,
         CoarseGrainedDependencyGraph::MarkTracer *tracer = nullptr) {
-      if (Comp.getEnableFineGrainedDependencies())
-        getFineGrainedDepGraph(forRanges).markTransitive(visited, Cmd, tracer);
-      else
-        getDepGraph(forRanges).markTransitive(visited, Cmd, tracer);
+      return Comp.getEnableFineGrainedDependencies()
+        ? getFineGrainedDepGraph(forRanges).markTransitive(Cmd, tracer)
+        : getDepGraph(forRanges).markTransitive(Cmd, tracer);
     }
 
     void addIndependentNodeToDepGraph(const Job *Cmd, const bool forRanges) {

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1579,7 +1579,8 @@ namespace driver {
                                 StringRef externalDependency,
                                 const bool forRanges) {
       if (Comp.getEnableFineGrainedDependencies())
-        getFineGrainedDepGraph(forRanges).markExternal(uses, externalDependency);
+        getFineGrainedDepGraph(forRanges).markExternal(uses,
+                                                       externalDependency);
       else
         getDepGraph(forRanges).markExternal(uses, externalDependency);
     }
@@ -1594,7 +1595,8 @@ namespace driver {
     loadDepGraphFromPath(const Job *Cmd, StringRef path,
                          DiagnosticEngine &diags, const bool forRanges) {
       return Comp.getEnableFineGrainedDependencies()
-                 ? getFineGrainedDepGraph(forRanges).loadFromPath(Cmd, path, diags)
+                 ? getFineGrainedDepGraph(forRanges).loadFromPath(Cmd, path,
+                                                                  diags)
                  : getDepGraph(forRanges).loadFromPath(Cmd, path, diags);
     }
 

--- a/unittests/Driver/CoarseGrainedDependencyGraphTests.cpp
+++ b/unittests/Driver/CoarseGrainedDependencyGraphTests.cpp
@@ -79,29 +79,23 @@ TEST(CoarseGrainedDependencyGraph, IndependentNodes) {
                            providesTopLevel, "c0"),
       LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_FALSE(graph.isMarked(1));
   EXPECT_FALSE(graph.isMarked(2));
 
   // Mark 0 again -- should be no change.
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_FALSE(graph.isMarked(1));
   EXPECT_FALSE(graph.isMarked(2));
 
-  graph.markTransitive(marked, 2);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(2).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_FALSE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
 
-  graph.markTransitive(marked, 1);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(1).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -119,10 +113,7 @@ TEST(CoarseGrainedDependencyGraph, IndependentDepKinds) {
                            providesTopLevel, "a"),
       LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_FALSE(graph.isMarked(1));
 }
@@ -139,10 +130,7 @@ TEST(CoarseGrainedDependencyGraph, IndependentDepKinds2) {
                            providesTopLevel, "a"),
       LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 1);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(1).size());
   EXPECT_FALSE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -161,10 +149,7 @@ TEST(CoarseGrainedDependencyGraph, IndependentMembers) {
   EXPECT_EQ(loadFromString(graph, 4, dependsMember, "[b,bb]"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_FALSE(graph.isMarked(1));
   EXPECT_FALSE(graph.isMarked(2));
@@ -179,20 +164,17 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent) {
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1, dependsTopLevel, "x, b, z"),
             LoadResult::UpToDate);
+  {
+    auto marked = graph.markTransitive(0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(1u, marked.front());
+  }
+    EXPECT_TRUE(graph.isMarked(0));
+    EXPECT_TRUE(graph.isMarked(1));
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
-  EXPECT_TRUE(graph.isMarked(0));
-  EXPECT_TRUE(graph.isMarked(1));
-
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
-  EXPECT_TRUE(graph.isMarked(0));
-  EXPECT_TRUE(graph.isMarked(1));
+    EXPECT_EQ(0u, graph.markTransitive(0).size());
+    EXPECT_TRUE(graph.isMarked(0));
+    EXPECT_TRUE(graph.isMarked(1));
 }
 
 TEST(CoarseGrainedDependencyGraph, SimpleDependentReverse) {
@@ -203,17 +185,15 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependentReverse) {
   EXPECT_EQ(loadFromString(graph, 1, providesTopLevel, "x, b, z"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 1);
+  {
+  auto marked = graph.markTransitive(1);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(0u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -226,17 +206,16 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent2) {
   EXPECT_EQ(loadFromString(graph, 1, dependsNominal, "x, b, z"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
 
-  graph.markTransitive(marked, 0);
+  {
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(1u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -251,17 +230,15 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent3) {
   EXPECT_EQ(loadFromString(graph, 1, dependsNominal, "a"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(1u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -276,17 +253,15 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent4) {
                            dependsTopLevel, "a"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive( 0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(1u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -303,17 +278,17 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent5) {
                            dependsTopLevel, "a"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
 
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(1u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  auto marked = graph.markTransitive(0);
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -326,19 +301,17 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent6) {
   EXPECT_EQ(loadFromString(graph, 1, dependsDynamicLookup, "x, b, z"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
+  {
+    auto marked = graph.markTransitive(0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(1u, marked.front());
+    }
+    EXPECT_TRUE(graph.isMarked(0));
+    EXPECT_TRUE(graph.isMarked(1));
 
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
-  EXPECT_TRUE(graph.isMarked(0));
-  EXPECT_TRUE(graph.isMarked(1));
-
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
-  EXPECT_TRUE(graph.isMarked(0));
-  EXPECT_TRUE(graph.isMarked(1));
+    EXPECT_EQ(0u, graph.markTransitive(0).size());
+    EXPECT_TRUE(graph.isMarked(0));
+    EXPECT_TRUE(graph.isMarked(1));
 }
 
 
@@ -352,17 +325,15 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependentMember) {
                            dependsMember, "[x, xx], [b,bb], [z,zz]"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(1u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -383,19 +354,17 @@ TEST(CoarseGrainedDependencyGraph, MultipleDependentsSame) {
   EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "q, b, s"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(2u, marked.size());
   EXPECT_TRUE(contains(marked, 1));
   EXPECT_TRUE(contains(marked, 2));
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -411,19 +380,17 @@ TEST(CoarseGrainedDependencyGraph, MultipleDependentsDifferent) {
   EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "q, r, c"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(2u, marked.size());
   EXPECT_TRUE(contains(marked, 1));
   EXPECT_TRUE(contains(marked, 2));
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -441,19 +408,18 @@ TEST(CoarseGrainedDependencyGraph, ChainedDependents) {
   EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "z"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
 
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(2u, marked.size());
   EXPECT_TRUE(contains(marked, 1));
   EXPECT_TRUE(contains(marked, 2));
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -481,12 +447,12 @@ TEST(CoarseGrainedDependencyGraph, MarkTwoNodes) {
                            providesNominal, "q"),
       LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(2u, marked.size());
   EXPECT_TRUE(contains(marked, 1));
   EXPECT_TRUE(contains(marked, 2));
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -494,10 +460,11 @@ TEST(CoarseGrainedDependencyGraph, MarkTwoNodes) {
   EXPECT_FALSE(graph.isMarked(11));
   EXPECT_FALSE(graph.isMarked(12));
 
-  marked.clear();
-  graph.markTransitive(marked, 10);
+{
+  auto marked = graph.markTransitive(10);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(11u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -516,11 +483,12 @@ TEST(CoarseGrainedDependencyGraph, MarkOneNodeTwice) {
   EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "b"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
 
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(1u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_FALSE(graph.isMarked(2));
@@ -528,11 +496,12 @@ TEST(CoarseGrainedDependencyGraph, MarkOneNodeTwice) {
   // Reload 0.
   EXPECT_EQ(loadFromString(graph, 0, providesNominal, "b"),
             LoadResult::UpToDate);
-  marked.clear();
 
-  graph.markTransitive(marked, 0);
+ {
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(2u, marked.front());
+}
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -548,11 +517,11 @@ TEST(CoarseGrainedDependencyGraph, MarkOneNodeTwice2) {
   EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "b"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
+{
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(1u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_FALSE(graph.isMarked(2));
@@ -560,11 +529,12 @@ TEST(CoarseGrainedDependencyGraph, MarkOneNodeTwice2) {
   // Reload 0.
   EXPECT_EQ(loadFromString(graph, 0, providesNominal, "a, b"),
             LoadResult::UpToDate);
-  marked.clear();
 
-  graph.markTransitive(marked, 0);
+ {
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(2u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -580,10 +550,8 @@ TEST(CoarseGrainedDependencyGraph, NotTransitiveOnceMarked) {
   EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "b"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
 
-  graph.markTransitive(marked, 1);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(1).size());
   EXPECT_FALSE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_FALSE(graph.isMarked(2));
@@ -593,18 +561,18 @@ TEST(CoarseGrainedDependencyGraph, NotTransitiveOnceMarked) {
                            dependsNominal, "a",
                            providesNominal, "b"),
             LoadResult::UpToDate);
-  marked.clear();
 
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_FALSE(graph.isMarked(2));
 
   // Re-mark 1.
-  graph.markTransitive(marked, 1);
+  {
+  auto marked = graph.markTransitive(1);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(2u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -625,19 +593,17 @@ TEST(CoarseGrainedDependencyGraph, DependencyLoops) {
   EXPECT_EQ(loadFromString(graph, 2, dependsTopLevel, "x"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
+  {
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(2u, marked.size());
   EXPECT_TRUE(contains(marked, 1));
   EXPECT_TRUE(contains(marked, 2));
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
 
-  marked.clear();
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -655,11 +621,11 @@ TEST(CoarseGrainedDependencyGraph, MarkIntransitive) {
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_FALSE(graph.isMarked(1));
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
+  {
+  auto marked = graph.markTransitive(0);
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(1u, marked.front());
+  }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -693,10 +659,7 @@ TEST(CoarseGrainedDependencyGraph, MarkIntransitiveThenIndirect) {
   EXPECT_FALSE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  SmallVector<uintptr_t, 4> marked;
-
-  graph.markTransitive(marked, 0);
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -710,14 +673,10 @@ TEST(CoarseGrainedDependencyGraph, SimpleExternal) {
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
 
-  SmallVector<uintptr_t, 4> marked;
-  graph.markExternal(marked, "/foo");
-  EXPECT_EQ(1u, marked.size());
+  EXPECT_EQ(1u, graph.markExternal("/foo").size());
   EXPECT_TRUE(graph.isMarked(0));
 
-  marked.clear();
-  graph.markExternal(marked, "/foo");
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
   EXPECT_TRUE(graph.isMarked(0));
 }
 
@@ -727,14 +686,10 @@ TEST(CoarseGrainedDependencyGraph, SimpleExternal2) {
   EXPECT_EQ(loadFromString(graph, 0, dependsExternal, "/foo, /bar"),
             LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-  graph.markExternal(marked, "/bar");
-  EXPECT_EQ(1u, marked.size());
+  EXPECT_EQ(1u, graph.markExternal("/bar").size());
   EXPECT_TRUE(graph.isMarked(0));
 
-  marked.clear();
-  graph.markExternal(marked, "/bar");
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markExternal("/bar").size());
   EXPECT_TRUE(graph.isMarked(0));
 }
 
@@ -753,15 +708,11 @@ TEST(CoarseGrainedDependencyGraph, ChainedExternal) {
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
 
-  SmallVector<uintptr_t, 4> marked;
-  graph.markExternal(marked, "/foo");
-  EXPECT_EQ(2u, marked.size());
+  EXPECT_EQ(2u, graph.markExternal("/foo").size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  marked.clear();
-  graph.markExternal(marked, "/foo");
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -778,23 +729,23 @@ TEST(CoarseGrainedDependencyGraph, ChainedExternalReverse) {
                            dependsTopLevel, "a"),
       LoadResult::UpToDate);
 
-  SmallVector<uintptr_t, 4> marked;
-  graph.markExternal(marked, "/bar");
+  {
+  auto marked = graph.markExternal("/bar");
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(1u, marked.front());
+  }
   EXPECT_FALSE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  marked.clear();
-  graph.markExternal(marked, "/bar");
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markExternal("/bar").size());
   EXPECT_FALSE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  marked.clear();
-  graph.markExternal(marked, "/foo");
+{
+  auto marked = graph.markExternal("/foo");
   EXPECT_EQ(1u, marked.size());
   EXPECT_EQ(0u, marked.front());
+}
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 }
@@ -813,9 +764,7 @@ TEST(CoarseGrainedDependencyGraph, ChainedExternalPreMarked) {
 
   graph.markIntransitive(0);
 
-  SmallVector<uintptr_t, 4> marked;
-  graph.markExternal(marked, "/foo");
-  EXPECT_EQ(0u, marked.size());
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_FALSE(graph.isMarked(1));
 }


### PR DESCRIPTION
In preparation for unifying the dependency graphs, adopt a more functional interface to these two functions.