### PR TITLE
IRGen,Driver: extract tool usage into a variable (NFC)

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1153,21 +1153,17 @@ void IRGenModule::emitAutolinkInfo() {
                                        }),
                         AutolinkEntries.end());
 
-  if ((TargetInfo.OutputObjectFormat == llvm::Triple::COFF &&
-       !Triple.isOSCygMing()) ||
-      TargetInfo.OutputObjectFormat == llvm::Triple::MachO || Triple.isPS4()) {
+  const bool AutolinkExtractRequired =
+      (TargetInfo.OutputObjectFormat == llvm::Triple::ELF && !Triple.isPS4()) ||
+      TargetInfo.OutputObjectFormat == llvm::Triple::Wasm ||
+      Triple.isOSCygMing();
 
+  if (!AutolinkExtractRequired) {
     // On platforms that support autolinking, continue to use the metadata.
     Metadata->clearOperands();
     for (auto *Entry : AutolinkEntries)
       Metadata->addOperand(Entry);
-
   } else {
-    assert((TargetInfo.OutputObjectFormat == llvm::Triple::ELF ||
-            TargetInfo.OutputObjectFormat == llvm::Triple::Wasm ||
-            Triple.isOSCygMing()) &&
-           "expected ELF output format or COFF format for Cygwin/MinGW");
-
     // Merge the entries into null-separated string.
     llvm::SmallString<64> EntriesString;
     for (auto &EntryNode : AutolinkEntries) {


### PR DESCRIPTION
autolink-extract is needed on ELF (and windows-cygnus).  However, WASM
also has gone down this path and did not actually indicate that it
needed the autolink extract handling.  Extract the handling check into a
variable which helps readability.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
