### PR TITLE
[windows] Switch ICU4C from SourceForge to GitHub.

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -28,7 +28,7 @@ setlocal enableextensions enabledelayedexpansion
 set icu_version_major=64
 set icu_version_minor=2
 set icu_version=%icu_version_major%_%icu_version_minor%
-set icu_version_dotted=%icu_version_major%.%icu_version_minor%
+set icu_version_dashed=%icu_version_major%-%icu_version_minor%
 
 set "exitOnError=|| (exit /b)"
 set current_directory=%~dp0
@@ -101,7 +101,7 @@ endlocal
 setlocal enableextensions enabledelayedexpansion
 
 set file_name=icu4c-%icu_version%-Win64-MSVC2017.zip
-curl -L -O -z %file_name% "http://download.icu-project.org/files/icu4c/%icu_version_dotted%/%file_name%" %exitOnError%
+curl -L -O "https://github.com/unicode-org/icu/releases/download/release-%icu_version_dashed%/%file_name%" %exitOnError%
 :: unzip warns about the paths in the zip using slashes, which raises the
 :: errorLevel to 1. We cannot use exitOnError, and have to ignore errors.
 unzip -o %file_name% -d "%source_root%\icu-%icu_version%"


### PR DESCRIPTION
Use GitHub download instead of SourceForge for ICU4C binary package, since SF fails from time to time and the build fails because of it.

Also remove the usage of -z, since Community CI deletes the previous file anyway, so no point in checking for a cached copy, when the only thing that would happen is an annoying message in the build logs.
