### PR TITLE
[diagnose-unreachable] Fix a small part of diagnose unreachable that did not handle ossa correctly.

### DIFF
--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -471,7 +471,9 @@ class Klass2 {}
 
 // CHECK-LABEL: sil [ossa] @constant_fold_diagnose_unreachable_succ_match : $@convention(thin) (@owned Klass1) -> () {
 // CHECK: bb0([[ARG:%.*]] :
-// CHECK:   destroy_value [[ARG]]
+// CHECK:   [[ENUM_VAL:%.*]] = enum $Either<Klass1, Klass2>, #Either.left!enumelt.1, [[ARG]]
+// CHECK:   [[RESULT:%.*]] = unchecked_enum_data [[ENUM_VAL]]
+// CHECK:   destroy_value [[RESULT]]
 // CHECK: } // end sil function 'constant_fold_diagnose_unreachable_succ_match'
 sil [ossa] @constant_fold_diagnose_unreachable_succ_match : $@convention(thin) (@owned Klass1) -> () {
 bb0(%0 : @owned $Klass1):
@@ -759,4 +761,24 @@ bb2:
   dealloc_stack %1 : $*Singleton
   %9999 = tuple()
   return %9999 : $()
+}
+
+// Just make sure we apply the optimization and do not trigger the ownership verifier
+//
+// CHECK-LABEL: sil [ossa] @constant_fold_switch_enum_with_owned_payload :
+// CHECK: bb0(
+// CHECK:   br bb1
+// CHECK: bb1:
+// CHECK:   return
+// CHECK: } // end sil function 'constant_fold_switch_enum_with_owned_payload'
+sil [ossa] @constant_fold_switch_enum_with_owned_payload : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = enum $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt.1, %0 : $Builtin.NativeObject
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  return %2 : $Builtin.NativeObject
+
+bb2:
+  unreachable
 }


### PR DESCRIPTION
Specifically if we had:

```
%1 = enum $Enum, %0
switch_enum %1
```

We would propagate %0 without eliminating the enum in certain cases. Instead, we
insert unchecked_enum_data right before the branch to ensure that:

1. The types line up.
2. The enum is only consumed along the path through the switch_enum instead of
   dealing with the lifetime of the enum along other paths.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
