### PR TITLE
[Constant Evaluator] Fix a bug in the composition of substitution maps

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -19,6 +19,7 @@
 #define SWIFT_SIL_CONSTANTS_H
 
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/Support/CommandLine.h"
 
@@ -572,7 +573,7 @@ public:
   static SymbolicValue makeClosure(
       SILFunction *target,
       ArrayRef<std::pair<SILValue, Optional<SymbolicValue>>> capturedArguments,
-      SubstitutionMap substMap, SILType closureType,
+      SubstitutionMap substMap, SingleValueInstruction *closureInst,
       SymbolicValueAllocator &allocator);
 
   SymbolicClosure *getClosure() const {
@@ -689,21 +690,25 @@ private:
   // applied function to the generic arguments of passed to the call.
   SubstitutionMap substitutionMap;
 
-  SILType closureType;
+  // The closure instruction such as partial apply that resulted in this
+  // symbolic value. This is tracked to obtain SILType and other SIL-level
+  // information of the symbolic closure.
+  SingleValueInstruction *closureInst;
 
   SymbolicClosure() = delete;
   SymbolicClosure(const SymbolicClosure &) = delete;
   SymbolicClosure(SILFunction *callee, unsigned numArguments,
-                  SubstitutionMap substMap, SILType closureType,
+                  SubstitutionMap substMap, SingleValueInstruction *inst,
                   bool nonConstantCaptures)
       : target(callee), numCaptures(numArguments),
         hasNonConstantCaptures(nonConstantCaptures), substitutionMap(substMap),
-        closureType(closureType) {}
+        closureInst(inst) {}
 
 public:
   static SymbolicClosure *create(SILFunction *callee,
                                  ArrayRef<SymbolicClosureArgument> args,
-                                 SubstitutionMap substMap, SILType closureType,
+                                 SubstitutionMap substMap,
+                                 SingleValueInstruction *closureInst,
                                  SymbolicValueAllocator &allocator);
 
   ArrayRef<SymbolicClosureArgument> getCaptures() const {
@@ -719,7 +724,9 @@ public:
     return target;
   }
 
-  SILType getClosureType() { return closureType; }
+  SingleValueInstruction *getClosureInst() { return closureInst; }
+
+  SILType getClosureType() { return closureInst->getType(); }
 
   SubstitutionMap getCallSubstitutionMap() { return substitutionMap; }
 };

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1147,8 +1147,10 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
           calleeFnType->getWitnessMethodConformanceOrInvalid().getRequirement();
       // Compute a mapping that maps the Self type of the protocol given by
       // 'requirement' to the concrete type available in the substitutionMap.
-      auto protoSelfToConcreteType =
-          apply->getSubstitutionMap().subst(substitutionMap);
+      SubstitutionMap applySubstMap = apply->getSubstitutionMap();
+      auto protoSelfToConcreteType = substitutionMap.empty()
+                                         ? applySubstMap
+                                         : applySubstMap.subst(substitutionMap);
       // Get a concrete protocol conformance by using the mapping for the
       // Self type of the requirement.
       auto conf = protoSelfToConcreteType.lookupConformance(
@@ -1174,7 +1176,8 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
     // or conformance, with the mapping introduced by the call itself.  This
     // ensures that the callee's substitution map can map from its type
     // namespace back to concrete types and conformances.
-    calleeSubMap = callSubMap.subst(substitutionMap);
+    calleeSubMap = substitutionMap.empty() ? callSubMap
+                                           : callSubMap.subst(substitutionMap);
   }
 
   // Now that we have successfully folded all of the parameters, we can evaluate
@@ -1606,13 +1609,14 @@ llvm::Optional<SymbolicValue> ConstExprFunctionState::evaluateClosureCreation(
       }
       captures.push_back({capturedSILValue, capturedSymbolicValue});
     }
-    callSubstMap = papply->getSubstitutionMap().subst(this->substitutionMap);
+    SubstitutionMap applySubstMap = papply->getSubstitutionMap();
+    callSubstMap = substitutionMap.empty()
+                       ? applySubstMap
+                       : applySubstMap.subst(substitutionMap);
   }
 
-  SILType closureType = closureInst->getType();
-  assert(closureType.is<SILFunctionType>());
   auto closureVal = SymbolicValue::makeClosure(
-      target, captures, callSubstMap, closureType, evaluator.getAllocator());
+      target, captures, callSubstMap, closureInst, evaluator.getAllocator());
   setValue(closureInst, closureVal);
   return None;
 }

--- a/test/stdlib/OSLogPrototypeExecTest.swift
+++ b/test/stdlib/OSLogPrototypeExecTest.swift
@@ -647,3 +647,23 @@ InterpolationTestSuite.test("NSObject") {
       })
   }
 }
+
+// A generic function.
+func toString<T>(_ subject: T?) -> String {
+  return ""
+}
+
+protocol TestProto {
+}
+
+InterpolationTestSuite.test("Interpolation of complex expressions") {
+  class TestClass<T: TestProto>: NSObject {
+    func testFunction() {
+      // The following call should no crash.
+      _checkFormatStringAndBuffer("A complex expression \(toString(self))") {
+        (formatString, _) in
+        expectEqual("A complex expression %s", formatString)
+      }
+    }
+  }
+}


### PR DESCRIPTION
in the handling of partial applies. In particular, when using substMap.subst(otherSubstMap), ensure that otherSubstMap is not empty. Also, store the partial-apply instruction in the symbolic closure, which makes it easier to debug errors in the folding of partial applies.