### PR TITLE
[applysite] Add new methods that ease insertion of code after FullApplySites

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -398,24 +398,6 @@ public:
     }
   }
 
-  /// If this is a terminator apply site, then pass the first instruction of
-  /// each successor to fun. Otherwise, pass std::next(Inst).
-  ///
-  /// The intention is that this abstraction will enable the compiler writer to
-  /// ignore whether or not an apply site is a terminator when inserting
-  /// instructions after an apply site. This results in eliminating unnecessary
-  /// if-else code otherwise required to handle such situations.
-  void insertAfter(llvm::function_ref<void(SILBasicBlock::iterator)> func) {
-    auto *ti = dyn_cast<TermInst>(Inst);
-    if (!ti) {
-      return func(std::next(Inst->getIterator()));
-    }
-
-    for (auto *succBlock : ti->getSuccessorBlocks()) {
-      func(succBlock->begin());
-    }
-  }
-
   static ApplySite getFromOpaqueValue(void *p) { return ApplySite(p); }
 
   friend bool operator==(ApplySite lhs, ApplySite rhs) {
@@ -531,6 +513,63 @@ public:
   /// result argument to the apply site.
   bool isIndirectResultOperand(const Operand &op) const {
     return getCalleeArgIndex(op) < getNumIndirectSILResults();
+  }
+
+  /// If this is a terminator apply site, then pass the first instruction of
+  /// each successor to fun. Otherwise, pass std::next(Inst).
+  ///
+  /// The intention is that this abstraction will enable the compiler writer to
+  /// ignore whether or not an apply site is a terminator when inserting
+  /// instructions after an apply site. This results in eliminating unnecessary
+  /// if-else code otherwise required to handle such situations.
+  ///
+  /// NOTE: We return std::next() for begin_apply. If one wishes to insert code
+  /// /after/ the end_apply/abort_apply, please use instead
+  /// insertAfterFullEvaluation.
+  void insertAfterInvocation(
+      function_ref<void(SILBasicBlock::iterator)> func) const {
+    switch (getKind()) {
+    case FullApplySiteKind::ApplyInst:
+    case FullApplySiteKind::BeginApplyInst:
+      return func(std::next(getInstruction()->getIterator()));
+    case FullApplySiteKind::TryApplyInst:
+      for (auto *succBlock :
+           cast<TermInst>(getInstruction())->getSuccessorBlocks()) {
+        func(succBlock->begin());
+      }
+      return;
+    }
+    llvm_unreachable("Covered switch isn't covered");
+  }
+
+  /// Pass to func insertion points that are guaranteed to be immediately after
+  /// this full apply site has completely finished executing.
+  ///
+  /// This is just like insertAfterInvocation except that if the full apply site
+  /// is a begin_apply, we pass the insertion points after the end_apply,
+  /// abort_apply rather than an insertion point right after the
+  /// begin_apply. For such functionality, please invoke insertAfterInvocation.
+  void insertAfterFullEvaluation(
+      function_ref<void(SILBasicBlock::iterator)> func) const {
+    switch (getKind()) {
+    case FullApplySiteKind::ApplyInst:
+    case FullApplySiteKind::TryApplyInst:
+      return insertAfterInvocation(func);
+    case FullApplySiteKind::BeginApplyInst:
+      SmallVector<EndApplyInst *, 2> endApplies;
+      SmallVector<AbortApplyInst *, 2> abortApplies;
+      auto *bai = cast<BeginApplyInst>(getInstruction());
+      bai->getCoroutineEndPoints(endApplies, abortApplies);
+      for (auto *eai : endApplies) {
+        func(std::next(eai->getIterator()));
+      }
+      for (auto *aai : abortApplies) {
+        func(std::next(aai->getIterator()));
+      }
+      return;
+    }
+
+    llvm_unreachable("covered switch isn't covered");
   }
 
   static FullApplySite getFromOpaqueValue(void *p) { return FullApplySite(p); }

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -159,7 +159,7 @@ static void fixupReferenceCounts(
       // insert a destroy after the apply since the leak will just cover the
       // other path.
       if (!error.getFoundOverConsume()) {
-        applySite.insertAfter([&](SILBasicBlock::iterator iter) {
+        applySite.insertAfterInvocation([&](SILBasicBlock::iterator iter) {
           if (hasOwnership) {
             SILBuilderWithScope(iter).createEndBorrow(loc, argument);
           }
@@ -199,7 +199,7 @@ static void fixupReferenceCounts(
         }
       }
 
-      applySite.insertAfter([&](SILBasicBlock::iterator iter) {
+      applySite.insertAfterInvocation([&](SILBasicBlock::iterator iter) {
         SILBuilderWithScope(iter).emitDestroyValueOperation(loc, v);
       });
       break;
@@ -246,7 +246,7 @@ static void fixupReferenceCounts(
   // Destroy the callee as the apply would have done if our function is not
   // callee guaranteed.
   if (!isCalleeGuaranteed) {
-    applySite.insertAfter([&](SILBasicBlock::iterator iter) {
+    applySite.insertAfterInvocation([&](SILBasicBlock::iterator iter) {
       SILBuilderWithScope(iter).emitDestroyValueOperation(loc, calleeValue);
     });
   }


### PR DESCRIPTION
Specifically:

1. I renamed the method insertAfter -> insertAfterInvocation and added an
ehaustive switch to ensure that we properly update this code if we add new apply
sites.

2. I added a new method insertAfterFullEvaluation that is like
insertAfterInvocation except that the callback is called with insertion points
after the end/abort apply instead of after the initial invocation of the
begin_apply.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
