### PR TITLE
[SIL Optimization] Create a new utility InstructionDeleter to delete instructions and eliminate dead code.

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -641,8 +641,10 @@ BUILTIN_MISC_OPERATION(PoundAssert, "poundAssert", "", Special)
 
 /// globalStringTablePointer has type String -> Builtin.RawPointer.
 /// It returns an immortal, global string table pointer for strings constructed
-/// from string literals.
-BUILTIN_MISC_OPERATION_WITH_SILGEN(GlobalStringTablePointer, "globalStringTablePointer", "", Special)
+/// from string literals. We consider it effects as readnone meaning that it
+/// does not read any memory (note that even though it reads from a string, it
+/// is a pure value and therefore we can consider it as readnone).
+BUILTIN_MISC_OPERATION_WITH_SILGEN(GlobalStringTablePointer, "globalStringTablePointer", "n", Special)
 
 #undef BUILTIN_MISC_OPERATION_WITH_SILGEN
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -528,6 +528,9 @@ ERROR(oslog_non_constant_interpolation, none, "'OSLogInterpolation' instance "
 ERROR(oslog_property_not_constant, none, "'OSLogInterpolation.%0' is not a "
       "constant", (StringRef))
 
+ERROR(oslog_message_alive_after_opts, none, "OSLogMessage instance must not "
+      "be explicitly created and must be deletable", ())
+
 ERROR(global_string_pointer_on_non_constant, none, "globalStringTablePointer "
       "builtin must used only on string literals", ())
 

--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -207,6 +207,8 @@ public:
   void dumpState();
 };
 
+bool hasConstantEvaluableAnnotation(SILFunction *fun);
+
 bool isConstantEvaluable(SILFunction *fun);
 
 /// Return true if and only if the given function \p fun is specially modeled

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -991,7 +991,7 @@ void LoopTreeOptimization::hoistLoadsAndStores(SILValue addr, SILLoop *loop, Ins
   }
 
   // In case the value is only stored but never loaded in the loop.
-  recursivelyDeleteTriviallyDeadInstructions(initialLoad);
+  eliminateDeadInstruction(initialLoad);
 }
 
 bool LoopTreeOptimization::hoistAllLoadsAndStores(SILLoop *loop) {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2010,8 +2010,13 @@ void LifetimeChecker::deleteDeadRelease(unsigned ReleaseID) {
   SILInstruction *Release = Destroys[ReleaseID];
   if (isa<DestroyAddrInst>(Release)) {
     SILValue Addr = Release->getOperand(0);
-    if (auto *AddrI = Addr->getDefiningInstruction())
+    if (auto *AddrI = Addr->getDefiningInstruction()) {
+      // FIXME: AddrI will not be deleted (nor its operands) when Release is
+      // still using AddrI's result. Fix this, and migrate to using
+      // InstructionDeleter utility instead of
+      // recursivelyDeadTriviallyDeadInstructions.
       recursivelyDeleteTriviallyDeadInstructions(AddrI);
+    }
   }
   Release->eraseFromParent();
   Destroys[ReleaseID] = nullptr;

--- a/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
+++ b/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
@@ -56,12 +56,17 @@ static bool cleanFunction(SILFunction &fn) {
           LLVM_FALLTHROUGH;
         }
         case BuiltinValueKind::PoundAssert:
-        case BuiltinValueKind::StaticReport:
+        case BuiltinValueKind::StaticReport: {
           // The call to the builtin should get removed before we reach
           // IRGen.
-          recursivelyDeleteTriviallyDeadInstructions(bi, /* Force */ true);
+          InstructionDeleter deleter;
+          deleter.forceDelete(bi);
+          // StaticReport only takes trivial operands, and therefore doesn't
+          // require fixing the lifetime of its operands.
+          deleter.cleanUpDeadInstructions();
           madeChange = true;
           break;
+        }
         default:
           break;
       }

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -2118,7 +2118,7 @@ bool AllocOptimize::promoteLoadCopy(LoadInst *li) {
     SILValue addr = li->getOperand();
     li->eraseFromParent();
     if (auto *addrI = addr->getDefiningInstruction())
-      recursivelyDeleteTriviallyDeadInstructions(addrI);
+      eliminateDeadInstruction(addrI);
     return true;
   }
 
@@ -2139,7 +2139,7 @@ bool AllocOptimize::promoteLoadCopy(LoadInst *li) {
   SILValue addr = li->getOperand();
   li->eraseFromParent();
   if (auto *addrI = addr->getDefiningInstruction())
-    recursivelyDeleteTriviallyDeadInstructions(addrI);
+    eliminateDeadInstruction(addrI);
   return true;
 }
 
@@ -2242,7 +2242,7 @@ bool AllocOptimize::promoteLoadBorrow(LoadBorrowInst *lbi) {
   SILValue addr = lbi->getOperand();
   lbi->eraseFromParent();
   if (auto *addrI = addr->getDefiningInstruction())
-    recursivelyDeleteTriviallyDeadInstructions(addrI);
+    eliminateDeadInstruction(addrI);
   return true;
 }
 

--- a/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
+++ b/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
@@ -52,14 +52,12 @@ struct SILGenCanonicalize final : CanonicalizeInstruction {
       SILInstruction *deadOperInst = *deadOperands.begin();
       // Make sure at least the first instruction is removed from the set.
       deadOperands.erase(deadOperInst);
-      recursivelyDeleteTriviallyDeadInstructions(
-        deadOperInst, false,
-        [&](SILInstruction *deadInst) {
-          LLVM_DEBUG(llvm::dbgs() << "Trivially dead: " << *deadInst);
-          if (nextII == deadInst->getIterator())
-            ++nextII;
-          deadOperands.erase(deadInst);
-        });
+      eliminateDeadInstruction(deadOperInst, [&](SILInstruction *deadInst) {
+        LLVM_DEBUG(llvm::dbgs() << "Trivially dead: " << *deadInst);
+        if (nextII == deadInst->getIterator())
+          ++nextII;
+        deadOperands.erase(deadInst);
+      });
     }
     return nextII;
   }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -919,7 +919,11 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
     // apply. Since the apply was never rewritten, if they aren't removed here,
     // they will be removed later as dead when visited by SILCombine, causing
     // SILCombine to loop infinitely, creating and destroying the casts.
-    recursivelyDeleteTriviallyDeadInstructions(*Builder.getTrackingList());
+    InstructionDeleter deleter;
+    for (SILInstruction *inst : *Builder.getTrackingList()) {
+      deleter.trackIfDead(inst);
+    }
+    deleter.cleanUpDeadInstructions();
     Builder.getTrackingList()->clear();
     return nullptr;
   }

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -1261,7 +1261,7 @@ static bool sinkArgument(EnumCaseDataflowContext &Context, SILBasicBlock *BB, un
       TI->setOperand(ArgNum, CloneInst->getOperand(*DifferentOperandIndex));
       // Now delete the clone as we only needed it operand.
       if (CloneInst != FSI)
-        recursivelyDeleteTriviallyDeadInstructions(CloneInst);
+        eliminateDeadInstruction(CloneInst);
       ++CloneIt;
     }
     assert(CloneIt == Clones.end() && "Clone/pred mismatch");

--- a/lib/SILOptimizer/UtilityPasses/ConstantEvaluableSubsetChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ConstantEvaluableSubsetChecker.cpp
@@ -145,7 +145,8 @@ class ConstantEvaluableSubsetChecker : public SILModuleTransform {
       evaluatedFunctions.insert(callee);
 
       SILModule &calleeModule = callee->getModule();
-      if (callee->isAvailableExternally() && isConstantEvaluable(callee) &&
+      if (callee->isAvailableExternally() &&
+          hasConstantEvaluableAnnotation(callee) &&
           callee->getOptimizationMode() != OptimizationMode::NoOptimization) {
         diagnose(calleeModule.getASTContext(),
                  callee->getLocation().getSourceLoc(),
@@ -161,7 +162,7 @@ class ConstantEvaluableSubsetChecker : public SILModuleTransform {
 
     for (SILFunction &fun : *module) {
       // Record functions annotated as constant evaluable.
-      if (isConstantEvaluable(&fun)) {
+      if (hasConstantEvaluableAnnotation(&fun)) {
         constantEvaluableFunctions.insert(&fun);
         continue;
       }

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -150,11 +150,10 @@ void BasicBlockCloner::sinkAddressProjections() {
            && "canCloneInstruction should catch this.");
 
     auto nextII = std::next(ii);
-    recursivelyDeleteTriviallyDeadInstructions(
-        &*ii, false, [&nextII](SILInstruction *deadInst) {
-          if (deadInst->getIterator() == nextII)
-            ++nextII;
-        });
+    eliminateDeadInstruction(&*ii, [&nextII](SILInstruction *deadInst) {
+      if (deadInst->getIterator() == nextII)
+        ++nextII;
+    });
     ii = nextII;
   }
 }

--- a/lib/SILOptimizer/Utils/CFGOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/CFGOptUtils.cpp
@@ -86,7 +86,7 @@ deleteTriviallyDeadOperandsOfDeadArgument(MutableArrayRef<Operand> termOperands,
   if (!i)
     return;
   op.set(SILUndef::get(op.get()->getType(), *i->getFunction()));
-  recursivelyDeleteTriviallyDeadInstructions(i);
+  eliminateDeadInstruction(i);
 }
 
 // Our implementation assumes that our caller is attempting to remove a dead

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -2129,7 +2129,12 @@ bool swift::isKnownConstantEvaluableFunction(SILFunction *fun) {
   return classifyFunction(fun).hasValue();
 }
 
-bool swift::isConstantEvaluable(SILFunction *fun) {
+bool swift::hasConstantEvaluableAnnotation(SILFunction *fun) {
   assert(fun && "fun should not be nullptr");
   return fun->hasSemanticsAttr("constant_evaluable");
+}
+
+bool swift::isConstantEvaluable(SILFunction *fun) {
+  return hasConstantEvaluableAnnotation(fun) ||
+         isKnownConstantEvaluableFunction(fun);
 }

--- a/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
@@ -30,10 +30,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // expected-error @-2 {{globalStringTablePointer builtin must used only on string literals}}
   }
 
-  // FIXME: the following test should produce diagnostics and is a not
-  // valid uses of the log APIs. The string interpolation passed to the os log
-  // call must be apart of the log call, it cannot be constructed earlier.
-  // It nonetheless works fine, but should be rejected.
+  // FIXME: this case must be diagnosed as an error.
   func testNoninlinedOSLogMessage(h: Logger) {
     let logMessage: OSLogMessage = "Minimum integer value: \(Int.min)"
     h.log(level: .debug, logMessage)
@@ -41,6 +38,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
   func testNoninlinedOSLogMessageComplex(h: Logger, b: Bool) {
     let logMessage: OSLogMessage = "Maximum integer value: \(Int.max)"
+      // expected-error @-1 {{OSLogMessage instance must not be explicitly created and must be deletable}}
     if !b {
       return;
     }

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.sil
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.sil
@@ -57,7 +57,6 @@ bb0:
   destroy_value %7 : $OSLogMessageStub
   %13 = tuple ()
   return %13 : $()
-    // CHECK-NOT: {{%.*}} = struct_extract {{%.*}} : $OSLogInterpolationStub, #OSLogInterpolationStub.formatString
     // CHECK-DAG: [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
     // CHECK-DAG: {{%.*}} = apply [[STRINGUSE]]([[BORROW:%[0-9]+]])
     // CHECK-DAG: [[BORROW]] = begin_borrow [[STRINGCONST:%[0-9]+]]
@@ -98,8 +97,6 @@ bb0:
   dealloc_stack %11 : $*String
   %15 = tuple ()
   return %15 : $()
-    // Skip the first literal.
-    // CHECK: {{%.*}} = string_literal utf8 "some long message: %llx"
     // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "some long message: %llx"
     // CHECK: [[STRINGINIT:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
     // CHECK: [[STRINGCONST:%[0-9]+]] = apply [[STRINGINIT]]([[LIT]], {{%.*}}, {{%.*}}, {{%.*}})
@@ -175,13 +172,12 @@ bb0:
   destroy_value %9 : $String
   %12 = tuple ()
   return %12 : $()
-    // CHECK-NOT: ({{%.*}}) = destructure_struct {{%.*}} : $OSLogInterpolationStub
-    // CHECK-DAG: [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
-    // CHECK-DAG: {{%.*}} = apply [[STRINGUSE]]([[STRINGCONST:%[0-9]+]])
-    // CHECK-DAG: [[STRINGCONST]] = apply [[STRINGINIT:%[0-9]+]]([[LIT:%[0-9]+]], {{%.*}}, {{%.*}}, {{%.*}})
-    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-DAG: [[LIT]] = string_literal utf8 "test message: %lld"
-    // CHECK-DAG: destroy_value [[STRINGCONST]] : $String
+    // CHECK-DAG [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
+    // CHECK-DAG {{%.*}} = apply [[STRINGUSE]]([[STRINGCONST:%[0-9]+]])
+    // CHECK-DAG [[STRINGCONST]] = apply [[STRINGINIT:%[0-9]+]]([[LIT:%[0-9]+]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-DAG [[LIT]] = string_literal utf8 "test message: %lld"
+    // CHECK-DAG destroy_value [[STRINGCONST]] : $String
 }
 
 // Test that the OSLogOptimization pass does not fold instructions that define
@@ -215,7 +211,6 @@ bb0:
   destroy_value %7 : $OSLogMessageStub
   %15 = tuple ()
   return %15 : $()
-    // CHECK-NOT: {{%.*}} = struct_extract {{%.*}} : $OSLogInterpolationStub, #OSLogInterpolationStub.formatString
     // CHECK-DAG: [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
     // CHECK-DAG: {{%.*}} = apply [[STRINGUSE]]([[BORROW:%[0-9]+]])
     // CHECK-DAG: [[BORROW]] = begin_borrow [[COPYVAL:%[0-9]+]]
@@ -275,8 +270,6 @@ bb5:
     // We must have all string literals at the beginning of the borrowed scope,
     // and destorys of the literals at the end of the borrow scope.
 
-    // Skip the first literal which is the original one.
-    // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "test message: %lld"
     // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "test message: %lld"
     // CHECK: [[STRINGINIT:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
     // CHECK: [[STRINGCONST:%[0-9]+]] = apply [[STRINGINIT]]([[LIT]], {{%.*}}, {{%.*}}, {{%.*}})
@@ -535,8 +528,7 @@ bb0:
   destroy_value %2 : $OSLogMessageStringArrayStub
   %8 = tuple ()
   return %8 : $()
-    // Skip the first instance of "ab".
-    // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "ab"
+    // The first instance of "ab" will be dead code eliminated.
     // CHECK: [[LIT:%[0-9]+]] = string_literal utf8 "ab"
     // CHECK: [[STRINGINIT:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
     // CHECK: [[STRINGCONST:%[0-9]+]] = apply [[STRINGINIT]]([[LIT]], {{%.*}}, {{%.*}}, {{%.*}})
@@ -741,7 +733,7 @@ bb0(%0 : @guaranteed $String):
   destroy_value %6 : $OSLogMessageStringCapture
   %18 = tuple ()
   return %18 : $()
-    // CHECK: [[FUNREFORIG:%[0-9]+]] = function_ref @idString
+    // The first instance of function_ref @idString will be dead code eliminated.
     // CHECK: [[ORIGCAPTURE:%[0-9]+]] = copy_value %0 : $String
     // CHECK: [[NEWCAPTURE:%[0-9]+]] = copy_value [[ORIGCAPTURE]] : $String
     // CHECK: [[FUNREF:%[0-9]+]] = function_ref @idString
@@ -795,10 +787,9 @@ bb0:
   dealloc_stack %1 : $*Int64
   %18 = tuple ()
   return %18 : $()
-    // CHECK: [[FUNREFORIG:%[0-9]+]] = function_ref @genericFunction
-    // CHECK: [[CLOSUREORIG:%[0-9]+]] = partial_apply [callee_guaranteed] [[FUNREFORIG]]<Int64, Bool>([[CAPTURE1:%[0-9]+]], [[CAPTURE2:%[0-9]+]])
+    // The first instance of function_ref @genericFunction will be dead-code eliminated.
     // CHECK: [[FUNREF:%[0-9]+]] = function_ref @genericFunction
-    // CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FUNREF]]<Int64, Bool>([[CAPTURE1]], [[CAPTURE2]])
+    // CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FUNREF]]<Int64, Bool>([[CAPTURE1:%[0-9]+]], [[CAPTURE2:%[0-9]+]])
     // CHECK: [[BORROW:%[0-9]+]] = begin_borrow [[CLOSURE]] : $@callee_guaranteed () -> Int32
     // CHECK: [[USE:%[0-9]+]] = function_ref @useClosure
     // CHECK: apply [[USE]]([[BORROW]])
@@ -871,4 +862,106 @@ bb0:
   destroy_value %2 : $OSLogMessageClosureArrayStub
   %8 = tuple ()
   return %8 : $()
+}
+
+// The following tests are for checking dead-code elimination performed by the
+// OSLogOptimization pass.
+
+struct OSLogInterpolationDCEStub {
+  var formatString: String
+}
+
+struct OSLogMessageDCEStub {
+  var interpolation: OSLogInterpolationDCEStub
+}
+
+sil [ossa] [Onone] [_semantics "constant_evaluable"] [_semantics "oslog.message.init_stub"] @oslogMessageDCEInit : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub {
+bb0(%0 : @owned $OSLogInterpolationDCEStub):
+  %1 = struct $OSLogMessageDCEStub (%0 : $OSLogInterpolationDCEStub)
+  return %1 : $OSLogMessageDCEStub
+}
+
+// CHECK-LABEL: @testDCEOfStructCreation
+sil [ossa] @testDCEOfStructCreation : $@convention(thin) () -> () {
+bb0:
+  %0 = string_literal utf8 "some message"
+  %1 = integer_literal $Builtin.Word, 12
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = metatype $@thin String.Type
+  // function_ref String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%0, %1, %2, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = struct $OSLogInterpolationDCEStub(%5 : $String)
+  %7 = copy_value %6 : $OSLogInterpolationDCEStub
+  %8 = function_ref @oslogMessageDCEInit : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %9 = apply %8(%7) : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %10 = begin_borrow %9 : $OSLogMessageDCEStub
+  end_borrow %10 : $OSLogMessageDCEStub
+  destroy_value %9 : $OSLogMessageDCEStub
+  destroy_value %6 : $OSLogInterpolationDCEStub
+  %13 = tuple ()
+  return %13 : $()
+    // CHECK: bb0
+    // CHECK-NEXT: [[EMPTYTUP:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[EMPTYTUP]]
+}
+
+sil [ossa] [Onone] [_semantics "constant_evaluable"] [_semantics "oslog.message.init_stub"] @oslogMessageGuaranteedInit : $@convention(thin) (@guaranteed OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub {
+bb0(%0 : @guaranteed $OSLogInterpolationDCEStub):
+  %2 = copy_value %0 : $OSLogInterpolationDCEStub
+  %3 = struct $OSLogMessageDCEStub (%2 : $OSLogInterpolationDCEStub)
+  return %3 : $OSLogMessageDCEStub
+}
+
+// CHECK-LABEL: @testDCEOfGuaranteedStructCreation
+sil [ossa] @testDCEOfGuaranteedStructCreation : $@convention(thin) () -> () {
+bb0:
+  %0 = string_literal utf8 "some message"
+  %1 = integer_literal $Builtin.Word, 12
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = metatype $@thin String.Type
+  // function_ref String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%0, %1, %2, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = struct $OSLogInterpolationDCEStub(%5 : $String)
+  %7 = begin_borrow %6 : $OSLogInterpolationDCEStub
+  %9 = function_ref @oslogMessageGuaranteedInit : $@convention(thin) (@guaranteed OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %10 = apply %9(%7) : $@convention(thin) (@guaranteed OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  destroy_value %10 : $OSLogMessageDCEStub
+  end_borrow %7 : $OSLogInterpolationDCEStub
+  destroy_value %6 : $OSLogInterpolationDCEStub
+  %13 = tuple ()
+  return %13 : $()
+    // CHECK: bb0
+    // CHECK-NEXT: [[EMPTYTUP:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[EMPTYTUP]]
+}
+
+// CHECK-LABEL: @testLifetimeAdjustmentOfDCE
+sil [ossa] @testLifetimeAdjustmentOfDCE : $@convention(thin) () -> () {
+bb0:
+  %0 = string_literal utf8 "some message"
+  %1 = integer_literal $Builtin.Word, 12
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = metatype $@thin String.Type
+  // function_ref String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%0, %1, %2, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = copy_value %5 : $String
+  %7 = struct $OSLogInterpolationDCEStub(%5 : $String)
+  %8 = function_ref @oslogMessageDCEInit : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %9 = apply %8(%7) : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  destroy_value %9 : $OSLogMessageDCEStub
+  %11 = function_ref @useFormatString : $@convention(thin) (@guaranteed String) -> ()
+  %12 = apply %11(%6) : $@convention(thin) (@guaranteed String) -> ()
+  destroy_value %6 : $String
+  %13 = tuple ()
+  return %13 : $()
+    // CHECK: [[STRINGINITREF:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK: [[STRING:%[0-9]+]] = apply [[STRINGINITREF]](
+    // CHECK-NEXT: [[COPY:%[0-9]+]]  = copy_value [[STRING]]
+    // CHECK-NEXT: destroy_value [[STRING]]
+    // CHECK-NOT: OSLogInterpolationDCEStub
+    // CHECK-NOT: OSLogMessageDCEStub
+    // CHECK: return
 }

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -460,5 +460,34 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
       // CHECK-DAG: [[ARRAYINIT]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
       // CHECK-DAG: [[ARRAYSIZE]] = integer_literal $Builtin.Word, 6
   }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest23testDeadCodeEliminationL_1h6number8num32bit6stringy0aB06LoggerV_Sis5Int32VSStF
+  func testDeadCodeElimination(
+    h: Logger,
+    number: Int,
+    num32bit: Int32,
+    string: String
+  ) {
+    h.log("A message with no data")
+    h.log("smallstring")
+    h.log(
+      level: .error,
+      """
+      A message with many interpolations \(number), \(num32bit), \(string), \
+      and a suffix
+      """)
+    h.log(
+      level: .info,
+      """
+      \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \
+      \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \
+      \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \
+      \(1) \(1) \(1) \(1) \(1) \(48) \(49)
+      """)
+    let concatString = string + ":" + String(number)
+    h.log("\(concatString)")
+      // CHECK-NOT: OSLogMessage
+      // CHECK-LABEL: end sil function '$s25OSLogPrototypeCompileTest23testDeadCodeEliminationL_1h6number8num32bit6stringy0aB06LoggerV_Sis5Int32VSStF'
+  }
 }
 

--- a/test/SILOptimizer/access_marker_mandatory.swift
+++ b/test/SILOptimizer/access_marker_mandatory.swift
@@ -49,8 +49,6 @@ func takeS(_ s: S) {}
 // CHECK: [[ADDRI:%.*]] = struct_element_addr [[WRITE]] : $*S, #S.i
 // CHECK: store %{{.*}} to [[ADDRI]] : $*Int
 // CHECK: end_access [[WRITE]]
-// CHECK: [[READ:%.*]] = begin_access [read] [static] [[STK]] : $*S
-// CHECK: end_access [[READ]]
 // CHECK: [[FTAKE:%.*]] = function_ref @$s23access_marker_mandatory5takeSyyAA1SVF : $@convention(thin) (@guaranteed S) -> ()
 // CHECK: apply [[FTAKE]](%{{.*}}) : $@convention(thin) (@guaranteed S) -> ()
 // CHECK-LABEL: } // end sil function '$s23access_marker_mandatory14modifyAndReadS1oyyXl_tF'

--- a/test/SILOptimizer/predictable_memopt_ownership.sil
+++ b/test/SILOptimizer/predictable_memopt_ownership.sil
@@ -428,7 +428,7 @@ bb0:
 // CHECK-LABEL: sil [ossa] @dead_allocation_1
 sil [ossa] @dead_allocation_1 : $@convention(thin) (@owned Optional<AnyObject>) -> () {
 bb0(%0 : @owned $Optional<AnyObject>):
-// CHECK: copy_value %0
+// CHECK-NOT: alloc_stack
   %1 = alloc_stack $Optional<AnyObject>
   %2 = alloc_stack $Optional<AnyObject>
   store %0 to [init] %2 : $*Optional<AnyObject>
@@ -438,6 +438,7 @@ bb0(%0 : @owned $Optional<AnyObject>):
   dealloc_stack %2 : $*Optional<AnyObject>
   destroy_addr %1 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
+// CHECK: destroy_value %0
   %3 = tuple ()
   return %3 : $()
 }
@@ -445,7 +446,6 @@ bb0(%0 : @owned $Optional<AnyObject>):
 // CHECK-LABEL: sil [ossa] @dead_allocation_2
 sil [ossa] @dead_allocation_2 : $@convention(thin) (@owned Optional<AnyObject>) -> () {
 bb0(%0 : @owned $Optional<AnyObject>):
-// CHECK: copy_value %0
 // CHECK-NOT: alloc_stack
   %1 = alloc_stack $Optional<AnyObject>
   %2 = alloc_stack $Optional<AnyObject>
@@ -457,6 +457,7 @@ bb0(%0 : @owned $Optional<AnyObject>):
   destroy_addr %1 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
   %3 = tuple ()
+// CHECK: destroy_value %0
   return %3 : $()
 }
 


### PR DESCRIPTION
This is meant to a replacement for the utility: recursivelyDeleteTriviallyDeadInstructions. The new utility performs more aggresive dead-code elimination for ownership SIL.

This patch also migrates most non-force-delete uses of recursivelyDeleteTriviallyDeadInstructions to the new utility. and migrates one force-delete use of recursivelyDeleteTriviallyDeadInstructions
(in IRGenPrepare) to use the new utility.
