### PR TITLE
[NFC] Please linter by reducing width to < 80 columns.

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -242,7 +242,8 @@ class CMake(object):
 
         cwd = os.getcwd()
         os.chdir(cmake_build_dir)
-        shell.call_without_sleeping([cmake_bootstrap, '--no-qt-gui'], echo=True)
+        shell.call_without_sleeping([cmake_bootstrap, '--no-qt-gui'],
+                                    echo=True)
         shell.call_without_sleeping(['make', '-j%s' % self.args.build_jobs],
                                     echo=True)
         os.chdir(cwd)


### PR DESCRIPTION
Seeing CI failure in https://github.com/apple/swift/pull/28479

```
./utils/swift_build_support/swift_build_support/cmake.py:245:80: E501 line too long (80 > 79 characters)
```