### PR TITLE
[Driver, Incremental] Improved fine-grained dependency graph & on-by-default

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -325,7 +325,7 @@ private:
 /// Write out the .swiftdeps file for a frontend compilation of a primary file.
 bool emitReferenceDependencies(DiagnosticEngine &diags, SourceFile *SF,
                                const DependencyTracker &depTracker,
-                               StringRef outputPath);
+                               StringRef outputPath, bool alsoEmitDotFile);
 //==============================================================================
 // MARK: Enums
 //==============================================================================
@@ -449,7 +449,7 @@ public:
   StringRef getContext() const { return context; }
   StringRef getName() const { return name; }
 
-  StringRef getSwiftDepsFromSourceFileProvide() const {
+  StringRef getSwiftDepsFromASourceFileProvideNodeKey() const {
     assert(getKind() == NodeKind::sourceFileProvide &&
            "Receiver must be sourceFileProvide.");
     return getName();
@@ -494,8 +494,11 @@ public:
   static std::string computeNameForProvidedEntity(Entity);
 
   /// Given some type of depended-upon entity create the key.
-  template <NodeKind kind, typename Entity>
-  static DependencyKey createDependedUponKey(const Entity &);
+  static DependencyKey createDependedUponKey(StringRef mangledHolderName,
+                                             StringRef memberBaseName);
+
+  template <NodeKind kind>
+  static DependencyKey createDependedUponKey(StringRef);
 
   std::string humanReadableName() const;
 
@@ -684,6 +687,8 @@ public:
   }
 
   /// Record the sequence number, \p n, of another use.
+  /// The relationship between an interface and its implementation is NOT included here.
+  /// See \c SourceFileDepGraph::findExistingNodePairOrCreateAndAddIfNew.
   void addDefIDependUpon(size_t n) {
     if (n != getSequenceNumber())
       defsIDependUpon.insert(n);
@@ -727,6 +732,24 @@ public:
   SourceFileDepGraph(const SourceFileDepGraph &g) = delete;
   SourceFileDepGraph(SourceFileDepGraph &&g) = default;
 
+  /// Simulate loading for unit testing:
+  /// \param swiftDepsFileName The name of the swiftdeps file of the phony job
+  /// \param includePrivateDeps Whether the graph includes intra-file arcs
+  /// \param hadCompilationError Simulate a compilation error
+  /// \param interfaceHash The interface hash of the simulated graph
+  /// \param simpleNamesByRDK A map of vectors of names keyed by reference dependency key
+  /// \param compoundNamesByRDK A map of (mangledHolder,
+  /// baseName) pairs keyed by reference dependency key. For single-name dependencies, an initial
+  /// underscore indicates that the name does not cascade. For compound names, it is the
+  /// first name, the holder which indicates non-cascading. For member names, an
+  /// initial underscore indicates file-privacy.
+  static SourceFileDepGraph simulateLoad(
+      std::string swiftDepsFileName, const bool includePrivateDeps,
+      const bool hadCompilationError, std::string interfaceHash,
+      llvm::StringMap<std::vector<std::string>> simpleNamesByRDK,
+      llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
+        compoundNamesByRDK);
+
   /// Nodes are owned by the graph.
   ~SourceFileDepGraph() {
     forEachNode([&](SourceFileDepGraphNode *n) { delete n; });
@@ -746,7 +769,7 @@ public:
   InterfaceAndImplementationPair<SourceFileDepGraphNode>
   getSourceFileNodePair() const;
 
-  StringRef getSwiftDepsFromSourceFileProvide() const;
+  StringRef getSwiftDepsOfJobThatProducedThisGraph() const;
 
   std::string getGraphID() const {
     return getSourceFileNodePair().getInterface()->getKey().humanReadableName();
@@ -892,7 +915,7 @@ private:
   }
   void emitArcs() {
     g.forEachArc([&](const NodeT *def, const NodeT *use) {
-      if (includeGraphArc(use, def))
+      if (includeGraphArc(def, use))
         emitGraphArc(def, use);
     });
   }

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -282,10 +282,14 @@ namespace swift {
     /// Whether to verify the parsed syntax tree and emit related diagnostics.
     bool VerifySyntaxTree = false;
 
-    /// Scaffolding to permit experimentation with finer-grained dependencies
-    /// and faster rebuilds.
+    /// Emit the newer, finer-grained swiftdeps file. Eventually will support
+    /// faster rebuilds.
     bool EnableFineGrainedDependencies = false;
-    
+
+    /// When using fine-grained dependencies, emit dot files for every swiftdeps
+    /// file.
+    bool EmitFineGrainedDependencySourcefileDotFiles = false;
+
     /// To mimic existing system, set to false.
     /// To experiment with including file-private and private dependency info,
     /// set to true.

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -168,6 +168,26 @@ public:
   static bool classof(const Action *A) {
     return A->getKind() == Action::Kind::CompileJob;
   }
+
+  /// Return a _single_ TY_Swift InputAction, if one exists;
+  /// if 0 or >1 such inputs exist, return nullptr.
+  const InputAction *findSingleSwiftInput() const {
+    auto Inputs = getInputs();
+    const InputAction *IA = nullptr;
+    for (auto const *I : Inputs) {
+      if (auto const *S = dyn_cast<InputAction>(I)) {
+        if (S->getType() == file_types::TY_Swift) {
+          if (IA == nullptr) {
+            IA = S;
+          } else {
+            // Already found one, two is too many.
+            return nullptr;
+          }
+        }
+      }
+    }
+    return IA;
+  }
 };
 
 class InterpretJobAction : public JobAction {

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -521,6 +521,18 @@ public:
   /// How many .swift input files?
   unsigned countSwiftInputs() const;
 
+  /// Unfortunately the success or failure of a Swift compilation is currently
+  /// sensitive to the order in which files are processed, at least in terms of
+  /// the order of processing extensions (and likely other ways we haven't
+  /// discovered yet). So long as this is true, we need to make sure any batch
+  /// job we build names its inputs in an order that's a subsequence of the
+  /// sequence of inputs the driver was initially invoked with.
+  ///
+  /// Also use to write out information in a consistent order.
+  void sortJobsToMatchCompilationInputs(
+      ArrayRef<const Job *> unsortedJobs,
+      SmallVectorImpl<const Job *> &sortedJobs) const;
+
 private:
   /// Perform all jobs.
   ///

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -48,9 +48,9 @@ namespace fine_grained_dependencies {
 /// Keep separate type from Node for type-checking.
 class ModuleDepGraphNode : public DepGraphNode {
 
-  /// The swiftDeps file that holds this entity.
+  /// The swiftDeps file that holds this entity iff this is a provides node.
   /// If more than one source file has the same DependencyKey, then there
-  /// will be one node for each in the driver.
+  /// will be one node for each in the driver, distinguished by this field.
   Optional<std::string> swiftDeps;
 
 public:
@@ -76,26 +76,18 @@ public:
 
   const Optional<std::string> &getSwiftDeps() const { return swiftDeps; }
 
-  bool assertImplementationMustBeInAFile() const {
-    assert((getSwiftDeps().hasValue() || !getKey().isImplementation()) &&
-           "Implementations must be in some file.");
-    return true;
+  std::string getSwiftDepsOrEmpty() const {
+    return getSwiftDeps().getValueOr(std::string());
   }
 
-  std::string humanReadableName() const {
-    StringRef where =
-        !getSwiftDeps().hasValue()
-            ? ""
-            : llvm::sys::path::filename(getSwiftDeps().getValue());
-    return DepGraphNode::humanReadableName(where);
+  std::string getSwiftDepsForMapKey() const {
+    // Use the empty string for nodes whose source file is unknown,
+    // i.e. depends. (Known depends are represented by arcs, not nodes.)
+    return getSwiftDepsOrEmpty();
   }
 
-  SWIFT_DEBUG_DUMP;
-
-  bool assertProvidedEntityMustBeInAFile() const {
-    assert((getSwiftDeps().hasValue() || !getKey().isImplementation()) &&
-           "Implementations must be in some file.");
-    return true;
+  const std::string &getSwiftDepsOfProvides() const {
+    return getSwiftDeps().getValue();
   }
 
   /// Nodes can move from file to file when the driver reads the result of a
@@ -103,6 +95,29 @@ public:
   void setSwiftDeps(Optional<std::string> s) { swiftDeps = s; }
 
   bool getIsProvides() const { return getSwiftDeps().hasValue(); }
+
+  /// Return true if this node describes a definition for which the job is known
+  bool isDefinedInAKnownFile() const { return getIsProvides(); }
+
+  bool doesNodeProvideAnInterface() const {
+    return getKey().isInterface() && getIsProvides();
+  }
+
+  bool assertImplementationMustBeInAFile() const {
+    assert((isDefinedInAKnownFile() || !getKey().isImplementation()) &&
+           "Implementations must be in some file.");
+    return true;
+  }
+
+  std::string humanReadableName() const {
+    StringRef where = !getIsProvides()
+                          ? ""
+                          : llvm::sys::path::filename(getSwiftDepsOfProvides());
+    return DepGraphNode::humanReadableName(where);
+  }
+
+  SWIFT_DEBUG_DUMP;
+
 };
 
 /// A placeholder allowing the experimental system to fit into the driver
@@ -159,18 +174,10 @@ class ModuleDepGraph {
   std::unordered_set<std::string> externalDependencies;
 
   /// The new version of "Marked."
-  /// Record cascading jobs by swiftDepsFilename because that's what
-  /// nodes store directly.
-  ///
-  /// The status quo system uses "cascade" for the following:
-  /// Def1 -> def2 -> def3, where arrows are uses, so 3 depends on 2 which
-  /// depends on 1. The first use is said to "cascade" if when def1 changes,
-  /// def3 is dirtied.
-  /// TODO: Move cascadingJobs out of the graph, ultimately.
-  /// If marked, any Job that depends on me must be rebuilt after compiling me
-  /// if I have changed.
-
-  std::unordered_set<std::string> cascadingJobs;
+  /// Aka "isMarked". Holds the swiftDeps paths for jobs the driver has or will
+  /// schedule.
+  /// TODO: Move scheduledJobs out of the graph, ultimately.
+  std::unordered_set<std::string> swiftDepsOfJobsThatNeedRunning;
 
   /// Keyed by swiftdeps filename, so we can get back to Jobs.
   std::unordered_map<std::string, const driver::Job *> jobsBySwiftDeps;
@@ -190,10 +197,12 @@ class ModuleDepGraph {
   const bool verifyFineGrainedDependencyGraphAfterEveryImport;
   const bool emitFineGrainedDependencyDotFileAfterEveryImport;
 
-  /// If tracing dependencies, holds the current node traversal path
+  /// If tracing dependencies, holds a vector used to hold the current path
+  /// def - use/def - use/def - ...
   Optional<std::vector<const ModuleDepGraphNode *>> currentPathIfTracing;
 
-  /// If tracing dependencies, record the node sequence
+  /// If tracing dependencies, holds the sequence of defs used to get to the job
+  /// that is the key
   std::unordered_multimap<const driver::Job *,
                           std::vector<const ModuleDepGraphNode *>>
       dependencyPathsToJobs;
@@ -204,7 +213,7 @@ class ModuleDepGraph {
   /// Encapsulate the invariant between where the node resides in
   /// nodesBySwiftDepsFile and the swiftDeps node instance variable here.
   void addToMap(ModuleDepGraphNode *n) {
-    nodeMap.insert(n->getSwiftDeps().getValueOr(std::string()), n->getKey(), n);
+    nodeMap.insert(n->getSwiftDepsForMapKey(), n->getKey(), n);
   }
 
   /// When integrating a SourceFileDepGraph, there might be a node representing
@@ -223,13 +232,34 @@ class ModuleDepGraph {
   /// Remove node from nodeMap, check invariants.
   ModuleDepGraphNode *eraseNodeFromMap(ModuleDepGraphNode *nodeToErase) {
     ModuleDepGraphNode *nodeActuallyErased = nodeMap.findAndErase(
-        nodeToErase->getSwiftDeps().getValueOr(std::string()),
-        nodeToErase->getKey());
+        nodeToErase->getSwiftDepsForMapKey(), nodeToErase->getKey());
     (void)nodeActuallyErased;
     assert(
         nodeToErase == nodeActuallyErased ||
         mapCorruption("Node found from key must be same as node holding key."));
     return nodeToErase;
+  }
+
+  void eraseNodeFromUsesByDef(ModuleDepGraphNode *nodeToErase) {
+    for (auto &defAndUses : usesByDef)
+      defAndUses.second.erase(nodeToErase);
+  }
+
+  void eraseNodeFromCurrentPathIfTracing(ModuleDepGraphNode *nodeToErase) {
+    if (currentPathIfTracing)
+      eraseNodeFromVector(currentPathIfTracing.getValue(), nodeToErase);
+  }
+
+  void eraseNodeFromDependencyPathToJobs(ModuleDepGraphNode *nodeToErase) {
+    for (auto &jobAndPath : dependencyPathsToJobs)
+      eraseNodeFromVector(jobAndPath.second, nodeToErase);
+  }
+
+  static void eraseNodeFromVector(std::vector<const ModuleDepGraphNode *> &v,
+                                  const ModuleDepGraphNode *n) {
+    const auto where = std::find(v.begin(), v.end(), n);
+    if (where != v.end())
+      v.erase(where);
   }
 
   static StringRef getSwiftDeps(const driver::Job *cmd) {
@@ -268,12 +298,21 @@ public:
     assert(verify() && "ModuleDepGraph should be fine when created");
   }
 
+  ModuleDepGraph() : ModuleDepGraph(false, false, false, nullptr) {}
+
   /// Unlike the standard \c CoarseGrainedDependencyGraph, returns \c
   /// CoarseGrainedDependencyGraphImpl::LoadResult::AffectsDownstream when
   /// loading a new file, i.e. when determining the initial set. Caller
   /// compensates.
   CoarseGrainedDependencyGraphImpl::LoadResult
   loadFromPath(const driver::Job *, StringRef, DiagnosticEngine &);
+
+  CoarseGrainedDependencyGraphImpl::LoadResult
+  loadFromString(const driver::Job *cmd, StringRef data);
+
+  CoarseGrainedDependencyGraphImpl::LoadResult
+  loadFromSourceFileDepGraph(const driver::Job *cmd,
+                             const SourceFileDepGraph &);
 
   /// For the dot file.
   std::string getGraphID() const { return "driver"; }
@@ -302,8 +341,12 @@ public:
   /// 1. Return value (via visited) is the set of jobs needing recompilation
   /// after this one, and
   /// 2. Jobs not previously known to need dependencies reexamined after they
-  /// are recompiled. Such jobs are added to the \ref cascadingJobs set, and
+  /// are recompiled. Such jobs are added to the \ref scheduledJobs set, and
   /// accessed via \ref isMarked.
+  ///
+  /// Only return jobs marked that were previously unmarked. Not required for
+  /// the driver because it won't run a job twice, but required for the unit
+  /// test.
   std::vector<const driver::Job*> markTransitive(
       const driver::Job *jobToBeRecompiled, const void *ignored = nullptr);
 
@@ -315,6 +358,8 @@ public:
 
   std::vector<StringRef> getExternalDependencies() const;
 
+  /// Find jobs that were previously not known to need compilation but that
+  /// depend on \c externalDependency.
   std::vector<const driver::Job*> markExternal(StringRef externalDependency);
 
   void forEachUnmarkedJobDirectlyDependentOnExternalSwiftdeps(
@@ -428,13 +473,13 @@ private:
   /// Given a definition node, and a list of already found dependents,
   /// recursively add transitive closure of dependents of the definition
   /// into the already found dependents.
-  /// Also record any dependents that "cascade", i.e. whose dependencies must be
-  /// recomputed after recompilation so that its dependents can be recompiled.
-  void findDependentNodesAndRecordCascadingOnes(
+  void findDependentNodes(
       std::unordered_set<const ModuleDepGraphNode *> &foundDependents,
       const ModuleDepGraphNode *definition);
 
-  std::vector<const driver::Job*> computeUniqueJobsFromNodes(
+  /// Givien a set of nodes, return the set of swiftDeps for the jobs those
+  /// nodes are in.
+  llvm::StringSet<> computeSwiftDepsFromInterfaceNodes(
       const std::unordered_set<const ModuleDepGraphNode *> &nodes);
 
   /// Record a visit to this node for later dependency printing
@@ -447,9 +492,9 @@ private:
       const std::vector<const ModuleDepGraphNode *> &pathToJob,
       const driver::Job *dependentJob);
 
-  /// Return true if job did not cascade before
-  bool rememberThatJobCascades(StringRef swiftDeps) {
-    return cascadingJobs.insert(swiftDeps).second;
+  /// Return true if job was not scheduled before
+  bool recordJobNeedsRunning(StringRef swiftDeps) {
+    return swiftDepsOfJobsThatNeedRunning.insert(swiftDeps).second;
   }
 
   /// For debugging, write out the graph to a dot file.
@@ -469,6 +514,13 @@ public:
   void printPath(raw_ostream &out, const driver::Job *node) const;
 
 private:
+  /// Get a printable filename, given a node's swiftDeps.
+  StringRef getProvidingFilename(Optional<std::string> swiftDeps) const;
+
+  /// Print one node on the dependency path.
+  static void printOneNodeOfPath(raw_ostream &out, const DependencyKey &key,
+                                 const StringRef filename);
+
   bool isCurrentPathForTracingEmpty() const {
     return !currentPathIfTracing.hasValue() || currentPathIfTracing->empty();
   }

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -150,6 +150,9 @@ class CommandOutput {
 public:
   CommandOutput(file_types::ID PrimaryOutputType, OutputFileMap &Derived);
 
+  /// For testing dependency graphs that use Jobs
+  CommandOutput(StringRef dummyBaseName, OutputFileMap &);
+
   /// Return the primary output type for this CommandOutput.
   file_types::ID getPrimaryOutputType() const;
 
@@ -318,6 +321,12 @@ public:
         Executable(Executable), Arguments(std::move(Arguments)),
         ExtraEnvironment(std::move(ExtraEnvironment)),
         FilelistFileInfos(std::move(Infos)), ResponseFile(ResponseFile) {}
+
+  /// For testing dependency graphs that use Jobs
+  Job(OutputFileMap &OFM, StringRef dummyBaseName)
+      : Job(CompileJobAction(file_types::TY_Object),
+            SmallVector<const Job *, 4>(),
+            std::make_unique<CommandOutput>(dummyBaseName, OFM), nullptr, {}) {}
 
   virtual ~Job();
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -137,7 +137,11 @@ def driver_always_rebuild_dependents :
 
 def enable_fine_grained_dependencies :
 Flag<["-"], "enable-fine-grained-dependencies">, Flags<[FrontendOption, HelpHidden]>,
-HelpText<"Experimental work-in-progress to be more selective about incremental recompilation">;
+HelpText<"Be more selective about incremental recompilation">;
+
+def disable_fine_grained_dependencies :
+Flag<["-"], "disable-fine-grained-dependencies">, Flags<[FrontendOption, HelpHidden]>,
+HelpText<"Don't be more selective about incremental recompilation">;
 
 
 def enable_only_one_dependency_file :
@@ -182,6 +186,11 @@ def fine_grained_dependency_include_intrafile :
 Flag<["-"], "fine-grained-dependency-include-intrafile">,
 InternalDebugOpt,
 HelpText<"Include within-file dependencies.">;
+
+def emit_fine_grained_dependency_sourcefile_dot_files :
+Flag<["-"], "emit-fine-grained-dependency-sourcefile-dot-files">,
+InternalDebugOpt,
+HelpText<"Emit dot files for every source file.">;
 
 def driver_mode : Joined<["--"], "driver-mode=">, Flags<[HelpHidden]>,
   HelpText<"Set the driver mode to either 'swift' or 'swiftc'">;

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -57,11 +57,11 @@ SourceFileDepGraph::getSourceFileNodePair() const {
                                                                 getNode(1));
 }
 
-StringRef SourceFileDepGraph::getSwiftDepsFromSourceFileProvide() const {
+StringRef SourceFileDepGraph::getSwiftDepsOfJobThatProducedThisGraph() const {
   return getSourceFileNodePair()
       .getInterface()
       ->getKey()
-      .getSwiftDepsFromSourceFileProvide();
+      .getSwiftDepsFromASourceFileProvideNodeKey();
 }
 
 void SourceFileDepGraph::forEachArc(
@@ -86,8 +86,11 @@ SourceFileDepGraph::findExistingNodePairOrCreateAndAddIfNew(
       findExistingNodeOrCreateIfNew(
           DependencyKey(k, DeclAspect::implementation, context, name),
           fingerprint, true /* = isProvides */)};
-  // if interface changes, have to rebuild implementation
-  addArc(nodePair.getInterface(), nodePair.getImplementation());
+  // if interface changes, have to rebuild implementation.
+  // But, if an arc is added for this, then *any* change that causes
+  // a same-named interface to be dirty will dirty this implementation,
+  // even if that interface is in another file.
+  // So, make the interface->implementation arc implicit.
   return nodePair;
 }
 

--- a/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
+++ b/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/FileSystem.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/ReferenceDependencyKeys.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Frontend/FrontendOptions.h"
 #include "llvm/ADT/MapVector.h"
@@ -214,8 +215,11 @@ public:
 private:
   /// Extensions may contain nominals and operators.
   void findNominalsFromExtensions() {
-    for (auto *ED : extensions)
-      findNominalsAndOperatorsIn(ED->getExtendedNominal(), ED);
+    for (auto *ED : extensions) {
+      const auto *const NTD = ED->getExtendedNominal();
+      if (NTD)
+        findNominalsAndOperatorsIn(NTD, ED);
+    }
   }
   /// Top-level nominals may contain nominals and operators.
   void findNominalsInTopNominals() {
@@ -260,16 +264,19 @@ private:
   /// Extensions may contain ValueDecls.
   void findValuesInExtensions() {
     for (const auto *ED : extensions) {
-      if (excludeIfPrivate(ED->getExtendedNominal()))
+      const auto *const NTD = ED->getExtendedNominal();
+      if (!NTD || excludeIfPrivate(NTD))
         continue;
       if (!includePrivateDecls &&
           (!allInheritedProtocolsArePrivate(ED) || allMembersArePrivate(ED)))
         continue;
       for (const auto *member : ED->getMembers())
         if (const auto *VD = dyn_cast<ValueDecl>(member))
-          if (VD->hasName() && (includePrivateDecls || !declIsPrivate(VD)))
-            valuesInExtensions.push_back(
-                std::make_pair(ED->getExtendedNominal(), VD));
+          if (VD->hasName() && (includePrivateDecls || !declIsPrivate(VD))) {
+            const auto *const NTD = ED->getExtendedNominal();
+            if (NTD)
+              valuesInExtensions.push_back(std::make_pair(NTD, VD));
+          }
     }
   }
 
@@ -424,46 +431,38 @@ std::string DependencyKey::computeNameForProvidedEntity<
 
 template <>
 DependencyKey
-DependencyKey::createDependedUponKey<NodeKind::topLevel, DeclBaseName>(
-    const DeclBaseName &dbn) {
-  return DependencyKey(NodeKind::topLevel, DeclAspect::interface, "",
-                       dbn.userFacingName());
+DependencyKey::createDependedUponKey<NodeKind::topLevel>(StringRef name) {
+  return DependencyKey(NodeKind::topLevel, DeclAspect::interface, "", name);
 }
 
 template <>
 DependencyKey
-DependencyKey::createDependedUponKey<NodeKind::dynamicLookup, DeclBaseName>(
-    const DeclBaseName &dbn) {
+DependencyKey::createDependedUponKey<NodeKind::dynamicLookup>(StringRef name) {
   return DependencyKey(NodeKind::dynamicLookup, DeclAspect::interface, "",
-                       dbn.userFacingName());
+                       name);
 }
 
 template <>
-DependencyKey DependencyKey::createDependedUponKey<
-    NodeKind::nominal, std::pair<const NominalTypeDecl *, DeclBaseName>>(
-    const std::pair<const NominalTypeDecl *, DeclBaseName> &p) {
-  return DependencyKey(NodeKind::nominal, DeclAspect::interface,
-                       mangleTypeAsContext(p.first), "");
+DependencyKey
+DependencyKey::createDependedUponKey<NodeKind::externalDepend>(StringRef name) {
+  return DependencyKey(NodeKind::externalDepend, DeclAspect::interface, "",
+                       name);
 }
 
 template <>
-DependencyKey DependencyKey::createDependedUponKey<
-    NodeKind::member, std::pair<const NominalTypeDecl *, DeclBaseName>>(
-    const std::pair<const NominalTypeDecl *, DeclBaseName> &p) {
-  const bool isMemberBlank = p.second.empty();
+DependencyKey
+DependencyKey::createDependedUponKey<NodeKind::nominal>(StringRef mangledName) {
+  return DependencyKey(NodeKind::nominal, DeclAspect::interface, mangledName,
+                       "");
+}
+
+DependencyKey DependencyKey::createDependedUponKey(StringRef mangledHolderName,
+                                                   StringRef memberBaseName) {
+  const bool isMemberBlank = memberBaseName.empty();
   const auto kind =
       isMemberBlank ? NodeKind::potentialMember : NodeKind::member;
-  return DependencyKey(kind, DeclAspect::interface,
-                       mangleTypeAsContext(p.first),
-                       isMemberBlank ? "" : p.second.userFacingName());
-}
-
-template <>
-DependencyKey
-DependencyKey::createDependedUponKey<NodeKind::externalDepend, std::string>(
-    const std::string &file) {
-  return DependencyKey(NodeKind::externalDepend, DeclAspect::interface, "",
-                       file);
+  return DependencyKey(kind, DeclAspect::interface, mangledHolderName,
+                       isMemberBlank ? "" : memberBaseName);
 }
 
 //==============================================================================
@@ -475,12 +474,6 @@ namespace {
 /// Reads the information provided by the frontend and builds the
 /// SourceFileDepGraph
 class SourceFileDepGraphConstructor {
-  /// The SourceFile containing the Decls.
-  SourceFile *SF;
-
-  /// Furnishes depended-upon names resulting from lookups.
-  const DependencyTracker &depTracker;
-
   /// Name of the swiftDeps file, for inclusion in the constructed graph.
   StringRef swiftDeps; // TODO rm?
 
@@ -491,18 +484,134 @@ class SourceFileDepGraphConstructor {
   /// If there was an error, cannot get accurate info.
   const bool hadCompilationError;
 
+  /// Functions as the fingerprint of the entire file
+  const std::string interfaceHash;
+
+  /// Top-level base names of decls that are depended-upon and a flag indicating
+  /// if the dependency "cascades"
+  const std::vector<std::pair<std::string, bool>> topLevelDepends;
+
+  /// A mangled nominal name and the member base name that are depended-upon,
+  /// a flag indicating if the member is private to its enclosing file, and
+  /// a flag indicating if the dependency cascades.
+  const std::vector<std::pair<std::tuple<std::string, std::string, bool>, bool>>
+      memberDepends;
+
+  /// The base name of a class member depended-upon for dynamic lookup, and a
+  /// cascades flag.
+  const std::vector<std::pair<std::string, bool>> dynamicLookupDepends;
+
+  /// The paths of swiftdeps files of other modules that are depended-upon.
+  const std::vector<std::string> externalDependencies;
+
+  /// Provided names
+
+  std::vector<std::pair<std::string, std::string>> precedenceGroups;
+  std::vector<std::pair<std::string, std::string>> memberOperatorDecls;
+  std::vector<std::pair<std::string, std::string>> operators;
+  std::vector<std::pair<std::string, std::string>> topNominals;
+  std::vector<std::pair<std::string, std::string>> topValues;
+  std::vector<std::pair<std::string, std::string>> allNominals;
+  std::vector<std::pair<std::string, std::string>> potentialMemberHolders;
+  std::vector<std::pair<std::string, std::string>> valuesInExtensions;
+  std::vector<std::pair<std::string, std::string>> classMembers;
+
   /// Graph under construction
   SourceFileDepGraph g;
 
 public:
-  SourceFileDepGraphConstructor(SourceFile *SF,
+  /// Expose this layer to enable faking up a constructor for testing.
+  /// See the instance variable comments for explanation.
+  // clang-format off
+  SourceFileDepGraphConstructor(
+    StringRef swiftDeps,
+    bool includePrivateDeps,
+    bool hadCompilationError,
+    const std::string &interfaceHash,
+    ArrayRef<std::pair<std::string, bool>> topLevelDepends,
+    ArrayRef<std::pair<std::tuple<std::string, std::string, bool>, bool>> memberDepends,
+    ArrayRef<std::pair<std::string, bool>> dynamicLookupDepends,
+    ArrayRef<std::string> externalDependencies,
+
+    ArrayRef<std::pair<std::string, std::string>> precedenceGroups,
+    ArrayRef<std::pair<std::string, std::string>> memberOperatorDecls,
+    ArrayRef<std::pair<std::string, std::string>> operators,
+    ArrayRef<std::pair<std::string, std::string>> topNominals,
+    ArrayRef<std::pair<std::string, std::string>> topValues,
+    ArrayRef<std::pair<std::string, std::string>> allNominals,
+    ArrayRef<std::pair<std::string, std::string>> potentialMemberHolders,
+    ArrayRef<std::pair<std::string, std::string>> valuesInExtensions,
+    ArrayRef<std::pair<std::string, std::string>> classMembers
+    ) :
+    swiftDeps(swiftDeps),
+    includePrivateDeps(includePrivateDeps),
+    hadCompilationError(hadCompilationError),
+
+    interfaceHash(interfaceHash),
+    topLevelDepends(topLevelDepends),
+    memberDepends(memberDepends),
+    dynamicLookupDepends(dynamicLookupDepends),
+    externalDependencies(externalDependencies),
+
+    precedenceGroups(precedenceGroups),
+    memberOperatorDecls(memberOperatorDecls),
+    operators(operators),
+    topNominals(topNominals),
+    topValues(topValues),
+    allNominals(allNominals),
+    potentialMemberHolders(potentialMemberHolders),
+    valuesInExtensions(valuesInExtensions),
+    classMembers(classMembers)
+    {}
+
+  SourceFileDepGraphConstructor static forSourceFile(SourceFile *SF,
                                 const DependencyTracker &depTracker,
                                 StringRef swiftDeps,
                                 const bool includePrivateDeps,
-                                const bool hadCompilationError)
-      : SF(SF), depTracker(depTracker), swiftDeps(swiftDeps),
-        includePrivateDeps(includePrivateDeps),
-        hadCompilationError(hadCompilationError) {}
+                                const bool hadCompilationError) {
+
+  SourceFileDeclFinder declFinder(SF, includePrivateDeps);
+    std::vector<std::pair<std::string, bool>> topLevelDepends;
+    for (const auto p: SF->getReferencedNameTracker()->getTopLevelNames())
+      topLevelDepends.push_back(std::make_pair(p.getFirst().userFacingName(), p.getSecond()));
+
+    std::vector<std::pair<std::string, bool>> dynamicLookupDepends;
+    for (const auto p: SF->getReferencedNameTracker()->getDynamicLookupNames())
+      dynamicLookupDepends.push_back(std::make_pair(p.getFirst().userFacingName(), p.getSecond()));
+
+    std::vector<std::pair<std::tuple<std::string, std::string, bool>, bool>> memberDepends;
+    for (const auto &p: SF->getReferencedNameTracker()->getUsedMembers())
+      memberDepends.push_back(
+        std::make_pair(
+          std::make_tuple(
+            mangleTypeAsContext(p.getFirst().first),
+            p.getFirst().second.userFacingName(),
+            declIsPrivate(p.getFirst().first)),
+          p.getSecond()));
+
+      return SourceFileDepGraphConstructor(
+        swiftDeps,
+        includePrivateDeps,
+        hadCompilationError,
+
+        getInterfaceHash(SF),
+        topLevelDepends,
+        memberDepends,
+        dynamicLookupDepends,
+        depTracker.getDependencies(),
+
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.precedenceGroups),
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.memberOperatorDecls),
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.operators),
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.topNominals),
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.topValues),
+        namesForProvidersOfAGivenType<NodeKind::nominal>(declFinder.allNominals),
+        namesForProvidersOfAGivenType<NodeKind::potentialMember>(declFinder.potentialMemberHolders),
+        namesForProvidersOfAGivenType<NodeKind::member>(declFinder.valuesInExtensions),
+        namesForProvidersOfAGivenType<NodeKind::dynamicLookup>(declFinder.classMembers)
+        );
+  }
+  // clang-format on
 
   /// Construct the graph and return it.
   SourceFileDepGraph construct() {
@@ -517,7 +626,7 @@ public:
   }
 
 private:
-  std::string getSourceFileFingerprint() const { return getInterfaceHash(SF); }
+  std::string getSourceFileFingerprint() const { return interfaceHash; }
 
   static std::string getInterfaceHash(SourceFile *SF) {
     llvm::SmallString<32> interfaceHash;
@@ -533,18 +642,27 @@ private:
   void addDependencyArcsToGraph();
 
   /// Given an array of Decls or pairs of them in \p declsOrPairs
-  /// create nodes if needed and add the new nodes to the graph.
+  /// create string pairs for context and name
   template <NodeKind kind, typename ContentsT>
-  void addAllProviderNodesOfAGivenType(std::vector<ContentsT> &contentsVec) {
-    for (const auto declOrPair : contentsVec) {
+  static std::vector<std::pair<std::string, std::string>>
+  namesForProvidersOfAGivenType(std::vector<ContentsT> &contentsVec) {
+    std::vector<std::pair<std::string, std::string>> result;
+    for (const auto declOrPair : contentsVec)
+      result.push_back(
+          {DependencyKey::computeContextForProvidedEntity<kind>(declOrPair),
+           DependencyKey::computeNameForProvidedEntity<kind>(declOrPair)});
+    return result;
+  }
+
+  template <NodeKind kind>
+  void addAllProviderNodesOfAGivenType(
+      ArrayRef<std::pair<std::string, std::string>> providers) {
+    for (const auto &contextAndName : providers) {
       // No fingerprints for providers (Decls) yet.
       // Someday ...
       const Optional<std::string> fingerprint = None;
       auto p = g.findExistingNodePairOrCreateAndAddIfNew(
-          kind,
-          DependencyKey::computeContextForProvidedEntity<kind>(declOrPair),
-          DependencyKey::computeNameForProvidedEntity<kind>(declOrPair),
-          fingerprint);
+          kind, contextAndName.first, contextAndName.second, fingerprint);
       // Since we don't have fingerprints yet, must rebuild every provider when
       // interfaceHash changes. So when interface (i.e. interface hash) of
       // sourceFile changes, every provides is dirty. And since we don't know
@@ -557,8 +675,8 @@ private:
   /// Given a map of names and isCascades, add the resulting dependencies to the
   /// graph.
   template <NodeKind kind>
-  void addAllDependenciesFrom(const llvm::DenseMap<DeclBaseName, bool> &map) {
-    for (const auto &p : map)
+  void addAllDependenciesFrom(ArrayRef<std::pair<std::string, bool>> names) {
+    for (const auto &p : names)
       recordThatThisWholeFileDependsOn(
           DependencyKey::createDependedUponKey<kind>(p.first), p.second);
   }
@@ -566,8 +684,7 @@ private:
   /// Given a map of holder-and-member-names and isCascades, add the resulting
   /// dependencies to the graph.
   void addAllDependenciesFrom(
-      const llvm::DenseMap<std::pair<const NominalTypeDecl *, DeclBaseName>,
-                           bool> &);
+      ArrayRef<std::pair<std::tuple<std::string, std::string, bool>, bool>>);
 
   /// Given an array of external swiftDeps files, add the resulting external
   /// dependencies to the graph.
@@ -587,28 +704,27 @@ private:
 };
 } // namespace
 
-using UsedMembersMap =
-    llvm::DenseMap<std::pair<const NominalTypeDecl *, DeclBaseName>, bool>;
 void SourceFileDepGraphConstructor::addAllDependenciesFrom(
-    const UsedMembersMap &map) {
+    ArrayRef<std::pair<std::tuple<std::string, std::string, bool>, bool>>
+        members) {
 
-  UsedMembersMap filteredMap;
-  for (const auto &entry : map)
-    if (includePrivateDeps || !declIsPrivate(entry.first.first))
-      filteredMap[entry.getFirst()] = entry.getSecond();
-
-  std::unordered_set<const NominalTypeDecl *> holdersOfCascadingMembers;
-  for (auto &entry : filteredMap)
+  llvm::StringSet<> holdersOfCascadingMembers;
+  for (const auto &entry : members) {
+    if (!includePrivateDeps && std::get<2>(entry.first))
+      continue;
     if (entry.second)
-      holdersOfCascadingMembers.insert(entry.first.first);
-
-  for (auto &entry : filteredMap) {
-    // mangles twice in the name of symmetry
+      holdersOfCascadingMembers.insert(std::get<0>(entry.first));
+  }
+  for (const auto &entry : members) {
+    if (!includePrivateDeps && std::get<2>(entry.first))
+      continue;
     recordThatThisWholeFileDependsOn(
-        DependencyKey::createDependedUponKey<NodeKind::nominal>(entry.first),
-        holdersOfCascadingMembers.count(entry.first.first) != 0);
+        DependencyKey::createDependedUponKey<NodeKind::nominal>(
+            std::get<0>(entry.first)),
+        holdersOfCascadingMembers.count(std::get<0>(entry.first)) != 0);
     recordThatThisWholeFileDependsOn(
-        DependencyKey::createDependedUponKey<NodeKind::member>(entry.first),
+        DependencyKey::createDependedUponKey(std::get<0>(entry.first),
+                                             std::get<1>(entry.first)),
         entry.second);
   }
 }
@@ -628,39 +744,32 @@ void SourceFileDepGraphConstructor::addSourceFileNodesToGraph() {
 }
 
 void SourceFileDepGraphConstructor::addProviderNodesToGraph() {
-  SourceFileDeclFinder declFinder(SF, includePrivateDeps);
   // TODO: express the multiple provides and depends streams with variadic
   // templates
 
   // Many kinds of Decls become top-level depends.
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(
-      declFinder.precedenceGroups);
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(
-      declFinder.memberOperatorDecls);
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(declFinder.operators);
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(declFinder.topNominals);
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(declFinder.topValues);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(precedenceGroups);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(memberOperatorDecls);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(operators);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(topNominals);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(topValues);
 
-  addAllProviderNodesOfAGivenType<NodeKind::nominal>(declFinder.allNominals);
+  addAllProviderNodesOfAGivenType<NodeKind::nominal>(allNominals);
 
   addAllProviderNodesOfAGivenType<NodeKind::potentialMember>(
-      declFinder.potentialMemberHolders);
-  addAllProviderNodesOfAGivenType<NodeKind::member>(
-      declFinder.valuesInExtensions);
+      potentialMemberHolders);
+  addAllProviderNodesOfAGivenType<NodeKind::member>(valuesInExtensions);
 
-  addAllProviderNodesOfAGivenType<NodeKind::dynamicLookup>(
-      declFinder.classMembers);
+  addAllProviderNodesOfAGivenType<NodeKind::dynamicLookup>(classMembers);
 }
 
 void SourceFileDepGraphConstructor::addDependencyArcsToGraph() {
   // TODO: express the multiple provides and depends streams with variadic
   // templates
-  addAllDependenciesFrom<NodeKind::topLevel>(
-      SF->getReferencedNameTracker()->getTopLevelNames());
-  addAllDependenciesFrom(SF->getReferencedNameTracker()->getUsedMembers());
-  addAllDependenciesFrom<NodeKind::dynamicLookup>(
-      SF->getReferencedNameTracker()->getDynamicLookupNames());
-  addAllDependenciesFrom(depTracker.getDependencies());
+  addAllDependenciesFrom<NodeKind::topLevel>(topLevelDepends);
+  addAllDependenciesFrom(memberDepends);
+  addAllDependenciesFrom<NodeKind::dynamicLookup>(dynamicLookupDepends);
+  addAllDependenciesFrom(externalDependencies);
 }
 
 void SourceFileDepGraphConstructor::recordThatThisWholeFileDependsOn(
@@ -676,7 +785,8 @@ void SourceFileDepGraphConstructor::recordThatThisWholeFileDependsOn(
 
 bool swift::fine_grained_dependencies::emitReferenceDependencies(
     DiagnosticEngine &diags, SourceFile *const SF,
-    const DependencyTracker &depTracker, StringRef outputPath) {
+    const DependencyTracker &depTracker, StringRef outputPath,
+    const bool alsoEmitDotFile) {
 
   // Before writing to the dependencies file path, preserve any previous file
   // that may have been there. No error handling -- this is just a nicety, it
@@ -685,8 +795,8 @@ bool swift::fine_grained_dependencies::emitReferenceDependencies(
   const bool includeIntrafileDeps =
       SF->getASTContext().LangOpts.FineGrainedDependenciesIncludeIntrafileOnes;
   const bool hadCompilationError = SF->getASTContext().hadError();
-  SourceFileDepGraphConstructor gc(SF, depTracker, outputPath,
-                                   includeIntrafileDeps, hadCompilationError);
+  auto gc = SourceFileDepGraphConstructor::forSourceFile(
+      SF, depTracker, outputPath, includeIntrafileDeps, hadCompilationError);
   SourceFileDepGraph g = gc.construct();
 
   const bool hadError =
@@ -697,12 +807,113 @@ bool swift::fine_grained_dependencies::emitReferenceDependencies(
         return false;
       });
 
-  assert(g.verifyReadsWhatIsWritten(outputPath));
+  assert(outputPath == "-" || g.verifyReadsWhatIsWritten(outputPath));
 
-  std::string dotFileName = outputPath.str() + ".dot";
-  withOutputFile(diags, dotFileName, [&](llvm::raw_pwrite_stream &out) {
-    DotFileEmitter<SourceFileDepGraph>(out, g, false, false).emit();
-    return false;
-  });
+  if (alsoEmitDotFile) {
+    std::string dotFileName = outputPath.str() + ".dot";
+    withOutputFile(diags, dotFileName, [&](llvm::raw_pwrite_stream &out) {
+      DotFileEmitter<SourceFileDepGraph>(out, g, false, false).emit();
+      return false;
+    });
+  }
   return hadError;
+}
+
+//==============================================================================
+// Entry point from the unit tests
+//==============================================================================
+
+static std::vector<std::pair<std::string, std::string>>
+getBaseNameProvides(ArrayRef<std::string> simpleNames) {
+  std::vector<std::pair<std::string, std::string>> result;
+  for (StringRef n : simpleNames)
+    result.push_back({"", n.str()});
+  return result;
+}
+
+static std::vector<std::pair<std::string, std::string>>
+getMangledHolderProvides(ArrayRef<std::string> simpleNames) {
+  std::vector<std::pair<std::string, std::string>> result;
+  for (StringRef n : simpleNames)
+    result.push_back({n.str(), ""});
+  return result;
+}
+
+static std::vector<std::pair<std::string, std::string>> getCompoundProvides(
+    ArrayRef<std::pair<std::string, std::string>> compoundNames) {
+  return compoundNames;
+}
+
+// Use '_' as a prefix indicating non-cascading
+static bool cascades(const std::string &s) { return s.empty() || s[0] != '_'; }
+
+// Use '_' as a prefix for a file-private member
+static bool isPrivate(const std::string &s) {
+  return !s.empty() && s[0] == '_';
+}
+
+static std::vector<std::pair<std::string, bool>>
+getSimpleDepends(ArrayRef<std::string> simpleNames) {
+  std::vector<std::pair<std::string, bool>> result;
+  for (std::string n : simpleNames)
+    result.push_back({n, cascades((n))});
+  return result;
+}
+
+static std::vector<std::string>
+getExternalDepends(ArrayRef<std::string> simpleNames) {
+  return simpleNames;
+}
+
+static std::vector<std::pair<std::tuple<std::string, std::string, bool>, bool>>
+getCompoundDepends(
+    ArrayRef<std::string> simpleNames,
+    ArrayRef<std::pair<std::string, std::string>> compoundNames) {
+  std::vector<std::pair<std::tuple<std::string, std::string, bool>, bool>>
+      result;
+  for (std::string n : simpleNames) {
+    // (On Linux, the compiler needs more verbosity than:
+    //  result.push_back({{n, "", false}, cascades(n)});
+    result.push_back(
+        std::make_pair(std::make_tuple(n, std::string(), false), cascades(n)));
+  }
+  for (auto &p : compoundNames) {
+    // Likewise, for Linux expand the following out:
+    //    result.push_back(
+    //        {{p.first, p.second, isPrivate(p.second)}, cascades(p.first)});
+    result.push_back(
+        std::make_pair(std::make_tuple(p.first, p.second, isPrivate(p.second)),
+                       cascades(p.first)));
+  }
+  return result;
+}
+
+SourceFileDepGraph SourceFileDepGraph::simulateLoad(
+    std::string swiftDepsFilename, const bool includePrivateDeps,
+    const bool hadCompilationError, std::string interfaceHash,
+    llvm::StringMap<std::vector<std::string>> simpleNamesByRDK,
+    llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
+        compoundNamesByRDK) {
+
+  using namespace reference_dependency_keys;
+
+  // clang-format off
+  SourceFileDepGraphConstructor c(
+    swiftDepsFilename, includePrivateDeps, hadCompilationError, interfaceHash,
+    getSimpleDepends(simpleNamesByRDK[dependsTopLevel]),
+    getCompoundDepends(simpleNamesByRDK[dependsNominal], compoundNamesByRDK[dependsMember]),
+    getSimpleDepends(simpleNamesByRDK[dependsDynamicLookup]),
+    getExternalDepends(simpleNamesByRDK[dependsExternal]),
+    {}, // precedence groups
+    {}, // memberOperatorDecls
+    {}, // operators
+    getMangledHolderProvides(simpleNamesByRDK[providesNominal]), // topNominals
+    getBaseNameProvides(simpleNamesByRDK[providesTopLevel]), // topValues
+    getMangledHolderProvides(simpleNamesByRDK[providesNominal]), // allNominals
+    getMangledHolderProvides(simpleNamesByRDK[providesNominal]), // potentialMemberHolders
+    getCompoundProvides(compoundNamesByRDK[providesMember]), // valuesInExtensions
+    getBaseNameProvides(simpleNamesByRDK[providesDynamicLookup]) // classMembers
+    );
+  // clang-format on
+  return c.construct();
 }

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -272,7 +272,7 @@ namespace driver {
 
     void noteBuilding(const Job *cmd, const bool willBeBuilding,
                       const bool isTentative, const bool forRanges,
-                      StringRef reason) {
+                      StringRef reason) const {
       if (!Comp.getShowIncrementalBuildDecisions())
         return;
       if (ScheduledCommands.count(cmd))
@@ -298,6 +298,23 @@ namespace driver {
                                      llvm::outs(), cmd, [](raw_ostream &out, const Job *base) {
                                        out << llvm::sys::path::filename(base->getOutput().getBaseInput(0));
                                      });
+    }
+
+    template <typename JobsCollection>
+    void noteBuildingJobs(const JobsCollection &unsortedJobsArg,
+                          const bool forRanges, const StringRef reason) const {
+      if (!Comp.getShowIncrementalBuildDecisions() &&
+          !Comp.getShowJobLifecycle())
+        return;
+      // Sigh, must manually convert SmallPtrSet to ArrayRef-able container
+      llvm::SmallVector<const Job *, 16> unsortedJobs;
+      for (const Job *j : unsortedJobsArg)
+        unsortedJobs.push_back(j);
+      llvm::SmallVector<const Job *, 16> sortedJobs;
+      Comp.sortJobsToMatchCompilationInputs(unsortedJobs, sortedJobs);
+      for (const Job *j : sortedJobs)
+        noteBuilding(j, /*willBeBuilding=*/true, /*isTentative=*/false,
+                     forRanges, reason);
     }
 
     const Job *findUnfinishedJob(ArrayRef<const Job *> JL) {
@@ -432,7 +449,7 @@ namespace driver {
                                  diag::warn_unable_to_load_dependencies,
                                  DependenciesFile);
       Comp.disableIncrementalBuild(
-          Twine("Malformed swift dependencies file ' ") + DependenciesFile +
+          Twine("malformed swift dependencies file ' ") + DependenciesFile +
           "'");
     }
 
@@ -468,7 +485,7 @@ namespace driver {
         // other recompilations. It is possible that the current code marks
         // things that do not need to be marked. Unecessary compilation would
         // result if that were the case.
-        bool wasCascading = isMarkedInDepGraph(FinishedCmd, forRanges);
+        bool wasKnownToNeedRunning = isMarkedInDepGraph(FinishedCmd, forRanges);
 
         switch (loadDepGraphFromPath(FinishedCmd, DependenciesFile,
                                      Comp.getDiags(), forRanges)) {
@@ -484,7 +501,7 @@ namespace driver {
           break;
 
         case CoarseGrainedDependencyGraph::LoadResult::UpToDate:
-          if (!wasCascading)
+          if (!wasKnownToNeedRunning)
             break;
           LLVM_FALLTHROUGH;
         case CoarseGrainedDependencyGraph::LoadResult::AffectsDownstream:
@@ -674,14 +691,22 @@ namespace driver {
       const CommandSet &DependentsInEffect = useRangesForScheduling
                                                  ? DependentsWithRanges
                                                  : DependentsWithoutRanges;
-      for (const Job *Cmd : DependentsInEffect) {
+
+      noteBuildingJobs(DependentsInEffect, useRangesForScheduling,
+                       "because of dependencies discovered later");
+
+      // Sort dependents for more deterministic behavior
+      llvm::SmallVector<const Job *, 16> UnsortedDependents;
+      for (const Job *j : DependentsInEffect)
+        UnsortedDependents.push_back(j);
+      llvm::SmallVector<const Job *, 16> SortedDependents;
+      Comp.sortJobsToMatchCompilationInputs(UnsortedDependents,
+                                            SortedDependents);
+
+      for (const Job *Cmd : SortedDependents) {
         DeferredCommands.erase(Cmd);
-        noteBuilding(Cmd, /*willBeBuilding=*/true, useRangesForScheduling,
-                     /*isTentative=*/false,
-                     "because of dependencies discovered later");
         scheduleCommandIfNecessaryAndPossible(Cmd);
       }
-
       return TaskFinishedResponse::ContinueExecution;
     }
 
@@ -692,6 +717,7 @@ namespace driver {
 
       // Store this task's ReturnCode as our Result if we haven't stored
       // anything yet.
+
       if (Result == EXIT_SUCCESS)
         Result = ReturnCode;
 
@@ -1007,10 +1033,6 @@ namespace driver {
 
       const bool isCascading = isCascadingJobAccordingToCondition(
           Cmd, Cond, HasDependenciesFileName);
-
-      if (Comp.getEnableFineGrainedDependencies())
-        assert(getFineGrainedDepGraph(/*forRanges=*/false)
-                   .emitDotFileAndVerify(Comp.getDiags()));
       return std::make_pair(shouldSched, isCascading);
     }
 
@@ -1118,11 +1140,7 @@ namespace driver {
                                  IncrementalTracer))
           CascadedJobs.insert(transitiveCmd);
       }
-      for (auto *transitiveCmd : CascadedJobs)
-        noteBuilding(transitiveCmd, /*willBeBuilding=*/true,
-                     /*isTentative=*/false, forRanges,
-                     "because of the initial set");
-
+      noteBuildingJobs(CascadedJobs, forRanges, "because of the initial set");
       return CascadedJobs;
     }
 
@@ -1138,11 +1156,8 @@ namespace driver {
         for (const Job * marked: markExternalInDepGraph(dependency, forRanges))
           ExternallyDependentJobs.push_back(marked);
       });
-      for (auto *externalCmd : ExternallyDependentJobs) {
-        noteBuilding(externalCmd, /*willBeBuilding=*/true,
-                     /*isTentative=*/false, forRanges,
-                     "because of external dependencies");
-      }
+      noteBuildingJobs(ExternallyDependentJobs, forRanges,
+                       "because of external dependencies");
       return ExternallyDependentJobs;
     }
 
@@ -1493,11 +1508,11 @@ namespace driver {
             continue;
 
           // Be conservative, in case we use ranges this time but not next.
-          bool isCascading = true;
+          bool mightBeCascading = true;
           if (Comp.getIncrementalBuildEnabled())
-            isCascading = isMarkedInDepGraph(
+            mightBeCascading = isMarkedInDepGraph(
                 Cmd, /*forRanges=*/Comp.getEnableSourceRangeDependencies());
-          UnfinishedCommands.insert({Cmd, isCascading});
+          UnfinishedCommands.insert({Cmd, mightBeCascading});
         }
       }
     }
@@ -1824,8 +1839,6 @@ int Compilation::performJobsImpl(bool &abnormalExit,
                                CompilationRecordPath + "~moduleonly");
     }
   }
-  if (getEnableFineGrainedDependencies())
-    assert(State.FineGrainedDepGraph.emitDotFileAndVerify(getDiags()));
   abnormalExit = State.hadAnyAbnormalExit();
   return State.getResult();
 }
@@ -2051,5 +2064,25 @@ void Compilation::addDependencyPathOrCreateDummy(
     // Create dummy empty file
     std::error_code EC;
     llvm::raw_fd_ostream(depPath, EC, llvm::sys::fs::F_None);
+  }
+}
+
+void Compilation::sortJobsToMatchCompilationInputs(
+    const ArrayRef<const Job *> unsortedJobs,
+    SmallVectorImpl<const Job *> &sortedJobs) const {
+  llvm::DenseMap<StringRef, const Job *> jobsByInput;
+  for (const Job *J : unsortedJobs) {
+    const CompileJobAction *CJA = cast<CompileJobAction>(&J->getSource());
+    const InputAction *IA = CJA->findSingleSwiftInput();
+    auto R =
+        jobsByInput.insert(std::make_pair(IA->getInputArg().getValue(), J));
+    assert(R.second);
+    (void)R;
+  }
+  for (const InputPair &P : getInputFiles()) {
+    auto I = jobsByInput.find(P.second->getValue());
+    if (I != jobsByInput.end()) {
+      sortedJobs.push_back(I->second);
+    }
   }
 }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -958,7 +958,8 @@ Driver::buildCompilation(const ToolChain &TC,
 
     // relies on the new dependency graph
     const bool EnableFineGrainedDependencies =
-        ArgList->hasArg(options::OPT_enable_fine_grained_dependencies);
+        ArgList->hasFlag(options::OPT_enable_fine_grained_dependencies,
+                         options::OPT_disable_fine_grained_dependencies, false);
 
     const bool VerifyFineGrainedDependencyGraphAfterEveryImport = ArgList->hasArg(
         options::

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -959,7 +959,7 @@ Driver::buildCompilation(const ToolChain &TC,
     // relies on the new dependency graph
     const bool EnableFineGrainedDependencies =
         ArgList->hasFlag(options::OPT_enable_fine_grained_dependencies,
-                         options::OPT_disable_fine_grained_dependencies, false);
+                         options::OPT_disable_fine_grained_dependencies, true);
 
     const bool VerifyFineGrainedDependencyGraphAfterEveryImport = ArgList->hasArg(
         options::

--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -66,6 +66,11 @@ LoadResult ModuleDepGraph::loadFromPath(const Job *Cmd, StringRef path,
   return r;
 }
 
+LoadResult ModuleDepGraph::loadFromString(const Job *cmd, StringRef data) {
+  auto buffer = llvm::MemoryBuffer::getMemBuffer(data);
+  return loadFromBuffer(cmd, *buffer.get());
+}
+
 LoadResult ModuleDepGraph::loadFromBuffer(const Job *job,
                                           llvm::MemoryBuffer &buffer) {
 
@@ -73,50 +78,70 @@ LoadResult ModuleDepGraph::loadFromBuffer(const Job *job,
       SourceFileDepGraph::loadFromBuffer(buffer);
   if (!sourceFileDepGraph)
     return CoarseGrainedDependencyGraphImpl::LoadResult::HadError;
+  return loadFromSourceFileDepGraph(job, sourceFileDepGraph.getValue());
+}
+
+LoadResult ModuleDepGraph::loadFromSourceFileDepGraph(
+    const Job *job, const SourceFileDepGraph &sourceFileDepGraph) {
   addIndependentNode(job);
-  return integrate(sourceFileDepGraph.getValue());
+  return integrate(sourceFileDepGraph);
 }
 
 bool ModuleDepGraph::isMarked(const Job *cmd) const {
-  return cascadingJobs.count(getSwiftDeps(cmd));
+  return swiftDepsOfJobsThatNeedRunning.count(getSwiftDeps(cmd));
 }
 
 std::vector<const Job*> ModuleDepGraph::markTransitive(
     const Job *jobToBeRecompiled, const void *ignored) {
   FrontendStatsTracer tracer(stats, "fine-grained-dependencies-markTransitive");
+  assert(jobToBeRecompiled && "Ensure there is really a job");
 
   std::unordered_set<const ModuleDepGraphNode *> dependentNodes;
   const StringRef swiftDepsToBeRecompiled = getSwiftDeps(jobToBeRecompiled);
-  // Do the traversal.
+  assert(!swiftDepsToBeRecompiled.empty() && "Must have a swift deps");
+  // Caller already knows to run this job, no need to return it.
+  recordJobNeedsRunning(swiftDepsToBeRecompiled);
+
+  // Do the traversal for every node in the job to be recompiled.
   for (auto &fileAndNode : nodeMap[swiftDepsToBeRecompiled]) {
     assert(isCurrentPathForTracingEmpty());
-    findDependentNodesAndRecordCascadingOnes(dependentNodes,
-                                             fileAndNode.second);
+    findDependentNodes(dependentNodes, fileAndNode.second);
   }
-  return computeUniqueJobsFromNodes(dependentNodes);
-}
-
-std::vector<const Job*> ModuleDepGraph::computeUniqueJobsFromNodes(
-    const std::unordered_set<const ModuleDepGraphNode *> &nodes) {
-
-  std::vector<const Job*>jobs;
-
-  std::unordered_set<std::string> swiftDepsOfNodes;
-  for (const ModuleDepGraphNode *n : nodes) {
-    if (!n->getSwiftDeps().hasValue())
-      continue;
-    const std::string &swiftDeps = n->getSwiftDeps().getValue();
-    if (swiftDepsOfNodes.insert(swiftDeps).second) {
-      assert(n->assertImplementationMustBeInAFile());
-      ensureJobIsTracked(swiftDeps);
-      jobs.push_back(getJob(swiftDeps));
+  std::vector<const Job *> newJobsToCompile;
+  // The job containing the interface "cascades", in other words
+  // whenever that job gets recompiled, anything depending on it
+  // (since we don't have interface-specific dependency info as of Dec.
+  // 2018) must be recompiled.
+  for (const auto &entry : computeSwiftDepsFromInterfaceNodes(dependentNodes)) {
+    const StringRef swiftDeps = entry.getKey();
+    if (recordJobNeedsRunning(swiftDeps)) {
+      const Job *j = getJob(swiftDeps.str());
+      newJobsToCompile.push_back(j);
     }
   }
-  return jobs;
+  return newJobsToCompile;
 }
 
-bool ModuleDepGraph::markIntransitive(const Job *node) {
-  return rememberThatJobCascades(getSwiftDeps(node));
+llvm::StringSet<> ModuleDepGraph::computeSwiftDepsFromInterfaceNodes(
+    const std::unordered_set<const ModuleDepGraphNode *> &nodes) {
+
+  llvm::StringSet<> swiftDepsOfNodes;
+  for (const ModuleDepGraphNode *n : nodes) {
+    //    if (!n->doesNodeProvideAnInterface())
+    //      continue;
+    if (!n->getIsProvides())
+      continue;
+    const std::string &swiftDeps = n->getSwiftDepsOfProvides();
+    if (swiftDepsOfNodes.insert(swiftDeps).second) {
+      assert(n->assertImplementationMustBeInAFile());
+      assert(ensureJobIsTracked(swiftDeps));
+    }
+  }
+  return swiftDepsOfNodes;
+}
+
+bool ModuleDepGraph::markIntransitive(const Job *job) {
+  return recordJobNeedsRunning(getSwiftDeps(job));
 }
 
 void ModuleDepGraph::addIndependentNode(const Job *job) {
@@ -150,11 +175,10 @@ void ModuleDepGraph::forEachUnmarkedJobDirectlyDependentOnExternalSwiftdeps(
   DependencyKey key =
       DependencyKey::createDependedUponKey<NodeKind::externalDepend>(
           externalSwiftDeps.str());
-  // collect answers into useSet
-  std::unordered_set<std::string> visitedSet;
   for (const ModuleDepGraphNode *useNode : usesByDef[key]) {
-    const Job *job = getJob(useNode->getSwiftDeps());
-    if (!isMarked(job))
+    const auto swiftDepsOfUse = useNode->getSwiftDepsOfProvides();
+    const Job *job = getJob(swiftDepsOfUse);
+    if (isMarked(job))
       continue;
     fn(job);
   }
@@ -167,7 +191,7 @@ void ModuleDepGraph::forEachUnmarkedJobDirectlyDependentOnExternalSwiftdeps(
 LoadResult ModuleDepGraph::integrate(const SourceFileDepGraph &g) {
   FrontendStatsTracer tracer(stats, "fine-grained-dependencies-integrate");
 
-  StringRef swiftDeps = g.getSwiftDepsFromSourceFileProvide();
+  StringRef swiftDeps = g.getSwiftDepsOfJobThatProducedThisGraph();
   // When done, disappearedNodes contains the nodes which no longer exist.
   auto disappearedNodes = nodeMap[swiftDeps];
   // When done, changeDependencyKeys contains a list of keys that changed
@@ -229,10 +253,14 @@ bool ModuleDepGraph::integrateSourceFileDepGraphNode(
   if (integrand->getKey().getKind() == NodeKind::externalDepend)
     return externalDependencies.insert(integrand->getKey().getName()).second;
 
+  // Since dependencies are modeled as arcs in both SourceFile and Module
+  // dependency graphs, no more integration need be done for a depends node. The
+  // information will be obtained front the using node's arcs.
   if (integrand->isDepends())
-    return false; // dependency will be handled by the use node
+    return false;
 
-  StringRef swiftDepsOfSourceFileGraph = g.getSwiftDepsFromSourceFileProvide();
+  StringRef swiftDepsOfSourceFileGraph =
+      g.getSwiftDepsOfJobThatProducedThisGraph();
   auto changedAndUseNode = integrateSourceFileDeclNode(
       integrand, swiftDepsOfSourceFileGraph, preexistingMatch);
   recordWhatUseDependsUpon(g, integrand, changedAndUseNode.second);
@@ -292,6 +320,10 @@ void ModuleDepGraph::recordWhatUseDependsUpon(
 
 void ModuleDepGraph::removeNode(ModuleDepGraphNode *n) {
   eraseNodeFromMap(n);
+  eraseNodeFromUsesByDef(n);
+  eraseNodeFromCurrentPathIfTracing(n);
+  eraseNodeFromDependencyPathToJobs(n);
+
   delete n;
 }
 
@@ -307,6 +339,15 @@ void ModuleDepGraph::forEachUseOf(
     return;
   for (const ModuleDepGraphNode *useNode : iter->second)
     fn(useNode);
+  // Add in implicit interface->implementation dependency
+  if (def->getKey().isInterface() && def->getSwiftDeps()) {
+    const auto &dk = def->getKey();
+    const DependencyKey key(dk.getKind(), DeclAspect::interface,
+                            dk.getContext(), dk.getName());
+    if (const auto interfaceNode =
+            nodeMap.find(def->getSwiftDeps().getValue(), dk))
+      fn(interfaceNode.getValue());
+  }
 }
 
 void ModuleDepGraph::forEachNode(
@@ -340,31 +381,22 @@ void ModuleDepGraph::forEachArc(
 // Could be faster by passing in a file, not a node, but we are trying for
 // generality.
 
-void ModuleDepGraph::findDependentNodesAndRecordCascadingOnes(
+void ModuleDepGraph::findDependentNodes(
     std::unordered_set<const ModuleDepGraphNode *> &foundDependents,
     const ModuleDepGraphNode *definition) {
 
-    size_t pathLengthAfterArrival = traceArrival(definition);
+  size_t pathLengthAfterArrival = traceArrival(definition);
 
   // Moved this out of the following loop for effieciency.
-  assert(definition->getSwiftDeps().hasValue() &&
-         "Should only call me for Decl nodes.");
+  assert(definition->getIsProvides() && "Should only call me for Decl nodes.");
 
   forEachUseOf(definition, [&](const ModuleDepGraphNode *u) {
     // Cycle recording and check.
     if (!foundDependents.insert(u).second)
       return;
-    if (u->getKey().isInterface() && u->getSwiftDeps().hasValue()) {
-      // An interface depends on something. Thus, if that something changes
-      // the interface must be recompiled. But if an interface changes, then
-      // anything using that interface must also be recompiled.
-      // So, the job containing the interface "cascades", in other words
-      // whenever that job gets recompiled, anything depending on it
-      // (since we don't have interface-specific dependency info as of Dec.
-      // 2018) must be recompiled.
-      rememberThatJobCascades(u->getSwiftDeps().getValue());
-      findDependentNodesAndRecordCascadingOnes(foundDependents, u);
-    }
+    // If this use also provides something, follow it
+    if (u->getIsProvides())
+      findDependentNodes(foundDependents, u);
   });
   traceDeparture(pathLengthAfterArrival);
 }
@@ -373,9 +405,9 @@ size_t ModuleDepGraph::traceArrival(const ModuleDepGraphNode *visitedNode) {
   if (!currentPathIfTracing.hasValue())
     return 0;
   auto &currentPath = currentPathIfTracing.getValue();
-  recordDependencyPathToJob(currentPath, getJob(visitedNode->getSwiftDeps()));
-
   currentPath.push_back(visitedNode);
+  const auto visitedSwiftDepsIfAny = visitedNode->getSwiftDeps();
+  recordDependencyPathToJob(currentPath, getJob(visitedSwiftDepsIfAny));
   return currentPath.size();
 }
 
@@ -404,7 +436,8 @@ void ModuleDepGraph::emitDotFileForJob(DiagnosticEngine &diags,
 
 void ModuleDepGraph::emitDotFile(DiagnosticEngine &diags, StringRef baseName) {
   unsigned seqNo = dotFileSequenceNumber[baseName]++;
-  std::string fullName = baseName.str() + "." + std::to_string(seqNo) + ".dot";
+  std::string fullName =
+      baseName.str() + "-post-integration." + std::to_string(seqNo) + ".dot";
   withOutputFile(diags, fullName, [&](llvm::raw_ostream &out) {
     emitDotFile(out);
     return false;
@@ -422,8 +455,8 @@ void ModuleDepGraph::emitDotFile(llvm::raw_ostream &out) {
 
 void ModuleDepGraphNode::dump() const {
   DepGraphNode::dump();
-  if (getSwiftDeps().hasValue())
-    llvm::errs() << " swiftDeps: <" << getSwiftDeps().getValue() << ">\n";
+  if (getIsProvides())
+    llvm::errs() << " swiftDeps: <" << getSwiftDepsOfProvides() << ">\n";
   else
     llvm::errs() << " no swiftDeps\n";
 }
@@ -478,9 +511,7 @@ void ModuleDepGraph::verifyNodeIsUniqueWithinSubgraph(
   assert(submapIndex < nodesSeenInNodeMap.size() &&
          "submapIndex is out of bounds.");
   auto iterInserted = nodesSeenInNodeMap[submapIndex][n->getKey()].insert(
-      std::make_pair(n->getSwiftDeps().hasValue() ? n->getSwiftDeps().getValue()
-                                                  : std::string(),
-                     n));
+      std::make_pair(n->getSwiftDepsForMapKey(), n));
   if (!iterInserted.second) {
     llvm_unreachable("duplicate driver keys");
   }
@@ -523,23 +554,78 @@ void ModuleDepGraph::verifyEachJobInGraphIsTracked() const {
       });
 }
 
-bool ModuleDepGraph::emitDotFileAndVerify(DiagnosticEngine &diags) {
-  if (!driverDotFileBasePath.empty())
-    emitDotFile(diags, driverDotFileBasePath);
-  return verify();
-}
-
-/// Dump the path that led to \p node.
-/// TODO: make output more like existing system's
+/// Dump the path(s) that led to \p node.
+/// TODO: break up
 void ModuleDepGraph::printPath(raw_ostream &out,
                                const driver::Job *jobToBeBuilt) const {
   assert(currentPathIfTracing.hasValue() &&
          "Cannot print paths of paths weren't tracked.");
-  auto const allPaths = dependencyPathsToJobs.find(jobToBeBuilt);
-  if (allPaths == dependencyPathsToJobs.cend())
-    return;
-  for (const auto *n : allPaths->second) {
-    out << n->humanReadableName() << "\n";
+
+  for (auto paths = dependencyPathsToJobs.find(jobToBeBuilt);
+       paths != dependencyPathsToJobs.end() && paths->first == jobToBeBuilt;
+       ++paths) {
+    const auto &path = paths->second;
+    bool first = true;
+    out << "\t";
+    for (const ModuleDepGraphNode *n : path) {
+      if (first)
+        first = false;
+      else
+        out << " -> ";
+
+      const StringRef providerName = getProvidingFilename(n->getSwiftDeps());
+      printOneNodeOfPath(out, n->getKey(), providerName);
+    }
+    out << "\n";
   }
-  out << "\n";
+}
+
+StringRef ModuleDepGraph::getProvidingFilename(
+    const Optional<std::string> swiftDeps) const {
+  if (!swiftDeps)
+    return "<unknown";
+  const StringRef inputName =
+      llvm::sys::path::filename(getJob(swiftDeps)->getFirstSwiftPrimaryInput());
+  // FineGrainedDependencyGraphTests work with simulated jobs with empty
+  // input names.
+  return !inputName.empty() ? inputName : StringRef(swiftDeps.getValue());
+}
+
+void ModuleDepGraph::printOneNodeOfPath(raw_ostream &out,
+                                        const DependencyKey &key,
+                                        const StringRef filename) {
+  auto typeForPrinting = [](const DependencyKey &key) {
+    SmallString<64> fixedUpType{key.getContext()};
+    if (!fixedUpType.empty() && fixedUpType.front() == 'P')
+      fixedUpType.push_back('_');
+    return swift::Demangle::demangleTypeAsString(fixedUpType.str());
+  };
+  switch (key.getKind()) {
+  case NodeKind::topLevel:
+    out << "top-level name '" << key.getName() << "' in " << filename;
+    break;
+  case NodeKind::nominal:
+    out << "type '" << typeForPrinting(key) << "' in " << filename;
+    break;
+  case NodeKind::potentialMember:
+    out << "non-private members of type '" << typeForPrinting(key) << "' in "
+        << filename;
+    break;
+  case NodeKind::member:
+    out << "member '" << key.getName() << "' of type '" << typeForPrinting(key)
+        << "' in " << filename;
+    break;
+  case NodeKind::dynamicLookup:
+    out << "AnyObject member '" << key.getName() << "' in " << filename;
+    break;
+  case NodeKind::externalDepend:
+    out << filename << " depends on module '"
+        << llvm::sys::path::filename(key.getName()) << "'";
+    break;
+  case NodeKind::sourceFileProvide:
+    out << "source file " << filename;
+    break;
+  default:
+    llvm_unreachable("unknown NodeKind");
+  }
 }

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -25,6 +25,11 @@
 using namespace swift;
 using namespace swift::driver;
 
+CommandOutput::CommandOutput(StringRef dummyBase, OutputFileMap &dummyOFM)
+    : Inputs({CommandInputPair(dummyBase, "")}), DerivedOutputMap(dummyOFM) {
+  setAdditionalOutputForType(file_types::TY_SwiftDeps, dummyBase);
+}
+
 StringRef CommandOutput::getOutputForInputAndType(StringRef PrimaryInputFile,
                                                   file_types::ID Type) const {
   if (Type == file_types::TY_Nothing)

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -641,6 +641,12 @@ void ToolChain::JobContext::addFrontendCommandLineInputArguments(
     if ((!isPrimary || usePrimaryFileList) && !useFileList)
       arguments.push_back(inputName);
   }
+  if (C.getEnableFineGrainedDependencies())
+    arguments.push_back("-enable-fine-grained-dependencies");
+
+  if (Args.hasArg(
+          options::OPT_emit_fine_grained_dependency_sourcefile_dot_files))
+    arguments.push_back("-emit-fine-grained-dependency-sourcefile-dot-files");
 }
 
 void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -357,9 +357,13 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.BuildSyntaxTree = true;
     Opts.VerifySyntaxTree = true;
   }
-  
-  if (Args.hasArg(OPT_enable_fine_grained_dependencies))
-    Opts.EnableFineGrainedDependencies = true;
+
+  Opts.EnableFineGrainedDependencies =
+      Args.hasFlag(options::OPT_enable_fine_grained_dependencies,
+                   options::OPT_disable_fine_grained_dependencies, true);
+
+  if (Args.hasArg(OPT_emit_fine_grained_dependency_sourcefile_dot_files))
+    Opts.EmitFineGrainedDependencySourcefileDotFiles = true;
 
   if (Args.hasArg(OPT_fine_grained_dependency_include_intrafile))
     Opts.FineGrainedDependenciesIncludeIntrafileOnes = true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -979,7 +979,9 @@ static void emitReferenceDependenciesForAllPrimaryInputsIfNeeded(
       if (Invocation.getLangOptions().EnableFineGrainedDependencies)
         (void)fine_grained_dependencies::emitReferenceDependencies(
             Instance.getASTContext().Diags, SF,
-            *Instance.getDependencyTracker(), referenceDependenciesFilePath);
+            *Instance.getDependencyTracker(), referenceDependenciesFilePath,
+            Invocation.getLangOptions()
+                .EmitFineGrainedDependencySourcefileDotFiles);
       else
         (void)emitReferenceDependencies(Instance.getASTContext().Diags, SF,
                                         *Instance.getDependencyTracker(),

--- a/test/Driver/Dependencies/bindings-build-record-options.swift
+++ b/test/Driver/Dependencies/bindings-build-record-options.swift
@@ -2,7 +2,7 @@
 // RUN: cp -r %S/Inputs/bindings-build-record/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings -driver-show-incremental ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 |  %FileCheck %s -check-prefix=MUST-EXEC-INITIAL
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings -driver-show-incremental ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 |  %FileCheck %s -check-prefix=MUST-EXEC-INITIAL
 
 // MUST-EXEC-INITIAL-NOT: warning
 // MUST-EXEC-INITIAL: inputs: ["./main.swift"], output: {object: "./main.o", swift-dependencies: "./main.swiftdeps"}
@@ -16,39 +16,39 @@
 // MUST-EXEC-ALL: inputs: ["./other.swift"], output: {{[{].*[}]$}}
 // MUST-EXEC-ALL: inputs: ["./yet-another.swift"], output: {{[{].*[}]$}}
 
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
 
 // NO-EXEC: inputs: ["./main.swift"], output: {{[{].*[}]}}, condition: check-dependencies
 // NO-EXEC: inputs: ["./other.swift"], output: {{[{].*[}]}}, condition: check-dependencies
 // NO-EXEC: inputs: ["./yet-another.swift"], output: {{[{].*[}]}}, condition: check-dependencies
 
 
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings -serialize-diagnostics ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings -serialize-diagnostics ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
 
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -O -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -O -output-file-map %t/output.json
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -O -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -O -serialize-diagnostics -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -O -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -O -output-file-map %t/output.json
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -O -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -O -serialize-diagnostics -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
 
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -Onone -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -Onone -output-file-map %t/output.json
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -Onone -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -Onone -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -Onone -output-file-map %t/output.json
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -Onone -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
 
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
 
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -I. -output-file-map %t/output.json
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -I. -output-file-map %t/output.json
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
 
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -I/ -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -I. -I/ -output-file-map %t/output.json
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -I/ -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -I/ -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -I. -I/ -output-file-map %t/output.json
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -I/ -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
 
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -DDEBUG -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -I. -DDEBUG -output-file-map %t/output.json
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -DDEBUG -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
-// RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -DDEBUG -I. -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -DDEBUG -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-ALL
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" ./main.swift ./other.swift ./yet-another.swift -incremental -I. -DDEBUG -output-file-map %t/output.json
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -I. -DDEBUG -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -DDEBUG -I. -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=NO-EXEC

--- a/test/Driver/Dependencies/build-record-invalid.swift
+++ b/test/Driver/Dependencies/build-record-invalid.swift
@@ -2,11 +2,11 @@
 // RUN: cp -r %S/Inputs/bindings-build-record/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s -check-prefix=CHECK-ALL-BUILT
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s -check-prefix=CHECK-ALL-BUILT
 
 // CHECK-ALL-BUILT: Handled main.swift
 // CHECK-ALL-BUILT: Handled other.swift
 
 // RUN: echo '{version: "bogus", inputs: {"./main.swift": [443865900, 0], "./other.swift": !private [443865900, 0], "./yet-another.swift": !dirty [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 // RUN: echo 'provides-nominal: garbage' > %t/main.swiftdeps
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s -check-prefix=CHECK-ALL-BUILT
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s -check-prefix=CHECK-ALL-BUILT

--- a/test/Driver/Dependencies/chained-additional-kinds.swift
+++ b/test/Driver/Dependencies/chained-additional-kinds.swift
@@ -4,25 +4,25 @@
 // RUN: cp -r %S/Inputs/chained-additional-kinds/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Handled yet-another.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-DAG: Handled other.swift
 // CHECK-THIRD-DAG: Handled main.swift
 // CHECK-THIRD-DAG: Handled yet-another.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240008 %t/other.swift

--- a/test/Driver/Dependencies/chained-after.swift
+++ b/test/Driver/Dependencies/chained-after.swift
@@ -6,17 +6,17 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/chained-after/*.swiftdeps %t
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift

--- a/test/Driver/Dependencies/chained-private-after-multiple-nominal-members.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple-nominal-members.swift
@@ -6,17 +6,17 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/chained-private-after-multiple-nominal-members/*.swiftdeps %t
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-DAG: Handled other.swift
 // CHECK-SECOND-DAG: Handled main.swift

--- a/test/Driver/Dependencies/chained-private-after-multiple.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple.swift
@@ -6,17 +6,17 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/chained-private-after-multiple/*.swiftdeps %t
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | tee out | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-DAG: Handled other.swift
 // CHECK-SECOND-DAG: Handled main.swift

--- a/test/Driver/Dependencies/chained-private-after.swift
+++ b/test/Driver/Dependencies/chained-private-after.swift
@@ -6,17 +6,17 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/chained-private-after/*.swiftdeps %t
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-DAG: Handled other.swift
 // CHECK-SECOND-DAG: Handled main.swift

--- a/test/Driver/Dependencies/chained-private.swift
+++ b/test/Driver/Dependencies/chained-private.swift
@@ -4,19 +4,19 @@
 // RUN: cp -r %S/Inputs/chained-private/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Handled yet-another.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | tee out| %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v >%t/outputToCheck 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v >%t/outputToCheck 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-THIRD %s < %t/outputToCheck
 
 // Driver now schedules jobs in the order the inputs were given, but
@@ -27,3 +27,4 @@
 // RUN: %FileCheck -check-prefix=CHECK-THIRD-EXCLUSION %s < %t/outputToCheck
 
 // CHECK-THIRD-EXCLUSION-NOT: Handled yet-another.swift
+

--- a/test/Driver/Dependencies/chained.swift
+++ b/test/Driver/Dependencies/chained.swift
@@ -4,29 +4,29 @@
 // RUN: cp -r %S/Inputs/chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Handled yet-another.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-DAG: Handled other.swift
 // CHECK-THIRD-DAG: Handled main.swift
 // CHECK-THIRD-DAG: Handled yet-another.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240008 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240009 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./yet-another.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./yet-another.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s

--- a/test/Driver/Dependencies/crash-added.swift
+++ b/test/Driver/Dependencies/crash-added.swift
@@ -4,13 +4,13 @@
 // RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL: Handled main.swift
 // CHECK-INITIAL: Handled other.swift
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./crash.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./crash.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-ADDED-NOT: Handled
@@ -26,7 +26,7 @@
 // RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/crash-new.swift
+++ b/test/Driver/Dependencies/crash-new.swift
@@ -6,7 +6,7 @@
 
 // Initially compile all inputs, crash will fail.
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 // CHECK-NOT: warning
 // CHECK: Handled main.swift
 // CHECK: Handled crash.swift
@@ -15,7 +15,7 @@
 // Put crash.swift first to assure it gets scheduled first.
 // The others get queued, but not dispatched because crash crashes.
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
 
 // CHECK-BAD-ONLY-NOT: warning
 // CHECK-BAD-ONLY-NOT: Handled
@@ -24,7 +24,7 @@
 
 // Make crash succeed and all get compiled, exactly once.
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
 // CHECK-OKAY: Handled main.swift
 // CHECK-OKAY: Handled crash.swift
 // CHECK-OKAY: Handled other.swift
@@ -34,12 +34,12 @@
 
 // RUN: touch -t 201401240006 %t/crash.swift
 // RUN: rm %t/crash.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 
 // And repair crash:
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
 
 // CHECK-OKAY-2-DAG: Handled crash.swift
 // CHECK-OKAY-2-DAG: Handled other.swift
@@ -51,7 +51,7 @@
 
 // RUN: touch -t 201401240006 %t/main.swift
 // RUN: rm %t/main.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-MAIN-SWIFTDEPS %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-MAIN-SWIFTDEPS %s
 
 // CHECK-NO-MAIN-SWIFTDEPS-NOT: warning
 // CHECK-NO-MAIN-SWIFTDEPS: Handled main.swift
@@ -62,7 +62,7 @@
 // Touch all files earlier than last compiled date in the build record.
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 -driver-show-incremental |tee /tmp/out1 | %FileCheck -check-prefix=CHECK-CURRENT-WITH-CRASH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 -driver-show-incremental |tee /tmp/out1 | %FileCheck -check-prefix=CHECK-CURRENT-WITH-CRASH %s
 
 // CHECK-CURRENT-WITH-CRASH: Handled main.swift
 // CHECK-CURRENT-WITH-CRASH: Handled crash.swift
@@ -73,4 +73,4 @@
 
 // RUN: touch -t 201401240006 %t/other.swift
 // RUN: rm %t/other.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/crash-simple.swift
+++ b/test/Driver/Dependencies/crash-simple.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -12,7 +12,7 @@
 // CHECK-FIRST: Handled other.swift
 
 // RUN: touch -t 201401240006 %t/crash.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled crash.swift
 // CHECK-SECOND-NOT: Handled main.swift

--- a/test/Driver/Dependencies/driver-show-incremental-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-arguments.swift
@@ -14,11 +14,11 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-ARGS-MISMATCH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-ARGS-MISMATCH %s
 // CHECK-ARGS-MISMATCH: Incremental compilation has been disabled{{.*}}different arguments
 // CHECK-ARGS-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}
 

--- a/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
@@ -14,19 +14,19 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO %s
 // CHECK-WMO: Incremental compilation has been disabled{{.*}}whole module optimization
 // CHECK-WMO-NOT: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-BITCODE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-BITCODE %s
 // CHECK-BITCODE: Incremental compilation has been disabled{{.*}}LLVM IR bitcode
 // CHECK-BITCODE-NOT: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO-AND-BITCODE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO-AND-BITCODE %s
 // CHECK-WMO-AND-BITCODE: Incremental compilation has been disabled{{.*}}whole module optimization
 // CHECK-WMO-AND-BITCODE-NOT: Incremental compilation has been disabled
 // CHECK-WMO-AND-BITCODE-NOT: Queuing (initial): {compile: main.o <= main.swift}

--- a/test/Driver/Dependencies/driver-show-incremental-inputs.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-inputs.swift
@@ -14,11 +14,11 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -disable-fine-grained-dependencies -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INPUTS-MISMATCH %s
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -disable-fine-grained-dependencies -c ./main.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INPUTS-MISMATCH %s
 // CHECK-INPUTS-MISMATCH: Incremental compilation has been disabled{{.*}}inputs
 // CHECK-INPUTS-MISMATCH: ./other.swift
 // CHECK-INPUTS-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}

--- a/test/Driver/Dependencies/driver-show-incremental-malformed.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-malformed.swift
@@ -13,24 +13,24 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: rm %t/main~buildrecord.swiftdeps && touch %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
 
 // RUN: echo 'foo' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
 
 // CHECK-MALFORMED: Incremental compilation has been disabled{{.*}}malformed build record file
 // CHECK-MALFORMED-NOT: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: echo '{version, inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
 
 // CHECK-MISSING-KEY: Incremental compilation has been disabled{{.*}}malformed build record file{{.*}}Malformed value for key
 // CHECK-MISSING-KEY-NOT: Queuing (initial): {compile: main.o <= main.swift}

--- a/test/Driver/Dependencies/driver-show-incremental-mutual.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-mutual.swift
@@ -4,16 +4,16 @@
 // RUN: cp -r %S/Inputs/mutual-with-swiftdeps/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Disabling incremental build: could not read build record
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 // CHECK-SECOND-NOT: Queuing
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 // CHECK-THIRD: Queuing (initial): {compile: other.o <= other.swift}
 // CHECK-THIRD: Queuing because of the initial set: {compile: main.o <= main.swift}
 // CHECK-THIRD-NEXT: other.swift provides top-level name 'a'

--- a/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
@@ -14,12 +14,12 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: echo '{version: "bogus", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-VERSION-MISMATCH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-VERSION-MISMATCH %s
 // CHECK-VERSION-MISMATCH: Incremental compilation has been disabled{{.*}}compiler version mismatch
 // CHECK-VERSION-MISMATCH: Compiling with:
 // CHECK-VERSION-MISMATCH: Previously compiled with: bogus

--- a/test/Driver/Dependencies/fail-added.swift
+++ b/test/Driver/Dependencies/fail-added.swift
@@ -4,13 +4,13 @@
 // RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL: Handled main.swift
 // CHECK-INITIAL: Handled other.swift
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-ADDED-NOT: Handled
@@ -26,7 +26,7 @@
 // RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/fail-chained.swift
+++ b/test/Driver/Dependencies/fail-chained.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/fail-chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-FIRST-NOT: warning
@@ -26,7 +26,7 @@
 
 
 // RUN: touch -t 201401240006 %t/a.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./bad.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v > %t/a.txt 2>&1
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./bad.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v > %t/a.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-A %s < %t/a.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-A %s < %t/main~buildrecord.swiftdeps
@@ -47,7 +47,7 @@
 // CHECK-RECORD-A-DAG: "./f.swift": [
 // CHECK-RECORD-A-DAG: "./bad.swift": !dirty [
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/a2.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/a2.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A2 %s < %t/a2.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-A2 %s < %t/a2.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
@@ -65,10 +65,10 @@
 // RUN: cp -r %S/Inputs/fail-chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/b.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b.txt 2>&1
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-B %s < %t/b.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-B %s < %t/b.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-B %s < %t/main~buildrecord.swiftdeps
@@ -89,7 +89,7 @@
 // CHECK-RECORD-B-DAG: "./f.swift": [
 // CHECK-RECORD-B-DAG: "./bad.swift": !private [
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b2.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b2.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-B2 %s < %t/b2.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-B2 %s < %t/b2.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
@@ -107,10 +107,10 @@
 // RUN: cp -r %S/Inputs/fail-chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/bad.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v > %t/bad.txt 2>&1
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v > %t/bad.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-BAD %s < %t/bad.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-BAD %s < %t/bad.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-A %s < %t/main~buildrecord.swiftdeps
@@ -123,7 +123,7 @@
 // NEGATIVE-BAD-NOT: Handled e.swift
 // NEGATIVE-BAD-NOT: Handled f.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/bad2.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/bad2.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A2 %s < %t/bad2.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-A2 %s < %t/bad2.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/fail-interface-hash.swift
+++ b/test/Driver/Dependencies/fail-interface-hash.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/fail-interface-hash/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -16,7 +16,7 @@
 // RUN: cp -r %S/Inputs/fail-interface-hash/*.swiftdeps %t
 
 // RUN: touch -t 201401240006 %t/bad.swift %t/main.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-SECOND: Handled main.swift

--- a/test/Driver/Dependencies/fail-new.swift
+++ b/test/Driver/Dependencies/fail-new.swift
@@ -4,20 +4,20 @@
 // RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 // CHECK-NOT: warning
 // CHECK: Handled main.swift
 // CHECK: Handled bad.swift
 // CHECK-NOT: Handled other.swift
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
 
 // CHECK-BAD-ONLY-NOT: warning
 // CHECK-BAD-ONLY-NOT: Handled
 // CHECK-BAD-ONLY: Handled bad.swift
 // CHECK-BAD-ONLY-NOT: Handled
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
 // CHECK-OKAY: Handled main.swift
 // CHECK-OKAY: Handled bad.swift
 // CHECK-OKAY: Handled other.swift
@@ -25,10 +25,10 @@
 
 // RUN: touch -t 201401240006 %t/bad.swift
 // RUN: rm %t/bad.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
 
 // CHECK-OKAY-2-DAG: Handled bad.swift
 // CHECK-OKAY-2-DAG: Handled other.swift
@@ -36,10 +36,10 @@
 
 // RUN: touch -t 201401240006 %t/main.swift
 // RUN: rm %t/main.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
 // RUN: touch -t 201401240006 %t/other.swift
 // RUN: rm %t/other.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/fail-simple.swift
+++ b/test/Driver/Dependencies/fail-simple.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -12,7 +12,7 @@
 // CHECK-FIRST: Handled other.swift
 
 // RUN: touch -t 201401240006 %t/bad.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-SECOND: Handled bad.swift

--- a/test/Driver/Dependencies/fail-with-bad-deps.swift
+++ b/test/Driver/Dependencies/fail-with-bad-deps.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/fail-with-bad-deps/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -15,14 +15,14 @@
 // Reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/fail-with-bad-deps/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NONE %s
 // CHECK-NONE-NOT: Handled
 
 // Reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/fail-with-bad-deps/*.swiftdeps %t
 
 // RUN: touch -t 201401240006 %t/bad.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BUILD-ALL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BUILD-ALL %s
 
 // CHECK-BUILD-ALL-NOT: warning
 // CHECK-BUILD-ALL: Handled bad.swift
@@ -34,7 +34,7 @@
 // RUN: cp -r %S/Inputs/fail-with-bad-deps/*.swiftdeps %t
 
 // RUN: touch -t 201401240007 %t/bad.swift %t/main.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-WITH-FAIL %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-WITH-FAIL %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-WITH-FAIL: Handled main.swift

--- a/test/Driver/Dependencies/file-added.swift
+++ b/test/Driver/Dependencies/file-added.swift
@@ -4,16 +4,16 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled other.swift
 // CHECK-THIRD: Handled main.swift

--- a/test/Driver/Dependencies/independent-half-dirty.swift
+++ b/test/Driver/Dependencies/independent-half-dirty.swift
@@ -2,7 +2,7 @@
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -10,14 +10,14 @@
 
 // RUN: touch -t 201401240005 %t/other.o
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled main.swift
 // CHECK-SECOND: Handled other.swift
 // CHECK-SECOND-NOT: Handled main.swift
 
 // RUN: rm %t/other.swiftdeps
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift

--- a/test/Driver/Dependencies/independent-parseable.swift
+++ b/test/Driver/Dependencies/independent-parseable.swift
@@ -2,7 +2,7 @@
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
@@ -17,7 +17,7 @@
 // CHECK-FIRST: "output": "Handled main.swift{{(\\r)?}}\n"
 // CHECK-FIRST: {{^}$}}
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: {{^{$}}
 // CHECK-SECOND: "kind": "skipped"
@@ -26,14 +26,14 @@
 // CHECK-SECOND: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 // CHECK-FIRST-MULTI: {{^{$}}
 // CHECK-FIRST-MULTI: "kind": "began"
@@ -59,7 +59,7 @@
 // CHECK-FIRST-MULTI: "output": "Handled other.swift{{(\\r)?}}\n"
 // CHECK-FIRST-MULTI: {{^}$}}
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND-MULTI %s
 
 // CHECK-SECOND-MULTI: {{^{$}}
 // CHECK-SECOND-MULTI: "kind": "skipped"
@@ -74,5 +74,5 @@
 // CHECK-SECOND-MULTI: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 

--- a/test/Driver/Dependencies/independent.swift
+++ b/test/Driver/Dependencies/independent.swift
@@ -4,43 +4,43 @@
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 // RUN: ls %t/main~buildrecord.swiftdeps
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 // CHECK-FIRST-MULTI: Handled main.swift
 // CHECK-FIRST-MULTI: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // RUN: touch -t 201401240006 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SINGLE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SINGLE %s
 // CHECK-SINGLE: Handled main.swift
 
 // RUN: ls %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/malformed-but-valid-yaml.swift
+++ b/test/Driver/Dependencies/malformed-but-valid-yaml.swift
@@ -3,24 +3,24 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/malformed-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled other.swift
 // CHECK-SECOND: Handled main.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
@@ -30,18 +30,18 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/malformed-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/malformed.swift
+++ b/test/Driver/Dependencies/malformed.swift
@@ -3,24 +3,24 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/malformed-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled other.swift
 // CHECK-SECOND: Handled main.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
@@ -30,18 +30,18 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/malformed-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/mutual-interface-hash.swift
+++ b/test/Driver/Dependencies/mutual-interface-hash.swift
@@ -5,17 +5,17 @@
 // RUN: touch -t 201401240005 %t/*
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/mutual-interface-hash/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
 
 // CHECK-CLEAN-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/does-change.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CHANGE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CHANGE %s
 
 // CHECK-CHANGE: Handled does-change.swift
 // CHECK-CHANGE: Handled does-not-change.swift
@@ -24,7 +24,7 @@
 // RUN: cp -r %S/Inputs/mutual-interface-hash/*.swiftdeps %t
 
 // RUN: touch -t 201401240006 %t/does-not-change.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-CHANGE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-CHANGE %s
 
 // CHECK-NO-CHANGE-NOT: Handled
 // CHECK-NO-CHANGE: Handled does-not-change.swift
@@ -36,7 +36,7 @@
 // Make sure the files really were dependent on one another.
 
 // RUN: touch -t 201401240007 %t/does-not-change.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s
 
 // CHECK-REBUILD-DEPENDENTS-DAG: Handled does-not-change.swift
 // CHECK-REBUILD-DEPENDENTS-DAG: Handled does-change.swift
@@ -47,4 +47,4 @@
 
 // RUN: cp -r %S/Inputs/mutual-interface-hash/*.swiftdeps %t
 // RUN: sed -E -e 's/"[^"]*does-not-change.swift":/& !dirty/' -i.prev %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s

--- a/test/Driver/Dependencies/mutual.swift
+++ b/test/Driver/Dependencies/mutual.swift
@@ -4,21 +4,21 @@
 // RUN: cp -r %S/Inputs/mutual/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/nominal-members.swift
+++ b/test/Driver/Dependencies/nominal-members.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/nominal-members/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL: Handled a.swift
@@ -12,12 +12,12 @@
 // CHECK-INITIAL: Handled depends-on-a-foo.swift
 // CHECK-INITIAL: Handled depends-on-a-ext.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
 
 // CHECK-CLEAN-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/a.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v > %t/touched-a.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v > %t/touched-a.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-TOUCHED-A %s < %t/touched-a.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-TOUCHED-A %s < %t/touched-a.txt
 
@@ -26,11 +26,11 @@
 // CHECK-TOUCHED-A-DAG: Handled depends-on-a-ext.swift
 // NEGATIVE-TOUCHED-A-NOT: Handled a-ext.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
 
 
 // RUN: touch -t 201401240007 %t/a-ext.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-TOUCHED-EXT %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-TOUCHED-EXT %s
 
 // CHECK-TOUCHED-EXT-NOT: Handled
 // CHECK-TOUCHED-EXT: Handled a-ext.swift

--- a/test/Driver/Dependencies/one-way-depends-after.swift
+++ b/test/Driver/Dependencies/one-way-depends-after.swift
@@ -6,25 +6,25 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-depends-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled main.swift
 // CHECK-SECOND: Handled other.swift
 // CHECK-SECOND-NOT: Handled main.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 
 // RUN: %empty-directory(%t)
@@ -32,25 +32,25 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-depends-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled other.swift
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD-NOT: Handled other.swift
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240008 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-DAG: Handled other.swift
 // CHECK-FOURTH-DAG: Handled main.swift

--- a/test/Driver/Dependencies/one-way-depends-before.swift
+++ b/test/Driver/Dependencies/one-way-depends-before.swift
@@ -6,24 +6,24 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-depends-before/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled main.swift
 // CHECK-SECOND: Handled other.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled main.swift
 // CHECK-THIRD: Handled other.swift
@@ -35,22 +35,22 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-depends-before/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift
 // CHECK-FOURTH-NOT: Handled other.swift
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: touch -t 201401240008 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s

--- a/test/Driver/Dependencies/one-way-external-delete.swift
+++ b/test/Driver/Dependencies/one-way-external-delete.swift
@@ -2,13 +2,13 @@
 // RUN: cp -r %S/Inputs/one-way-external/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
@@ -17,7 +17,7 @@
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: rm %t/other1-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-DAG: Handled other.swift
 // CHECK-THIRD-DAG: Handled main.swift
@@ -27,14 +27,14 @@
 // RUN: cp -r %S/Inputs/one-way-external/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
 // RUN: touch -t 201401240005 %t/*
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: rm %t/main1-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/one-way-external.swift
+++ b/test/Driver/Dependencies/one-way-external.swift
@@ -8,13 +8,13 @@
 // RUN: cp -r %S/Inputs/one-way-external/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
@@ -23,7 +23,7 @@
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/other1-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-DAG: Handled other.swift
 // CHECK-THIRD-DAG: Handled main.swift
@@ -32,14 +32,14 @@
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/other2-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 
 // RUN: touch -t 201401240005 %t/*
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/main1-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift
@@ -49,4 +49,4 @@
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/main2-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s

--- a/test/Driver/Dependencies/one-way-merge-module.swift
+++ b/test/Driver/Dependencies/one-way-merge-module.swift
@@ -4,14 +4,14 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Produced master.swiftmodule
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: warning
 // CHECK-SECOND-NOT: Handled

--- a/test/Driver/Dependencies/one-way-parallel.swift
+++ b/test/Driver/Dependencies/one-way-parallel.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
@@ -32,7 +32,7 @@
 // CHECK-FIRST: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: {{^{$}}
 // CHECK-SECOND: "kind": "began"

--- a/test/Driver/Dependencies/one-way-parseable.swift
+++ b/test/Driver/Dependencies/one-way-parseable.swift
@@ -2,7 +2,7 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
@@ -29,7 +29,7 @@
 // CHECK-FIRST: "output": "Handled other.swift{{(\\r)?}}\n"
 // CHECK-FIRST: {{^}$}}
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: {{^{$}}
 // CHECK-SECOND: "kind": "skipped"
@@ -44,7 +44,7 @@
 // CHECK-SECOND: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: {{^{$}}
 // CHECK-THIRD: "kind": "began"
@@ -71,7 +71,7 @@
 // CHECK-THIRD: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH: {{^{$}}
 // CHECK-FOURTH: "kind": "began"

--- a/test/Driver/Dependencies/one-way-provides-after.swift
+++ b/test/Driver/Dependencies/one-way-provides-after.swift
@@ -6,42 +6,42 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-provides-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-DAG: Handled other.swift
 // CHECK-SECOND-DAG: Handled main.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-provides-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-provides-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240008 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled other.swift
 // CHECK-THIRD: Handled main.swift

--- a/test/Driver/Dependencies/one-way-provides-before.swift
+++ b/test/Driver/Dependencies/one-way-provides-before.swift
@@ -6,24 +6,24 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-provides-before/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled main.swift
 // CHECK-SECOND: Handled other.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled main.swift
 // CHECK-THIRD: Handled other.swift
@@ -34,18 +34,18 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-provides-before/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/one-way-while-editing.swift
+++ b/test/Driver/Dependencies/one-way-while-editing.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 
 // CHECK: Handled main.swift
 // CHECK: Handled other.swift
@@ -12,14 +12,14 @@
 // CHECK: error: input file 'other.swift' was modified during the build
 // CHECK-NOT: error
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-RECOVER %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-RECOVER %s
 
 // CHECK-RECOVER: Handled main.swift
 // CHECK-RECOVER: Handled other.swift
 
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED %s
 
 // CHECK-REVERSED: Handled other.swift
 // CHECK-REVERSED: Handled main.swift
@@ -27,7 +27,7 @@
 // CHECK-REVERSED: error: input file 'main.swift' was modified during the build
 // CHECK-REVERSED-NOT: error
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED-RECOVER %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED-RECOVER %s
 
 // CHECK-REVERSED-RECOVER-NOT: Handled other.swift
 // CHECK-REVERSED-RECOVER: Handled main.swift

--- a/test/Driver/Dependencies/one-way.swift
+++ b/test/Driver/Dependencies/one-way.swift
@@ -4,34 +4,34 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift
 // CHECK-FOURTH-NOT: Handled other.swift
 
 // RUN: rm %t/main.o
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: rm %t/other.o
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIFTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIFTH %s
 
 // CHECK-FIFTH-NOT: Handled main.swift
 // CHECK-FIFTH: Handled other.swift
@@ -41,34 +41,34 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // Try modifying the inputs /backwards/ in time rather than forwards.
 // RUN: touch -t 201401240004 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240004 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
 
 // CHECK-REV-FIRST: Handled other.swift
 // CHECK-REV-FIRST: Handled main.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-SECOND %s
 
 // CHECK-REV-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FOURTH %s
 
 // CHECK-REV-FOURTH-NOT: Handled other.swift
 // CHECK-REV-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/private-after.swift
+++ b/test/Driver/Dependencies/private-after.swift
@@ -6,18 +6,18 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/private-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/a.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/a.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/a.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
 // RUN: %FileCheck -check-prefix=CHECK-A-NEG %s < %t/a.txt
 
@@ -35,13 +35,13 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/private-after/*.swiftdeps %t
 
 // RUN: touch -t 201401240006 %t/f.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/f.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/f.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-F %s < %t/f.txt
 // RUN: %FileCheck -check-prefix=CHECK-F-NEG %s < %t/f.txt
 

--- a/test/Driver/Dependencies/private.swift
+++ b/test/Driver/Dependencies/private.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/private/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL: Handled a.swift
@@ -14,7 +14,7 @@
 // CHECK-INITIAL: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/a.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/a.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/a.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
 // RUN: %FileCheck -check-prefix=CHECK-A-NEG %s < %t/a.txt
 
@@ -25,7 +25,7 @@
 // CHECK-A-NEG-NOT: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/b.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/b.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/b.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-B %s < %t/b.txt
 // RUN: %FileCheck -check-prefix=CHECK-B-NEG %s < %t/b.txt
 
@@ -36,7 +36,7 @@
 // CHECK-B-NEG-NOT: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/c.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/c.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/c.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-C %s < %t/c.txt
 // RUN: %FileCheck -check-prefix=CHECK-C-NEG %s < %t/c.txt
 
@@ -47,7 +47,7 @@
 // CHECK-C-NEG-NOT: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/d.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/d.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/d.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-D %s < %t/d.txt
 // RUN: %FileCheck -check-prefix=CHECK-D-NEG %s < %t/d.txt
 
@@ -58,7 +58,7 @@
 // CHECK-D-NEG-NOT: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/e.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/e.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/e.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-E %s < %t/e.txt
 // RUN: %FileCheck -check-prefix=CHECK-E-NEG %s < %t/e.txt
 
@@ -75,7 +75,7 @@
 // CHECK-E-NEG-NOT: Handled b.swift
 
 // RUN: touch -t 201401240007 %t/a.swift %t/e.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/ae.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/ae.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-AE %s < %t/ae.txt
 // RUN: %FileCheck -check-prefix=CHECK-AE-NEG %s < %t/ae.txt
 

--- a/test/Driver/SourceRanges/range-lifecycle.swift
+++ b/test/Driver/SourceRanges/range-lifecycle.swift
@@ -1,4 +1,4 @@
-// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t) 
 // RUN: cp -r %S/Inputs/range-lifecycle/* %t && cp %t/fileB{0-baseline,}.swift
 
 // =============================================================================
@@ -161,6 +161,6 @@
 // CHECK-EXERNAL-CHANGE: Queuing <With ranges> changed at [4:18--4:18): {compile: fileB.o <= fileB.swift}
 // CHECK-EXERNAL-CHANGE-NEXT:   - Will immediately schedule dependents of {compile: fileB.o <= fileB.swift} because changed outside a function body at: [4:18--4:18)
 // CHECK-EXERNAL-CHANGE: Queuing <With ranges> because of the initial set: {compile: fileA.o <= fileA.swift}
-// CHECK-EXERNAL-CHANGE-NEXT:   fileB.swift provides type 'main.Struct1InB'
+// CHECK-EXERNAL-CHANGE-NEXT:   top-level name 'Struct1InB' in fileB.swift -> source file fileB.swift -> {{.*}} in fileB.swift -> source file fileA.swift
 // CHECK-EXERNAL-CHANGE: Skipping <With ranges> : {compile: main.o <= main.swift}
 // CHECK-EXERNAL-CHANGE: *** Range benefit: 0 compilations, 1 stages, without ranges: 2, with ranges: 2, used ranges, total: 3 ***

--- a/test/Driver/SourceRanges/range-lifecycle.swift
+++ b/test/Driver/SourceRanges/range-lifecycle.swift
@@ -150,7 +150,7 @@
 // RUN: %FileCheck -check-prefix=CHECK-NO-FILEA %s < %t/output5
 
 // =============================================================================
-// Make an external change, should  recompile dependents right away with ranges
+// Make an external change, should recompile dependents right away with ranges
 // =============================================================================
 
 // RUN: cp %t/fileB{2-external-change,}.swift

--- a/test/Driver/SourceRanges/range-sourcecomparator.swift
+++ b/test/Driver/SourceRanges/range-sourcecomparator.swift
@@ -1,6 +1,9 @@
 // Tests the diff algorithm (the SourceComparator) used for range-based
 // incremental compilation.
 //
+// Disable fine-grained-dependencies because this test copies over dummy
+// swiftdeps.
+//
 // If you try to add inputs, be sure to update output.json and add a swiftranges
 // input.
 
@@ -14,7 +17,7 @@
 // The lack of a build record or swiftdeps files should disable incremental compilation
 // So, do one run just to build the build record
 
-// RUN: cd %t && %swiftc_driver -output-file-map %t/output.json -incremental -c ./in1.swift ./in2.swift ./in3.swift ./in4.swift ./in5.swift ./in6.swift -module-name main -incremental -enable-source-range-dependencies  -driver-skip-execution -driver-compare-incremental-schemes >& output
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -output-file-map %t/output.json -incremental -c ./in1.swift ./in2.swift ./in3.swift ./in4.swift ./in5.swift ./in6.swift -module-name main -incremental -enable-source-range-dependencies  -driver-skip-execution -driver-compare-incremental-schemes >& output
 
 // RUN: cp %S/Inputs/range-sourcecomparator/dummy.swiftdeps %t/in1.swiftdeps
 // RUN: cp %S/Inputs/range-sourcecomparator/dummy.swiftdeps %t/in2.swiftdeps
@@ -23,7 +26,7 @@
 // RUN: cp %S/Inputs/range-sourcecomparator/dummy.swiftdeps %t/in5.swiftdeps
 // RUN: cp %S/Inputs/range-sourcecomparator/dummy.swiftdeps %t/in6.swiftdeps
 
-// RUN: cd %t && %swiftc_driver -output-file-map %t/output.json -incremental -c ./in1.swift ./in2.swift ./in3.swift ./in4.swift ./in5.swift ./in6.swift -module-name main -incremental -enable-source-range-dependencies -driver-dump-compiled-source-diffs -driver-skip-execution -driver-compare-incremental-schemes >& output1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -output-file-map %t/output.json -incremental -c ./in1.swift ./in2.swift ./in3.swift ./in4.swift ./in5.swift ./in6.swift -module-name main -incremental -enable-source-range-dependencies -driver-dump-compiled-source-diffs -driver-skip-execution -driver-compare-incremental-schemes >& output1
 
 
 // RUN: %FileCheck  %s <%t/output1 --match-full-lines

--- a/test/Driver/batch_mode_dependencies_make_wrong_order.swift
+++ b/test/Driver/batch_mode_dependencies_make_wrong_order.swift
@@ -16,13 +16,13 @@
 // RUN: cd %t && %swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift -driver-show-incremental -driver-show-job-lifecycle >%t/out.txt 2>&1
 // RUN: %FileCheck %s <%t/out.txt
 //
-// Check that we saw invalidation happen in alphabetic order
-// CHECK: Queuing because of dependencies discovered later: {compile: b.o <= b.swift}
-// CHECK: Queuing because of dependencies discovered later: {compile: c.o <= c.swift}
+// Check that we saw invalidation happen in command-line argument order
 // CHECK: Queuing because of dependencies discovered later: {compile: d.o <= d.swift}
-// CHECK: Batchable: {compile: b.o <= b.swift}
-// CHECK: Batchable: {compile: c.o <= c.swift}
+// CHECK: Queuing because of dependencies discovered later: {compile: c.o <= c.swift}
+// CHECK: Queuing because of dependencies discovered later: {compile: b.o <= b.swift}
 // CHECK: Batchable: {compile: d.o <= d.swift}
+// CHECK: Batchable: {compile: c.o <= c.swift}
+// CHECK: Batchable: {compile: b.o <= b.swift}
 //
-// But check that we still issued the job in reverse-alphabetic order
+// Check that we still issued the job in reverse-alphabetic order
 // CHECK: Adding batch job to task queue: {compile: d.o c.o b.o <= d.swift c.swift b.swift}

--- a/test/Driver/batch_mode_parseable_output.swift
+++ b/test/Driver/batch_mode_parseable_output.swift
@@ -9,7 +9,7 @@
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -c -primary-file {{.*}}/file-01.swift{{(\\")?}} {{.*}}file-02.swift{{(\\")?}} {{.*}}file-03.swift{{(\\")?}} {{.*}}main.swift{{(\\")?}} -emit-module-path {{.*}}file-01-[[MODULE01:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*}}file-01-[[SWIFTDOC01:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -module-name main -o {{.*}}file-01-[[OBJ01:[a-z0-9]+]].o{{(\\")?}}",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -c -primary-file {{.*}}/file-01.swift{{(\\")?}} {{.*}}file-02.swift{{(\\")?}} {{.*}}file-03.swift{{(\\")?}} {{.*}}main.swift{{(\\")?}} -enable-fine-grained-dependencies -emit-module-path {{.*}}file-01-[[MODULE01:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*}}file-01-[[SWIFTDOC01:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -module-name main -o {{.*}}file-01-[[OBJ01:[a-z0-9]+]].o{{(\\")?}}",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
 // CHECK-NEXT:     "-frontend",
@@ -19,6 +19,7 @@
 // CHECK-NEXT:     "{{.*[\\/]}}file-02.swift",
 // CHECK-NEXT:     "{{.*[\\/]}}file-03.swift",
 // CHECK-NEXT:     "{{.*[\\/]}}main.swift",
+// CHECK-NEXT:     "-enable-fine-grained-dependencies",
 // CHECK-NEXT:     "-emit-module-path",
 // CHECK-NEXT:     "{{.*[\\/]}}file-01-[[MODULE01:[a-z0-9]+]].swiftmodule",
 // CHECK-NEXT:     "-emit-module-doc-path",
@@ -58,7 +59,7 @@
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -c {{.*}}file-01.swift{{(\\")?}} -primary-file {{.*}}file-02.swift{{(\\")?}} {{.*}}file-03.swift{{(\\")?}} {{.*}}main.swift{{(\\")?}} -emit-module-path {{.*}}file-02-[[MODULE02:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*}}file-02-[[SWIFTDOC02:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -module-name main -o {{.*}}file-02-[[OBJ02:[a-z0-9]+]].o{{(\\")?}}",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -c {{.*}}file-01.swift{{(\\")?}} -primary-file {{.*}}file-02.swift{{(\\")?}} {{.*}}file-03.swift{{(\\")?}} {{.*}}main.swift{{(\\")?}} -enable-fine-grained-dependencies -emit-module-path {{.*}}file-02-[[MODULE02:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*}}file-02-[[SWIFTDOC02:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -module-name main -o {{.*}}file-02-[[OBJ02:[a-z0-9]+]].o{{(\\")?}}",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}}",
 // CHECK-NEXT:   "command_arguments": [
 // CHECK-NEXT:     "-frontend",
@@ -68,6 +69,7 @@
 // CHECK-NEXT:     "{{.*[\\/]}}file-02.swift",
 // CHECK-NEXT:     "{{.*[\\/]}}file-03.swift",
 // CHECK-NEXT:     "{{.*[\\/]}}main.swift",
+// CHECK-NEXT:     "-enable-fine-grained-dependencies",
 // CHECK-NEXT:     "-emit-module-path",
 // CHECK-NEXT:     "{{.*[\\/]}}file-02-[[MODULE02:[a-z0-9]+]].swiftmodule",
 // CHECK-NEXT:     "-emit-module-doc-path",
@@ -107,7 +109,7 @@
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*}}swift{{c?(\.exe)?(\\")?}} -frontend -c {{.*}}file-01.swift{{(\\")?}} {{.*}}file-02.swift{{(\\")?}} -primary-file {{.*}}file-03.swift{{(\\")?}} {{.*}}main.swift{{(\\")?}} -emit-module-path {{.*}}file-03-[[MODULE03:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*}}file-03-[[SWIFTDOC03:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -module-name main -o {{.*}}file-03-[[OBJ03:[a-z0-9]+]].o{{(\\")?}}",
+// CHECK-NEXT:   "command": "{{.*}}swift{{c?(\.exe)?(\\")?}} -frontend -c {{.*}}file-01.swift{{(\\")?}} {{.*}}file-02.swift{{(\\")?}} -primary-file {{.*}}file-03.swift{{(\\")?}} {{.*}}main.swift{{(\\")?}} -enable-fine-grained-dependencies -emit-module-path {{.*}}file-03-[[MODULE03:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*}}file-03-[[SWIFTDOC03:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -module-name main -o {{.*}}file-03-[[OBJ03:[a-z0-9]+]].o{{(\\")?}}",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
 // CHECK-NEXT:     "-frontend",
@@ -117,6 +119,7 @@
 // CHECK-NEXT:     "-primary-file",
 // CHECK-NEXT:     "{{.*}}/file-03.swift",
 // CHECK-NEXT:     "{{.*}}/main.swift",
+// CHECK-NEXT:     "-enable-fine-grained-dependencies",
 // CHECK-NEXT:     "-emit-module-path",
 // CHECK-NEXT:     "{{.*[\\/]}}file-03-[[MODULE03:[a-z0-9]+]].swiftmodule",
 // CHECK-NEXT:     "-emit-module-doc-path",
@@ -156,7 +159,7 @@
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -c {{.*[\\/]}}file-01.swift{{(\\")?}} {{.*[\\/]}}file-02.swift{{(\\")?}} {{.*[\\/]}}file-03.swift{{(\\")?}} -primary-file {{.*[\\/]}}main.swift{{(\\")?}} -emit-module-path {{.*[\\/]}}main-[[MODULEMAIN:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*[\\/]}}main-[[SWIFTDOCMAIN:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -module-name main -o {{.*[\\/]}}main-[[OBJMAIN:[a-z0-9]+]].o{{(\\")?}}",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -c {{.*[\\/]}}file-01.swift{{(\\")?}} {{.*[\\/]}}file-02.swift{{(\\")?}} {{.*[\\/]}}file-03.swift{{(\\")?}} -primary-file {{.*[\\/]}}main.swift{{(\\")?}} -enable-fine-grained-dependencies -emit-module-path {{.*[\\/]}}main-[[MODULEMAIN:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*[\\/]}}main-[[SWIFTDOCMAIN:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -module-name main -o {{.*[\\/]}}main-[[OBJMAIN:[a-z0-9]+]].o{{(\\")?}}",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
 // CHECK-NEXT:     "-frontend",
@@ -166,6 +169,7 @@
 // CHECK-NEXT:     "{{.*[\\/]}}file-03.swift",
 // CHECK-NEXT:     "-primary-file",
 // CHECK-NEXT:     "{{.*[\\/]}}main.swift",
+// CHECK-NEXT:     "-enable-fine-grained-dependencies",
 // CHECK-NEXT:     "-emit-module-path",
 // CHECK-NEXT:     "{{.*[\\/]}}main-[[MODULEMAIN:[a-z0-9]+]].swiftmodule",
 // CHECK-NEXT:     "-emit-module-doc-path",

--- a/test/NameBinding/reference-dependencies-consistency.swift
+++ b/test/NameBinding/reference-dependencies-consistency.swift
@@ -12,4 +12,7 @@
 //
 // RUN:  %target-swift-frontend -typecheck -primary-file %t/1.swift -primary-file %t/2.swift -emit-reference-dependencies-path %t/1.swiftdeps -emit-reference-dependencies-path %t/2.swiftdeps
 //
-// RUN: cmp -s %t/1.swiftdeps %t/2.swiftdeps
+// Fine-grained dependencies includes the swiftdeps path so patch it:
+// RUN: sed 's/1.swiftdeps/2.swiftdeps/' <%t/1.swiftdeps >%t/ed.1.swiftdeps
+
+// RUN: cmp -s %t/ed.1.swiftdeps %t/2.swiftdeps

--- a/unittests/Driver/CMakeLists.txt
+++ b/unittests/Driver/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_swift_unittest(SwiftDriverTests
   CoarseGrainedDependencyGraphTests.cpp
+  FineGrainedDependencyGraphTests.cpp
 )
 
 target_link_libraries(SwiftDriverTests
    PRIVATE
    swiftDriver
+   swiftClangImporter
+   swiftAST
 )

--- a/unittests/Driver/FineGrainedDependencyGraphTests.cpp
+++ b/unittests/Driver/FineGrainedDependencyGraphTests.cpp
@@ -1,0 +1,726 @@
+#include "swift/Basic/ReferenceDependencyKeys.h"
+#include "swift/Driver/CoarseGrainedDependencyGraph.h"
+#include "swift/Driver/FineGrainedDependencyDriverGraph.h"
+#include "swift/Driver/Job.h"
+#include "gtest/gtest.h"
+
+// This file adapts the unit tests from the older, coarse-grained, dependency
+// graph to the new fine-grained graph.
+
+// \c markTransitive and \c markExternal may include jobs in their result
+// that would be excluded in the coarse-grained graph. But since these will be
+// jobs that have already been scheduled, downstream mechanisms will filter
+// them out.
+
+using namespace swift;
+using LoadResult = CoarseGrainedDependencyGraphImpl::LoadResult;
+using namespace reference_dependency_keys;
+using namespace fine_grained_dependencies;
+using Job = driver::Job;
+
+/// Initial underscore makes non-cascading, on member means private.
+static LoadResult
+simulateLoad(ModuleDepGraph &dg, const Job *cmd,
+             llvm::StringMap<std::vector<std::string>> simpleNames,
+             llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
+                 compoundNames = {},
+             const bool includePrivateDeps = true,
+             const bool hadCompilationError = false) {
+  StringRef swiftDeps = cmd->getOutput().getAdditionalOutputForType(file_types::TY_SwiftDeps);
+  assert(!swiftDeps.empty());
+  StringRef interfaceHash = swiftDeps;
+  auto sfdg = SourceFileDepGraph::simulateLoad(
+      swiftDeps,
+      includePrivateDeps, hadCompilationError, interfaceHash, simpleNames,
+      compoundNames);
+
+  return dg.loadFromSourceFileDepGraph(cmd, sfdg);
+}
+
+LLVM_ATTRIBUTE_UNUSED
+static std::vector<const Job *>
+printForDebugging(std::vector<const Job *> jobs) {
+  llvm::errs() << "\nprintForDebugging: ";
+  for( auto *j: jobs) {
+    const auto swiftDeps = j->getOutput().getAdditionalOutputForType(file_types::TY_SwiftDeps);
+    assert(!swiftDeps.empty());
+    llvm::errs() << "job" << swiftDeps << ", ";
+  }
+  llvm::errs() << "\n";
+  return jobs;
+}
+
+static OutputFileMap OFM;
+
+static Job
+  job0(OFM, "0"),
+  job1(OFM, "1"),
+  job2(OFM, "2"),
+  job3(OFM, "3"),
+  job4(OFM, "4"),
+  job5(OFM, "5"),
+  job6(OFM, "6"),
+  job7(OFM, "7"),
+  job8(OFM, "8"),
+  job9(OFM, "9"),
+  job10(OFM, "10"),
+  job11(OFM, "11"),
+  job12(OFM, "12");
+
+template <typename Range, typename T>
+static bool contains(const Range &range, const T &value) {
+  return std::find(std::begin(range), std::end(range), value) !=
+         std::end(range);
+}
+
+TEST(ModuleDepGraph, BasicLoad) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsTopLevel, {"a", "b"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"c", "d"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{providesTopLevel, {"e", "f"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job3, {{providesNominal, {"g", "h"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job4, {{providesDynamicLookup, {"i", "j"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job5, {{dependsDynamicLookup, {"k", "l"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job6, {},
+                         {{providesMember, {{"m", "mm"}, {"n", "nn"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job7, {},
+                         {{dependsMember, {{"o", "oo"}, {"p", "pp"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job8, {{dependsExternal, {"/foo", "/bar"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(simulateLoad(graph, &job9,
+                         {{providesNominal, {"a", "b"}},
+                          {providesTopLevel, {"b", "c"}},
+                          {dependsNominal, {"c", "d"}},
+                          {dependsTopLevel, {"d", "a"}}}),
+            LoadResult::AffectsDownstream);
+}
+
+TEST(ModuleDepGraph, IndependentNodes) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsTopLevel, {"a"}}, {providesTopLevel, {"a0"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel, {"b"}}, {providesTopLevel, {"b0"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsTopLevel, {"c"}}, {providesTopLevel, {"c0"}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Mark 0 again -- should be no change.
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job2).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, IndependentDepKinds) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ( simulateLoad(graph, &job0, {{dependsNominal,  {"a"}}, {providesNominal,  {"b"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ( simulateLoad(graph, &job1, {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, IndependentDepKinds2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ( simulateLoad(graph, &job0, {{dependsNominal,  {"a"}}, {providesNominal,  {"b"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ( simulateLoad(graph, &job1, {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}), LoadResult::AffectsDownstream);
+
+
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, IndependentMembers) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {}, {{providesMember, {{"a", "aa"}}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {}, {{dependsMember,  {{"a", "bb"}}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {}, {{dependsMember,  {{"a", ""  }}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job3, {}, {{dependsMember,  {{"b", "aa"}}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job4, {}, {{dependsMember,  {{"b", "bb"}}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+  EXPECT_FALSE(graph.isMarked(&job3));
+  EXPECT_FALSE(graph.isMarked(&job4));
+}
+
+TEST(ModuleDepGraph, SimpleDependent) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel,  {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependentReverse) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsTopLevel,  {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{providesTopLevel, {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job1);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job0, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent3) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"a"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent4) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"a"}}, {dependsTopLevel, {"a"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+
+TEST(ModuleDepGraph, SimpleDependent5) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"a"}}, {dependsTopLevel,  {"a"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  auto marked = graph.markTransitive(&job0);
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+
+TEST(ModuleDepGraph, SimpleDependent6) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesDynamicLookup, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsDynamicLookup,  {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependentMember) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ( simulateLoad(graph, &job0, {}, {{providesMember, {{"a", "aa"}, {"b", "bb"}, {"c", "cc"}}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ( simulateLoad(graph, &job1, {}, {{dependsMember,  {{"x", "xx"}, {"b", "bb"}, {"z", "zz"}}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, MultipleDependentsSame) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal,  {"q", "b", "s"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MultipleDependentsDifferent) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal,  {"q", "r", "c"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedDependents) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"x", "b"}}, {providesNominal, {"z"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal,  {"z"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedNoncascadingDependents) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"x", "b"}}, {providesNominal, {"_z"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal,  {"_z"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedNoncascadingDependents2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "_b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel,  {"x", "_b"}}, {providesNominal, {"z"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal,  {"z"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MarkTwoNodes) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,  {{providesTopLevel, {"a", "b"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,  {{dependsTopLevel,  {"a"}}, {providesTopLevel, {"z"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2,  {{dependsTopLevel,  {"z"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job10, {{providesTopLevel, {"y", "z"}}, {dependsTopLevel, {"q"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job11, {{dependsTopLevel,  {"y"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job12, {{dependsTopLevel,  {"q"}}, {providesTopLevel, {"q"}}}), LoadResult::AffectsDownstream);
+
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+  EXPECT_FALSE(graph.isMarked(&job10));
+  EXPECT_FALSE(graph.isMarked(&job11));
+  EXPECT_FALSE(graph.isMarked(&job12));
+
+  {
+    auto marked = graph.markTransitive(&job10);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job11, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+  EXPECT_TRUE(graph.isMarked(&job10));
+  EXPECT_TRUE(graph.isMarked(&job11));
+  EXPECT_FALSE(graph.isMarked(&job12));
+}
+
+TEST(ModuleDepGraph, MarkOneNodeTwice) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal,  {"b"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 0.
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job2, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MarkOneNodeTwice2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal,  {"b"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 0.
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job2, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ReloadDetectsChange) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal,  {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal,  {"b"}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 1.
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job2, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  // Re-mark 1.
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, DependencyLoops) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}, {dependsTopLevel, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{providesTopLevel, {"x"}}, {dependsTopLevel, {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsTopLevel,  {"x"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+
+TEST(ModuleDepGraph, MarkIntransitive) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel,  {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(graph.markIntransitive(&job0));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, MarkIntransitiveTwice) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel,  {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(graph.markIntransitive(&job0));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+
+  EXPECT_FALSE(graph.markIntransitive(&job0));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, MarkIntransitiveThenIndirect) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel,  {"x", "b", "z"}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(graph.markIntransitive(&job1));
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleExternal) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsExternal, {"/foo", "/bar"}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
+
+  EXPECT_EQ(1u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+}
+
+TEST(ModuleDepGraph, SimpleExternal2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsExternal, {"/foo", "/bar"}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(1u, graph.markExternal("/bar").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+
+  EXPECT_EQ(0u, graph.markExternal("/bar").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+}
+
+TEST(ModuleDepGraph, ChainedExternal) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsExternal, {"/bar"}}, {dependsTopLevel,  {"a"}}}), LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
+
+  EXPECT_EQ(2u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, ChainedExternalReverse) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsExternal, {"/bar"}}, {dependsTopLevel,  {"a"}}}), LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markExternal("/bar");
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markExternal("/bar").size());
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  {
+    auto marked = graph.markExternal("/foo");
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job0, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, ChainedExternalPreMarked) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}), LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsExternal, {"/bar"}}, {dependsTopLevel,  {"a"}}}), LoadResult::AffectsDownstream);
+
+  graph.markIntransitive(&job0);
+
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+}


### PR DESCRIPTION
1. The unit tests for the coarse-grained (status quo) dependency graph have been ported to the fine-grained graph, which has been restructured to accommodate. 

2. `-disable-fine-grained-dependencies` command-line option has been added.

3. Fine-grained dependencies are enabled by default. The new infrastructure is used, although at present no more information is being fed into it.