### PR TITLE
[AutoDiff] Fix `SILFunctionBuilder::addFunctionAttributes` crash.

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -543,7 +543,7 @@ static SILFunction *getFunctionToInsertAfter(SILGenModule &SGM,
   return nullptr;
 }
 
-static bool haveProfiledDerivativeFunction(SILDeclRef constant) {
+static bool haveProfiledAssociatedFunction(SILDeclRef constant) {
   return constant.isDefaultArgGenerator() || constant.isForeign ||
          constant.isCurried;
 }
@@ -555,7 +555,7 @@ static void setUpForProfiling(SILDeclRef constant, SILFunction *F,
     return;
 
   ASTNode profiledNode;
-  if (!haveProfiledDerivativeFunction(constant)) {
+  if (!haveProfiledAssociatedFunction(constant)) {
     if (constant.hasDecl()) {
       if (auto *fd = constant.getFuncDecl()) {
         if (fd->hasBody()) {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -103,7 +103,6 @@ SILGenModule::emitVTableMethod(ClassDecl *theClass,
     implFn = getFunction(derived, NotForDefinition);
   }
 
-
   // As a fast path, if there is no override, definitely no thunk is necessary.
   if (derived == base)
     return SILVTable::Entry(base, implFn, implKind);

--- a/test/AutoDiff/differentiable_sil_attr_roundtrip.swift
+++ b/test/AutoDiff/differentiable_sil_attr_roundtrip.swift
@@ -19,6 +19,8 @@
 
 @differentiable(wrt: x)
 func TF_656(_ x: Float, _ y: Float) -> Float {
+  // FIXME(TF-988): Cannot differentiate external functions.
+  // return x + y
   return 0
 }
 _ = gradient(at: 1, in: { x in TF_656(x, 2) })


### PR DESCRIPTION
In `SILFunctionBuilder::getOrCreateFunction`, do not pass `constant` to
`SILFunctionBuilder::addFunctionAttributes` for `AccessorDecl`s.

Passing `constant` was a `tensorflow` branch-specific change that causes
dynamically replaced functions to be registered multiple times for
`AccessorDecl`s.

Fixed tests:
```
Failing Tests (6):
    Swift(macosx-x86_64) :: SILGen/objc_dynamic_replacement.swift
    Swift(macosx-x86_64) :: SILGen/dynamically_replaceable.swift
    Swift(macosx-x86_64) :: Interpreter/dynamic_replacement_protocol_self.swift
    Swift(macosx-x86_64) :: Interpreter/dynamic_replacement.swift
    Swift(macosx-x86_64) :: Interpreter/dynamicReplacement_property_observer.swift
    Swift(macosx-x86_64) :: IRGen/dynamic_replaceable_opaque_return.swift
```

Gardening included to reduce diff with `master`.

Resolves TF-1057.