### PR TITLE
Clang function types v2: Electric Boogaloo (parsing + printing)

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -14,6 +14,7 @@
 #define SWIFT_AST_ASTPRINTER_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/QuotedString.h"
 #include "swift/Basic/UUID.h"
 #include "swift/AST/Identifier.h"
 #include "llvm/ADT/StringRef.h"
@@ -184,6 +185,8 @@ public:
     printTextImpl(Text);
     return *this;
   }
+
+  ASTPrinter &operator<<(QuotedString s);
 
   ASTPrinter &operator<<(unsigned long long N);
   ASTPrinter &operator<<(UUID UU);

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -107,6 +107,10 @@ public:
   /// Returns null if there was a parsing failure.
   virtual const clang::Type *parseClangFunctionType(StringRef type,
                                                     SourceLoc loc) const = 0;
+
+  /// Print the Clang type.
+  virtual void printClangType(const clang::Type *type,
+                              llvm::raw_ostream &os) const = 0;
 };
 
 } // namespace swift

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -21,6 +21,7 @@ class CompilerInstance;
 class Preprocessor;
 class Sema;
 class TargetInfo;
+class Type;
 } // namespace clang
 
 namespace swift {
@@ -100,6 +101,12 @@ public:
   lookupRelatedEntity(StringRef clangName, ClangTypeKind kind,
                       StringRef relatedEntityKind,
                       llvm::function_ref<void(TypeDecl *)> receiver) = 0;
+
+  /// Try to parse the string as a Clang function type.
+  ///
+  /// Returns null if there was a parsing failure.
+  virtual const clang::Type *parseClangFunctionType(StringRef type,
+                                                    SourceLoc loc) const = 0;
 };
 
 } // namespace swift

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3924,6 +3924,13 @@ ERROR(unsupported_convention,none,
       "convention '%0' not supported", (StringRef))
 ERROR(unreferenced_generic_parameter,none,
       "generic parameter '%0' is not used in function signature", (StringRef))
+ERROR(unexpected_ctype_for_non_c_convention,none,
+      "convention '%0' does not support the 'cType' argument label, did you "
+      "mean @convention(c, cType: \"%1\") or @convention(block, cType: \"%1\") "
+      "instead?", (StringRef, StringRef))
+ERROR(unable_to_parse_c_function_type,none,
+      "unable to parse '%0'; it should be a C function pointer type or a "
+      "block pointer type", (StringRef))
 
 // Opaque types
 ERROR(unsupported_opaque_type,none,

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -306,8 +306,21 @@ struct PrintOptions {
   /// List of decls that should be printed even if they are implicit and \c SkipImplicit is set to true.
   std::vector<const Decl*> TreatAsExplicitDeclList;
 
+  enum class FunctionRepresentationMode : uint8_t {
+    /// Print the entire convention, including an arguments.
+    /// For example, this will print a cType argument label if applicable.
+    Full,
+    /// Print only the name of the convention, skipping extra argument labels.
+    NameOnly,
+    /// Skip printing the @convention(..) altogether.
+    None
+  };
+
   /// Whether to print function @convention attribute on function types.
-  bool PrintFunctionRepresentationAttrs = true;
+  // FIXME: [clang-function-type-serialization] Once we start serializing Clang
+  // types, we should also start printing the full type in the swiftinterface.
+  FunctionRepresentationMode PrintFunctionRepresentationAttrs =
+    FunctionRepresentationMode::NameOnly;
 
   /// Whether to print storage representation attributes on types, e.g.
   /// '@sil_weak', '@sil_unmanaged'.
@@ -502,7 +515,8 @@ struct PrintOptions {
   /// consistent and well-formed.
   ///
   /// \see swift::emitSwiftInterface
-  static PrintOptions printSwiftInterfaceFile(bool preferTypeRepr);
+  static PrintOptions printSwiftInterfaceFile(bool preferTypeRepr,
+                                              bool printFullConvention);
 
   /// Retrieve the set of options suitable for "Generated Interfaces", which
   /// are a prettified representation of the public API of a module, to be
@@ -585,7 +599,8 @@ struct PrintOptions {
     PO.SkipUnderscoredKeywords = true;
     PO.EnumRawValues = EnumRawValueMode::Print;
     PO.PrintImplicitAttrs = false;
-    PO.PrintFunctionRepresentationAttrs = false;
+    PO.PrintFunctionRepresentationAttrs =
+      PrintOptions::FunctionRepresentationMode::None;
     PO.PrintDocumentationComments = false;
     PO.ExcludeAttrList.push_back(DAK_Available);
     PO.SkipPrivateStdlibDecls = true;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -59,6 +59,7 @@ class AssociatedTypeDecl;
 class ASTContext;
 enum BufferPointerTypeKind : unsigned;
 class ClassDecl;
+class ClangModuleLoader;
 class DependentMemberType;
 class GenericTypeParamDecl;
 class GenericTypeParamType;
@@ -2950,6 +2951,11 @@ public:
 
       bool empty() const { return !ClangFunctionType; }
       Uncommon(const clang::Type *type) : ClangFunctionType(type) {}
+
+    public:
+      /// Use the ClangModuleLoader to print the Clang type as a string.
+      void printClangFunctionType(ClangModuleLoader *cml,
+                                  llvm::raw_ostream &os);
     };
 
   private:

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3953,6 +3953,11 @@ public:
       return getSILFunctionLanguage(getRepresentation());
     }
 
+    /// Return the underlying Uncommon value if it is not the default value.
+    Optional<Uncommon> getUncommonInfo() const {
+      return Other.empty() ? Optional<Uncommon>() : Other;
+    }
+
     bool hasSelfParam() const {
       switch (getRepresentation()) {
       case Representation::Thick:

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3900,6 +3900,11 @@ public:
 
       bool empty() const { return !ClangFunctionType; }
       Uncommon(const clang::FunctionType *type) : ClangFunctionType(type) {}
+
+    public:
+      /// Analog of AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType.
+      void printClangFunctionType(ClangModuleLoader *cml,
+                                  llvm::raw_ostream &os) const;
     };
 
     Uncommon Other;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -40,6 +40,7 @@ namespace clang {
   class NamedDecl;
   class Sema;
   class TargetInfo;
+  class Type;
   class VisibleDeclConsumer;
   class DeclarationName;
 }
@@ -416,6 +417,9 @@ public:
   /// with -import-objc-header option.
   getPCHFilename(const ClangImporterOptions &ImporterOptions,
                  StringRef SwiftPCHHash, bool &isExplicit);
+
+  const clang::Type *parseClangFunctionType(StringRef type,
+                                            SourceLoc loc) const override;
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -420,6 +420,8 @@ public:
 
   const clang::Type *parseClangFunctionType(StringRef type,
                                             SourceLoc loc) const override;
+  void printClangType(const clang::Type *type,
+                      llvm::raw_ostream &os) const override;
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -31,6 +31,10 @@ struct ModuleInterfaceOptions {
   /// interface, or should we fully-qualify them?
   bool PreserveTypesAsWritten = false;
 
+  /// Should we emit the cType when printing @convention(c) or no?
+  /// FIXME: [clang-function-type-serialization] This check should go away.
+  bool PrintFullConvention = false;
+
   /// Copy of all the command-line flags passed at .swiftinterface
   /// generation time, re-applied to CompilerInvocation when reading
   /// back .swiftinterface and reconstructing .swiftmodule.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -602,6 +602,11 @@ def module_interface_preserve_types_as_written :
   HelpText<"When emitting a module interface, preserve types as they were "
            "written in the source">;
 
+def experimental_print_full_convention :
+ Flag<["-"], "experimental-print-full-convention">,
+ HelpText<"When emitting a module interface, emit additional @convention "
+          "arguments, regardless of whether they were written in the source">;
+
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,
   HelpText<"Directory of prebuilt modules for loading module interfaces">;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3156,6 +3156,11 @@ ArrayRef<Requirement> GenericFunctionType::getRequirements() const {
   return Signature->getRequirements();
 }
 
+void SILFunctionType::ExtInfo::Uncommon::printClangFunctionType(
+    ClangModuleLoader *cml, llvm::raw_ostream &os) const {
+  cml->printClangType(ClangFunctionType, os);
+}
+
 void SILFunctionType::Profile(
     llvm::FoldingSetNodeID &id,
     GenericSignature genericParams,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/Types.h"
 #include "ForeignRepresentationInfo.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ReferenceCounting.h"
 #include "swift/AST/TypeCheckRequests.h"
@@ -3237,6 +3238,11 @@ Type ProtocolCompositionType::get(const ASTContext &C,
   // TODO: Canonicalize away HasExplicitAnyObject if it is implied
   // by one of our member protocols.
   return build(C, CanTypes, HasExplicitAnyObject);
+}
+
+void AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType(
+    ClangModuleLoader *cml, llvm::raw_ostream &os) {
+  cml->printClangType(ClangFunctionType, os);
 }
 
 void

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3275,6 +3275,23 @@ void ClangImporter::verifyAllModules() {
 #endif
 }
 
+const clang::Type *
+ClangImporter::parseClangFunctionType(StringRef typeStr,
+                                      SourceLoc loc) const {
+  auto &sema = Impl.getClangSema();
+  StringRef filename = Impl.SwiftContext.SourceMgr.getDisplayNameForLoc(loc);
+  // TODO: Obtain a clang::SourceLocation from the swift::SourceLoc we have
+  auto parsedType = sema.ParseTypeFromStringCallback(typeStr, filename, {});
+  if (!parsedType.isUsable())
+    return nullptr;
+  clang::QualType resultType = clang::Sema::GetTypeFromParser(parsedType.get());
+  auto *typePtr = resultType.getTypePtrOrNull();
+  if (typePtr && (typePtr->isFunctionPointerType()
+                  || typePtr->isBlockPointerType()))
+      return typePtr;
+  return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 // ClangModule Implementation
 //===----------------------------------------------------------------------===//

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3292,6 +3292,12 @@ ClangImporter::parseClangFunctionType(StringRef typeStr,
   return nullptr;
 }
 
+void ClangImporter::printClangType(const clang::Type *type,
+                                   llvm::raw_ostream &os) const {
+  auto policy = clang::PrintingPolicy(getClangASTContext().getLangOpts());
+  clang::QualType(type, 0).print(os, policy);
+}
+
 //===----------------------------------------------------------------------===//
 // ClangModule Implementation
 //===----------------------------------------------------------------------===//

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -227,6 +227,8 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
 
   Opts.PreserveTypesAsWritten |=
     Args.hasArg(OPT_module_interface_preserve_types_as_written);
+  Opts.PrintFullConvention |=
+    Args.hasArg(OPT_experimental_print_full_convention);
 }
 
 /// Save a copy of any flags marked as ModuleInterfaceOption, if running

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -440,7 +440,7 @@ bool swift::emitSwiftInterface(raw_ostream &out,
   printImports(out, M);
 
   const PrintOptions printOptions = PrintOptions::printSwiftInterfaceFile(
-      Opts.PreserveTypesAsWritten);
+      Opts.PreserveTypesAsWritten, Opts.PrintFullConvention);
   InheritedProtocolCollector::PerTypeMap inheritedProtocolMap;
 
   SmallVector<Decl *, 16> topLevelDecls;

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -400,7 +400,8 @@ public:
     if (auto AFT = Ty->getAs<AnyFunctionType>()) {
       // If this is a closure type, add ChunkKind::CallParameterClosureType.
       PrintOptions PO;
-      PO.PrintFunctionRepresentationAttrs = false;
+      PO.PrintFunctionRepresentationAttrs =
+        PrintOptions::FunctionRepresentationMode::None;
       PO.SkipAttributes = true;
       PO.OpaqueReturnTypePrinting =
           PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -85,7 +85,8 @@ PrintOptions PrintOptions::printDocInterface() {
       PrintOptions::ArgAndParamPrintingMode::BothAlways;
   result.PrintDocumentationComments = false;
   result.PrintRegularClangComments = false;
-  result.PrintFunctionRepresentationAttrs = false;
+  result.PrintFunctionRepresentationAttrs =
+    PrintOptions::FunctionRepresentationMode::None;
   return result;
 }
 

--- a/test/ClangImporter/clang-function-types.swift
+++ b/test/ClangImporter/clang-function-types.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -emit-module-interface-path - -sdk %clang-importer-sdk -enable-library-evolution %s -experimental-print-full-convention | tee ~/tmp.si | %FileCheck %s
+
+import ctypes
+
+// CHECK: f1: (@convention(c, cType: "int (*)(int)") (Swift.Int32) -> Swift.Int32)?
+public let f1 = getFunctionPointer_()
+
+// CHECK: f2: (@convention(c, cType: "int (*(*)(int (*)(int)))(int)") ((@convention(c, cType: "int (*)(int)") (Swift.Int32) -> Swift.Int32)?) -> (@convention(c, cType: "int (*)(int)") (Swift.Int32) -> Swift.Int32)?)?
+public let f2 = getHigherOrderFunctionPointer()
+
+// CHECK: f3: () -> (@convention(c, cType: "Dummy *(*)(Dummy *)") (Swift.UnsafeMutablePointer<ctypes.Dummy>?) -> Swift.UnsafeMutablePointer<ctypes.Dummy>?)?
+public let f3 = getFunctionPointer3

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -205,6 +205,8 @@ typedef int (*fptr)(int);
 fptr getFunctionPointer(void);
 void useFunctionPointer(fptr);
 
+int (*getFunctionPointer_(void))(int);
+
 struct FunctionPointerWrapper {
   fptr a;
   fptr b;
@@ -213,6 +215,14 @@ struct FunctionPointerWrapper {
 typedef void (*fptr2)(int, long, void *);
 fptr2 getFunctionPointer2(void);
 void useFunctionPointer2(fptr2);
+
+int (*(*getHigherOrderFunctionPointer(void))(int (*)(int)))(int);
+
+typedef struct Dummy {
+    int x;
+} Dummy;
+
+Dummy * (*getFunctionPointer3(void))(Dummy *);
 
 //===---
 // Unions

--- a/test/ModuleInterface/full-convention.swift
+++ b/test/ModuleInterface/full-convention.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -emit-module-interface-path - -enable-library-evolution %s -experimental-print-full-convention | %FileCheck %s
+
+public func f(
+  // CHECK: g: @convention(c, cType: "void (*)(void)")
+  g: @convention(c) () -> (),
+
+  // CHECK: h0: @convention(c, cType: "int (*)(long long)")
+  h0: @convention(c) (Int64) -> Int32,
+  // CHECK: h1: @convention(c, cType: "int (*)(long long)")
+  h1: @convention(c, cType: "int (*)(long long)") (Int64) -> Int32,
+
+  // CHECK: i0: @convention(c, cType: "int *(*)(long long, int)")
+  i0: @convention(c) (Int64, Int32) -> Optional<UnsafeMutablePointer<Int32>>,
+  // CHECK: i1: @convention(c, cType: "int *(*)(long long, int)")
+  i1: @convention(c, cType: "int *(*)(long long, int)") (Int64, Int32) -> Optional<UnsafeMutablePointer<Int32>>,
+
+  // CHECK: p0: @convention(c, cType: "void (*)(void (*)(long))")
+  // CHECK:     @convention(c, cType: "void (*)(long)")
+  p0: @convention(c) (@convention(c) (Int) -> Void) -> Void,
+
+  // CHECK: p1: @convention(c, cType: "void (*)(void (*)(long))")
+  // CHECK:     @convention(c, cType: "void (*)(long)")
+  p1: @convention(c, cType: "void (*)(void (*)(long))") (@convention(c) (Int) -> Void) -> Void,
+
+  // CHECK: p2: @convention(c, cType: "void (*)(void (*)(long))")
+  // CHECK:     @convention(c, cType: "void (*)(long)")
+  p2: @convention(c) (@convention(c, cType: "void (*)(long)") (Int) -> Void) -> Void,
+
+  // CHECK: p3: @convention(c, cType: "void (*)(void (*)(long))")
+  // CHECK:     @convention(c, cType: "void (*)(long)")
+  p3: @convention(c, cType: "void (*)(void (*)(long))") (@convention(c, cType: "void (*)(long)") (Int) -> Void) -> Void
+) {}

--- a/test/Parse/c_function_pointers.swift
+++ b/test/Parse/c_function_pointers.swift
@@ -50,8 +50,8 @@ let f: @convention(c) (Int) -> Int = genericFunc // expected-error{{cannot be fo
 
 func ct1() -> () { print("") }
 
-let ct1ref0 : @convention(c, cType: "void *(void)") () -> () = ct1
-let ct1ref1 : @convention(c, cType: "void *(void)") = ct1 // expected-error{{expected type}}
+let ct1ref0 : @convention(c, cType: "void (*)(void)") () -> () = ct1
+let ct1ref1 : @convention(c, cType: "void (*)(void)") = ct1 // expected-error{{expected type}}
 let ct1ref2 : @convention(c, ) () -> () = ct1 // expected-error{{expected 'cType' label in 'convention' attribute}}
 let ct1ref3 : @convention(c, cType) () -> () = ct1 // expected-error{{expected ':' after 'cType' for 'convention' attribute}}
 let ct1ref4 : @convention(c, cType: ) () -> () = ct1 // expected-error{{expected string literal containing clang type for 'cType' in 'convention' attribute}}

--- a/test/attr/attr_convention.swift
+++ b/test/attr/attr_convention.swift
@@ -2,8 +2,12 @@
 
 let f1: (Int) -> Int = { $0 }
 let f2: @convention(swift) (Int) -> Int = { $0 }
+let f2a: @convention(swift, cType: "int *(int)") (Int32) -> Int32 = { $0 } // expected-error{{convention 'swift' does not support the 'cType' argument label, did you mean @convention(c, cType: "int *(int)") or @convention(block, cType: "int *(int)") instead?}}
 let f3: @convention(block) (Int) -> Int = { $0 }
 let f4: @convention(c) (Int) -> Int = { $0 }
+let f4a: @convention(c, cType: "int (int)") (Int32) -> Int32 = { $0 } // expected-error{{unable to parse 'int (int)'; it should be a C function pointer type or a block pointer type}}
+let f4b: @convention(c, cType: "void *") (Int32) -> Int32 = { $0 } // expected-error{{unable to parse 'void *'; it should be a C function pointer type or a block pointer type}}
+let f4c: @convention(c, cType: "int (*)(int)") (Int32) -> Int32 = { $0 }
 
 let f5: @convention(INTERCAL) (Int) -> Int = { $0 } // expected-error{{convention 'INTERCAL' not supported}}
 


### PR DESCRIPTION
~~First three commits are from https://github.com/apple/swift/pull/28726.~~ Tried to get it out soon for review. Some things are still TODO but the core things are done:

- [x] Add some test cases to check that diagnostics trigger. I tested manually and it seemed to work,  but still.
- [x] ~~Add some test cases for SIL printing. AST and SIL logic are very close, so this should be minimal work.~~ We can't add test cases for this right now, because we aren't storing the type in SIL
- [x] Add some test cases when the Clang type is coming from the ClangImporter. Technically, that shouldn't have any effect, but still.
- [x] Add some complex test cases using typedefs, struct pointers etc?