### PR TITLE
[Typechecker] Fix a crash related to use of invalid @autoclosure param

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2265,6 +2265,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
 
   // Validate use of @autoclosure
   if (attrs.has(TAK_autoclosure)) {
+    bool didDiagnose = false;
     if (attrs.hasConvention()) {
       if (attrs.getConventionName() == "c" ||
           attrs.getConventionName() == "block") {
@@ -2272,16 +2273,23 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
                  diag::invalid_autoclosure_and_convention_attributes,
                  attrs.getConventionName());
         attrs.clearAttribute(TAK_convention);
+        didDiagnose = true;
       }
     } else if (options.is(TypeResolverContext::VariadicFunctionInput) &&
                !options.hasBase(TypeResolverContext::EnumElementDecl)) {
       diagnose(attrs.getLoc(TAK_autoclosure),
                diag::attr_not_on_variadic_parameters, "@autoclosure");
       attrs.clearAttribute(TAK_autoclosure);
+      didDiagnose = true;
     } else if (!options.is(TypeResolverContext::FunctionInput)) {
       diagnose(attrs.getLoc(TAK_autoclosure), diag::attr_only_on_parameters,
                "@autoclosure");
       attrs.clearAttribute(TAK_autoclosure);
+      didDiagnose = true;
+    }
+
+    if (didDiagnose) {
+      ty = ErrorType::get(Context);
     }
   }
 

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5
 
 // Simple case.
-var fn : @autoclosure () -> Int = 4  // expected-error {{'@autoclosure' may only be used on parameters}}  expected-error {{cannot convert value of type 'Int' to specified type '() -> Int'}}
+var fn : @autoclosure () -> Int = 4  // expected-error {{'@autoclosure' may only be used on parameters}}
 
 @autoclosure func func1() {}  // expected-error {{attribute can only be applied to types, not declarations}}
 

--- a/validation-test/compiler_crashers_2_fixed/sr11939.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11939.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend %s -typecheck -verify
+
+func sr_11939(_ closure: @autoclosure () -> String...) {} // expected-error {{'@autoclosure' must not be used on variadic parameters}}
+sr_11939("A") // No crash


### PR DESCRIPTION
The following code was hitting an assert in CSApply in Swift 5.2 (it didn't in 5.1):

```swift
func foo(_ closure: @autoclosure () -> String...) {} // gets diagnosed
foo("A") // but crashes here (although it shouldn't)
```

This seems like one of those problems where we need to do some sort of "invalidation" however invalidating the `TypeRepr` does not work, but setting an `ErrorType` does.

Resolves SR-11939
Resolves rdar://problem/57888481