### PR TITLE
[SILOptimizer] Generalize optimization of static keypaths

### DIFF
--- a/include/swift/SILOptimizer/Utils/KeyPathProjector.h
+++ b/include/swift/SILOptimizer/Utils/KeyPathProjector.h
@@ -1,0 +1,81 @@
+//===-- KeyPathProjector.h - Project a static key path ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Utility class to project a statically known key path
+/// expression to a direct property access sequence.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_KEYPATHPROJECTOR_H
+#define SWIFT_SILOPTIMIZER_UTILS_KEYPATHPROJECTOR_H
+
+#include "swift/SIL/SILBuilder.h"
+#include <memory>
+
+namespace swift {
+
+/// Projects a statically known key path expression to
+/// a direct property access.
+class KeyPathProjector {
+public:
+  /// The type of a key path access.
+  enum class AccessType {
+    /// A get-only access (i.e. swift_getAtKeyPath).
+    Get,
+    
+    /// A set-only access (i.e. swift_setAtWritableKeyPath).
+    Set,
+    
+    /// A modification (i.e. swift_modifyAtWritableKeyPath).
+    Modify
+  };
+  
+  /// Creates a key path projector for a key path.
+  ///
+  /// Returns nullptr if \p keyPath is not a keypath instruction or if there is
+  /// any other reason why the optimization cannot be done.
+  ///
+  /// \param keyPath The key path to project. Must be the result of either
+  ///    a keypath instruction or an upcast of a key path instruction.
+  /// \param root The address of the object the key path is applied to.
+  /// \param loc The location of the key path application.
+  /// \param builder The SILBuilder to use.
+  static std::unique_ptr<KeyPathProjector>
+  create(SILValue keyPath, SILValue root, SILLocation loc, SILBuilder &builder);
+  
+  /// Projects the key path to an address. Sets up the projection,
+  /// invokes the callback, then tears down the projection.
+  /// \param accessType The access type of the projected address.
+  /// \param callback A callback to invoke with the projected adddress.
+  ///     The projected address is only valid from within \p callback.
+  virtual void project(AccessType accessType,
+               std::function<void(SILValue addr)> callback) = 0;
+    
+  virtual ~KeyPathProjector() {};
+  
+  /// Whether this projection returns a struct.
+  virtual bool isStruct() = 0;
+protected:
+  KeyPathProjector(SILLocation loc, SILBuilder &builder)
+      : loc(loc), builder(builder) {}
+  
+  /// The location of the key path application.
+  SILLocation loc;
+  
+  /// The SILBuilder to use.
+  SILBuilder &builder;
+};
+
+}  // end namespace swift
+
+#endif /* KeyPathProjector_h */

--- a/include/swift/SILOptimizer/Utils/KeyPathProjector.h
+++ b/include/swift/SILOptimizer/Utils/KeyPathProjector.h
@@ -58,6 +58,9 @@ public:
   /// \param accessType The access type of the projected address.
   /// \param callback A callback to invoke with the projected adddress.
   ///     The projected address is only valid from within \p callback.
+  ///     If accessType is Get or Modify, the projected addres is an
+  ///     initialized address type. If accessType is set, the projected
+  ///     address points to uninitialized memory.
   virtual void project(AccessType accessType,
                std::function<void(SILValue addr)> callback) = 0;
     

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1458,6 +1458,7 @@ void SILGenModule::tryEmitPropertyDescriptor(AbstractStorageDecl *decl) {
                                                baseOperand, needsGenericContext,
                                                subs, decl, {},
                                                baseTy->getCanonicalType(),
+                                               M.getSwiftModule(),
                                                /*property descriptor*/ true);
   
   (void)SILProperty::create(M, /*serialized*/ false, decl, component);

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -342,6 +342,7 @@ public:
                               AbstractStorageDecl *storage,
                               ArrayRef<ProtocolConformanceRef> indexHashables,
                               CanType baseTy,
+                              DeclContext *useDC,
                               bool forPropertyDescriptor);
 
   /// Known functions for bridging.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3354,6 +3354,7 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
                                 AbstractStorageDecl *storage,
                                 ArrayRef<ProtocolConformanceRef> indexHashables,
                                 CanType baseTy,
+                                DeclContext *useDC,
                                 bool forPropertyDescriptor) {
   auto baseDecl = storage;
 
@@ -3423,8 +3424,8 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     // supply the settability if needed. We only reference it here if the
     // setter is public.
     if (shouldUseExternalKeyPathComponent())
-      return storage->isSettable(M.getSwiftModule())
-        && storage->isSetterAccessibleFrom(M.getSwiftModule());
+      return storage->isSettable(useDC)
+        && storage->isSetterAccessibleFrom(useDC);
     return storage->isSettable(storage->getDeclContext());
   };
 
@@ -3578,6 +3579,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
                             decl,
                             component.getSubscriptIndexHashableConformances(),
                             baseTy,
+                            SGF.FunctionDC,
                             /*for descriptor*/ false));
       baseTy = loweredComponents.back().getComponentType();
       if (kind == KeyPathExpr::Component::Kind::Property)

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -28,11 +28,13 @@
 #include "swift/SILOptimizer/Analysis/ValueTracking.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/Existential.h"
+#include "swift/SILOptimizer/Utils/KeyPathProjector.h"
 #include "swift/SILOptimizer/Utils/ValueLifetime.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
+#include <utility>
 
 using namespace swift;
 using namespace swift::PatternMatch;
@@ -199,92 +201,6 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
   return NAI;
 }
 
-/// Ends the begin_access "scope" if a begin_access was inserted for optimizing
-/// a keypath pattern.
-static void insertEndAccess(BeginAccessInst *&beginAccess, bool isModify,
-                            SILBuilder &builder) {
-  if (beginAccess) {
-    builder.createEndAccess(beginAccess->getLoc(), beginAccess,
-                            /*aborted*/ false);
-    if (isModify)
-      beginAccess->setAccessKind(SILAccessKind::Modify);
-    beginAccess = nullptr;
-  }
-}
-
-/// Creates the projection pattern for a keypath instruction.
-///
-/// Currently only the StoredProperty pattern is handled.
-/// TODO: handle other patterns, like getters/setters, optional chaining, etc.
-///
-/// Returns false if \p keyPath is not a keypath instruction or if there is any
-/// other reason why the optimization cannot be done.
-static SILValue createKeypathProjections(SILValue keyPath, SILValue root,
-                                         SILLocation loc,
-                                         BeginAccessInst *&beginAccess,
-                                         SILBuilder &builder) {
-  if (auto *upCast = dyn_cast<UpcastInst>(keyPath))
-    keyPath = upCast->getOperand();
-
-  // Is it a keypath instruction at all?
-  auto *kpInst = dyn_cast<KeyPathInst>(keyPath);
-  if (!kpInst || !kpInst->hasPattern())
-    return SILValue();
-
-  auto components = kpInst->getPattern()->getComponents();
-
-  // Check if the keypath only contains patterns which we support.
-  for (const KeyPathPatternComponent &comp : components) {
-    if (comp.getKind() != KeyPathPatternComponent::Kind::StoredProperty)
-      return SILValue();
-  }
-
-  SILValue addr = root;
-  for (const KeyPathPatternComponent &comp : components) {
-    assert(comp.getKind() == KeyPathPatternComponent::Kind::StoredProperty);
-    VarDecl *storedProperty = comp.getStoredPropertyDecl();
-    SILValue elementAddr;
-    if (addr->getType().getStructOrBoundGenericStruct()) {
-      addr = builder.createStructElementAddr(loc, addr, storedProperty);
-    } else if (addr->getType().getClassOrBoundGenericClass()) {
-      SingleValueInstruction *Ref = builder.createLoad(loc, addr,
-                                         LoadOwnershipQualifier::Unqualified);
-      insertEndAccess(beginAccess, /*isModify*/ false, builder);
-
-      // Handle the case where the storedProperty is in a super class.
-      while (Ref->getType().getClassOrBoundGenericClass() !=
-             storedProperty->getDeclContext()) {
-        SILType superCl = Ref->getType().getSuperclass();
-        if (!superCl) {
-          // This should never happen, because the property should be in the
-          // decl or in a superclass of it. Just handle this to be on the safe
-          // side.
-          return SILValue();
-        }
-        Ref = builder.createUpcast(loc, Ref, superCl);
-      }
-
-      addr = builder.createRefElementAddr(loc, Ref, storedProperty);
-
-      // Class members need access enforcement.
-      if (builder.getModule().getOptions().EnforceExclusivityDynamic) {
-        beginAccess = builder.createBeginAccess(loc, addr, SILAccessKind::Read,
-                                                SILAccessEnforcement::Dynamic,
-                                                /*noNestedConflict*/ false,
-                                                /*fromBuiltin*/ false);
-        addr = beginAccess;
-      }
-    } else {
-      // This should never happen, as a stored-property pattern can only be
-      // applied to classes and structs. But to be safe - and future prove -
-      // let's handle this case and bail.
-      insertEndAccess(beginAccess, /*isModify*/ false, builder);
-      return SILValue();
-    }
-  }
-  return addr;
-}
-
 /// Try to optimize a keypath application with an apply instruction.
 ///
 /// Replaces (simplified SIL):
@@ -317,22 +233,26 @@ bool SILCombiner::tryOptimizeKeypath(ApplyInst *AI) {
   } else {
     return false;
   }
-
-  BeginAccessInst *beginAccess = nullptr;
-  SILValue projectedAddr = createKeypathProjections(keyPath, rootAddr,
-                                                    AI->getLoc(), beginAccess,
-                                                    Builder);
-  if (!projectedAddr)
+  
+  auto projector = KeyPathProjector::create(keyPath, rootAddr,
+                                            AI->getLoc(), Builder);
+  if (!projector)
     return false;
-
-  if (isModify) {
-    Builder.createCopyAddr(AI->getLoc(), valueAddr, projectedAddr,
-                           IsTake, IsNotInitialization);
-  } else {
-    Builder.createCopyAddr(AI->getLoc(), projectedAddr, valueAddr,
-                           IsNotTake, IsInitialization);
-  }
-  insertEndAccess(beginAccess, isModify, Builder);
+  
+  KeyPathProjector::AccessType accessType;
+  if (isModify) accessType = KeyPathProjector::AccessType::Set;
+  else accessType = KeyPathProjector::AccessType::Get;
+  
+  projector->project(accessType, [&](SILValue projectedAddr) {
+    if (isModify) {
+      Builder.createCopyAddr(AI->getLoc(), valueAddr, projectedAddr,
+                             IsTake, IsNotInitialization);
+    } else {
+      Builder.createCopyAddr(AI->getLoc(), projectedAddr, valueAddr,
+                             IsNotTake, IsInitialization);
+    }
+  });
+  
   eraseInstFromFunction(*AI);
   ++NumOptimizedKeypaths;
   return true;
@@ -377,19 +297,24 @@ bool SILCombiner::tryOptimizeInoutKeypath(BeginApplyInst *AI) {
   EndApplyInst *endApply = dyn_cast<EndApplyInst>(AIUse->getUser());
   if (!endApply)
     return false;
-
-  BeginAccessInst *beginAccess = nullptr;
-  SILValue projectedAddr = createKeypathProjections(keyPath, rootAddr,
-                                                    AI->getLoc(), beginAccess,
-                                                    Builder);
-  if (!projectedAddr)
+  
+  auto projector = KeyPathProjector::create(keyPath, rootAddr,
+                                            AI->getLoc(), Builder);
+  if (!projector)
     return false;
+    
+  KeyPathProjector::AccessType accessType;
+  if (isModify) accessType = KeyPathProjector::AccessType::Modify;
+  else accessType = KeyPathProjector::AccessType::Get;
+  
+  projector->project(accessType, [&](SILValue projectedAddr) {
+    // Replace the projected address.
+    valueAddr->replaceAllUsesWith(projectedAddr);
+    
+    // Skip to the end of the key path application before cleaning up.
+    Builder.setInsertionPoint(endApply);
+  });
 
-  // Replace the projected address.
-  valueAddr->replaceAllUsesWith(projectedAddr);
-
-  Builder.setInsertionPoint(endApply);
-  insertEndAccess(beginAccess, isModify, Builder);
   eraseInstFromFunction(*endApply);
   eraseInstFromFunction(*AI);
   ++NumOptimizedKeypaths;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -219,13 +219,13 @@ bool SILCombiner::tryOptimizeKeypath(ApplyInst *AI) {
     return false;
 
   SILValue keyPath, rootAddr, valueAddr;
-  bool isModify = false;
+  bool isSet = false;
   if (callee->getName() == "swift_setAtWritableKeyPath" ||
       callee->getName() == "swift_setAtReferenceWritableKeyPath") {
     keyPath = AI->getArgument(1);
     rootAddr = AI->getArgument(0);
     valueAddr = AI->getArgument(2);
-    isModify = true;
+    isSet = true;
   } else if (callee->getName() == "swift_getAtKeyPath") {
     keyPath = AI->getArgument(2);
     rootAddr = AI->getArgument(1);
@@ -240,13 +240,13 @@ bool SILCombiner::tryOptimizeKeypath(ApplyInst *AI) {
     return false;
   
   KeyPathProjector::AccessType accessType;
-  if (isModify) accessType = KeyPathProjector::AccessType::Set;
+  if (isSet) accessType = KeyPathProjector::AccessType::Set;
   else accessType = KeyPathProjector::AccessType::Get;
   
   projector->project(accessType, [&](SILValue projectedAddr) {
-    if (isModify) {
+    if (isSet) {
       Builder.createCopyAddr(AI->getLoc(), valueAddr, projectedAddr,
-                             IsTake, IsNotInitialization);
+                             IsTake, IsInitialization);
     } else {
       Builder.createCopyAddr(AI->getLoc(), projectedAddr, valueAddr,
                              IsNotTake, IsInitialization);

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -11,6 +11,7 @@ silopt_register_sources(
   GenericCloner.cpp
   Generics.cpp
   InstOptUtils.cpp
+  KeyPathProjector.cpp
   LoadStoreOptUtils.cpp
   LoopUtils.cpp
   OptimizerStatsUtils.cpp

--- a/lib/SILOptimizer/Utils/KeyPathProjector.cpp
+++ b/lib/SILOptimizer/Utils/KeyPathProjector.cpp
@@ -1,0 +1,723 @@
+//===-- KeyPathProjector.cpp - Project a static key path --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Utility class to project a statically known key path
+/// expression to a direct property access sequence.
+///
+//===----------------------------------------------------------------------===//
+
+
+#include "swift/SILOptimizer/Utils/KeyPathProjector.h"
+
+#include "swift/SIL/SILInstruction.h"
+
+using namespace swift;
+
+
+// Projectors to handle individual key path components.
+
+/// Projects the root of a key path application.
+class RootProjector : public KeyPathProjector {
+public:
+    RootProjector(SILValue root, SILLocation loc, SILBuilder &builder)
+        : KeyPathProjector(loc, builder), root(root) {}
+    
+    void project(AccessType accessType,
+                 std::function<void (SILValue)> callback) override {
+        callback(root);
+    }
+    
+    bool isStruct() override {
+        return root->getType().getStructOrBoundGenericStruct() != nullptr;
+    }
+private:
+    SILValue root;
+};
+
+/// Projects a single key path component.
+class ComponentProjector : public KeyPathProjector {
+protected:
+    ComponentProjector(const KeyPathPatternComponent &component,
+                       std::unique_ptr<KeyPathProjector> parent,
+                       SILLocation loc, SILBuilder &builder)
+        : KeyPathProjector(loc, builder),
+          component(component), parent(std::move(parent)) {}
+    
+    /// The key path component.
+    const KeyPathPatternComponent &component;
+    
+    /// The projector for the previous components.
+    std::unique_ptr<KeyPathProjector> parent;
+    
+    bool isStruct() override {
+        auto type = component.getComponentType();
+        return type.getStructOrBoundGenericStruct() != nullptr;
+    }
+    
+    ~ComponentProjector() override {};
+};
+
+
+/// Ends the begin_access "scope" if a begin_access was inserted for optimizing
+/// a keypath pattern.
+static void insertEndAccess(BeginAccessInst *&beginAccess,
+                            SILBuilder &builder) {
+  if (beginAccess) {
+    builder.createEndAccess(beginAccess->getLoc(), beginAccess,
+                            /*aborted*/ false);
+    beginAccess = nullptr;
+  }
+}
+
+class StoredPropertyProjector : public ComponentProjector {
+public:
+    StoredPropertyProjector(const KeyPathPatternComponent &component,
+                            std::unique_ptr<KeyPathProjector> parent,
+                            BeginAccessInst *&beginAccess,
+                            SILLocation loc, SILBuilder &builder)
+        : ComponentProjector(component, std::move(parent), loc, builder),
+          beginAccess(beginAccess) {}
+  
+  void project(AccessType accessType,
+               std::function<void(SILValue addr)> callback) override {
+    assert(component.getKind() ==
+           KeyPathPatternComponent::Kind::StoredProperty);
+    
+    VarDecl *storedProperty = component.getStoredPropertyDecl();
+    
+    if (parent->isStruct()) {
+      // Reading a struct field -> reading the struct
+      // Writing or modifying a struct field -> modifying the struct
+      AccessType parentAccessType;
+      if (accessType == AccessType::Get)
+        parentAccessType = AccessType::Get;
+      else
+        parentAccessType = AccessType::Modify;
+      
+      parent->project(parentAccessType, [&](SILValue parent) {
+        callback(builder.createStructElementAddr(loc, parent, storedProperty));
+      });
+    } else {
+      // Accessing a class member -> reading the class
+      parent->project(AccessType::Get, [&](SILValue parent) {
+        SingleValueInstruction *Ref = builder.createLoad(loc, parent,
+                                                         LoadOwnershipQualifier::Unqualified);
+        
+        // If we were previously accessing a class member, we're done now.
+        insertEndAccess(beginAccess, builder);
+        
+        // Handle the case where the storedProperty is in a super class.
+        while (Ref->getType().getClassOrBoundGenericClass() !=
+               storedProperty->getDeclContext()) {
+          SILType superCl = Ref->getType().getSuperclass();
+          if (!superCl) {
+            // This should never happen, because the property should be in the
+            // decl or in a superclass of it. Just handle this to be on the safe
+            // side.
+            callback(SILValue());
+            return;
+          }
+          Ref = builder.createUpcast(loc, Ref, superCl);
+        }
+        
+        SILValue addr = builder.createRefElementAddr(loc, Ref, storedProperty);
+        
+        // Class members need access enforcement.
+        if (builder.getModule().getOptions().EnforceExclusivityDynamic) {
+          beginAccess = builder.createBeginAccess(loc, addr, SILAccessKind::Read,
+                                                  SILAccessEnforcement::Dynamic,
+                                                  /*noNestedConflict*/ false,
+                                                  /*fromBuiltin*/ false);
+          if (accessType != AccessType::Get)
+            beginAccess->setAccessKind(SILAccessKind::Modify);
+          addr = beginAccess;
+        }
+        
+        callback(addr);
+        
+        // if a child hasn't started a new access (i.e. beginAccess is unchanged),
+        // end the access now
+        if (beginAccess == addr) {
+          insertEndAccess(beginAccess, builder);
+          beginAccess = nullptr;
+        }
+      });
+    }
+  }
+private:
+  BeginAccessInst *&beginAccess;
+};
+
+class TupleElementProjector : public ComponentProjector {
+public:
+  TupleElementProjector(const KeyPathPatternComponent &component,
+                        std::unique_ptr<KeyPathProjector> parent,
+                        SILLocation loc, SILBuilder &builder)
+        : ComponentProjector(component, std::move(parent), loc, builder) {}
+  
+  void project(AccessType accessType,
+               std::function<void(SILValue addr)> callback) override {
+    assert(component.getKind() ==
+           KeyPathPatternComponent::Kind::TupleElement);
+    
+    // Reading a tuple field -> reading the tuple
+    // Writing or modifying a tuple field -> modifying the tuple
+    AccessType parentAccessType;
+    if (accessType == AccessType::Get)
+      parentAccessType = AccessType::Get;
+    else
+      parentAccessType = AccessType::Modify;
+    
+    parent->project(parentAccessType, [&](SILValue parent) {
+      callback(builder.createTupleElementAddr(loc, parent,
+                                              component.getTupleIndex()));
+    });
+  }
+};
+
+class GettablePropertyProjector : public ComponentProjector {
+public:
+    GettablePropertyProjector(KeyPathInst *keyPath,
+                              const KeyPathPatternComponent &component,
+                              std::unique_ptr<KeyPathProjector> parent,
+                              SubstitutionMap subs, BeginAccessInst *&beginAccess,
+                              SILLocation loc, SILBuilder &builder)
+        : ComponentProjector(component, std::move(parent), loc, builder),
+          keyPath(keyPath), subs(subs), beginAccess(beginAccess) {}
+  
+  void project(AccessType accessType,
+               std::function<void(SILValue addr)> callback) override {
+    assert(component.getKind() ==
+           KeyPathPatternComponent::Kind::GettableProperty ||
+           component.getKind() ==
+           KeyPathPatternComponent::Kind::SettableProperty);
+    assert(accessType == AccessType::Get && "property is not settable");
+    
+    parent->project(accessType, [&](SILValue parent) {
+      auto getter = component.getComputedPropertyGetter();
+      
+      // The callback expects a memory address it can read from,
+      // so allocate a buffer.
+      auto &function = builder.getFunction();
+      SILType type = function.getLoweredType(component.getComponentType());
+      auto addr = builder.createAllocStack(loc, type);
+      
+      // Get subscript indices.
+      auto context = createContextContainer();
+      SILValue contextPtr = SILValue();
+      if (context) {
+        auto rawPtrType = builder.getASTContext().TheRawPointerType;
+        auto rawPtrLoweredType = function.getLoweredLoadableType(rawPtrType);
+        auto rawPtr = builder.createAddressToPointer(loc, context, rawPtrLoweredType);
+        
+        auto ptrDecl = builder.getASTContext().getUnsafeRawPointerDecl();
+        SILType ptrType = function.getLoweredType(ptrDecl->getDeclaredType());
+        contextPtr = builder.createStruct(loc, ptrType, {rawPtr});
+      }
+      
+      auto ref = builder.createFunctionRef(loc, getter);
+      if (contextPtr)
+        builder.createApply(loc, ref, subs, {addr, parent, contextPtr});
+      else
+        builder.createApply(loc, ref, subs, {addr, parent});
+      
+      // If we were previously accessing a class member, we're done now.
+      insertEndAccess(beginAccess, builder);
+      beginAccess = nullptr;
+      
+      callback(addr);
+      
+      if (context) {
+        builder.createDestroyAddr(loc, context);
+        builder.createDeallocStack(loc, context);
+      }
+      
+      builder.createDestroyAddr(loc, addr);
+      builder.createDeallocStack(loc, addr);
+    });
+    
+  }
+protected:
+  KeyPathInst *keyPath;
+  SubstitutionMap subs;
+  BeginAccessInst *&beginAccess;
+  
+  // Creates the subscript index context for a computed property.
+  // Returns either null or a stack address that must be deallocated.
+  SILValue createContextContainer() {
+    auto indices = component.getSubscriptIndices();
+    if (indices.empty()) return SILValue();
+    
+    if (indices.size() == 1) {
+      auto index = indices.front();
+      auto addr = builder.createAllocStack(loc, index.LoweredType);
+      auto value = keyPath->getAllOperands()[index.Operand].get();
+      if (value->getType().isObject())
+        builder.createStore(loc, value, addr,
+                            StoreOwnershipQualifier::Unqualified);
+      else
+        builder.createCopyAddr(loc, value, addr,
+                               IsNotTake, IsInitialization);
+      return addr;
+    } else {
+      // Create a tuple containing the context.
+      std::vector<TupleTypeElt> elementTypes;
+      elementTypes.reserve(indices.size());
+      for (auto index : indices) {
+        elementTypes.push_back(TupleTypeElt(index.FormalType));
+      }
+      auto tupleType = TupleType::get(ArrayRef<TupleTypeElt>(elementTypes),
+                                      builder.getASTContext());
+      
+      auto &function = builder.getFunction();
+      SILType lowered = function.getLoweredType(tupleType);
+      
+      auto tupleAddr = builder.createAllocStack(loc, lowered);
+      
+      // Copy the context elements into the tuple.
+      for (size_t i = 0; i < indices.size(); i++) {
+        auto index = indices[i];
+        auto elementAddr = builder.createTupleElementAddr(loc, tupleAddr, i);
+        auto value = keyPath->getAllOperands()[index.Operand].get();
+        if (value->getType().isObject())
+          builder.createStore(loc, value, elementAddr,
+                              StoreOwnershipQualifier::Unqualified);
+        else
+          builder.createCopyAddr(loc, value, elementAddr,
+                                 IsNotTake, IsInitialization);
+      }
+      return tupleAddr;
+    }
+  }
+};
+
+class SettablePropertyProjector : public GettablePropertyProjector {
+public:
+    SettablePropertyProjector(KeyPathInst *keyPath,
+                              const KeyPathPatternComponent &component,
+                              std::unique_ptr<KeyPathProjector> parent,
+                              SubstitutionMap subs, BeginAccessInst *&beginAccess,
+                              SILLocation loc, SILBuilder &builder)
+        : GettablePropertyProjector(keyPath, component, std::move(parent),
+                                    subs, beginAccess, loc, builder) {}
+  
+  
+  void project(AccessType accessType,
+               std::function<void(SILValue addr)> callback) override {
+    assert(component.getKind() ==
+           KeyPathPatternComponent::Kind::GettableProperty ||
+           component.getKind() ==
+           KeyPathPatternComponent::Kind::SettableProperty);
+    
+    switch (accessType) {
+      case AccessType::Get:
+        GettablePropertyProjector::project(accessType, callback);
+        break;
+        
+      case AccessType::Modify:
+      case AccessType::Set:
+        AccessType parentAccessType;
+        if (component.isComputedSettablePropertyMutating()) {
+          // A mutating setter modifies the parent
+          parentAccessType = AccessType::Modify;
+          if (beginAccess) beginAccess->setAccessKind(SILAccessKind::Modify);
+        } else parentAccessType = AccessType::Get;
+        
+        parent->project(parentAccessType, [&](SILValue parent) {
+          auto getter = component.getComputedPropertyGetter();
+          auto setter = component.getComputedPropertySetter();
+          
+          // The callback expects a memory address it can write to,
+          // so allocate a writeback buffer.
+          auto &function = builder.getFunction();
+          SILType type = function.getLoweredType(component.getComponentType());
+          auto addr = builder.createAllocStack(loc, type);
+          
+          // Get subscript indices.
+          auto context = createContextContainer();
+          SILValue contextPtr = SILValue();
+          if (context) {
+            auto rawPtrType = builder.getASTContext().TheRawPointerType;
+            auto rawPtrLoweredType = function.getLoweredLoadableType(rawPtrType);
+            auto rawPtr = builder.createAddressToPointer(loc, context, rawPtrLoweredType);
+            
+            auto ptrDecl = builder.getASTContext().getUnsafeRawPointerDecl();
+            SILType ptrType = function.getLoweredType(ptrDecl->getDeclaredType());
+            contextPtr = builder.createStruct(loc, ptrType, {rawPtr});
+          }
+          
+          // If this is a modify, we need to call the getter and
+          // store the result in the writeback buffer.
+          if (accessType == AccessType::Modify) {
+            auto getterRef = builder.createFunctionRef(loc, getter);
+            if (contextPtr)
+              builder.createApply(loc, getterRef, subs, {addr, parent, contextPtr});
+            else
+              builder.createApply(loc, getterRef, subs, {addr, parent});
+          }
+          
+          // The callback function will write into the writeback buffer.
+          callback(addr);
+          
+          // Pass the value from the writeback buffer to the setter.
+          auto setterRef = builder.createFunctionRef(loc, setter);
+          if (contextPtr)
+            builder.createApply(loc, setterRef, subs, {addr, parent, contextPtr});
+          else
+            builder.createApply(loc, setterRef, subs, {addr, parent});
+          
+          if (context) {
+            builder.createDestroyAddr(loc, context);
+            builder.createDeallocStack(loc, context);
+          }
+          
+          // Deallocate the writeback buffer.
+          builder.createDestroyAddr(loc, addr);
+          builder.createDeallocStack(loc, addr);
+        });
+        break;
+    }
+  }
+};
+
+
+class OptionalWrapProjector : public ComponentProjector {
+public:
+  OptionalWrapProjector(const KeyPathPatternComponent &component,
+                        std::unique_ptr<KeyPathProjector> parent,
+                        SILLocation loc, SILBuilder &builder)
+        : ComponentProjector(component, std::move(parent), loc, builder) {}
+  
+  void project(AccessType accessType,
+               std::function<void(SILValue addr)> callback) override {
+    assert(component.getKind() ==
+           KeyPathPatternComponent::Kind::OptionalWrap);
+    assert(accessType == AccessType::Get && "optional wrap components are immutable");
+    
+    parent->project(AccessType::Get, [&](SILValue parent) {
+      auto &function = builder.getFunction();
+      SILType optType = function.getLoweredType(component.getComponentType());
+      SILType objType = optType.getOptionalObjectType().getAddressType();
+      
+      assert(objType && "optional wrap must return an optional");
+
+      // Allocate a buffer for the result.
+      auto optAddr = builder.createAllocStack(loc, optType);
+      
+      // Store the parent result in the enum payload address.
+      auto someDecl = builder.getASTContext().getOptionalSomeDecl();
+      auto objAddr = builder.createInitEnumDataAddr(loc, optAddr,
+                                                    someDecl, objType);
+      builder.createCopyAddr(loc, parent, objAddr, IsNotTake, IsInitialization);
+      
+      // Initialize the Optional enum.
+      builder.createInjectEnumAddr(loc, optAddr, someDecl);
+      
+      callback(optAddr);
+      
+      // Destroy the Optional.
+      builder.createDestroyAddr(loc, optAddr);
+      builder.createDeallocStack(loc, optAddr);
+    });
+  }
+};
+
+class OptionalForceProjector : public ComponentProjector {
+public:
+  OptionalForceProjector(const KeyPathPatternComponent &component,
+                         std::unique_ptr<KeyPathProjector> parent,
+                         SILLocation loc, SILBuilder &builder)
+        : ComponentProjector(component, std::move(parent), loc, builder) {}
+  
+  void project(AccessType accessType,
+               std::function<void(SILValue addr)> callback) override {
+    assert(component.getKind() ==
+           KeyPathPatternComponent::Kind::OptionalForce);
+    
+    parent->project(accessType, [&](SILValue optAddr) {
+      auto &ctx = builder.getASTContext();
+      
+      auto noneDecl = ctx.getOptionalNoneDecl();
+      auto someDecl = ctx.getOptionalSomeDecl();
+      
+      SILType optType = optAddr->getType();
+      SILType objType = optType.getOptionalObjectType();
+      
+      if (accessType != AccessType::Set) {
+        // We're getting (or modifying), so we need to unwrap the optional.
+        auto int1Type = SILType::getBuiltinIntegerType(1, ctx);
+        auto falseLiteral = builder.createIntegerLiteral(loc, int1Type, false);
+        auto trueLiteral = builder.createIntegerLiteral(loc, int1Type, true);
+        
+        auto isNil = builder.createSelectEnumAddr(loc, optAddr, int1Type, SILValue(), {
+          {noneDecl, trueLiteral}, {someDecl, falseLiteral}
+        });
+        builder.createCondFail(loc, isNil, "unexpectedly found nil while "
+                               "unwrapping an Optional key-path expression");
+      }
+      
+      switch (accessType) {
+        case AccessType::Get: {
+          // We have to copy the optional, since unwrapping is destructive.
+          auto tempAddr = builder.createAllocStack(loc, optType);
+          builder.createCopyAddr(loc, optAddr, tempAddr, IsNotTake, IsInitialization);
+          
+          // Unwrap the optional.
+          auto objAddr = builder.createUncheckedTakeEnumDataAddr(loc, tempAddr, someDecl, objType);
+          
+          callback(objAddr);
+          
+          builder.createDestroyAddr(loc, objAddr);
+          builder.createDeallocStack(loc, tempAddr);
+          break;
+        }
+        case AccessType::Set: {
+          // We can destroy the old value and write the new value in its place.
+          builder.createDestroyAddr(loc, optAddr);
+          auto objAddr = builder.createInitEnumDataAddr(loc, optAddr, someDecl, objType);
+          
+          callback(objAddr);
+          
+          // Finish creating the enum.
+          builder.createInjectEnumAddr(loc, optAddr, someDecl);
+          break;
+        }
+        case AccessType::Modify: {
+          // We have to copy the old value out, perform the modification,
+          // and copy the new value back in.
+          auto objAddr = builder.createAllocStack(loc, objType);
+          
+          // Unwrap the optional and copy it to the new buffer.
+          auto unwrappedAddr = builder.createUncheckedTakeEnumDataAddr(loc, optAddr, someDecl, objType);
+          builder.createCopyAddr(loc, unwrappedAddr, objAddr, IsTake, IsInitialization);
+          
+          callback(objAddr);
+          
+          auto initAddr = builder.createInitEnumDataAddr(loc, optAddr, someDecl, objType);
+          builder.createCopyAddr(loc, objAddr, initAddr, IsTake, IsInitialization);
+          builder.createDeallocStack(loc, objAddr);
+          builder.createInjectEnumAddr(loc, optAddr, someDecl);
+          break;
+        }
+      }
+    });
+  }
+};
+
+class OptionalChainProjector : public ComponentProjector {
+public:
+  OptionalChainProjector(const KeyPathPatternComponent &component,
+                         std::unique_ptr<KeyPathProjector> parent,
+                         SILValue optionalChainResult,
+                         SILLocation loc, SILBuilder &builder)
+        : ComponentProjector(component, std::move(parent), loc, builder),
+          optionalChainResult(optionalChainResult) {}
+  
+  void project(AccessType accessType,
+               std::function<void(SILValue addr)> callback) override {
+    assert(component.getKind() ==
+           KeyPathPatternComponent::Kind::OptionalChain);
+    assert(accessType == AccessType::Get &&
+           "Optional chain components are immutable");
+    
+    parent->project(accessType, [&](SILValue optAddr) {
+      auto &ctx = builder.getASTContext();
+      
+      auto noneDecl = ctx.getOptionalNoneDecl();
+      auto someDecl = ctx.getOptionalSomeDecl();
+      
+      SILType optType = optAddr->getType();
+      SILType objType = optType.getOptionalObjectType();
+      
+      // Continue projecting only if the optional is non-nil
+      // i.e. if let objAddr = optAddr {
+      auto continuation = builder.splitBlockForFallthrough();
+      auto ifSome = builder.getFunction().createBasicBlockAfter(builder.getInsertionBB());
+      auto ifNone = builder.getFunction().createBasicBlockAfter(ifSome);
+      builder.createSwitchEnumAddr(loc, optAddr, /*defaultBB*/ nullptr,
+                                   {{noneDecl, ifNone}, {someDecl, ifSome}});
+      
+      assert(ifSome->empty());
+      builder.setInsertionPoint(ifSome);
+      
+      // We have to copy the optional, since unwrapping is destructive.
+      auto tempAddr = builder.createAllocStack(loc, optType);
+      builder.createCopyAddr(loc, optAddr, tempAddr, IsNotTake, IsInitialization);
+      
+      // Unwrap the optional.
+      auto objAddr = builder.createUncheckedTakeEnumDataAddr(loc, tempAddr, someDecl, objType);
+      
+      // at the end of the projection, callback will store a value in optionalChainResult
+      callback(objAddr);
+      
+      builder.createDestroyAddr(loc, objAddr);
+      builder.createDeallocStack(loc, tempAddr);
+      
+      builder.createBranch(loc, continuation);
+      // else, store nil in the result
+      builder.setInsertionPoint(ifNone);
+      builder.createInjectEnumAddr(loc, optionalChainResult, noneDecl);
+      
+      builder.createBranch(loc, continuation);
+      // end if, allow parents to clean up regardless of whether the chain continued
+      builder.setInsertionPoint(continuation, continuation->begin());
+    });
+  }
+  
+private:
+  SILValue optionalChainResult;
+};
+
+
+
+
+/// A projector to handle a complete key path.
+class CompleteKeyPathProjector : public KeyPathProjector {
+public:
+  CompleteKeyPathProjector(KeyPathInst *keyPath, SILValue root,
+                           SILLocation loc, SILBuilder &builder)
+  : KeyPathProjector(loc, builder), keyPath(keyPath), root(root) {}
+
+  void project(AccessType accessType,
+               std::function<void (SILValue)> callback) override {
+    auto components = keyPath->getPattern()->getComponents();
+    
+    // Check if the keypath has an optional chain.
+    bool isOptionalChain = false;
+    for (const KeyPathPatternComponent &comp : components) {
+      if (comp.getKind() == KeyPathPatternComponent::Kind::OptionalChain) {
+        isOptionalChain = true;
+        break;
+      }
+    }
+    
+    // Root projector
+    auto rootProjector = std::make_unique<RootProjector>(root, loc, builder);
+    
+    BeginAccessInst *beginAccess = nullptr;
+    
+    if (isOptionalChain) {
+      assert(accessType == AccessType::Get && "Optional chains are read-only");
+      
+      // If we're reading an optional chain, create an optional result.
+      auto resultCanType = components.back().getComponentType();
+      auto &function = builder.getFunction();
+      auto optType = function.getLoweredType(resultCanType);
+      
+      assert(optType.getOptionalObjectType() &&
+             "Optional-chained key path should result in an optional");
+      SILValue optionalChainResult = builder.createAllocStack(loc, optType);
+      
+      // Get the (conditional) result projector.
+      auto projector = create(0, std::move(rootProjector),
+                              beginAccess, optionalChainResult);
+      
+      projector->project(accessType, [&](SILValue result) {
+        // This will only run if all optional chains succeeded.
+        // Store the result in optionalChainResult.
+        builder.createCopyAddr(loc, result, optionalChainResult,
+                               IsNotTake, IsInitialization);
+      });
+      
+      // If the optional chain succeeded, optionalChainResult will have
+      // .some(result). Otherwise, projectOptionalChain will have written .none.
+      callback(optionalChainResult);
+      builder.createDestroyAddr(loc, optionalChainResult);
+      builder.createDeallocStack(loc, optionalChainResult);
+    } else {
+      // If we're not optional chaining, or we're writing to an optional chain,
+      // we don't need an optional result.
+      auto projector =  create(0, std::move(rootProjector),
+                               beginAccess, /*optionalChainResult*/ nullptr);
+      projector->project(accessType, callback);
+    }
+    assert(beginAccess == nullptr &&
+           "key path projector returned with dangling access enforcement");
+  }
+  
+  bool isStruct() override {
+    auto components = keyPath->getPattern()->getComponents();
+    auto resultType = components.back().getComponentType();
+    return resultType.getStructOrBoundGenericStruct() != nullptr;
+  }
+  
+private:
+  KeyPathInst *keyPath;
+  SILValue root;
+  
+  /// Recursively creates a chain of key path projectors
+  /// for components from index..<components.end()
+  std::unique_ptr<KeyPathProjector>
+  create(size_t index, std::unique_ptr<KeyPathProjector> parent,
+         BeginAccessInst *&beginAccess, SILValue optionalChainResult) {
+    auto components = keyPath->getPattern()->getComponents();
+    
+    if (index >= components.size()) return parent;
+    
+    auto &comp = components[index];
+    std::unique_ptr<KeyPathProjector> projector;
+    
+    // Create a projector for this component.
+    switch (comp.getKind()) {
+      case KeyPathPatternComponent::Kind::StoredProperty:
+        projector = std::make_unique<StoredPropertyProjector>
+            (comp, std::move(parent), beginAccess, loc, builder);
+        break;
+      case KeyPathPatternComponent::Kind::TupleElement:
+        projector = std::make_unique<TupleElementProjector>
+            (comp, std::move(parent), loc, builder);
+        break;
+      case KeyPathPatternComponent::Kind::GettableProperty:
+        projector = std::make_unique<GettablePropertyProjector>
+            (keyPath, comp, std::move(parent), keyPath->getSubstitutions(),
+             beginAccess, loc, builder);
+        break;
+      case KeyPathPatternComponent::Kind::SettableProperty:
+        projector = std::make_unique<SettablePropertyProjector>
+            (keyPath, comp, std::move(parent), keyPath->getSubstitutions(),
+             beginAccess, loc, builder);
+        break;
+      case KeyPathPatternComponent::Kind::OptionalWrap:
+        projector = std::make_unique<OptionalWrapProjector>
+            (comp, std::move(parent), loc, builder);
+        break;
+      case KeyPathPatternComponent::Kind::OptionalForce:
+        projector = std::make_unique<OptionalForceProjector>
+            (comp, std::move(parent), loc, builder);
+        break;
+      case KeyPathPatternComponent::Kind::OptionalChain:
+        projector = std::make_unique<OptionalChainProjector>
+            (comp, std::move(parent), optionalChainResult, loc, builder);
+        break;
+    }
+    
+    // Project the rest of the chain on top of this component.
+    return create(index + 1, std::move(projector),
+                  beginAccess, optionalChainResult);
+  }
+};
+
+std::unique_ptr<KeyPathProjector>
+KeyPathProjector::create(SILValue keyPath, SILValue root,
+                         SILLocation loc, SILBuilder &builder) {
+  if (auto *upCast = dyn_cast<UpcastInst>(keyPath))
+    keyPath = upCast->getOperand();
+  
+  // Is it a keypath instruction at all?
+  auto *kpInst = dyn_cast<KeyPathInst>(keyPath);
+  if (!kpInst || !kpInst->hasPattern())
+    return nullptr;
+
+  return std::make_unique<CompleteKeyPathProjector>(kpInst, root,
+                                                    loc, builder);
+}

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -130,7 +130,8 @@ func testGenStructRead<T>(_ s: GenStruct<T>) -> T {
 
 // CHECK-LABEL: sil {{.*}}testGenStructWrite
 // CHECK: [[A:%[0-9]+]] = struct_element_addr %0
-// CHECK: copy_addr %1 to [[A]]
+// CHECK: destroy_addr [[A]]
+// CHECK: copy_addr {{.*}} to [initialization] [[A]]
 // CHECK: return
 @inline(never)
 @_semantics("optimize.sil.specialize.generic.never")
@@ -183,7 +184,8 @@ func testDerivedClass2Read(_ c: DerivedClass2) -> Int {
 // CHECK: [[S:%[0-9]+]] = alloc_stack $T
 // CHECK: [[E:%[0-9]+]] = ref_element_addr %0
 // CHECK: [[A:%[0-9]+]] = begin_access [modify] [dynamic] [[E]]
-// CHECK: copy_addr [take] [[S]] to [[A]]
+// CHECK: destroy_addr [[A]]
+// CHECK: copy_addr [take] [[S]] to [initialization] [[A]]
 // CHECK: end_access [[A]]
 // CHECK: return
 @inline(never)


### PR DESCRIPTION
We have an optimization in SILCombiner (introduced in  #24929) that inlines compile-time constant key paths by performing the property access directly instead of calling a runtime function (leading to huge performance gains e.g. for heavy use of `@dynamicMemberLookup`). However, this optimization previously only supported key paths which solely access stored properties, so computed properties, optional chaining, etc. still had to call a runtime function. This commit generalizes the optimization to support all types of key paths.

This is my first time contributing to any sort of compiler development, so it's likely I've overlooked something. The previous iteration of this optimzation essentially computed the stored property offsets and returned the resulting address. I still used with a design that projects the key path to an address since that's what's returned by the runtime functions that we're replacing, but my implementation is more complex because projections for most types of key path components need both setup and teardown logic to e.g. deallocate temporaries, call getters and setters, or re-wrap optionals.

I created an abstract class called `KeyPathProjector`. It has a method called `project`, which accepts an access type (get, set, or modify) and a callback lambda. This method inserts SIL instructions to project the key path to an address, invokes the callback, and then inserts instructions to tear down the projection. A complete key path is handled (internally to `KeyPathProjector.cpp`) by creating a "chained" projector: each projector in the chain is responsible for projecting a single component on top of the previously projected result. For each type of key path component, there is one subclass of `KeyPathProjector` (again, all of these are implementation details of `KeyPathProjector.cpp`).

There are a few special cases (such as access enforcement and optional chaining), but I think my logic works, and it passes all the tests I've tried. I do have a couple concerns though:
- Subscripts in key paths are treated as computed properties with indices, and they require an additional context pointer to be passed to the property accessor. The key path projector needs to create this context object with the correct memory layout; I implemented this by creating a tuple which contains the context operands. Is a tuple guaranteed to have the correct memory layout? Will this work in all cases, and is it guaranteed to work in the future?
- Some code in IRGen, along with the key path ABI documentation, seemed to make references to including a "generic environment" along with these context pointers. However, SILVerifier [doesn't seem to know about this](https://github.com/apple/swift/blob/master/lib/SIL/SILVerifier.cpp#L248), and I haven't been able to figure out anything more. Is this something I need to account for? Under what circumstances would I need to pass a generic environment to an accessor, and what exactly would that involve?