### PR TITLE
[semantic-arc-opts] Convert load [copy] -> load_borrow given single init alloc_stack.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -488,6 +488,17 @@ AccessedStorage findAccessedStorageNonNested(SILValue sourceAddr);
 /// uninitialized.
 bool memInstMustInitialize(Operand *memOper);
 
+/// Is this an alloc_stack instruction that is:
+///
+/// 1. Only initialized once in its own def block.
+/// 2. Never written to again except by destroy_addr.
+///
+/// On return, destroyingUsers contains the list of users that destroy the
+/// alloc_stack. If the alloc_stack is destroyed in pieces, we do not guarantee
+/// that the list of destroying users is a minimal jointly post-dominating set.
+bool isSingleInitAllocStack(AllocStackInst *asi,
+                            SmallVectorImpl<SILInstruction *> &destroyingUsers);
+
 /// Return true if the given address producer may be the source of a formal
 /// access (a read or write of a potentially aliased, user visible variable).
 ///

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -183,6 +183,21 @@ public:
                        nullptr /*leakingBlocks*/)
                 .getFoundError();
   }
+
+  bool validateLifetime(SILValue value,
+                        ArrayRef<SILInstruction *> consumingUses,
+                        ArrayRef<SILInstruction *> nonConsumingUses) {
+    auto *consumingUsesCast =
+        reinterpret_cast<const BranchPropagatedUser *>(consumingUses.data());
+    auto *nonConsumingUsesCast =
+        reinterpret_cast<const BranchPropagatedUser *>(nonConsumingUses.data());
+    ArrayRef<BranchPropagatedUser> consumingUsesCastArray(consumingUsesCast,
+                                                          consumingUses.size());
+    ArrayRef<BranchPropagatedUser> nonConsumingUsesCastArray(
+        nonConsumingUsesCast, nonConsumingUses.size());
+    return validateLifetime(value, consumingUsesCastArray,
+                            nonConsumingUsesCastArray);
+  }
 };
 
 /// Returns true if v is an address or trivial.

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -948,3 +948,98 @@ bb0(%0 : @guaranteed $ClassLet):
   %9999 = tuple()
   return %9999 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @single_init_allocstack : $@convention(thin) (@owned Klass) -> () {
+// CHECK-NOT: load [copy]
+// CHECK: } // end sil function 'single_init_allocstack'
+sil [ossa] @single_init_allocstack : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack $Klass
+  store %0 to [init] %1 : $*Klass
+  %2 = load [copy] %1 : $*Klass
+
+  %3 = function_ref @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %3(%2) : $@convention(thin) (@guaranteed Klass) -> ()
+
+  destroy_value %2 : $Klass
+  destroy_addr %1 : $*Klass
+  dealloc_stack %1 : $*Klass
+
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_init_allocstack : $@convention(thin) (@owned Klass) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'multiple_init_allocstack'
+sil [ossa] @multiple_init_allocstack : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %0a = copy_value %0 : $Klass
+  %1 = alloc_stack $Klass
+  store %0 to [init] %1 : $*Klass
+  %2 = load [copy] %1 : $*Klass
+
+  %3 = function_ref @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %3(%2) : $@convention(thin) (@guaranteed Klass) -> ()
+
+  destroy_value %2 : $Klass
+  destroy_addr %1 : $*Klass
+
+  store %0a to [init] %1 : $*Klass
+  destroy_addr %1 : $*Klass
+  dealloc_stack %1 : $*Klass
+
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We could support this, but for now we are keeping things simple. If we do add
+// support, this test will need to be updated.
+//
+// CHECK-LABEL: sil [ossa] @single_init_wrongblock : $@convention(thin) (@owned Klass) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'single_init_wrongblock'
+sil [ossa] @single_init_wrongblock : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack $Klass
+  br bb1
+
+bb1:
+  store %0 to [init] %1 : $*Klass
+  %2 = load [copy] %1 : $*Klass
+
+  %3 = function_ref @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %3(%2) : $@convention(thin) (@guaranteed Klass) -> ()
+
+  destroy_value %2 : $Klass
+  destroy_addr %1 : $*Klass
+  dealloc_stack %1 : $*Klass
+
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We could support this, but for now we are keeping things simple. If we do add
+// support, this test will need to be updated.
+//
+// CHECK-LABEL: sil [ossa] @single_init_loadtake : $@convention(thin) (@owned Klass) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'single_init_loadtake'
+sil [ossa] @single_init_loadtake : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack $Klass
+  store %0 to [init] %1 : $*Klass
+  %2 = load [copy] %1 : $*Klass
+
+  %3 = function_ref @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %3(%2) : $@convention(thin) (@guaranteed Klass) -> ()
+
+  destroy_value %2 : $Klass
+
+  %4 = load [take] %1 : $*Klass
+  destroy_value %4 : $Klass
+  dealloc_stack %1 : $*Klass
+
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
This is just a quick optimization I saw. I am going to add a load [take] forwarding optimization in a bit that should build on this to hit more test cases.