### PR TITLE
Don't re-force member loading in already-forced class hierarchies

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3714,12 +3714,11 @@ void ClangImporter::Implementation::lookupAllObjCMembers(
   }
 }
 
-// Force the named member of the entire inheritance hierarchy to be loaded and
+// Force the members of the entire inheritance hierarchy to be loaded and
 // deserialized before loading the named member of this class. This allows the
 // decl members table to be warmed up and enables the correct identification of
 // overrides.
-static void loadNamedMemberOfSuperclassIfNeeded(const ClassDecl *CD,
-                                                  DeclBaseName name) {
+static void ensureSuperclassMembersAreLoaded(const ClassDecl *CD) {
   if (!CD)
     return;
 
@@ -3727,9 +3726,7 @@ static void loadNamedMemberOfSuperclassIfNeeded(const ClassDecl *CD,
   if (!CD || !CD->hasClangNode())
     return;
   
-  auto ci = CD->getASTContext().getOrCreateLazyIterableContextData(
-      CD, /*lazyLoader=*/nullptr);
-  ci->loader->loadNamedMembers(CD, name, ci->memberData);
+  CD->loadAllMembers();
 }
 
 Optional<TinyPtrVector<ValueDecl *>>
@@ -3793,7 +3790,7 @@ ClangImporter::Implementation::loadNamedMembers(
 
   assert(isa<clang::ObjCContainerDecl>(CD) || isa<clang::NamespaceDecl>(CD));
 
-  loadNamedMemberOfSuperclassIfNeeded(dyn_cast<ClassDecl>(D), N);
+  ensureSuperclassMembersAreLoaded(dyn_cast<ClassDecl>(D));
 
   TinyPtrVector<ValueDecl *> Members;
   for (auto entry : table->lookup(SerializedSwiftName(N),

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8427,14 +8427,15 @@ createUnavailableDecl(Identifier name, DeclContext *dc, Type type,
 // deserialized before loading the members of this class. This allows the
 // decl members table to be warmed up and enables the correct identification of
 // overrides.
-static void loadAllMembersOfSuperclassesIfNeeded(const ClassDecl *CD) {
+static void loadAllMembersOfSuperclassIfNeeded(const ClassDecl *CD) {
   if (!CD)
     return;
 
-  while ((CD = CD->getSuperclassDecl())) {
-    if (CD->hasClangNode())
-      CD->loadAllMembers();
-  }
+  CD = CD->getSuperclassDecl();
+  if (!CD || !CD->hasClangNode())
+    return;
+
+  CD->loadAllMembers();
 }
 
 void
@@ -8449,7 +8450,7 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
 
   // If not, we're importing globals-as-members into an extension.
   if (objcContainer) {
-    loadAllMembersOfSuperclassesIfNeeded(dyn_cast<ClassDecl>(D));
+    loadAllMembersOfSuperclassIfNeeded(dyn_cast<ClassDecl>(D));
     loadAllMembersOfObjcContainer(D, objcContainer);
     return;
   }

--- a/test/NameBinding/named_lazy_member_loading_objc_interface.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_interface.swift
@@ -8,7 +8,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -disable-named-lazy-member-loading -stats-output-dir %t/stats-pre -primary-file %s %S/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-post -primary-file %s %S/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift
-// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -10' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities <= -1' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 


### PR DESCRIPTION
When deserializing a the (named) members of a class hierarchy, we
needn't walk all the way up the hierarchy, just into our superclass.
This will, in turn, walk to its superclass, etc.  This is as opposed to
this work being repeated at each level of the recursive hierarchy.
Should be a small perf win over the last patch.

Resolves rdar://57882571 and SR-11949