### PR TITLE
[SourceKit] ⚡️Fast code completion within function bodies

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5841,13 +5841,7 @@ public:
   /// \sa hasBody()
   BraceStmt *getBody(bool canSynthesize = true) const;
 
-  void setBody(BraceStmt *S, BodyKind NewBodyKind = BodyKind::Parsed) {
-    assert(getBodyKind() != BodyKind::Skipped &&
-           "cannot set a body if it was skipped");
-
-    Body = S;
-    setBodyKind(NewBodyKind);
-  }
+  void setBody(BraceStmt *S, BodyKind NewBodyKind = BodyKind::Parsed);
 
   /// Note that the body was skipped for this function.  Function body
   /// cannot be attached after this call.
@@ -5866,7 +5860,8 @@ public:
 
   /// Note that parsing for the body was delayed.
   void setBodyDelayed(SourceRange bodyRange) {
-    assert(getBodyKind() == BodyKind::None);
+    assert(getBodyKind() == BodyKind::None ||
+           getBodyKind() == BodyKind::Skipped);
     assert(bodyRange.isValid());
     BodyRange = bodyRange;
     setBodyKind(BodyKind::Unparsed);
@@ -6657,6 +6652,9 @@ public:
   /// initializer.
   BodyInitKind getDelegatingOrChainedInitKind(DiagnosticEngine *diags,
                                               ApplyExpr **init = nullptr) const;
+  void clearCachedDelegatingOrChainedInitKind() {
+    Bits.ConstructorDecl.ComputedBodyInitKind = 0;
+  }
 
   /// Whether this constructor is required.
   bool isRequired() const {

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -214,6 +214,9 @@ ERROR(repl_must_be_initialized,none,
 ERROR(error_doing_code_completion,none,
       "compiler is in code completion mode (benign diagnostic)", ())
 
+WARNING(completion_reusing_astcontext,none,
+        "completion reusing previous ASTContext (benign diagnostic)", ())
+
 ERROR(verify_encountered_fatal,none,
       "fatal error encountered while in -verify mode", ())
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -404,9 +404,11 @@ public:
     InterfaceHash->update(a);
   }
 
-  void getInterfaceHash(llvm::SmallString<32> &str) {
+  void getInterfaceHash(llvm::SmallString<32> &str) const {
+    // Copy to preserve idempotence.
+    llvm::MD5 md5 = *InterfaceHash;
     llvm::MD5::MD5Result result;
-    InterfaceHash->final(result);
+    md5.final(result);
     llvm::MD5::stringifyResult(result, str);
   }
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -318,18 +318,9 @@ public:
     return CodeCompletionOffset != ~0U;
   }
 
-  void setCodeCompletionFactory(CodeCompletionCallbacksFactory *Factory) {
-    CodeCompletionFactory = Factory;
-    disableASTScopeLookup();
-  }
-  
   /// Called from lldb, see rdar://53971116
   void disableASTScopeLookup() {
     LangOpts.EnableASTScopeLookup = false;
-  }
-
-  CodeCompletionCallbacksFactory *getCodeCompletionFactory() const {
-    return CodeCompletionFactory;
   }
 
   /// Retrieve a module hash string that is suitable for uniquely
@@ -483,6 +474,10 @@ public:
     Diagnostics.addConsumer(*DC);
   }
 
+  void removeDiagnosticConsumer(DiagnosticConsumer *DC) {
+    Diagnostics.removeConsumer(*DC);
+  }
+
   void createDependencyTracker(bool TrackSystemDeps) {
     assert(!Context && "must be called before setup()");
     DepTracker = llvm::make_unique<DependencyTracker>(TrackSystemDeps);
@@ -546,6 +541,18 @@ public:
 
   /// Returns true if there was an error during setup.
   bool setup(const CompilerInvocation &Invocation);
+
+  const CompilerInvocation &getInvocation() {
+    return Invocation;
+  }
+
+  bool hasPersistentParserState() const {
+    return bool(PersistentState);
+  }
+
+  PersistentParserState &getPersistentParserState() {
+    return *PersistentState.get();
+  }
 
 private:
   /// Set up the file system by loading and validating all VFS overlay YAML

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -40,12 +40,11 @@ class CompletionInstance {
   unsigned MaxASTReuseCount = 100;
   bool EnableASTCaching = false;
 
-  struct CachedInstance {
-    CompilerInstance CI;
-    llvm::hash_code ArgHash;
-    unsigned ReuseCound = 0;
-  };
-  std::shared_ptr<CachedInstance> CachedInst;
+  std::mutex mtx;
+
+  std::unique_ptr<CompilerInstance> CachedCI;
+  llvm::hash_code CachedArgHash;
+  unsigned CachedReuseCound = 0;
 
   /// Calls \p Callback with cached \c CompilerInstance if it's usable for the
   /// specified completion request.

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -40,9 +40,12 @@ class CompletionInstance {
   unsigned MaxASTReuseCount = 100;
   bool EnableASTCaching = false;
 
-  std::shared_ptr<CompilerInstance> CachedCI = nullptr;
-  llvm::hash_code CachedArgsHash;
-  unsigned CurrentASTReuseCount = 0;
+  struct CachedInstance {
+    CompilerInstance CI;
+    llvm::hash_code ArgHash;
+    unsigned ReuseCound = 0;
+  };
+  std::shared_ptr<CachedInstance> CachedInst;
 
   /// Calls \p Callback with cached \c CompilerInstance if it's usable for the
   /// specified completion request.

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -37,6 +37,8 @@ makeCodeCompletionMemoryBuffer(const llvm::MemoryBuffer *origBuf,
 class CompletionInstance {
   std::unique_ptr<CompilerInstance> CachedCI = nullptr;
   bool EnableASTCaching = false;
+  unsigned MaxASTReuseCount = 100;
+  unsigned CurrentASTReuseCount = 0;
 
   swift::CompilerInstance *
   getReusingCompilerInstance(const swift::CompilerInvocation &Invocation,

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -36,6 +36,7 @@ makeCodeCompletionMemoryBuffer(const llvm::MemoryBuffer *origBuf,
 
 class CompletionInstance {
   std::unique_ptr<CompilerInstance> CachedCI = nullptr;
+  bool EnableASTCaching = false;
 
   swift::CompilerInstance *
   getReusingCompilerInstance(const swift::CompilerInvocation &Invocation,
@@ -49,6 +50,10 @@ class CompletionInstance {
       std::string &Error, DiagnosticConsumer *DiagC);
 
 public:
+  void setEnableASTCaching(bool Flag) {
+    EnableASTCaching = Flag;
+  }
+
   swift::CompilerInstance *getCompilerInstance(
       swift::CompilerInvocation &Invocation,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -1,0 +1,62 @@
+//===--- CompletionInstance.h ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IDE_COMPLETIONINSTANCE_H
+#define SWIFT_IDE_COMPLETIONINSTANCE_H
+
+#include "swift/Frontend/Frontend.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/VirtualFileSystem.h"
+
+namespace swift {
+
+class CompilerInstance;
+class CompilerInvocation;
+class DiagnosticConsumer;
+
+namespace ide {
+
+/// Copy a memory buffer inserting '0' at the position of \c origBuf.
+std::unique_ptr<llvm::MemoryBuffer>
+makeCodeCompletionMemoryBuffer(const llvm::MemoryBuffer *origBuf,
+                               unsigned &Offset,
+                               llvm::StringRef bufferIdentifier);
+
+class CompletionInstance {
+  std::unique_ptr<CompilerInstance> CachedCI = nullptr;
+
+  swift::CompilerInstance *
+  getReusingCompilerInstance(const swift::CompilerInvocation &Invocation,
+                             llvm::MemoryBuffer *completionBuffer,
+                             unsigned int Offset, DiagnosticConsumer *DiagC);
+
+  swift::CompilerInstance *renewCompilerInstance(
+      swift::CompilerInvocation &Invocation,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+      llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
+      std::string &Error, DiagnosticConsumer *DiagC);
+
+public:
+  swift::CompilerInstance *getCompilerInstance(
+      swift::CompilerInvocation &Invocation,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+      llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
+      std::string &Error, DiagnosticConsumer *DiagC);
+};
+
+} // namespace ide
+} // namespace swift
+
+#endif // SWIFT_IDE_COMPLETIONINSTANCE_H

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -47,9 +47,9 @@ class CompletionInstance {
   /// changed, primary file is not the same, the \c Offset is not in function
   /// bodies, or the interface hash of the file has changed.
   swift::CompilerInstance *
-  getReusingCompilerInstance(const swift::CompilerInvocation &Invocation,
-                             llvm::MemoryBuffer *completionBuffer,
-                             unsigned int Offset, DiagnosticConsumer *DiagC);
+  getCachedCompilerInstance(const swift::CompilerInvocation &Invocation,
+                            llvm::MemoryBuffer *completionBuffer,
+                            unsigned int Offset, DiagnosticConsumer *DiagC);
 
   /// Returns new \c CompilerInstance for the completion request. Users still
   /// have to call \c performParseAndResolveImportsOnly() , and perform the

--- a/include/swift/Parse/LocalContext.h
+++ b/include/swift/Parse/LocalContext.h
@@ -19,6 +19,7 @@
 #define SWIFT_PARSE_LOCALCONTEXT_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "swift/AST/Identifier.h"
 #include <cassert>
 
 namespace swift {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1642,12 +1642,8 @@ public:
   //===--------------------------------------------------------------------===//
   // Code completion second pass.
 
-  static void
-  performCodeCompletionSecondPass(PersistentParserState &ParserState,
-                                  CodeCompletionCallbacksFactory &Factory);
-
   void performCodeCompletionSecondPassImpl(
-      PersistentParserState::CodeCompletionDelayedDeclState &info);
+      CodeCompletionDelayedDeclState &info);
 };
 
 /// Describes a parsed declaration name.

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -37,13 +37,13 @@ enum class CodeCompletionDelayedDeclKind {
 
 class CodeCompletionDelayedDeclState {
 public:
-  const CodeCompletionDelayedDeclKind Kind;
-  const unsigned Flags;
-  DeclContext *const ParentContext;
+  CodeCompletionDelayedDeclKind Kind;
+  unsigned Flags;
+  DeclContext *ParentContext;
   SavedScope Scope;
-  const unsigned StartOffset;
-  const unsigned EndOffset;
-  const unsigned PrevOffset;
+  unsigned StartOffset;
+  unsigned EndOffset;
+  unsigned PrevOffset;
 
   SavedScope takeScope() { return std::move(Scope); }
 
@@ -95,9 +95,15 @@ public:
                                          DeclContext *ParentContext,
                                          SourceRange BodyRange,
                                          SourceLoc PreviousLoc);
+  void restoreCodeCompletionDelayedDeclState(
+      const CodeCompletionDelayedDeclState &other);
 
   bool hasCodeCompletionDelayedDeclState() {
     return CodeCompletionDelayedDeclStat.get() != nullptr;
+  }
+
+  CodeCompletionDelayedDeclState &getCodeCompletionDelayedDeclState() {
+    return *CodeCompletionDelayedDeclStat.get();
   }
 
   std::unique_ptr<CodeCompletionDelayedDeclState>

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -29,6 +29,33 @@ class SourceFile;
 class DeclContext;
 class IterableDeclContext;
 
+enum class CodeCompletionDelayedDeclKind {
+  TopLevelCodeDecl,
+  Decl,
+  FunctionBody,
+};
+
+class CodeCompletionDelayedDeclState {
+public:
+  const CodeCompletionDelayedDeclKind Kind;
+  const unsigned Flags;
+  DeclContext *const ParentContext;
+  SavedScope Scope;
+  const unsigned StartOffset;
+  const unsigned EndOffset;
+  const unsigned PrevOffset;
+
+  SavedScope takeScope() { return std::move(Scope); }
+
+  CodeCompletionDelayedDeclState(CodeCompletionDelayedDeclKind Kind,
+                                 unsigned Flags, DeclContext *ParentContext,
+                                 SavedScope &&Scope, unsigned StartOffset,
+                                 unsigned EndOffset, unsigned PrevOffset)
+      : Kind(Kind), Flags(Flags), ParentContext(ParentContext),
+        Scope(std::move(Scope)), StartOffset(StartOffset), EndOffset(EndOffset),
+        PrevOffset(PrevOffset) {}
+};
+
 /// Parser state persistent across multiple parses.
 class PersistentParserState {
 public:
@@ -37,36 +64,6 @@ public:
     SourceLoc PrevLoc;
 
     bool isValid() const { return Loc.isValid(); }
-  };
-
-  enum class CodeCompletionDelayedDeclKind {
-    TopLevelCodeDecl,
-    Decl,
-    FunctionBody,
-  };
-
-  class CodeCompletionDelayedDeclState {
-    friend class PersistentParserState;
-    friend class Parser;
-    CodeCompletionDelayedDeclKind Kind;
-    unsigned Flags;
-    DeclContext *ParentContext;
-    ParserPos BodyPos;
-    SourceLoc BodyEnd;
-    SavedScope Scope;
-
-    SavedScope takeScope() {
-      return std::move(Scope);
-    }
-
-  public:
-    CodeCompletionDelayedDeclState(CodeCompletionDelayedDeclKind Kind,
-                                   unsigned Flags, DeclContext *ParentContext,
-                                   SourceRange BodyRange, SourceLoc PreviousLoc,
-                                   SavedScope &&Scope)
-        : Kind(Kind), Flags(Flags),
-          ParentContext(ParentContext), BodyPos{BodyRange.Start, PreviousLoc},
-          BodyEnd(BodyRange.End), Scope(std::move(Scope)) {}
   };
 
   bool InPoundLineEnvironment = false;
@@ -92,7 +89,8 @@ public:
   PersistentParserState(ASTContext &ctx) : PersistentParserState() { }
   ~PersistentParserState();
 
-  void setCodeCompletionDelayedDeclState(CodeCompletionDelayedDeclKind Kind,
+  void setCodeCompletionDelayedDeclState(SourceManager &SM, unsigned BufferID,
+                                         CodeCompletionDelayedDeclKind Kind,
                                          unsigned Flags,
                                          DeclContext *ParentContext,
                                          SourceRange BodyRange,

--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -141,6 +141,8 @@ class Scope {
   bool isResolvable() const;
 
 public:
+  Scope(ScopeInfo &SI, ScopeKind SC, bool isInactiveConfigBlock = false);
+
   /// Create a lexical scope of the specified kind.
   Scope(Parser *P, ScopeKind SC, bool isInactiveConfigBlock = false);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6621,6 +6621,20 @@ BraceStmt *AbstractFunctionDecl::getBody(bool canSynthesize) const {
                            nullptr);
 }
 
+void AbstractFunctionDecl::setBody(BraceStmt *S, BodyKind NewBodyKind) {
+  assert(getBodyKind() != BodyKind::Skipped &&
+         "cannot set a body if it was skipped");
+
+  Body = S;
+  setBodyKind(NewBodyKind);
+
+  // Need to recompute init body kind.
+  if (NewBodyKind < BodyKind::TypeChecked) {
+    if (auto *ctor = dyn_cast<ConstructorDecl>(this))
+      ctor->clearCachedDelegatingOrChainedInitKind();
+  }
+}
+
 SourceRange AbstractFunctionDecl::getBodySourceRange() const {
   switch (getBodyKind()) {
   case BodyKind::None:
@@ -7397,8 +7411,11 @@ ConstructorDecl::getDelegatingOrChainedInitKind(DiagnosticEngine *diags,
 
   // If we already computed the result, return it.
   if (Bits.ConstructorDecl.ComputedBodyInitKind) {
-    return static_cast<BodyInitKind>(
-             Bits.ConstructorDecl.ComputedBodyInitKind - 1);
+    auto Kind = static_cast<BodyInitKind>(
+        Bits.ConstructorDecl.ComputedBodyInitKind - 1);
+    assert((Kind == BodyInitKind::None || !init) &&
+           "can't return cached result with the init expr");
+    return Kind;
   }
 
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -894,12 +894,6 @@ void CompilerInstance::parseAndCheckTypesUpTo(
     }
   });
 
-  if (Invocation.isCodeCompletion()) {
-    assert(limitStage == SourceFile::NameBound);
-    performCodeCompletionSecondPass(*PersistentState.get(),
-                                    *Invocation.getCodeCompletionFactory());
-  }
-
   // If the limiting AST stage is name binding, we're done.
   if (limitStage <= SourceFile::NameBound) {
     return;

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_host_library(swiftIDE STATIC
   CodeCompletion.cpp
   CodeCompletionCache.cpp
   CommentConversion.cpp
+  CompletionInstance.cpp
   ConformingMethodList.cpp
   ExprContextAnalysis.cpp
   Formatting.cpp

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -74,7 +74,7 @@ template <typename Range> Decl *getElementAt(const Range &Decls, unsigned N) {
 /// This assumes the AST which contains \p DC has exact the same structure with
 /// \p SF.
 /// FIXME: This doesn't support IfConfigDecl blocks. If \p DC is in an inactive
-///        config block, this function probably returns false.
+///        config block, this function returns \c false.
 static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
                                                            SourceFile *SF) {
   auto *newDC = DC;

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -202,6 +202,11 @@ CompilerInstance *CompletionInstance::getReusingCompilerInstance(
   if (!EnableASTCaching)
     return nullptr;
 
+  if (CurrentASTReuseCount >= MaxASTReuseCount) {
+    CurrentASTReuseCount = 0;
+    return nullptr;
+  }
+
   if (!CachedCI)
     return nullptr;
 
@@ -295,6 +300,8 @@ CompilerInstance *CompletionInstance::getReusingCompilerInstance(
   CachedCI->getDiags().diagnose(
       SM.getLocForOffset(BufferID, newInfo.StartOffset),
       diag::completion_reusing_astcontext);
+
+  CurrentASTReuseCount += 1;
 
   return CachedCI.get();
 }

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -1,0 +1,276 @@
+//===--- CompletionInstance.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/IDE/CompletionInstance.h"
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/SourceFile.h"
+#include "swift/Basic/LangOptions.h"
+#include "swift/Basic/SourceManager.h"
+#include "swift/Driver/FrontendUtil.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/Parse/PersistentParserState.h"
+#include "swift/Subsystems.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+using namespace swift;
+using namespace ide;
+
+std::unique_ptr<llvm::MemoryBuffer>
+swift::ide::makeCodeCompletionMemoryBuffer(const llvm::MemoryBuffer *origBuf,
+                                           unsigned &Offset,
+                                           StringRef bufferIdentifier) {
+
+  auto origBuffSize = origBuf->getBufferSize();
+  if (Offset > origBuffSize)
+    Offset = origBuffSize;
+
+  auto newBuffer = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
+      origBuffSize + 1, bufferIdentifier);
+  auto *pos = origBuf->getBufferStart() + Offset;
+  auto *newPos =
+      std::copy(origBuf->getBufferStart(), pos, newBuffer->getBufferStart());
+  *newPos = '\0';
+  std::copy(pos, origBuf->getBufferEnd(), newPos + 1);
+
+  return std::unique_ptr<llvm::MemoryBuffer>(newBuffer.release());
+}
+
+namespace {
+/// Returns index number of \p D in \p Decls . If it's not found, returns ~0.
+template <typename Range>
+unsigned findIndexInRange(Decl *D, const Range &Decls) {
+  unsigned N = 0;
+  for (auto I = Decls.begin(), E = Decls.end(); I != E; ++I) {
+    if (*I == D)
+      return N;
+    ++N;
+  }
+  return ~0U;
+}
+
+/// Return the element at \p N in \p Decls .
+template <typename Range> Decl *getElementAt(const Range &Decls, unsigned N) {
+  assert(std::distance(Decls.begin(), Decls.end()) > N);
+  auto I = Decls.begin();
+  std::advance(I, N);
+  return *I;
+}
+
+/// Find the equivalent \c DeclContext with \p DC from \p SF AST.
+/// This assumes the AST which contains \p DC has exact the same structure with
+/// \p SF.
+/// FIXME: This doesn't support IfConfigDecl blocks. If \p DC is in an inactive
+///        config block, this function probably returns false.
+static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
+                                                           SourceFile *SF) {
+  auto *newDC = DC;
+  // NOTE: Shortcut for DC->getParentSourceFile() == SF case is not needed
+  // because they should be always different.
+
+  // Get the index path in the current AST.
+  SmallVector<unsigned, 4> IndexStack;
+  do {
+    auto *D = newDC->getAsDecl();
+    auto *parentDC = newDC->getParent();
+    unsigned N;
+    if (auto parentSF = dyn_cast<SourceFile>(parentDC))
+      N = findIndexInRange(D, parentSF->Decls);
+    else if (auto parentIDC =
+                 dyn_cast<IterableDeclContext>(parentDC->getAsDecl()))
+      N = findIndexInRange(D, parentIDC->getMembers());
+    else
+      llvm_unreachable("invalid DC kind for finding equivalent DC (indexpath)");
+
+    // Not found in the decl context tree.
+    // FIXME: Probably DC is in an inactive #if block.
+    if (N == ~0U) {
+      return nullptr;
+    }
+
+    IndexStack.push_back(N);
+    newDC = parentDC;
+  } while (!newDC->isModuleScopeContext());
+
+  assert(isa<SourceFile>(newDC) && "DC should be in a SourceFile");
+
+  // Query the equivalent decl context from the base SourceFile using the index
+  // path.
+  newDC = SF;
+  do {
+    auto N = IndexStack.pop_back_val();
+    Decl *D;
+    if (auto parentSF = dyn_cast<SourceFile>(newDC))
+      D = getElementAt(parentSF->Decls, N);
+    else if (auto parentIDC = dyn_cast<IterableDeclContext>(newDC->getAsDecl()))
+      D = getElementAt(parentIDC->getMembers(), N);
+    else
+      llvm_unreachable("invalid DC kind for finding equivalent DC (query)");
+    newDC = dyn_cast<DeclContext>(D);
+  } while (!IndexStack.empty());
+
+  assert(newDC->getContextKind() == DC->getContextKind());
+
+  return newDC;
+}
+} // namespace
+
+CompilerInstance *CompletionInstance::getReusingCompilerInstance(
+    const swift::CompilerInvocation &Invocation,
+    llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
+    DiagnosticConsumer *DiagC) {
+  if (!CachedCI)
+    return nullptr;
+
+  if (Invocation.getPCHHash() != CachedCI->getInvocation().getPCHHash())
+    return nullptr;
+
+  auto &oldState = CachedCI->getPersistentParserState();
+  if (!oldState.hasCodeCompletionDelayedDeclState())
+    return nullptr;
+
+  auto &SM = CachedCI->getSourceMgr();
+  if (SM.getIdentifierForBuffer(SM.getCodeCompletionBufferID()) !=
+      completionBuffer->getBufferIdentifier())
+    return nullptr;
+
+  auto &oldInfo = oldState.getCodeCompletionDelayedDeclState();
+
+  // Currently, only completions within a function body is supported.
+  if (oldInfo.Kind != CodeCompletionDelayedDeclKind::FunctionBody)
+    return nullptr;
+
+  auto newBufferID = SM.addMemBufferCopy(completionBuffer);
+  SM.setCodeCompletionPoint(newBufferID, Offset);
+
+  // Parse the new buffer into temporary SourceFile.
+  LangOptions langOpts;
+  langOpts.DisableParserLookup = true;
+  TypeCheckerOptions typeckOpts;
+  SearchPathOptions searchPathOpts;
+  DiagnosticEngine Diags(SM);
+  std::unique_ptr<ASTContext> Ctx(
+      ASTContext::get(langOpts, typeckOpts, searchPathOpts, SM, Diags));
+  registerIDERequestFunctions(Ctx->evaluator);
+  registerTypeCheckerRequestFunctions(Ctx->evaluator);
+  ModuleDecl *M = ModuleDecl::create(Identifier(), *Ctx);
+  unsigned BufferID = SM.getCodeCompletionBufferID();
+  PersistentParserState newState;
+  SourceFile *newSF =
+      new (*Ctx) SourceFile(*M, SourceFileKind::Library, BufferID,
+                            SourceFile::ImplicitModuleImportKind::None);
+  newSF->enableInterfaceHash();
+  parseIntoSourceFileFull(*newSF, BufferID, &newState);
+  // Couldn't find any completion token?
+  if (!newState.hasCodeCompletionDelayedDeclState())
+    return nullptr;
+
+  auto &newInfo = newState.getCodeCompletionDelayedDeclState();
+
+  // The new completion must happens in function body too.
+  if (newInfo.Kind != CodeCompletionDelayedDeclKind::FunctionBody)
+    return nullptr;
+
+  auto *oldSF = oldInfo.ParentContext->getParentSourceFile();
+
+  // If the interface has changed, AST must be refreshed.
+  llvm::SmallString<32> oldInterfaceHash{};
+  llvm::SmallString<32> newInterfaceHash{};
+  oldSF->getInterfaceHash(oldInterfaceHash);
+  newSF->getInterfaceHash(newInterfaceHash);
+  if (oldInterfaceHash != newInterfaceHash)
+    return nullptr;
+
+  DeclContext *DC =
+      getEquivalentDeclContextFromSourceFile(newInfo.ParentContext, oldSF);
+  if (!DC)
+    return nullptr;
+
+  // OK, we can perform fast completion for this. Update the orignal delayed
+  // decl state.
+
+  // Construct dummy scopes. We don't need to restore the original scope
+  // because they are probably not 'isResolvable()' anyway.
+  auto &SI = oldState.getScopeInfo();
+  assert(SI.getCurrentScope() == nullptr);
+  Scope Top(SI, ScopeKind::TopLevel);
+  Scope Body(SI, ScopeKind::FunctionBody);
+
+  oldInfo.ParentContext = DC;
+  oldInfo.StartOffset = newInfo.StartOffset;
+  oldInfo.EndOffset = newInfo.EndOffset;
+  oldInfo.PrevOffset = newInfo.PrevOffset;
+  oldState.restoreCodeCompletionDelayedDeclState(oldInfo);
+
+  auto *AFD = cast<AbstractFunctionDecl>(DC);
+  if (AFD->isBodySkipped())
+    AFD->setBodyDelayed(AFD->getBodySourceRange());
+  if (DiagC)
+    CachedCI->addDiagnosticConsumer(DiagC);
+  return CachedCI.get();
+}
+
+CompilerInstance *CompletionInstance::renewCompilerInstance(
+    swift::CompilerInvocation &Invocation,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+    llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
+    std::string &Error, DiagnosticConsumer *DiagC) {
+  CachedCI.reset();
+  CachedCI = std::make_unique<CompilerInstance>();
+  auto *CI = CachedCI.get();
+  if (DiagC)
+    CachedCI->addDiagnosticConsumer(DiagC);
+
+  if (FileSystem != llvm::vfs::getRealFileSystem())
+    CI->getSourceMgr().setFileSystem(FileSystem);
+
+  Invocation.setCodeCompletionPoint(completionBuffer, Offset);
+
+  if (CI->setup(Invocation)) {
+    Error = "failed to setup compiler instance";
+    return nullptr;
+  }
+  registerIDERequestFunctions(CI->getASTContext().evaluator);
+
+  return CI;
+}
+
+CompilerInstance *swift::ide::CompletionInstance::getCompilerInstance(
+    swift::CompilerInvocation &Invocation,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+    llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
+    std::string &Error, DiagnosticConsumer *DiagC) {
+
+  // Always disable source location resolutions from .swiftsourceinfo file
+  // because they're somewhat heavy operations and aren't needed for completion.
+  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+
+  // Disable to build syntax tree because code-completion skips some portion of
+  // source text. That breaks an invariant of syntax tree building.
+  Invocation.getLangOptions().BuildSyntaxTree = false;
+
+  // FIXME: ASTScopeLookup doesn't support code completion yet.
+  Invocation.disableASTScopeLookup();
+
+  if (auto *cached = getReusingCompilerInstance(Invocation, completionBuffer,
+                                                Offset, DiagC))
+    return cached;
+
+  if (auto *renewed = renewCompilerInstance(
+          Invocation, FileSystem, completionBuffer, Offset, Error, DiagC))
+    return renewed;
+
+  assert(!Error.empty());
+  return nullptr;
+}

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -14,6 +14,7 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/LangOptions.h"
@@ -290,6 +291,11 @@ CompilerInstance *CompletionInstance::getReusingCompilerInstance(
     AFD->setBodyDelayed(AFD->getBodySourceRange());
   if (DiagC)
     CachedCI->addDiagnosticConsumer(DiagC);
+
+  CachedCI->getDiags().diagnose(
+      SM.getLocForOffset(BufferID, newInfo.StartOffset),
+      diag::completion_reusing_astcontext);
+
   return CachedCI.get();
 }
 

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -195,7 +195,7 @@ static llvm::hash_code calculateInvocationHash(const CompilerInvocation &Inv) {
 
 } // namespace
 
-CompilerInstance *CompletionInstance::getReusingCompilerInstance(
+CompilerInstance *CompletionInstance::getCachedCompilerInstance(
     const swift::CompilerInvocation &Invocation,
     llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
     DiagnosticConsumer *DiagC) {
@@ -348,8 +348,8 @@ CompilerInstance *swift::ide::CompletionInstance::getCompilerInstance(
   // FIXME: ASTScopeLookup doesn't support code completion yet.
   Invocation.disableASTScopeLookup();
 
-  if (auto *cached = getReusingCompilerInstance(Invocation, completionBuffer,
-                                                Offset, DiagC))
+  if (auto *cached = getCachedCompilerInstance(Invocation, completionBuffer,
+                                              Offset, DiagC))
     return cached;
 
   if (auto *renewed = renewCompilerInstance(

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -130,6 +130,9 @@ CompilerInstance *CompletionInstance::getReusingCompilerInstance(
     const swift::CompilerInvocation &Invocation,
     llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
     DiagnosticConsumer *DiagC) {
+  if (!EnableASTCaching)
+    return nullptr;
+
   if (!CachedCI)
     return nullptr;
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3437,7 +3437,8 @@ void Parser::consumeDecl(ParserPosition BeginParserPosition,
   SourceLoc BeginLoc = Tok.getLoc();
 
   State->setCodeCompletionDelayedDeclState(
-      PersistentParserState::CodeCompletionDelayedDeclKind::Decl,
+      SourceMgr, L->getBufferID(),
+      CodeCompletionDelayedDeclKind::Decl,
       Flags.toRaw(), CurDeclContext, {BeginLoc, EndLoc},
       BeginParserPosition.PreviousLoc);
 
@@ -3953,7 +3954,7 @@ std::vector<Decl *> Parser::parseDeclListDelayed(IterableDeclContext *IDC) {
     return { };
   }
 
-  auto BeginParserPosition = getParserPosition({BodyRange.Start,BodyRange.End});
+  auto BeginParserPosition = getParserPosition({BodyRange.Start, SourceLoc()});
   auto EndLexerState = L->getStateForEndOfTokenLoc(BodyRange.End);
 
   // ParserPositionRAII needs a primed parser to restore to.
@@ -6014,7 +6015,8 @@ void Parser::consumeAbstractFunctionBody(AbstractFunctionDecl *AFD,
   if (isCodeCompletionFirstPass()) {
     if (SourceMgr.rangeContainsCodeCompletionLoc(BodyRange)) {
       State->setCodeCompletionDelayedDeclState(
-          PersistentParserState::CodeCompletionDelayedDeclKind::FunctionBody,
+          SourceMgr, L->getBufferID(),
+          CodeCompletionDelayedDeclKind::FunctionBody,
           PD_Default, AFD, BodyRange, BeginParserPosition.PreviousLoc);
     } else {
       AFD->setBodySkipped(BodyRange);
@@ -6302,7 +6304,7 @@ BraceStmt *Parser::parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD) {
          "function body should be delayed");
 
   auto bodyRange = AFD->getBodySourceRange();
-  auto BeginParserPosition = getParserPosition({bodyRange.Start,bodyRange.End});
+  auto BeginParserPosition = getParserPosition({bodyRange.Start,SourceLoc()});
   auto EndLexerState = L->getStateForEndOfTokenLoc(AFD->getEndLoc());
 
   // ParserPositionRAII needs a primed parser to restore to.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6211,19 +6211,6 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
 
 /// Parse function body into \p AFD.
 void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
-  Scope S(this, ScopeKind::FunctionBody);
-
-  // Enter the arguments for the function into a new function-body scope.  We
-  // need this even if there is no function body to detect argument name
-  // duplication.
-  if (auto *P = AFD->getImplicitSelfDecl())
-    addToScope(P);
-  addParametersToScope(AFD->getParameters());
-
-   // Establish the new context.
-  ParseFunctionBody CC(*this, AFD);
-  setLocalDiscriminatorToParamList(AFD->getParameters());
-
   if (!Tok.is(tok::l_brace)) {
     checkForInputIncomplete();
     return;
@@ -6240,6 +6227,19 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
     consumeAbstractFunctionBody(AFD, AFD->getAttrs());
     return;
   }
+
+  Scope S(this, ScopeKind::FunctionBody);
+
+  // Enter the arguments for the function into a new function-body scope.  We
+  // need this even if there is no function body to detect argument name
+  // duplication.
+  if (auto *P = AFD->getImplicitSelfDecl())
+    addToScope(P);
+  addParametersToScope(AFD->getParameters());
+
+   // Establish the new context.
+  ParseFunctionBody CC(*this, AFD);
+  setLocalDiscriminatorToParamList(AFD->getParameters());
 
   if (Context.Stats)
     Context.Stats->getFrontendCounters().NumFunctionsParsed++;
@@ -6304,7 +6304,7 @@ BraceStmt *Parser::parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD) {
          "function body should be delayed");
 
   auto bodyRange = AFD->getBodySourceRange();
-  auto BeginParserPosition = getParserPosition({bodyRange.Start,SourceLoc()});
+  auto BeginParserPosition = getParserPosition({bodyRange.Start, SourceLoc()});
   auto EndLexerState = L->getStateForEndOfTokenLoc(AFD->getEndLoc());
 
   // ParserPositionRAII needs a primed parser to restore to.
@@ -6326,6 +6326,9 @@ BraceStmt *Parser::parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD) {
   // Re-enter the lexical scope.
   Scope TopLevelScope(this, ScopeKind::TopLevel);
   Scope S(this, ScopeKind::FunctionBody);
+  if (auto *P = AFD->getImplicitSelfDecl())
+    addToScope(P);
+  addParametersToScope(AFD->getParameters());
   ParseFunctionBody CC(*this, AFD);
   setLocalDiscriminatorToParamList(AFD->getParameters());
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -257,7 +257,8 @@ void Parser::consumeTopLevelDecl(ParserPosition BeginParserPosition,
   backtrackToPosition(BeginParserPosition);
   SourceLoc BeginLoc = Tok.getLoc();
   State->setCodeCompletionDelayedDeclState(
-      PersistentParserState::CodeCompletionDelayedDeclKind::TopLevelCodeDecl,
+      SourceMgr, L->getBufferID(),
+      CodeCompletionDelayedDeclKind::TopLevelCodeDecl,
       PD_Default, TLCD, {BeginLoc, EndLoc}, BeginParserPosition.PreviousLoc);
 
   // Skip the rest of the file to prevent the parser from constructing the AST

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
+#include "swift/Basic/SourceManager.h"
 #include "swift/Parse/PersistentParserState.h"
 
 using namespace swift;
@@ -26,13 +27,20 @@ PersistentParserState::PersistentParserState() { }
 PersistentParserState::~PersistentParserState() { }
 
 void PersistentParserState::setCodeCompletionDelayedDeclState(
+    SourceManager &SM, unsigned BufferID,
     CodeCompletionDelayedDeclKind Kind, unsigned Flags,
     DeclContext *ParentContext, SourceRange BodyRange, SourceLoc PreviousLoc) {
   assert(!CodeCompletionDelayedDeclStat.get() &&
          "only one decl can be delayed for code completion");
+  unsigned startOffset = SM.getLocOffsetInBuffer(BodyRange.Start, BufferID);
+  unsigned endOffset = SM.getLocOffsetInBuffer(BodyRange.End, BufferID);
+  unsigned prevOffset = ~0U;
+  if (PreviousLoc.isValid())
+    prevOffset = SM.getLocOffsetInBuffer(PreviousLoc, BufferID);
+
   CodeCompletionDelayedDeclStat.reset(new CodeCompletionDelayedDeclState(
-      Kind, Flags, ParentContext, BodyRange, PreviousLoc,
-      ScopeInfo.saveCurrentScope()));
+      Kind, Flags, ParentContext, ScopeInfo.saveCurrentScope(),
+      startOffset, endOffset, prevOffset));
 }
 
 void PersistentParserState::delayDeclList(IterableDeclContext *D) {

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -27,9 +27,9 @@ PersistentParserState::PersistentParserState() { }
 PersistentParserState::~PersistentParserState() { }
 
 void PersistentParserState::setCodeCompletionDelayedDeclState(
-    SourceManager &SM, unsigned BufferID,
-    CodeCompletionDelayedDeclKind Kind, unsigned Flags,
-    DeclContext *ParentContext, SourceRange BodyRange, SourceLoc PreviousLoc) {
+    SourceManager &SM, unsigned BufferID, CodeCompletionDelayedDeclKind Kind,
+    unsigned Flags, DeclContext *ParentContext, SourceRange BodyRange,
+    SourceLoc PreviousLoc) {
   assert(!CodeCompletionDelayedDeclStat.get() &&
          "only one decl can be delayed for code completion");
   unsigned startOffset = SM.getLocOffsetInBuffer(BodyRange.Start, BufferID);
@@ -39,8 +39,16 @@ void PersistentParserState::setCodeCompletionDelayedDeclState(
     prevOffset = SM.getLocOffsetInBuffer(PreviousLoc, BufferID);
 
   CodeCompletionDelayedDeclStat.reset(new CodeCompletionDelayedDeclState(
-      Kind, Flags, ParentContext, ScopeInfo.saveCurrentScope(),
-      startOffset, endOffset, prevOffset));
+      Kind, Flags, ParentContext, ScopeInfo.saveCurrentScope(), startOffset,
+      endOffset, prevOffset));
+}
+
+void PersistentParserState::restoreCodeCompletionDelayedDeclState(
+    const CodeCompletionDelayedDeclState &other) {
+  CodeCompletionDelayedDeclStat.reset(new CodeCompletionDelayedDeclState(
+      other.Kind, other.Flags, other.ParentContext,
+      ScopeInfo.saveCurrentScope(), other.StartOffset, other.EndOffset,
+      other.PrevOffset));
 }
 
 void PersistentParserState::delayDeclList(IterableDeclContext *D) {

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -50,14 +50,14 @@ static bool isResolvableScope(ScopeKind SK) {
 }
 
 Scope::Scope(Parser *P, ScopeKind SC, bool isInactiveConfigBlock)
-  : SI(P->getScopeInfo()),
-    HTScope(SI.HT, SI.CurScope ? &SI.CurScope->HTScope : nullptr),
-    PrevScope(SI.CurScope),
-    PrevResolvableDepth(SI.ResolvableDepth),
-    Kind(SC),
-    IsInactiveConfigBlock(isInactiveConfigBlock) {
+    : Scope(P->getScopeInfo(), SC, isInactiveConfigBlock) {}
+
+Scope::Scope(ScopeInfo &SI, ScopeKind SC, bool isInactiveConfigBlock)
+    : SI(SI), HTScope(SI.HT, SI.CurScope ? &SI.CurScope->HTScope : nullptr),
+      PrevScope(SI.CurScope), PrevResolvableDepth(SI.ResolvableDepth), Kind(SC),
+      IsInactiveConfigBlock(isInactiveConfigBlock) {
   assert(PrevScope || Kind == ScopeKind::TopLevel);
-  
+
   if (SI.CurScope) {
     Depth = SI.CurScope->Depth + 1;
     IsInactiveConfigBlock |= SI.CurScope->IsInactiveConfigBlock;

--- a/test/SourceKit/CodeComplete/complete_sequence.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence.swift
@@ -1,0 +1,55 @@
+class Foo {
+  var x: Int
+  var y: Int
+  func fooMethod() {}
+}
+struct Bar {
+  var a: Int
+  var b: Int
+  func barMethod() {}
+}
+func foo(arg: Foo) {
+  _ = arg.
+}
+func bar(arg: Bar) {
+  _ = arg.
+}
+
+// NOTE: Tests for 'key.codecomplete.reuseastcontex' option.
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=track-compiles == \
+// RUN:   -req=complete -pos=12:11 %s -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -- %s > %t.response
+// RUN: %FileCheck --check-prefix=RESULT %s < %t.response
+// RUN: %FileCheck --check-prefix=TRACE_NORMAL %s < %t.response
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=track-compiles == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -- %s > %t.response.reuseastcontext
+// RUN: %FileCheck --check-prefix=RESULT  %s < %t.response.reuseastcontext
+// RUN: %FileCheck --check-prefix=TRACE_REUSEAST  %s < %t.response.reuseastcontext
+
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.name: "fooMethod()"
+// RESULT-DAG: key.name: "self"
+// RESULT-DAG: key.name: "x"
+// RESULT-DAG: key.name: "y"
+// RESULT: ]
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.name: "barMethod()"
+// RESULT-DAG: key.name: "self"
+// RESULT-DAG: key.name: "a"
+// RESULT-DAG: key.name: "b"
+// RESULT: ]
+
+// TRACE_NORMAL-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE_NORMAL-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// TRACE_NORMAL-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE_NORMAL-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+
+// TRACE_REUSEAST-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE_REUSEAST-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// TRACE_REUSEAST-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE_REUSEAST: key.description: "completion reusing previous ASTContext (benign diagnostic)"

--- a/test/SourceKit/CodeComplete/complete_sequence.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence.swift
@@ -17,6 +17,7 @@ func bar(arg: Bar) {
 
 // NOTE: Tests for 'key.codecomplete.reuseastcontex' option.
 
+// Disabled.
 // RUN: %sourcekitd-test \
 // RUN:   -req=track-compiles == \
 // RUN:   -req=complete -pos=12:11 %s -- %s == \
@@ -24,12 +25,21 @@ func bar(arg: Bar) {
 // RUN: %FileCheck --check-prefix=RESULT %s < %t.response
 // RUN: %FileCheck --check-prefix=TRACE_NORMAL %s < %t.response
 
+// Enabled.
 // RUN: %sourcekitd-test \
 // RUN:   -req=track-compiles == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -- %s > %t.response.reuseastcontext
 // RUN: %FileCheck --check-prefix=RESULT  %s < %t.response.reuseastcontext
 // RUN: %FileCheck --check-prefix=TRACE_REUSEAST  %s < %t.response.reuseastcontext
+
+// Enabled - compiler argument mismatch.
+// RUN: %sourcekitd-test \
+// RUN:   -req=track-compiles == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -- %s -DNOTUSED == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -- -DNOTUSED %s > %t.response.reuseastcontext_argmismatch
+// RUN: %FileCheck --check-prefix=RESULT  %s < %t.response.reuseastcontext_argmismatch
+// RUN: %FileCheck --check-prefix=TRACE_NORMAL   %s < %t.response.reuseastcontext_argmismatch
 
 // RESULT-LABEL: key.results: [
 // RESULT-DAG: key.name: "fooMethod()"

--- a/test/SourceKit/CodeComplete/complete_sequence_crossfile.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_crossfile.swift
@@ -1,0 +1,55 @@
+// BEGIN file1.swift
+class Foo {
+  var x: Int
+  var y: Int
+}
+
+func foo(arg: Foo) {
+  _ = arg.
+}
+
+class Bar {
+  var a: Int
+  var b: Int
+  func barMethod() {}
+}
+
+// BEGIN file2.swift
+extension Foo {
+  func fooMethod() {}
+}
+
+func bar(arg: Bar) {
+  _ = arg.
+}
+
+extension Bar {
+  func barMethod() {}
+}
+
+// BEGIN dummy.swift
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=track-compiles == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=7:11 %t/file1.swift -- %t/file1.swift %t/file2.swift == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=6:11 %t/file2.swift -- %t/file1.swift %t/file2.swift > %t.response
+// RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
+// RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
+
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.name: "fooMethod()"
+// RESULT-DAG: key.name: "self"
+// RESULT-DAG: key.name: "x"
+// RESULT-DAG: key.name: "y"
+// RESULT: ]
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.name: "barMethod()"
+// RESULT-DAG: key.name: "self"
+// RESULT-DAG: key.name: "a"
+// RESULT-DAG: key.name: "b"
+// RESULT: ]
+
+// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"

--- a/test/SourceKit/CodeComplete/complete_sequence_edit.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_edit.swift
@@ -1,0 +1,89 @@
+// BEGIN State1.swift
+// Initial state.
+class Foo {
+  var x: Int
+  var y: Int
+  func fooMethod() {}
+}
+func foo(arg: Foo) {
+  _ = arg.
+}
+
+// BEGIN State2.swift
+// Compatible change: implemented 'Foo.fooMethod()', indentation change, added white line.
+class Foo {
+    var x: Int
+    var y: Int
+    func fooMethod() {
+        print(x + y)
+    }
+}
+
+func foo(arg: Foo) {
+    _ = arg.
+}
+
+// BEGIN State3.swift
+// Incompatible change: added 'Foo.z'
+class Foo {
+    var x: Int
+    var y: Int
+    var z: Int
+    func fooMethod() {
+        print(x + y)
+    }
+}
+
+func foo(arg: Foo) {
+    _ = arg.
+}
+
+// BEGIN DUMMY.swift
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=track-compiles == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=8:11 -name file.swift -text-input %t/State1.swift -- file.swift == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=11:13 -name file.swift -text-input %t/State2.swift -- file.swift == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:13 -name file.swift -text-input %t/State3.swift -- file.swift > %t.response
+// RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
+// RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
+
+// RESULT-LABEL: key.results: [
+// RESULT-NOT: key.name: "z"
+// RESULT-DAG: key.name: "fooMethod()"
+// RESULT-DAG: key.name: "self"
+// RESULT-DAG: key.name: "x"
+// RESULT-DAG: key.name: "y"
+// RESULT: ]
+
+// RESULT-LABEL: key.results: [
+// RESULT-NOT: key.name: "z"
+// RESULT-DAG: key.name: "fooMethod()"
+// RESULT-DAG: key.name: "self"
+// RESULT-DAG: key.name: "x"
+// RESULT-DAG: key.name: "y"
+// RESULT: ]
+
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.name: "fooMethod()"
+// RESULT-DAG: key.name: "self"
+// RESULT-DAG: key.name: "x"
+// RESULT-DAG: key.name: "y"
+// RESULT-DAG: key.name: "z"
+// RESULT: ]
+
+// TRACE:      key.notification: source.notification.compile-did-finish,
+// TRACE-NEXT: key.diagnostics: [
+// TRACE-NEXT: ]
+
+// TRACE:      key.notification: source.notification.compile-did-finish,
+// TRACE-NEXT: key.diagnostics: [
+// TRACE:          key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// TRACE:      ]
+
+// TRACE:      key.notification: source.notification.compile-did-finish,
+// TRACE-NEXT: key.diagnostics: [
+// TRACE-NEXT: ]

--- a/test/SourceKit/CodeComplete/complete_sequence_race.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_race.swift
@@ -1,0 +1,44 @@
+class Foo {
+  var x: Int
+  var y: Int
+  func fooMethod() {}
+}
+struct Bar {
+  var a: Int
+  var b: Int
+  func barMethod() {}
+}
+func foo(arg: Foo) {
+  _ = arg.
+}
+func bar(arg: Bar) {
+  _ = arg.
+}
+
+// NOTE: Test for simultaneous completion requests don't cause compiler crashes.
+
+// ReuseASTContext disabled.
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=15:11 %s -async -- %s
+
+// ReuseASTContext enabled.
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s

--- a/test/SourceKit/CodeComplete/complete_sequence_race.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_race.swift
@@ -23,10 +23,12 @@ func bar(arg: Bar) {
 // RUN:   -req=complete -pos=15:11 %s -async -- %s == \
 // RUN:   -req=complete -pos=12:11 %s -async -- %s == \
 // RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=17:1 %s -async -- %s == \
 // RUN:   -req=complete -pos=12:11 %s -async -- %s == \
 // RUN:   -req=complete -pos=15:11 %s -async -- %s == \
 // RUN:   -req=complete -pos=12:11 %s -async -- %s == \
 // RUN:   -req=complete -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -pos=17:1 %s -async -- %s == \
 // RUN:   -req=complete -pos=12:11 %s -async -- %s == \
 // RUN:   -req=complete -pos=15:11 %s -async -- %s
 
@@ -36,9 +38,11 @@ func bar(arg: Bar) {
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -async -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=17:1 %s -async -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -async -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -async -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=17:1 %s -async -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=12:11 %s -async -- %s == \
 // RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=15:11 %s -async -- %s

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -653,6 +653,7 @@ public:
 
   virtual void
   codeComplete(llvm::MemoryBuffer *InputBuf, unsigned Offset,
+               OptionsDictionary *options,
                CodeCompletionConsumer &Consumer, ArrayRef<const char *> Args,
                Optional<VFSOptions> vfsOptions) = 0;
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -801,13 +801,15 @@ public:
   virtual void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf,
                                         unsigned Offset,
                                         ArrayRef<const char *> Args,
-                                        TypeContextInfoConsumer &Consumer) = 0;
+                                        TypeContextInfoConsumer &Consumer,
+                                        Optional<VFSOptions> vfsOptions) = 0;
 
   virtual void getConformingMethodList(llvm::MemoryBuffer *inputBuf,
                                        unsigned Offset,
                                        ArrayRef<const char *> Args,
                                        ArrayRef<const char *> ExpectedTypes,
-                                       ConformingMethodListConsumer &Consumer) = 0;
+                                       ConformingMethodListConsumer &Consumer,
+                                       Optional<VFSOptions> vfsOptions) = 0;
 
   virtual void getStatistics(StatisticsReceiver) = 0;
 };

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -58,7 +58,7 @@ class ImportDepth {
 
 public:
   ImportDepth() = default;
-  ImportDepth(ASTContext &context, CompilerInvocation &invocation);
+  ImportDepth(ASTContext &context, const CompilerInvocation &invocation);
 
   Optional<uint8_t> lookup(StringRef module) {
     auto I = depths.find(module);
@@ -320,7 +320,8 @@ CodeCompletionViewRef CodeCompletionOrganizer::takeResultsView() {
 // ImportDepth
 //===----------------------------------------------------------------------===//
 
-ImportDepth::ImportDepth(ASTContext &context, CompilerInvocation &invocation) {
+ImportDepth::ImportDepth(ASTContext &context,
+                         const CompilerInvocation &invocation) {
   llvm::DenseSet<ModuleDecl *> seen;
   std::deque<std::pair<ModuleDecl *, uint8_t>> worklist;
 

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -53,7 +53,7 @@ struct Options {
 
 struct SwiftCompletionInfo {
   swift::ASTContext *swiftASTContext = nullptr;
-  swift::CompilerInvocation *invocation = nullptr;
+  const swift::CompilerInvocation *invocation = nullptr;
   swift::ide::CodeCompletionContext *completionContext = nullptr;
 };
 

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -42,6 +42,7 @@ struct Options {
   bool hideLowPriority = true;
   bool hideByNameStyle = true;
   bool fuzzyMatching = true;
+  bool reuseASTContextIfPossible = false;
   unsigned minFuzzyLength = 2;
   unsigned showTopNonLiteralResults = 3;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -176,7 +176,7 @@ static bool swiftCodeCompleteImpl(
   // Pin completion instance.
   auto CompletionInst =  Lang.getCompletionInstance();
   CompilerInstance *CI = CompletionInst->getCompilerInstance(
-      Invocation, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
+      Invocation, Args, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
   if (!CI)
     return false;
   SWIFT_DEFER { CI->removeDiagnosticConsumer(&CIDiags); };

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -1177,7 +1177,8 @@ static void transformAndForwardResults(
 void SwiftLangSupport::codeCompleteOpen(
     StringRef name, llvm::MemoryBuffer *inputBuf, unsigned offset,
     OptionsDictionary *options, ArrayRef<FilterRule> rawFilterRules,
-    GroupedCodeCompletionConsumer &consumer, ArrayRef<const char *> args, Optional<VFSOptions> vfsOptions) {
+    GroupedCodeCompletionConsumer &consumer, ArrayRef<const char *> args,
+    Optional<VFSOptions> vfsOptions) {
   StringRef filterText;
   unsigned resultOffset = 0;
   unsigned maxResults = 0;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -172,7 +172,10 @@ static bool swiftCodeCompleteImpl(
     Error = "no input filenames specified";
     return false;
   }
-  CompilerInstance *CI = Lang.getCompletionInstance().getCompilerInstance(
+
+  // Pin completion instance.
+  auto CompletionInst =  Lang.getCompletionInstance();
+  CompilerInstance *CI = CompletionInst->getCompilerInstance(
       Invocation, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
   if (!CI)
     return false;

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -16,6 +16,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/ConformingMethodList.h"
+#include "swift/IDE/CompletionInstance.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Comment.h"
 #include "clang/AST/Decl.h"
@@ -32,25 +33,30 @@ static bool swiftConformingMethodListImpl(
     ide::ConformingMethodListConsumer &Consumer,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) {
-  auto bufferIdentifier =
-      Lang.resolvePathSymlinks(UnresolvedInputFile->getBufferIdentifier());
+
+  // Resolve symlinks for the input file.
+  llvm::SmallString<128> bufferIdentifier;
+  if (auto err = FileSystem->getRealPath(
+          UnresolvedInputFile->getBufferIdentifier(), bufferIdentifier))
+    bufferIdentifier = UnresolvedInputFile->getBufferIdentifier();
 
   auto origOffset = Offset;
-  auto newBuffer = SwiftLangSupport::makeCodeCompletionMemoryBuffer(
+  auto newBuffer = ide::makeCodeCompletionMemoryBuffer(
       UnresolvedInputFile, Offset, bufferIdentifier);
 
-  CompilerInstance CI;
+  SourceManager SM;
+  DiagnosticEngine Diags(SM);
   PrintingDiagnosticConsumer PrintDiags;
-  CI.addDiagnosticConsumer(&PrintDiags);
-
   EditorDiagConsumer TraceDiags;
-  trace::TracedOperation TracedOp(trace::OperationKind::CodeCompletion);
+  trace::TracedOperation TracedOp{trace::OperationKind::CodeCompletion};
+
+  Diags.addConsumer(PrintDiags);
   if (TracedOp.enabled()) {
-    CI.addDiagnosticConsumer(&TraceDiags);
+    Diags.addConsumer(TraceDiags);
     trace::SwiftInvocation SwiftArgs;
     trace::initTraceInfo(SwiftArgs, bufferIdentifier, Args);
     TracedOp.setDiagnosticProvider(
-        [&TraceDiags](SmallVectorImpl<DiagnosticEntryInfo> &diags) {
+        [&](SmallVectorImpl<DiagnosticEntryInfo> &diags) {
           TraceDiags.getAllDiagnostics(diags);
         });
     TracedOp.start(
@@ -58,22 +64,27 @@ static bool swiftConformingMethodListImpl(
         {std::make_pair("OriginalOffset", std::to_string(origOffset)),
          std::make_pair("Offset", std::to_string(Offset))});
   }
+  ForwardingDiagnosticConsumer CIDiags(Diags);
 
   CompilerInvocation Invocation;
   bool Failed = Lang.getASTManager()->initCompilerInvocation(
-      Invocation, Args, CI.getDiags(), bufferIdentifier, FileSystem, Error);
+      Invocation, Args, Diags, newBuffer->getBufferIdentifier(), FileSystem,
+      Error);
   if (Failed)
     return false;
   if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
     Error = "no input filenames specified";
     return false;
   }
+  CompilerInstance *CI = Lang.getCompletionInstance().getCompilerInstance(
+      Invocation, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
+  if (!CI)
+    return false;
+  SWIFT_DEFER { CI->removeDiagnosticConsumer(&CIDiags); };
 
-  // Always disable source location resolutions from .swiftsourceinfo file
-  // because they're somewhat heavy operations and aren't needed for completion.
-  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
-
-  Invocation.setCodeCompletionPoint(newBuffer.get(), Offset);
+  // Perform the parsing and completion.
+  if (!CI->hasPersistentParserState())
+    CI->performParseAndResolveImportsOnly();
 
   // Create a factory for code completion callbacks that will feed the
   // Consumer.
@@ -81,18 +92,8 @@ static bool swiftConformingMethodListImpl(
       ide::makeConformingMethodListCallbacksFactory(ExpectedTypeNames,
                                                     Consumer));
 
-  Invocation.setCodeCompletionFactory(callbacksFactory.get());
-
-  if (FileSystem != llvm::vfs::getRealFileSystem()) {
-    CI.getSourceMgr().setFileSystem(FileSystem);
-  }
-
-  if (CI.setup(Invocation)) {
-    // FIXME: error?
-    return true;
-  }
-  registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
+  performCodeCompletionSecondPass(CI->getPersistentParserState(),
+                                  *callbacksFactory);
 
   return true;
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -32,9 +32,9 @@ static bool swiftConformingMethodListImpl(
     ArrayRef<const char *> ExpectedTypeNames,
     ide::ConformingMethodListConsumer &Consumer,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-    std::string &Error) {
+    bool EnableASTCaching, std::string &Error) {
   return Lang.performCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, FileSystem, Error,
+      UnresolvedInputFile, Offset, Args, FileSystem, EnableASTCaching, Error,
       [&](CompilerInstance &CI) {
         // Create a factory for code completion callbacks that will feed the
         // Consumer.
@@ -176,7 +176,7 @@ void SwiftLangSupport::getConformingMethodList(
 
   if (!swiftConformingMethodListImpl(*this, UnresolvedInputFile, Offset, Args,
                                      ExpectedTypeNames, Consumer, fileSystem,
-                                     error)) {
+                                     /*EnableASTCaching=*/false, error)) {
     SKConsumer.failed(error);
   }
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -76,7 +76,10 @@ static bool swiftConformingMethodListImpl(
     Error = "no input filenames specified";
     return false;
   }
-  CompilerInstance *CI = Lang.getCompletionInstance().getCompilerInstance(
+
+  // Pin completion instance.
+  auto CompletionInst =  Lang.getCompletionInstance();
+  CompilerInstance *CI = CompletionInst->getCompilerInstance(
       Invocation, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
   if (!CI)
     return false;

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -80,7 +80,7 @@ static bool swiftConformingMethodListImpl(
   // Pin completion instance.
   auto CompletionInst =  Lang.getCompletionInstance();
   CompilerInstance *CI = CompletionInst->getCompilerInstance(
-      Invocation, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
+      Invocation, Args, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
   if (!CI)
     return false;
   SWIFT_DEFER { CI->removeDiagnosticConsumer(&CIDiags); };

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -33,72 +33,18 @@ static bool swiftConformingMethodListImpl(
     ide::ConformingMethodListConsumer &Consumer,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) {
+  return Lang.performCompletionLikeOperation(
+      UnresolvedInputFile, Offset, Args, FileSystem, Error,
+      [&](CompilerInstance &CI) {
+        // Create a factory for code completion callbacks that will feed the
+        // Consumer.
+        std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
+            ide::makeConformingMethodListCallbacksFactory(ExpectedTypeNames,
+                                                          Consumer));
 
-  // Resolve symlinks for the input file.
-  llvm::SmallString<128> bufferIdentifier;
-  if (auto err = FileSystem->getRealPath(
-          UnresolvedInputFile->getBufferIdentifier(), bufferIdentifier))
-    bufferIdentifier = UnresolvedInputFile->getBufferIdentifier();
-
-  auto origOffset = Offset;
-  auto newBuffer = ide::makeCodeCompletionMemoryBuffer(
-      UnresolvedInputFile, Offset, bufferIdentifier);
-
-  SourceManager SM;
-  DiagnosticEngine Diags(SM);
-  PrintingDiagnosticConsumer PrintDiags;
-  EditorDiagConsumer TraceDiags;
-  trace::TracedOperation TracedOp{trace::OperationKind::CodeCompletion};
-
-  Diags.addConsumer(PrintDiags);
-  if (TracedOp.enabled()) {
-    Diags.addConsumer(TraceDiags);
-    trace::SwiftInvocation SwiftArgs;
-    trace::initTraceInfo(SwiftArgs, bufferIdentifier, Args);
-    TracedOp.setDiagnosticProvider(
-        [&](SmallVectorImpl<DiagnosticEntryInfo> &diags) {
-          TraceDiags.getAllDiagnostics(diags);
-        });
-    TracedOp.start(
-        SwiftArgs,
-        {std::make_pair("OriginalOffset", std::to_string(origOffset)),
-         std::make_pair("Offset", std::to_string(Offset))});
-  }
-  ForwardingDiagnosticConsumer CIDiags(Diags);
-
-  CompilerInvocation Invocation;
-  bool Failed = Lang.getASTManager()->initCompilerInvocation(
-      Invocation, Args, Diags, newBuffer->getBufferIdentifier(), FileSystem,
-      Error);
-  if (Failed)
-    return false;
-  if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
-    Error = "no input filenames specified";
-    return false;
-  }
-
-  // Pin completion instance.
-  auto CompletionInst =  Lang.getCompletionInstance();
-  CompilerInstance *CI = CompletionInst->getCompilerInstance(
-      Invocation, Args, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
-  if (!CI)
-    return false;
-  SWIFT_DEFER { CI->removeDiagnosticConsumer(&CIDiags); };
-
-  // Perform the parsing and completion.
-  if (!CI->hasPersistentParserState())
-    CI->performParseAndResolveImportsOnly();
-
-  // Create a factory for code completion callbacks that will feed the
-  // Consumer.
-  std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
-      ide::makeConformingMethodListCallbacksFactory(ExpectedTypeNames,
-                                                    Consumer));
-
-  performCodeCompletionSecondPass(CI->getPersistentParserState(),
-                                  *callbacksFactory);
-
-  return true;
+        performCodeCompletionSecondPass(CI.getPersistentParserState(),
+                                        *callbacksFactory);
+      });
 }
 
 void SwiftLangSupport::getConformingMethodList(

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -957,7 +957,8 @@ bool SwiftLangSupport::performCompletionLikeOperation(
     llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
     ArrayRef<const char *> Args,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-    std::string &Error, llvm::function_ref<void(CompilerInstance &)> Callback) {
+    bool EnableASTCaching, std::string &Error,
+    llvm::function_ref<void(CompilerInstance &)> Callback) {
   assert(FileSystem);
 
   // Resolve symlinks for the input file; we resolve them for the input files
@@ -1011,7 +1012,8 @@ bool SwiftLangSupport::performCompletionLikeOperation(
   auto CompletionInst = getCompletionInstance();
 
   return CompletionInst->performOperation(Invocation, Args, FileSystem,
-                                          newBuffer.get(), Offset, Error,
+                                          newBuffer.get(), Offset,
+                                          EnableASTCaching, Error,
                                           &CIDiags, Callback);
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -445,6 +445,7 @@ public:
 
   void codeComplete(
       llvm::MemoryBuffer *InputBuf, unsigned Offset,
+      OptionsDictionary *options,
       SourceKit::CodeCompletionConsumer &Consumer, ArrayRef<const char *> Args,
       Optional<VFSOptions> vfsOptions) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -50,6 +50,7 @@ namespace syntax {
 
 namespace ide {
   class CodeCompletionCache;
+  class CompletionInstance;
   class OnDiskCodeCompletionCache;
   class SourceEditConsumer;
   enum class CodeCompletionDeclKind;
@@ -294,6 +295,7 @@ class SwiftLangSupport : public LangSupport {
   ThreadSafeRefCntPtr<SwiftCustomCompletions> CustomCompletions;
   std::shared_ptr<SwiftStatistics> Stats;
   llvm::StringMap<std::unique_ptr<FileSystemProvider>> FileSystemProviders;
+  std::unique_ptr<swift::ide::CompletionInstance> CompletionInst;
 
 public:
   explicit SwiftLangSupport(SourceKit::Context &SKCtx);
@@ -311,6 +313,10 @@ public:
   SwiftInterfaceGenMap &getIFaceGenContexts() { return IFaceGenContexts; }
   IntrusiveRefCntPtr<SwiftCompletionCache> getCodeCompletionCache() {
     return CCCache;
+  }
+
+  swift::ide::CompletionInstance &getCompletionInstance() {
+    return *CompletionInst;
   }
 
   /// Returns the FileSystemProvider registered under Name, or nullptr if not
@@ -341,13 +347,6 @@ public:
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
   getFileSystem(const Optional<VFSOptions> &vfsOptions,
                 Optional<StringRef> primaryFile, std::string &error);
-
-  /// Copy a memory buffer inserting '0' at the position of \c origBuf.
-  // TODO: Share with code completion.
-  static std::unique_ptr<llvm::MemoryBuffer>
-  makeCodeCompletionMemoryBuffer(const llvm::MemoryBuffer *origBuf,
-                                 unsigned &Offset,
-                                 const std::string bufferIdentifier);
 
   static SourceKit::UIdent getUIDForDecl(const swift::Decl *D,
                                          bool IsRef = false);

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -585,12 +585,14 @@ public:
 
   void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf, unsigned Offset,
                                 ArrayRef<const char *> Args,
-                                TypeContextInfoConsumer &Consumer) override;
+                                TypeContextInfoConsumer &Consumer,
+                                Optional<VFSOptions> vfsOptions) override;
 
   void getConformingMethodList(llvm::MemoryBuffer *inputBuf, unsigned Offset,
                                ArrayRef<const char *> Args,
                                ArrayRef<const char *> ExpectedTypes,
-                               ConformingMethodListConsumer &Consumer) override;
+                               ConformingMethodListConsumer &Consumer,
+                               Optional<VFSOptions> vfsOptions) override;
 
   void getStatistics(StatisticsReceiver) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -295,7 +295,7 @@ class SwiftLangSupport : public LangSupport {
   ThreadSafeRefCntPtr<SwiftCustomCompletions> CustomCompletions;
   std::shared_ptr<SwiftStatistics> Stats;
   llvm::StringMap<std::unique_ptr<FileSystemProvider>> FileSystemProviders;
-  std::unique_ptr<swift::ide::CompletionInstance> CompletionInst;
+  std::shared_ptr<swift::ide::CompletionInstance> CompletionInst;
 
 public:
   explicit SwiftLangSupport(SourceKit::Context &SKCtx);
@@ -315,8 +315,8 @@ public:
     return CCCache;
   }
 
-  swift::ide::CompletionInstance &getCompletionInstance() {
-    return *CompletionInst;
+  std::shared_ptr<swift::ide::CompletionInstance> getCompletionInstance() {
+    return CompletionInst;
   }
 
   /// Returns the FileSystemProvider registered under Name, or nullptr if not

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -436,6 +436,16 @@ public:
   /// returns the original path;
   static std::string resolvePathSymlinks(StringRef FilePath);
 
+  /// Perform a completion like operation. It initializes a \c CompilerInstance,
+  /// the calls \p Callback with it. \p Callback must perform the second pass
+  /// using that instance.
+  bool performCompletionLikeOperation(
+      llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
+      ArrayRef<const char *> Args,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+      std::string &Error,
+      llvm::function_ref<void(swift::CompilerInstance &)> Callback);
+
   //==========================================================================//
   // LangSupport Interface
   //==========================================================================//

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -443,7 +443,7 @@ public:
       llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
       ArrayRef<const char *> Args,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-      std::string &Error,
+      bool EnableASTCaching, std::string &Error,
       llvm::function_ref<void(swift::CompilerInstance &)> Callback);
 
   //==========================================================================//

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -74,7 +74,10 @@ static bool swiftTypeContextInfoImpl(
     Error = "no input filenames specified";
     return false;
   }
-  CompilerInstance *CI = Lang.getCompletionInstance().getCompilerInstance(
+
+  // Pin completion instance.
+  auto CompletionInst =  Lang.getCompletionInstance();
+  CompilerInstance *CI = CompletionInst->getCompilerInstance(
       Invocation, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
   if (!CI)
     return false;

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -30,9 +30,9 @@ static bool swiftTypeContextInfoImpl(
     unsigned Offset, ide::TypeContextInfoConsumer &Consumer,
     ArrayRef<const char *> Args,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-    std::string &Error) {
+    bool EnableASTCaching, std::string &Error) {
   return Lang.performCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, FileSystem, Error,
+      UnresolvedInputFile, Offset, Args, FileSystem, EnableASTCaching, Error,
       [&](CompilerInstance &CI) {
         // Create a factory for code completion callbacks that will feed the
         // Consumer.
@@ -151,7 +151,8 @@ void SwiftLangSupport::getExpressionContextInfo(
   } Consumer(SKConsumer);
 
   if (!swiftTypeContextInfoImpl(*this, UnresolvedInputFile, Offset, Consumer,
-                                Args, fileSystem, error)) {
+                                Args, fileSystem, /*EnableASTCaching=*/false,
+                                error)) {
     SKConsumer.failed(error);
   }
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -78,7 +78,7 @@ static bool swiftTypeContextInfoImpl(
   // Pin completion instance.
   auto CompletionInst =  Lang.getCompletionInstance();
   CompilerInstance *CI = CompletionInst->getCompilerInstance(
-      Invocation, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
+      Invocation, Args, FileSystem, newBuffer.get(), Offset, Error, &CIDiags);
   if (!CI)
     return false;
   SWIFT_DEFER { CI->removeDiagnosticConsumer(&CIDiags); };

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -573,6 +573,7 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
   case SourceKitRequest::CodeComplete:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestCodeComplete);
     sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
+    addCodeCompleteOptions(Req, Opts);
     break;
 
   case SourceKitRequest::CodeCompleteOpen:

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -573,6 +573,7 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
   case SourceKitRequest::CodeComplete:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestCodeComplete);
     sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
+    sourcekitd_request_dictionary_set_string(Req, KeyName, SemaName.c_str());
     addCodeCompleteOptions(Req, Opts);
     break;
 
@@ -971,6 +972,8 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
   if (Opts.SourceText) {
     sourcekitd_request_dictionary_set_string(Req, KeySourceText,
                                              Opts.SourceText->c_str());
+    sourcekitd_request_dictionary_set_string(Req, KeySourceFile,
+                                             SemaName.c_str());
   }
 
   if (!Opts.CompilerArgs.empty()) {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -175,12 +175,14 @@ static sourcekitd_response_t codeCompleteClose(StringRef name, int64_t Offset);
 
 static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
                                              int64_t Offset,
-                                             ArrayRef<const char *> Args);
+                                             ArrayRef<const char *> Args,
+                                             Optional<VFSOptions> vfsOptions);
 
 static sourcekitd_response_t
 conformingMethodList(llvm::MemoryBuffer *InputBuf, int64_t Offset,
                      ArrayRef<const char *> Args,
-                     ArrayRef<const char *> ExpectedTypes);
+                     ArrayRef<const char *> ExpectedTypes,
+                     Optional<VFSOptions> vfsOptions);
 
 static sourcekitd_response_t
 editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
@@ -976,7 +978,8 @@ static void handleSemanticRequest(
     int64_t Offset;
     if (Req.getInt64(KeyOffset, Offset, /*isOptional=*/false))
       return Rec(createErrorRequestInvalid("missing 'key.offset'"));
-    return Rec(typeContextInfo(InputBuf.get(), Offset, Args));
+    return Rec(typeContextInfo(InputBuf.get(), Offset, Args,
+                               std::move(vfsOptions)));
   }
 
   if (ReqUID == RequestConformingMethodList) {
@@ -991,7 +994,8 @@ static void handleSemanticRequest(
     if (Req.getStringArray(KeyExpectedTypes, ExpectedTypeNames, true))
       return Rec(createErrorRequestInvalid("invalid 'key.expectedtypes'"));
     return Rec(
-        conformingMethodList(InputBuf.get(), Offset, Args, ExpectedTypeNames));
+        conformingMethodList(InputBuf.get(), Offset, Args, ExpectedTypeNames,
+                             std::move(vfsOptions)));
   }
 
   if (!SourceFile.hasValue())
@@ -2205,7 +2209,8 @@ void SKGroupedCodeCompletionConsumer::setNextRequestStart(unsigned offset) {
 
 static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
                                              int64_t Offset,
-                                             ArrayRef<const char *> Args) {
+                                             ArrayRef<const char *> Args,
+                                             Optional<VFSOptions> vfsOptions) {
   ResponseBuilder RespBuilder;
 
   class Consumer : public TypeContextInfoConsumer {
@@ -2242,7 +2247,8 @@ static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
   } Consumer(RespBuilder);
 
   LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-  Lang.getExpressionContextInfo(InputBuf, Offset, Args, Consumer);
+  Lang.getExpressionContextInfo(InputBuf, Offset, Args, Consumer,
+                                std::move(vfsOptions));
 
   if (Consumer.isError())
     return createErrorRequestFailed(Consumer.getErrorDescription());
@@ -2256,7 +2262,8 @@ static sourcekitd_response_t typeContextInfo(llvm::MemoryBuffer *InputBuf,
 static sourcekitd_response_t
 conformingMethodList(llvm::MemoryBuffer *InputBuf, int64_t Offset,
                      ArrayRef<const char *> Args,
-                     ArrayRef<const char *> ExpectedTypes) {
+                     ArrayRef<const char *> ExpectedTypes,
+                     Optional<VFSOptions> vfsOptions) {
   ResponseBuilder RespBuilder;
 
   class Consumer : public ConformingMethodListConsumer {
@@ -2293,7 +2300,8 @@ conformingMethodList(llvm::MemoryBuffer *InputBuf, int64_t Offset,
   } Consumer(RespBuilder);
 
   LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-  Lang.getConformingMethodList(InputBuf, Offset, Args, ExpectedTypes, Consumer);
+  Lang.getConformingMethodList(InputBuf, Offset, Args, ExpectedTypes, Consumer,
+                               std::move(vfsOptions));
 
   if (Consumer.isError())
     return createErrorRequestFailed(Consumer.getErrorDescription());

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -33,6 +33,7 @@
 #include "swift/Driver/FrontendUtil.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/IDE/CompletionInstance.h"
 #include "swift/IDE/CodeCompletion.h"
 #include "swift/IDE/CommentConversion.h"
 #include "swift/IDE/ConformingMethodList.h"
@@ -716,11 +717,13 @@ removeCodeCompletionTokens(llvm::MemoryBuffer *Input,
                                            Input->getBufferIdentifier()));
 }
 
-static int doTypeContextInfo(const CompilerInvocation &InitInvok,
-                             StringRef SourceFilename,
-                             StringRef SecondSourceFileName,
-                             StringRef CodeCompletionToken,
-                             bool CodeCompletionDiagnostics) {
+static bool doCodeCompletionImpl(
+    CodeCompletionCallbacksFactory *callbacksFactory,
+    const CompilerInvocation &InitInvok,
+    StringRef SourceFilename,
+    StringRef SecondSourceFileName,
+    StringRef CodeCompletionToken,
+    bool CodeCompletionDiagnostics) {
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
       llvm::MemoryBuffer::getFile(SourceFilename);
   if (!FileBufOrErr) {
@@ -746,16 +749,31 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
 
   CompilerInvocation Invocation(InitInvok);
 
-  // Disable source location resolutions from .swiftsourceinfo file because
-  // they are somewhat heavy operations and are not needed for completions.
-  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
+  if (!SecondSourceFileName.empty()) {
+    Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
+        SecondSourceFileName);
+  }
 
-  // Disable to build syntax tree because code-completion skips some portion of
-  // source text. That breaks an invariant of syntax tree building.
-  Invocation.getLangOptions().BuildSyntaxTree = false;
+  std::string Error;
+  PrintingDiagnosticConsumer PrintDiags;
+  CompletionInstance CompletionInst;
+  auto *CI = CompletionInst.getCompilerInstance(
+      Invocation, llvm::vfs::getRealFileSystem(), CleanFile.get(), Offset,
+      Error, CodeCompletionDiagnostics ? &PrintDiags : nullptr);
+  if (!CI)
+    return 1;
 
-  Invocation.setCodeCompletionPoint(CleanFile.get(), Offset);
+  CI->performParseAndResolveImportsOnly();
+  performCodeCompletionSecondPass(CI->getPersistentParserState(),
+                                  *callbacksFactory);
+  return 0;
+}
 
+static int doTypeContextInfo(const CompilerInvocation &InitInvok,
+                             StringRef SourceFilename,
+                             StringRef SecondSourceFileName,
+                             StringRef CodeCompletionToken,
+                             bool CodeCompletionDiagnostics) {
   // Create a CodeCompletionConsumer.
   std::unique_ptr<ide::TypeContextInfoConsumer> Consumer(
       new ide::PrintingTypeContextInfoConsumer(llvm::outs()));
@@ -765,23 +783,9 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
   std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
       ide::makeTypeContextInfoCallbacksFactory(*Consumer));
 
-  Invocation.setCodeCompletionFactory(callbacksFactory.get());
-  if (!SecondSourceFileName.empty()) {
-    Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
-        SecondSourceFileName);
-  }
-  CompilerInstance CI;
-
-  PrintingDiagnosticConsumer PrintDiags;
-  if (CodeCompletionDiagnostics) {
-    // Display diagnostics to stderr.
-    CI.addDiagnosticConsumer(&PrintDiags);
-  }
-  if (CI.setup(Invocation))
-    return 1;
-  registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
-  return 0;
+  return doCodeCompletionImpl(callbacksFactory.get(), InitInvok, SourceFilename,
+                              SecondSourceFileName, CodeCompletionToken,
+                              CodeCompletionDiagnostics);
 }
 
 static int
@@ -790,41 +794,6 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
                        StringRef CodeCompletionToken,
                        bool CodeCompletionDiagnostics,
                        const std::vector<std::string> expectedTypeNames) {
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-      llvm::MemoryBuffer::getFile(SourceFilename);
-  if (!FileBufOrErr) {
-    llvm::errs() << "error opening input file: "
-                 << FileBufOrErr.getError().message() << '\n';
-    return 1;
-  }
-
-  unsigned Offset;
-
-  std::unique_ptr<llvm::MemoryBuffer> CleanFile(removeCodeCompletionTokens(
-      FileBufOrErr.get().get(), CodeCompletionToken, &Offset));
-
-  if (Offset == ~0U) {
-    llvm::errs() << "could not find code completion token \""
-                 << CodeCompletionToken << "\"\n";
-    return 1;
-  }
-  llvm::outs() << "found code completion token " << CodeCompletionToken
-               << " at offset " << Offset << "\n";
-  llvm::errs() << "found code completion token " << CodeCompletionToken
-               << " at offset " << Offset << "\n";
-
-  CompilerInvocation Invocation(InitInvok);
-
-  // Disable source location resolutions from .swiftsourceinfo file because
-  // they are somewhat heavy operations and are not needed for completions.
-  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
-
-  // Disable to build syntax tree because code-completion skips some portion of
-  // source text. That breaks an invariant of syntax tree building.
-  Invocation.getLangOptions().BuildSyntaxTree = false;
-
-  Invocation.setCodeCompletionPoint(CleanFile.get(), Offset);
-
   SmallVector<const char *, 4> typeNames;
   for (auto &name : expectedTypeNames)
     typeNames.push_back(name.c_str());
@@ -838,23 +807,9 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
   std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
       ide::makeConformingMethodListCallbacksFactory(typeNames, *Consumer));
 
-  Invocation.setCodeCompletionFactory(callbacksFactory.get());
-  if (!SecondSourceFileName.empty()) {
-    Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
-        SecondSourceFileName);
-  }
-  CompilerInstance CI;
-
-  PrintingDiagnosticConsumer PrintDiags;
-  if (CodeCompletionDiagnostics) {
-    // Display diagnostics to stderr.
-    CI.addDiagnosticConsumer(&PrintDiags);
-  }
-  if (CI.setup(Invocation))
-    return 1;
-  registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
-  return 0;
+  return doCodeCompletionImpl(callbacksFactory.get(), InitInvok, SourceFilename,
+                              SecondSourceFileName, CodeCompletionToken,
+                              CodeCompletionDiagnostics);
 }
 
 static int doCodeCompletion(const CompilerInvocation &InitInvok,
@@ -864,42 +819,6 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
                             bool CodeCompletionDiagnostics,
                             bool CodeCompletionKeywords,
                             bool CodeCompletionComments) {
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-    llvm::MemoryBuffer::getFile(SourceFilename);
-  if (!FileBufOrErr) {
-    llvm::errs() << "error opening input file: "
-                 << FileBufOrErr.getError().message() << '\n';
-    return 1;
-  }
-
-  unsigned CodeCompletionOffset;
-
-  std::unique_ptr<llvm::MemoryBuffer> CleanFile(
-      removeCodeCompletionTokens(FileBufOrErr.get().get(), CodeCompletionToken,
-                                 &CodeCompletionOffset));
-
-  if (CodeCompletionOffset == ~0U) {
-    llvm::errs() << "could not find code completion token \""
-                 << CodeCompletionToken << "\"\n";
-    return 1;
-  }
-  llvm::outs() << "found code completion token " << CodeCompletionToken
-               << " at offset " << CodeCompletionOffset << "\n";
-  llvm::errs() << "found code completion token " << CodeCompletionToken
-               << " at offset " << CodeCompletionOffset << "\n";
-
-  CompilerInvocation Invocation(InitInvok);
-
-  Invocation.setCodeCompletionPoint(CleanFile.get(), CodeCompletionOffset);
-
-  // Disable source location resolutions from .swiftsourceinfo file because
-  // they are somewhat heavy operations and are not needed for completions.
-  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = true;
-
-  // Disable to build syntax tree because code-completion skips some portion of
-  // source text. That breaks an invariant of syntax tree building.
-  Invocation.getLangOptions().BuildSyntaxTree = false;
-
   std::unique_ptr<ide::OnDiskCodeCompletionCache> OnDiskCache;
   if (!options::CompletionCachePath.empty()) {
     OnDiskCache = llvm::make_unique<ide::OnDiskCodeCompletionCache>(
@@ -915,27 +834,12 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
 
   // Create a factory for code completion callbacks that will feed the
   // Consumer.
-  std::unique_ptr<CodeCompletionCallbacksFactory> CompletionCallbacksFactory(
-      ide::makeCodeCompletionCallbacksFactory(CompletionContext,
-                                              *Consumer));
+  std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
+      ide::makeCodeCompletionCallbacksFactory(CompletionContext, *Consumer));
 
-  Invocation.setCodeCompletionFactory(CompletionCallbacksFactory.get());
-  if (!SecondSourceFileName.empty()) {
-    Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
-        SecondSourceFileName);
-  }
-  CompilerInstance CI;
-
-  PrintingDiagnosticConsumer PrintDiags;
-  if (CodeCompletionDiagnostics) {
-    // Display diagnostics to stderr.
-    CI.addDiagnosticConsumer(&PrintDiags);
-  }
-  if (CI.setup(Invocation))
-    return 1;
-  registerIDERequestFunctions(CI.getASTContext().evaluator);
-  CI.performParseAndResolveImportsOnly();
-  return 0;
+  return doCodeCompletionImpl(callbacksFactory.get(), InitInvok, SourceFilename,
+                              SecondSourceFileName, CodeCompletionToken,
+                              CodeCompletionDiagnostics);
 }
 
 static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -759,11 +759,12 @@ static bool doCodeCompletionImpl(
   CompletionInstance CompletionInst;
   auto isSuccess = CompletionInst.performOperation(
       Invocation, /*Args=*/{}, llvm::vfs::getRealFileSystem(), CleanFile.get(),
-      Offset, Error, CodeCompletionDiagnostics ? &PrintDiags : nullptr,
-                                                [&](CompilerInstance &CI) {
-    performCodeCompletionSecondPass(CI.getPersistentParserState(),
-                                    *callbacksFactory);
-  });
+      Offset, /*EnableASTCaching=*/false, Error,
+      CodeCompletionDiagnostics ? &PrintDiags : nullptr,
+      [&](CompilerInstance &CI) {
+        performCodeCompletionSecondPass(CI.getPersistentParserState(),
+                                        *callbacksFactory);
+      });
   return isSuccess ? 0 : 1;
 }
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -758,8 +758,8 @@ static bool doCodeCompletionImpl(
   PrintingDiagnosticConsumer PrintDiags;
   CompletionInstance CompletionInst;
   auto *CI = CompletionInst.getCompilerInstance(
-      Invocation, llvm::vfs::getRealFileSystem(), CleanFile.get(), Offset,
-      Error, CodeCompletionDiagnostics ? &PrintDiags : nullptr);
+      Invocation, /*Args=*/{}, llvm::vfs::getRealFileSystem(), CleanFile.get(),
+      Offset, Error, CodeCompletionDiagnostics ? &PrintDiags : nullptr);
   if (!CI)
     return 1;
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -757,16 +757,14 @@ static bool doCodeCompletionImpl(
   std::string Error;
   PrintingDiagnosticConsumer PrintDiags;
   CompletionInstance CompletionInst;
-  auto *CI = CompletionInst.getCompilerInstance(
+  auto isSuccess = CompletionInst.performOperation(
       Invocation, /*Args=*/{}, llvm::vfs::getRealFileSystem(), CleanFile.get(),
-      Offset, Error, CodeCompletionDiagnostics ? &PrintDiags : nullptr);
-  if (!CI)
-    return 1;
-
-  CI->performParseAndResolveImportsOnly();
-  performCodeCompletionSecondPass(CI->getPersistentParserState(),
-                                  *callbacksFactory);
-  return 0;
+      Offset, Error, CodeCompletionDiagnostics ? &PrintDiags : nullptr,
+                                                [&](CompilerInstance &CI) {
+    performCodeCompletionSecondPass(CI.getPersistentParserState(),
+                                    *callbacksFactory);
+  });
+  return isSuccess ? 0 : 1;
 }
 
 static int doTypeContextInfo(const CompilerInvocation &InitInvok,


### PR DESCRIPTION
Reuse `ASTContext`(`CompilerInstance`) from the previous completions when possible.

`ide::CompletionInstance` manages `CompilerInstance` for completion like requests (i.e. code completion, type context info, and conforming method list).
It vends the cached `CompilerInstance` if:
- This functionality is enabled, and
- The compiler arguments (i.e. `CompilerInvocation`) has not changed, and
- The primary file is the same, and
- The completion happens inside function bodies in both previous and current completion, and
- The interface hash of of the primary file has not changed

Since cached instance already have `AST` including imported modules, we just run the second pass.

Otherwise, `CompletionInstance` vends new `CompilerInstance`, so we run both first and second pass using that instance. This instance is cached for the next completion request.

NOTE: currently it's disabled by default.

For example, using this simple example:
```
func test(x: Int) {
  x.#^COMPLETE^#
}
```
```
# Disabled
$ sourcekitd-test -req=complete -pos=2:5 $PWD/test.swift -repeat-request=10 -dont-print-request -dont-print-response -time-request -- $PWD/test.swift
request time: 109.469 ms
request time: 102.269 ms
request time: 101.260 ms
request time: 99.622 ms
request time: 100.751 ms
request time: 100.154 ms
request time: 99.670 ms
request time: 100.965 ms
request time: 101.426 ms
request time: 100.784 ms
```
```
# Enabled
$ sourcekitd-test -req=complete -req-opts=reuseastcontext=1 -pos=2:5 $PWD/test.swift -repeat-request=10 -dont-print-request -dont-print-response -time-request -- $PWD/test.swift
request time: 108.051 ms
request time: 1.716 ms
request time: 1.553 ms
request time: 1.559 ms
request time: 1.466 ms
request time: 1.497 ms
request time: 1.445 ms
request time: 1.544 ms
request time: 1.447 ms
request time: 1.506 ms
```

rdar://problem/20787086