### PR TITLE
Unset IFS after its use in set_build_options_for_host

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -542,10 +542,10 @@ function set_build_options_for_host() {
             esac
 
             if [[ "${DARWIN_SDK_DEPLOYMENT_TARGETS}" != "" ]]; then
-                local IFS=";"; DARWIN_SDK_DEPLOYMENT_TARGETS=($DARWIN_SDK_DEPLOYMENT_TARGETS)
+                local IFS=";"; DARWIN_SDK_DEPLOYMENT_TARGETS=($DARWIN_SDK_DEPLOYMENT_TARGETS); unset IFS
 
                 for target in "${DARWIN_SDK_DEPLOYMENT_TARGETS[@]}"; do
-                    local IFS="-"; triple=($target)
+                    local IFS="-"; triple=($target); unset IFS
                     sdk_target=$(toupper ${triple[0]}_${triple[1]})
                     swift_cmake_options+=(
                         "-DSWIFTLIB_DEPLOYMENT_VERSION_${sdk_target}=${triple[2]}"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -542,9 +542,13 @@ function set_build_options_for_host() {
             esac
 
             if [[ "${DARWIN_SDK_DEPLOYMENT_TARGETS}" != "" ]]; then
+                # IFS is immediately unset after its use to avoid unwanted
+                # replacement of characters in subsequent lines.
                 local IFS=";"; DARWIN_SDK_DEPLOYMENT_TARGETS=($DARWIN_SDK_DEPLOYMENT_TARGETS); unset IFS
 
                 for target in "${DARWIN_SDK_DEPLOYMENT_TARGETS[@]}"; do
+                    # IFS is immediately unset after its use to avoid unwanted
+                    # replacement of characters in subsequent lines.
                     local IFS="-"; triple=($target); unset IFS
                     sdk_target=$(toupper ${triple[0]}_${triple[1]})
                     swift_cmake_options+=(


### PR DESCRIPTION
If IFS remains set, it may cause compilation errors due to unanticipated
replacement of characters in some parameters.

Addresses rdar://problem/57927748