### PR TITLE
[test] Modernize test/stdlib/OptionSetTest.swift

### DIFF
--- a/test/stdlib/OptionSetTest.swift
+++ b/test/stdlib/OptionSetTest.swift
@@ -12,114 +12,110 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+import StdlibUnittest
+
 struct PackagingOptions : OptionSet {
   let rawValue: Int
   init(rawValue: Int) { self.rawValue = rawValue }
 
-  static let
-    Box = PackagingOptions(rawValue: 1),
-    Carton = PackagingOptions(rawValue: 2),
-    Bag = PackagingOptions(rawValue: 4),
-    Satchel = PackagingOptions(rawValue: 8)
+  static let box = PackagingOptions(rawValue: 1)
+  static let carton = PackagingOptions(rawValue: 2)
+  static let bag = PackagingOptions(rawValue: 4)
+  static let satchel = PackagingOptions(rawValue: 8)
 
-  // FIXME: these must be separate decls because of <rdar://20962990>
-  static let BoxOrBag: PackagingOptions = [Box, Bag]
-  static let BoxOrCartonOrBag: PackagingOptions = [Box, Carton, Bag]
-  static let SatchelOrBag = Satchel.union(Bag)
+  static let boxOrBag: PackagingOptions = [box, bag]
+  static let boxOrCartonOrBag: PackagingOptions = [box, carton, bag]
+  static let satchelOrBag = satchel.union(bag)
 }
 
-import StdlibUnittest
-
-
 var tests = TestSuite("OptionSet")
+defer { runAllTests() }
 
 tests.test("basics") {
   typealias P = PackagingOptions
 
-  expectNotEqual(P(), .Box)
-  expectEqual(P.Box, .Box)
-  expectNotEqual(P.Box, .Carton)
-  expectNotEqual(P.Box, .BoxOrBag)
+  expectNotEqual(P(), .box)
+  expectEqual(P.box, .box)
+  expectNotEqual(P.box, .carton)
+  expectNotEqual(P.box, .boxOrBag)
 
-  expectEqual(.Box, P.Box.intersection(.BoxOrBag))
-  expectEqual(.Bag, P.Bag.intersection(.BoxOrBag))
-  expectEqual(P(), P.Bag.intersection(.Box))
-  expectEqual(P(), P.Box.intersection(.Satchel))
-  expectEqual(.BoxOrBag, P.Bag.union(.Box))
-  expectEqual(.BoxOrBag, P.Box.union(.Bag))
-  expectEqual(.BoxOrCartonOrBag, P.BoxOrBag.union(.Carton))
-  expectEqual([.Satchel, .Box], P.SatchelOrBag.symmetricDifference(.BoxOrBag))
+  expectEqual(.box, P.box.intersection(.boxOrBag))
+  expectEqual(.bag, P.bag.intersection(.boxOrBag))
+  expectEqual(P(), P.bag.intersection(.box))
+  expectEqual(P(), P.box.intersection(.satchel))
+  expectEqual(.boxOrBag, P.bag.union(.box))
+  expectEqual(.boxOrBag, P.box.union(.bag))
+  expectEqual(.boxOrCartonOrBag, P.boxOrBag.union(.carton))
+  expectEqual([.satchel, .box], P.satchelOrBag.symmetricDifference(.boxOrBag))
 
-  var p = P.Box
-  p.formIntersection(.BoxOrBag)
-  expectEqual(.Box, p)
-  
-  p = .Bag
-  p.formIntersection(.BoxOrBag)
-  expectEqual(.Bag, p)
-  
-  p = .Bag
-  p.formIntersection(.Box)
+  var p = P.box
+  p.formIntersection(.boxOrBag)
+  expectEqual(.box, p)
+
+  p = .bag
+  p.formIntersection(.boxOrBag)
+  expectEqual(.bag, p)
+
+  p = .bag
+  p.formIntersection(.box)
   expectEqual(P(), p)
-  
-  p = .Box
-  p.formIntersection(.Satchel)
-  expectEqual(P(), p)
-  
-  p = .Bag
-  p.formUnion(.Box)
-  expectEqual(.BoxOrBag, p)
-  
-  p = .Box
-  p.formUnion(.Bag)
-  expectEqual(.BoxOrBag, p)
-  
-  p = .BoxOrBag
-  p.formUnion(.Carton)
-  expectEqual(.BoxOrCartonOrBag, p)
 
-  p = .SatchelOrBag
-  p.formSymmetricDifference(.BoxOrBag)
-  expectEqual([.Satchel, .Box], p)
+  p = .box
+  p.formIntersection(.satchel)
+  expectEqual(P(), p)
+
+  p = .bag
+  p.formUnion(.box)
+  expectEqual(.boxOrBag, p)
+
+  p = .box
+  p.formUnion(.bag)
+  expectEqual(.boxOrBag, p)
+
+  p = .boxOrBag
+  p.formUnion(.carton)
+  expectEqual(.boxOrCartonOrBag, p)
+
+  p = .satchelOrBag
+  p.formSymmetricDifference(.boxOrBag)
+  expectEqual([.satchel, .box], p)
 }
 
 tests.test("set algebra") {
   typealias P = PackagingOptions
-  
+
   // remove
-  var p = P.BoxOrBag
-  expectNil(p.remove(P.Carton))
-  
-  p = P.BoxOrBag
-  p.remove(P.BoxOrCartonOrBag)
+  var p = P.boxOrBag
+  expectNil(p.remove(P.carton))
+
+  p = P.boxOrBag
+  p.remove(P.boxOrCartonOrBag)
   expectEqual(P(), p)
-  
-  p = P.BoxOrBag
+
+  p = P.boxOrBag
   if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
     // https://github.com/apple/swift/pull/28378
-    expectEqual(P.Bag, p.remove(P.SatchelOrBag))
+    expectEqual(P.bag, p.remove(P.satchelOrBag))
   }
-  expectEqual(P.Box, p)
-  
-  // insert
-  p = P.Box
-  var insertionResult = p.insert(.Bag)
-  expectTrue(insertionResult.inserted)
-  expectEqual(P.Bag, insertionResult.memberAfterInsert)
-  expectEqual(P.BoxOrBag, p)
-  
-  insertionResult = p.insert(.Bag)
-  expectFalse(insertionResult.inserted)
-  expectEqual(P.Bag, insertionResult.memberAfterInsert)
-  
-  // update
-  p = P.Box
-  expectNil(p.update(with: .Bag))
-  expectEqual(P.BoxOrBag, p)
-  
-  p = P.Box
-  expectEqual(P.Box, p.update(with: .BoxOrBag))
-  expectEqual(P.BoxOrBag, p)
-}
+  expectEqual(P.box, p)
 
-runAllTests()
+  // insert
+  p = P.box
+  var insertionResult = p.insert(.bag)
+  expectTrue(insertionResult.inserted)
+  expectEqual(P.bag, insertionResult.memberAfterInsert)
+  expectEqual(P.boxOrBag, p)
+
+  insertionResult = p.insert(.bag)
+  expectFalse(insertionResult.inserted)
+  expectEqual(P.bag, insertionResult.memberAfterInsert)
+
+  // update
+  p = P.box
+  expectNil(p.update(with: .bag))
+  expectEqual(P.boxOrBag, p)
+
+  p = P.box
+  expectEqual(P.box, p.update(with: .boxOrBag))
+  expectEqual(P.boxOrBag, p)
+}


### PR DESCRIPTION
While we're tweaking the OptionSet tests (https://github.com/apple/swift/pull/28715), modernize things a bit by upgrading from Swift 2-era naming conventions.