### PR TITLE
[AutoDiff] Fix type lowering due to upstream changes.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4457,11 +4457,16 @@ public:
   ///                    ^~~~~~~         ^~~~~~            ^~~~~~~~~~~~~~~~~~~
   ///          original results | derivative wrt result | derivatives wrt params
   ///
-  /// The JVP/VJP generic signature is a "constrained" version of the given
-  /// `derivativeFunctionGenericSignature` if specified. Otherwise, it is a
-  /// "constrained" version of the original generic signature. A "constrained"
-  /// generic signature requires all "wrt" parameters to conform to
+  /// A "constrained derivative generic signature" is computed from
+  /// `derivativeFunctionGenericSignature`, if specified. Otherwise, it is
+  /// computed from the original generic signature. A "constrained derivative
+  /// generic signature" requires all "wrt" parameters to conform to
   /// `Differentiable`; this is important for correctness.
+  ///
+  /// This "constrained derivative generic signature" is used for
+  /// parameter/result type lowering. It is used as the actual generic signature
+  /// of the derivative function type iff the original function type has a
+  /// generic signature; otherwise, no derivative generic signature is used.
   ///
   /// Other properties of the original function type are copied exactly:
   /// `ExtInfo`, coroutine kind, callee convention, yields, optional error

--- a/include/swift/SILOptimizer/Utils/Differentiation/LinearMapInfo.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/LinearMapInfo.h
@@ -163,7 +163,10 @@ public:
     auto *linMapStruct = getLinearMapStruct(origBB);
     auto linMapStructType =
         linMapStruct->getDeclaredInterfaceType()->getCanonicalType();
-    return typeConverter.getLoweredType(linMapStructType,
+    Lowering::AbstractionPattern pattern(
+        derivative->getLoweredFunctionType()->getSubstGenericSignature(),
+        linMapStructType);
+    return typeConverter.getLoweredType(pattern, linMapStructType,
                                         TypeExpansionContext::minimal());
   }
 
@@ -178,7 +181,10 @@ public:
     auto *traceDecl = getBranchingTraceDecl(origBB);
     auto traceDeclType =
         traceDecl->getDeclaredInterfaceType()->getCanonicalType();
-    return typeConverter.getLoweredType(traceDeclType,
+    Lowering::AbstractionPattern pattern(
+        derivative->getLoweredFunctionType()->getSubstGenericSignature(),
+        traceDeclType);
+    return typeConverter.getLoweredType(pattern, traceDeclType,
                                         TypeExpansionContext::minimal());
   }
 

--- a/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
@@ -210,6 +210,9 @@ private:
   // Type transformer
   //--------------------------------------------------------------------------//
 
+  /// Get the type lowering for the given AST type.
+  const Lowering::TypeLowering &getTypeLowering(Type type);
+
   /// Remap any archetypes into the current function's context.
   SILType remapType(SILType ty);
 

--- a/include/swift/SILOptimizer/Utils/Differentiation/VJPEmitter.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/VJPEmitter.h
@@ -111,6 +111,9 @@ public:
   void visitSILInstruction(SILInstruction *inst);
 
 private:
+  /// Get the lowered SIL type of the given AST type.
+  SILType getLoweredType(Type type);
+
   /// Get the lowered SIL type of the given nominal type declaration.
   SILType getNominalDeclLoweredType(NominalTypeDecl *nominal);
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -265,17 +265,18 @@ namespace {
         CanSILFunctionType type, AbstractionPattern origType) {
       auto &M = TC.M;
       auto origTy = type->getWithoutDifferentiability();
+      // Pass the `AbstractionPattern` generic signature to
+      // `SILFunctionType:getAutoDiffDerivativeFunctionType` for correct type
+      // lowering.
       auto jvpTy = origTy->getAutoDiffDerivativeFunctionType(
           type->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
           AutoDiffDerivativeFunctionKind::JVP, TC,
-          LookUpConformanceInModule(&M));
+          LookUpConformanceInModule(&M), origType.getGenericSignature());
       auto vjpTy = origTy->getAutoDiffDerivativeFunctionType(
           type->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
           AutoDiffDerivativeFunctionKind::VJP, TC,
-          LookUpConformanceInModule(&M));
+          LookUpConformanceInModule(&M), origType.getGenericSignature());
       RecursiveProperties props;
-      // TODO(TF-1050): Fix `AbstractionPattern` argument to `classifyType`
-      // calls.
       props.addSubobject(classifyType(origType, origTy, TC, Expansion));
       props.addSubobject(classifyType(origType, jvpTy, TC, Expansion));
       props.addSubobject(classifyType(origType, vjpTy, TC, Expansion));
@@ -289,10 +290,8 @@ namespace {
       auto origTy = type->getWithoutDifferentiability();
       auto transTy = origTy->getAutoDiffTransposeFunctionType(
           type->getDifferentiationParameterIndices(), TC,
-          LookUpConformanceInModule(&M));
+          LookUpConformanceInModule(&M), origType.getGenericSignature());
       RecursiveProperties props;
-      // TODO(TF-1050): Fix `AbstractionPattern` argument to `classifyType`
-      // calls.
       props.addSubobject(classifyType(origType, origTy, TC, Expansion));
       props.addSubobject(classifyType(origType, transTy, TC, Expansion));
       return props;

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3364,9 +3364,10 @@ static ManagedValue createAutoDiffThunk(SILGenFunction &SGF,
       [&](AutoDiffDerivativeFunctionKind kind) -> ManagedValue {
     auto derivativeFnInputOrigType =
         getDerivativeFnPattern(inputOrigTypeNotDiff, kind);
-    auto derivativeFnInputSubstType = getDerivativeFnTy(inputSubstTypeNotDiff, kind);
-    auto derivativeFnOutputOrigType = getDerivativeFnPattern(outputOrigTypeNotDiff,
-                                                   kind);
+    auto derivativeFnInputSubstType =
+        getDerivativeFnTy(inputSubstTypeNotDiff, kind);
+    auto derivativeFnOutputOrigType =
+        getDerivativeFnPattern(outputOrigTypeNotDiff, kind);
     auto derivativeFnOutputSubstType =
         getDerivativeFnTy(outputSubstTypeNotDiff, kind);
     auto &derivativeFnExpectedTL = SGF.getTypeLowering(

--- a/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
@@ -80,8 +80,10 @@ SILFunction *VJPEmitter::createEmptyPullback() {
   // Given a type, returns its formal SIL parameter info.
   auto getTangentParameterInfoForOriginalResult =
       [&](CanType tanType, ResultConvention origResConv) -> SILParameterInfo {
+    Lowering::AbstractionPattern pattern(
+        vjp->getLoweredFunctionType()->getSubstGenericSignature(), tanType);
     auto &tl = context.getTypeConverter().getTypeLowering(
-        tanType, TypeExpansionContext::minimal());
+        pattern, tanType, TypeExpansionContext::minimal());
     ParameterConvention conv;
     switch (origResConv) {
     case ResultConvention::Owned:
@@ -103,8 +105,10 @@ SILFunction *VJPEmitter::createEmptyPullback() {
   // Given a type, returns its formal SIL result info.
   auto getTangentResultInfoForOriginalParameter =
       [&](CanType tanType, ParameterConvention origParamConv) -> SILResultInfo {
+    Lowering::AbstractionPattern pattern(
+        vjp->getLoweredFunctionType()->getSubstGenericSignature(), tanType);
     auto &tl = context.getTypeConverter().getTypeLowering(
-        tanType, TypeExpansionContext::minimal());
+        pattern, tanType, TypeExpansionContext::minimal());
     ResultConvention conv;
     switch (origParamConv) {
     case ParameterConvention::Direct_Owned:
@@ -220,12 +224,17 @@ void VJPEmitter::visitSILInstruction(SILInstruction *inst) {
   errorOccurred = true;
 }
 
+SILType VJPEmitter::getLoweredType(Type type) {
+  Lowering::AbstractionPattern pattern(
+      vjp->getLoweredFunctionType()->getSubstGenericSignature(),
+      type->getCanonicalType());
+  return vjp->getLoweredType(pattern, type);
+}
+
 SILType VJPEmitter::getNominalDeclLoweredType(NominalTypeDecl *nominal) {
   auto nomType =
       getOpASTType(nominal->getDeclaredInterfaceType()->getCanonicalType());
-  auto nomSILType = context.getTypeConverter().getLoweredType(
-      nomType, TypeExpansionContext::minimal());
-  return nomSILType;
+  return getLoweredType(nomType);
 }
 
 StructInst *VJPEmitter::buildPullbackValueStructValue(TermInst *termInst) {
@@ -614,9 +623,7 @@ void VJPEmitter::visitApplyInst(ApplyInst *ai) {
   auto actualPullbackType =
       getOpType(pullback->getType()).getAs<SILFunctionType>();
   auto loweredPullbackType =
-      getOpType(context.getTypeConverter().getLoweredType(
-                    pullbackDecl->getInterfaceType()->getCanonicalType(),
-                    TypeExpansionContext::minimal()))
+      getOpType(getLoweredType(pullbackDecl->getInterfaceType()))
           .castTo<SILFunctionType>();
   if (!loweredPullbackType->isEqual(actualPullbackType)) {
     // Set non-reabstracted original pullback type in nested apply info.

--- a/stdlib/public/Differentiation/DifferentiationSupport.swift
+++ b/stdlib/public/Differentiation/DifferentiationSupport.swift
@@ -399,6 +399,8 @@ public extension Differentiable {
 
 // Transpose
 
+// FIXME(TF-1053): Fix SemanticARCOpts crash for `func transpose`.
+/*
 @inlinable
 public func transpose<T, R>(
   of body: @escaping @differentiable(linear) (T) -> R
@@ -407,6 +409,7 @@ public func transpose<T, R>(
   let transpose = { x in Builtin.applyTranspose_arity1(body, x) }
   return Builtin.linearFunction_arity1(transpose, original)
 }
+*/
 
 // Value with differential
 


### PR DESCRIPTION
Previously, `Lowering::GenericContextScope` was used to specify generic
signatures for type lowering APIs.

https://github.com/apple/swift/pull/28424 moved `Lowering::GenericContextScope` from SIL to IRGen.
Type lowering APIs must now specify generic signatures via
`AbstractionPattern` arguments.

Fix AutoDiff type lowering to use `AbstractionPattern`:
- `SILFunctionType::getAutoDiffDerivativeFunctionType`
  - A "constrained derivative generic signature" is now used for
    parameter/result type lowering. However, it is used as the actual
    derivative function type generic signature only if the original function
    type has a generic signature.
- `SILFunctionType::getAutoDiffTransposeFunctionType`
  - Similar logic as above.
- `TypeClassifierBase::getNormalDifferentiableSILFunctionTypeRecursiveProperties`
- `TypeClassifierBase::getLinearDifferentiableSILFunctionTypeRecursiveProperties`
- Differentiation transform: `VJPEmitter`, `PullbackEmitter`.
  - Add type lowering utilities: `VJPEmitter::getLoweredType` and
    `PullbackEmitter::getTypeLowering`.

Resolves TF-1050.
Exposes TF-1053: `func transpose` crash.
Remaining merge issue: TF-1054.