### PR TITLE
[Docs] [AutoDiff] Correct AD builtins.

### DIFF
--- a/docs/DifferentiableProgramming.md
+++ b/docs/DifferentiableProgramming.md
@@ -2059,7 +2059,7 @@ func valueWithDifferential<T, R>(
 ) -> (value: R,
       differential: @differentiable(linear) (T.TangentVector) -> R.TangentVector) {
     // Compiler built-in.
-    Builtin.autodiffApply_jvp_arity1(body, x)
+    Builtin.applyDerivative_arity1(body, x)
 }
 
 
@@ -2068,7 +2068,7 @@ func transpose<T, R>(
     of body: @escaping @differentiable(linear) (T) -> R
 ) -> @differentiable(linear) (R) -> T {
     // Compiler built-in.
-    { x in Builtin.autodiffApply_transpose(body, x) }
+    { x in Builtin.applyTranspose_arity1(body, x) }
 }
 ```
 


### PR DESCRIPTION
* `Builtin.autodiffApply*` has been renamed to `Builtin.applyDerivative*`.
  * The reason I'm not adding `_jvp` is because there will no longer be `_vjp`, which will make this suffix entirely unnecessary.
* The transpose application builtin is named `Builtin.applyTranspose*`.