### PR TITLE
[lit] Fix a typo causing us to not put a space in between an && and a run command.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1498,21 +1498,21 @@ if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift_parameterized =                               \
         (SubstituteCaptures('%%empty-directory(%%t) && '
                             '%s %s %%s \\1 -o %%t/a.out -module-name main  && '
-                            '%s %%t/a.out &&'
+                            '%s %%t/a.out && '
                             '%s %%t/a.out' % (config.target_build_swift,
                                               mcp_opt, config.target_codesign,
                                               config.target_run)))
     config.target_run_simple_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main  && '
-        '%s %%t/a.out &&'
+        '%s %%t/a.out && '
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
     config.target_run_stdlib_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main '
         '-Xfrontend -disable-access-control  && '
-        '%s %%t/a.out &&'
+        '%s %%t/a.out && '
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
     config.target_run_simple_swiftgyb = (
@@ -1520,7 +1520,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%%gyb %%s -o %%t/main.swift && '
         '%%line-directive %%t/main.swift -- '
         '%s %s %%t/main.swift -o %%t/a.out -module-name main  && '
-        '%s %%t/a.out &&'
+        '%s %%t/a.out && '
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
@@ -1530,7 +1530,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%%line-directive %%t/main.swift -- '
         '%s %s %%t/main.swift -o %%t/a.out -module-name main '
         '-Xfrontend -disable-access-control  && '
-        '%s %%t/a.out &&'
+        '%s %%t/a.out && '
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))


### PR DESCRIPTION
Noticed while debugging why a test was failing locally. It was causing my test not to run with the proper env AFAIKT.