### PR TITLE
[DNM: Incremental, Driver] Only emit a real make-style dependency file for one frontend job.

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -257,6 +257,21 @@ private:
   /// limit filelists will be used.
   size_t FilelistThreshold;
 
+  /// Because each frontend job outputs the same info in its .d file, only do it
+  /// on the first job that actually runs. Write out dummies for the rest of the
+  /// jobs. This hack saves a lot of time in the build system when incrementally
+  /// building a project with many files. Record if a scheduled job has already
+  /// added -emit-dependency-path.
+  bool HaveAlreadyAddedDependencyPath = false;
+
+  /// When set, only the first scheduled frontend job gets the argument needed
+  /// to produce a make-style dependency file. The other jobs create dummy files
+  /// in the driver. This hack speeds up incremental compilation by reducing the
+  /// time for the build system to read each dependency file, which are all
+  /// identical. This optimization can be disabled by passing
+  /// -disable-only-one-dependency-file on the command line.
+  const bool OnlyOneDependencyFile;
+
   /// Scaffolding to permit experimentation with finer-grained dependencies and
   /// faster rebuilds.
   const bool EnableFineGrainedDependencies;
@@ -309,6 +324,7 @@ public:
               bool SaveTemps = false,
               bool ShowDriverTimeCompilation = false,
               std::unique_ptr<UnifiedStatsReporter> Stats = nullptr,
+              bool OnlyOneDependencyFile = false,
               bool EnableFineGrainedDependencies = false,
               bool VerifyFineGrainedDependencyGraphAfterEveryImport = false,
               bool EmitFineGrainedDependencyDotFileAfterEveryImport = false,
@@ -426,6 +442,14 @@ public:
   size_t getFilelistThreshold() const {
     return FilelistThreshold;
   }
+
+  /// Called to decide whether to add a dependency path argument, or whether to
+  /// create a dummy file. Responds by invoking one of the two passed-in
+  /// functions.
+  void addDependencyPathOrCreateDummy(
+      const CommandOutput &Output,
+      function_ref<void(StringRef)> addDependencyPath,
+      function_ref<void(StringRef)> createDummy);
 
   UnifiedStatsReporter *getStatsReporter() const {
     return Stats.get();

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -139,6 +139,16 @@ def enable_fine_grained_dependencies :
 Flag<["-"], "enable-fine-grained-dependencies">, Flags<[FrontendOption, HelpHidden]>,
 HelpText<"Experimental work-in-progress to be more selective about incremental recompilation">;
 
+
+def enable_only_one_dependency_file :
+Flag<["-"], "enable-only-one-dependency-file">, Flags<[DoesNotAffectIncrementalBuild]>,
+ HelpText<"Enables incremental build optimization that only produces one dependencies file">;
+
+def disable_only_one_dependency_file :
+Flag<["-"], "disable-only-one-dependency-file">, Flags<[DoesNotAffectIncrementalBuild]>,
+ HelpText<"Disables incremental build optimization that only produces one dependencies file">;
+ 
+
 def enable_source_range_dependencies :
 Flag<["-"], "enable-source-range-dependencies">, Flags<[]>,
 HelpText<"Try using source range information">;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -951,6 +951,11 @@ Driver::buildCompilation(const ToolChain &TC,
         ArgList->hasArg(options::OPT_driver_time_compilation);
     std::unique_ptr<UnifiedStatsReporter> StatsReporter =
         createStatsReporter(ArgList.get(), Inputs, OI, DefaultTargetTriple);
+
+    const bool OnlyOneDependencyFile =
+        ArgList->hasFlag(options::OPT_enable_only_one_dependency_file,
+                     options::OPT_disable_only_one_dependency_file, true);
+
     // relies on the new dependency graph
     const bool EnableFineGrainedDependencies =
         ArgList->hasArg(options::OPT_enable_fine_grained_dependencies);
@@ -984,6 +989,7 @@ Driver::buildCompilation(const ToolChain &TC,
         SaveTemps,
         ShowDriverTimeCompilation,
         std::move(StatsReporter),
+        OnlyOneDependencyFile,
         EnableFineGrainedDependencies,
         VerifyFineGrainedDependencyGraphAfterEveryImport,
         EmitFineGrainedDependencyDotFileAfterEveryImport,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -34,6 +34,8 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Program.h"
 
+#include <fstream>
+
 using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
@@ -671,8 +673,17 @@ void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(
            "mode!");
   }
 
-  addOutputsOfType(arguments, Output, Args, file_types::TY_Dependencies,
-                   "-emit-dependencies-path");
+  C.addDependencyPathOrCreateDummy(
+      Output,
+      [&](StringRef) {
+        addOutputsOfType(arguments, Output, Args, file_types::TY_Dependencies,
+                         "-emit-dependencies-path");
+      },
+      [&](StringRef dependencyFile) {
+        // Create an empty file
+        std::ofstream(dependencyFile.str().c_str());
+      });
+
   addOutputsOfType(arguments, Output, Args, file_types::TY_SwiftDeps,
                    "-emit-reference-dependencies-path");
   addOutputsOfType(arguments, Output, Args, file_types::TY_SwiftRanges,


### PR DESCRIPTION
Because every frontend job emits the same make-style dependency file, the build system uses a lot of time to read them all, slowing incremental builds of projects with many files.

This changes adds a driver flag, -only-one-dependency-file, which causes the driver to omit the -emit-dependency-path argument for subsequent frontend jobs, instead creating dummy files.

On a dummy 3,000 file project where it reduced incremental compilation time from ~40 secs to ~3 secs.