### PR TITLE
Revert "[build-script] Do not specify LLDB_FRAMEWORK_INSTALL_PATH (#2…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2229,6 +2229,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
                     -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+                    -DLLDB_FRAMEWORK_INSTALL_DIR="$(get_host_install_prefix ${host})../System/Library/PrivateFrameworks"
                     -DLLVM_DIR:PATH=${llvm_build_dir}/lib/cmake/llvm
                     -DClang_DIR:PATH=${llvm_build_dir}/lib/cmake/clang
                     -DSwift_DIR:PATH=${swift_build_dir}/lib/cmake/swift


### PR DESCRIPTION
…8418)"

This reverts commit 486e2e76ba91761bf20d68362c95134136abafb1.

----

This fixes LLDB and the Swift REPL on macOS.

Before:
```console
$ swift --version
Swift version 5.1.2-dev (Swift 3cbc14893e)
Target: x86_64-apple-darwin18.7.0
$ swift
dyld: Library not loaded: @rpath/LLDB.framework/Versions/A/LLDB
  Referenced from: /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2019-12-09-a.xctoolchain/usr/bin/lldb
  Reason: image not found
```

After:
```console
$ swift
Welcome to Swift version 5.1.2-dev (Swift f920eeee0a).
Type :help for assistance.
  1>
```

---

I debugged this issue by comparing the toolchain directory structure: `System/Library/PrivateFrameworks` is missing from the broken toolchain.
```
diff --git a/ok.txt b/bad.txt
index 62fb78a..6ec76d6 100644
--- a/ok.txt
+++ b/bad.txt
@@ -1,1028 +1,5 @@
 .
 ├── Info.plist
-├── System
-│   └── Library
-│       └── PrivateFrameworks
-│           └── LLDB.framework
-│               ├── Headers -> Versions/Current/Headers
-│               ├── LLDB -> Versions/Current/LLDB
-│               ├── Resources -> Versions/Current/Resources
-│               └── Versions
-│                   ├── A
-│                   │   ├── Headers
...
```