### PR TITLE
[SourceKit/CodeCompletion] Remove unnecessary sorting in completion

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -100,7 +100,6 @@ struct SwiftCodeCompletionConsumer
 
   void handleResults(MutableArrayRef<CodeCompletionResult *> Results) override {
     assert(swiftContext.swiftASTContext);
-    CodeCompletionContext::sortCompletionResults(Results);
     handleResultsImpl(Results, swiftContext);
   }
 };


### PR DESCRIPTION
`codeCompleteOpen()` has its own sorting algorithm.
`codeComplete()` [calls this `sortCompletionResults()` in its own callback](https://github.com/rintaro/swift/blob/c35c9ecc3d436c3f5d0f2553fc4b901e6ea7c512/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp#L246). So this pre-sorting is completely unnecessary.

rdar://problem/57926003