### PR TITLE
-(enable|disable)-only-one-dependency-file causes only the first frontend job to emit a real dependency file.

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -374,6 +374,8 @@ public:
     return FilelistThreshold;
   }
 
+  void resetHaveAlreadyAddedDependencyPath();
+
   /// Called to decide whether to add a dependency path argument, or whether to
   /// create a dummy file. Responds by invoking one of the two passed-in
   /// functions.

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -206,6 +206,21 @@ private:
   /// limit filelists will be used.
   size_t FilelistThreshold;
 
+  /// Because each frontend job outputs the same info in its .d file, only do it
+  /// on the first job that actually runs. Write out dummies for the rest of the
+  /// jobs. This hack saves a lot of time in the build system when incrementally
+  /// building a project with many files. Record if a scheduled job has already
+  /// added -emit-dependency-path.
+  bool HaveAlreadyAddedDependencyPath = false;
+
+  /// When set, only the first scheduled frontend job gets the argument needed
+  /// to produce a make-style dependency file. The other jobs create dummy files
+  /// in the driver. This hack speeds up incremental compilation by reducing the
+  /// time for the build system to read each dependency file, which are all
+  /// identical. This optimization can be disabled by passing
+  /// -disable-only-one-dependency-file on the command line.
+  const bool OnlyOneDependencyFile;
+
   /// Scaffolding to permit experimentation with finer-grained dependencies and
   /// faster rebuilds.
   const bool EnableExperimentalDependencies;
@@ -250,6 +265,7 @@ public:
               bool SaveTemps = false,
               bool ShowDriverTimeCompilation = false,
               std::unique_ptr<UnifiedStatsReporter> Stats = nullptr,
+              bool OnlyOneDependencyFile = false,
               bool EnableExperimentalDependencies = false,
               bool VerifyExperimentalDependencyGraphAfterEveryImport = false,
               bool EmitExperimentalDependencyDotFileAfterEveryImport = false,
@@ -357,6 +373,14 @@ public:
   size_t getFilelistThreshold() const {
     return FilelistThreshold;
   }
+
+  /// Called to decide whether to add a dependency path argument, or whether to
+  /// create a dummy file. Responds by invoking one of the two passed-in
+  /// functions.
+  void addDependencyPathOrCreateDummy(
+      const CommandOutput &Output,
+      function_ref<void(StringRef)> addDependencyPath,
+      function_ref<void(StringRef)> createDummy);
 
   UnifiedStatsReporter *getStatsReporter() const {
     return Stats.get();

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -133,6 +133,16 @@ def enable_experimental_dependencies :
 Flag<["-"], "enable-experimental-dependencies">, Flags<[FrontendOption, HelpHidden]>,
 HelpText<"Experimental work-in-progress to be more selective about incremental recompilation">;
 
+
+def enable_only_one_dependency_file :
+Flag<["-"], "enable-only-one-dependency-file">, Flags<[DoesNotAffectIncrementalBuild]>,
+HelpText<"Enables incremental build optimization that only produces one dependencies file">;
+
+def disable_only_one_dependency_file :
+Flag<["-"], "disable-only-one-dependency-file">, Flags<[DoesNotAffectIncrementalBuild]>,
+HelpText<"Disables incremental build optimization that only produces one dependencies file">;
+
+
 def driver_verify_experimental_dependency_graph_after_every_import :
 Flag<["-"], "driver-verify-experimental-dependency-graph-after-every-import">,
 InternalDebugOpt,

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1098,6 +1098,10 @@ namespace driver {
       BatchPartition Partition(NumPartitions);
       partitionIntoBatches(Batchable.takeVector(), Partition);
 
+      // Ensure that at least one batch job gets a -emit-dependency-path
+      // argument when constructInvocation isCalled.
+      Comp.resetHaveAlreadyAddedDependencyPath();
+
       // Construct a BatchJob from each batch in the partition.
       for (auto const &Batch : Partition) {
         formBatchJobFromPartitionBatch(Batches, Batch);
@@ -1405,6 +1409,7 @@ static bool writeFilelistIfNecessary(const Job *job, const ArgList &args,
       break;
     }
     case FilelistInfo::WhichFiles::SupplementaryOutput:
+    #error fix writeOutputFileMap???
       job->getOutput().writeOutputFileMap(out);
       break;
     }
@@ -1563,6 +1568,11 @@ const char *Compilation::getAllSourcesPath() const {
   }
   return AllSourceFilesPath;
 }
+
+void Compilation::resetHaveAlreadyAddedDependencyPath() {
+   HaveAlreadyAddedDependencyPath = false;
+ }
+
 
 void Compilation::addDependencyPathOrCreateDummy(
     const CommandOutput &Output,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -925,6 +925,11 @@ Driver::buildCompilation(const ToolChain &TC,
         ArgList->hasArg(options::OPT_driver_time_compilation);
     std::unique_ptr<UnifiedStatsReporter> StatsReporter =
         createStatsReporter(ArgList.get(), Inputs, OI, DefaultTargetTriple);
+
+    const bool OnlyOneDependencyFile =
+        ArgList->hasFlag(options::OPT_enable_only_one_dependency_file,
+                     options::OPT_disable_only_one_dependency_file, false);
+
     const bool EnableExperimentalDependencies =
         ArgList->hasArg(options::OPT_enable_experimental_dependencies);
     const bool VerifyExperimentalDependencyGraphAfterEveryImport = ArgList->hasArg(
@@ -956,6 +961,7 @@ Driver::buildCompilation(const ToolChain &TC,
         SaveTemps,
         ShowDriverTimeCompilation,
         std::move(StatsReporter),
+        OnlyOneDependencyFile,
         EnableExperimentalDependencies,
         VerifyExperimentalDependencyGraphAfterEveryImport,
         EmitExperimentalDependencyDotFileAfterEveryImport,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -34,6 +34,8 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Program.h"
 
+#include <fstream>
+
 using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
@@ -605,8 +607,17 @@ void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(
            "mode!");
   }
 
-  addOutputsOfType(arguments, Output, Args, file_types::TY_Dependencies,
-                   "-emit-dependencies-path");
+  C.addDependencyPathOrCreateDummy(
+      Output,
+      [&](StringRef) {
+        addOutputsOfType(arguments, Output, Args, file_types::TY_Dependencies,
+                         "-emit-dependencies-path");
+      },
+      [&](StringRef dependencyFile) {
+        // Create an empty file
+        std::ofstream(dependencyFile.str().c_str());
+      });
+
   addOutputsOfType(arguments, Output, Args, file_types::TY_SwiftDeps,
                    "-emit-reference-dependencies-path");
   addOutputsOfType(arguments, Output, Args, file_types::TY_ModuleTrace,


### PR DESCRIPTION
Fixes a problem with incremental performance: Since each frontend job contains the same info in its emitted make-style dependencies file, the build system slows down the build when the it reads all the redundant info. Disabled-by-default, this feature causes only one frontend job to emit the real info, the rest create dummy files.

rdar://57882772