### PR TITLE
[AutoDiff] NFC: Clean up `@transpose` attribute.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2087,7 +2087,7 @@ class TransposeAttr final
   /// non-null only for parsed attributes that reference a qualified original
   /// declaration. This field is not serialized; type-checking uses it to
   /// resolve the original declaration, which is serialized.
-  TypeRepr *BaseType;
+  TypeRepr *BaseTypeRepr;
   /// The original function name.
   DeclNameWithLoc OriginalFunctionName;
   /// The original function declaration, resolved by the type checker.
@@ -2098,25 +2098,25 @@ class TransposeAttr final
   IndexSubset *ParameterIndices = nullptr;
 
   explicit TransposeAttr(bool implicit, SourceLoc atLoc, SourceRange baseRange,
-                         TypeRepr *baseType, DeclNameWithLoc original,
+                         TypeRepr *baseTypeRepr, DeclNameWithLoc original,
                          ArrayRef<ParsedAutoDiffParameter> params);
 
   explicit TransposeAttr(bool implicit, SourceLoc atLoc, SourceRange baseRange,
-                         TypeRepr *baseType, DeclNameWithLoc original,
+                         TypeRepr *baseTypeRepr, DeclNameWithLoc original,
                          IndexSubset *indices);
 
 public:
   static TransposeAttr *create(ASTContext &context, bool implicit,
                                SourceLoc atLoc, SourceRange baseRange,
-                               TypeRepr *baseType, DeclNameWithLoc original,
+                               TypeRepr *baseTypeRepr, DeclNameWithLoc original,
                                ArrayRef<ParsedAutoDiffParameter> params);
 
   static TransposeAttr *create(ASTContext &context, bool implicit,
                                SourceLoc atLoc, SourceRange baseRange,
-                               TypeRepr *baseType, DeclNameWithLoc original,
+                               TypeRepr *baseTypeRepr, DeclNameWithLoc original,
                                IndexSubset *indices);
 
-  TypeRepr *getBaseType() const { return BaseType; }
+  TypeRepr *getBaseTypeRepr() const { return BaseTypeRepr; }
   DeclNameWithLoc getOriginalFunctionName() const {
     return OriginalFunctionName;
   }

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1581,30 +1581,24 @@ ERROR(differentiable_attribute_expected_rparen,none,
 ERROR(unexpected_argument_differentiable,none,
       "unexpected argument '%0' in '@differentiable' attribute", (StringRef))
 
+// derivative
+WARNING(attr_differentiating_deprecated,PointsToFirstBadToken,
+        "'@differentiating' attribute is deprecated; use '@derivative(of:)' "
+        "instead", ())
+
 // differentiation `wrt` parameters clause
 ERROR(expected_colon_after_label,PointsToFirstBadToken,
       "expected a colon ':' after '%0'", (StringRef))
 ERROR(diff_params_clause_expected_parameter,PointsToFirstBadToken,
       "expected a parameter, which can be a function parameter name, "
       "parameter index, or 'self'", ())
+ERROR(diff_params_clause_expected_parameter_unnamed,PointsToFirstBadToken,
+      "expected a parameter, which can be a function parameter index or 'self'",
+      ())
 
-// derivative
-ERROR(attr_derivative_expected_original_name,PointsToFirstBadToken,
+// Automatic differentiation attributes
+ERROR(autodiff_attr_expected_original_decl_name,PointsToFirstBadToken,
       "expected an original function name", ())
-WARNING(attr_differentiating_deprecated,PointsToFirstBadToken,
-        "'@differentiating' attribute is deprecated; use '@derivative(of:)' "
-        "instead", ())
-
-// transpose
-ERROR(attr_transpose_expected_original_name,PointsToFirstBadToken,
-      "expected an original function name", ())
-ERROR(attr_transpose_expected_label_linear_or_wrt,none,
-      "expected 'wrt:'", ())
-
-// transpose `wrt` parameters clause
-ERROR(transpose_params_clause_expected_parameter,PointsToFirstBadToken,
-      "expected a parameter, which can be a 'unsigned int' parameter number "
-      "or 'self'", ())
 
 // SIL autodiff
 ERROR(sil_autodiff_expected_lsquare,PointsToFirstBadToken,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -993,10 +993,13 @@ public:
       Optional<DeclNameWithLoc> &jvpSpec, Optional<DeclNameWithLoc> &vjpSpec,
       TrailingWhereClause *&whereClause);
 
-  /// Parse a differentiation parameters clause, i.e. the "wrt:" clause in
-  /// @differentiable and @derivative attributes.
+  /// Parse a differentiation parameters clause, i.e. the 'wrt:' clause in
+  /// `@differentiable` and `@derivative` attributes.
+  /// If `allowNamedParameters` is false, allow only index parameters and
+  /// 'self'.
   bool parseDifferentiationParametersClause(
-      SmallVectorImpl<ParsedAutoDiffParameter> &params, StringRef attrName);
+      SmallVectorImpl<ParsedAutoDiffParameter> &params, StringRef attrName,
+      bool allowNamedParameters = true);
 
   /// Parse the @derivative attribute.
   ParserResult<DerivativeAttr> parseDerivativeAttribute(SourceLoc AtLoc,
@@ -1006,11 +1009,6 @@ public:
   // TODO(TF-999): Remove the deprecated `@differentiating` attribute.
   ParserResult<DerivativeAttr> parseDifferentiatingAttribute(SourceLoc AtLoc,
                                                              SourceLoc Loc);
-
-  /// Parse a transposed parameters clause, i.e. the "wrt:" clause in @transpose
-  /// attributes.
-  bool parseTransposedParametersClause(
-      SmallVectorImpl<ParsedAutoDiffParameter> &params, StringRef attrName);
 
   /// Parse the @transpose attribute.
   ParserResult<TransposeAttr> parseTransposeAttribute(SourceLoc AtLoc,
@@ -1395,11 +1393,9 @@ public:
   bool canParseTypedPattern();
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Determines whether a type qualifier for a decl name can be parsed. e.g.:
-  ///   'Foo.f' -> true
-  ///   'Foo.Bar.f' -> true
-  ///   'f' -> false
-  bool canParseTypeQualifierForDeclName();
+  /// Returns true if a base type for a qualified declaration name can be
+  /// parsed.
+  bool canParseBaseTypeForQualifiedDeclName();
 
   //===--------------------------------------------------------------------===//
   // Expression Parsing

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4058,21 +4058,22 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   std::function<bool(AbstractFunctionDecl *)> hasValidTypeContext =
       [&](AbstractFunctionDecl *decl) { return true; };
 
-  auto typeRes = TypeResolution::forContextual(transpose->getDeclContext());
-  auto baseType = Type();
-  if (attr->getBaseType())
-    baseType = typeRes.resolveType(attr->getBaseType(), None);
-  auto lookupOptions = (attr->getBaseType() ? defaultMemberLookupOptions
-                                            : defaultUnqualifiedLookupOptions) |
-                        NameLookupFlags::IgnoreAccessControl;
+  auto resolution = TypeResolution::forContextual(transpose->getDeclContext());
+  Type baseType;
+  if (attr->getBaseTypeRepr())
+    baseType = resolution.resolveType(attr->getBaseTypeRepr(), None);
+  auto lookupOptions =
+      (attr->getBaseTypeRepr() ? defaultMemberLookupOptions
+                               : defaultUnqualifiedLookupOptions) |
+      NameLookupFlags::IgnoreAccessControl;
   auto transposeTypeCtx = transpose->getInnermostTypeContext();
   if (!transposeTypeCtx) transposeTypeCtx = transpose->getParent();
   assert(transposeTypeCtx);
 
   // Look up original function.
   auto funcLoc = originalName.Loc.getBaseNameLoc();
-  if (attr->getBaseType())
-    funcLoc = attr->getBaseType()->getLoc();
+  if (attr->getBaseTypeRepr())
+    funcLoc = attr->getBaseTypeRepr()->getLoc();
   auto *originalAFD = findAbstractFunctionDecl(
       originalName.Name, funcLoc, baseType, transposeTypeCtx, isValidOriginal,
       noneValidDiagnostic, ambiguousDiagnostic, notFunctionDiagnostic,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4150,7 +4150,6 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         break;
       }
 
-      // SWIFT_ENABLE_TENSORFLOW
       case decls_block::Differentiable_DECL_ATTR: {
         bool isImplicit;
         bool linear;

--- a/test/AutoDiff/transpose_attr_parse.swift
+++ b/test/AutoDiff/transpose_attr_parse.swift
@@ -2,71 +2,87 @@
 
 /// Good
 
-@transpose(of: linearFunc) // ok
-func transpose(x: @nondiff Float) -> Float {
-  return (x, { 2 * $0 })
-}
+@transpose(of: foo)
+func transpose(v: Float) -> Float
 
-@transpose(of: linearFunc, wrt: 0) // ok
-func transposeWrt(t: @nondiff Float) -> Float {
-  return 2 * t
-}
+@transpose(of: foo(_:_:))
+func transpose(v: Float) -> Float
 
-@transpose(of: add, wrt: (0, 1)) // ok
-func transposeWrtList(t: Float) -> (Float, Float) {
-  return (t, t)
-}
+@transpose(of: wrt, wrt: 0)
+func transpose(v: Float) -> Float
 
-extension AdditiveArithmetic where Self : Differentiable {
-  @transpose(of: +) // ok
-  static func addTranspose(t: Self) -> (TangentVector, TangentVector) {
-    return (t, t)
-  }
-}
+@transpose(of: foo, wrt: 0)
+func transpose(v: Float) -> Float
+
+@transpose(of: foo, wrt: (0, 1))
+func transpose(v: Float) -> (Float, Float)
+
+@transpose(of: foo, wrt: (self, 0, 1, 2))
+func transpose(v: Float) -> (Float, Float, Float, Float)
+
+// Qualified declaration.
+@transpose(of: A.B.C.foo(x:y:_:z:))
+func transpose(v: Float) -> Float
+
+// Qualified operator.
+// TODO(TF-1065): Consider disallowing qualified operators.
+@transpose(of: Swift.Float.+)
+func transpose(v: Float) -> Float
+
+// Qualified leading-period operator (confusing).
+// TODO(TF-1065): Consider disallowing qualified operators.
+@transpose(of: Swift.Float..<)
+func transpose(v: Float) -> Float
+
+// `init` keyword edge case.
+@transpose(of: Swift.Float.init(_:))
+func transpose(v: Float) -> Float
+
+// `subscript` keyword edge case.
+@transpose(of: Swift.Array.subscript(_:))
+func transpose(v: Float) -> Float
 
 /// Bad
-
-// expected-error @+1 {{expected label 'wrt:' in '@transpose' attribute}}
-@transpose(of: linearFunc, linear)
-func tfoo(t: Float) -> Float {
-  return t
-}
 
 // expected-error @+2 {{expected an original function name}}
 // expected-error @+1 {{expected declaration}}
 @transpose(of: 3)
-func tfoo(t: Float) -> Float {
-  return t
-}
+func transpose(v: Float) -> Float
+
+// expected-error @+1 {{expected label 'wrt:' in '@transpose' attribute}}
+@transpose(of: foo, blah)
+func transpose(v: Float) -> Float
 
 // expected-error @+1 {{unexpected ',' separator}}
 @transpose(of: foo,)
-func tfoo(t: Float) -> Float {
-  return t
-}
+func transpose(v: Float) -> Float
 
 // expected-error @+2 {{expected ')' in 'transpose' attribute}}
 // expected-error @+1 {{expected declaration}}
 @transpose(of: foo, wrt: 0,)
-func tfoo(t: Float) -> Float {
-  return t
-}
+func transpose(v: Float) -> Float
 
-// expected-error @+1 {{expected a parameter, which can be a 'unsigned int' parameter number or 'self'}}
-@transpose(of: foo, wrt: x)
-func tfoo(t: Float) -> Float {
-  return t
-}
+// expected-error @+1 {{expected a parameter, which can be a function parameter index or 'self'}}
+@transpose(of: foo, wrt: v)
+func transpose(v: Float) -> Float
 
-// expected-error @+1 {{expected a parameter, which can be a 'unsigned int' parameter number or 'self'}}
-@transpose(of: foo, wrt: (0, x))
-func tfoo(t: Float) -> Float {
-  return t
-}
+// expected-error @+1 {{expected a parameter, which can be a function parameter index or 'self'}}
+@transpose(of: foo, wrt: (0, v))
+func transpose(v: Float) -> Float
 
-func localTransposeRegistration() {
-  // Not okay. Transpose registration can only be non-local.
+// expected-error @+2 {{expected ')' in 'transpose' attribute}}
+// expected-error @+1 {{expected declaration}}
+@transpose(of: Swift.Float.+(_:_))
+func transpose(v: Float) -> Float
+
+// expected-error @+2 {{expected ')' in 'transpose' attribute}}
+// expected-error @+1 {{expected declaration}}
+@transpose(of: Swift.Float.+.a)
+func transpose(v: Float) -> Float
+
+func testLocalTransposeRegistration() {
+  // Transpose registration can only be non-local.
   // expected-error @+1 {{attribute '@transpose' can only be used in a non-local scope}}
   @transpose(of: +)
-  func foo(_ x: Float) -> (Float, Float)
+  func transpose(_ x: Float) -> (Float, Float)
 }

--- a/test/AutoDiff/transpose_attr_type_checking.swift
+++ b/test/AutoDiff/transpose_attr_type_checking.swift
@@ -274,9 +274,19 @@ struct A : Differentiable & AdditiveArithmetic {
     return A(x: -a.x)
   }
 
-  @transpose(of: A.-, wrt: 0)
-  func negationT(a: A.Type) -> A {
-    return A(x: 1)
+  @transpose(of: -, wrt: 0)
+  func transposeNegate(a: A.Type) -> A {
+    return A(x: -x)
+  }
+
+  static prefix func +(a: A) -> A {
+    return a
+  }
+
+  // TODO(TF-1065): Consider disallowing qualified operator names.
+  @transpose(of: A.+, wrt: 0)
+  func transposeIdQualified(a: A.Type) -> A {
+    return self
   }
 }
 


### PR DESCRIPTION
Clean up `@transpose` attribute printing and parsing.

- Remove `Parser::parseTransposedParametersClause`.
  - Instead, reuse `Parser::parseDifferentiationParametersClause` by
    adding a `allowNamedParameters` flag.
- Remove `getTransposedParametersClauseString`.
  - Instead, reuse `getDifferentiationParametersClauseString` by adding
    a `DifferentiationParameterPrintingStyle` argument.
- Remove code from qualified declaration parsing utilities to reduce diff
  with master.
- Revamp `test/AutoDiff/transpose_attr_parse.swift`.

Preparation for upstreaming `@transpose` attribute definition.

Filed TF-1060: finalize `@transpose` type-checking rules.
Filed TF-1065: disallow qualified operators in `@transpose` attribute.