### PR TITLE
[AutoDiff] Add `@transpose` attribute serialization.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -557,8 +557,8 @@ SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
   101)
 DECL_ATTR(transpose, Transpose,
   OnFunc | LongAttribute | AllowMultipleAttributes |
-  ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove |
-  NotSerialized, 102)
+  ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove,
+  102)
 // SWIFT_ENABLE_TENSORFLOW END
 
 #undef TYPE_ATTR

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2083,9 +2083,10 @@ class TransposeAttr final
       private llvm::TrailingObjects<TransposeAttr, ParsedAutoDiffParameter> {
   friend TrailingObjects;
 
-  /// The base type of the original function.
-  /// This is non-null only when the original function is not top-level (i.e. it
-  /// is an instance/static method).
+  /// The base type for the referenced original declaration. This field is
+  /// non-null only for parsed attributes that reference a qualified original
+  /// declaration. This field is not serialized; type-checking uses it to
+  /// resolve the original declaration, which is serialized.
   TypeRepr *BaseType;
   /// The original function name.
   DeclNameWithLoc OriginalFunctionName;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -984,7 +984,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   // SWIFT_ENABLE_TENSORFLOW
   case DAK_Transpose: {
     Printer.printAttrName("@transpose");
-    Printer << '(';
+    Printer << "(of: ";
     auto *attr = cast<TransposeAttr>(this);
     Printer << attr->getOriginalFunctionName().Name;
     auto *transpose = cast<AbstractFunctionDecl>(D);

--- a/test/Serialization/transpose_attr.swift
+++ b/test/Serialization/transpose_attr.swift
@@ -1,0 +1,94 @@
+// SWIFT_ENABLE_TENSORFLOW
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
+// RUN: llvm-bcanalyzer %t/transpose_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
+// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/transpose_attr.swiftmodule -o - | %FileCheck %s
+
+// BCANALYZER-NOT: UnknownCode
+
+// Dummy `Differentiable`-conforming type.
+struct S: Differentiable & AdditiveArithmetic {
+  static var zero: S { S() }
+  static func + (_: S, _: S) -> S { S() }
+  static func - (_: S, _: S) -> S { S() }
+  typealias TangentVector = S
+}
+
+// Test top-level functions.
+
+func top1(_ x: S) -> S {
+  x
+}
+// CHECK: @transpose(of: top1, wrt: 0)
+@transpose(of: top1, wrt: 0)
+func transposeTop1(v: S) -> S {
+  v
+}
+
+func top2<T, U>(_ x: T, _ i: Int, _ y: U) -> U {
+  y
+}
+// CHECK: @transpose(of: top2, wrt: (0, 2))
+@transpose(of: top2, wrt: (0, 2))
+func transposeTop2<T, U>(_ int: Int, v: U) -> (T, U)
+where T: Differentiable, U: Differentiable,
+      T == T.TangentVector, U == U.TangentVector {
+  (.zero, v)
+}
+
+// Test instance methods.
+
+extension S {
+  func instanceMethod(_ other: S) -> S {
+    self + other
+  }
+
+  // CHECK: @transpose(of: instanceMethod, wrt: 0)
+  @transpose(of: instanceMethod, wrt: 0)
+  func transposeInstanceMethod(v: S) -> (S, S) {
+    (v, v)
+  }
+
+  // CHECK: @transpose(of: instanceMethod, wrt: self)
+  @transpose(of: instanceMethod, wrt: self)
+  func transposeInstanceMethodWrtSelf(v: S) -> (S, S) {
+    (v, v)
+  }
+}
+
+// Test static methods.
+
+extension S {
+  static func staticMethod(x: S) -> S {
+    x
+  }
+
+  // CHECK: @transpose(of: staticMethod, wrt: 0)
+  @transpose(of: staticMethod, wrt: 0)
+  func transposeStaticMethod(_: S.Type) -> S {
+    self
+  }
+}
+
+// Test computed properties.
+extension S {
+  var computedProperty: S { self }
+
+  // CHECK: @transpose(of: computedProperty, wrt: self)
+  @transpose(of: computedProperty, wrt: self)
+  func transposeProperty() -> Self {
+    self
+  }
+}
+
+// Test subscripts.
+extension S {
+  subscript<T: Differentiable>(x: T) -> Self { self }
+
+  // CHECK: @transpose(of: subscript, wrt: self)
+  @transpose(of: subscript(_:), wrt: self)
+  func transposeSubscript<T: Differentiable>(x: T) -> Self {
+    self
+  }
+}


### PR DESCRIPTION
Add `@transpose` attribute serialization/deserialization.
Minor `@transpose` attribute printing fix: `@transpose(xxx)` -> `@transpose(of: xxx)`.