### PR TITLE
[NFC] Refactor name parsing into `parseDeclNameRef()`

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1422,7 +1422,7 @@ public:
 
     /// If passed, 'deinit' and 'subscript' should be parsed as special names,
     /// not ordinary identifiers.
-    UseSpecialNamesForDeinitAndSubscript = AllowKeywords | 1 << 2,
+    AllowKeywordsUsingSpecialNames = AllowKeywords | 1 << 2,
 
     /// If passed, compound names with argument lists are allowed, unless they
     /// have empty argument lists.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1450,39 +1450,6 @@ public:
   DeclNameRef parseDeclNameRef(DeclNameLoc &loc, const Diagnostic &diag,
                                DeclNameOptions flags);
 
-  /// Parse an unqualified-decl-base-name.
-  ///
-  ///   unqualified-decl-name:
-  ///     identifier
-  ///
-  /// \param afterDot Whether this identifier is coming after a period, which
-  /// enables '.init' and '.default' like expressions.
-  /// \param loc Will be populated with the location of the name.
-  /// \param diag The diagnostic to emit if this is not a name.
-  /// \param allowOperators Whether to allow operator basenames too.
-  DeclNameRef parseUnqualifiedDeclBaseName(bool afterDot, DeclNameLoc &loc,
-                                           const Diagnostic &diag,
-                                           bool allowOperators=false,
-                                           bool allowDeinitAndSubscript=false);
-
-  /// Parse an unqualified-decl-name.
-  ///
-  ///   unqualified-decl-name:
-  ///     unqualified-decl-base-name
-  ///     unqualified-decl-base-name '(' ((identifier | '_') ':') + ')'
-  ///
-  /// \param afterDot Whether this identifier is coming after a period, which
-  /// enables '.init' and '.default' like expressions.
-  /// \param loc Will be populated with the location of the name.
-  /// \param diag The diagnostic to emit if this is not a name.
-  /// \param allowOperators Whether to allow operator basenames too.
-  /// \param allowZeroArgCompoundNames Whether to allow empty argument lists.
-  DeclNameRef parseUnqualifiedDeclName(bool afterDot, DeclNameLoc &loc,
-                                       const Diagnostic &diag,
-                                       bool allowOperators=false,
-                                       bool allowZeroArgCompoundNames=false,
-                                       bool allowDeinitAndSubscript=false);
-
   Expr *parseExprIdentifier();
   Expr *parseExprEditorPlaceholder(Token PlaceholderTok,
                                    Identifier PlaceholderId);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1412,6 +1412,44 @@ public:
   /// \param loc The location of the label (empty if it doesn't exist)
   void parseOptionalArgumentLabel(Identifier &name, SourceLoc &loc);
 
+  enum class DeclNameFlag : uint8_t {
+    /// If passed, operator basenames are allowed.
+    AllowOperators = 1 << 0,
+
+    /// If passed, names that coincide with keywords are allowed. Used after a
+    /// dot to enable things like '.init' and '.default'.
+    AllowKeywords = 1 << 1,
+
+    /// If passed, 'deinit' and 'subscript' should be parsed as special names,
+    /// not ordinary identifiers.
+    UseSpecialNamesForDeinitAndSubscript = AllowKeywords | 1 << 2,
+
+    /// If passed, compound names with argument lists are allowed, unless they
+    /// have empty argument lists.
+    AllowCompoundNames = 1 << 4,
+
+    /// If passed, compound names with empty argument lists are allowed.
+    AllowZeroArgCompoundNames = AllowCompoundNames | 1 << 5,
+  };
+  using DeclNameOptions = OptionSet<DeclNameFlag>;
+
+  friend DeclNameOptions operator|(DeclNameFlag flag1, DeclNameFlag flag2) {
+    return DeclNameOptions(flag1) | flag2;
+  }
+
+  /// Without \c DeclNameFlag::AllowCompoundNames, parse an
+  /// unqualified-decl-base-name.
+  ///
+  ///   unqualified-decl-base-name: identifier
+  ///
+  /// With \c DeclNameFlag::AllowCompoundNames, parse an unqualified-base-name.
+  ///
+  ///   unqualified-decl-name:
+  ///     unqualified-decl-base-name
+  ///     unqualified-decl-base-name '(' ((identifier | '_') ':') + ')'
+  DeclNameRef parseDeclNameRef(DeclNameLoc &loc, const Diagnostic &diag,
+                               DeclNameOptions flags);
+
   /// Parse an unqualified-decl-base-name.
   ///
   ///   unqualified-decl-name:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1129,8 +1129,8 @@ ParserResult<DerivativeAttr> Parser::parseDerivativeAttribute(SourceLoc atLoc,
       original.Name = parseDeclNameRef(original.Loc,
           diag::attr_derivative_expected_original_name,
           DeclNameFlag::AllowZeroArgCompoundNames |
-          DeclNameFlag::AllowKeywords | DeclNameFlag::AllowOperators |
-          DeclNameFlag::UseSpecialNamesForDeinitAndSubscript);
+          DeclNameFlag::AllowKeywordsUsingSpecialNames |
+          DeclNameFlag::AllowOperators);
     }
     if (consumeIfTrailingComma())
       return makeParserError();
@@ -2061,8 +2061,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
         replacedFunction = parseDeclNameRef(loc,
             diag::attr_dynamic_replacement_expected_function,
             DeclNameFlag::AllowZeroArgCompoundNames |
-            DeclNameFlag::AllowKeywords | DeclNameFlag::AllowOperators |
-            DeclNameFlag::UseSpecialNamesForDeinitAndSubscript);
+            DeclNameFlag::AllowKeywordsUsingSpecialNames |
+            DeclNameFlag::AllowOperators);
       }
     }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -768,11 +768,10 @@ Parser::parseImplementsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
     }
 
     if (!Status.shouldStopParsing()) {
-      MemberName =
-          parseUnqualifiedDeclName(/*afterDot=*/false, MemberNameLoc,
-                                   diag::attr_implements_expected_member_name,
-                                   /*allowOperators=*/true,
-                                   /*allowZeroArgCompoundNames=*/true);
+      MemberName = parseDeclNameRef(MemberNameLoc,
+          diag::attr_implements_expected_member_name,
+          DeclNameFlag::AllowZeroArgCompoundNames |
+          DeclNameFlag::AllowOperators);
       if (!MemberName) {
         Status.setIsParseError();
       }
@@ -1022,10 +1021,8 @@ bool Parser::parseDifferentiableAttributeArguments(
          SyntaxContext, SyntaxKind::FunctionDeclName);
     Diagnostic funcDiag(diag::attr_differentiable_expected_function_name.ID,
                         { label });
-    result.Name =
-        parseUnqualifiedDeclName(/*afterDot=*/false, result.Loc,
-                                 funcDiag, /*allowOperators=*/true,
-                                 /*allowZeroArgCompoundNames=*/true);
+    result.Name = parseDeclNameRef(result.Loc, funcDiag,
+        DeclNameFlag::AllowZeroArgCompoundNames | DeclNameFlag::AllowOperators);
     // If no trailing comma or 'where' clause, terminate parsing arguments.
     if (Tok.isNot(tok::comma, tok::kw_where))
       terminateParsingArgs = true;
@@ -1129,10 +1126,11 @@ ParserResult<DerivativeAttr> Parser::parseDerivativeAttribute(SourceLoc atLoc,
                                                SyntaxKind::FunctionDeclName);
       // NOTE: Use `afterDot = true` and `allowDeinitAndSubscript = true` to
       // enable, e.g. `@derivative(of: init)` and `@derivative(of: subscript)`.
-      original.Name = parseUnqualifiedDeclName(
-          /*afterDot*/ true, original.Loc,
-          diag::attr_derivative_expected_original_name, /*allowOperators*/ true,
-          /*allowZeroArgCompoundNames*/ true, /*allowDeinitAndSubscript*/ true);
+      original.Name = parseDeclNameRef(original.Loc,
+          diag::attr_derivative_expected_original_name,
+          DeclNameFlag::AllowZeroArgCompoundNames |
+          DeclNameFlag::AllowKeywords | DeclNameFlag::AllowOperators |
+          DeclNameFlag::UseSpecialNamesForDeinitAndSubscript);
     }
     if (consumeIfTrailingComma())
       return makeParserError();
@@ -2060,10 +2058,11 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                             SyntaxKind::DeclName);
 
         DeclNameLoc loc;
-        replacedFunction = parseUnqualifiedDeclName(
-            true, loc, diag::attr_dynamic_replacement_expected_function,
-            /*allowOperators*/ true, /*allowZeroArgCompoundNames*/ true,
-            /*allowDeinitAndSubscript*/ true);
+        replacedFunction = parseDeclNameRef(loc,
+            diag::attr_dynamic_replacement_expected_function,
+            DeclNameFlag::AllowZeroArgCompoundNames |
+            DeclNameFlag::AllowKeywords | DeclNameFlag::AllowOperators |
+            DeclNameFlag::UseSpecialNamesForDeinitAndSubscript);
       }
     }
 
@@ -2572,11 +2571,9 @@ bool Parser::parseConventionAttributeInternal(
       return true;
     }
 
-    DeclNameLoc unusedWitnessMethodProtocolLoc;
-    convention.WitnessMethodProtocol = parseUnqualifiedDeclBaseName(
-        /*afterDot=*/false, unusedWitnessMethodProtocolLoc,
-       diag::convention_attribute_witness_method_expected_protocol
-    );
+    DeclNameLoc unusedLoc;
+    convention.WitnessMethodProtocol = parseDeclNameRef(unusedLoc,
+        diag::convention_attribute_witness_method_expected_protocol, {});
   }
   
   // Parse the ')'.  We can't use parseMatchingToken if we're in

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2219,47 +2219,6 @@ DeclNameRef Parser::parseDeclNameRef(DeclNameLoc &loc,
   return DeclNameRef({ Context, baseName, argumentLabels });
 }
 
-DeclNameRef Parser::parseUnqualifiedDeclBaseName(
-                                                 bool afterDot,
-                                                 DeclNameLoc &loc,
-                                                 const Diagnostic &diag,
-                                                 bool allowOperators,
-                                                 bool allowDeinitAndSubscript) {
-  DeclNameOptions flags = {};
-  if (afterDot)
-    flags |= DeclNameFlag::AllowKeywords;
-  if (allowOperators)
-    flags |= DeclNameFlag::AllowOperators;
-  if (allowDeinitAndSubscript) {
-    assert(afterDot);
-    flags |= DeclNameFlag::UseSpecialNamesForDeinitAndSubscript;
-  }
-
-  return parseDeclNameRef(loc, diag, flags);
-}
-
-
-DeclNameRef Parser::parseUnqualifiedDeclName(bool afterDot,
-                                             DeclNameLoc &loc,
-                                             const Diagnostic &diag,
-                                             bool allowOperators,
-                                             bool allowZeroArgCompoundNames,
-                                             bool allowDeinitAndSubscript) {
-  DeclNameOptions flags = DeclNameFlag::AllowCompoundNames;
-  if (afterDot)
-    flags |= DeclNameFlag::AllowKeywords;
-  if (allowOperators)
-    flags |= DeclNameFlag::AllowOperators;
-  if (allowDeinitAndSubscript) {
-    assert(afterDot);
-    flags |= DeclNameFlag::UseSpecialNamesForDeinitAndSubscript;
-  }
-  if (allowZeroArgCompoundNames)
-    flags |= DeclNameFlag::AllowZeroArgCompoundNames;
-
-  return parseDeclNameRef(loc, diag, flags);
-}
-
 ///   expr-identifier:
 ///     unqualified-decl-name generic-args?
 Expr *Parser::parseExprIdentifier() {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2176,7 +2176,7 @@ DeclNameRef Parser::parseDeclNameRef(DeclNameLoc &loc,
     baseNameLoc = consumeToken();
   } else if (flags.contains(DeclNameFlag::AllowKeywords) && Tok.isKeyword()) {
     bool specialDeinitAndSubscript =
-        flags.contains(DeclNameFlag::UseSpecialNamesForDeinitAndSubscript);
+        flags.contains(DeclNameFlag::AllowKeywordsUsingSpecialNames);
 
     // Syntax highlighting should treat this token as an identifier and
     // not as a keyword.

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -667,9 +667,8 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifier() {
   SourceLoc EndLoc;
   while (true) {
     DeclNameLoc Loc;
-    DeclNameRef Name = parseUnqualifiedDeclBaseName(
-        /*afterDot=*/false, Loc,
-        diag::expected_identifier_in_dotted_type);
+    DeclNameRef Name =
+        parseDeclNameRef(Loc, diag::expected_identifier_in_dotted_type, {});
     if (!Name)
       Status.setIsParseError();
 


### PR DESCRIPTION
The parser currently has two DeclNameRef-parsing functions, `parseUnqualifiedDeclName()` and `parseUnqualifiedDeclBaseName()`, which take four undifferentiated `bool`s to control their behavior. I will soon need yet another flag, so this is getting a bit out of hand.

This PR replaces them with a `parseDeclNameRef()` function and a flag enum to control these behaviors. This should improve the readability of existing code and help accommodate future flag additions.