### PR TITLE
Use -[NSSet getObjects:] instead of -[NSSet getObjects:count:] to maintain compatibility with existing code passing NSArrays into this function

### DIFF
--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -20,7 +20,7 @@ internal func _stdlib_NSSet_allObjects(_ object: AnyObject) -> _BridgingBuffer {
   let nss = unsafeBitCast(object, to: _NSSet.self)
   let count = nss.count
   let storage = _BridgingBuffer(count)
-  nss.getObjects(storage.baseAddress, count: count)
+  nss.getObjects(storage.baseAddress)
   return storage
 }
 

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -175,6 +175,10 @@ internal protocol _NSSet: _NSSetCore {
     _ buffer: UnsafeMutablePointer<AnyObject>,
     count: Int
   )
+
+  @objc(getObjects:) func getObjects(
+    _ buffer: UnsafeMutablePointer<AnyObject>
+  )
 }
 
 /// A shadow for the API of NSNumber we will use in the core


### PR DESCRIPTION
5.2 version of https://github.com/apple/swift/pull/28817

Fixes rdar://57801853