### PR TITLE
[AutoDiff] NFC: Use consistent headers for IndexSubset.{h,cpp}.

### DIFF
--- a/include/swift/AST/IndexSubset.h
+++ b/include/swift/AST/IndexSubset.h
@@ -1,8 +1,8 @@
-//===---------- IndexSubset.h - Fixed-size subset of indices --------------===//
+//===--- IndexSubset.h - Fixed-size subset of indices ---------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/IndexSubset.cpp
+++ b/lib/AST/IndexSubset.cpp
@@ -1,8 +1,8 @@
-//===-------- IndexSubset.cpp - Swift Differentiable Programming ----------===//
+//===--- IndexSubset.cpp - Fixed-size subset of indices -------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
Left-align headers. Use consistent message. Use accurate year in copyright.