### PR TITLE
Always allow JSON fragments

### DIFF
--- a/stdlib/public/Darwin/Foundation/JSONEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/JSONEncoder.swift
@@ -270,7 +270,7 @@ open class JSONEncoder {
 
         let writingOptions = JSONSerialization.WritingOptions(rawValue: self.outputFormatting.rawValue)
         do {
-           return try JSONSerialization.data(withJSONObject: topLevel, options: writingOptions)
+           return try JSONSerialization.data(withJSONObject: topLevel, options: [writingOptions, .fragmentsAllowed])
         } catch {
             throw EncodingError.invalidValue(value, 
                                              EncodingError.Context(codingPath: [], debugDescription: "Unable to encode the given top-level value to JSON.", underlyingError: error))
@@ -1205,7 +1205,7 @@ open class JSONDecoder {
     open func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T {
         let topLevel: Any
         do {
-           topLevel = try JSONSerialization.jsonObject(with: data)
+           topLevel = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
         } catch {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: error))
         }

--- a/stdlib/public/Darwin/Foundation/JSONEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/JSONEncoder.swift
@@ -257,17 +257,6 @@ open class JSONEncoder {
                                              EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) did not encode any values."))
         }
 
-        if topLevel is NSNull {
-            throw EncodingError.invalidValue(value, 
-                                             EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) encoded as null JSON fragment."))
-        } else if topLevel is NSNumber {
-            throw EncodingError.invalidValue(value, 
-                                             EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) encoded as number JSON fragment."))
-        } else if topLevel is NSString {
-            throw EncodingError.invalidValue(value, 
-                                             EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) encoded as string JSON fragment."))
-        }
-
         let writingOptions = JSONSerialization.WritingOptions(rawValue: self.outputFormatting.rawValue)
         do {
            return try JSONSerialization.data(withJSONObject: topLevel, options: [writingOptions, .fragmentsAllowed])


### PR DESCRIPTION
<!-- What's in this pull request? -->
This updates the public versions of `JSONEncoder` and `JSONDecoder` to match the behavior shipped with the stdlib in iOS 13. More specifically, always passing `.fragmentsAllowed` to `JSONSerialization`'s reading/writing options.

For more information see:
* https://bugs.swift.org/browse/SR-6163
* https://drewag.me/posts/2019/09/11/json-encoder-change-in-swift-5

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-6163.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
