### PR TITLE
[AutoDiff] forbid overly-constrained derivative requirement implementations

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -560,6 +560,14 @@ swift::matchWitness(
       bool foundSupersetAttr = false;
       for (auto witnessConfig :
            witnessAFD->getDerivativeFunctionConfigurations()) {
+        // We can't use witnesses that have generic signatures not satisfied by
+        // the requirement's generic signature.
+        if (!witnessConfig.derivativeGenericSignature
+                 ->requirementsNotSatisfiedBy(
+                     reqDiffAttr->getDerivativeGenericSignature())
+                 .empty())
+          continue;
+
         if (witnessConfig.parameterIndices ==
             reqDiffAttr->getParameterIndices())
           foundExactAttr = true;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -562,7 +562,8 @@ swift::matchWitness(
            witnessAFD->getDerivativeFunctionConfigurations()) {
         // We can't use witnesses that have generic signatures not satisfied by
         // the requirement's generic signature.
-        if (!witnessConfig.derivativeGenericSignature
+        if (witnessConfig.derivativeGenericSignature &&
+            !witnessConfig.derivativeGenericSignature
                  ->requirementsNotSatisfiedBy(
                      reqDiffAttr->getDerivativeGenericSignature())
                  .empty())

--- a/test/AutoDiff/protocol_requirement_autodiff.swift
+++ b/test/AutoDiff/protocol_requirement_autodiff.swift
@@ -163,6 +163,8 @@ func blah2<T: DoubleDifferentiableDistribution>(_ x: T, _ value: T.Value) -> Tra
   x.logProbability(of: value)
 }
 
+// Satisfying the requirement with more wrt indices than are necessary.
+
 protocol DifferentiableFoo {
   associatedtype T: Differentiable
   @differentiable(wrt: x)
@@ -179,6 +181,20 @@ struct MoreDifferentiableFooStruct: MoreDifferentiableFoo {
   func foo(_ x: Tracked<Float>) -> Tracked<Float> {
     x
   }
+}
+
+// Satisfiying the requirement with a less-constrained derivative than is necessary.
+
+protocol ExtraDerivativeConstraint {}
+
+protocol HasExtraConstrainedDerivative {
+  @differentiable
+  func requirement<T: Differentiable & ExtraDerivativeConstraint>(_ x: T) -> T
+}
+
+struct SatisfiesDerivativeWithLessConstraint: HasExtraConstrainedDerivative {
+  @differentiable
+  func requirement<T: Differentiable>(_ x: T) -> T { x }
 }
 
 runAllTests()

--- a/test/AutoDiff/protocol_requirement_autodiff_diags.swift
+++ b/test/AutoDiff/protocol_requirement_autodiff_diags.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+protocol P {}
+
+protocol HasRequirement {
+  @differentiable
+  // expected-note @+1 {{protocol requires function 'requirement' with type '<T> (T, T) -> T'; do you want to add a stub?}}
+  func requirement<T: Differentiable>(_ x: T, _ y: T) -> T
+}
+
+// expected-error @+1 {{type 'AttemptsToSatisfyRequirement' does not conform to protocol 'HasRequirement'}}
+struct AttemptsToSatisfyRequirement: HasRequirement {
+  // This does not satisfy the requirement because the differentiable attribute is more
+  // constrained than the requirement's differentiable attribute.
+  @differentiable(where T: P)
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  func requirement<T: Differentiable>(_ x: T, _ y: T) -> T { x }
+}


### PR DESCRIPTION
As demonstrated in the new test file, we should reject derivative requirement implementations that are too constrained.