### PR TITLE
[AutoDiff upstream] Conform floating-point types to `Differentiable`.

### DIFF
--- a/stdlib/public/Differentiation/Differentiable.swift
+++ b/stdlib/public/Differentiation/Differentiable.swift
@@ -42,3 +42,19 @@ public extension Differentiable where TangentVector == Self {
     self += direction
   }
 }
+
+//===----------------------------------------------------------------------===//
+// `Differentiable` conformances
+//===----------------------------------------------------------------------===//
+
+extension Float: Differentiable {
+  public typealias TangentVector = Self
+}
+extension Double: Differentiable {
+  public typealias TangentVector = Self
+}
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
+extension Float80: Differentiable {
+  public typealias TangentVector = Self
+}
+#endif

--- a/test/AutoDiff/stdlib/differentiable_protocol.swift
+++ b/test/AutoDiff/stdlib/differentiable_protocol.swift
@@ -3,7 +3,7 @@
 
 import _Differentiation
 
-// Test conformances.
+// Test `Differentiable` protocol conformances.
 
 struct FloatWrapper {
   var value: Float

--- a/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
+++ b/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: differentiable_programming
+
+import _Differentiation
+
+// Test `Differentiable` protocol conformances for stdlib types.
+
+func assertConformsToDifferentiable<T>(_: T.Type) where T: Differentiable {}
+
+func assertSelfEqualsTangentVector<T>(_: T.Type)
+where T: Differentiable, T == T.TangentVector {}
+
+// Test `FloatingPoint` types.
+func testFloatingPointDifferentiableConformance() {
+  assertSelfEqualsTangentVector(Float.self)
+  assertSelfEqualsTangentVector(Double.self)
+  #if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
+  assertSelfEqualsTangentVector(Float80.self)
+  #endif
+}


### PR DESCRIPTION
Add `Differentiable` conformances for floating-point types to the `_Differentiation` module.
The `TangentVector` associated type for floating-point types is `Self`.

This design adheres to the [Swift differentiable programming manifesto](https://github.com/apple/swift/blob/master/docs/DifferentiableProgramming.md#the-differentiable-protocol).

Adding `Differentiable` conformances for concrete stdlib types facilitates
future upstreaming work, e.g. `@differentiable` attribute type-checking (TF-828).

Partially resolves TF-1052.