### PR TITLE
[Incremental, Driver] Only emit a real make-style dependency file for one frontend job.

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -264,7 +264,12 @@ private:
   /// added -emit-dependency-path.
   bool HaveAlreadyAddedDependencyPath = false;
 
-  /// Set if the -only-one-dependency-file flag is set
+  /// When set, only the first scheduled frontend job gets the argument needed
+  /// to produce a make-style dependency file. The other jobs create dummy files
+  /// in the driver. This hack speeds up incremental compilation by reducing the
+  /// time for the build system to read each dependency file, which are all
+  /// identical. This optimization can be disabled by passing
+  /// -disable-only-one-dependency-file on the command line.
   const bool OnlyOneDependencyFile;
 
   /// Scaffolding to permit experimentation with finer-grained dependencies and

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -140,10 +140,9 @@ Flag<["-"], "enable-fine-grained-dependencies">, Flags<[FrontendOption, HelpHidd
 HelpText<"Experimental work-in-progress to be more selective about incremental recompilation">;
 
 
-def only_one_dependency_file :
-Flag<["-"], "only-one-dependency-file">, Flags<[DoesNotAffectIncrementalBuild]>,
- HelpText<"Experimental flag for faster thousand-source-file incremental builds">;
-
+def disable_only_one_dependency_file :
+Flag<["-"], "disable-only-one-dependency-file">, Flags<[DoesNotAffectIncrementalBuild]>,
+ HelpText<"Disables incremental build optimization that only produces one dependencies file">;
 
 def enable_source_range_dependencies :
 Flag<["-"], "enable-source-range-dependencies">, Flags<[]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -139,6 +139,12 @@ def enable_fine_grained_dependencies :
 Flag<["-"], "enable-fine-grained-dependencies">, Flags<[FrontendOption, HelpHidden]>,
 HelpText<"Experimental work-in-progress to be more selective about incremental recompilation">;
 
+
+def only_one_dependency_file :
+Flag<["-"], "only-one-dependency-file">, Flags<[DoesNotAffectIncrementalBuild]>,
+ HelpText<"Experimental flag for faster thousand-source-file incremental builds">;
+
+
 def enable_source_range_dependencies :
 Flag<["-"], "enable-source-range-dependencies">, Flags<[]>,
 HelpText<"Try using source range information">;

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -121,13 +121,15 @@ Compilation::Compilation(DiagnosticEngine &Diags,
                          bool SaveTemps,
                          bool ShowDriverTimeCompilation,
                          std::unique_ptr<UnifiedStatsReporter> StatsReporter,
+                         bool OnlyOneDependencyFile,
                          bool EnableFineGrainedDependencies,
                          bool VerifyFineGrainedDependencyGraphAfterEveryImport,
                          bool EmitFineGrainedDependencyDotFileAfterEveryImport,
                          bool FineGrainedDependenciesIncludeIntrafileOnes,
                          bool EnableSourceRangeDependencies,
                          bool CompareIncrementalSchemes,
-                         StringRef CompareIncrementalSchemesPath)
+                         StringRef CompareIncrementalSchemesPath
+                         )
   : Diags(Diags), TheToolChain(TC),
     TheOutputInfo(OI),
     Level(Level),
@@ -149,6 +151,7 @@ Compilation::Compilation(DiagnosticEngine &Diags,
     ShowDriverTimeCompilation(ShowDriverTimeCompilation),
     Stats(std::move(StatsReporter)),
     FilelistThreshold(FilelistThreshold),
+    OnlyOneDependencyFile(OnlyOneDependencyFile),
     EnableFineGrainedDependencies(EnableFineGrainedDependencies),
     VerifyFineGrainedDependencyGraphAfterEveryImport(
       VerifyFineGrainedDependencyGraphAfterEveryImport),
@@ -156,7 +159,8 @@ Compilation::Compilation(DiagnosticEngine &Diags,
       EmitFineGrainedDependencyDotFileAfterEveryImport),
     FineGrainedDependenciesIncludeIntrafileOnes(
       FineGrainedDependenciesIncludeIntrafileOnes),
-    EnableSourceRangeDependencies(EnableSourceRangeDependencies) {
+    EnableSourceRangeDependencies(EnableSourceRangeDependencies)
+    {
     if (CompareIncrementalSchemes)
       IncrementalComparator.emplace(
       // Ensure the references are to inst vars, NOT arguments
@@ -2035,4 +2039,20 @@ unsigned Compilation::countSwiftInputs() const {
     if (p.first == file_types::TY_Swift)
       ++inputCount;
   return inputCount;
+}
+
+void Compilation::addDependencyPathOrCreateDummy(
+    const CommandOutput &Output,
+    function_ref<void(StringRef)> addDependencyPath,
+    function_ref<void(StringRef)> createDummy) {
+  StringRef path =
+      Output.getAdditionalOutputForType(file_types::TY_Dependencies);
+  if (path.empty())
+    return;
+  if (HaveAlreadyAddedDependencyPath && OnlyOneDependencyFile)
+    createDummy(path);
+  else {
+    addDependencyPath(path);
+    HaveAlreadyAddedDependencyPath = true;
+  }
 }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -951,7 +951,11 @@ Driver::buildCompilation(const ToolChain &TC,
         ArgList->hasArg(options::OPT_driver_time_compilation);
     std::unique_ptr<UnifiedStatsReporter> StatsReporter =
         createStatsReporter(ArgList.get(), Inputs, OI, DefaultTargetTriple);
+
+    const bool OnlyOneDependencyFile =
+        ArgList->hasArg(options::OPT_only_one_dependency_file);
     // relies on the new dependency graph
+
     const bool EnableFineGrainedDependencies =
         ArgList->hasArg(options::OPT_enable_fine_grained_dependencies);
 
@@ -984,6 +988,7 @@ Driver::buildCompilation(const ToolChain &TC,
         SaveTemps,
         ShowDriverTimeCompilation,
         std::move(StatsReporter),
+        OnlyOneDependencyFile,
         EnableFineGrainedDependencies,
         VerifyFineGrainedDependencyGraphAfterEveryImport,
         EmitFineGrainedDependencyDotFileAfterEveryImport,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -953,7 +953,7 @@ Driver::buildCompilation(const ToolChain &TC,
         createStatsReporter(ArgList.get(), Inputs, OI, DefaultTargetTriple);
 
     const bool OnlyOneDependencyFile =
-        ArgList->hasArg(options::OPT_only_one_dependency_file);
+        !ArgList->hasArg(options::OPT_disable_only_one_dependency_file);
     // relies on the new dependency graph
 
     const bool EnableFineGrainedDependencies =

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -34,6 +34,8 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Program.h"
 
+#include <fstream>
+
 using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
@@ -679,10 +681,7 @@ void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(
       },
       [&](StringRef dependencyFile) {
         // Create an empty file
-        using namespace llvm::sys::fs;
-        if (auto file = openNativeFileForWrite(dependencyFile, CD_CreateAlways,
-                                               OF_Text))
-          closeFile(file.get());
+        std::ofstream(dependencyFile.str().c_str());
       });
 
   addOutputsOfType(arguments, Output, Args, file_types::TY_SwiftDeps,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -671,8 +671,20 @@ void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(
            "mode!");
   }
 
-  addOutputsOfType(arguments, Output, Args, file_types::TY_Dependencies,
-                   "-emit-dependencies-path");
+  C.addDependencyPathOrCreateDummy(
+      Output,
+      [&](StringRef) {
+        addOutputsOfType(arguments, Output, Args, file_types::TY_Dependencies,
+                         "-emit-dependencies-path");
+      },
+      [&](StringRef dependencyFile) {
+        // Create an empty file
+        using namespace llvm::sys::fs;
+        if (auto file = openNativeFileForWrite(dependencyFile, CD_CreateAlways,
+                                               OF_Text))
+          closeFile(file.get());
+      });
+
   addOutputsOfType(arguments, Output, Args, file_types::TY_SwiftDeps,
                    "-emit-reference-dependencies-path");
   addOutputsOfType(arguments, Output, Args, file_types::TY_SwiftRanges,


### PR DESCRIPTION
Because every frontend job emits the same make-style dependency file, the build system uses a lot of time to read them all, slowing incremental builds of projects with many files.

This changes adds a driver flag, `-only-one-dependency-file`, which causes the driver to omit the -emit-dependency-path argument for subsequent frontend jobs, instead creating dummy files.

Not tested yet, except on a dummy 3,000 file project where it reduced incremental compilation time from ~40 secs to ~3 secs.