### PR TITLE
[CS] Pass SelectedOverload in a couple of places

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1005,9 +1005,6 @@ namespace {
 
       return finishApply(apply, memberRef, openedType, locator);
     }
-    
-    /// Describes either a type or the name of a type to be resolved.
-    using TypeOrName = llvm::PointerUnion<Identifier, Type>;
 
     /// Convert the given literal expression via a protocol pair.
     ///

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2357,6 +2357,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
   auto overload = SelectedOverload{choice, openedFullType, refType, boundType};
   auto result = ResolvedOverloads.insert({locator, overload});
   assert(result.second && "Already resolved this overload?");
+  (void)result;
 
   // In some cases we already created the appropriate bind constraints.
   if (!bindConstraintCreated) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -804,13 +804,6 @@ public:
   explicit SolutionDiff(ArrayRef<Solution> solutions);
 };
 
-/// Identifies a specific conversion from
-struct SpecificConstraint {
-  CanType First;
-  CanType Second;
-  ConstraintKind Kind;
-};
-
 /// An intrusive, doubly-linked list of constraints.
 using ConstraintList = llvm::ilist<Constraint>;
 


### PR DESCRIPTION
Clean up a couple of members in CSApply by passing the `SelectedOverload` instead of individual parameters for things like the function ref kind, choice, and opened type.

