### PR TITLE
[5.2] [Typechecker] Fix a few regressions related to use of @autoclosure

### DIFF
--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -281,3 +281,14 @@ func test_autoclosure_with_generic_argument_mismatch() {
 
   foo(S<String>()) // expected-error {{cannot convert value of type 'S<String>' to expected argument type 'S<Int>'}}
 }
+
+// SR-11934
+func sr_11934(_ x: @autoclosure String...) {} // expected-error {{'@autoclosure' must not be used on variadic parameters}}
+
+// SR-11938
+let sr_11938_1: Array<@autoclosure String> = [] // expected-error {{'@autoclosure' may only be used on parameters}}
+func sr_11938_2() -> @autoclosure String { "" } // expected-error {{'@autoclosure' may only be used on parameters}}
+func sr_11938_3(_ x: [@autoclosure String]) {} // expected-error {{'@autoclosure' may only be used on parameters}}
+
+protocol SR_11938_P {}
+struct SR_11938_S : @autoclosure SR_11938_P {} // expected-error {{'@autoclosure' may only be used on parameters}}


### PR DESCRIPTION
Cherry-pick of #28677, with a small tweak (it's called `getConvention` instead of `getConventionName` on 5.2 branch).

- __Explanation__: There were a few regressions around the use of `@autoclosure` since Swift 5.1. The issues were mostly around `@autoclosure` being accepted in non-parameter positions, plus a crash.

- __Scope__: Affects the use of `@autoclosure` attribute

- __Issue__: SR-11934 | SR-11938 | rdar://problem/57824033

- __Risk__: Very low. This fixes regressions and a crash.

- __Testing__: Swift CI testing (validation and source compat)

- __Reviewed by__: @xedin
