### PR TITLE
Requestify hasDynamicMemberLookupAttribute for Sema too

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -371,6 +371,9 @@ private:
   void operator!=(Type T) const = delete;
 };
 
+/// Extract the source location from a given type.
+SourceLoc extractNearestSourceLoc(Type ty);
+
 /// CanType - This is a Type that is statically known to be canonical.  To get
 /// one of these, use Type->getCanonicalType().  Since all CanType's can be used
 /// as 'Type' (they just don't have sugar) we derive from Type.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1968,6 +1968,29 @@ public:
   void cacheResult(bool result) const;
 };
 
+/// Computes whether the specified type or a super-class/super-protocol has the
+/// @dynamicMemberLookup attribute on it.
+class HasDynamicMemberLookupAttributeRequest
+    : public SimpleRequest<HasDynamicMemberLookupAttributeRequest,
+                           bool(CanType), CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<bool> evaluate(Evaluator &evaluator, CanType ty) const;
+
+public:
+  bool isCached() const {
+    // Don't cache types containing type variables, as they must not outlive
+    // the constraint system that created them.
+    auto ty = std::get<0>(getStorage());
+    return !ty->hasTypeVariable();
+  }
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -73,6 +73,8 @@ SWIFT_REQUEST(TypeChecker, HasCircularInheritedProtocolsRequest,
               bool(ProtocolDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, HasCircularRawValueRequest,
               bool(EnumDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, HasDynamicMemberLookupAttributeRequest,
+              bool(CanType), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
               GenericSignature (ModuleDecl *, GenericSignatureImpl *,
                                  GenericParamList *,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -829,6 +829,10 @@ public:
   /// check access control.
   bool isCallableNominalType(DeclContext *dc);
 
+  /// Return true if the specified type or a super-class/super-protocol has the
+  /// @dynamicMemberLookup attribute on it.
+  bool hasDynamicMemberLookupAttribute();
+
   /// Retrieve the superclass of this type.
   ///
   /// \param useArchetypes Whether to use context archetypes for outer generic

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -232,10 +232,6 @@ namespace swift {
   /// written by the user; this performs the reverse transformation.
   OriginalArgumentList getOriginalArgumentList(Expr *expr);
 
-  /// Return true if the specified type or a super-class/super-protocol has the
-  /// @dynamicMemberLookup attribute on it.
-  bool hasDynamicMemberLookupAttribute(Type type);
-
   /// Returns the root type and result type of the keypath type in a keypath
   /// dynamic member lookup subscript, or \c None if it cannot be determined.
   ///

--- a/include/swift/Sema/IDETypeCheckingRequestIDZone.def
+++ b/include/swift/Sema/IDETypeCheckingRequestIDZone.def
@@ -15,8 +15,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(IDETypeChecking, HasDynamicMemberLookupAttributeRequest,
-              bool(TypeBase *), Cached, NoLocationInfo)
 SWIFT_REQUEST(IDETypeChecking, IsDeclApplicableRequest,
               bool(DeclApplicabilityOwner), Cached, NoLocationInfo)
 SWIFT_REQUEST(IDETypeChecking, RootAndResultTypeOfKeypathDynamicMemberRequest,

--- a/include/swift/Sema/IDETypeCheckingRequests.h
+++ b/include/swift/Sema/IDETypeCheckingRequests.h
@@ -227,29 +227,6 @@ public:
   SourceLoc getNearestLoc() const { return SourceLoc(); };
 };
 
-//----------------------------------------------------------------------------//
-// HasDynamicMemberLookupAttributeRequest
-//----------------------------------------------------------------------------//
-class HasDynamicMemberLookupAttributeRequest:
-    public SimpleRequest<HasDynamicMemberLookupAttributeRequest,
-                         bool(TypeBase*),
-                         CacheKind::Cached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator, TypeBase *ty) const;
-
-public:
-  // Caching
-  bool isCached() const { return true; }
-  // Source location
-  SourceLoc getNearestLoc() const { return SourceLoc(); };
-};
-
 /// The zone number for the IDE.
 #define SWIFT_TYPEID_ZONE IDETypeChecking
 #define SWIFT_TYPEID_HEADER "swift/Sema/IDETypeCheckingRequestIDZone.def"

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1498,6 +1498,13 @@ bool TypeBase::isCallableNominalType(DeclContext *dc) {
                            IsCallableNominalTypeRequest{canTy, dc}, false);
 }
 
+bool TypeBase::hasDynamicMemberLookupAttribute() {
+  auto canTy = getCanonicalType();
+  auto &ctx = canTy->getASTContext();
+  return evaluateOrDefault(
+      ctx.evaluator, HasDynamicMemberLookupAttributeRequest{canTy}, false);
+}
+
 Type TypeBase::getSuperclass(bool useArchetypes) {
   auto *nominalDecl = getAnyNominal();
   auto *classDecl = dyn_cast_or_null<ClassDecl>(nominalDecl);
@@ -4856,4 +4863,11 @@ SILFunctionType::withSubstitutions(SubstitutionMap subs) const {
                           getOptionalErrorResult(),
                           subs, isGenericSignatureImplied(),
                           const_cast<SILFunctionType*>(this)->getASTContext());
+}
+
+SourceLoc swift::extractNearestSourceLoc(Type ty) {
+  if (auto nominal = ty->getAnyNominal())
+    return extractNearestSourceLoc(nominal);
+
+  return SourceLoc();
 }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -759,8 +759,3 @@ Type swift::getResultTypeOfKeypathDynamicMember(SubscriptDecl *SD) {
     RootAndResultTypeOfKeypathDynamicMemberRequest{SD}, TypePair()).
       SecondTy;
 }
-
-bool swift::hasDynamicMemberLookupAttribute(Type ty) {
-  return evaluateOrDefault(ty->getASTContext().evaluator,
-    HasDynamicMemberLookupAttributeRequest{ty.getPointer()}, false);
-}

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1297,9 +1297,6 @@ public:
   /// types.
   llvm::DenseMap<CanType, DynamicCallableMethods> DynamicCallableCache;
 
-  /// A cache that stores whether types are valid @dynamicMemberLookup types.
-  llvm::DenseMap<CanType, bool> DynamicMemberLookupCache;
-
 private:
   /// Describe the candidate expression for partial solving.
   /// This class used by shrink & solve methods which apply

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -128,10 +128,3 @@ RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(Evaluator &evaluator,
          "invalid keypath dynamic member");
   return TypePair(genericArgs[0], genericArgs[1]);
 }
-
-llvm::Expected<bool>
-HasDynamicMemberLookupAttributeRequest::evaluate(Evaluator &evaluator,
-                                                 TypeBase *ty) const {
-  llvm::DenseMap<CanType, bool> DynamicMemberLookupCache;
-  return hasDynamicMemberLookupAttribute(Type(ty), DynamicMemberLookupCache);
-}

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -986,8 +986,7 @@ static void lookupVisibleDynamicMemberLookupDecls(
   if (!seenDynamicLookup.insert(baseType.getPointer()).second)
     return;
 
-  if (!evaluateOrDefault(dc->getASTContext().evaluator,
-         HasDynamicMemberLookupAttributeRequest{baseType.getPointer()}, false))
+  if (!baseType->hasDynamicMemberLookupAttribute())
     return;
 
   auto &ctx = dc->getASTContext();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1740,9 +1740,6 @@ bool areGenericRequirementsSatisfied(const DeclContext *DC,
                                      GenericSignature sig,
                                      SubstitutionMap Substitutions,
                                      bool isExtension);
-
-bool hasDynamicMemberLookupAttribute(Type type,
-  llvm::DenseMap<CanType, bool> &DynamicMemberLookupCache);
 } // end namespace swift
 
 #endif


### PR DESCRIPTION
Previously we had a request for this in IDETypeChecking, but this wasn't used for queries made from Sema. Move the request into Sema, and move `hasDynamicMemberLookupAttribute` onto `TypeBase`.