### PR TITLE
Adapt to new ASTContext::getConstantArrayType API

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -363,7 +363,7 @@ clang::QualType ClangTypeConverter::visitTupleType(TupleType *type) {
     return clang::QualType();
 
   APInt size(32, tupleNumElements);
-  return ClangASTContext.getConstantArrayType(clangEltTy, size,
+  return ClangASTContext.getConstantArrayType(clangEltTy, size, nullptr,
            clang::ArrayType::Normal, 0);
 }
 

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -216,12 +216,12 @@ public:
   using IRBuilderBase::CreateMemSet;
   llvm::CallInst *CreateMemSet(Address dest, llvm::Value *value, Size size) {
     return CreateMemSet(dest.getAddress(), value, size.getValue(),
-                        dest.getAlignment().getValue());
+                        llvm::MaybeAlign(dest.getAlignment().getValue()));
   }
   llvm::CallInst *CreateMemSet(Address dest, llvm::Value *value,
                                llvm::Value *size) {
     return CreateMemSet(dest.getAddress(), value, size,
-                        dest.getAlignment().getValue());
+                        llvm::MaybeAlign(dest.getAlignment().getValue()));
   }
   
   using IRBuilderBase::CreateLifetimeStart;

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -752,7 +752,7 @@ public:
     ZeroInitBuilder.SetCurrentDebugLocation(nullptr);
     ZeroInitBuilder.CreateMemSet(
         AI, llvm::ConstantInt::get(IGM.Int8Ty, 0),
-        Size, AI->getAlignment());
+        Size, llvm::MaybeAlign(AI->getAlignment()));
   }
 
   /// Account for bugs in LLVM.

--- a/lib/IRGen/TypeLayoutVerifier.cpp
+++ b/lib/IRGen/TypeLayoutVerifier.cpp
@@ -129,7 +129,7 @@ IRGenTypeVerifierFunction::emit(ArrayRef<CanType> formalTypes) {
           Builder.CreateMemSet(xiBuf.getAddress(),
                                    llvm::ConstantInt::get(IGM.Int8Ty, 0x5A),
                                    fixedTI->getFixedSize().getValue(),
-                                   fixedTI->getFixedAlignment().getValue());
+                                   llvm::MaybeAlign(fixedTI->getFixedAlignment().getValue()));
           
           // Ask the runtime to store an extra inhabitant.
           auto tag = llvm::ConstantInt::get(IGM.Int32Ty, i+1);


### PR DESCRIPTION
The SizeExpr only matters for templates so we can just pass a nullptr here to get this code to compile.