### PR TITLE
[Docs] Fix a typo in ${NEW} variable in Post-processing tools for diagnostics section

### DIFF
--- a/docs/CompilerPerformance.md
+++ b/docs/CompilerPerformance.md
@@ -793,7 +793,7 @@ performance between two compilers, say `${OLD}/swiftc` and `${NEW}/swiftc`:
 ```
 $ mkdir stats-old stats-new
 $ ${OLD}/swiftc -stats-output-dir stats-old test.swift
-$ ${OLD}/swiftc -stats-output-dir stats-new test.swift
+$ ${NEW}/swiftc -stats-output-dir stats-new test.swift
 $ utils/process-stats-dir.py --compare-stats-dirs stats-old stats-new
 old     new     delta_pct       name
 1402939 1430732 1.98    AST.NumASTBytesAllocated


### PR DESCRIPTION

<!-- What's in this pull request? -->
While reading up I realized there is a typo in: `how to use  utils/process-stats-dir.py`. The example asks to use OLD and NEW compiler but the documentation uses only ${OLD} compiler in example

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

None

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
