### PR TITLE
[os log][stdlib/private] Add extensions for logging NSObjects.

### DIFF
--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -6,11 +6,12 @@ add_swift_target_library(swiftOSLogPrototype
   OSLogMessage.swift
   OSLogIntegerTypes.swift
   OSLogStringTypes.swift
+  OSLogNSObjectType.swift
 
-  SWIFT_MODULE_DEPENDS_IOS Darwin os
-  SWIFT_MODULE_DEPENDS_OSX Darwin os
-  SWIFT_MODULE_DEPENDS_TVOS Darwin os
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin os
+  SWIFT_MODULE_DEPENDS_IOS Darwin os ObjectiveC
+  SWIFT_MODULE_DEPENDS_OSX Darwin os ObjectiveC
+  SWIFT_MODULE_DEPENDS_TVOS Darwin os ObjectiveC
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin os ObjectiveC
   TARGET_SDKS ALL_APPLE_PLATFORMS
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT never_install

--- a/stdlib/private/OSLog/OSLogNSObjectType.swift
+++ b/stdlib/private/OSLog/OSLogNSObjectType.swift
@@ -1,0 +1,118 @@
+//===----------------- OSLogNSObjectType.swift ----------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This file defines extensions for interpolating NSObject into a OSLogMesage.
+// It defines `appendInterpolation` function for NSObject type. It also defines
+// extensions for generating an os_log format string for NSObjects (using the
+// format specifier %@) and for serializing NSObject into the argument buffer
+// passed to os_log ABIs.
+//
+// The `appendInterpolation` function defined in this file accept formatting
+// and privacy options along with the interpolated expression as shown below:
+//
+//         "\(x, privacy: .public\)"
+import ObjectiveC
+
+extension OSLogInterpolation {
+
+  /// Define interpolation for expressions of type NSObject.
+  /// - Parameters:
+  ///  - argumentObject: the interpolated expression of type NSObject, which is autoclosured.
+  ///  - privacy: a privacy qualifier which is either private or public. Default is private.
+  ///  TODO: create a specifier to denote auto-inferred privacy level and make it default.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public mutating func appendInterpolation(
+    _ argumentObject: @autoclosure @escaping () -> NSObject,
+    privacy: Privacy = .private
+  ) {
+    guard argumentCount < maxOSLogArgumentCount else { return }
+
+    let isPrivateArgument = isPrivate(privacy)
+    formatString += getNSObjectFormatSpecifier(isPrivateArgument)
+    addNSObjectHeaders(isPrivateArgument)
+
+    arguments.append(argumentObject)
+    argumentCount += 1
+  }
+
+  /// Update preamble and append argument headers based on the parameters of
+  /// the interpolation.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  internal mutating func addNSObjectHeaders(_ isPrivate: Bool) {
+    // Append argument header.
+    let header = getArgumentHeader(isPrivate: isPrivate, type: .object)
+    arguments.append(header)
+
+    // Append number of bytes needed to serialize the argument.
+    let byteCount = pointerSizeInBytes()
+    arguments.append(UInt8(byteCount))
+
+    // Increment total byte size by the number of bytes needed for this
+    // argument, which is the sum of the byte size of the argument and
+    // two bytes needed for the headers.
+    totalBytesForSerializingArguments += byteCount + 2
+
+    preamble = getUpdatedPreamble(isPrivate: isPrivate, isScalar: false)
+  }
+
+  /// Construct an os_log format specifier from the given parameters.
+  /// This function must be constant evaluable and all its arguments
+  /// must be known at compile time.
+  @inlinable
+  @_semantics("constant_evaluable")
+  @_effects(readonly)
+  @_optimize(none)
+  internal func getNSObjectFormatSpecifier(_ isPrivate: Bool) -> String {
+    // TODO: create a specifier to denote auto-inferred privacy.
+    return isPrivate ? "%{private}@" : "%{public}@"
+  }
+}
+
+extension OSLogArguments {
+  /// Append an (autoclosured) interpolated expression of type NSObject, passed to
+  /// `OSLogMessage.appendInterpolation`, to the array of closures tracked
+  /// by this instance.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  internal mutating func append(_ value: @escaping () -> NSObject) {
+    argumentClosures.append({ (position, _) in
+      serialize(value(), at: &position)
+    })
+  }
+}
+
+/// Serialize an NSObject pointer at the buffer location pointed by
+/// `bufferPosition`.
+@inlinable
+@_alwaysEmitIntoClient
+@inline(__always)
+internal func serialize(
+  _ object: NSObject,
+  at bufferPosition: inout ByteBufferPointer
+) {
+  let byteCount = pointerSizeInBytes();
+  let dest =
+    UnsafeMutableRawBufferPointer(start: bufferPosition, count: byteCount)
+  // Get the address of this NSObject as an UnsafeRawPointer.
+  let objectAddress = Unmanaged.passUnretained(object).toOpaque()
+  // Copy the address into the destination buffer. Note that the input NSObject
+  // is an interpolated expression and is guaranteed to be alive until the
+  // os_log ABI call is completed by the implementation. Therefore, passing
+  // this address to the os_log ABI is safe.
+  withUnsafeBytes(of: objectAddress) { dest.copyMemory(from: $0) }
+  bufferPosition += byteCount
+}

--- a/stdlib/private/OSLog/OSLogStringTypes.swift
+++ b/stdlib/private/OSLog/OSLogStringTypes.swift
@@ -60,7 +60,7 @@ extension OSLogInterpolation {
     arguments.append(header)
 
     // Append number of bytes needed to serialize the argument.
-    let byteCount = sizeForEncoding()
+    let byteCount = pointerSizeInBytes()
     arguments.append(UInt8(byteCount))
 
     // Increment total byte size by the number of bytes needed for this
@@ -105,7 +105,7 @@ extension OSLogArguments {
 @_semantics("constant_evaluable")
 @inlinable
 @_optimize(none)
-internal func sizeForEncoding() -> Int {
+internal func pointerSizeInBytes() -> Int {
   return Int.bitWidth &>> logBitsPerByte
 }
 
@@ -129,7 +129,7 @@ internal func serialize(
     storageObjects.append(storage)
   }
 
-  let byteCount = sizeForEncoding()
+  let byteCount = pointerSizeInBytes()
   let dest =
     UnsafeMutableRawBufferPointer(start: bufferPosition, count: byteCount)
   withUnsafeBytes(of: bytePointer) { dest.copyMemory(from: $0) }

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -8,6 +8,7 @@
 // the size of the byte buffer etc. are literals after the mandatory pipeline.
 
 import OSLogPrototype
+import Foundation
 
 if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
@@ -409,6 +410,55 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
     // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
     // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 6
+  }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest25testNSObjectInterpolationL_1hy0aB06LoggerV_tF
+  func testNSObjectInterpolation(h: Logger) {
+    let nsArray: NSArray = [0, 1, 2]
+    let nsDictionary: NSDictionary = [1 : ""]
+    h.log("""
+      NSArray: \(nsArray, privacy: .public) \
+      NSDictionary: \(nsDictionary, privacy: .private)
+      """)
+      // Check if there is a call to _os_log_impl with a literal format string.
+      // CHECK-DAG is used here as it is easier to perform the checks backwards
+      // from uses to the definitions.
+
+      // CHECK-DAG: [[OS_LOG_IMPL:%[0-9]+]] = function_ref @_os_log_impl : $@convention(c)
+      // CHECK-DAG: apply [[OS_LOG_IMPL]]({{%.*}}, {{%.*}}, {{%.*}}, [[CHARPTR:%[0-9]+]], {{%.*}}, {{%.*}})
+      // CHECK-DAG: [[CHARPTR]] = struct $UnsafePointer<Int8> ([[LIT:%[0-9]+]] : $Builtin.RawPointer)
+      // CHECK-DAG: [[LIT]] = string_literal utf8 "NSArray: %{public}@ NSDictionary: %{private}@"
+
+      // Check if the size of the argument buffer is a constant.
+
+      // CHECK-DAG: [[ALLOCATE:%[0-9]+]] = function_ref @$sSp8allocate8capacitySpyxGSi_tFZ
+      // CHECK-DAG: apply [[ALLOCATE]]<UInt8>([[BUFFERSIZE:%[0-9]+]], {{%.*}})
+      // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
+      // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 22
+      // CHECK-32-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int32, 14
+
+      // Check whether the header bytes: premable and argument count are constants.
+
+      // CHECK-DAG: [[SERIALIZE:%[0-9]+]] = function_ref @$s14OSLogPrototype9serialize_2atys5UInt8V_SpyAEGztF
+      // CHECK-DAG: apply [[SERIALIZE]]([[PREAMBLE:%[0-9]+]], {{%.*}})
+      // CHECK-DAG: [[PREAMBLE]] =  struct $UInt8 ([[PREAMBLELIT:%[0-9]+]] : $Builtin.Int8)
+      // CHECK-DAG: [[PREAMBLELIT]] = integer_literal $Builtin.Int8, 3
+
+      // CHECK-DAG: [[SERIALIZE:%[0-9]+]] = function_ref @$s14OSLogPrototype9serialize_2atys5UInt8V_SpyAEGztF
+      // CHECK-DAG: apply [[SERIALIZE]]([[ARGCOUNT:%[0-9]+]], {{%.*}})
+      // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
+      // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 2
+
+      // Check whether argument array is folded. We need not check the contents of
+      // the array which is checked by a different test suite.
+
+      // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
+      // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>>({{%.*}}, [[ARGSARRAYADDR:%[0-9]+]])
+      // CHECK-DAG: store [[ARGSARRAY:%[0-9]+]] to [[ARGSARRAYADDR]]
+      // CHECK-DAG: [[ARGSARRAY]] = tuple_extract [[ARRAYINITRES:%[0-9]+]] : $(Array<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>, Builtin.RawPointer), 0
+      // CHECK-DAG: [[ARRAYINITRES]] = apply [[ARRAYINIT:%[0-9]+]]<(inout UnsafeMutablePointer<UInt8>, inout Array<AnyObject>) -> ()>([[ARRAYSIZE:%[0-9]+]])
+      // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+      // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 6
   }
 }
 


### PR DESCRIPTION
The extensions for supporting NSObjects are in the file:
`OSLogNSObjectType.swift`. This creates a new dependency for the
OSLogPrototype overlay on the module: ObjectiveC. However,
ObjectiveC is already a dependency for the os module.

This patch includes tests for the NSObject extensions.
In addition, this patch contains a few other minor changes.
1. It makes the `osLog` function public (so that it can be
used by clients directly). 2. It fixes a lifetime-related
bug in the osLog function implementation. 3. It improves
the `OSLogPrototypeExecTest` suite by refactoring a few
helper functions.