### PR TITLE
[AutoDiff] TF-1041 is done

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -573,10 +573,6 @@ swift::matchWitness(
           // If the witness has a "superset" derivative configuration, create an
           // implicit `@differentiable` attribute with the exact requirement
           // `@differentiable` attribute parameter indices.
-          // TODO(TF-1041): Investigate why this logic is necessary. When
-          // "implicit `@differentiable` attribute" logic is removed, core
-          // stdlib compilation succeeds and AutoDiff tests pass, but TensorFlow
-          // compilation crashes. An AutoDiff reproducer test should be added.
           auto *newAttr = DifferentiableAttr::create(
               witnessAFD, /*implicit*/ true, reqDiffAttr->AtLoc,
               reqDiffAttr->getRange(), reqDiffAttr->isLinear(),


### PR DESCRIPTION
[This test](https://github.com/apple/swift/blob/b58309116d69c2bf47962d010d9282c7eface699/test/AutoDiff/protocol_requirement_autodiff.swift#L177) fails with the following error when the implicit differentiable attr is removed:
```
/usr/local/google/home/marcrasi/swift-base/swift/test/AutoDiff/protocol_requirement_autodiff.swift:177:8: error: type 'MoreDifferentiableFooStruct' does not conform to protocol 'DifferentiableFoo'
struct MoreDifferentiableFooStruct: MoreDifferentiableFoo {
       ^
/usr/local/google/home/marcrasi/swift-base/swift/test/AutoDiff/protocol_requirement_autodiff.swift:174:8: note: protocol requires function 'foo' with type '(MoreDifferentiableFooStruct.T) -> Tracked<Float>'; do you want to add a stub?
  func foo(_ x: T) -> Tracked<Float>
       ^
/usr/local/google/home/marcrasi/swift-base/swift/test/AutoDiff/protocol_requirement_autodiff.swift:167:18: note: protocol requires nested type 'T'; do you want to add it?
  associatedtype T: Differentiable
                 ^
```

Therefore, TF-1041 is done and we can remove the comment.