### PR TITLE
Explicitly State CodingKeys as a Codable Requirement

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -534,6 +534,12 @@ DECL_ATTR(derivative, Derivative,
   ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove,
   97)
 
+DECL_ATTR(_implicitly_synthesizes_nested_requirement, ImplicitlySynthesizesNestedRequirement,
+  OnProtocol |
+  UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  98)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -687,6 +687,23 @@ public:
   }
 };
 
+/// Defines the @_implicitly_synthesizes_nested_requirement attribute.
+class ImplicitlySynthesizesNestedRequirementAttr : public DeclAttribute {
+public:
+  ImplicitlySynthesizesNestedRequirementAttr(StringRef Value, SourceLoc AtLoc,
+                                             SourceRange Range)
+    : DeclAttribute(DAK_ImplicitlySynthesizesNestedRequirement,
+                    AtLoc, Range, /*Implicit*/false),
+      Value(Value) {}
+
+  /// The name of the phantom requirement.
+  const StringRef Value;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_ImplicitlySynthesizesNestedRequirement;
+  }
+};
+
 /// Determine the result of comparing an availability attribute to a specific
 /// platform or language version.
 enum class AvailableVersionComparison {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -467,10 +467,14 @@ protected:
     IsDebuggerAlias : 1
   );
 
-  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1,
+  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1+1,
     /// Whether we have already added implicitly-defined initializers
     /// to this declaration.
     AddedImplicitInitializers : 1,
+
+    /// Whether we have already added the phantom CodingKeys
+    /// nested requirement to this declaration.
+    AddedPhantomCodingKeys : 1,
 
     /// Whether there is are lazily-loaded conformances for this nominal type.
     HasLazyConformances : 1,
@@ -3323,6 +3327,7 @@ protected:
     IterableDeclContext(IterableDeclContextKind::NominalTypeDecl)
   {
     Bits.NominalTypeDecl.AddedImplicitInitializers = false;
+    Bits.NominalTypeDecl.AddedPhantomCodingKeys = false;
     ExtensionGeneration = 0;
     Bits.NominalTypeDecl.HasLazyConformances = false;
     Bits.NominalTypeDecl.IsComputingSemanticMembers = false;
@@ -3361,6 +3366,18 @@ public:
   /// Note that we have attempted to add implicit initializers.
   void setAddedImplicitInitializers() {
     Bits.NominalTypeDecl.AddedImplicitInitializers = true;
+  }
+
+  /// Determine whether we have already attempted to add the
+  /// phantom CodingKeys type to this declaration.
+  bool addedPhantomCodingKeys() const {
+    return Bits.NominalTypeDecl.AddedPhantomCodingKeys;
+  }
+
+  /// Note that we have attempted to add the phantom CodingKeys type
+  /// to this declaration.
+  void setAddedPhantomCodingKeys() {
+    Bits.NominalTypeDecl.AddedPhantomCodingKeys = true;
   }
 
   /// getDeclaredType - Retrieve the type declared by this entity, without

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -296,7 +296,8 @@ struct PrintOptions {
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {DAK_Transparent, DAK_Effects,
                                               DAK_FixedLayout,
-                                              DAK_ShowInInterface};
+                                              DAK_ShowInInterface,
+                                              DAK_ImplicitlySynthesizesNestedRequirement};
 
   /// List of attribute kinds that should be printed exclusively.
   /// Empty means allow all.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1679,8 +1679,6 @@ public:
 enum class ImplicitMemberAction : uint8_t {
   ResolveImplicitInit,
   ResolveCodingKeys,
-  ResolveEncodable,
-  ResolveDecodable,
 };
 
 class ResolveImplicitMemberRequest

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -897,6 +897,11 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_ImplicitlySynthesizesNestedRequirement:
+    Printer.printAttrName("@_implicitly_synthesizes_nested_requirement");
+    Printer << "(\"" << cast<ImplicitlySynthesizesNestedRequirementAttr>(this)->Value << "\")";
+    break;
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 
@@ -958,6 +963,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_swift_native_objc_runtime_base";
   case DAK_Semantics:
     return "_semantics";
+  case DAK_ImplicitlySynthesizesNestedRequirement:
+    return "_implicitly_synthesizes_nested_requirement";
   case DAK_Available:
     return "availability";
   case DAK_ObjC:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3995,19 +3995,6 @@ void NominalTypeDecl::synthesizeSemanticMembersIfNeeded(DeclName member) {
     if (baseName.getIdentifier() == getASTContext().Id_CodingKeys) {
       action.emplace(ImplicitMemberAction::ResolveCodingKeys);
     }
-  } else {
-    auto argumentNames = member.getArgumentNames();
-    if (!member.isCompoundName() || argumentNames.size() == 1) {
-      if (baseName == DeclBaseName::createConstructor() &&
-          (member.isSimpleName() || argumentNames.front() == Context.Id_from)) {
-        action.emplace(ImplicitMemberAction::ResolveDecodable);
-      } else if (!baseName.isSpecial() &&
-                 baseName.getIdentifier() == Context.Id_encode &&
-                 (member.isSimpleName() ||
-                  argumentNames.front() == Context.Id_to)) {
-        action.emplace(ImplicitMemberAction::ResolveEncodable);
-      }
-    }
   }
 
   if (auto actionToTake = action) {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1074,12 +1074,6 @@ void swift::simple_display(llvm::raw_ostream &out,
   case ImplicitMemberAction::ResolveCodingKeys:
     out << "resolve CodingKeys";
     break;
-  case ImplicitMemberAction::ResolveEncodable:
-    out << "resolve Encodable.encode(to:)";
-    break;
-  case ImplicitMemberAction::ResolveDecodable:
-    out << "resolve Decodable.init(from:)";
-    break;
   }
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1736,6 +1736,43 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     }
     break;
   }
+
+  case DAK_ImplicitlySynthesizesNestedRequirement: {
+    if (!consumeIf(tok::l_paren)) {
+      diagnose(Loc, diag::attr_expected_lparen, AttrName,
+               DeclAttribute::isDeclModifier(DK));
+      return false;
+    }
+
+    if (Tok.isNot(tok::string_literal)) {
+      diagnose(Loc, diag::attr_expected_string_literal, AttrName);
+      return false;
+    }
+
+    auto Value = getStringLiteralIfNotInterpolated(
+        Loc, ("'" + AttrName + "'").str());
+
+    consumeToken(tok::string_literal);
+
+    if (Value.hasValue())
+      AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+    else
+      DiscardAttribute = true;
+
+    if (!consumeIf(tok::r_paren)) {
+      diagnose(Loc, diag::attr_expected_rparen, AttrName,
+               DeclAttribute::isDeclModifier(DK));
+      return false;
+    }
+
+    if (!DiscardAttribute) {
+      Attributes.add(new (Context)
+                     ImplicitlySynthesizesNestedRequirementAttr(Value.getValue(), AtLoc,
+                                                   AttrRange));
+    }
+    break;
+  }
+
   case DAK_Available: {
     if (!consumeIf(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1070,11 +1070,8 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
   // FIXME: This entire request is a layering violation made of smaller,
   // finickier layering violations. See rdar://56844567
 
-  // Checks whether the target conforms to the given protocol. If the
-  // conformance is incomplete, force the conformance.
-  //
-  // Returns whether the target conforms to the protocol.
-  auto evaluateTargetConformanceTo = [&](ProtocolDecl *protocol) {
+  auto &Context = target->getASTContext();
+  auto tryToInstallCodingKeys = [&](ProtocolDecl *protocol) {
     if (!protocol)
       return false;
 
@@ -1097,7 +1094,6 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     return true;
   };
 
-  auto &Context = target->getASTContext();
   switch (action) {
   case ImplicitMemberAction::ResolveImplicitInit:
     TypeChecker::addImplicitConstructors(target);
@@ -1115,28 +1111,9 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     // synthesized, it will be synthesized.
     auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
     auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
-    if (!evaluateTargetConformanceTo(decodableProto)) {
-      (void)evaluateTargetConformanceTo(encodableProto);
+    if (!tryToInstallCodingKeys(decodableProto)) {
+      (void)tryToInstallCodingKeys(encodableProto);
     }
-  }
-    break;
-  case ImplicitMemberAction::ResolveEncodable: {
-    // encode(to:) may be synthesized as part of derived conformance to the
-    // Encodable protocol.
-    // If the target should conform to the Encodable protocol, check the
-    // conformance here to attempt synthesis.
-    auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
-    (void)evaluateTargetConformanceTo(encodableProto);
-  }
-    break;
-  case ImplicitMemberAction::ResolveDecodable: {
-    // init(from:) may be synthesized as part of derived conformance to the
-    // Decodable protocol.
-    // If the target should conform to the Decodable protocol, check the
-    // conformance here to attempt synthesis.
-    TypeChecker::addImplicitConstructors(target);
-    auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
-    (void)evaluateTargetConformanceTo(decodableProto);
   }
     break;
   }

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1139,3 +1139,21 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
 
   return nullptr;
 }
+
+TypeDecl *DerivedConformance::derivePhantomCodingKeysRequirement() {
+  // We can only synthesize CodingKeys for structs and classes.
+  if (!isa<StructDecl>(Nominal) && !isa<ClassDecl>(Nominal))
+    return nullptr;
+
+  // Pull out a user-defined CodingKeys declaration.
+  auto result = Nominal->lookupDirect(DeclName(Context.Id_CodingKeys));
+  TypeDecl *keysDecl = nullptr;
+  if (!result.empty()) {
+    return dyn_cast<TypeDecl>(result.front());
+  } else {
+    // That failed, try to synthesize one.
+    keysDecl = synthesizeCodingKeysEnum(*this);
+  }
+
+  return keysDecl;
+}

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -61,14 +61,6 @@ static bool superclassIsDecodable(ClassDecl *target) {
                                C.getProtocol(KnownProtocolKind::Decodable));
 }
 
-/// Represents the possible outcomes of checking whether a decl conforms to
-/// Encodable or Decodable.
-enum CodableConformanceType {
-  TypeNotValidated,
-  DoesNotConform,
-  Conforms
-};
-
 /// Returns whether the given type conforms to the given {En,De}codable
 /// protocol.
 ///
@@ -77,7 +69,7 @@ enum CodableConformanceType {
 /// \param target The \c Type to validate.
 ///
 /// \param proto The \c ProtocolDecl to check conformance to.
-static CodableConformanceType typeConformsToCodable(DeclContext *context,
+static ProtocolConformanceRef typeConformsToCodable(DeclContext *context,
                                                     Type target, bool isIUO,
                                                     ProtocolDecl *proto) {
   target = context->mapTypeIntoContext(target);
@@ -86,8 +78,7 @@ static CodableConformanceType typeConformsToCodable(DeclContext *context,
     return typeConformsToCodable(context, target->getOptionalObjectType(),
                                  false, proto);
 
-  auto conf = TypeChecker::conformsToProtocol(target, proto, context, None);
-  return conf.isInvalid() ? DoesNotConform : Conforms;
+  return TypeChecker::conformsToProtocol(target, proto, context, None);
 }
 
 /// Returns whether the given variable conforms to the given {En,De}codable
@@ -98,7 +89,7 @@ static CodableConformanceType typeConformsToCodable(DeclContext *context,
 /// \param varDecl The \c VarDecl to validate.
 ///
 /// \param proto The \c ProtocolDecl to check conformance to.
-static CodableConformanceType
+static ProtocolConformanceRef
 varConformsToCodable(DeclContext *DC, VarDecl *varDecl, ProtocolDecl *proto) {
   // If the decl doesn't yet have a type, we may be seeing it before the type
   // checker has gotten around to evaluating its type. For example:
@@ -167,22 +158,13 @@ static bool validateCodingKeysEnum(DerivedConformance &derived,
     // We have a property to map to. Ensure it's {En,De}codable.
     auto conformance =
         varConformsToCodable(conformanceDC, it->second, derived.Protocol);
-    switch (conformance) {
-      case Conforms:
-        // The property was valid. Remove it from the list.
-        properties.erase(it);
-        break;
-
-      case DoesNotConform:
-        it->second->diagnose(diag::codable_non_conforming_property_here,
-                             derived.getProtocolType(), it->second->getType());
-        LLVM_FALLTHROUGH;
-
-      case TypeNotValidated:
-        // We don't produce a diagnostic for a type which failed to validate.
-        // This will produce a diagnostic elsewhere anyway.
-        propertiesAreValid = false;
-        continue;
+    if (conformance.isInvalid()) {
+      it->second->diagnose(diag::codable_non_conforming_property_here,
+                           derived.getProtocolType(), it->second->getType());
+      propertiesAreValid = false;
+    } else {
+      // The property was valid. Remove it from the list.
+      properties.erase(it);
     }
   }
 
@@ -341,28 +323,17 @@ static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
     // context, not the type.
     auto conformance = varConformsToCodable(derived.getConformanceContext(),
                                             varDecl, derived.Protocol);
-    switch (conformance) {
-      case Conforms:
-      {
-        auto *elt = new (C) EnumElementDecl(SourceLoc(),
-                                            getVarNameForCoding(varDecl),
-                                            nullptr, SourceLoc(), nullptr,
-                                            enumDecl);
-        elt->setImplicit();
-        enumDecl->addMember(elt);
-        break;
-      }
-
-      case DoesNotConform:
-        varDecl->diagnose(diag::codable_non_conforming_property_here,
-                          derived.getProtocolType(), varDecl->getType());
-        LLVM_FALLTHROUGH;
-
-      case TypeNotValidated:
-        // We don't produce a diagnostic for a type which failed to validate.
-        // This will produce a diagnostic elsewhere anyway.
-        allConform = false;
-        continue;
+    if (conformance.isInvalid()) {
+      varDecl->diagnose(diag::codable_non_conforming_property_here,
+                        derived.getProtocolType(), varDecl->getType());
+      allConform = false;
+    } else {
+      auto *elt = new (C) EnumElementDecl(SourceLoc(),
+                                          getVarNameForCoding(varDecl),
+                                          nullptr, SourceLoc(), nullptr,
+                                          enumDecl);
+      elt->setImplicit();
+      enumDecl->addMember(elt);
     }
   }
 
@@ -1164,7 +1135,7 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
 }
 
 ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
-  // We can only synthesize Encodable for structs and classes.
+  // We can only synthesize Decodable for structs and classes.
   if (!isa<StructDecl>(Nominal) && !isa<ClassDecl>(Nominal))
     return nullptr;
 

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -189,6 +189,9 @@ public:
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveDecodable(ValueDecl *requirement);
 
+  /// Derive the CodingKeys requirement for a value type.
+  TypeDecl *derivePhantomCodingKeysRequirement();
+
   /// Declare a read-only property.
   std::pair<VarDecl *, PatternBindingDecl *>
   declareDerivedProperty(Identifier name, Type propertyInterfaceType,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -96,6 +96,7 @@ public:
   IGNORED_ATTR(HasMissingDesignatedInitializers)
   IGNORED_ATTR(InheritsConvenienceInitializers)
   IGNORED_ATTR(Inline)
+  IGNORED_ATTR(ImplicitlySynthesizesNestedRequirement)
   IGNORED_ATTR(ObjCBridged)
   IGNORED_ATTR(ObjCNonLazyRealization)
   IGNORED_ATTR(ObjCRuntimeName)

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1298,6 +1298,7 @@ namespace  {
     UNINTERESTING_ATTR(IBInspectable)
     UNINTERESTING_ATTR(IBOutlet)
     UNINTERESTING_ATTR(IBSegueAction)
+    UNINTERESTING_ATTR(ImplicitlySynthesizesNestedRequirement)
     UNINTERESTING_ATTR(Indirect)
     UNINTERESTING_ATTR(InheritsConvenienceInitializers)
     UNINTERESTING_ATTR(Inline)

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3391,6 +3391,14 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDerivation(
     return ResolveWitnessResult::Missing;
   }
 
+  // If the protocol has a phantom nested type requirement, resolve it now.
+  auto &attrs = Proto->getAttrs();
+  if (auto *IARA =
+          attrs.getAttribute<ImplicitlySynthesizesNestedRequirementAttr>()) {
+    (void)TypeChecker::derivePhantomWitness(DC, derivingTypeDecl,
+                                            Proto, IARA->Value);
+  }
+
   // Attempt to derive the witness.
   auto derived =
       TypeChecker::deriveProtocolRequirement(DC, derivingTypeDecl, requirement);
@@ -5398,6 +5406,34 @@ Type TypeChecker::deriveTypeWitness(DeclContext *DC,
     return derived.deriveRawRepresentable(AssocType);
   case KnownProtocolKind::CaseIterable:
     return derived.deriveCaseIterable(AssocType);
+  default:
+    return nullptr;
+  }
+}
+
+
+TypeDecl *TypeChecker::derivePhantomWitness(DeclContext *DC,
+                                            NominalTypeDecl *nominal,
+                                            ProtocolDecl *proto,
+                                            const StringRef Name) {
+  assert(proto->getASTContext().Id_CodingKeys.is(Name) &&
+         "CodingKeys is the only supported phantom requirement");
+
+  if (nominal->addedPhantomCodingKeys())
+    return nullptr;
+  nominal->setAddedPhantomCodingKeys();
+
+  auto knownKind = proto->getKnownProtocolKind();
+  if (!knownKind)
+    return nullptr;
+
+  auto Decl = DC->getInnermostDeclarationDeclContext();
+
+  DerivedConformance derived(nominal->getASTContext(), Decl, nominal, proto);
+  switch (*knownKind) {
+  case KnownProtocolKind::Decodable:
+  case KnownProtocolKind::Encodable:
+    return derived.derivePhantomCodingKeysRequirement();
   default:
     return nullptr;
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1214,6 +1214,17 @@ public:
   static Type deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
                                 AssociatedTypeDecl *assocType);
 
+  /// Derive an implicit type witness for a given "phantom" nested type
+  /// requirement that is known to the compiler but unstated as a
+  /// formal type requirement.
+  ///
+  /// This exists to support Codable and only Codable. Do not expand its
+  /// usage outside of that domain.
+  static TypeDecl *derivePhantomWitness(DeclContext *DC,
+                                        NominalTypeDecl *nominal,
+                                        ProtocolDecl *proto,
+                                        const StringRef Name);
+
   /// \name Name lookup
   ///
   /// Routines that perform name lookup.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4165,6 +4165,13 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         break;
       }
 
+      case decls_block::ImplicitlySynthesizesNestedRequirement_DECL_ATTR: {
+        serialization::decls_block::ImplicitlySynthesizesNestedRequirementDeclAttrLayout
+            ::readRecord(scratch);
+        Attr = new (ctx) ImplicitlySynthesizesNestedRequirementAttr(blobData, {}, {});
+        break;
+      }
+
 #define SIMPLE_DECL_ATTR(NAME, CLASS, ...) \
       case decls_block::CLASS##_DECL_ATTR: { \
         bool isImplicit; \

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 529; // SILFunctionType substitutions
+const uint16_t SWIFTMODULE_VERSION_MINOR = 530; // @_implicitly_synthesizes_nested_requirement
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1811,6 +1811,10 @@ namespace decls_block {
     TypeIDField // type referenced by this custom attribute
   >;
 
+  using ImplicitlySynthesizesNestedRequirementDeclAttrLayout = BCRecordLayout<
+    ImplicitlySynthesizesNestedRequirement_DECL_ATTR,
+    BCBlob      // member name
+  >;
 }
 
 /// Returns the encoding kind for the given decl.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2364,6 +2364,13 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           origDeclID, derivativeKind, indices);
       return;
     }
+    case DAK_ImplicitlySynthesizesNestedRequirement: {
+      auto *theAttr = cast<ImplicitlySynthesizesNestedRequirementAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[ImplicitlySynthesizesNestedRequirementDeclAttrLayout::Code];
+      ImplicitlySynthesizesNestedRequirementDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                                          theAttr->Value);
+      return;
+    }
     }
   }
 

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A type that can encode itself to an external representation.
+@_implicitly_synthesizes_nested_requirement("CodingKeys")
 public protocol Encodable {
   /// Encodes this value into the given encoder.
   ///
@@ -29,6 +30,7 @@ public protocol Encodable {
 }
 
 /// A type that can decode itself from an external representation.
+@_implicitly_synthesizes_nested_requirement("CodingKeys")
 public protocol Decodable {
   /// Creates a new instance by decoding from the given decoder.
   ///

--- a/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
@@ -162,17 +162,13 @@ class NonConformingClass : Codable { // expected-error {{type 'NonConformingClas
   // These lines have to be within the NonConformingClass type because
   // CodingKeys should be private.
   func foo() {
-    // They should not get a CodingKeys type.
-    let _ = NonConformingClass.CodingKeys.self // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
-    let _ = NonConformingClass.CodingKeys.x // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
-    let _ = NonConformingClass.CodingKeys.y // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
-    let _ = NonConformingClass.CodingKeys.z // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+    let _ = NonConformingClass.CodingKeys.self
+    let _ = NonConformingClass.CodingKeys.x
+    let _ = NonConformingClass.CodingKeys.y
+    let _ = NonConformingClass.CodingKeys.z // expected-error {{type 'NonConformingClass.CodingKeys' has no member 'z'}}
   }
 }
 
 // They should not receive Codable methods.
 let _ = NonConformingClass.init(from:) // expected-error {{type 'NonConformingClass' has no member 'init(from:)'}}
 let _ = NonConformingClass.encode(to:) // expected-error {{type 'NonConformingClass' has no member 'encode(to:)'}}
-
-// They should not get a CodingKeys type.
-let _ = NonConformingClass.CodingKeys.self // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}

--- a/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
@@ -163,16 +163,13 @@ struct NonConformingStruct : Codable { // expected-error {{type 'NonConformingSt
   // CodingKeys should be private.
   func foo() {
     // They should not get a CodingKeys type.
-    let _ = NonConformingStruct.CodingKeys.self // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
-    let _ = NonConformingStruct.CodingKeys.x // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
-    let _ = NonConformingStruct.CodingKeys.y // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
-    let _ = NonConformingStruct.CodingKeys.z // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+    let _ = NonConformingStruct.CodingKeys.self
+    let _ = NonConformingStruct.CodingKeys.x
+    let _ = NonConformingStruct.CodingKeys.y
+    let _ = NonConformingStruct.CodingKeys.z // expected-error {{type 'NonConformingStruct.CodingKeys' has no member 'z'}}
   }
 }
 
 // They should not receive Codable methods.
 let _ = NonConformingStruct.init(from:) // expected-error {{type 'NonConformingStruct' has no member 'init(from:)'}}
 let _ = NonConformingStruct.encode(to:) // expected-error {{type 'NonConformingStruct' has no member 'encode(to:)'}}
-
-// They should not get a CodingKeys type.
-let _ = NonConformingStruct.CodingKeys.self // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}

--- a/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
@@ -162,7 +162,6 @@ struct NonConformingStruct : Codable { // expected-error {{type 'NonConformingSt
   // These lines have to be within the NonConformingStruct type because
   // CodingKeys should be private.
   func foo() {
-    // They should not get a CodingKeys type.
     let _ = NonConformingStruct.CodingKeys.self
     let _ = NonConformingStruct.CodingKeys.x
     let _ = NonConformingStruct.CodingKeys.y

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -785,6 +785,7 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
     }
 
     // Ignore these.
+    case DAK_ImplicitlySynthesizesNestedRequirement:
     case DAK_ShowInInterface:
     case DAK_RawDocComment:
     case DAK_HasInitialValue:


### PR DESCRIPTION
Refactors the way we model the `CodingKeys` "requirement" in Codable. The idea is that it should be cheap and easy to synthesize `CodingKeys`.  But it should also be clear that `Codable` synthesis has the unique ability to synthesize type witnesses to requirements that don't formally exist, hence "Phantom Requirements".  This patch adds a new, terrifyingly-named, user-inaccessible attribute `@_implicitly_synthesizes_nested_requirement`, and attaches it to `Encodable` and `Decodable`.  The synthesis machinery looks for the attribute and, if it must synthesize a value witness, attempts to install the phantom witness first.

This pull request and #28624 together will let us eliminate `ImplicitMemberAction::ResolveEncodable` and `ImplicitMemberAction::ResolveDecodable`.

Relates to rdar://56844567