### PR TITLE
[android] Mark differentiable_stdlib_conformances as executable.

### DIFF
--- a/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
+++ b/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// REQUIRES: executable_test
 // REQUIRES: differentiable_programming
 
 import _Differentiation


### PR DESCRIPTION
Android CI cannot execute tests, so tests needs to be marked as
executable to be skipped.

Introduced in #28718 and first seen in https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/4717/ and https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/3000/