### PR TITLE
[5.2][SourceKit/CodeCompletion] Remove unnecessary sorting in completion

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -100,7 +100,6 @@ struct SwiftCodeCompletionConsumer
 
   void handleResults(MutableArrayRef<CodeCompletionResult *> Results) override {
     assert(swiftContext.swiftASTContext);
-    CodeCompletionContext::sortCompletionResults(Results);
     handleResultsImpl(Results, swiftContext);
   }
 };


### PR DESCRIPTION
Cherry-pick #28786 into `swift-5.2-branch` originally reviewed by @benlangmuir 

rdar://problem/57926003