### PR TITLE
[stdlib] Don’t use assert() in the stdlib

### DIFF
--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -319,7 +319,7 @@ fileprivate func _myers<C,D>(
         y &-= 1
       }
 
-      assert((x == prev_x && y > prev_y) || (y == prev_y && x > prev_x))
+      _internalInvariant((x == prev_x && y > prev_y) || (y == prev_y && x > prev_x))
       if y != prev_y {
         changes.append(.insert(offset: prev_y, element: b[prev_y], associatedWith: nil))
       } else {

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3151,7 +3151,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
       case .unresolvedIndirectOffset(let pointerToOffset):
         // Look up offset in the indirectly-referenced variable we have a
         // pointer.
-        assert(pointerToOffset.pointee <= UInt32.max)
+        _internalInvariant(pointerToOffset.pointee <= UInt32.max)
         let offset = UInt32(truncatingIfNeeded: pointerToOffset.pointee)
         let header = RawKeyPathComponent.Header(storedWithOutOfLineOffset: kind,
                                                 mutable: mutable)

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -692,7 +692,7 @@ extension UnsafeMutableBufferPointer {
       
       result = try result && _finalizeRuns(
         &runs, buffer: buffer.baseAddress!, by: areInIncreasingOrder)
-      assert(runs.count == 1, "Didn't complete final merge")
+      _internalInvariant(runs.count == 1, "Didn't complete final merge")
     }
 
     // FIXME: Remove this, it works around rdar://problem/45044610

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -108,7 +108,7 @@ extension UnsafeBufferPointer where Element == UInt8 {
     if index == 0 || index == count {
       return true
     }
-    assert(!UTF8.isContinuation(self[_unchecked: index]))
+    _internalInvariant(!UTF8.isContinuation(self[_unchecked: index]))
 
     // Sub-300 latiny fast-path
     if self[_unchecked: index] < 0xCC { return true }

--- a/stdlib/public/core/StringSwitch.swift
+++ b/stdlib/public/core/StringSwitch.swift
@@ -92,7 +92,8 @@ internal func _createStringTableCache(_ cacheRawPtr: Builtin.RawPointer) {
   let context = UnsafePointer<_StringSwitchContext>(cacheRawPtr).pointee
   var cache = _StringSwitchCache()
   cache.reserveCapacity(context.cases.count)
-  assert(MemoryLayout<_StringSwitchCache>.size <= MemoryLayout<Builtin.Word>.size)
+  _internalInvariant(
+    MemoryLayout<_StringSwitchCache>.size <= MemoryLayout<Builtin.Word>.size)
 
   for (idx, s) in context.cases.enumerated() {
     let key = String(_builtinStringLiteral: s.utf8Start._rawValue,


### PR DESCRIPTION
`assert()` is designed to be used in user code only; the equivalent stdlib function is called `_internalInvariant()`.

rdar://57101013
