### PR TITLE
[5.2] ClosureLifetimeFixup: Handle undef partial_apply arguments gracefully

### DIFF
--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -458,9 +458,6 @@ static bool tryRewriteToPartialApplyStack(
     saveDeleteInst(convertOrPartialApply);
   saveDeleteInst(origPA);
 
-  // Only insert destroys for defined partial_apply arguments.
-  auto isDefined = [](SILValue arg) -> bool { return !isa<SILUndef>(arg); };
-
   // Insert destroys of arguments after the apply and the dealloc_stack.
   if (auto *apply = dyn_cast<ApplyInst>(singleApplyUser)) {
     auto insertPt = std::next(SILBasicBlock::iterator(apply));
@@ -469,12 +466,12 @@ static bool tryRewriteToPartialApplyStack(
       return true;
     SILBuilderWithScope b3(insertPt);
     b3.createDeallocStack(loc, newPA);
-    insertDestroyOfCapturedArguments(newPA, b3, isDefined);
+    insertDestroyOfCapturedArguments(newPA, b3);
   } else if (auto *tai = dyn_cast<TryApplyInst>(singleApplyUser)) {
     for (auto *succBB : tai->getSuccessorBlocks()) {
       SILBuilderWithScope b3(succBB->begin());
       b3.createDeallocStack(loc, newPA);
-      insertDestroyOfCapturedArguments(newPA, b3, isDefined);
+      insertDestroyOfCapturedArguments(newPA, b3);
     }
   } else {
     llvm_unreachable("Unknown FullApplySite instruction kind");

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1020,7 +1020,7 @@ void swift::releasePartialApplyCapturedArg(SILBuilder &builder, SILLocation loc,
   // possible for that value.
 
   // If we have qualified ownership, we should just emit a destroy value.
-  if (arg->getFunction()->hasOwnership()) {
+  if (builder.getFunction().hasOwnership()) {
     callbacks.createdNewInst(builder.createDestroyValue(loc, arg));
     return;
   }

--- a/test/SILOptimizer/closure-lifetime-fixup.sil
+++ b/test/SILOptimizer/closure-lifetime-fixup.sil
@@ -155,3 +155,26 @@ bb1:
   %86 = tuple ()
   return %86 : $()
 }
+
+sil [ossa] @closureImpl :  $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> Bool
+sil [ossa] @useClosure : $@convention(thin) (@noescape @callee_guaranteed () -> Bool) -> ()
+
+// Don't crash.
+// CHECK-LABEL: sil hidden [ossa] @testUndefined
+// CHECK:  [[PA:%.*]] = partial_apply [callee_guaranteed] [on_stack]
+// CHECK:  mark_dependence
+// CHECK:  mark_dependence
+// CHECK:  dealloc_stack [[PA]] : $@noescape @callee_guaranteed () -> Bool
+// CHECK:  destroy_value
+sil hidden [ossa] @testUndefined : $@convention(method) (@guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
+  %4 = function_ref @closureImpl : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> Bool
+  %5 = copy_value %1 : $Klass
+  %6 = partial_apply [callee_guaranteed] %4(%5, undef) : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> Bool
+  %7 = convert_escape_to_noescape [not_guaranteed] %6 : $@callee_guaranteed () -> Bool to $@noescape @callee_guaranteed () -> Bool
+  %21 = function_ref @useClosure : $@convention(thin) (@noescape @callee_guaranteed () -> Bool) -> ()
+  %22 = apply %21(%7) : $@convention(thin) (@noescape @callee_guaranteed () -> Bool) -> ()
+  destroy_value %6 : $@callee_guaranteed () -> Bool
+  %42 = tuple ()
+  return %42 : $()
+}

--- a/test/SILOptimizer/closure_lifetime_fixup_undef.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_undef.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend %s -sil-verify-all -c 2>&1 | %FileCheck %s
+
+// Report the error but don't crash.
+// CHECK: error: closure captures 'stringList' before it is declared
+
+class TestUndefined {
+  private var stringList: [String]!
+
+  func dontCrash(strings: [String]) {
+    assert(stringList.allSatisfy({ $0 == stringList.first!}))
+    let stringList = strings.filter({ $0 == "a" })
+  }
+}


### PR DESCRIPTION
We have to handle undef partial_apply arguments to handle the following
source gracefully during the diagnosis pipeline.

```
class TestUndefined {
  private var stringList: [String]!

  func dontCrash(strings: [String]) {
    assert(stringList.allSatisfy({ $0 == stringList.first!}))
    let stringList = strings.filter({ $0 == "a" })
  }
}
```

rdar://57893008