### PR TITLE
[build] Add lld to LLVM_ENABLE_PROJECTS

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1693,7 +1693,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${llvm_cmake_options[@]}"
                 )
 
-                llvm_enable_projects=("clang")
+                llvm_enable_projects=("clang" "lld")
 
                 if [[ ! "${SKIP_BUILD_COMPILER_RT}" ]]; then
                     llvm_enable_projects+=("compiler-rt")


### PR DESCRIPTION
LLD wasn't actually getting built even though we set LLVM_TOOL_LLD_BUILD to
TRUE. Adding it to LLVM_ENABLE_PROJECTS will fix that.

cc @compnerd @shahmishal 