### PR TITLE
[ownership] Change BorrowScopeIntroducerValue::areInstructionsWithinScope to take SILInstructions instead of BranchPropagatedUser.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -187,6 +187,14 @@ public:
   bool validateLifetime(SILValue value,
                         ArrayRef<SILInstruction *> consumingUses,
                         ArrayRef<SILInstruction *> nonConsumingUses) {
+    assert(llvm::all_of(
+               consumingUses,
+               [](SILInstruction *i) { return !isa<CondBranchInst>(i); }) &&
+           "Passed cond branch to a non-BranchPropagatedUser API");
+    assert(llvm::all_of(
+               nonConsumingUses,
+               [](SILInstruction *i) { return !isa<CondBranchInst>(i); }) &&
+           "Passed cond branch to a non-BranchPropagatedUser API");
     auto *consumingUsesCast =
         reinterpret_cast<const BranchPropagatedUser *>(consumingUses.data());
     auto *nonConsumingUsesCast =
@@ -420,11 +428,11 @@ struct BorrowScopeIntroducingValue {
   ///
   /// NOTE: Scratch space is used internally to this method to store the end
   /// borrow scopes if needed.
-  bool areInstructionsWithinScope(
-      ArrayRef<BranchPropagatedUser> instructions,
-      SmallVectorImpl<BranchPropagatedUser> &scratchSpace,
-      SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
-      DeadEndBlocks &deadEndBlocks) const;
+  bool
+  areInstructionsWithinScope(ArrayRef<SILInstruction *> instructions,
+                             SmallVectorImpl<SILInstruction *> &scratchSpace,
+                             SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
+                             DeadEndBlocks &deadEndBlocks) const;
 
 private:
   /// Internal constructor for failable static constructor. Please do not expand

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -195,8 +195,8 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
 }
 
 bool BorrowScopeIntroducingValue::areInstructionsWithinScope(
-    ArrayRef<BranchPropagatedUser> instructions,
-    SmallVectorImpl<BranchPropagatedUser> &scratchSpace,
+    ArrayRef<SILInstruction *> instructions,
+    SmallVectorImpl<SILInstruction *> &scratchSpace,
     SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
     DeadEndBlocks &deadEndBlocks) const {
   // Make sure that we clear our scratch space/utilities before we exit.
@@ -214,8 +214,9 @@ bool BorrowScopeIntroducingValue::areInstructionsWithinScope(
     return true;
 
   // Otherwise, gather up our local scope ending instructions.
-  visitLocalScopeEndingUses(
-      [&scratchSpace](Operand *op) { scratchSpace.emplace_back(op); });
+  visitLocalScopeEndingUses([&scratchSpace](Operand *op) {
+    scratchSpace.emplace_back(op->getUser());
+  });
 
   LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
   return checker.validateLifetime(value, scratchSpace, instructions);


### PR DESCRIPTION
All non cond_br SILInstructions are layout compatible with BranchPropagatedUser
since BPU just stores a PointerIntPair that leaves its low bits as zero unless
one adds a cond_br. Since in these cases, the SILInstructions are all not
cond_br, we can use this alternative API.

I also added some asserts to validate that the assumption that all such
SILInstructions are not cond_br is respected.
