### PR TITLE
[AutoDiff] Add `Array.zeroTangentVectorInitializer`.

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -2064,6 +2064,14 @@ extension Array : Differentiable where Element : Differentiable {
     view.move(along: direction)
     self = view.base
   }
+
+  /// A closure that produces a `TangentVector` of zeros with the same
+  /// `count` as `self`.
+  public var zeroTangentVectorInitializer: () -> TangentVector {
+    { [count = self.count] in
+      TangentVector(.init(repeating: .zero, count: count))
+    }
+  }
 }
 
 extension Array : EuclideanDifferentiable

--- a/test/AutoDiff/array.swift
+++ b/test/AutoDiff/array.swift
@@ -398,4 +398,10 @@ ArrayAutoDiffTests.test("Array.DifferentiableView : KeyPathIterable") {
     })
 }
 
+ArrayAutoDiffTests.test("Array.zeroTangentVectorInitializer") {
+  let count = 10
+  let array: [Float] = Array((0..<count).map(Float.init))
+  expectEqual(array.zeroTangentVector.base, Array(repeating: 0, count: count))
+}
+
 runAllTests()


### PR DESCRIPTION
`Array.zeroTangentVectorInitializer` produces a `TangentVector` of zeros with
the same `count` as `self`.