### PR TITLE
[5.2] SR-7732: Dynamic casting CFError to Error results in a memory leak (from #28686)

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -911,7 +911,9 @@ static bool _dynamicCastToExistential(OpaqueValue *dest,
                                                         srcDynamicType,
                                                         errorWitness)) {
       *destBoxAddr = reinterpret_cast<SwiftError*>(embedded);
-      maybeDeallocateSource(true);
+      if (shouldDeallocateSource(true, flags)) {
+        srcType->vw_destroy(src);
+      }
       return true;
     }
 #endif

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -684,9 +684,9 @@ ErrorBridgingTests.test("Wrapped NSError identity") {
 }
 
 extension Error {
-	func asNSError() -> NSError {
-		return self as NSError
-	}
+  func asNSError() -> NSError {
+    return self as NSError
+  }
 }
 
 func unconditionalCast<T>(_ x: Any, to: T.Type) -> T {
@@ -800,11 +800,11 @@ ErrorBridgingTests.test("CFError-to-Error casts") {
     } else {
       expectUnreachable()
     }
-	}
+  }
 
-	// TODO: Wrap some leak checking around this
-	// Until then, this is a helpful debug tool
-	should_not_leak()
+  // TODO: Wrap some leak checking around this
+  // Until then, this is a helpful debug tool
+  should_not_leak()
 }
 
 runAllTests()

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -795,9 +795,11 @@ ErrorBridgingTests.test("CFError-to-Error casts") {
     expectTrue(something is Error)
   }
 
-  // TODO: Wrap some leak checking around this
-  // Until then, this is a helpful debug tool
-  should_not_leak()
+  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+    // TODO: Wrap some leak checking around this
+    // Until then, this is a helpful debug tool
+    should_not_leak()
+  }
 }
 
 runAllTests()

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -792,14 +792,7 @@ ErrorBridgingTests.test("error-to-NSObject casts") {
 ErrorBridgingTests.test("CFError-to-Error casts") {
   func should_not_leak() {
     let something: Any? = NSError(domain: "Foo", code: 1)
-
-    if let error = something as? Error {
-      expectEqual(
-        "The operation couldn’t be completed. (Foo error 1.)",
-        error.localizedDescription)
-    } else {
-      expectUnreachable()
-    }
+    expectTrue(something is Error)
   }
 
   // TODO: Wrap some leak checking around this

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -788,4 +788,23 @@ ErrorBridgingTests.test("error-to-NSObject casts") {
   }
 }
 
+// SR-7732: Casting CFError to Error results in a memory leak
+ErrorBridgingTests.test("CFError-to-Error casts") {
+  func should_not_leak() {
+    let something: Any? = NSError(domain: "Foo", code: 1)
+
+    if let error = something as? Error {
+      expectEqual(
+        "The operation couldn’t be completed. (Foo error 1.)",
+        error.localizedDescription)
+    } else {
+      expectUnreachable()
+    }
+	}
+
+	// TODO: Wrap some leak checking around this
+	// Until then, this is a helpful debug tool
+	should_not_leak()
+}
+
 runAllTests()

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -788,9 +788,9 @@ ErrorBridgingTests.test("error-to-NSObject casts") {
   }
 }
 
-// SR-7732: Casting CFError to Error results in a memory leak
-ErrorBridgingTests.test("CFError-to-Error casts") {
-  func should_not_leak() {
+// SR-7732: Casting CFError or NSError to Error results in a memory leak
+ErrorBridgingTests.test("NSError-to-Error casts") {
+  func should_not_leak_nserror() {
     let something: Any? = NSError(domain: "Foo", code: 1)
     expectTrue(something is Error)
   }
@@ -798,7 +798,20 @@ ErrorBridgingTests.test("CFError-to-Error casts") {
   if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
     // TODO: Wrap some leak checking around this
     // Until then, this is a helpful debug tool
-    should_not_leak()
+		should_not_leak_nserror()
+  }
+}
+
+ErrorBridgingTests.test("CFError-to-Error casts") {
+  func should_not_leak_cferror() {
+    let something: Any? = CFErrorCreate(kCFAllocatorDefault, kCFErrorDomainCocoa, 1, [:] as CFDictionary)
+    expectTrue(something is Error)
+  }
+
+  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+    // TODO: Wrap some leak checking around this
+    // Until then, this is a helpful debug tool
+		should_not_leak_cferror()
   }
 }
 


### PR DESCRIPTION
The special handling for casting CFError/NSError to Swift Error
type was using cleanup code that didn't correctly handle this case.
This replaces the cleanup code with a more targeted version.

Resolves SR-7732
Resolves rdar://40423061