### PR TITLE
[Clang importer] Ensure that we check a bridging PCH in a source file context

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -800,6 +800,11 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
   auto FID = clangSrcMgr.createFileID(
                         llvm::make_unique<ZeroFilledMemoryBuffer>(1, "<main>"));
   clangSrcMgr.setMainFileID(FID);
+  auto &diagConsumer = CI.getDiagnosticClient();
+  diagConsumer.BeginSourceFile(CI.getLangOpts());
+  SWIFT_DEFER {
+    diagConsumer.EndSourceFile();
+  };
 
   // Pass in TU_Complete, which is the default mode for the Preprocessor
   // constructor and the right one for reading a PCH.

--- a/test/ClangImporter/Inputs/ModuleMapWarning/PrivateWarning.framework/Headers/PrivateWarning.h
+++ b/test/ClangImporter/Inputs/ModuleMapWarning/PrivateWarning.framework/Headers/PrivateWarning.h
@@ -1,0 +1,1 @@
+/* No content */

--- a/test/ClangImporter/Inputs/ModuleMapWarning/PrivateWarning.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/ModuleMapWarning/PrivateWarning.framework/Modules/module.modulemap
@@ -1,0 +1,3 @@
+framework module PrivateWarning {
+  header "PrivateWarning.h"
+}

--- a/test/ClangImporter/Inputs/ModuleMapWarning/PrivateWarning.framework/Modules/module.private.modulemap
+++ b/test/ClangImporter/Inputs/ModuleMapWarning/PrivateWarning.framework/Modules/module.private.modulemap
@@ -1,0 +1,3 @@
+framework module PrivateWarning.Private {
+  header "PrivateWarning_Private.h"
+}

--- a/test/ClangImporter/Inputs/ModuleMapWarning/PrivateWarning.framework/PrivateHeaders/PrivateWarning_Private.h
+++ b/test/ClangImporter/Inputs/ModuleMapWarning/PrivateWarning.framework/PrivateHeaders/PrivateWarning_Private.h
@@ -1,0 +1,1 @@
+/* No content */

--- a/test/ClangImporter/Inputs/ModuleMapWarning/bridging-pch.h
+++ b/test/ClangImporter/Inputs/ModuleMapWarning/bridging-pch.h
@@ -1,0 +1,2 @@
+@import PrivateWarning;
+@import PrivateWarning.Private;

--- a/test/ClangImporter/pch-bridging-header-module-map-diags.swift
+++ b/test/ClangImporter/pch-bridging-header-module-map-diags.swift
@@ -1,0 +1,12 @@
+// RUN: rm -f %t.*
+
+// Build a bridging PCH for involving a module map that contains a warning
+// RUN: %target-swift-frontend -F %S/Inputs/ModuleMapWarning -emit-pch %S/Inputs/ModuleMapWarning/bridging-pch.h -pch-output-dir %t/pch 2> %t.stderr
+// RUN: %FileCheck %s < %t.stderr
+
+// CHECK: module.private.modulemap:1:33: warning: private submodule 'PrivateWarning.Private' in private module map, expected top-level module
+
+// Check that loading that bridging PCH Does not crash the compiler.
+// RUN: %target-swift-frontend -F %S/Inputs/ModuleMapWarning -import-objc-header %S/Inputs/ModuleMapWarning/bridging-pch.h -pch-output-dir %t/pch -typecheck %s
+
+

--- a/test/ClangImporter/pch-bridging-header-module-map-diags.swift
+++ b/test/ClangImporter/pch-bridging-header-module-map-diags.swift
@@ -1,4 +1,5 @@
 // RUN: rm -f %t.*
+// REQUIRES: objc_interop
 
 // Build a bridging PCH for involving a module map that contains a warning
 // RUN: %target-swift-frontend -F %S/Inputs/ModuleMapWarning -emit-pch %S/Inputs/ModuleMapWarning/bridging-pch.h -pch-output-dir %t/pch 2> %t.stderr


### PR DESCRIPTION
When checking whether we can load a bridging precompiled header (PCH), we end
up parsing module maps. If Clang emits a warning or error while parsing the
module maps we encounter, the Swift compiler would crash because we have not
properly established the invariants of Clang's diagnostic engine. Perform a
pairsed set of BeginSourceFile/EndSourceFile calls on the Clang diagnostic
consumer to set up the appropriate state.

Fixes rdar://problem/57626886.
