### PR TITLE
Add an option to disable ClangImporter imports form source.  …

### DIFF
--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -99,6 +99,10 @@ public:
   /// When set, don't enforce warnings with -Werror.
   bool DebuggerSupport = false;
 
+  /// When set, ClangImporter is disabled, and all requests go to the
+  /// DWARFImporter delegate.
+  bool DisableSourceImport = false;
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -268,6 +268,10 @@ def debug_crash_after_parse : Flag<["-"], "debug-crash-after-parse">,
 def debugger_support : Flag<["-"], "debugger-support">,
   HelpText<"Process swift code as if running in the debugger">;
 
+def disable_clangimporter_source_import : Flag<["-"],
+  "disable-clangimporter-source-import">,
+  HelpText<"Disable ClangImporter and forward all requests straight the DWARF importer.">;
+
 def disable_arc_opts : Flag<["-"], "disable-arc-opts">,
   HelpText<"Don't run SIL ARC optimization passes.">;
 def disable_ossa_opts : Flag<["-"], "disable-ossa-opts">,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -605,6 +605,10 @@ public:
   bool shouldIgnoreBridgeHeaderTopLevelDecl(clang::Decl *D);
 
 private:
+  /// When set, ClangImporter is disabled, and all requests go to the
+  /// DWARFImporter delegate.
+  bool DisableSourceImport;
+  
   /// The DWARF importer delegate, if installed.
   DWARFImporterDelegate *DWARFImporter = nullptr;
 public:
@@ -614,7 +618,7 @@ public:
 private:
   /// The list of Clang modules found in the debug info.
   llvm::DenseMap<Identifier, LoadedFile *> DWARFModuleUnits;
-public:
+
   /// Load a module using the clang::CompilerInstance.
   ModuleDecl *loadModuleClang(SourceLoc importLoc,
                               ArrayRef<std::pair<Identifier, SourceLoc>> path);
@@ -624,7 +628,11 @@ public:
   ModuleDecl *loadModuleDWARF(SourceLoc importLoc,
                               ArrayRef<std::pair<Identifier, SourceLoc>> path);
 
-  
+public:
+  /// Load a module using either method.
+  ModuleDecl *loadModule(SourceLoc importLoc,
+                         ArrayRef<std::pair<Identifier, SourceLoc>> path);
+
   void recordImplicitUnwrapForDecl(ValueDecl *decl, bool isIUO) {
     if (!isIUO)
       return;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -638,7 +638,12 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
 
   if (Args.hasArg(OPT_warnings_as_errors))
     Opts.ExtraArgs.push_back("-Werror");
+
   Opts.DebuggerSupport |= Args.hasArg(OPT_debugger_support);
+
+  Opts.DisableSourceImport |=
+      Args.hasArg(OPT_disable_clangimporter_source_import);
+
   return false;
 }
 

--- a/test/ClangImporter/disable-source-import.swift
+++ b/test/ClangImporter/disable-source-import.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t.mcp)
+
+// This should fail only if -disable-clangimporter-source-import is present.
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:    -enable-objc-interop -typecheck -I %S/Inputs/custom-modules \
+// RUN:    -module-cache-path %t.mcp %s | %FileCheck --allow-empty %s
+
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:    -enable-objc-interop -typecheck -o - -I %S/Inputs/custom-modules \
+// RUN:    -module-cache-path %t.mcp -disable-clangimporter-source-import %s \
+// RUN:    2>&1 | %FileCheck --check-prefix=ERROR %s
+
+import ExternIntX
+
+public let y = x // ERROR: error
+
+// CHECK-NOT: error


### PR DESCRIPTION
This is primarily meant to used for testing LLDB's DWARFImporterDelegate,
however, this could become the default option for LLDB once
DWARFImporterDelegate is sufficiently mature.

<rdar://problem/57880844>
