### PR TITLE
Bump tensorflow-swift-apis to include categorical initializer change

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -295,7 +295,7 @@
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-12-09-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-12-09-a",
                 "tensorflow": "7c7d924821a8b1b20433c2f3f484bbd409873a84",
-                "tensorflow-swift-apis": "47de23315b574f936daefe1e781bbfd5dfe1a247",
+                "tensorflow-swift-apis": "0aaf944b91703ea6ae9062b3a720d3e27b7eba36",
                 "tensorflow-swift-quote": "34d4112c294e9eccfb575dd8f39e6e3b0b6bc008"
             }
         }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR bumps tensorflow-swift-apis to
https://github.com/tensorflow/swift-apis/commit/0aaf944b91703ea6ae9062b3a720d3e27b7eba36

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
