### PR TITLE
[AutoDiff] Mangle derivative generic signatures.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -158,18 +158,21 @@ public:
   /// Mangle the derivative function (JVP/VJP) with the given:
   /// - Mangled original function name.
   /// - Derivative function kind.
-  /// - Parameter/result indices.
-  std::string mangleAutoDiffDerivativeFunctionHelper(
-      StringRef name, AutoDiffDerivativeFunctionKind kind,
-      const SILAutoDiffIndices &indices);
+  /// - Derivative function configuration: parameter/result indices and
+  ///   derivative generic signature.
+  std::string
+  mangleAutoDiffDerivativeFunctionHelper(StringRef name,
+                                         AutoDiffDerivativeFunctionKind kind,
+                                         AutoDiffConfig config);
 
   /// Mangle the autodiff linear map (differential/pullback) with the given:
   /// - Mangled original function name.
   /// - Linear map kind.
-  /// - Parameter/result indices.
-  std::string mangleAutoDiffLinearMapHelper(
-      StringRef name, AutoDiffLinearMapKind kind,
-      const SILAutoDiffIndices &indices);
+  /// - Derivative function configuration: parameter/result indices and
+  ///   derivative generic signature.
+  std::string mangleAutoDiffLinearMapHelper(StringRef name,
+                                            AutoDiffLinearMapKind kind,
+                                            AutoDiffConfig config);
 
   /// Mangle a SIL differentiability witness key.
   /// - Mangled original function name.

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -306,25 +306,34 @@ struct AutoDiffConfig {
 class AutoDiffDerivativeFunctionIdentifier : public llvm::FoldingSetNode {
   const AutoDiffDerivativeFunctionKind kind;
   IndexSubset *const parameterIndices;
-  // TODO(TF-680): Mangle derivative generic signature requirements as well.
+  GenericSignature derivativeGenericSignature;
 
   AutoDiffDerivativeFunctionIdentifier(
-      AutoDiffDerivativeFunctionKind kind, IndexSubset *parameterIndices) :
-    kind(kind), parameterIndices(parameterIndices) {}
+      AutoDiffDerivativeFunctionKind kind, IndexSubset *parameterIndices,
+      GenericSignature derivativeGenericSignature)
+      : kind(kind), parameterIndices(parameterIndices),
+        derivativeGenericSignature(derivativeGenericSignature) {}
 
 public:
   AutoDiffDerivativeFunctionKind getKind() const { return kind; }
   IndexSubset *getParameterIndices() const {
     return parameterIndices;
   }
+  GenericSignature getDerivativeGenericSignature() const {
+    return derivativeGenericSignature;
+  }
 
-  static AutoDiffDerivativeFunctionIdentifier *get(
-      AutoDiffDerivativeFunctionKind kind,
-      IndexSubset *parameterIndices, ASTContext &C);
+  static AutoDiffDerivativeFunctionIdentifier *
+  get(AutoDiffDerivativeFunctionKind kind, IndexSubset *parameterIndices,
+      GenericSignature derivativeGenericSignature, ASTContext &C);
 
   void Profile(llvm::FoldingSetNodeID &ID) {
     ID.AddInteger(kind);
     ID.AddPointer(parameterIndices);
+    CanGenericSignature derivativeCanGenSig;
+    if (derivativeGenericSignature)
+      derivativeCanGenSig = derivativeGenericSignature->getCanonicalSignature();
+    ID.AddPointer(derivativeCanGenSig.getPointer());
   }
 };
 

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -93,14 +93,14 @@ template <class T> class SILVTableVisitor {
       auto constant = SILDeclRef(fd, SILDeclRef::Kind::Func);
       auto jvpConstant = constant.asAutoDiffDerivativeFunction(
           AutoDiffDerivativeFunctionIdentifier::get(
-              AutoDiffDerivativeFunctionKind::JVP,
-              DA->getParameterIndices(), fd->getASTContext()));
+              AutoDiffDerivativeFunctionKind::JVP, DA->getParameterIndices(),
+              DA->getDerivativeGenericSignature(), fd->getASTContext()));
       maybeAddEntry(jvpConstant);
 
       auto vjpConstant = constant.asAutoDiffDerivativeFunction(
           AutoDiffDerivativeFunctionIdentifier::get(
-              AutoDiffDerivativeFunctionKind::VJP,
-              DA->getParameterIndices(), fd->getASTContext()));
+              AutoDiffDerivativeFunctionKind::VJP, DA->getParameterIndices(),
+              DA->getDerivativeGenericSignature(), fd->getASTContext()));
       maybeAddEntry(vjpConstant);
     }
     // SWIFT_ENABLE_TENSORFLOW END
@@ -120,14 +120,14 @@ template <class T> class SILVTableVisitor {
       auto constant = SILDeclRef(cd, SILDeclRef::Kind::Allocator);
       auto jvpConstant = constant.asAutoDiffDerivativeFunction(
           AutoDiffDerivativeFunctionIdentifier::get(
-              AutoDiffDerivativeFunctionKind::JVP,
-              DA->getParameterIndices(), cd->getASTContext()));
+              AutoDiffDerivativeFunctionKind::JVP, DA->getParameterIndices(),
+              DA->getDerivativeGenericSignature(), cd->getASTContext()));
       maybeAddEntry(jvpConstant);
 
       auto vjpConstant = constant.asAutoDiffDerivativeFunction(
           AutoDiffDerivativeFunctionIdentifier::get(
-              AutoDiffDerivativeFunctionKind::VJP,
-              DA->getParameterIndices(), cd->getASTContext()));
+              AutoDiffDerivativeFunctionKind::VJP, DA->getParameterIndices(),
+              DA->getDerivativeGenericSignature(), cd->getASTContext()));
       maybeAddEntry(vjpConstant);
     }
     // SWIFT_ENABLE_TENSORFLOW END

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -183,12 +183,12 @@ private:
     for (auto *DA : func->getAttrs().getAttributes<DifferentiableAttr>()) {
       asDerived().addMethod(funcDeclRef.asAutoDiffDerivativeFunction(
           AutoDiffDerivativeFunctionIdentifier::get(
-              AutoDiffDerivativeFunctionKind::JVP,
-              DA->getParameterIndices(), func->getASTContext())));
+              AutoDiffDerivativeFunctionKind::JVP, DA->getParameterIndices(),
+              DA->getDerivativeGenericSignature(), func->getASTContext())));
       asDerived().addMethod(funcDeclRef.asAutoDiffDerivativeFunction(
           AutoDiffDerivativeFunctionIdentifier::get(
-              AutoDiffDerivativeFunctionKind::VJP,
-              DA->getParameterIndices(), func->getASTContext())));
+              AutoDiffDerivativeFunctionKind::VJP, DA->getParameterIndices(),
+              DA->getDerivativeGenericSignature(), func->getASTContext())));
     }
   }
 };

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -383,9 +383,8 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
 // SWIFT_ENABLE_TENSORFLOW
 std::string ASTMangler::mangleAutoDiffDerivativeFunctionHelper(
     StringRef name, AutoDiffDerivativeFunctionKind kind,
-    const SILAutoDiffIndices &indices) {
-  // TODO(TF-20): Make the mangling scheme robust.
-  // TODO(TF-680): Mangle derivative generic signature as well.
+    AutoDiffConfig config) {
+  // TODO(TF-20): Make the mangling scheme robust. Support demangling.
   beginManglingWithoutPrefix();
 
   Buffer << "AD__" << name << '_';
@@ -397,7 +396,11 @@ std::string ASTMangler::mangleAutoDiffDerivativeFunctionHelper(
     Buffer << "_vjp_";
     break;
   }
-  Buffer << indices.mangle();
+  Buffer << config.getSILAutoDiffIndices().mangle();
+  if (config.derivativeGenericSignature) {
+    Buffer << '_';
+    appendGenericSignature(config.derivativeGenericSignature);
+  }
 
   auto result = Storage.str().str();
   Storage.clear();
@@ -405,10 +408,8 @@ std::string ASTMangler::mangleAutoDiffDerivativeFunctionHelper(
 }
 
 std::string ASTMangler::mangleAutoDiffLinearMapHelper(
-    StringRef name, AutoDiffLinearMapKind kind,
-    const SILAutoDiffIndices &indices) {
-  // TODO(TF-20): Make the mangling scheme robust.
-  // TODO(TF-680): Mangle derivative generic signature as well.
+    StringRef name, AutoDiffLinearMapKind kind, AutoDiffConfig config) {
+  // TODO(TF-20): Make the mangling scheme robust. Support demangling.
   beginManglingWithoutPrefix();
 
   Buffer << "AD__" << name << '_';
@@ -420,7 +421,11 @@ std::string ASTMangler::mangleAutoDiffLinearMapHelper(
     Buffer << "_pullback_";
     break;
   }
-  Buffer << indices.mangle();
+  Buffer << config.getSILAutoDiffIndices().mangle();
+  if (config.derivativeGenericSignature) {
+    Buffer << '_';
+    appendGenericSignature(config.derivativeGenericSignature);
+  }
 
   auto result = Storage.str().str();
   Storage.clear();
@@ -429,7 +434,7 @@ std::string ASTMangler::mangleAutoDiffLinearMapHelper(
 
 std::string ASTMangler::mangleSILDifferentiabilityWitnessKey(
     SILDifferentiabilityWitnessKey key) {
-  // TODO(TF-20): Make the mangling scheme robust.
+  // TODO(TF-20): Make the mangling scheme robust. Support demangling.
   beginManglingWithoutPrefix();
 
   auto originalName = key.first;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1546,19 +1546,19 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
       } else if (Id.str() == "jvp" || Id.str() == "vjp") {
         AutoDiffDerivativeFunctionKind kind;
         IndexSubset *parameterIndices = nullptr;
-
+        GenericSignature derivativeGenSig;
+        // Parse derivative function kind.
         if (Id.str() == "jvp")
           kind = AutoDiffDerivativeFunctionKind::JVP;
         else if (Id.str() == "vjp")
           kind = AutoDiffDerivativeFunctionKind::VJP;
         else
           llvm_unreachable("Should only have JVP and VJP here");
-
         if (!P.consumeIf(tok::period)) {
           P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, ".");
           return true;
         }
-
+        // Parse parameter indices.
         parameterIndices = IndexSubset::getFromString(
             SILMod.getASTContext(), P.Tok.getText());
         if (!parameterIndices) {
@@ -1566,10 +1566,19 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
           return true;
         }
         P.consumeToken();
-
+        // Parse derivative generic signature (optional).
+        if (P.Tok.is(tok::oper_binary_unspaced) && P.Tok.getText() == ".<") {
+          P.consumeStartingCharacterOfCurrentToken(tok::period);
+          // Create a new scope to avoid type redefinition errors.
+          Scope genericsScope(&P, ScopeKind::Generics);
+          auto *genericParams = P.maybeParseGenericParams().getPtrOrNull();
+          assert(genericParams);
+          auto *derivativeGenEnv = handleSILGenericParams(genericParams, &P.SF);
+          derivativeGenSig = derivativeGenEnv->getGenericSignature();
+        }
         autoDiffFuncId = AutoDiffDerivativeFunctionIdentifier::get(
-            kind, parameterIndices, SILMod.getASTContext());
-
+            kind, parameterIndices, derivativeGenSig,
+            SILMod.getASTContext());
         break;
       } else
         break;

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -693,10 +693,14 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
     auto *silParameterIndices = autodiff::getLoweredParameterIndices(
         autoDiffDerivativeFunctionIdentifier->getParameterIndices(),
         getDecl()->getInterfaceType()->castTo<AnyFunctionType>());
-    SILAutoDiffIndices indices(/*source*/ 0, silParameterIndices);
+    auto &ctx = getDecl()->getASTContext();
+    auto *resultIndices = IndexSubset::get(ctx, 1, {0});
+    AutoDiffConfig silConfig(
+        silParameterIndices, resultIndices,
+        autoDiffDerivativeFunctionIdentifier->getDerivativeGenericSignature());
     auto derivativeFnKind = autoDiffDerivativeFunctionIdentifier->getKind();
     return mangler.mangleAutoDiffDerivativeFunctionHelper(
-        originalMangled, derivativeFnKind, indices);
+        originalMangled, derivativeFnKind, silConfig);
   }
 
   // As a special case, Clang functions and globals don't get mangled at all.

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -362,6 +362,10 @@ void SILDeclRef::print(raw_ostream &OS) const {
       break;
     }
     OS << autoDiffFuncId->getParameterIndices()->getString();
+    if (auto derivativeGenSig =
+            autoDiffFuncId->getDerivativeGenericSignature()) {
+      OS << "." << derivativeGenSig;
+    }
   }
 }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -868,12 +868,13 @@ void SILGenModule::emitDifferentiabilityWitness(
     if (reorderSelf ||
         derivative->getLoweredFunctionType() != expectedDerivativeType) {
       derivativeThunk = getOrCreateAutoDiffDerivativeReabstractionThunk(
-          originalFunction, indices, derivative, kind, reorderSelf);
+          originalFunction, silConfig, derivative, kind, reorderSelf);
     } else {
       // Note: `AutoDiffDerivativeFunctionIdentifier` must be constructed with
       // the AST-level parameter indices, not the SIL-level ones.
       auto *id = AutoDiffDerivativeFunctionIdentifier::get(
-          kind, config.parameterIndices, getASTContext());
+          kind, config.parameterIndices, config.derivativeGenericSignature,
+          getASTContext());
       derivativeThunk = getOrCreateAutoDiffDerivativeForwardingThunk(
           SILDeclRef(originalAFD).asAutoDiffDerivativeFunction(id), derivative,
           expectedDerivativeType);

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -227,8 +227,7 @@ public:
   /// - The last parameter in the returned differential.
   /// - The last result in the returned pullback.
   SILFunction *getOrCreateAutoDiffDerivativeReabstractionThunk(
-      SILFunction *original, SILAutoDiffIndices &indices,
-      SILFunction *derivativeFn,
+      SILFunction *original, AutoDiffConfig config, SILFunction *derivativeFn,
       AutoDiffDerivativeFunctionKind derivativeFnKind, bool reorderSelf);
 
   /// Determine whether the given class has any instance variables that

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3690,19 +3690,18 @@ SILGenFunction::getThunkedAutoDiffLinearMap(
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-SILFunction *
-SILGenModule::getOrCreateAutoDiffDerivativeReabstractionThunk(
-    SILFunction *original, SILAutoDiffIndices &indices,
-    SILFunction *derivativeFn, AutoDiffDerivativeFunctionKind derivativeFnKind,
-    bool reorderSelf) {
+SILFunction *SILGenModule::getOrCreateAutoDiffDerivativeReabstractionThunk(
+    SILFunction *original, AutoDiffConfig config, SILFunction *derivativeFn,
+    AutoDiffDerivativeFunctionKind derivativeFnKind, bool reorderSelf) {
   auto derivativeFnType = derivativeFn->getLoweredFunctionType();
 
   // TODO(TF-685): Use principled thunk mangling.
   // Do not simply reuse reabstraction thunk mangling.
   Mangle::ASTMangler mangler;
-  auto name = getASTContext().getIdentifier(
-      mangler.mangleAutoDiffDerivativeFunctionHelper(
-          original->getName(), derivativeFnKind, indices)).str();
+  auto name = getASTContext()
+                  .getIdentifier(mangler.mangleAutoDiffDerivativeFunctionHelper(
+                      original->getName(), derivativeFnKind, config))
+                  .str();
 
   Lowering::GenericContextScope genericContextScope(
       Types, derivativeFnType->getSubstGenericSignature());
@@ -3711,8 +3710,10 @@ SILGenModule::getOrCreateAutoDiffDerivativeReabstractionThunk(
       : nullptr;
 
   auto origFnType = original->getLoweredFunctionType();
+  assert(config.resultIndices->getNumIndices() == 1 &&
+         "Only single result index is currently supported");
   auto origDerivativeFnType = origFnType->getAutoDiffDerivativeFunctionType(
-      indices.parameters, indices.source,
+      config.parameterIndices, *config.resultIndices->getIndices().begin(),
       derivativeFnKind, Types, LookUpConformanceInModule(M.getSwiftModule()),
       derivativeFnType->getSubstGenericSignature());
   assert(!origDerivativeFnType->getExtInfo().hasContext());

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -696,7 +696,8 @@ emitDerivativeFunctionReference(
         kind, context.getTypeConverter(),
         LookUpConformanceInModule(builder.getModule().getSwiftModule()));
     auto *autoDiffFuncId = AutoDiffDerivativeFunctionIdentifier::get(
-        kind, minimalASTParamIndices, context.getASTContext());
+        kind, minimalASTParamIndices, minimalConfig->derivativeGenericSignature,
+        context.getASTContext());
     auto *ref = builder.createWitnessMethod(
         loc, witnessMethod->getLookupType(), witnessMethod->getConformance(),
         requirementDeclRef.asAutoDiffDerivativeFunction(autoDiffFuncId),
@@ -740,7 +741,8 @@ emitDerivativeFunctionReference(
         context.getTypeConverter(),
         LookUpConformanceInModule(builder.getModule().getSwiftModule()));
     auto *autoDiffFuncId = AutoDiffDerivativeFunctionIdentifier::get(
-        kind, minimalASTParamIndices, context.getASTContext());
+        kind, minimalASTParamIndices, minimalConfig->derivativeGenericSignature,
+        context.getASTContext());
     auto *ref = builder.createClassMethod(
         loc, classMethodInst->getOperand(),
         methodDeclRef.asAutoDiffDerivativeFunction(autoDiffFuncId),
@@ -776,10 +778,12 @@ static SILFunction *createEmptyVJP(ADContext &context, SILFunction *original,
 
   // === Create an empty VJP. ===
   Mangle::ASTMangler mangler;
-  auto vjpName = original->getASTContext().getIdentifier(
-      mangler.mangleAutoDiffDerivativeFunctionHelper(
-          original->getName(), AutoDiffDerivativeFunctionKind::VJP, indices))
-              .str();
+  auto vjpName =
+      original->getASTContext()
+          .getIdentifier(mangler.mangleAutoDiffDerivativeFunctionHelper(
+              original->getName(), AutoDiffDerivativeFunctionKind::VJP,
+              witness->getConfig()))
+          .str();
   auto vjpGenericSig = getDerivativeGenericSignature(witness, original);
 
   // RAII that pushes the original function's generic signature to
@@ -824,10 +828,12 @@ static SILFunction *createEmptyJVP(ADContext &context, SILFunction *original,
 
   // === Create an empty JVP. ===
   Mangle::ASTMangler mangler;
-  auto jvpName = original->getASTContext().getIdentifier(
-      mangler.mangleAutoDiffDerivativeFunctionHelper(
-          original->getName(), AutoDiffDerivativeFunctionKind::JVP, indices))
-              .str();
+  auto jvpName =
+      original->getASTContext()
+          .getIdentifier(mangler.mangleAutoDiffDerivativeFunctionHelper(
+              original->getName(), AutoDiffDerivativeFunctionKind::JVP,
+              witness->getConfig()))
+          .str();
   auto jvpGenericSig = getDerivativeGenericSignature(witness, original);
 
   // RAII that pushes the original function's generic signature to

--- a/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
@@ -1067,11 +1067,12 @@ JVPEmitter::createEmptyDifferential(ADContext &context,
   dfParams.push_back({dfStructType, ParameterConvention::Direct_Owned});
 
   Mangle::ASTMangler mangler;
-  auto diffName = original->getASTContext()
-                      .getIdentifier(mangler.mangleAutoDiffLinearMapHelper(
-                          original->getName(),
-                          AutoDiffLinearMapKind::Differential, indices))
-                      .str();
+  auto diffName =
+      original->getASTContext()
+          .getIdentifier(mangler.mangleAutoDiffLinearMapHelper(
+              original->getName(), AutoDiffLinearMapKind::Differential,
+              witness->getConfig()))
+          .str();
   auto diffGenericSig = getDerivativeGenericSignature(witness, original);
   auto *diffGenericEnv =
       diffGenericSig ? diffGenericSig->getGenericEnvironment() : nullptr;

--- a/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
@@ -166,11 +166,11 @@ SILFunction *VJPEmitter::createEmptyPullback() {
   }
 
   Mangle::ASTMangler mangler;
-  auto pbName =
-      original->getASTContext()
-          .getIdentifier(mangler.mangleAutoDiffLinearMapHelper(
-              original->getName(), AutoDiffLinearMapKind::Pullback, indices))
-          .str();
+  auto pbName = original->getASTContext()
+                    .getIdentifier(mangler.mangleAutoDiffLinearMapHelper(
+                        original->getName(), AutoDiffLinearMapKind::Pullback,
+                        witness->getConfig()))
+                    .str();
   auto pbGenericSig = getDerivativeGenericSignature(witness, original);
   auto *pbGenericEnv =
       pbGenericSig ? pbGenericSig->getGenericEnvironment() : nullptr;

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -76,22 +76,25 @@ private:
 
   // SWIFT_ENABLE_TENSORFLOW
   /// Adds the symbol for the linear map function of the given kind associated
-  /// with the given original function and parameter indices.
+  /// with the given original function and derivative function configuration.
   void addAutoDiffLinearMapFunction(AbstractFunctionDecl *original,
-                                    IndexSubset *parameterIndices,
+                                    AutoDiffConfig config,
                                     AutoDiffLinearMapKind kind);
 
   /// Adds the symbol for the autodiff function of the given kind associated
-  /// with the given original function and parameter indices.
-  void addAutoDiffDerivativeFunction(AbstractFunctionDecl *original,
-                                     IndexSubset *parameterIndices,
-                                     AutoDiffDerivativeFunctionKind kind);
+  /// with the given original function, parameter indices, and derivative
+  /// generic signature.
+  void
+  addAutoDiffDerivativeFunction(AbstractFunctionDecl *original,
+                                IndexSubset *parameterIndices,
+                                GenericSignature derivativeGenericSignature,
+                                AutoDiffDerivativeFunctionKind kind);
 
   /// Adds the symbol for the differentiability witness associated with the
-  /// given original function, parameter indices, result indices, and derivative
-  /// generic signature.
+  /// given original function, AST parameter indices, result indices, and
+  /// derivative generic signature.
   void addDifferentiabilityWitness(AbstractFunctionDecl *original,
-                                   IndexSubset *parameterIndices,
+                                   IndexSubset *astParameterIndices,
                                    IndexSubset *resultIndices,
                                    GenericSignature derivativeGenericSignature);
 

--- a/test/AutoDiff/compiler_crashers_fixed/tf1037-unmangled-derivative-generic-signatures.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1037-unmangled-derivative-generic-signatures.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-emit-sil %s -verify
+// RUN: %target-swift-emit-sil %s -verify
 // REQUIRES: asserts
 
 // TF-1037: Differentiation transform crashes due to multiple SIL

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -1024,6 +1024,13 @@ class Super : Differentiable {
     fatalError()
   }
 
+  // Test duplicate attributes with different derivative generic signatures.
+  // expected-error @+1 {{duplicate '@differentiable' attribute with same parameters}}
+  @differentiable(wrt: x where T: Differentiable)
+  // expected-note @+1 {{other attribute declared here}}
+  @differentiable(wrt: x)
+  func instanceMethod<T>(_ x: Float, y: T) -> Float { x }
+
   // expected-error @+1 {{'@differentiable' attribute cannot be declared on class methods returning 'Self'}}
   @differentiable(vjp: vjpDynamicSelfResult)
   func dynamicSelfResult() -> Self { self }

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -9,7 +9,7 @@ _ = gradient(at: Float(1), in: { x in identity(x) })
 // Test AdjointEmitter local buffer allocation.
 // Verify that local buffers are immediately set to zero.
 
-// CHECK-SIL-LABEL: sil private @AD__identity__pullback_src_0_wrt_0
+// CHECK-SIL-LABEL: sil private @AD__identity__pullback_src_0_wrt_0_s14DifferentiableRzl
 // CHECK-SIL:      [[ORIG_COTAN:%.*]] = alloc_stack $τ_0_0.TangentVector
 // CHECK-SIL-NEXT: [[ZERO_WITNESS:%.*]] = witness_method $τ_0_0.TangentVector, #AdditiveArithmetic.zero!getter.1
 // CHECK-SIL-NEXT: [[ORIG_COTAN_METATYPE:%.*]] = metatype $@thick τ_0_0.TangentVector.Type

--- a/test/AutoDiff/sildeclref_parse.sil
+++ b/test/AutoDiff/sildeclref_parse.sil
@@ -1,14 +1,21 @@
 // RUN: %target-sil-opt %s -module-name=sildeclref_parse | %target-sil-opt -module-name=sildeclref_parse | %FileCheck %s
 
+// Parse SILDeclRef for JVP/VJP vtable/witness table entries.
+
 import Swift
+
+class Class<T> {
+  @differentiable(wrt: (x, y) where T: Differentiable)
+  func f(_ x: T, _ y: Float) -> T
+}
 
 protocol Proto {
   @differentiable(wrt: (x, y))
   func f(_ x: Float, _ y: Float) -> Float
 }
 
-// CHECK-LABEL: sil hidden @generic
-sil hidden @generic : $@convention(thin) <T where T : Proto> (@in T) -> () {
+// CHECK-LABEL: sil hidden @witness_method
+sil hidden @witness_method : $@convention(thin) <T where T : Proto> (@in T) -> () {
 bb0(%0 : $*T):
   // CHECK: witness_method $T, #Proto.f!1
   %1 = witness_method $T, #Proto.f!1 : <Self where Self : Proto> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
@@ -24,6 +31,22 @@ bb0(%0 : $*T):
 
   // CHECK: witness_method $T, #Proto.f!1.vjp.UUS
   %5 = witness_method $T, #Proto.f!1.vjp.UUS : <Self where Self : Proto> (Self) -> (Float, Float) -> Float : $@convention(witness_method: Proto) <τ_0_0 where τ_0_0 : Proto> (@in_guaranteed τ_0_0) -> (Float, Float) -> Float
+
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil hidden @class_method
+sil hidden @class_method : $@convention(thin) <T where T : Differentiable> (@guaranteed Class<T>) -> () {
+bb0(%0 : $Class<T>):
+  // CHECK: class_method %0 : $Class<T>, #Class.f!1
+  %1 = class_method %0 : $Class<T>, #Class.f!1 : <T> (Class<T>) -> (T, Float) -> T, $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, Float, @guaranteed Class<τ_0_0>) -> @out τ_0_0
+
+  // CHECK: class_method %0 : $Class<T>, #Class.f!1.jvp.SSU
+  %2 = class_method %0 : $Class<T>, #Class.f!1.jvp.SSU.<T where T : Differentiable> : <T> (Class<T>) -> (T, Float) -> T, $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float, @guaranteed Class<τ_0_0>) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector)
+
+  // CHECK: class_method %0 : $Class<T>, #Class.f!1.vjp.SSU
+  %3 = class_method %0 : $Class<T>, #Class.f!1.vjp.SSU.<T where T : Differentiable> : <T> (Class<T>) -> (T, Float) -> T, $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float, @guaranteed Class<τ_0_0>) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
 
   %6 = tuple ()
   return %6 : $()

--- a/test/AutoDiff/vtable_sil.swift
+++ b/test/AutoDiff/vtable_sil.swift
@@ -37,6 +37,11 @@ class Super : Differentiable {
     return (f(x, y), { v in v * y })
   }
 
+  @differentiable(wrt: x where T: Differentiable)
+  func generic<T>(_ x: T, _ y: T) -> T {
+    return x
+  }
+
   @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
   subscript(_ x: Float, _ y: Float) -> Float {
     return x * y
@@ -96,6 +101,9 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil5SuperC1fyS2f_SftF
 // CHECK-NEXT:   #Super.f!1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperC1fyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk
 // CHECK-NEXT:   #Super.f!1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperC1fyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk
+// CHECK-NEXT:   #Super.generic!1: <T> (Super) -> (T, T) -> T : @$s10vtable_sil5SuperC7genericyxx_xtlF
+// CHECK-NEXT:   #Super.generic!1.jvp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__jvp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk
+// CHECK-NEXT:   #Super.generic!1.vjp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__vjp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk
 // CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil5SuperCyS2f_Sftcig
 // CHECK-NEXT:   #Super.subscript!getter.1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk
 // CHECK-NEXT:   #Super.subscript!getter.1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk
@@ -117,6 +125,9 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubC1fyS2f_SftF [override]
 // CHECK-NEXT:   #Super.f!1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk [override]
 // CHECK-NEXT:   #Super.f!1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk [override]
+// CHECK-NEXT:   #Super.generic!1: <T> (Super) -> (T, T) -> T : @$s10vtable_sil5SuperC7genericyxx_xtlF [inherited]
+// CHECK-NEXT:   #Super.generic!1.jvp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__jvp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk [inherited]
+// CHECK-NEXT:   #Super.generic!1.vjp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__vjp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubCyS2f_Sftcig [override]
 // CHECK-NEXT:   #Super.subscript!getter.1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk [override]
 // CHECK-NEXT:   #Super.subscript!getter.1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk [override]
@@ -140,6 +151,9 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubC1fyS2f_SftF [inherited]
 // CHECK-NEXT:   #Super.f!1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.f!1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]
+// CHECK-NEXT:   #Super.generic!1: <T> (Super) -> (T, T) -> T : @$s10vtable_sil5SuperC7genericyxx_xtlF [inherited]
+// CHECK-NEXT:   #Super.generic!1.jvp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__jvp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk [inherited]
+// CHECK-NEXT:   #Super.generic!1.vjp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__vjp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubCyS2f_Sftcig [inherited]
 // CHECK-NEXT:   #Super.subscript!getter.1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.subscript!getter.1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]


### PR DESCRIPTION
Mangle derivative generic signatures for derivative functions:

- `ASTMangler::mangleAutoDiffLinearMapHelper`
- `ASTMangler::mangleAutoDiffDerivativeFunctionHelper`
- `AutoDiffDerivativeFunctionIdentifier`

This resolves name collision issues for derivative functions that have the
same parameter indices but different derivative generic signatures (TF-1037).

This also enables detecting duplicate `@differentiable` and `@derivative`
attributes based on derivative generic signatures, not just parameter indices,
during type-checking.

Resolves TF-680 and TF-1037.
TF-20 tracks principled mangling for AutoDiff generated functions.

---

Example:
```swift
protocol P1: Differentiable {}
extension P1 {
  @differentiable // derivative generic signature: none
  func foo() -> Float { 1 }
}
extension P1 {
  @derivative(of: foo) // derivative generic signature: `<P1 where Self: P1>`
  func vjpFoo() -> (value: Float, pullback: (Float) -> (TangentVector)) {
    fatalError()
  }
}
```

Before: programs crash due to a name conflict for `AD__$s4main2P1PAAE3fooSfyF__vjp_src_0_wrt_0`, since derivative generic signatures are not mangled.

After: program no longer crashes. However, two separate differentiability witnesses are created for the `@differentiable` attribute and the `@derivative` attribute, since they currently have different derivative generic signatures.

```
// differentiability witness for P1.foo()
sil_differentiability_witness hidden [parameters 0] [results 0] @$s36sil_differentiability_witness_silgen2P1PAAE3fooSfyF : $@convention(method) <Self where Self : P1> (@in_guaranteed Self) -> Float {
}

// differentiability witness for P1.foo()
sil_differentiability_witness hidden [parameters 0] [results 0] <Self where Self : P1> @$s36sil_differentiability_witness_silgen2P1PAAE3fooSfyF : $@convention(method) <Self where Self : P1> (@in_guaranteed Self) -> Float {
  vjp: @AD__$s36sil_differentiability_witness_silgen2P1PAAE3fooSfyF__vjp_src_0_wrt_0_36sil_differentiability_witness_silgen2P1Rzl : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> (Float, @owned @callee_guaranteed (Float) -> @out τ_0_0.TangentVector)
}
```

This is not expected. TF-1046 will resolve this so that only one differentiability witness is created.

---

New SILDeclRef syntax for JVP/VJP functions with a derivative generic signature:
```swift
class Class<T> {
  @differentiable(wrt: (x, y) where T: Differentiable)
  func f(_ x: T, _ y: Float) -> T { x }
}
```
```
sil_vtable Class {
  #Class.f!1: <T> (Class<T>) -> (T, Float) -> T : @$s2tf5ClassC1fyxx_SftF	// Class.f(_:_:)
  #Class.f!1.jvp.SSU.<T where T : Differentiable>: <T> (Class<T>) -> (T, Float) -> T : @AD__$s2tf5ClassC1fyxx_SftF__jvp_src_0_wrt_0_1_s14DifferentiableRzl_vtable_entry_thunk	// AD__$s2tf5ClassC1fyxx_SftF__jvp_src_0_wrt_0_1_s14DifferentiableRzl_vtable_entry_thunk
  #Class.f!1.vjp.SSU.<T where T : Differentiable>: <T> (Class<T>) -> (T, Float) -> T : @AD__$s2tf5ClassC1fyxx_SftF__vjp_src_0_wrt_0_1_s14DifferentiableRzl_vtable_entry_thunk	// AD__$s2tf5ClassC1fyxx_SftF__vjp_src_0_wrt_0_1_s14DifferentiableRzl_vtable_entry_thunk
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     derivative generic signature
  ...
}
```