### PR TITLE
[CS] Resolve callees for key path dynamic members

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -788,9 +788,7 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
 
   // Our remaining path can only be 'ApplyArgument'.
   auto path = callLocator->getPath();
-  if (!path.empty() &&
-      !(path.size() <= 2 &&
-        path.back().getKind() == ConstraintLocator::ApplyArgument))
+  if (!path.empty() && !path.back().is<LocatorPathElt::ApplyArgument>())
     return formUnknownCallee();
 
   // Dig out the callee information.


### PR DESCRIPTION
Change the locator for the applicable fn constraint for the inner subscript reference in an implicit `outer[dynamicMember: \Inner.[0]]` expr such that it uses the member locator with a `KeyPathDynamicMember` element.

Then add a case to `getCalleeLocator` to handle these locators. We also need to handle this specially in `getArgumentInfoLocator` due to the fact that the argument labels for the inner subscript reference correspond to those written by the user for the outer subscript reference.

Resolves SR-11933.
Resolves rdar://problem/57824025.
