### PR TITLE
Revert "[Frontend] Add some paths to the output of -print-target-info."

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2128,18 +2128,9 @@ bool Driver::handleImmediateArgs(const ArgList &Args, const ToolChain &TC) {
     SmallVector<const char *, 5> commandLine;
     commandLine.push_back("-frontend");
     commandLine.push_back("-print-target-info");
-    if (const Arg *targetArg = Args.getLastArg(options::OPT_target)) {
+    if (const Arg *TargetArg = Args.getLastArg(options::OPT_target)) {
       commandLine.push_back("-target");
-      commandLine.push_back(targetArg->getValue());
-    }
-    if (const Arg *sdkArg = Args.getLastArg(options::OPT_sdk)) {
-      commandLine.push_back("-sdk");
-      commandLine.push_back(sdkArg->getValue());
-    }
-
-    if (const Arg *resourceDirArg = Args.getLastArg(options::OPT_resource_dir)) {
-      commandLine.push_back("-resource-dir");
-      commandLine.push_back(resourceDirArg->getValue());
+      commandLine.push_back(TargetArg->getValue());
     }
 
     std::string executable = getSwiftProgramPath();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1895,38 +1895,6 @@ static void printTargetInfo(CompilerInvocation &invocation,
       << (tripleRequiresRPathForSwiftInOS(langOpts.Target) ? "true" : "false")
       << "\n";
 
-  out << "  },\n";
-
-  // Various paths.
-  auto &searchOpts = invocation.getSearchPathOptions();
-  out << "  \"paths\": {\n";
-
-  if (!searchOpts.SDKPath.empty()) {
-    out << "    \"sdkPath\": \"";
-    out.write_escaped(searchOpts.SDKPath);
-    out << "\",\n";
-  }
-
-  auto outputPaths = [&](StringRef name, const std::vector<std::string> &paths){
-    out << "    \"" << name << "\": [\n";
-    interleave(paths, [&out](const std::string &path) {
-      out << "      \"";
-      out.write_escaped(path);
-      out << "\"";
-    }, [&out] {
-      out << ",\n";
-    });
-    out << "\n    ],\n";
-  };
-
-  outputPaths("runtimeLibraryPaths", searchOpts.RuntimeLibraryPaths);
-  outputPaths("runtimeLibraryImportPaths",
-              searchOpts.RuntimeLibraryImportPaths);
-
-  out << "    \"runtimeResourcePath\": \"";
-  out.write_escaped(searchOpts.RuntimeResourcePath);
-  out << "\"\n";
-
   out << "  }\n";
 
   out << "}\n";

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -11,12 +11,6 @@
 // CHECK-IOS:     "librariesRequireRPath": true
 // CHECK-IOS:   }
 
-// CHECK-IOS:   "paths": {
-// CHECK-IOS:     "runtimeLibraryPaths": [
-// CHECK-IOS:     "runtimeResourcePath":{{.*}}lib{{(/|\\)}}swift"
-// CHECK-IOS:   }
-
-
 // CHECK-LINUX:   "target": {
 // CHECK-LINUX:     "triple": "x86_64-unknown-linux",
 // CHECK-LINUX:     "moduleTriple": "x86_64-unknown-linux",


### PR DESCRIPTION
Reverts apple/swift#28646

This caused Window build failure, so going to revert it for now. 