### PR TITLE
[DO NOT MERGE] Always prespecialize generic metadata.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -262,7 +262,7 @@ public:
         EnableAnonymousContextMangledNames(false), ForcePublicLinkage(false),
         LazyInitializeClassMetadata(false),
         LazyInitializeProtocolConformances(false), DisableLegacyTypeInfo(false),
-        PrespecializeGenericMetadata(false), UseIncrementalLLVMCodeGen(true),
+        PrespecializeGenericMetadata(true), UseIncrementalLLVMCodeGen(true),
         UseSwiftCall(false), GenerateProfile(false),
         EnableDynamicReplacementChaining(false),
         DisableRoundTripDebugTypes(false), DisableDebuggerShadowCopies(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -651,9 +651,9 @@ def disable_verify_exclusivity : Flag<["-"], "disable-verify-exclusivity">,
 def disable_legacy_type_info : Flag<["-"], "disable-legacy-type-info">,
   HelpText<"Completely disable legacy type layout">;
 
-def prespecialize_generic_metadata : Flag<["-"], "prespecialize-generic-metadata">,
-  HelpText<"Statically specialize metadata for generic types at types that "
-           "are known to be used in source.">;
+def disable_generic_metadata_prespecialization : Flag<["-"], "disable-generic-metadata-prespecialization">,
+  HelpText<"Do not statically specialize metadata for generic types at types "
+           "that are known to be used in source.">;
 
 def read_legacy_type_info_path_EQ : Joined<["-"], "read-legacy-type-info-path=">,
   HelpText<"Read legacy type layout from the given path instead of default path">;

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -243,7 +243,7 @@ AvailabilityContext ASTContext::getTypesInAbstractMetadataStateAvailability() {
 }
 
 AvailabilityContext ASTContext::getPrespecializedGenericMetadataAvailability() {
-  return getSwiftFutureAvailability();
+  return AvailabilityContext::alwaysAvailable();
 }
 
 AvailabilityContext ASTContext::getSwift52Availability() {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1327,8 +1327,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.DisableLegacyTypeInfo = true;
   }
 
-  if (Args.hasArg(OPT_prespecialize_generic_metadata)) {
-    Opts.PrespecializeGenericMetadata = true;
+  if (Args.hasArg(OPT_disable_generic_metadata_prespecialization)) {
+    Opts.PrespecializeGenericMetadata = false;
   }
 
   if (const Arg *A = Args.getLastArg(OPT_read_legacy_type_info_path_EQ)) {

--- a/lib/IRGen/EnumMetadataVisitor.h
+++ b/lib/IRGen/EnumMetadataVisitor.h
@@ -62,6 +62,14 @@ public:
            Target->getDeclaredTypeInContext()->getCanonicalType());
     if (strategy.needsPayloadSizeInMetadata())
       asImpl().addPayloadSize();
+
+    if (asImpl().hasTrailingFlags())
+      asImpl().addTrailingFlags();
+  }
+
+  bool hasTrailingFlags() {
+    return Target->isGenericContext() &&
+           IGM.shouldPrespecializeGenericMetadata();
   }
 };
 
@@ -86,6 +94,7 @@ public:
   void addGenericWitnessTable(GenericRequirement requirement) { addPointer(); }
   void addPayloadSize() { addPointer(); }
   void noteStartOfTypeSpecificMembers() {}
+  void addTrailingFlags() { addPointer(); }
 
 private:
   void addPointer() {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1859,7 +1859,21 @@ void irgen::emitLazyMetadataAccessor(IRGenModule &IGM,
 
 void irgen::emitLazySpecializedGenericTypeMetadata(IRGenModule &IGM,
                                                    CanType type) {
-  emitSpecializedGenericStructMetadata(IGM, type);
+  switch (type->getKind()) {
+  case TypeKind::Struct:
+  case TypeKind::BoundGenericStruct:
+    emitSpecializedGenericStructMetadata(IGM, type,
+                                         *type.getStructOrBoundGenericStruct());
+    break;
+  case TypeKind::Enum:
+  case TypeKind::BoundGenericEnum:
+    emitSpecializedGenericEnumMetadata(IGM, type,
+                                       *type.getEnumOrBoundGenericEnum());
+    break;
+  default:
+    llvm_unreachable("Cannot statically specialize types of kind other than "
+                     "struct and enum.");
+  }
 }
 
 llvm::Constant *
@@ -3472,8 +3486,12 @@ namespace {
          : public ValueMetadataBuilderBase<StructMetadataVisitor<Impl>> {
     using super = ValueMetadataBuilderBase<StructMetadataVisitor<Impl>>;
 
+    bool HasUnfilledFieldOffset = false;
+
   protected:
-    ConstantStructBuilder &B;
+    using ConstantBuilder = ConstantStructBuilder;
+    ConstantBuilder &B;
+    using NominalDecl = StructDecl;
     using super::IGM;
     using super::Target;
     using super::asImpl;
@@ -3562,16 +3580,6 @@ namespace {
 
       return flags;
     }
-  };
-
-  class StructMetadataBuilder :
-    public StructMetadataBuilderBase<StructMetadataBuilder> {
-
-    bool HasUnfilledFieldOffset = false;
-  public:
-    StructMetadataBuilder(IRGenModule &IGM, StructDecl *theStruct,
-                          ConstantStructBuilder &B)
-      : StructMetadataBuilderBase(IGM, theStruct, B) {}
 
     void flagUnfilledFieldOffset() {
       HasUnfilledFieldOffset = true;
@@ -3580,13 +3588,21 @@ namespace {
     bool canBeConstant() {
       return !HasUnfilledFieldOffset;
     }
+  };
+
+  class StructMetadataBuilder
+      : public StructMetadataBuilderBase<StructMetadataBuilder> {
+  public:
+    StructMetadataBuilder(IRGenModule &IGM, StructDecl *theStruct,
+                          ConstantStructBuilder &B)
+        : StructMetadataBuilderBase(IGM, theStruct, B) {}
 
     void createMetadataAccessFunction() {
       createNonGenericMetadataAccessFunction(IGM, Target);
       maybeCreateSingletonMetadataInitialization();
     }
   };
-  
+
   /// Emit a value witness table for a fixed-layout generic type, or a template
   /// if the value witness table is dependent on generic parameters.
   static ConstantReference
@@ -3710,24 +3726,25 @@ namespace {
     }
   };
 
-  class SpecializedGenericStructMetadataBuilder
-      : public StructMetadataBuilderBase<
-            SpecializedGenericStructMetadataBuilder> {
-    using super =
-        StructMetadataBuilderBase<SpecializedGenericStructMetadataBuilder>;
+  template <template <typename> class MetadataBuilderBase, typename Impl>
+  class SpecializedGenericNominalMetadataBuilderBase
+      : public MetadataBuilderBase<Impl> {
+    using super = MetadataBuilderBase<Impl>;
+
     CanType type;
-    bool HasUnfilledFieldOffset = false;
 
   protected:
     using super::asImpl;
     using super::getLoweredType;
     using super::IGM;
     using super::Target;
+    using typename super::ConstantBuilder;
+    using typename super::NominalDecl;
 
   public:
-    SpecializedGenericStructMetadataBuilder(IRGenModule &IGM, CanType type,
-                                            StructDecl &decl,
-                                            ConstantStructBuilder &B)
+    SpecializedGenericNominalMetadataBuilderBase(IRGenModule &IGM, CanType type,
+                                                 NominalDecl &decl,
+                                                 ConstantBuilder &B)
         : super(IGM, &decl, B), type(type) {}
 
     void noteStartOfTypeSpecificMembers() {}
@@ -3750,7 +3767,7 @@ namespace {
       auto t = requirement.TypeParameter.subst(genericSubstitutions());
       ConstantReference ref = IGM.getAddrOfTypeMetadata(
           CanType(t), SymbolReferenceKind::Relative_Direct);
-      B.add(ref.getDirectValue());
+      this->B.add(ref.getDirectValue());
     }
 
     void addGenericWitnessTable(GenericRequirement requirement) {
@@ -3773,7 +3790,7 @@ namespace {
         addr = IGM.getAddrOfWitnessTable(rootConformance);
       }
 
-      B.add(addr);
+      this->B.add(addr);
     }
 
     SubstitutionMap genericSubstitutions() {
@@ -3789,10 +3806,21 @@ namespace {
 
       return flags;
     }
+  };
 
-    void flagUnfilledFieldOffset() { HasUnfilledFieldOffset = true; }
+  class SpecializedGenericStructMetadataBuilder
+      : public SpecializedGenericNominalMetadataBuilderBase<
+            StructMetadataBuilderBase,
+            SpecializedGenericStructMetadataBuilder> {
+    using super = SpecializedGenericNominalMetadataBuilderBase<
+        StructMetadataBuilderBase, SpecializedGenericStructMetadataBuilder>;
 
-    bool canBeConstant() { return !HasUnfilledFieldOffset; }
+
+  public:
+    SpecializedGenericStructMetadataBuilder(IRGenModule &IGM, CanType type,
+                                            StructDecl &decl,
+                                            ConstantStructBuilder &B)
+        : super(IGM, type, decl, B) {}
   };
 
 } // end anonymous namespace
@@ -3828,8 +3856,8 @@ void irgen::emitStructMetadata(IRGenModule &IGM, StructDecl *structDecl) {
                          init.finishAndCreateFuture());
 }
 
-void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM,
-                                                 CanType type) {
+void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type,
+                                                 StructDecl &decl) {
   Type ty = type.getPointer();
   auto &context = type->getNominalOrBoundGenericNominal()->getASTContext();
   PrettyStackTraceType stackTraceRAII(
@@ -3840,7 +3868,6 @@ void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM,
 
   bool isPattern = false;
 
-  auto &decl = *type.getStructOrBoundGenericStruct();
   SpecializedGenericStructMetadataBuilder builder(IGM, type, decl, init);
   builder.layout();
 
@@ -3871,9 +3898,13 @@ namespace {
   class EnumMetadataBuilderBase
          : public ValueMetadataBuilderBase<EnumMetadataVisitor<Impl>> {
     using super = ValueMetadataBuilderBase<EnumMetadataVisitor<Impl>>;
+    bool HasUnfilledPayloadSize = false;
 
   protected:
-    ConstantStructBuilder &B;
+    using ConstantBuilder = ConstantStructBuilder;
+    using NominalDecl = EnumDecl;
+    ConstantBuilder &B;
+    using super::asImpl;
     using super::IGM;
     using super::Target;
 
@@ -3894,8 +3925,12 @@ namespace {
       return irgen::emitValueWitnessTable(IGM, type, false, relativeReference);
     }
 
+    ConstantReference getValueWitnessTable(bool relativeReference) {
+      return emitValueWitnessTable(relativeReference);
+    }
+
     void addValueWitnessTable() {
-      B.add(emitValueWitnessTable(/*relative*/ false).getValue());
+      B.add(asImpl().getValueWitnessTable(false).getValue());
     }
 
     llvm::Constant *emitNominalTypeDescriptor() {
@@ -3904,8 +3939,12 @@ namespace {
       return descriptor;
     }
 
+    llvm::Constant *getNominalTypeDescriptor() {
+      return emitNominalTypeDescriptor();
+    }
+
     void addNominalTypeDescriptor() {
-      B.add(emitNominalTypeDescriptor());
+      B.add(asImpl().getNominalTypeDescriptor());
     }
 
     void addGenericArgument(GenericRequirement requirement) {
@@ -3915,16 +3954,22 @@ namespace {
     void addGenericWitnessTable(GenericRequirement requirement) {
       llvm_unreachable("Concrete type metadata cannot have generic requirements");
     }
-  };
 
-  class EnumMetadataBuilder
-    : public EnumMetadataBuilderBase<EnumMetadataBuilder> {
-    bool HasUnfilledPayloadSize = false;
+    bool hasTrailingFlags() {
+      return IGM.shouldPrespecializeGenericMetadata();
+    }
 
-  public:
-    EnumMetadataBuilder(IRGenModule &IGM, EnumDecl *theEnum,
-                        ConstantStructBuilder &B)
-      : EnumMetadataBuilderBase(IGM, theEnum, B) {}
+    void addTrailingFlags() {
+      auto flags = asImpl().getTrailingFlags();
+
+      B.addInt(IGM.Int64Ty, flags.getOpaqueValue());
+    }
+
+    MetadataTrailingFlags getTrailingFlags() {
+      MetadataTrailingFlags flags;
+
+      return flags;
+    }
 
     void addPayloadSize() {
       auto payloadSize = getConstantPayloadSize(IGM, Target);
@@ -3940,6 +3985,27 @@ namespace {
     bool canBeConstant() {
       return !HasUnfilledPayloadSize;
     }
+  };
+
+  class SpecializedGenericEnumMetadataBuilder
+      : public SpecializedGenericNominalMetadataBuilderBase<
+            EnumMetadataBuilderBase, SpecializedGenericEnumMetadataBuilder> {
+
+    using super = SpecializedGenericNominalMetadataBuilderBase<
+        EnumMetadataBuilderBase, SpecializedGenericEnumMetadataBuilder>;
+
+  public:
+    SpecializedGenericEnumMetadataBuilder(IRGenModule &IGM, CanType type,
+                                          EnumDecl &decl, ConstantBuilder &B)
+        : super(IGM, type, decl, B){};
+  };
+
+  class EnumMetadataBuilder
+      : public EnumMetadataBuilderBase<EnumMetadataBuilder> {
+  public:
+    EnumMetadataBuilder(IRGenModule &IGM, EnumDecl *theEnum,
+                        ConstantStructBuilder &B)
+        : EnumMetadataBuilderBase(IGM, theEnum, B) {}
 
     void createMetadataAccessFunction() {
       createNonGenericMetadataAccessFunction(IGM, Target);
@@ -3990,6 +4056,16 @@ namespace {
       return EnumContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
     }
 
+    GenericMetadataPatternFlags getPatternFlags() {
+      auto flags = super::getPatternFlags();
+
+      if (IGM.shouldPrespecializeGenericMetadata()) {
+        flags.setHasTrailingFlags(true);
+      }
+
+      return flags;
+    }
+
     ConstantReference emitValueWitnessTable(bool relativeReference) {
       assert(relativeReference && "should only relative reference");
       return getValueWitnessTableForGenericValueType(IGM, Target,
@@ -4030,6 +4106,26 @@ void irgen::emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum) {
   CanType declaredType = theEnum->getDeclaredType()->getCanonicalType();
 
   IGM.defineTypeMetadata(declaredType, isPattern, canBeConstant,
+                         init.finishAndCreateFuture());
+}
+
+void irgen::emitSpecializedGenericEnumMetadata(IRGenModule &IGM, CanType type,
+                                               EnumDecl &decl) {
+  Type ty = type.getPointer();
+  auto &context = type->getNominalOrBoundGenericNominal()->getASTContext();
+  PrettyStackTraceType stackTraceRAII(
+      context, "emitting prespecialized metadata for", ty);
+  ConstantInitBuilder initBuilder(IGM);
+  auto init = initBuilder.beginStruct();
+  init.setPacked(true);
+
+  bool isPattern = false;
+
+  SpecializedGenericEnumMetadataBuilder builder(IGM, type, decl, init);
+  builder.layout();
+
+  bool canBeConstant = builder.canBeConstant();
+  IGM.defineTypeMetadata(type, isPattern, canBeConstant,
                          init.finishAndCreateFuture());
 }
 

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -85,7 +85,11 @@ namespace irgen {
   /// Emit the metadata associated with the given enum declaration.
   void emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum);
 
-  void emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type);
+  void emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type,
+                                            StructDecl &decl);
+
+  void emitSpecializedGenericEnumMetadata(IRGenModule &IGM, CanType type,
+                                          EnumDecl &decl);
 
   /// Get what will be the index into the generic type argument array at the end
   /// of a nominal type's metadata.

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -684,11 +684,6 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
     return false;
   }
 
-  if (isa<EnumType>(type) || isa<BoundGenericEnumType>(type)) {
-    // TODO: Support enums.
-    return false;
-  }
-
   if (isa<ClassType>(type) || isa<BoundGenericClassType>(type)) {
     // TODO: Support classes.
     return false;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5223,6 +5223,8 @@ template <>
 bool Metadata::isCanonicalStaticallySpecializedGenericMetadata() const {
   if (auto *metadata = dyn_cast<StructMetadata>(this))
     return metadata->isCanonicalStaticallySpecializedGenericMetadata();
+  if (auto *metadata = dyn_cast<EnumMetadata>(this))
+    return metadata->isCanonicalStaticallySpecializedGenericMetadata();
 
   return false;
 }

--- a/test/IRGen/prespecialized-metadata/Inputs/protocol-public.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/protocol-public.swift
@@ -1,0 +1,2 @@
+public protocol P {
+}

--- a/test/IRGen/prespecialized-metadata/Inputs/struct-public-frozen-0argument.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/struct-public-frozen-0argument.swift
@@ -1,0 +1,8 @@
+@frozen
+public struct Integer {
+  public let value: Int
+
+  public init(_ value: Int) {
+    self.value = value
+  }
+}

--- a/test/IRGen/prespecialized-metadata/Inputs/struct-public-nonfrozen-0argument.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/struct-public-nonfrozen-0argument.swift
@@ -1,0 +1,7 @@
+public struct Integer {
+  public let value: Int
+
+  public init(_ value: Int) {
+    self.value = value
+  }
+}

--- a/test/IRGen/prespecialized-metadata/enum-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -1,0 +1,87 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]OySiGMf" = internal constant <{
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    [[INT]],
+// CHECK-SAME:    %swift.type_descriptor*,
+// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    i64
+// CHECK-SAME: }> <{
+//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5Value[[UNIQUE_ID_1]]OySiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
+// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5Value[[UNIQUE_ID_1]]OMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    i64 3
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+fileprivate enum Value<First> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5Value[[UNIQUE_ID_1]]OySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]OMa"([[INT]], %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5Value[[UNIQUE_ID_1]]OySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5Value[[UNIQUE_ID_1]]OMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -1,0 +1,94 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main9NamespaceC5ValueOySi_GMf" = internal constant <{
+// CHECk-SAME:    i8**,
+// CHECK-SAME:    [[INT]],
+// CHECK-SAME:    %swift.type_descriptor*,
+// CHECK-SAME:    %swift.type*,
+// CHECK-SAME: }> <{
+//                i8** getelementptr inbounds (
+//                  %swift.enum_vwtable, 
+//                  %swift.enum_vwtable* @"$s4main9NamespaceC5ValueOySi_GWV", 
+//                  i32 0, 
+//                  i32 0
+//                ),
+// CHECK-SAME:    [[INT]] 513,
+// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceC5ValueOMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    i64 3
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+
+final class Namespace<First> {
+  enum Value {
+    case first(First)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySi_GMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Namespace.Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueOMa"([[INT]], %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_1]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*,  
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySi_GMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:   [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* undef, i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceC5ValueOMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-0distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-0distinct_use.swift
@@ -1,0 +1,39 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+enum Value<First> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK: }
+func doit() {
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main5ValueOMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-1distinct_use.swift
@@ -1,0 +1,96 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_type
+
+// CHECK: @"$s4main5ValueOySiGMf" = internal constant <{
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    [[INT]],
+// CHECK-SAME:    %swift.type_descriptor*,
+// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    i64
+// CHECK-SAME: }> <{
+// CHECK-SAME:    i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
+// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
+// CHECK-SAME:    i64 3
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+protocol P {}
+extension Int : P {}
+enum Value<First : P> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*, i8**) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* [[ERASED_TABLE]], i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*))
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/protocol-public.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
+// RUN: %target-swift-frontend -target %module-target-future -prespecialize-generic-metadata -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+import TestModule
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_type
+
+// CHECK-NOT: @"$s4main5ValueOySiGMf"
+
+extension Int : P {}
+enum Value<First : P> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[DEMANGLED_TYPE:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s4main5ValueOyS2i10TestModule1PAAyHCg_GMD") #{{[0-9]+}}
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[DEMANGLED_TYPE]]
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*, i8**) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* [[ERASED_TABLE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME:   )
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_resilient-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_resilient-1distinct_use.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -enable-library-evolution -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/protocol-public.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
+// RUN: %target-swift-frontend -target %module-target-future -prespecialize-generic-metadata -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+import TestModule
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_type
+
+// CHECK-NOT: @"$s4main5ValueOySiGMf"
+
+extension Int : P {}
+enum Value<First : P> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[DEMANGLED_TYPE:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s4main5ValueOyS2i10TestModule1PAAyHCg_GMD") #{{[0-9]+}}
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[DEMANGLED_TYPE]]
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*, i8**) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* [[ERASED_TABLE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME:   )
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-public-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-public-1distinct_use.swift
@@ -1,0 +1,96 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_type
+
+// CHECK: @"$s4main5ValueOySiGMf" = internal constant <{
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    [[INT]],
+// CHECK-SAME:    %swift.type_descriptor*,
+// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    i64
+// CHECK-SAME: }> <{
+// CHECK-SAME:    i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
+// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
+// CHECK-SAME:    i64 3
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+public protocol P {}
+extension Int : P {}
+enum Value<First : P> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*, i8**) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* [[ERASED_TABLE]], i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*))
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
@@ -1,0 +1,43 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK-NOT: @"$s4main5ValueOyAA7IntegerVGMf"
+enum Value<First : Equatable> {
+  case first(First)
+}
+
+struct Integer : Equatable {
+  let value: Int
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+func doit() {
+  consume( Value.first(Integer(value: 13)) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*, i8**) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_CONFORMANCE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* [[ERASED_CONFORMANCE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_generic_use.swift
@@ -1,0 +1,54 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+enum Outer<First> {
+  case first(First)
+}
+
+struct Inner<First> {
+  let first: First
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// TODO: Once prespecialization is done for generic arguments which are 
+//       themselves generic (Outer<Inner<Int>>, here), a direct reference to
+//       the prespecialized metadata should be emitted here.
+// CHECK:  [[TYPE:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName(
+// CHECK-SAME:     { i32, i32 }* @"$s4main5OuterOyAA5InnerVySiGGMD"
+// CHECK-SAME:   )
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[TYPE]]
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Outer.first(Inner(first: 13)) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5OuterOMa"([[INT]], %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main5OuterOMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
@@ -1,0 +1,77 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOySiGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOySiGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOySiGwst" to i8*), 
+// CHECK-SAME:   [[INT]] [[ALIGNMENT]], 
+// CHECK-SAME:   [[INT]] [[ALIGNMENT]], 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 0, i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOySiGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOySiGwup" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOySiGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOySiGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME: }> <{ 
+// CHECK-SAME: i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0), 
+// CHECK-SAME: [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First> {
+  case only(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i64 }>* @"$s4main5ValueOySiGMf" to %swift.full_type*), i32 0, i32 1)
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.only(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i64 }>* @"$s4main5ValueOySiGMf" to %swift.full_type*), i32 0, i32 1), [[INT]] 0 }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   i8* %2, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-class-1argument-1distinct_use.swift
@@ -4,32 +4,29 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK: @"$s4main9NamespaceV5ValueVySS_SiGMf" = internal constant <{
+// CHECK: @"$s4main9NamespaceC5ValueOySS_SiGMf" = internal constant <{
 // CHECK-SAME:    i8**,
 // CHECK-SAME:    [[INT]],
 // CHECK-SAME:    %swift.type_descriptor*,
 // CHECK-SAME:    %swift.type*,
 // CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceV5ValueVySS_SiGWV", i32 0, i32 0),
-// CHECK-SAME:    [[INT]] 512,
+//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main9NamespaceC5ValueOySS_SiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
 // CHECK-SAME:    %swift.type_descriptor* bitcast (
 // CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:      @"$s4main9NamespaceV5ValueVMn" 
+// CHECK-SAME:      @"$s4main9NamespaceC5ValueOMn" 
 // CHECK-SAME:      to %swift.type_descriptor*
 // CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
-struct Namespace<Arg> {
-  struct Value<First> {
-    let first: First
+final class Namespace<Arg> {
+  enum Value<First> {
+    case first(First)
   }
 }
 
@@ -51,9 +48,8 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -62,12 +58,12 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {
-  consume( Namespace<String>.Value(first: 13) )
+  consume( Namespace<String>.Value.first(13) )
 }
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceV5ValueVMa"([[INT]], %swift.type*, %swift.type*) #{{[0-9]+}} {
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueOMa"([[INT]], %swift.type*, %swift.type*) #{{[0-9]+}} {
 // CHECK: entry:
 // CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
@@ -87,10 +83,10 @@ doit()
 // CHECK-SAME:           i8**, 
 // CHECK-SAME:           [[INT]], 
 // CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -106,7 +102,7 @@ doit()
 // CHECK-SAME:     i8* undef, 
 // CHECK-SAME:     %swift.type_descriptor* bitcast (
 // CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:       @"$s4main9NamespaceV5ValueVMn" 
+// CHECK-SAME:       @"$s4main9NamespaceC5ValueOMn" 
 // CHECK-SAME:       to %swift.type_descriptor*
 // CHECK-SAME:     )
 // CHECK-SAME:   ) #{{[0-9]+}}

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -4,32 +4,29 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK: @"$s4main9NamespaceV5ValueVySS_SiGMf" = internal constant <{
+// CHECK: @"$s4main9NamespaceO5ValueOySS_SiGMf" = internal constant <{
 // CHECK-SAME:    i8**,
 // CHECK-SAME:    [[INT]],
 // CHECK-SAME:    %swift.type_descriptor*,
 // CHECK-SAME:    %swift.type*,
 // CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceV5ValueVySS_SiGWV", i32 0, i32 0),
-// CHECK-SAME:    [[INT]] 512,
+//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main9NamespaceO5ValueOySS_SiGWV", i32 0, i32 0)
+// CHECK-SAME:    [[INT]] 513,
 // CHECK-SAME:    %swift.type_descriptor* bitcast (
 // CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:      @"$s4main9NamespaceV5ValueVMn" 
+// CHECK-SAME:      @"$s4main9NamespaceO5ValueOMn" 
 // CHECK-SAME:      to %swift.type_descriptor*
 // CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
-struct Namespace<Arg> {
-  struct Value<First> {
-    let first: First
+enum Namespace<Arg> {
+  enum Value<First> {
+    case first(First)
   }
 }
 
@@ -51,9 +48,8 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -62,12 +58,12 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {
-  consume( Namespace<String>.Value(first: 13) )
+  consume( Namespace<String>.Value.first(13) )
 }
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceV5ValueVMa"([[INT]], %swift.type*, %swift.type*) #{{[0-9]+}} {
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceO5ValueOMa"([[INT]], %swift.type*, %swift.type*) #{{[0-9]+}} {
 // CHECK: entry:
 // CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
@@ -87,10 +83,10 @@ doit()
 // CHECK-SAME:           i8**, 
 // CHECK-SAME:           [[INT]], 
 // CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -106,7 +102,7 @@ doit()
 // CHECK-SAME:     i8* undef, 
 // CHECK-SAME:     %swift.type_descriptor* bitcast (
 // CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:       @"$s4main9NamespaceV5ValueVMn" 
+// CHECK-SAME:       @"$s4main9NamespaceO5ValueOMn" 
 // CHECK-SAME:       to %swift.type_descriptor*
 // CHECK-SAME:     )
 // CHECK-SAME:   ) #{{[0-9]+}}

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-struct-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-struct-1argument-1distinct_use.swift
@@ -4,32 +4,29 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK: @"$s4main9NamespaceV5ValueVySS_SiGMf" = internal constant <{
+// CHECK: @"$s4main9NamespaceV5ValueOySS_SiGMf" = internal constant <{
 // CHECK-SAME:    i8**,
 // CHECK-SAME:    [[INT]],
 // CHECK-SAME:    %swift.type_descriptor*,
 // CHECK-SAME:    %swift.type*,
 // CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceV5ValueVySS_SiGWV", i32 0, i32 0),
-// CHECK-SAME:    [[INT]] 512,
+//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main9NamespaceV5ValueOySS_SiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
 // CHECK-SAME:    %swift.type_descriptor* bitcast (
 // CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:      @"$s4main9NamespaceV5ValueVMn" 
+// CHECK-SAME:      @"$s4main9NamespaceV5ValueOMn" 
 // CHECK-SAME:      to %swift.type_descriptor*
 // CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
 struct Namespace<Arg> {
-  struct Value<First> {
-    let first: First
+  enum Value<First> {
+    case first(First)
   }
 }
 
@@ -51,9 +48,8 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -62,12 +58,12 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {
-  consume( Namespace<String>.Value(first: 13) )
+  consume( Namespace<String>.Value.first(13) )
 }
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceV5ValueVMa"([[INT]], %swift.type*, %swift.type*) #{{[0-9]+}} {
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceV5ValueOMa"([[INT]], %swift.type*, %swift.type*) #{{[0-9]+}} {
 // CHECK: entry:
 // CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
@@ -88,9 +84,8 @@ doit()
 // CHECK-SAME:           [[INT]], 
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -106,7 +101,7 @@ doit()
 // CHECK-SAME:     i8* undef, 
 // CHECK-SAME:     %swift.type_descriptor* bitcast (
 // CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:       @"$s4main9NamespaceV5ValueVMn" 
+// CHECK-SAME:       @"$s4main9NamespaceV5ValueOMn" 
 // CHECK-SAME:       to %swift.type_descriptor*
 // CHECK-SAME:     )
 // CHECK-SAME:   ) #{{[0-9]+}}

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-2argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-2argument-1distinct_use.swift
@@ -1,0 +1,115 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOyS2iGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS2iGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOyS2iGwst" to i8*), 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS2iGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS2iGwup" to i8*), 
+// CHECK-SAME    i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS2iGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOyS2iGMf" = internal global <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME:   }> <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS2iGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First, Second> {
+  case first(First)
+  case second(First, Second)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOyS2iGMf" 
+// CHECK-SAME:       to %swift.full_type*), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.second(13, 13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*, %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   [[EQUAL_TYPE_1_2:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_2]]
+// CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_2]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, %swift.type*, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOyS2iGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME: [[INT]] %0, 
+// CHECK-SAME: i8* [[ERASED_TYPE_1]], 
+// CHECK-SAME: i8* [[ERASED_TYPE_2]], 
+// CHECK-SAME: i8* undef, 
+// CHECK-SAME: %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-3argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-3argument-1distinct_use.swift
@@ -1,0 +1,123 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOyS3iGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS3iGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOyS3iGwst" to i8*), 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS3iGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS3iGwup" to i8*), 
+// CHECK-SAME    i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS3iGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOyS3iGMf" = internal global <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME:   }> <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS3iGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First, Second, Third> {
+  case first(First)
+  case second(First, Second)
+  case third(First, Second, Third)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOyS3iGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.third(13, 14, 15) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*, %swift.type*, %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
+// CHECK:   [[ERASED_TYPE_3:%[0-9]+]] = bitcast %swift.type* %3 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   [[EQUAL_TYPE_1_2:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_2]]
+// CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
+// CHECK:   [[EQUAL_TYPE_1_3:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_3]]
+// CHECK:   [[EQUAL_TYPES_1_3:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_2]], [[EQUAL_TYPE_1_3]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_3]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOyS3iGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME: [[INT]] %0, 
+// CHECK-SAME: i8* [[ERASED_TYPE_1]], 
+// CHECK-SAME: i8* [[ERASED_TYPE_2]], 
+// CHECK-SAME: i8* [[ERASED_TYPE_3]], 
+// CHECK-SAME: %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-4argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-4argument-1distinct_use.swift
@@ -1,0 +1,132 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOyS4iGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS4iGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOyS4iGwst" to i8*), 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS4iGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS4iGwup" to i8*), 
+// CHECK-SAME    i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS4iGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOyS4iGMf" = internal global <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME:   }> <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS4iGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First, Second, Third, Fourth> {
+  case first(First)
+  case second(First, Second)
+  case third(First, Second, Third)
+  case fourth(First, Second, Third, Fourth)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOyS4iGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.fourth(13, 14, 15, 16) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], i8**) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_BUFFER:%[0-9]+]] = bitcast i8** %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[ERASED_TYPE_ADDRESS_1:%[0-9]+]] = getelementptr i8*, i8** %1, i64 0
+// CHECK:   [[ERASED_TYPE_1:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_1]]
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_2:%[0-9]+]] = getelementptr i8*, i8** %1, i64 1
+// CHECK:   [[ERASED_TYPE_2:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_2]]
+// CHECK:   [[EQUAL_TYPE_1_2:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_2]]
+// CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_3:%[0-9]+]] = getelementptr i8*, i8** %1, i64 2
+// CHECK:   [[ERASED_TYPE_3:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_3]]
+// CHECK:   [[EQUAL_TYPE_1_3:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_3]]
+// CHECK:   [[EQUAL_TYPES_1_3:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_2]], [[EQUAL_TYPE_1_3]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_4:%[0-9]+]] = getelementptr i8*, i8** %1, i64 3
+// CHECK:   [[ERASED_TYPE_4:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_4]]
+// CHECK:   [[EQUAL_TYPE_1_4:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_4]]
+// CHECK:   [[EQUAL_TYPES_1_4:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_3]], [[EQUAL_TYPE_1_4]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_4]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOyS4iGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getGenericMetadata(
+// CHECK-SAME: [[INT]] %0, 
+// CHECK-SAME: i8* [[ERASED_BUFFER]], 
+// CHECK-SAME: %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-5argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-5argument-1distinct_use.swift
@@ -1,0 +1,139 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOyS5iGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS5iGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOyS5iGwst" to i8*), 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS5iGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS5iGwup" to i8*), 
+// CHECK-SAME    i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS5iGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOyS5iGMf" = internal global <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME:   }> <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS5iGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First, Second, Third, Fourth, Fifth> {
+  case first(First)
+  case second(First, Second)
+  case third(First, Second, Third)
+  case fourth(First, Second, Third, Fourth)
+  case fifth(First, Second, Third, Fourth, Fifth)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOyS5iGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.fifth(13, 14, 15, 16, 17) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], i8**) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_BUFFER:%[0-9]+]] = bitcast i8** %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[ERASED_TYPE_ADDRESS_1:%[0-9]+]] = getelementptr i8*, i8** %1, i64 0
+// CHECK:   [[ERASED_TYPE_1:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_1]]
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_2:%[0-9]+]] = getelementptr i8*, i8** %1, i64 1
+// CHECK:   [[ERASED_TYPE_2:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_2]]
+// CHECK:   [[EQUAL_TYPE_1_2:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_2]]
+// CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_3:%[0-9]+]] = getelementptr i8*, i8** %1, i64 2
+// CHECK:   [[ERASED_TYPE_3:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_3]]
+// CHECK:   [[EQUAL_TYPE_1_3:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_3]]
+// CHECK:   [[EQUAL_TYPES_1_3:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_2]], [[EQUAL_TYPE_1_3]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_4:%[0-9]+]] = getelementptr i8*, i8** %1, i64 3
+// CHECK:   [[ERASED_TYPE_4:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_4]]
+// CHECK:   [[EQUAL_TYPE_1_4:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_4]]
+// CHECK:   [[EQUAL_TYPES_1_4:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_3]], [[EQUAL_TYPE_1_4]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_5:%[0-9]+]] = getelementptr i8*, i8** %1, i64 4
+// CHECK:   [[ERASED_TYPE_5:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_5]]
+// CHECK:   [[EQUAL_TYPE_1_5:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_5]]
+// CHECK:   [[EQUAL_TYPES_1_5:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_4]], [[EQUAL_TYPE_1_5]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_5]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOyS5iGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getGenericMetadata(
+// CHECK-SAME: [[INT]] %0, 
+// CHECK-SAME: i8* [[ERASED_BUFFER]], 
+// CHECK-SAME: %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-frozen.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-frozen.swift
@@ -1,0 +1,99 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -enable-library-evolution -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/struct-public-frozen-0argument.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
+// RUN: %target-swift-frontend -target %module-target-future -prespecialize-generic-metadata -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+import TestModule
+
+// CHECK: @"$s4main5ValueOy10TestModule7IntegerVGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME: }> 
+// CHECK-SAME: <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOy10TestModule7IntegerVGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$s10TestModule7IntegerVN", 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+enum Value<First> {
+  case only(First)
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOy10TestModule7IntegerVGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.only(Integer(13)) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$s10TestModule7IntegerVN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOy10TestModule7IntegerVGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   i8* %2, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -enable-library-evolution -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/struct-public-nonfrozen-0argument.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
+// RUN: %target-swift-frontend -target %module-target-future -prespecialize-generic-metadata -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+import TestModule
+
+// CHECK-NOT: @"$s4main5ValueOy10TestModule7IntegerVGMf"
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+enum Value<First> {
+  case only(First)
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[DEMANGLED_TYPE:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s4main5ValueOy10TestModule7IntegerVGMD") #{{[0-9]+}}
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   %swift.type* [[DEMANGLED_TYPE]]
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.only(Integer(13)) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
@@ -5,11 +5,11 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK-NOT: @"$s4main5ValueVyAA7IntegerVGMf"
-struct Value<First : Hashable> {
+struct Value<First : Equatable> {
   let first: First
 }
 
-struct Integer : Hashable {
+struct Integer : Equatable {
   let value: Int
 }
 

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
@@ -16,7 +16,11 @@
 //                i8** @"$sB[[INT]]_WV",
 //                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceC5ValueVySS_SiGWV", i32 0, i32 0),
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceC5ValueVMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type_descriptor* bitcast (
+// CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:      @"$s4main9NamespaceC5ValueVMn" 
+// CHECK-SAME:      to %swift.type_descriptor*
+// CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
 // CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
@@ -36,7 +40,26 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" to %swift.full_type*), i32 0, i32 1))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( Namespace<String>.Value(first: 13) )
@@ -56,8 +79,37 @@ doit()
 // CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
 // CHECK:   br i1 [[EQUAL_TYPES_1_2]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
 // CHECK: [[EXIT_PRESPECIALIZED_1]]:
-// CHECK:   ret %swift.metadata_response { %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" to %swift.full_type*), i32 0, i32 1), [[INT]] 0 }
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
 // CHECK: [[EXIT_NORMAL]]:
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceC5ValueVMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main9NamespaceC5ValueVMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -16,7 +16,11 @@
 //                i8** @"$sB[[INT]]_WV",
 //                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceO5ValueVySS_SiGWV", i32 0, i32 0)
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceO5ValueVMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type_descriptor* bitcast (
+// CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:      @"$s4main9NamespaceO5ValueVMn" 
+// CHECK-SAME:      to %swift.type_descriptor*
+// CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
 // CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
@@ -36,7 +40,26 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main9NamespaceO5ValueVySS_SiGMf" to %swift.full_type*), i32 0, i32 1))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueVySS_SiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( Namespace<String>.Value(first: 13) )
@@ -56,8 +79,37 @@ doit()
 // CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
 // CHECK:   br i1 [[EQUAL_TYPES_1_2]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
 // CHECK: [[EXIT_PRESPECIALIZED_1]]:
-// CHECK:   ret %swift.metadata_response { %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main9NamespaceO5ValueVySS_SiGMf" to %swift.full_type*), i32 0, i32 1), [[INT]] 0 }
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueVySS_SiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
 // CHECK: [[EXIT_NORMAL]]:
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceO5ValueVMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main9NamespaceO5ValueVMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }


### PR DESCRIPTION
Leaving open to benchmark and test source compatibility of turning on metadata prespecialization always, independent of target version.