### PR TITLE
[semantic-arc] Teach the optimizer how to eliminate dead live ranges that are copied/consumed

### DIFF
--- a/test/SILOptimizer/existential_transform.swift
+++ b/test/SILOptimizer/existential_transform.swift
@@ -299,10 +299,8 @@ func wrap_gcp<T:GP>(_ a:T,_ b:GP) -> Int {
 // CHECK: store
 // CHECK: function_ref @$s21existential_transform8wrap_gcpySix_AA2GP_ptAaCRzlFTf4ne_n : $@convention(thin) <τ_0_0 where τ_0_0 : GP><τ_1_0 where τ_1_0 : GP> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0) -> Int 
 // CHECK: open_existential_addr 
-// CHECK: strong_retain 
 // CHECK: apply
 // CHECK: destroy_addr 
-// CHECK: strong_release 
 // CHECK: dealloc_stack
 // CHECK: return 
 // CHECK: } // end sil function '$s21existential_transform3gcpySixAA2GPRzlF'
@@ -326,10 +324,8 @@ func wrap_gcp_arch<T:GP>(_ a:T,_ b:GP, _ c:inout Array<T>) -> Int {
 // CHECK: store
 // CHECK: function_ref @$s21existential_transform13wrap_gcp_archySix_AA2GP_pSayxGztAaCRzlFTf4nen_n : $@convention(thin) <τ_0_0 where τ_0_0 : GP><τ_1_0 where τ_1_0 : GP> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0, @inout Array<τ_0_0>) -> Int
 // CHECK: open_existential_addr
-// CHECK: strong_retain
 // CHECK: apply
 // CHECK: destroy_addr
-// CHECK: strong_release
 // CHECK: dealloc_stack
 // CHECK: return
 // CHECK-LABEL: } // end sil function '$s21existential_transform8gcp_archySix_SayxGztAA2GPRzlF'

--- a/test/SILOptimizer/opaque_values_opt.sil
+++ b/test/SILOptimizer/opaque_values_opt.sil
@@ -31,10 +31,8 @@ bb0(%0 : $Builtin.Int64):
 // CHECK: bb0(%0 : $T):
 // CHECK:   %1 = copy_value %0 : $T
 // CHECK:   %2 = copy_value %0 : $T
-// CHECK:   %3 = copy_value %0 : $T
-// CHECK:   destroy_value %0 : $T
-// CHECK:   %5 = tuple (%1 : $T, %2 : $T, %3 : $T)
-// CHECK:   return %5 : $(T, T, T)
+// CHECK:   %3 = tuple (%1 : $T, %2 : $T, %0 : $T)
+// CHECK:   return %3 : $(T, T, T)
 // CHECK-LABEL: } // end sil function 'f020_multiResult'
 sil hidden [noinline] @f020_multiResult : $@convention(thin) <T> (@in T) -> (@out T, @out T, @out T) {
 bb0(%0 : $T):

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -21,9 +21,11 @@ struct NativeObjectPair {
 }
 
 sil @get_nativeobject_pair : $@convention(thin) () -> @owned NativeObjectPair
+sil @use_nativeobject_pair : $@convention(thin) (@owned NativeObjectPair) -> ()
 
 class Klass {}
 sil @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+sil @owned_klass_user : $@convention(thin) (@owned Klass) -> ()
 
 struct MyInt {
   var value: Builtin.Int32
@@ -1040,6 +1042,284 @@ bb0(%0 : @owned $Klass):
   destroy_value %4 : $Klass
   dealloc_stack %1 : $*Klass
 
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @single_eliminate_inner_consume : $@convention(thin) (@in Klass) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'single_eliminate_inner_consume'
+sil [ossa] @single_eliminate_inner_consume : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0 : $*Klass
+  %2 = function_ref @owned_klass_user : $@convention(thin) (@owned Klass) -> ()
+  %3 = copy_value %1 : $Klass
+  apply %2(%3) : $@convention(thin) (@owned Klass) -> ()
+  destroy_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @single_eliminate_inner_consume_forwarding : $@convention(thin) (@in Klass) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'single_eliminate_inner_consume_forwarding'
+sil [ossa] @single_eliminate_inner_consume_forwarding : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0 : $*Klass
+  %2 = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %3 = copy_value %1 : $Klass
+  %4 = unchecked_ref_cast %3 : $Klass to $Builtin.NativeObject
+  apply %2(%4) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  destroy_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// This is not handled today due to there being a usage of %1 in between %3 and
+// %3's use when we call %2. If we knew that %3 did not have any forwarding uses
+// or if we taught the optimization how to deal with projections, we would be
+// able to handle this.
+//
+// CHECK-LABEL: sil [ossa] @single_eliminate_outer_deadliverange_forwarding_1 : $@convention(thin) (@in Klass) -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'single_eliminate_outer_deadliverange_forwarding_1'
+sil [ossa] @single_eliminate_outer_deadliverange_forwarding_1 : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0 : $*Klass
+  %2 = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %3 = copy_value %1 : $Klass
+  %4 = unchecked_ref_cast %3 : $Klass to $Builtin.NativeObject
+  %5 = function_ref @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %5(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %2(%4) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  destroy_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// This is not handled today, since we have a forwarding use of %1
+//
+// CHECK-LABEL: sil [ossa] @single_eliminate_outer_deadliverange_forwarding_2 : $@convention(thin) (@in Klass) -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'single_eliminate_outer_deadliverange_forwarding_2'
+sil [ossa] @single_eliminate_outer_deadliverange_forwarding_2 : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0 : $*Klass
+  %2 = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %3 = copy_value %1 : $Klass
+  %4 = unchecked_ref_cast %3 : $Klass to $Builtin.NativeObject
+  %5 = unchecked_ref_cast %1 : $Klass to $Builtin.NativeObject
+  %6 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %6(%5) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %2(%4) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  destroy_value %5 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Since our copy_value is in a diamond, we can eliminate this, but need to put
+// a compensating destroy in bb2. We do not support this yet, so make sure we do
+// not optimize.
+//
+// CHECK-LABEL: sil [ossa] @single_eliminate_inner_consume_forwarding_diamond : $@convention(thin) (@in Klass) -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'single_eliminate_inner_consume_forwarding_diamond'
+sil [ossa] @single_eliminate_inner_consume_forwarding_diamond : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0 : $*Klass
+  %2 = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = copy_value %1 : $Klass
+  %4 = unchecked_ref_cast %3 : $Klass to $Builtin.NativeObject
+  apply %2(%4) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Since our copy_value is in a loop, we can not eliminate this.
+//
+// CHECK-LABEL: sil [ossa] @single_eliminate_inner_consume_forwarding_loop : $@convention(thin) (@in Klass) -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'single_eliminate_inner_consume_forwarding_loop'
+sil [ossa] @single_eliminate_inner_consume_forwarding_loop : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0 : $*Klass
+  %2 = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  br bb1
+
+bb1:
+  br bb2
+
+bb2:
+  %3 = copy_value %1 : $Klass
+  %4 = unchecked_ref_cast %3 : $Klass to $Builtin.NativeObject
+  apply %2(%4) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  cond_br undef, bb3, bb4
+
+bb3:
+  br bb2
+
+bb4:
+  destroy_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We can not eliminate the copy_value here without being able to hoist the
+// guaranteed_klass_user before the @owned_klass_user.
+//
+// CHECK-LABEL: sil [ossa] @single_cannoteliminate_inner_consume_due_to_postdom_issue : $@convention(thin) (@in Klass) -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'single_cannoteliminate_inner_consume_due_to_postdom_issue'
+sil [ossa] @single_cannoteliminate_inner_consume_due_to_postdom_issue : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0 : $*Klass
+  %2 = function_ref @owned_klass_user : $@convention(thin) (@owned Klass) -> ()
+  %3 = copy_value %1 : $Klass
+  apply %2(%3) : $@convention(thin) (@owned Klass) -> ()
+  %4 = function_ref @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %4(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We can not eliminate the copy_value here since the pass currently does not
+// know how to understand that it needs to be a destroy at the end of bb2. This
+// can be improved in the future.
+//
+// CHECK-LABEL: sil [ossa] @single_cannoteliminate_inner_consume_due_to_postdom_issue_diamond : $@convention(thin) (@in Klass) -> () {
+// CHECK: copy_value
+// CHECK: } // end sil function 'single_cannoteliminate_inner_consume_due_to_postdom_issue_diamond'
+sil [ossa] @single_cannoteliminate_inner_consume_due_to_postdom_issue_diamond : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0 : $*Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = function_ref @owned_klass_user : $@convention(thin) (@owned Klass) -> ()
+  %3 = copy_value %1 : $Klass
+  apply %2(%3) : $@convention(thin) (@owned Klass) -> ()
+  br bb3
+
+bb2:
+  %4 = function_ref @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %4(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  br bb3
+
+bb3:
+  destroy_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We do not handle this yet today. But we should be able to once we add support
+// for diamonds.
+//
+// CHECK-LABEL: sil [ossa] @handle_end_borrows_when_eliminating_parent_dead_live_ranges : $@convention(thin) (@owned NativeObjectPair) -> () {
+// CHECK-NOT: begin_borrow
+// CHECK: copy_value
+// CHECK-NOT: begin_borrow
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'handle_end_borrows_when_eliminating_parent_dead_live_ranges
+sil [ossa] @handle_end_borrows_when_eliminating_parent_dead_live_ranges : $@convention(thin) (@owned NativeObjectPair) -> () {
+bb0(%0 : @owned $NativeObjectPair):
+  %1 = begin_borrow %0 : $NativeObjectPair
+  %2 = struct_extract %1 : $NativeObjectPair, #NativeObjectPair.obj1
+  %3 = copy_value %2 : $Builtin.NativeObject
+  destroy_value %3 : $Builtin.NativeObject
+  end_borrow %1 : $NativeObjectPair
+  cond_br undef, bb1, bb2
+
+bb1:
+  %0b = begin_borrow %0 : $NativeObjectPair
+  %0b_copy = copy_value %0b : $NativeObjectPair
+  %4 = copy_value %0 : $NativeObjectPair
+  %5 = function_ref @use_nativeobject_pair : $@convention(thin) (@owned NativeObjectPair) -> ()
+  apply %5(%4) : $@convention(thin) (@owned NativeObjectPair) -> ()
+  cond_br undef, bb3, bb4
+
+bb2:
+  destroy_value %0 : $NativeObjectPair
+  br bb5
+
+bb3:
+  destroy_value %0b_copy : $NativeObjectPair
+  end_borrow %0b : $NativeObjectPair
+  destroy_value %0 : $NativeObjectPair
+  br bb5
+
+bb4:
+  destroy_value %0b_copy : $NativeObjectPair
+  end_borrow %0b : $NativeObjectPair
+  destroy_value %0 : $NativeObjectPair
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We should be able to handle this with time, but we do not yet.
+//
+// CHECK-LABEL: sil [ossa] @handle_end_borrows_when_eliminating_parent_dead_live_ranges_1 : $@convention(thin) (@owned NativeObjectPair) -> () {
+// CHECK: begin_borrow
+// CHECK-NOT: begin_borrow
+// CHECK: copy_value
+// CHECK-NOT: begin_borrow
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'handle_end_borrows_when_eliminating_parent_dead_live_ranges_1'
+sil [ossa] @handle_end_borrows_when_eliminating_parent_dead_live_ranges_1 : $@convention(thin) (@owned NativeObjectPair) -> () {
+bb0(%0 : @owned $NativeObjectPair):
+  %1 = begin_borrow %0 : $NativeObjectPair
+  %2 = struct_extract %1 : $NativeObjectPair, #NativeObjectPair.obj1
+  %3 = copy_value %2 : $Builtin.NativeObject
+  %3fun = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %3fun(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3 : $Builtin.NativeObject
+  end_borrow %1 : $NativeObjectPair
+  cond_br undef, bb1, bb2
+
+bb1:
+  %0b = begin_borrow %0 : $NativeObjectPair
+  %0b_copy = copy_value %0b : $NativeObjectPair
+  %4 = copy_value %0 : $NativeObjectPair
+  %5 = function_ref @use_nativeobject_pair : $@convention(thin) (@owned NativeObjectPair) -> ()
+  apply %5(%4) : $@convention(thin) (@owned NativeObjectPair) -> ()
+  cond_br undef, bb3, bb4
+
+bb2:
+  destroy_value %0 : $NativeObjectPair
+  br bb5
+
+bb3:
+  destroy_value %0b_copy : $NativeObjectPair
+  end_borrow %0b : $NativeObjectPair
+  destroy_value %0 : $NativeObjectPair
+  br bb5
+
+bb4:
+  destroy_value %0b_copy : $NativeObjectPair
+  end_borrow %0b : $NativeObjectPair
+  destroy_value %0 : $NativeObjectPair
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
The diagnose unreachable commit is just something that I hit as I was implementing this.

The main caveats here is that we do not handle load [take] that are forwarded through a forwarding instruction before the copy_value. I think with a bit of time, I can fix this.