### PR TITLE
[AutoDiff] remove some jvp:, vjp: from stdlib

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4211,7 +4211,7 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
             scratch, isImplicit, origNameId, origDeclId, rawDerivativeKind,
             parameters);
 
-        DeclNameWithLoc origName{MF.getIdentifier(origNameId), DeclNameLoc()};
+        DeclNameWithLoc origName{MF.getDeclBaseName(origNameId), DeclNameLoc()};
         auto *origDecl = cast<AbstractFunctionDecl>(MF.getDecl(origDeclId));
         auto derivativeKind =
             getActualAutoDiffDerivativeFunctionKind(rawDerivativeKind);

--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
@@ -65,12 +65,12 @@ public struct Tracked<T> {
   }
   private var handle: Box
 
-  @differentiable(jvp: _jvpInit, vjp: _vjpInit where T : Differentiable, T == T.TangentVector)
+  @differentiable(where T : Differentiable, T == T.TangentVector)
   public init(_ value: T) {
     self.handle = Box(value)
   }
 
-  @differentiable(jvp: _jvpValue, vjp: _vjpValue where T : Differentiable, T == T.TangentVector)
+  @differentiable(where T : Differentiable, T == T.TangentVector)
   public var value: T {
     get { handle.value }
     set { handle.value = newValue }
@@ -172,24 +172,28 @@ extension Tracked : Differentiable where T : Differentiable, T == T.TangentVecto
 
 extension Tracked where T : Differentiable, T == T.TangentVector {
   @usableFromInline
+  @derivative(of: init)
   internal static func _vjpInit(_ value: T)
       -> (value: Self, pullback: (Self.TangentVector) -> (T.TangentVector)) {
     return (Tracked(value), { v in v.value })
   }
 
   @usableFromInline
+  @derivative(of: init)
   internal static func _jvpInit(_ value: T)
       -> (value: Self, differential: (T.TangentVector) -> (Self.TangentVector)) {
     return (Tracked(value), { v in Tracked(v) })
   }
 
   @usableFromInline
-  internal func _vjpValue() -> (T, (T.TangentVector) -> Self.TangentVector) {
+  @derivative(of: value)
+  internal func _vjpValue() -> (value: T, pullback: (T.TangentVector) -> Self.TangentVector) {
     return (value, { v in Tracked(v) })
   }
 
   @usableFromInline
-  internal func _jvpValue() -> (T, (Self.TangentVector) -> T.TangentVector) {
+  @derivative(of: value)
+  internal func _jvpValue() -> (value: T, differential: (Self.TangentVector) -> T.TangentVector) {
     return (value, { v in v.value })
   }
 }


### PR DESCRIPTION
Removes some `jvp:` and `vjp:` from the stdlib. This is partial progress towards unblocking TF-1001.

Some bugfixes were necessary:
* `DenseMapInfo<AutoDiffConfig>` wasn't canonicalizing the `GenericSignature`, causing equivalent configs to appear distinct.
* `@derivative(of:)` typechecking was not taking the generic signature into account when comparing actual/expected differential/pullback types, causing incorrect "incorrect pullback type" diagnositcs.
* In deserialization, `MF.getIdentifier` doesn't work on special identifiers like `init`, so `@derivative(of: init)` didn't work.

Open style question: When we have a choice about whether to put a `@differentiable` attribute on the original declaration, should we? This PR leaves all the `@differentiable` attributes, but it should also work if this PR removes them.