### PR TITLE
[Diagnostics] Upon keypath result contextual mismatch try to match ob…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2842,6 +2842,13 @@ bool ConstraintSystem::repairFailures(
       if (fnType && fnType->getResult()->isEqual(rhs))
         return true;
 
+      auto lastComponentType = lhs->lookThroughAllOptionalTypes();
+      auto keyPathResultType = rhs->lookThroughAllOptionalTypes();
+
+      // Propagate contextual information from/to keypath result type.
+      (void)matchTypes(lastComponentType, keyPathResultType, matchKind,
+                       TMF_ApplyingFix, getConstraintLocator(locator));
+
       conversionsOrFixes.push_back(IgnoreContextualType::create(
           *this, lhs, rhs, getConstraintLocator(locator)));
       return true;

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -102,3 +102,16 @@ func rdar56131416() {
   // This type should be selected correctly.
   Rdar56131416.takesCorrectType(result)
 }
+
+func test_mismatch_with_contextual_optional_result() {
+  struct A<T> {
+    init<U: Collection>(_ data: T, keyPath: KeyPath<T, U?>) {}
+  }
+
+  struct B {
+    var arr: [Int] = []
+  }
+
+  let _ = A(B(), keyPath: \.arr)
+  // expected-error@-1 {{key path value type '[Int]' cannot be converted to contextual type '[Int]?'}}
+}


### PR DESCRIPTION
…ject types

If there was a mismatch between last component type and contextual
key path result type, let's try to re-match the types with all optionals
stripped off. In cases where the problem is optionality difference
e.g. `[Int] vs. [Int]?` that propagates contextual information to
the last component which facilitates better diagnostics.

Resolves: rdar://problem/57843297

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
