### PR TITLE
[AutoDiff upstream] Upstream `@derivative` attribute type-checking.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -62,6 +62,7 @@ namespace swift {
   class Decl;
   class DeclContext;
   class DefaultArgumentInitializer;
+  class DerivativeAttr;
   class ExtensionDecl;
   class ForeignRepresentationInfo;
   class FuncDecl;
@@ -281,6 +282,16 @@ public:
   /// The next auto-closure discriminator.  This needs to be preserved
   /// across invocations of both the parser and the type-checker.
   unsigned NextAutoClosureDiscriminator = 0;
+
+  /// Cache of `@derivative` attributes keyed by parameter indices and
+  /// derivative function kind. Used to diagnose duplicate `@derivative`
+  /// attributes for the same key.
+  // TODO(TF-1042): remove `DerivativeAttrs` from `ASTContext`. Serialize
+  // derivative function configurations per original `AbstractFunctionDecl`.
+  llvm::DenseMap<
+      std::tuple<Decl *, IndexSubset *, AutoDiffDerivativeFunctionKind>,
+      DerivativeAttr *>
+      DerivativeAttrs;
 
 private:
   /// The current generation number, which reflects the number of

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1765,7 +1765,21 @@ public:
   }
 };
 
-/// Attribute that registers a function as a derivative of another function.
+/// The `@derivative` attribute registers a function as a derivative of another
+/// function-like declaration: a 'func', 'init', 'subscript', or 'var' computed
+/// property declaration.
+///
+/// The `@derivative` attribute also has an optional `wrt:` clause specifying
+/// the parameters that are differentiated "with respect to", i.e. the
+/// differentiation parameters. The differentiation parameters must conform to
+/// the `Differentiable` protocol.
+///
+/// If the `wrt:` clause is unspecified, the differentiation parameters are
+/// inferred to be all parameters that conform to `Differentiable`.
+///
+/// `@derivative` attribute type-checking verifies that the type of the
+/// derivative function declaration is consistent with the type of the
+/// referenced original declaration and the differentiation parameters.
 ///
 /// Examples:
 ///   @derivative(of: sin(_:))

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -1,4 +1,4 @@
-//===--- AutoDiff.h - Swift Automatic Differentiation ---------------------===//
+//===--- AutoDiff.h - Swift automatic differentiation utilities -----------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-//  This file defines AST support for automatic differentiation.
+//  This file defines utilities for automatic differentiation.
 //
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2756,6 +2756,9 @@ ERROR(attr_not_on_variadic_parameters,none,
 ERROR(attr_not_on_subscript_parameters,none,
       "'%0' must not be used on subscript parameters", (StringRef))
 
+ERROR(attr_ambiguous_reference_to_decl,none,
+      "ambiguous reference to %0 in '@%1' attribute", (DeclNameRef, StringRef))
+
 ERROR(override_final,none,
       "%0 overrides a 'final' %1", (DescriptiveDeclKind, DescriptiveDeclKind))
 
@@ -2890,6 +2893,68 @@ ERROR(implements_attr_non_protocol_type,none,
 ERROR(implements_attr_protocol_not_conformed_to,none,
       "containing type %0 does not conform to protocol %1",
       (DeclName, DeclName))
+
+// @derivative
+ERROR(derivative_attr_expected_result_tuple,none,
+      "'@derivative(of:)' attribute requires function to return a two-element "
+      "tuple of type '(value: T..., pullback: (U.TangentVector) -> T.TangentVector...)' "
+      "or '(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'", ())
+ERROR(derivative_attr_invalid_result_tuple_value_label,none,
+      "'@derivative(of:)' attribute requires function to return a two-element "
+      "tuple (first element must have label 'value:')", ())
+ERROR(derivative_attr_invalid_result_tuple_func_label,none,
+      "'@derivative(of:)' attribute requires function to return a two-element "
+      "tuple (second element must have label 'pullback:' or 'differential:')",
+      ())
+ERROR(derivative_attr_result_value_not_differentiable,none,
+      "'@derivative(of:)' attribute requires function to return a two-element "
+      "tuple (first element type %0 must conform to 'Differentiable')", (Type))
+ERROR(derivative_attr_result_func_type_mismatch,none,
+      "function result's %0 type does not match %1", (Identifier, DeclName))
+NOTE(derivative_attr_result_func_type_mismatch_note,none,
+     "%0 does not have expected type %1", (Identifier, Type))
+NOTE(derivative_attr_result_func_original_note,none,
+     "%0 defined here", (DeclName))
+ERROR(derivative_attr_not_in_same_file_as_original,none,
+      "derivative not in the same file as the original function", ())
+ERROR(derivative_attr_original_stored_property_unsupported,none,
+      "cannot register derivative for stored property %0", (DeclNameRef))
+ERROR(derivative_attr_original_already_has_derivative,none,
+      "a derivative already exists for %0", (DeclName))
+NOTE(derivative_attr_duplicate_note,none,
+     "other attribute declared here", ())
+
+// Automatic differentiation attributes
+ERROR(autodiff_attr_original_decl_invalid_kind,none,
+      "%0 is not a 'func', 'init', 'subscript', or 'var' computed property "
+      "declaration", (DeclNameRef))
+ERROR(autodiff_attr_original_decl_none_valid_found,none,
+      "could not find function %0 with expected type %1", (DeclNameRef, Type))
+ERROR(autodiff_attr_original_decl_not_same_type_context,none,
+      "%0 is not defined in the current type context", (DeclNameRef))
+
+// differentiation `wrt` parameters clause
+ERROR(diff_function_no_parameters,none,
+      "%0 has no parameters to differentiate with respect to", (DeclName))
+ERROR(diff_params_clause_param_name_unknown,none,
+      "unknown parameter name %0", (Identifier))
+ERROR(diff_params_clause_self_instance_method_only,none,
+      "'self' parameter is only applicable to instance methods", ())
+ERROR(diff_params_clause_self_must_be_first,none,
+      "'self' parameter must come first in the parameter list", ())
+ERROR(diff_params_clause_params_not_original_order,none,
+      "parameters must be specified in original order", ())
+ERROR(diff_params_clause_param_index_out_of_range,none,
+      "parameter index is larger than total number of parameters", ())
+ERROR(diff_params_clause_no_inferred_parameters,PointsToFirstBadToken,
+      "no differentiation parameters could be inferred; must differentiate "
+      "with respect to at least one parameter conforming to 'Differentiable'",
+      ())
+ERROR(diff_params_clause_cannot_diff_wrt_inout_parameter,none,
+      "cannot differentiate with respect to 'inout' parameter (%0)", (Type))
+ERROR(diff_params_clause_param_not_differentiable,none,
+      "can only differentiate with respect to parameters that conform to "
+      "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Expressions

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -197,6 +197,9 @@ IDENTIFIER_(nsError)
 // Custom string interpolation type used by os log APIs.
 IDENTIFIER(OSLogMessage)
 
+// Differentiable programming
+IDENTIFIER(TangentVector)
+
 #undef IDENTIFIER
 #undef IDENTIFIER_
 #undef IDENTIFIER_WITH_NAME

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -1,8 +1,8 @@
-//===--------- AutoDiff.cpp - Swift Differentiable Programming ------------===//
+//===--- AutoDiff.cpp - Swift automatic differentiation utilities ---------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -1,0 +1,68 @@
+//===--------- AutoDiff.cpp - Swift Differentiable Programming ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/AutoDiff.h"
+#include "swift/AST/Types.h"
+
+using namespace swift;
+
+// TODO(TF-874): This helper is inefficient and should be removed. Unwrapping at
+// most once (for curried method types) is sufficient.
+static void unwrapCurryLevels(AnyFunctionType *fnTy,
+                              SmallVectorImpl<AnyFunctionType *> &results) {
+  while (fnTy != nullptr) {
+    results.push_back(fnTy);
+    fnTy = fnTy->getResult()->getAs<AnyFunctionType>();
+  }
+}
+
+static unsigned countNumFlattenedElementTypes(Type type) {
+  if (auto *tupleTy = type->getCanonicalType()->getAs<TupleType>())
+    return accumulate(tupleTy->getElementTypes(), 0,
+                      [&](unsigned num, Type type) {
+                        return num + countNumFlattenedElementTypes(type);
+                      });
+  return 1;
+}
+
+// TODO(TF-874): Simplify this helper and remove the `reverseCurryLevels` flag.
+// See TF-874 for WIP.
+void autodiff::getSubsetParameterTypes(IndexSubset *subset,
+                                       AnyFunctionType *type,
+                                       SmallVectorImpl<Type> &results,
+                                       bool reverseCurryLevels) {
+  SmallVector<AnyFunctionType *, 2> curryLevels;
+  unwrapCurryLevels(type, curryLevels);
+
+  SmallVector<unsigned, 2> curryLevelParameterIndexOffsets(curryLevels.size());
+  unsigned currentOffset = 0;
+  for (unsigned curryLevelIndex : llvm::reverse(indices(curryLevels))) {
+    curryLevelParameterIndexOffsets[curryLevelIndex] = currentOffset;
+    currentOffset += curryLevels[curryLevelIndex]->getNumParams();
+  }
+
+  // If `reverseCurryLevels` is true, reverse the curry levels and offsets.
+  if (reverseCurryLevels) {
+    std::reverse(curryLevels.begin(), curryLevels.end());
+    std::reverse(curryLevelParameterIndexOffsets.begin(),
+                 curryLevelParameterIndexOffsets.end());
+  }
+
+  for (unsigned curryLevelIndex : indices(curryLevels)) {
+    auto *curryLevel = curryLevels[curryLevelIndex];
+    unsigned parameterIndexOffset =
+        curryLevelParameterIndexOffsets[curryLevelIndex];
+    for (unsigned paramIndex : range(curryLevel->getNumParams()))
+      if (subset->contains(parameterIndexOffset + paramIndex))
+        results.push_back(curryLevel->getParams()[paramIndex].getOldType());
+  }
+}

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -29,7 +29,7 @@ add_swift_host_library(swiftAST STATIC
   ASTVerifier.cpp
   ASTWalker.cpp
   Attr.cpp
-  IndexSubset.cpp
+  AutoDiff.cpp
   Availability.cpp
   AvailabilitySpec.cpp
   Builtins.cpp
@@ -55,6 +55,7 @@ add_swift_host_library(swiftAST STATIC
   Identifier.cpp
   ImportCache.cpp
   IncrementalRanges.cpp
+  IndexSubset.cpp
   InlinableText.cpp
   LayoutConstraint.cpp
   Module.cpp

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3354,7 +3354,15 @@ getAutoDiffOriginalFunctionType(AnyFunctionType *derivativeFnTy) {
 }
 
 void AttributeChecker::visitDerivativeAttr(DerivativeAttr *attr) {
-  FuncDecl *derivative = cast<FuncDecl>(D);
+  // `@derivative` attribute requires experimental differentiable programming
+  // to be enabled.
+  auto &ctx = D->getASTContext();
+  if (!ctx.LangOpts.EnableExperimentalDifferentiableProgramming) {
+    diagnoseAndRemoveAttr(
+        attr, diag::experimental_differentiable_programming_disabled);
+    return;
+  }
+  auto *derivative = cast<FuncDecl>(D);
   auto lookupConformance =
       LookUpConformanceInModule(D->getDeclContext()->getParentModule());
   auto originalName = attr->getOriginalFunctionName();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -119,9 +119,6 @@ public:
   // TODO(TF-828): Upstream `@differentiable` attribute type-checking from
   // tensorflow branch.
   IGNORED_ATTR(Differentiable)
-  // TODO(TF-829): Upstream `@derivative` attribute type-checking from
-  // tensorflow branch.
-  IGNORED_ATTR(Derivative)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {
@@ -254,6 +251,8 @@ public:
   void visitImplementationOnlyAttr(ImplementationOnlyAttr *attr);
   void visitNonEphemeralAttr(NonEphemeralAttr *attr);
   void checkOriginalDefinedInAttrs(ArrayRef<OriginallyDefinedInAttr*> Attrs);
+
+  void visitDerivativeAttr(DerivativeAttr *attr);
 };
 } // end anonymous namespace
 
@@ -2896,4 +2895,743 @@ DynamicallyReplacedDeclRequest::evaluate(Evaluator &evaluator,
   }
 
   return nullptr;
+}
+
+/// Returns true if the given type conforms to `Differentiable` in the given
+/// module.
+static bool conformsToDifferentiable(Type type, DeclContext *DC) {
+  auto &ctx = type->getASTContext();
+  auto *differentiableProto =
+      ctx.getProtocol(KnownProtocolKind::Differentiable);
+  auto conf = TypeChecker::conformsToProtocol(
+      type, differentiableProto, DC, ConformanceCheckFlags::InExpression);
+  if (!conf)
+    return false;
+  // Try to get the `TangentVector` type witness, in case the conformance has
+  // not been fully checked and the type witness cannot be resolved.
+  Type tanType = conf.getTypeWitnessByName(type, ctx.Id_TangentVector);
+  return !tanType.isNull() && !tanType->hasError();
+};
+
+IndexSubset *TypeChecker::inferDifferentiationParameters(
+    AbstractFunctionDecl *AFD, GenericEnvironment *derivativeGenEnv) {
+  auto &ctx = AFD->getASTContext();
+  auto *functionType = AFD->getInterfaceType()->castTo<AnyFunctionType>();
+  auto numUncurriedParams = functionType->getNumParams();
+  if (auto *resultFnType =
+          functionType->getResult()->getAs<AnyFunctionType>()) {
+    numUncurriedParams += resultFnType->getNumParams();
+  }
+  llvm::SmallBitVector parameterBits(numUncurriedParams);
+  SmallVector<Type, 4> allParamTypes;
+
+  // Returns true if the i-th parameter type is differentiable.
+  auto isDifferentiableParam = [&](unsigned i) -> bool {
+    if (i >= allParamTypes.size())
+      return false;
+    auto paramType = allParamTypes[i];
+    if (derivativeGenEnv)
+      paramType = derivativeGenEnv->mapTypeIntoContext(paramType);
+    else
+      paramType = AFD->mapTypeIntoContext(paramType);
+    // Return false for existential types.
+    if (paramType->isExistentialType())
+      return false;
+    // Return true if the type conforms to `Differentiable`.
+    return conformsToDifferentiable(paramType, AFD);
+  };
+
+  // Get all parameter types.
+  // NOTE: To be robust, result function type parameters should be added only if
+  // `functionType` comes from a static/instance method, and not a free function
+  // returning a function type. In practice, this code path should not be
+  // reachable for free functions returning a function type.
+  if (auto resultFnType = functionType->getResult()->getAs<AnyFunctionType>())
+    for (auto &param : resultFnType->getParams())
+      allParamTypes.push_back(param.getPlainType());
+  for (auto &param : functionType->getParams())
+    allParamTypes.push_back(param.getPlainType());
+
+  // Set differentiation parameters.
+  for (unsigned i : range(parameterBits.size()))
+    if (isDifferentiableParam(i))
+      parameterBits.set(i);
+
+  return IndexSubset::get(ctx, parameterBits);
+}
+
+// Computes `IndexSubset` from the given parsed differentiation parameters
+// (possibly empty) for the given function and derivative generic environment,
+// then verifies that the parameter indices are valid.
+// - If parsed parameters are empty, infer parameter indices.
+// - Otherwise, build parameter indices from parsed parameters.
+// The attribute name/location are used in diagnostics.
+static IndexSubset *computeDifferentiationParameters(
+    ArrayRef<ParsedAutoDiffParameter> parsedWrtParams,
+    AbstractFunctionDecl *function, GenericEnvironment *derivativeGenEnv,
+    StringRef attrName, SourceLoc attrLoc) {
+  auto &ctx = function->getASTContext();
+  auto &diags = ctx.Diags;
+
+  // Get function type and parameters.
+  auto *functionType = function->getInterfaceType()->castTo<AnyFunctionType>();
+  auto &params = *function->getParameters();
+  auto numParams = function->getParameters()->size();
+  auto isInstanceMethod = function->isInstanceMember();
+
+  // Diagnose if function has no parameters.
+  if (params.size() == 0) {
+    // If function is not an instance method, diagnose immediately.
+    if (!isInstanceMethod) {
+      diags
+          .diagnose(attrLoc, diag::diff_function_no_parameters,
+                    function->getFullName())
+          .highlight(function->getSignatureSourceRange());
+      return nullptr;
+    }
+    // If function is an instance method, diagnose only if `self` does not
+    // conform to `Differentiable`.
+    else {
+      auto selfType = function->getImplicitSelfDecl()->getInterfaceType();
+      if (derivativeGenEnv)
+        selfType = derivativeGenEnv->mapTypeIntoContext(selfType);
+      else
+        selfType = function->mapTypeIntoContext(selfType);
+      if (!conformsToDifferentiable(selfType, function)) {
+        diags
+            .diagnose(attrLoc, diag::diff_function_no_parameters,
+                      function->getFullName())
+            .highlight(function->getSignatureSourceRange());
+        return nullptr;
+      }
+    }
+  }
+
+  // If parsed differentiation parameters are empty, infer parameter indices
+  // from the function type.
+  if (parsedWrtParams.empty())
+    return TypeChecker::inferDifferentiationParameters(function,
+                                                       derivativeGenEnv);
+
+  // Otherwise, build parameter indices from parsed differentiation parameters.
+  auto numUncurriedParams = functionType->getNumParams();
+  if (auto *resultFnType =
+          functionType->getResult()->getAs<AnyFunctionType>()) {
+    numUncurriedParams += resultFnType->getNumParams();
+  }
+  llvm::SmallBitVector parameterBits(numUncurriedParams);
+  int lastIndex = -1;
+  for (unsigned i : indices(parsedWrtParams)) {
+    auto paramLoc = parsedWrtParams[i].getLoc();
+    switch (parsedWrtParams[i].getKind()) {
+    case ParsedAutoDiffParameter::Kind::Named: {
+      auto nameIter = llvm::find_if(params.getArray(), [&](ParamDecl *param) {
+        return param->getName() == parsedWrtParams[i].getName();
+      });
+      // Parameter name must exist.
+      if (nameIter == params.end()) {
+        diags.diagnose(paramLoc, diag::diff_params_clause_param_name_unknown,
+                       parsedWrtParams[i].getName());
+        return nullptr;
+      }
+      // Parameter names must be specified in the original order.
+      unsigned index = std::distance(params.begin(), nameIter);
+      if ((int)index <= lastIndex) {
+        diags.diagnose(paramLoc,
+                       diag::diff_params_clause_params_not_original_order);
+        return nullptr;
+      }
+      parameterBits.set(index);
+      lastIndex = index;
+      break;
+    }
+    case ParsedAutoDiffParameter::Kind::Self: {
+      // 'self' is only applicable to instance methods.
+      if (!isInstanceMethod) {
+        diags.diagnose(paramLoc,
+                       diag::diff_params_clause_self_instance_method_only);
+        return nullptr;
+      }
+      // 'self' can only be the first in the list.
+      if (i > 0) {
+        diags.diagnose(paramLoc, diag::diff_params_clause_self_must_be_first);
+        return nullptr;
+      }
+      parameterBits.set(parameterBits.size() - 1);
+      break;
+    }
+    case ParsedAutoDiffParameter::Kind::Ordered: {
+      auto index = parsedWrtParams[i].getIndex();
+      if (index >= numParams) {
+        diags.diagnose(paramLoc,
+                       diag::diff_params_clause_param_index_out_of_range);
+        return nullptr;
+      }
+      // Parameter names must be specified in the original order.
+      if ((int)index <= lastIndex) {
+        diags.diagnose(paramLoc,
+                       diag::diff_params_clause_params_not_original_order);
+        return nullptr;
+      }
+      parameterBits.set(index);
+      lastIndex = index;
+      break;
+    }
+    }
+  }
+  return IndexSubset::get(ctx, parameterBits);
+}
+
+// Checks if the given `IndexSubset` instance is valid for the given function
+// type in the given derivative generic environment and module context. Returns
+// true on error.
+// The parsed differentiation parameters and attribute location are used in
+// diagnostics.
+static bool checkDifferentiationParameters(
+    AbstractFunctionDecl *AFD, IndexSubset *indices,
+    AnyFunctionType *functionType, GenericEnvironment *derivativeGenEnv,
+    ModuleDecl *module, ArrayRef<ParsedAutoDiffParameter> parsedWrtParams,
+    SourceLoc attrLoc) {
+  auto &ctx = AFD->getASTContext();
+  auto &diags = ctx.Diags;
+
+  // Diagnose empty parameter indices. This occurs when no `wrt:` clause is
+  // declared and no differentiation parameters can be inferred.
+  if (indices->isEmpty()) {
+    diags.diagnose(attrLoc, diag::diff_params_clause_no_inferred_parameters);
+    return true;
+  }
+
+  // Check that differentiation parameters have allowed types.
+  SmallVector<Type, 4> wrtParamTypes;
+  autodiff::getSubsetParameterTypes(indices, functionType, wrtParamTypes);
+  for (unsigned i : range(wrtParamTypes.size())) {
+    SourceLoc loc =
+        parsedWrtParams.empty() ? attrLoc : parsedWrtParams[i].getLoc();
+    auto wrtParamType = wrtParamTypes[i];
+    // `inout` parameters are not yet supported.
+    if (wrtParamType->is<InOutType>()) {
+      diags.diagnose(loc,
+                     diag::diff_params_clause_cannot_diff_wrt_inout_parameter,
+                     wrtParamType);
+      return true;
+    }
+    if (!wrtParamType->hasTypeParameter())
+      wrtParamType = wrtParamType->mapTypeOutOfContext();
+    if (derivativeGenEnv)
+      wrtParamType = derivativeGenEnv->mapTypeIntoContext(wrtParamType);
+    else
+      wrtParamType = AFD->mapTypeIntoContext(wrtParamType);
+    // Parameter must conform to `Differentiable`.
+    if (!conformsToDifferentiable(wrtParamType, AFD)) {
+      diags.diagnose(loc, diag::diff_params_clause_param_not_differentiable,
+                     wrtParamType);
+      return true;
+    }
+  }
+  return false;
+}
+
+// Returns the function declaration corresponding to the given function name and
+// lookup context. If the base type of the function is specified, member lookup
+// is performed. Otherwise, unqualified lookup is performed.
+// If the function declaration cannot be resolved, emits a diagnostic and
+// returns nullptr.
+static AbstractFunctionDecl *findAbstractFunctionDecl(
+    DeclNameRef funcName, SourceLoc funcNameLoc, Type baseType,
+    DeclContext *lookupContext,
+    const std::function<bool(AbstractFunctionDecl *)> &isValidCandidate,
+    const std::function<void()> &noneValidDiagnostic,
+    const std::function<void()> &ambiguousDiagnostic,
+    const std::function<void()> &notFunctionDiagnostic,
+    NameLookupOptions lookupOptions,
+    const Optional<std::function<bool(AbstractFunctionDecl *)>>
+        &hasValidTypeCtx,
+    const Optional<std::function<void()>> &invalidTypeCtxDiagnostic) {
+  auto &ctx = lookupContext->getASTContext();
+  AbstractFunctionDecl *resolvedCandidate = nullptr;
+
+  // Perform lookup.
+  LookupResult results;
+  if (baseType) {
+    results = TypeChecker::lookupMember(lookupContext, baseType, funcName);
+  } else {
+    results = TypeChecker::lookupUnqualified(lookupContext, funcName,
+                                             funcNameLoc, lookupOptions);
+
+    // If looking up an operator within a type context, look specifically within
+    // the type context.
+    // This tries to resolve unqualified operators, like `+`.
+    if (funcName.isOperator() && lookupContext->isTypeContext()) {
+      if (auto tmp = TypeChecker::lookupMember(
+              lookupContext, lookupContext->getSelfTypeInContext(), funcName))
+        results = tmp;
+    }
+  }
+
+  // Initialize error flags.
+  bool notFunction = false;
+  bool wrongTypeContext = false;
+  bool ambiguousFuncDecl = false;
+  bool foundInvalid = false;
+
+  // Filter lookup results.
+  for (auto choice : results) {
+    auto decl = choice.getValueDecl();
+    if (!decl)
+      continue;
+    // Cast the candidate to an `AbstractFunctionDecl`.
+    auto *candidate = dyn_cast<AbstractFunctionDecl>(decl);
+    // If the candidate is an `AbstractStorageDecl`, use its getter as the
+    // candidate.
+    if (auto *asd = dyn_cast<AbstractStorageDecl>(decl))
+      candidate = asd->getAccessor(AccessorKind::Get);
+    if (!candidate) {
+      notFunction = true;
+      continue;
+    }
+    if (hasValidTypeCtx && !(*hasValidTypeCtx)(candidate)) {
+      wrongTypeContext = true;
+      continue;
+    }
+    if (!isValidCandidate(candidate)) {
+      foundInvalid = true;
+      continue;
+    }
+    if (resolvedCandidate) {
+      ambiguousFuncDecl = true;
+      resolvedCandidate = nullptr;
+      break;
+    }
+    resolvedCandidate = candidate;
+  }
+  // If function declaration was resolved, return it.
+  if (resolvedCandidate)
+    return resolvedCandidate;
+
+  // Otherwise, emit the appropriate diagnostic and return nullptr.
+  if (results.empty()) {
+    ctx.Diags.diagnose(funcNameLoc, diag::use_unresolved_identifier, funcName,
+                       funcName.isOperator());
+    return nullptr;
+  }
+  if (ambiguousFuncDecl) {
+    ambiguousDiagnostic();
+    return nullptr;
+  }
+  if (wrongTypeContext) {
+    assert(invalidTypeCtxDiagnostic &&
+           "Type context diagnostic should've been specified");
+    (*invalidTypeCtxDiagnostic)();
+    return nullptr;
+  }
+  if (foundInvalid) {
+    noneValidDiagnostic();
+    return nullptr;
+  }
+  assert(notFunction && "Expected 'not a function' error");
+  notFunctionDiagnostic();
+  return nullptr;
+}
+
+// Checks that the `candidate` function type equals the `required` function
+// type, disregarding parameter labels and tuple result labels.
+// `checkGenericSignature` is used to check generic signatures, if specified.
+// Otherwise, generic signatures are checked for equality.
+static bool checkFunctionSignature(
+    CanAnyFunctionType required, CanType candidate,
+    Optional<std::function<bool(GenericSignature, GenericSignature)>>
+        checkGenericSignature = None) {
+  // Check that candidate is actually a function.
+  auto candidateFnTy = dyn_cast<AnyFunctionType>(candidate);
+  if (!candidateFnTy)
+    return false;
+
+  // Erase dynamic self types.
+  required = dyn_cast<AnyFunctionType>(required->getCanonicalType());
+  candidateFnTy = dyn_cast<AnyFunctionType>(candidateFnTy->getCanonicalType());
+
+  // Check that generic signatures match.
+  auto requiredGenSig = required.getOptGenericSignature();
+  auto candidateGenSig = candidateFnTy.getOptGenericSignature();
+  // Call generic signature check function, if specified.
+  // Otherwise, check that generic signatures are equal.
+  if (!checkGenericSignature) {
+    if (candidateGenSig != requiredGenSig)
+      return false;
+  } else if (!(*checkGenericSignature)(requiredGenSig, candidateGenSig)) {
+    return false;
+  }
+
+  // Check that parameter types match, disregarding labels.
+  if (required->getNumParams() != candidateFnTy->getNumParams())
+    return false;
+  if (!std::equal(required->getParams().begin(), required->getParams().end(),
+                  candidateFnTy->getParams().begin(),
+                  [](AnyFunctionType::Param x, AnyFunctionType::Param y) {
+                    return x.getPlainType()->isEqual(y.getPlainType());
+                  }))
+    return false;
+
+  // If required result type is not a function type, check that result types
+  // match exactly.
+  auto requiredResultFnTy = dyn_cast<AnyFunctionType>(required.getResult());
+  if (!requiredResultFnTy) {
+    auto requiredResultTupleTy = dyn_cast<TupleType>(required.getResult());
+    auto candidateResultTupleTy =
+        dyn_cast<TupleType>(candidateFnTy.getResult());
+    if (!requiredResultTupleTy || !candidateResultTupleTy)
+      return required.getResult()->isEqual(candidateFnTy.getResult());
+    // If result types are tuple types, check that element types match,
+    // ignoring labels.
+    if (requiredResultTupleTy->getNumElements() !=
+        candidateResultTupleTy->getNumElements())
+      return false;
+    return std::equal(requiredResultTupleTy.getElementTypes().begin(),
+                      requiredResultTupleTy.getElementTypes().end(),
+                      candidateResultTupleTy.getElementTypes().begin(),
+                      [](CanType x, CanType y) { return x->isEqual(y); });
+  }
+
+  // Required result type is a function. Recurse.
+  return checkFunctionSignature(requiredResultFnTy, candidateFnTy.getResult());
+};
+
+// Returns an `AnyFunctionType` with the same `ExtInfo` as `fnType`, but with
+// the given parameters, result type, and generic signature. If the given
+// generic signature is `null`, use the generic signature of `fnType`.
+static AnyFunctionType *
+makeFunctionType(AnyFunctionType *fnType,
+                 ArrayRef<AnyFunctionType::Param> parameters, Type resultType,
+                 GenericSignature genericSignature) {
+  if (!genericSignature)
+    if (auto *genericFunctionType = fnType->getAs<GenericFunctionType>())
+      genericSignature = genericFunctionType->getGenericSignature();
+  if (genericSignature)
+    return GenericFunctionType::get(genericSignature, parameters, resultType,
+                                    fnType->getExtInfo());
+  return FunctionType::get(parameters, resultType, fnType->getExtInfo());
+}
+
+// Computes the original function type corresponding to the given derivative
+// function type.
+AnyFunctionType *
+getAutoDiffOriginalFunctionType(AnyFunctionType *derivativeFnTy) {
+  // Unwrap curry levels. At most, two parameter lists are necessary, for
+  // curried method types with a `(Self)` parameter list.
+  SmallVector<AnyFunctionType *, 2> curryLevels;
+  auto *currentLevel = derivativeFnTy;
+  for (unsigned i : range(2)) {
+    (void)i;
+    if (currentLevel == nullptr)
+      break;
+    curryLevels.push_back(currentLevel);
+    currentLevel = currentLevel->getResult()->getAs<AnyFunctionType>();
+  }
+
+  auto derivativeResult = curryLevels.back()->getResult()->getAs<TupleType>();
+  assert(derivativeResult && derivativeResult->getNumElements() == 2 &&
+         "Expected derivative result to be a two-element tuple");
+  auto originalResult = derivativeResult->getElement(0).getType();
+  auto *originalType = makeFunctionType(
+      curryLevels.back(), curryLevels.back()->getParams(), originalResult,
+      curryLevels.size() == 1 ? derivativeFnTy->getOptGenericSignature()
+                              : nullptr);
+
+  // Wrap the derivative function type in additional curry levels.
+  auto curryLevelsWithoutLast =
+      ArrayRef<AnyFunctionType *>(curryLevels).drop_back(1);
+  for (auto pair : enumerate(llvm::reverse(curryLevelsWithoutLast))) {
+    unsigned i = pair.index();
+    AnyFunctionType *curryLevel = pair.value();
+    originalType =
+        makeFunctionType(curryLevel, curryLevel->getParams(), originalType,
+                         i == curryLevelsWithoutLast.size() - 1
+                             ? derivativeFnTy->getOptGenericSignature()
+                             : nullptr);
+  }
+  return originalType;
+}
+
+void AttributeChecker::visitDerivativeAttr(DerivativeAttr *attr) {
+  FuncDecl *derivative = cast<FuncDecl>(D);
+  auto lookupConformance =
+      LookUpConformanceInModule(D->getDeclContext()->getParentModule());
+  auto originalName = attr->getOriginalFunctionName();
+
+  auto *derivativeInterfaceType =
+      derivative->getInterfaceType()->castTo<AnyFunctionType>();
+
+  // Perform preliminary `@derivative` declaration checks.
+
+  // The result type should be a two-element tuple.
+  // Either a value and pullback:
+  //     (value: R, pullback: (R.TangentVector) -> (T.TangentVector...)
+  // Or a value and differential:
+  //     (value: R, differential: (T.TangentVector...) -> (R.TangentVector)
+  auto derivativeResultType = derivative->getResultInterfaceType();
+  auto derivativeResultTupleType = derivativeResultType->getAs<TupleType>();
+  if (!derivativeResultTupleType ||
+      derivativeResultTupleType->getNumElements() != 2) {
+    diagnose(attr->getLocation(), diag::derivative_attr_expected_result_tuple);
+    attr->setInvalid();
+    return;
+  }
+  auto valueResultElt = derivativeResultTupleType->getElement(0);
+  auto funcResultElt = derivativeResultTupleType->getElement(1);
+  // Get derivative kind and derivative function identifier.
+  AutoDiffDerivativeFunctionKind kind;
+  if (valueResultElt.getName().str() != "value") {
+    diagnose(attr->getLocation(),
+             diag::derivative_attr_invalid_result_tuple_value_label);
+    attr->setInvalid();
+    return;
+  }
+  if (funcResultElt.getName().str() == "differential") {
+    kind = AutoDiffDerivativeFunctionKind::JVP;
+  } else if (funcResultElt.getName().str() == "pullback") {
+    kind = AutoDiffDerivativeFunctionKind::VJP;
+  } else {
+    diagnose(attr->getLocation(),
+             diag::derivative_attr_invalid_result_tuple_func_label);
+    attr->setInvalid();
+    return;
+  }
+  attr->setDerivativeKind(kind);
+  // `value: R` result tuple element must conform to `Differentiable`.
+  auto diffableProto = Ctx.getProtocol(KnownProtocolKind::Differentiable);
+  auto valueResultType = valueResultElt.getType();
+  if (valueResultType->hasTypeParameter())
+    valueResultType = derivative->mapTypeIntoContext(valueResultType);
+  auto valueResultConf = TypeChecker::conformsToProtocol(
+      valueResultType, diffableProto, derivative->getDeclContext(), None);
+  if (!valueResultConf) {
+    diagnose(attr->getLocation(),
+             diag::derivative_attr_result_value_not_differentiable,
+             valueResultElt.getType());
+    attr->setInvalid();
+    return;
+  }
+
+  // Compute expected original function type and look up original function.
+  auto *originalFnType =
+      getAutoDiffOriginalFunctionType(derivativeInterfaceType);
+
+  // Returns true if the generic parameters in `source` satisfy the generic
+  // requirements in `target`.
+  std::function<bool(GenericSignature, GenericSignature)>
+      checkGenericSignatureSatisfied = [&](GenericSignature source,
+                                           GenericSignature target) {
+        // If target is null, then its requirements are satisfied.
+        if (!target)
+          return true;
+        // If source is null but target is not null, then target's
+        // requirements are not satisfied.
+        if (!source)
+          return false;
+        // Check if target's requirements are satisfied by source.
+        // Cancel diagnostics using `DiagnosticTransaction`.
+        // Diagnostics should not be emitted because this function is used to
+        // check candidates; if no candidates match, a separate diagnostic will
+        // be produced.
+        DiagnosticTransaction transaction(Ctx.Diags);
+        SWIFT_DEFER { transaction.abort(); };
+        return TypeChecker::checkGenericArguments(
+                   derivative, originalName.Loc.getBaseNameLoc(),
+                   originalName.Loc.getBaseNameLoc(), Type(),
+                   source->getGenericParams(), target->getRequirements(),
+                   [](SubstitutableType *dependentType) {
+                     return Type(dependentType);
+                   },
+                   lookupConformance, None) == RequirementCheckResult::Success;
+      };
+
+  auto isValidOriginal = [&](AbstractFunctionDecl *originalCandidate) {
+    return checkFunctionSignature(
+        cast<AnyFunctionType>(originalFnType->getCanonicalType()),
+        originalCandidate->getInterfaceType()->getCanonicalType(),
+        checkGenericSignatureSatisfied);
+  };
+
+  auto noneValidDiagnostic = [&]() {
+    diagnose(originalName.Loc,
+             diag::autodiff_attr_original_decl_none_valid_found,
+             originalName.Name, originalFnType);
+  };
+  auto ambiguousDiagnostic = [&]() {
+    diagnose(originalName.Loc, diag::attr_ambiguous_reference_to_decl,
+             originalName.Name, attr->getAttrName());
+  };
+  auto notFunctionDiagnostic = [&]() {
+    diagnose(originalName.Loc, diag::autodiff_attr_original_decl_invalid_kind,
+             originalName.Name);
+  };
+  std::function<void()> invalidTypeContextDiagnostic = [&]() {
+    diagnose(originalName.Loc,
+             diag::autodiff_attr_original_decl_not_same_type_context,
+             originalName.Name);
+  };
+
+  // Returns true if the derivative function and original function candidate are
+  // defined in compatible type contexts. If the derivative function and the
+  // original function candidate have different parents, return false.
+  std::function<bool(AbstractFunctionDecl *)> hasValidTypeContext =
+      [&](AbstractFunctionDecl *func) {
+        // Check if both functions are top-level.
+        if (!derivative->getInnermostTypeContext() &&
+            !func->getInnermostTypeContext())
+          return true;
+        // Check if both functions are defined in the same type context.
+        if (auto typeCtx1 = derivative->getInnermostTypeContext())
+          if (auto typeCtx2 = func->getInnermostTypeContext()) {
+            return typeCtx1->getSelfNominalTypeDecl() ==
+                   typeCtx2->getSelfNominalTypeDecl();
+          }
+        return derivative->getParent() == func->getParent();
+      };
+
+  auto lookupOptions =
+      defaultMemberLookupOptions | NameLookupFlags::IgnoreAccessControl;
+  auto derivativeTypeCtx = derivative->getInnermostTypeContext();
+  if (!derivativeTypeCtx)
+    derivativeTypeCtx = derivative->getParent();
+  assert(derivativeTypeCtx);
+
+  // Look up original function.
+  auto *originalAFD = findAbstractFunctionDecl(
+      originalName.Name, originalName.Loc.getBaseNameLoc(), /*baseType*/ Type(),
+      derivativeTypeCtx, isValidOriginal, noneValidDiagnostic,
+      ambiguousDiagnostic, notFunctionDiagnostic, lookupOptions,
+      hasValidTypeContext, invalidTypeContextDiagnostic);
+  if (!originalAFD) {
+    attr->setInvalid();
+    return;
+  }
+  // Diagnose original stored properties. Stored properties cannot have custom
+  // registered derivatives.
+  if (auto *accessorDecl = dyn_cast<AccessorDecl>(originalAFD)) {
+    auto *asd = accessorDecl->getStorage();
+    if (asd->hasStorage()) {
+      diagnose(originalName.Loc,
+               diag::derivative_attr_original_stored_property_unsupported,
+               originalName.Name);
+      diagnose(originalAFD->getLoc(), diag::decl_declared_here,
+               asd->getFullName());
+      attr->setInvalid();
+      return;
+    }
+  }
+  attr->setOriginalFunction(originalAFD);
+
+  // Get the resolved `wrt:` parameter indices.
+  auto *resolvedWrtParamIndices = attr->getParameterIndices();
+
+  // Get the parsed `wrt:` parameter indices, which have not yet been resolved.
+  // Parsed `wrt:` paraeter indices are defined only for parsed attributes.
+  auto parsedWrtParams = attr->getParsedParameters();
+
+  // If parameter indices are not resolved, compute them.
+  if (!resolvedWrtParamIndices)
+    resolvedWrtParamIndices = computeDifferentiationParameters(
+        parsedWrtParams, derivative, derivative->getGenericEnvironment(),
+        attr->getAttrName(), attr->getLocation());
+  if (!resolvedWrtParamIndices) {
+    attr->setInvalid();
+    return;
+  }
+
+  // Check if the `wrt:` parameter indices are valid.
+  if (checkDifferentiationParameters(
+          originalAFD, resolvedWrtParamIndices, originalFnType,
+          derivative->getGenericEnvironment(), derivative->getModuleContext(),
+          parsedWrtParams, attr->getLocation())) {
+    attr->setInvalid();
+    return;
+  }
+
+  // Set the resolved `wrt:` parameter indices in the attribute.
+  attr->setParameterIndices(resolvedWrtParamIndices);
+
+  // Gather `wrt:` parameters.
+  SmallVector<Type, 4> wrtParamTypes;
+  autodiff::getSubsetParameterTypes(resolvedWrtParamIndices, originalFnType,
+                                    wrtParamTypes);
+
+  // Get the `TangentVector` associated types of the `wrt:` parameters.
+  auto wrtParamTanTypes =
+      map<SmallVector<TupleTypeElt, 4>>(wrtParamTypes, [&](Type paramType) {
+        if (paramType->hasTypeParameter())
+          paramType = derivative->mapTypeIntoContext(paramType);
+        auto conf = TypeChecker::conformsToProtocol(paramType, diffableProto,
+                                                    derivative, None);
+        assert(conf &&
+               "Expected resolved parameter to conform to `Differentiable`");
+        auto paramAssocType =
+            conf.getTypeWitnessByName(paramType, Ctx.Id_TangentVector);
+        return TupleTypeElt(paramAssocType);
+      });
+
+  // Get the `TangentVector` associated type of the `value:` result type.
+  auto resultTanType = valueResultConf.getTypeWitnessByName(
+      valueResultType, Ctx.Id_TangentVector);
+
+  // Compute expected differential/pullback type.
+  auto funcEltType = funcResultElt.getType();
+  Type expectedFuncEltType;
+  if (kind == AutoDiffDerivativeFunctionKind::JVP) {
+    auto diffParams = map<SmallVector<AnyFunctionType::Param, 4>>(
+        wrtParamTanTypes, [&](TupleTypeElt elt) {
+          return AnyFunctionType::Param(elt.getType());
+        });
+    expectedFuncEltType = FunctionType::get(diffParams, resultTanType);
+  } else {
+    expectedFuncEltType =
+        FunctionType::get({AnyFunctionType::Param(resultTanType)},
+                          TupleType::get(wrtParamTanTypes, Ctx));
+  }
+  expectedFuncEltType = expectedFuncEltType->mapTypeOutOfContext();
+
+  // Check if differential/pullback type matches expected type.
+  if (!funcEltType->isEqual(expectedFuncEltType)) {
+    // Emit differential/pullback type mismatch error on attribute.
+    diagnose(attr->getLocation(),
+             diag::derivative_attr_result_func_type_mismatch,
+             funcResultElt.getName(), originalAFD->getFullName());
+    // Emit note with expected differential/pullback type on actual type
+    // location.
+    auto *tupleReturnTypeRepr =
+        cast<TupleTypeRepr>(derivative->getBodyResultTypeLoc().getTypeRepr());
+    auto *funcEltTypeRepr = tupleReturnTypeRepr->getElementType(1);
+    diagnose(funcEltTypeRepr->getStartLoc(),
+             diag::derivative_attr_result_func_type_mismatch_note,
+             funcResultElt.getName(), expectedFuncEltType)
+        .highlight(funcEltTypeRepr->getSourceRange());
+    // Emit note showing original function location, if possible.
+    if (originalAFD->getLoc().isValid())
+      diagnose(originalAFD->getLoc(),
+               diag::derivative_attr_result_func_original_note,
+               originalAFD->getFullName());
+    attr->setInvalid();
+    return;
+  }
+
+  // Reject different-file derivative registration.
+  // TODO(TF-1021): Lift this restriction.
+  if (originalAFD->getParentSourceFile() != derivative->getParentSourceFile()) {
+    diagnoseAndRemoveAttr(attr,
+                          diag::derivative_attr_not_in_same_file_as_original);
+    return;
+  }
+
+  // Reject duplicate `@derivative` attributes.
+  auto insertion = Ctx.DerivativeAttrs.try_emplace(
+      {originalAFD, resolvedWrtParamIndices, kind}, attr);
+  if (!insertion.second) {
+    diagnoseAndRemoveAttr(attr,
+                          diag::derivative_attr_original_already_has_derivative,
+                          originalAFD->getFullName());
+    diagnose(insertion.first->getSecond()->getLocation(),
+             diag::derivative_attr_duplicate_note);
+    return;
+  }
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3625,7 +3625,7 @@ void AttributeChecker::visitDerivativeAttr(DerivativeAttr *attr) {
 
   // Reject duplicate `@derivative` attributes.
   auto insertion = Ctx.DerivativeAttrs.try_emplace(
-      {originalAFD, resolvedWrtParamIndices, kind}, attr);
+      std::make_tuple(originalAFD, resolvedWrtParamIndices, kind), attr);
   if (!insertion.second) {
     diagnoseAndRemoveAttr(attr,
                           diag::derivative_attr_original_already_has_derivative,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1593,6 +1593,19 @@ public:
   static DeclTypeCheckingSemantics
   getDeclTypeCheckingSemantics(ValueDecl *decl);
 
+  /// Creates an `IndexSubset` for the given function type, representing
+  /// all inferred differentiation parameters. Used by `@differentiable` and
+  /// `@derivative` attribute type-checking.
+  ///
+  /// The differentiation parameters are inferred to be:
+  /// - All parameters of the function type that conform to `Differentiable`.
+  /// - If the function type's result is a function type (i.e. it is a curried
+  ///   method type), then also all parameters of the function result type that
+  ///   conform to `Differentiable`.
+  static IndexSubset *
+  inferDifferentiationParameters(AbstractFunctionDecl *AFD,
+                                 GenericEnvironment *derivativeGenEnv);
+
 public:
   /// Require that the library intrinsics for working with Optional<T>
   /// exist.

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -1,0 +1,544 @@
+// RUN: %target-swift-frontend-typecheck -enable-experimental-differentiable-programming -verify %s
+// REQUIRES: differentiable_programming
+
+import _Differentiation
+
+// Test top-level functions.
+
+func id(_ x: Float) -> Float {
+  return x
+}
+@derivative(of: id)
+func jvpId(x: Float) -> (value: Float, differential: (Float) -> (Float)) {
+  return (x, { $0 })
+}
+@derivative(of: id, wrt: x)
+func vjpIdExplicitWrt(x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  return (x, { $0 })
+}
+
+func generic<T: Differentiable>(_ x: T, _ y: T) -> T {
+  return x
+}
+@derivative(of: generic)
+func jvpGeneric<T: Differentiable>(x: T, y: T) -> (
+  value: T, differential: (T.TangentVector, T.TangentVector) -> T.TangentVector
+) {
+  return (x, { $0 + $1 })
+}
+@derivative(of: generic)
+func vjpGenericExtraGenericRequirements<T: Differentiable & FloatingPoint>(
+  x: T, y: T
+) -> (value: T, pullback: (T) -> (T, T)) where T == T.TangentVector {
+  return (x, { ($0, $0) })
+}
+
+// Test `wrt` parameter clauses.
+
+func add(x: Float, y: Float) -> Float {
+  return x + y
+}
+@derivative(of: add, wrt: x) // ok
+func vjpAddWrtX(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float)) {
+  return (x + y, { $0 })
+}
+@derivative(of: add, wrt: (x, y)) // ok
+func vjpAddWrtXY(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
+  return (x + y, { ($0, $0) })
+}
+
+// Test index-based `wrt` parameters.
+
+func subtract(x: Float, y: Float) -> Float {
+  return x - y
+}
+@derivative(of: subtract, wrt: (0, y)) // ok
+func vjpSubtractWrt0Y(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
+  return (x - y, { ($0, $0) })
+}
+@derivative(of: subtract, wrt: (1)) // ok
+func vjpSubtractWrt1(x: Float, y: Float) -> (value: Float, pullback: (Float) -> Float) {
+  return (x - y, { $0 })
+}
+
+// Test incorrect `@derivative` declaration type.
+
+// expected-note @+1 {{'incorrectDerivativeType' defined here}}
+func incorrectDerivativeType(_ x: Float) -> Float {
+  return x
+}
+
+// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple of type '(value: T..., pullback: (U.TangentVector) -> T.TangentVector...)' or '(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'}}
+@derivative(of: incorrectDerivativeType)
+func jvpResultIncorrect(x: Float) -> Float {
+  return x
+}
+// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple (first element must have label 'value:'}}
+@derivative(of: incorrectDerivativeType)
+func vjpResultIncorrectFirstLabel(x: Float) -> (Float, (Float) -> Float) {
+  return (x, { $0 })
+}
+// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple (second element must have label 'pullback:' or 'differential:')}}
+@derivative(of: incorrectDerivativeType)
+func vjpResultIncorrectSecondLabel(x: Float) -> (value: Float, (Float) -> Float) {
+  return (x, { $0 })
+}
+// expected-error @+1 {{'@derivative(of:)' attribute requires function to return a two-element tuple (first element type 'Int' must conform to 'Differentiable')}}
+@derivative(of: incorrectDerivativeType)
+func vjpResultNotDifferentiable(x: Int) -> (
+  value: Int, pullback: (Int) -> Int
+) {
+  return (x, { $0 })
+}
+// expected-error @+2 {{function result's 'pullback' type does not match 'incorrectDerivativeType'}}
+// expected-note @+3 {{'pullback' does not have expected type '(Float.TangentVector) -> (Float.TangentVector)' (aka '(Float) -> Float')}}
+@derivative(of: incorrectDerivativeType)
+func vjpResultIncorrectPullbackType(x: Float) -> (
+  value: Float, pullback: (Double) -> Double
+) {
+  return (x, { $0 })
+}
+
+// Test invalid `wrt:` differentiation parameters.
+
+func invalidWrtParam(_ x: Float, _ y: Float) -> Float {
+  return x
+}
+
+// expected-error @+1 {{unknown parameter name 'z'}}
+@derivative(of: add, wrt: z)
+func vjpUnknownParam(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float)) {
+  return (x + y, { $0 })
+}
+// expected-error @+1 {{parameters must be specified in original order}}
+@derivative(of: invalidWrtParam, wrt: (y, x))
+func vjpParamOrderNotIncreasing(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
+  return (x + y, { ($0, $0) })
+}
+// expected-error @+1 {{'self' parameter is only applicable to instance methods}}
+@derivative(of: invalidWrtParam, wrt: self)
+func vjpInvalidSelfParam(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
+  return (x + y, { ($0, $0) })
+}
+// expected-error @+1 {{parameter index is larger than total number of parameters}}
+@derivative(of: invalidWrtParam, wrt: 2)
+func vjpSubtractWrt2(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
+  return (x - y, { ($0, $0) })
+}
+// expected-error @+1 {{parameters must be specified in original order}}
+@derivative(of: invalidWrtParam, wrt: (1, x))
+func vjpSubtractWrt1x(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
+  return (x - y, { ($0, $0) })
+}
+// expected-error @+1 {{parameters must be specified in original order}}
+@derivative(of: invalidWrtParam, wrt: (1, 0))
+func vjpSubtractWrt10(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
+  return (x - y, { ($0, $0) })
+}
+
+func noParameters() -> Float {
+  return 1
+}
+// expected-error @+1 {{'vjpNoParameters()' has no parameters to differentiate with respect to}}
+@derivative(of: noParameters)
+func vjpNoParameters() -> (value: Float, pullback: (Float) -> Float) {
+  return (1, { $0 })
+}
+
+func noDifferentiableParameters(x: Int) -> Float {
+  return 1
+}
+// expected-error @+1 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
+@derivative(of: noDifferentiableParameters)
+func vjpNoDifferentiableParameters(x: Int) -> (
+  value: Float, pullback: (Float) -> Int
+) {
+  return (1, { _ in 0 })
+}
+
+func functionParameter(_ fn: (Float) -> Float) -> Float {
+  return fn(1)
+}
+// expected-error @+1 {{can only differentiate with respect to parameters that conform to 'Differentiable', but '(Float) -> Float' does not conform to 'Differentiable'}}
+@derivative(of: functionParameter, wrt: fn)
+func vjpFunctionParameter(_ fn: (Float) -> Float) -> (
+  value: Float, pullback: (Float) -> Float
+) {
+  return (functionParameter(fn), { $0 })
+}
+
+func inoutParameter(_ x: inout Float) -> Float {
+  return x
+}
+// expected-error @+1 {{cannot differentiate with respect to 'inout' parameter ('inout Float'}}
+@derivative(of: inoutParameter)
+func vjpInoutParameter(x: inout Float) -> (
+  value: Float, pullback: (Float) -> Float
+) {
+  return (inoutParameter(&x), { $0 })
+}
+
+// Test static methods.
+
+protocol StaticMethod: Differentiable {
+  static func foo(_ x: Float) -> Float
+  static func generic<T: Differentiable>(_ x: T) -> T
+}
+
+extension StaticMethod {
+  @derivative(of: foo)
+  static func jvpFoo(x: Float) -> (value: Float, differential: (Float) -> Float)
+  {
+    return (x, { $0 })
+  }
+
+  @derivative(of: foo)
+  static func vjpFoo(x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (x, { $0 })
+  }
+
+  @derivative(of: generic)
+  static func vjpGeneric<T: Differentiable>(_ x: T) -> (
+    value: T, pullback: (T.TangentVector) -> (T.TangentVector)
+  ) {
+    return (x, { $0 })
+  }
+
+  // expected-error @+1 {{'self' parameter is only applicable to instance methods}}
+  @derivative(of: foo, wrt: (self, x))
+  static func vjpFooWrtSelf(x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (x, { $0 })
+  }
+}
+
+// Test instance methods.
+
+protocol InstanceMethod: Differentiable {
+  // expected-note @+1 {{'foo' defined here}}
+  func foo(_ x: Self) -> Self
+
+  // expected-note @+1 {{'generic' defined here}}
+  func generic<T: Differentiable>(_ x: T) -> Self
+}
+
+extension InstanceMethod {
+  @derivative(of: foo)
+  func jvpFoo(x: Self) -> (
+    value: Self, differential: (TangentVector, TangentVector) -> (TangentVector)
+  ) {
+    return (x, { $0 + $1 })
+  }
+
+  @derivative(of: generic)
+  func vjpGeneric<T: Differentiable>(_ x: T) -> (
+    value: Self, pullback: (TangentVector) -> (TangentVector, T.TangentVector)
+  ) {
+    return (self, { ($0, .zero) })
+  }
+
+  @derivative(of: generic, wrt: (self, x))
+  func jvpGenericWrt<T: Differentiable>(_ x: T) -> (value: Self, differential: (TangentVector, T.TangentVector) -> TangentVector) {
+    return (self, { dself, dx in dself })
+  }
+
+  // expected-error @+1 {{'self' parameter must come first in the parameter list}}
+  @derivative(of: generic, wrt: (x, self))
+  func jvpGenericWrtSelf<T: Differentiable>(_ x: T) -> (value: Self, differential: (TangentVector, T.TangentVector) -> TangentVector) {
+    return (self, { dself, dx in dself })
+  }
+}
+
+extension InstanceMethod {
+  // If `Self` conforms to `Differentiable`, then `Self` is inferred to be a differentiation parameter.
+  // expected-error @+2 {{function result's 'pullback' type does not match 'foo'}}
+  // expected-note @+3 {{'pullback' does not have expected type '(Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)'}}
+  @derivative(of: foo)
+  func vjpFoo(x: Self) -> (
+    value: Self, pullback: (TangentVector) -> TangentVector
+  ) {
+    return (x, { $0 })
+  }
+
+  // If `Self` conforms to `Differentiable`, then `Self` is inferred to be a differentiation parameter.
+  // expected-error @+2 {{function result's 'pullback' type does not match 'generic'}}
+  // expected-note @+3 {{'pullback' does not have expected type '(Self.TangentVector) -> (Self.TangentVector, T.TangentVector)'}}
+  @derivative(of: generic)
+  func vjpGeneric<T: Differentiable>(_ x: T) -> (
+    value: Self, pullback: (TangentVector) -> T.TangentVector
+  ) {
+    return (self, { _ in .zero })
+  }
+}
+
+// Test `@derivative` declaration with more constrained generic signature.
+
+func req1<T>(_ x: T) -> T {
+  return x
+}
+@derivative(of: req1)
+func vjpReq1<T: Differentiable>(_ x: T) -> (
+  value: T, pullback: (T.TangentVector) -> T.TangentVector
+) {
+  return (x, { $0 })
+}
+
+func req2<T, U>(_ x: T, _ y: U) -> T {
+  return x
+}
+@derivative(of: req2)
+func vjpReq2<T: Differentiable, U: Differentiable>(_ x: T, _ y: U)
+  -> (value: T, pullback: (T) -> (T, U))
+where T == T.TangentVector, U == U.TangentVector, T: CustomStringConvertible {
+  return (x, { ($0, .zero) })
+}
+
+// Test class methods.
+
+class Super {
+  @differentiable
+  func foo(_ x: Float) -> Float {
+    return x
+  }
+
+  @derivative(of: foo)
+  func vjpFoo(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (foo(x), { v in v })
+  }
+}
+
+class Sub: Super {
+  // TODO(TF-649): Enable `@derivative` to override derivatives for original
+  // declaration defined in superclass.
+  // expected-error @+1 {{'foo' is not defined in the current type context}}
+  @derivative(of: foo)
+  override func vjpFoo(_ x: Float) -> (value: Float, pullback: (Float) -> Float)
+  {
+    return (foo(x), { v in v })
+  }
+}
+
+// Test non-`func` original declarations.
+
+struct Struct<T> {
+  var x: T
+}
+extension Struct: Equatable where T: Equatable {}
+extension Struct: Differentiable & AdditiveArithmetic
+where T: Differentiable & AdditiveArithmetic {
+  static var zero: Self {
+    fatalError()
+  }
+  static func + (lhs: Self, rhs: Self) -> Self {
+    fatalError()
+  }
+  static func - (lhs: Self, rhs: Self) -> Self {
+    fatalError()
+  }
+  typealias TangentVector = Struct<T.TangentVector>
+  mutating func move(along direction: TangentVector) {
+    x.move(along: direction.x)
+  }
+}
+
+// Test computed properties.
+
+extension Struct {
+  var computedProperty: T { x }
+}
+extension Struct where T: Differentiable & AdditiveArithmetic {
+  @derivative(of: computedProperty)
+  func vjpProperty() -> (value: T, pullback: (T.TangentVector) -> TangentVector) {
+    return (x, { v in .init(x: v) })
+  }
+}
+
+// Test initializers.
+
+extension Struct {
+  init(_ x: Float) {}
+  init(_ x: T, y: Float) {}
+}
+extension Struct where T: Differentiable & AdditiveArithmetic {
+  @derivative(of: init)
+  static func vjpInit(_ x: Float) -> (
+    value: Struct, pullback: (TangentVector) -> Float
+  ) {
+    return (.init(x), { _ in .zero })
+  }
+
+  @derivative(of: init(_:y:))
+  static func vjpInit2(_ x: T, _ y: Float) -> (
+    value: Struct, pullback: (TangentVector) -> (T.TangentVector, Float)
+  ) {
+    return (.init(x, y: y), { _ in (.zero, .zero) })
+  }
+}
+
+// Test subscripts.
+
+extension Struct {
+  subscript() -> Float {
+    get { 1 }
+    set {}
+  }
+  subscript(float float: Float) -> Float { 1 }
+  subscript<T: Differentiable>(x: T) -> T { x }
+}
+extension Struct where T: Differentiable & AdditiveArithmetic {
+  @derivative(of: subscript)
+  func vjpSubscript() -> (value: Float, pullback: (Float) -> TangentVector) {
+    return (1, { _ in .zero })
+  }
+
+  @derivative(of: subscript(float:), wrt: self)
+  func vjpSubscriptLabelled(float: Float) -> (value: Float, pullback: (Float) -> TangentVector) {
+    return (1, { _ in .zero })
+  }
+
+  @derivative(of: subscript(_:), wrt: self)
+  func vjpSubscriptGeneric<T: Differentiable>(x: T) -> (value: T, pullback: (T.TangentVector) -> TangentVector) {
+    return (x, { _ in .zero })
+  }
+}
+
+// Test duplicate `@derivative` attribute.
+
+func duplicate(_ x: Float) -> Float { x }
+// expected-note @+1 {{other attribute declared here}}
+@derivative(of: duplicate)
+func jvpDuplicate1(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+  return (duplicate(x), { $0 })
+}
+// expected-error @+1 {{a derivative already exists for 'duplicate'}}
+@derivative(of: duplicate)
+func jvpDuplicate2(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+  return (duplicate(x), { $0 })
+}
+
+// Test invalid original declaration kind.
+
+var globalVariable: Float
+// expected-error @+1 {{'globalVariable' is not a 'func', 'init', 'subscript', or 'var' computed property declaration}}
+@derivative(of: globalVariable)
+func invalidOriginalDeclaration(x: Float) -> (
+  value: Float, differential: (Float) -> (Float)
+) {
+  return (x, { $0 })
+}
+
+// Test ambiguous original declaration.
+
+protocol P1 {}
+protocol P2 {}
+func ambiguous<T: P1>(_ x: T) -> T { x }
+func ambiguous<T: P2>(_ x: T) -> T { x }
+
+// expected-error @+1 {{ambiguous reference to 'ambiguous' in '@derivative' attribute}}
+@derivative(of: ambiguous)
+func jvpAmbiguous<T: P1 & P2 & Differentiable>(x: T)
+  -> (value: T, differential: (T.TangentVector) -> (T.TangentVector))
+{
+  return (x, { $0 })
+}
+
+// Test no valid original declaration.
+// Original declarations are invalid because they have extra generic
+// requirements unsatisfied by the `@derivative` function.
+
+func invalid<T: BinaryFloatingPoint>(x: T) -> T { x }
+func invalid<T: CustomStringConvertible>(x: T) -> T { x }
+func invalid<T: FloatingPoint>(x: T) -> T { x }
+
+// expected-error @+1 {{could not find function 'invalid' with expected type '<T where T : Differentiable> (x: T) -> T'}}
+@derivative(of: invalid)
+func jvpInvalid<T: Differentiable>(x: T) -> (
+  value: T, differential: (T.TangentVector) -> T.TangentVector
+) {
+  return (x, { $0 })
+}
+
+// Test invalid derivative type context: instance vs static method mismatch.
+
+struct InvalidTypeContext<T: Differentiable> {
+  static func staticMethod(_ x: T) -> T { x }
+
+  // expected-error @+1 {{could not find function 'staticMethod' with expected type '<T where T : Differentiable> (InvalidTypeContext<T>) -> (T) -> T'}}
+  @derivative(of: staticMethod)
+  func jvpStatic(_ x: T) -> (
+    value: T, differential: (T.TangentVector) -> (T.TangentVector)
+  ) {
+    return (x, { $0 })
+  }
+}
+
+// Test stored property original declaration.
+
+struct HasStoredProperty {
+  // expected-note @+1 {{'stored' declared here}}
+  var stored: Float
+}
+extension HasStoredProperty: Differentiable & AdditiveArithmetic {
+  static var zero: Self {
+    fatalError()
+  }
+  static func + (lhs: Self, rhs: Self) -> Self {
+    fatalError()
+  }
+  static func - (lhs: Self, rhs: Self) -> Self {
+    fatalError()
+  }
+  typealias TangentVector = Self
+}
+extension HasStoredProperty {
+  // expected-error @+1 {{cannot register derivative for stored property 'stored'}}
+  @derivative(of: stored)
+  func vjpStored() -> (value: Float, pullback: (Float) -> TangentVector) {
+    return (stored, { _ in .zero })
+  }
+}
+
+// Test cross-file derivative registration. Currently unsupported.
+// TODO(TF-1021): Lift this restriction.
+
+extension AdditiveArithmetic where Self: Differentiable {
+  // expected-error @+1 {{derivative not in the same file as the original function}}
+  @derivative(of: +)
+  static func vjpPlus(x: Self, y: Self) -> (
+    value: Self,
+    pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+  ) {
+    return (x + y, { v in (v, v) })
+  }
+}
+
+extension FloatingPoint where Self: Differentiable, Self == Self.TangentVector {
+  // expected-error @+1 {{derivative not in the same file as the original function}}
+  @derivative(of: +)
+  static func vjpPlus(x: Self, y: Self) -> (
+    value: Self, pullback: (Self) -> (Self, Self)
+  ) {
+    return (x + y, { v in (v, v) })
+  }
+}
+
+extension Differentiable where Self: AdditiveArithmetic {
+  // expected-error @+1 {{'+' is not defined in the current type context}}
+  @derivative(of: +)
+  static func vjpPlus(x: Self, y: Self) -> (
+    value: Self,
+    pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+  ) {
+    return (x + y, { v in (v, v) })
+  }
+}
+
+extension AdditiveArithmetic
+where Self: Differentiable, Self == Self.TangentVector {
+  // expected-error @+1 {{could not find function '+' with expected type '<Self where Self : Differentiable, Self == Self.TangentVector> (Self) -> (Self, Self) -> Self'}}
+  @derivative(of: +)
+  func vjpPlusInstanceMethod(x: Self, y: Self) -> (
+    value: Self, pullback: (Self) -> (Self, Self)
+  ) {
+    return (x + y, { v in (v, v) })
+  }
+}

--- a/test/AutoDiff/Sema/differentiable_features_disabled.swift
+++ b/test/AutoDiff/Sema/differentiable_features_disabled.swift
@@ -2,3 +2,12 @@
 
 // expected-error @+1 {{differentiable programming is an experimental feature that is currently disabled}}
 let _: @differentiable (Float) -> Float
+
+func id(_ x: Float) -> Float {
+  return x
+}
+// expected-error @+1 {{differentiable programming is an experimental feature that is currently disabled}}
+@derivative(of: id)
+func jvpId(x: Float) -> (value: Float, differential: (Float) -> (Float)) {
+  return (x, { $0 })
+}


### PR DESCRIPTION
The `@derivative` attribute registers a function as a derivative of another
function-like declaration: a `func`, `init`, `subscript`, or `var` computed
property declaration.

The `@derivative` attribute also has an optional `wrt:` clause specifying the
parameters that are differentiated "with respect to", i.e. the differentiation
parameters. The differentiation parameters must conform to the `Differentiable`
protocol.

If the `wrt:` clause is unspecified, the differentiation parameters are inferred
to be all parameters that conform to `Differentiable`.

`@derivative` attribute type-checking verifies that the type of the derivative
function declaration is consistent with the type of the referenced original
declaration and the differentiation parameters.

Resolves TF-829.

---

Examples:
```swift
func sin(_ x: Float) -> Float { ... }

@derivative(of: sin)
func derivativeSin(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
    (sin(x), { dx in dx * cos(x) })
}

public protocol ElementaryFunctions {
    static func log(_ x: Self) -> Self
    ...
}

public extension ElementaryFunctions
where Self: Differentiable & FloatingPoint, Self == Self.TangentVector {
    @inlinable
    @derivative(of: log)
    static func derivativeLog(_ x: Self) -> (value: Self, differential: (Self) -> Self) {
        (log(x), { dx in (1 / x) * dx })
    }
}
```

The [differentiable programming manifesto](https://github.com/apple/swift/blob/master/docs/DifferentiableProgramming.md#make-a-function-differentiable-using-derivative-or-transpose) has more information and examples.

---

Note: this code is upstreamed from `tensorflow` branch. Some functions are intentionally not `static` (fileprivate) because they have users in other files on `tensorflow` branch.

Known issues are referenced in comments:
* TF-874: Simplify type calculation helpers.
* TF-1042: Remove `DerivativeAttrs` cache from `ASTContext`.

We would like to upstream code and continue development on `master`, if that's acceptable!

cc @rxwei @marcrasi @bgogul