### PR TITLE
SR-11903 - Respect `closed` attribute in clang-imported enum raw inits/getters

### DIFF
--- a/test/ClangImporter/Inputs/enum-objc.h
+++ b/test/ClangImporter/Inputs/enum-objc.h
@@ -16,13 +16,17 @@
 typedef SWIFT_ENUM_NAMED(NSInteger, ObjCEnum, "SwiftEnum") {
     ObjCEnumOne = 1,
     ObjCEnumTwo,
-    ObjCEnumThree
+    ObjCEnumThree,
+
+    ObjCEnumUnavailable __attribute__((availability(swift,unavailable))) = 999 
 };
 
 typedef SWIFT_EXHAUSTIVE_ENUM(NSInteger, ExhaustiveEnum) {
     ExhaustiveEnumOne = 1,
     ExhaustiveEnumTwo,
-    ExhaustiveEnumThree
+    ExhaustiveEnumThree,
+
+    ExhaustiveEnumUnavailable __attribute__((availability(swift,unavailable))) = 999
 };
 
 enum BareForwardEnum;

--- a/test/ClangImporter/enum-objc-execute.swift
+++ b/test/ClangImporter/enum-objc-execute.swift
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -import-objc-header %S/Inputs/enum-objc.h %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+import Foundation
+
+// Test rawValue inits for non-frozen + frozen enums.
+
+// CHECK1-NEXT: SwiftEnum
+print(SwiftEnum.init(rawValue: 0)) 
+// CHECK1-NEXT: SwiftEnum
+print(SwiftEnum.init(rawValue: 1))
+// CHECK1-NEXT: SwiftEnum
+print(SwiftEnum.init(rawValue: 2))
+// CHECK1-NEXT: SwiftEnum
+print(SwiftEnum.init(rawValue: 3))
+// CHECK1-NEXT: SwiftEnum
+print(SwiftEnum.init(rawValue: 4))
+// CHECK1-NEXT: SwiftEnum
+print(ExhaustiveEnum.init(rawValue: 999))
+
+// CHECK1-NEXT: nil
+print(ExhaustiveEnum.init(rawValue: 0)) 
+// CHECK1-NEXT: Optional(ExhaustiveEnum)
+print(ExhaustiveEnum.init(rawValue: 1))
+// CHECK1-NEXT: Optional(ExhaustiveEnum)
+print(ExhaustiveEnum.init(rawValue: 2))
+// CHECK1-NEXT: Optional(ExhaustiveEnum)
+print(ExhaustiveEnum.init(rawValue: 3))
+// CHECK1-NEXT: nil
+print(ExhaustiveEnum.init(rawValue: 4))
+// CHECK1-NEXT: nil
+print(ExhaustiveEnum.init(rawValue: 999))
+
+// Test rawValue getters after an init for non-frozen + frozen enums.
+
+// CHECK1-NEXT: Optional(0)
+print(SwiftEnum.init(rawValue: 0)?.rawValue) 
+// CHECK1-NEXT: Optional(1)
+print(SwiftEnum.init(rawValue: 1)?.rawValue)
+// CHECK1-NEXT: Optional(2)
+print(SwiftEnum.init(rawValue: 2)?.rawValue)
+// CHECK1-NEXT: Optional(3)
+print(SwiftEnum.init(rawValue: 3)?.rawValue)
+// CHECK1-NEXT: Optional(4)
+print(SwiftEnum.init(rawValue: 4)?.rawValue)
+// CHECK1-NEXT: Optional(999)
+print(SwiftEnum.init(rawValue: 999)?.rawValue)
+
+// CHECK1-NEXT: nil
+print(ExhaustiveEnum.init(rawValue: 0)?.rawValue) 
+// CHECK1-NEXT: Optional(1)
+print(ExhaustiveEnum.init(rawValue: 1)?.rawValue)
+// CHECK1-NEXT: EOptional(2)
+print(ExhaustiveEnum.init(rawValue: 2)?.rawValue)
+// CHECK1-NEXT: Optional(3)
+print(ExhaustiveEnum.init(rawValue: 3)?.rawValue)
+// CHECK1-NEXT: nil
+print(ExhaustiveEnum.init(rawValue: 4)?.rawValue)
+// CHECK1-NEXT: nil
+print(SwiftEnum.init(rawValue: 999)?.rawValue)


### PR DESCRIPTION
In the [SE-0192 proposal section on C enums](https://github.com/apple/swift-evolution/blob/master/proposals/0192-non-exhaustive-enums.md#c-enums) it's mentioned that adding the `frozen` concept would enable Swift to drop the custom `init(rawValue:)` constructor that allows invalid values:

>Apart from the effect on switches, a frozen C enum's `init(rawValue:)` will also enforce that the case is one of those known at compile time. Imported non-frozen enums will continue to perform no checking on the raw value.

It seems like this got left out of the final implementation, which @jmesmith brought to my attention while trying to increment an enum that he was expecting to return nil when he passed in the maximum value. This is probably not great, given that the [work to opt out `frozen` enums from needing an `@unknown default` switch case was done](https://github.com/apple/swift/blob/66afe772d54fd74ef1697f16a47bfb76cd4e98c8/test/ClangImporter/enum-exhaustivity.swift#L18). 



<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SE-0192 / SR-8894 / SR-1419 / SR-11903

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
