### PR TITLE
[Sema] Fix ConstraintSystem crash related to derived conformances.

### DIFF
--- a/lib/Sema/DerivedConformanceElementaryFunctions.cpp
+++ b/lib/Sema/DerivedConformanceElementaryFunctions.cpp
@@ -159,12 +159,6 @@ deriveBodyElementaryFunction(AbstractFunctionDecl *funcDecl,
   // Create reference(s) to operator parameters: one for unary functions and two
   // for binary functions.
   auto params = funcDecl->getParameters();
-  auto *firstParamDRE =
-      new (C) DeclRefExpr(params->get(0), DeclNameLoc(), /*Implicit*/ true);
-  Expr *secondParamDRE = nullptr;
-  if (params->size() == 2)
-    secondParamDRE =
-        new (C) DeclRefExpr(params->get(1), DeclNameLoc(), /*Implicit*/ true);
 
   // Create call expression combining lhs and rhs members using member operator.
   auto createMemberOpCallExpr = [&](VarDecl *member) -> Expr * {
@@ -196,6 +190,12 @@ deriveBodyElementaryFunction(AbstractFunctionDecl *funcDecl,
     //   `<op>(x.member, y.member)`.
     // - For `pow(_ x: Self, _ n: Int)` and `root(_ x: Self, n: Int)`, create:
     //   `<op>(x.member, n)`.
+    auto *firstParamDRE =
+        new (C) DeclRefExpr(params->get(0), DeclNameLoc(), /*Implicit*/ true);
+    Expr *secondParamDRE = nullptr;
+    if (params->size() == 2)
+      secondParamDRE =
+          new (C) DeclRefExpr(params->get(1), DeclNameLoc(), /*Implicit*/ true);
     Expr *firstArg = new (C) MemberRefExpr(firstParamDRE, SourceLoc(), member,
                                          DeclNameLoc(), /*Implicit*/ true);
     Expr *secondArg = nullptr;

--- a/lib/Sema/DerivedConformanceRingMathProtocols.cpp
+++ b/lib/Sema/DerivedConformanceRingMathProtocols.cpp
@@ -154,10 +154,6 @@ deriveBodyMathOperator(AbstractFunctionDecl *funcDecl, MathOperator op) {
 
   // Create reference to operator parameters: lhs and rhs.
   auto params = funcDecl->getParameters();
-  auto *lhsDRE =
-      new (C) DeclRefExpr(params->get(0), DeclNameLoc(), /*Implicit*/ true);
-  auto *rhsDRE =
-      new (C) DeclRefExpr(params->get(1), DeclNameLoc(), /*Implicit*/ true);
 
   // Create expression combining lhs and rhs members using member operator.
   auto createMemberOpExpr = [&](VarDecl *member) -> Expr * {
@@ -185,6 +181,10 @@ deriveBodyMathOperator(AbstractFunctionDecl *funcDecl, MathOperator op) {
         new (C) DotSyntaxCallExpr(memberOpDRE, SourceLoc(), memberTypeExpr);
 
     // Create expression `lhs.member <op> rhs.member`.
+    auto *lhsDRE =
+        new (C) DeclRefExpr(params->get(0), DeclNameLoc(), /*Implicit*/ true);
+    auto *rhsDRE =
+        new (C) DeclRefExpr(params->get(1), DeclNameLoc(), /*Implicit*/ true);
     Expr *lhsArg = new (C) MemberRefExpr(lhsDRE, SourceLoc(), member,
                                          DeclNameLoc(), /*Implicit*/ true);
     auto *rhsArg = new (C) MemberRefExpr(rhsDRE, SourceLoc(), member,

--- a/lib/Sema/DerivedConformanceVectorProtocol.cpp
+++ b/lib/Sema/DerivedConformanceVectorProtocol.cpp
@@ -137,11 +137,7 @@ deriveBodyVectorProtocol_method(AbstractFunctionDecl *funcDecl,
 
   // Get references to `self` and parameter declarations.
   auto *selfDecl = funcDecl->getImplicitSelfDecl();
-  auto *selfDRE =
-      new (C) DeclRefExpr(selfDecl, DeclNameLoc(), /*Implicit*/ true);
   auto *paramDecl = funcDecl->getParameters()->get(0);
-  auto *paramDRE =
-      new (C) DeclRefExpr(paramDecl, DeclNameLoc(), /*Implicit*/ true);
 
   // Create call expression applying a member method to the parameter.
   // Format: `<member>.method(<parameter>)`.
@@ -171,6 +167,10 @@ deriveBodyVectorProtocol_method(AbstractFunctionDecl *funcDecl,
     memberMethodDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
 
     // Create reference to member method: `x.scaled(by:)`.
+    auto *selfDRE =
+        new (C) DeclRefExpr(selfDecl, DeclNameLoc(), /*Implicit*/ true);
+    auto *paramDRE =
+        new (C) DeclRefExpr(paramDecl, DeclNameLoc(), /*Implicit*/ true);
     auto memberExpr =
         new (C) MemberRefExpr(selfDRE, SourceLoc(), member, DeclNameLoc(),
                               /*Implicit*/ true);

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -289,7 +289,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     // TensorArrayProtocol._tensorHandleCount
     if (name.isSimpleName(ctx.Id_tensorHandleCount))
       return getRequirement(KnownProtocolKind::TensorArrayProtocol);
-    
+
     // SWIFT_ENABLE_TENSORFLOW
     // TensorArrayProtocol._typeList
     if (name.isSimpleName(ctx.Id_typeList) && !requirement->isStatic())
@@ -390,7 +390,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
 
     // SWIFT_ENABLE_TENSORFLOW
     // TensorArrayProtocol._unpackTensorHandles(into:)
-    if (name.isCompoundName() && 
+    if (name.isCompoundName() &&
         name.getBaseName() == ctx.Id_unpackTensorHandles) {
       auto argumentNames = name.getArgumentNames();
       if (argumentNames.size() == 1 &&
@@ -439,7 +439,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     } else if (argumentNames.size() == 2) {
       // SWIFT_ENABLE_TENSORFLOW
       // TensorArrayProtocol.init(_owning:count)
-      if (argumentNames[0] == ctx.getIdentifier("_owning") && 
+      if (argumentNames[0] == ctx.getIdentifier("_owning") &&
           argumentNames[1] == ctx.getIdentifier("count")) {
         return getRequirement(KnownProtocolKind::TensorArrayProtocol);
       }
@@ -528,7 +528,7 @@ DerivedConformance::declareDerivedPropertyGetter(VarDecl *property,
 std::pair<AccessorDecl *, AccessorDecl *>
 DerivedConformance::addGetterAndSetterToMutableDerivedProperty(
     VarDecl *property, Type propertyContextType) {
-  auto *getter = addGetterToReadOnlyDerivedProperty(property, propertyContextType);
+  auto *getter = declareDerivedPropertyGetter(property, propertyContextType);
   auto *setter = declareDerivedPropertySetter(property, propertyContextType);
   property->setImplInfo(StorageImplInfo::getMutableComputed());
   property->setAccessors(SourceLoc(), {getter, setter}, SourceLoc());

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -209,7 +209,7 @@ public:
   /// Determine if a TensorArrayProtocol requirement can be derived for a type.
   ///
   /// \returns True if the requirement can be derived.
-  static bool canDeriveTensorArrayProtocol(NominalTypeDecl *type, 
+  static bool canDeriveTensorArrayProtocol(NominalTypeDecl *type,
                                            DeclContext *DC);
 
   /// Derive a TensorArrayProtocol requirement for a nominal type.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2292,7 +2292,7 @@ public:
 };
   
 /// An AST walker that determines the underlying type of an opaque return decl
-/// from its derivative function body.
+/// from its associated function body.
 class OpaqueUnderlyingTypeChecker : public ASTWalker {
   ASTContext &Ctx;
   AbstractFunctionDecl *Implementation;


### PR DESCRIPTION
Derived conformances previously reused implicit `DeclRefExpr`s to reduce AST
code generation. However, `ConstraintSystem::resolveOverload` now crashes during
`ConstraintGenerator::visitDeclRefExpr` for `DeclRefExpr`s that already have an
resolved overload.

Instead, do not reuse implicit `DeclRefExpr`s.

Gardening included to reduce diff with master.

Resolves TF-1054.