### PR TITLE
[AutoDiff] Fix SemanticARCOpts.

### DIFF
--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -262,6 +262,10 @@ struct SemanticARCOptVisitor
   FORWARDING_INST(OpenExistentialValue)
   FORWARDING_INST(OpenExistentialBoxValue)
   FORWARDING_INST(MarkDependence)
+  // SWIFT_ENABLE_TENSORFLOW
+  FORWARDING_INST(DifferentiableFunctionExtract)
+  FORWARDING_INST(LinearFunctionExtract)
+  // SWIFT_ENABLE_TENSORFLOW END
 #undef FORWARDING_INST
 
 #define FORWARDING_TERM(NAME)                                                  \

--- a/stdlib/public/Differentiation/DifferentiationSupport.swift
+++ b/stdlib/public/Differentiation/DifferentiationSupport.swift
@@ -399,8 +399,6 @@ public extension Differentiable {
 
 // Transpose
 
-// FIXME(TF-1053): Fix SemanticARCOpts crash for `func transpose`.
-/*
 @inlinable
 public func transpose<T, R>(
   of body: @escaping @differentiable(linear) (T) -> R
@@ -409,7 +407,6 @@ public func transpose<T, R>(
   let transpose = { x in Builtin.applyTranspose_arity1(body, x) }
   return Builtin.linearFunction_arity1(transpose, original)
 }
-*/
 
 // Value with differential
 


### PR DESCRIPTION
Add missing visitors for `differentiable_function_extract` and
`linear_function_extract` to `SemanticARCOptVisitor`.

Resolves TF-1053.

---

Thanks @rxwei for the fix!