### PR TITLE
[5.2] [Dynamic casting] Fix overrelease on unsuccessful cast to an Error type.

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2439,7 +2439,10 @@ static bool swift_dynamicCastImpl(OpaqueValue *dest, OpaqueValue *src,
 #if SWIFT_OBJC_INTEROP
       // If the source is an NSError, and the target is a bridgeable
       // Error, try to bridge.
-      if (tryDynamicCastNSErrorToValue(dest, src, srcType, targetType, flags)) {
+      auto innerFlags = flags - DynamicCastFlags::Unconditional
+                              - DynamicCastFlags::DestroyOnFailure;
+      if (tryDynamicCastNSErrorToValue(dest, src, srcType, targetType,
+                                       innerFlags)) {
         return true;
       }
 #endif

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -815,4 +815,20 @@ ErrorBridgingTests.test("CFError-to-Error casts") {
   }
 }
 
+enum MyError: Error {
+  case someThing
+}
+
+ErrorBridgingTests.test("SR-9207 crash in failed cast to NSError") {
+
+  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+    let error = MyError.someThing
+    let foundationError = error as NSError
+
+    if let urlError = foundationError as? URLError {
+      expectUnreachable()
+    }
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
Fixes SR-9207 / rdar://problem/45961622, SR-10478 / rdar://problem/49906841,
and rdar://problem/50665156.
