### PR TITLE
validation-test: mark test as XFAIL

### DIFF
--- a/validation-test/execution/dsohandle-multi-module.swift
+++ b/validation-test/execution/dsohandle-multi-module.swift
@@ -9,6 +9,7 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: linux
+// XFAIL: windows
 
 import first
 import second


### PR DESCRIPTION
TBD generation is not constrained to Darwin and it trips on the linker
synthetic `__ImageBase`.  XFAIL this until the TBD generation is either
constrained or is taught to ignore the synthetic.  This should
temporarily allow us to enable validation tests on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
