### PR TITLE
[Playground transform] Retain ! expressions when logging variables.

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -320,8 +320,16 @@ public:
     }
     case ExprKind::Load:
       return digForVariable(cast<LoadExpr>(E)->getSubExpr());
-    case ExprKind::ForceValue:
-      return digForVariable(cast<ForceValueExpr>(E)->getSubExpr());
+    case ExprKind::ForceValue: {
+      std::pair<Added<Expr *>, ValueDecl *> BaseVariable =
+          digForVariable(cast<ForceValueExpr>(E)->getSubExpr());
+      if (!*BaseVariable.first || !BaseVariable.second)
+        return std::make_pair(nullptr, nullptr);
+
+      Added<Expr *> Forced(
+          new (Context) ForceValueExpr(*BaseVariable.first, SourceLoc()));
+      return std::make_pair(Forced, BaseVariable.second);
+    }
     case ExprKind::InOut:
       return digForVariable(cast<InOutExpr>(E)->getSubExpr());
     }

--- a/test/PlaygroundTransform/iuo.swift
+++ b/test/PlaygroundTransform/iuo.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -force-single-frontend-invocation -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
+
+import PlaygroundSupport
+
+class Layer {
+  var value: Double = 0
+}
+
+class Outer {
+  let layer: Layer! = Layer()
+}
+
+class Enclosing {
+  var outer: Outer! = Outer()
+
+  func test() {
+    // Ensure that this doesn't crash
+    outer.layer.value = 3.14159
+  }
+}
+
+Enclosing().test()


### PR DESCRIPTION
When a force-value expression (!) is encountered while logging
variables, retain the force-value expression rather than dropping it.
This allows logging involving implicitly unwrapped optionals.

Fixes rdar://problem/56098581.
