### PR TITLE
Revert "[build-script] Do not specify LLDB_FRAMEWORK_INSTALL_PATH"

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2069,6 +2069,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
                     -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+                    -DLLDB_FRAMEWORK_INSTALL_DIR="$(get_host_install_prefix ${host})../System/Library/PrivateFrameworks"
                     -DLLVM_DIR:PATH=${llvm_build_dir}/lib/cmake/llvm
                     -DClang_DIR:PATH=${llvm_build_dir}/lib/cmake/clang
                     -DSwift_DIR:PATH=${swift_build_dir}/lib/cmake/swift


### PR DESCRIPTION
Reverts apple/swift#28418. This likely regressed the toolchain build, causing LLDB.framework to go missing in the installed package.