### PR TITLE
[stdlib-private][os log] Add new log methods for each specific logging level.

### DIFF
--- a/stdlib/private/OSLog/OSLog.swift
+++ b/stdlib/private/OSLog/OSLog.swift
@@ -21,14 +21,19 @@ public struct Logger {
   @usableFromInline
   internal let logObject: OSLog
 
-  /// Create a custom OS log object.
+  /// Create a custom OSLog object for logging.
   public init(subsystem: String, category: String) {
     logObject = OSLog(subsystem: subsystem, category: category)
   }
 
-  /// Return the default OS log object.
+  /// Use the default OSLog object for logging.
   public init() {
     logObject = OSLog.default
+  }
+
+  /// Create a Logger instance from an existing OSLog Object.
+  public init(_ logObj: OSLog) {
+    logObject = logObj
   }
 
   // Functions defined below are marked @_optimize(none) to prevent inlining
@@ -44,8 +49,57 @@ public struct Logger {
     osLog(log: logObject, level: level, message)
   }
 
-  // TODO: define overloads for logging at specific levels: debug, info, notice,
-  // error, fault based on the Swift forum "logging-levels" discussion.
+  // The following overloads are for logging at specific levels. The levels that
+  // are supported are debug (also called trace), info, notice (also called
+  // default), error (also called warning), fault (also called critical).
+
+  @_transparent
+  @_optimize(none)
+  public func trace(_ message: OSLogMessage) {
+    osLog(log: logObject, level: .debug, message)
+  }
+
+  @_transparent
+  @_optimize(none)
+  public func debug(_ message: OSLogMessage) {
+    osLog(log: logObject, level: .debug, message)
+  }
+
+  @_transparent
+  @_optimize(none)
+  public func info(_ message: OSLogMessage) {
+    osLog(log: logObject, level: .info, message)
+  }
+
+  @_transparent
+  @_optimize(none)
+  public func notice(_ message: OSLogMessage) {
+    osLog(log: logObject, level: .default, message)
+  }
+
+  @_transparent
+  @_optimize(none)
+  public func warning(_ message: OSLogMessage) {
+    osLog(log: logObject, level: .error, message)
+  }
+
+  @_transparent
+  @_optimize(none)
+  public func error(_ message: OSLogMessage) {
+    osLog(log: logObject, level: .error, message)
+  }
+
+  @_transparent
+  @_optimize(none)
+  public func critical(_ message: OSLogMessage) {
+    osLog(log: logObject, level: .fault, message)
+  }
+
+  @_transparent
+  @_optimize(none)
+  public func fault(_ message: OSLogMessage) {
+    osLog(log: logObject, level: .fault, message)
+  }
 }
 
 /// Given an instance of the custom string interpolation type: `OSLogMessage`,

--- a/test/stdlib/OSLogPrototypeExecTest.swift
+++ b/test/stdlib/OSLogPrototypeExecTest.swift
@@ -26,23 +26,18 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     h.log("A message with no data")
 
     // Test logging at specific levels.
-    h.log(level: .debug, "Minimum integer value: \(Int.min, format: .hex)")
-    h.log(level: .info, "Maximum integer value: \(Int.max, format: .hex)")
+    h.debug("Minimum integer value: \(Int.min, format: .hex)")
+    h.info("Maximum integer value: \(Int.max, format: .hex)")
 
     let privateID = 0x79abcdef
-    h.log(
-      level: .error,
-      "Private Identifier: \(privateID, format: .hex, privacy: .private)")
+    h.error("Private Identifier: \(privateID, format: .hex, privacy: .private)")
     let addr = 0x7afebabe
-    h.log(
-      level: .fault,
-      "Invalid address: 0x\(addr, format: .hex, privacy: .public)")
+    h.fault("Invalid address: 0x\(addr, format: .hex, privacy: .public)")
 
     // Test logging with multiple arguments.
     let filePermissions = 0o777
     let pid = 122225
-    h.log(
-      level: .error,
+    h.error(
       """
       Access prevented: process \(pid) initiated by \
       user: \(privateID, privacy: .private) attempted resetting \


### PR DESCRIPTION
Also, add aliases for the logging levels for source compatibility with swift-server side logging. Create a new initializer of Logger that can directly accept an existing os log object of type `OSLog`. This aids in porting uses of existing os_log API to the new API.