### PR TITLE
[Foundation] UUID: LosslessStringConvertible

### DIFF
--- a/stdlib/public/Darwin/Foundation/UUID.swift
+++ b/stdlib/public/Darwin/Foundation/UUID.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,7 +16,7 @@ import _SwiftCoreFoundationOverlayShims
 
 /// Represents UUID strings, which can be used to uniquely identify types, interfaces, and other items.
 @available(macOS 10.8, iOS 6.0, *)
-public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConvertible {
+public struct UUID : ReferenceConvertible, Hashable, Equatable, LosslessStringConvertible {
     public typealias ReferenceType = NSUUID
 
     public private(set) var uuid: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -53,6 +53,11 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
             return nil
         }
     }
+
+    /// Create a UUID from a string such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".
+    public init?(_ description: __shared String) {
+        self.init(uuidString: description)
+    }
     
     /// Create a UUID from a `uuid_t`.
     public init(uuid: uuid_t) {
@@ -80,6 +85,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
         }
     }
 
+    /// Returns a string created from the UUID, such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
     public var description: String {
         return uuidString
     }

--- a/test/stdlib/TestUUID.swift
+++ b/test/stdlib/TestUUID.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -67,6 +67,15 @@ class TestUUID : TestUUIDSuper {
     func test_description() {
         let uuid = UUID()
         expectEqual(uuid.description, uuid.uuidString, "The description must be the same as the uuidString.")
+    }
+
+    func test_LosslessStringConvertible() {
+        let uuidA = UUID()
+        let uuidB = UUID(uuidA.description)
+        expectEqual(uuidA.uuidString, uuidA.description)
+        expectEqual(uuidA.uuidString, String(uuidA))
+        expectEqual(uuidA.uuidString, "\(uuidA)")
+        expectEqual(uuidA, uuidB)
     }
 
     func test_roundTrips() {
@@ -148,6 +157,7 @@ UUIDTests.test("test_InvalidUUID") { TestUUID().test_InvalidUUID() }
 UUIDTests.test("test_NS_uuidString") { TestUUID().test_NS_uuidString() }
 UUIDTests.test("test_uuidString") { TestUUID().test_uuidString() }
 UUIDTests.test("test_description") { TestUUID().test_description() }
+UUIDTests.test("test_LosslessStringConvertible") { TestUUID().test_LosslessStringConvertible() }
 UUIDTests.test("test_roundTrips") { TestUUID().test_roundTrips() }
 UUIDTests.test("test_hash") { TestUUID().test_hash() }
 UUIDTests.test("test_AnyHashableContainingUUID") { TestUUID().test_AnyHashableContainingUUID() }


### PR DESCRIPTION
`UUID` already conforms to `CustomStringConvertible`, 
but in [documentation][] its `description` property 
is only a "textual description of the UUID."

`LosslessStringConvertible` conformance will make:
* `description` and `uuidString` equivalent;
* `"\(UUID())"` interpolation more useful;
* `String(UUID())` creation possible.

[documentation]: <https://developer.apple.com/documentation/foundation/uuid>