### PR TITLE
Module selectors (formerly module qualifiers)

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2467,11 +2467,10 @@ public:
   /// names.
   DeclBaseName getBaseName() const { return Name.getBaseName(); }
 
-  /// Generates a DeclNameRef referring to this declaration with as much
-  /// specificity as possible.
-  DeclNameRef createNameRef() const {
-    return DeclNameRef(getFullName());
-  }
+  /// Generates a DeclNameRef referring to this declaration.
+  ///
+  /// \param moduleSelector If true, the name ref includes the module name.
+  DeclNameRef createNameRef(bool moduleSelector = false) const;
 
   /// Retrieve the name to use for this declaration when interoperating
   /// with the Objective-C runtime.

--- a/include/swift/AST/DeclNameLoc.h
+++ b/include/swift/AST/DeclNameLoc.h
@@ -65,12 +65,23 @@ public:
     : LocationInfo(baseNameLoc.getOpaquePointerValue()),
       NumArgumentLabels(0) { }
 
+  explicit DeclNameLoc(ASTContext &ctx, SourceLoc moduleSelectorLoc,
+                       SourceLoc baseNameLoc)
+    : DeclNameLoc(baseNameLoc) { }
+
   /// Create declaration name location information for a compound
   /// name.
   DeclNameLoc(ASTContext &ctx, SourceLoc baseNameLoc,
               SourceLoc lParenLoc,
               ArrayRef<SourceLoc> argumentLabelLocs,
               SourceLoc rParenLoc);
+
+  DeclNameLoc(ASTContext &ctx, SourceLoc moduleSelectorLoc,
+              SourceLoc baseNameLoc,
+              SourceLoc lParenLoc,
+              ArrayRef<SourceLoc> argumentLabelLocs,
+              SourceLoc rParenLoc)
+    : DeclNameLoc(ctx, baseNameLoc, lParenLoc, argumentLabelLocs, rParenLoc) { }
 
   /// Whether the location information is valid.
   bool isValid() const { return getBaseNameLoc().isValid(); }
@@ -103,6 +114,10 @@ public:
     if (index >= NumArgumentLabels)
       return SourceLoc();
     return getSourceLocs()[FirstArgumentLabelIndex + index];
+  }
+
+  SourceLoc getModuleSelectorLoc() const {
+    return SourceLoc();
   }
 
   SourceLoc getStartLoc() const {

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -115,6 +115,9 @@ ERROR(expected_identifier_in_module_selector,none,
       "expected identifier in module selector", ())
 ERROR(module_selector_not_allowed_here,none,
       "name cannot be qualified with module selector here", ())
+ERROR(module_selector_not_allowed_in_decl,none,
+      "%select{%1|name of %1 declaration}0 cannot be qualified with module "
+      "selector", (bool, StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Lexer diagnostics

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -111,6 +111,11 @@ ERROR(forbidden_interpolated_string,none,
 ERROR(forbidden_extended_escaping_string,none,
       "%0 cannot be an extended escaping string literal", (StringRef))
 
+ERROR(expected_identifier_in_module_selector,none,
+      "expected identifier in module selector", ())
+ERROR(module_selector_not_allowed_here,none,
+      "name cannot be qualified with module selector here", ())
+
 //------------------------------------------------------------------------------
 // MARK: Lexer diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -832,6 +832,10 @@ ERROR(use_undeclared_type,none,
       "use of undeclared type %0", (DeclNameRef))
 ERROR(use_undeclared_type_did_you_mean,none,
       "use of undeclared type %0; did you mean to use '%1'?", (DeclNameRef, StringRef))
+ERROR(type_not_in_module,none,
+      "type %0 is not imported through module %1", (DeclName, Identifier))
+NOTE(note_change_module_selector,none,
+     "did you mean module %0?", (Identifier))
 NOTE(note_typo_candidate_implicit_member,none,
      "did you mean the implicitly-synthesized %1 '%0'?", (StringRef, StringRef))
 NOTE(note_remapped_type,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -834,8 +834,14 @@ ERROR(use_undeclared_type_did_you_mean,none,
       "use of undeclared type %0; did you mean to use '%1'?", (DeclNameRef, StringRef))
 ERROR(type_not_in_module,none,
       "type %0 is not imported through module %1", (DeclName, Identifier))
+ERROR(decl_not_in_module,none,
+      "declaration %0 is not imported through module %1", (DeclName, Identifier))
 NOTE(note_change_module_selector,none,
      "did you mean module %0?", (Identifier))
+NOTE(note_remove_module_selector,none,
+     "did you mean the local declaration?", ())
+NOTE(note_add_explicit_self_with_module_selector,none,
+     "did you mean the member of 'self'?", ())
 NOTE(note_typo_candidate_implicit_member,none,
      "did you mean the implicitly-synthesized %1 '%0'?", (StringRef, StringRef))
 NOTE(note_remapped_type,none,

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -626,63 +626,69 @@ public:
   void *getOpaqueValue() const { return FullName.getOpaqueValue(); }
   static DeclNameRef getFromOpaqueValue(void *p);
 
+  explicit DeclNameRef(ASTContext &C, Identifier moduleSelector,
+                       DeclName fullName)
+    : FullName(fullName) { }
+
+  explicit DeclNameRef(ASTContext &C, Identifier moduleSelector,
+                       DeclBaseName baseName, ArrayRef<Identifier> argLabels)
+    : FullName(C, baseName, argLabels) { }
+
   explicit DeclNameRef(DeclName FullName)
-    : FullName(FullName) { }
-
-  explicit DeclNameRef(DeclBaseName BaseName)
     : FullName(BaseName) { }
 
-  explicit DeclNameRef(Identifier BaseName)
-    : FullName(BaseName) { }
+  bool hasModuleSelector() const {
+    return false;
+  }
+
+  Identifier getModuleSelector() const {
+    return Identifier();
+  }
 
   /// The name of the declaration being referenced.
   DeclName getFullName() const {
     return FullName;
   }
 
-  DeclName &getFullName() {
-    return FullName;
-  }
-
   /// The base name of the declaration being referenced.
   DeclBaseName getBaseName() const {
-    return FullName.getBaseName();
+    return getFullName().getBaseName();
   }
 
   Identifier getBaseIdentifier() const {
-    return FullName.getBaseIdentifier();
+    return getFullName().getBaseIdentifier();
   }
 
   ArrayRef<Identifier> getArgumentNames() const {
-    return FullName.getArgumentNames();
+    return getFullName().getArgumentNames();
   }
 
   bool isSimpleName() const {
-    return FullName.isSimpleName();
+    return getFullName().isSimpleName();
   }
 
   bool isSimpleName(DeclBaseName name) const {
-    return FullName.isSimpleName(name);
+    return getFullName().isSimpleName(name);
   }
 
   bool isSimpleName(StringRef name) const {
-    return FullName.isSimpleName(name);
+    return getFullName().isSimpleName(name);
   }
 
   bool isSpecial() const {
-    return FullName.isSpecial();
+    return getFullName().isSpecial();
   }
 
   bool isOperator() const {
-    return FullName.isOperator();
+    return getFullName().isOperator();
   }
 
   bool isCompoundName() const {
-    return FullName.isCompoundName();
+    return getFullName().isCompoundName();
   }
 
   explicit operator bool() const {
-    return (bool)FullName;
+    return (bool)getFullName();
   }
 
   /// Compare two declaration names, producing -1 if \c *this comes before
@@ -757,12 +763,12 @@ inline DeclNameRef DeclNameRef::getFromOpaqueValue(void *p) {
 }
 
 inline DeclNameRef DeclNameRef::withoutArgumentLabels(ASTContext &C) const {
-  return DeclNameRef(getBaseName());
+  return DeclNameRef(C, getModuleSelector(), getBaseName());
 }
 
 inline DeclNameRef DeclNameRef::withArgumentLabels(
     ASTContext &C, ArrayRef<Identifier> argumentNames) const {
-  return DeclNameRef(DeclName(C, getBaseName(), argumentNames));
+  return DeclNameRef(C, getModuleSelector(), getBaseName(), argumentNames);
 }
 
 inline DeclNameRef DeclNameRef::createSubscript() {

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -722,7 +722,7 @@ public:
     return lhs.compare(rhs) >= 0;
   }
 
-  DeclNameRef withoutArgumentLabels() const;
+  DeclNameRef withoutArgumentLabels(ASTContext &C) const;
   DeclNameRef withArgumentLabels(ASTContext &C,
                                  ArrayRef<Identifier> argumentNames) const;
 
@@ -756,7 +756,7 @@ inline DeclNameRef DeclNameRef::getFromOpaqueValue(void *p) {
   return DeclNameRef(DeclName::getFromOpaqueValue(p));
 }
 
-inline DeclNameRef DeclNameRef::withoutArgumentLabels() const {
+inline DeclNameRef DeclNameRef::withoutArgumentLabels(ASTContext &C) const {
   return DeclNameRef(getBaseName());
 }
 
@@ -764,7 +764,6 @@ inline DeclNameRef DeclNameRef::withArgumentLabels(
     ASTContext &C, ArrayRef<Identifier> argumentNames) const {
   return DeclNameRef(DeclName(C, getBaseName(), argumentNames));
 }
-
 
 inline DeclNameRef DeclNameRef::createSubscript() {
   return DeclNameRef(DeclBaseName::createSubscript());

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -41,14 +41,14 @@ enum class ResolutionKind {
 
 void simple_display(llvm::raw_ostream &out, ResolutionKind kind);
 
-/// Performs a lookup into the given module and it's imports.
+/// Performs a lookup into the given module and its imports.
 ///
-/// If 'moduleOrFile' is a ModuleDecl, we search the module and it's
+/// If 'moduleOrFile' is a ModuleDecl, we search the module and its
 /// public imports. If 'moduleOrFile' is a SourceFile, we search the
 /// file's parent module, the module's public imports, and the source
 /// file's private imports.
 ///
-/// \param moduleOrFile The module or file unit whose imports to search.
+/// \param moduleOrFile The module or file unit to search, including imports.
 /// \param name The name to look up.
 /// \param[out] decls Any found decls will be added to this vector.
 /// \param lookupKind Whether this lookup is qualified or unqualified.

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -440,6 +440,14 @@ public:
 /// \returns true if any declarations were removed, false otherwise.
 bool removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls);
 
+/// Remove any declarations in the given set that do not match the
+/// module selector, if it is not empty.
+///
+/// \returns true if any declarations were removed, false otherwise.
+bool removeOutOfModuleDecls(SmallVectorImpl<ValueDecl*> &decls,
+                            Identifier moduleSelector,
+                            const DeclContext *dc);
+
 /// Remove any declarations in the given set that are shadowed by
 /// other declarations in that set.
 ///
@@ -474,6 +482,7 @@ namespace namelookup {
 /// Once name lookup has gathered a set of results, perform any necessary
 /// steps to prune the result set before returning it to the caller.
 void pruneLookupResultSet(const DeclContext *dc, NLOptions options,
+                          Identifier moduleSelector,
                           SmallVectorImpl<ValueDecl *> &decls);
 
 /// Do nothing if debugClient is null.

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -380,7 +380,21 @@ public:
 private:
   friend SimpleRequest;
 
-  // Evaluation.
+  /// Performs a lookup into the given module and its imports.
+  ///
+  /// If 'moduleOrFile' is a ModuleDecl, we search the module and its
+  /// public imports. If 'moduleOrFile' is a SourceFile, we search the
+  /// file's parent module, the module's public imports, and the source
+  /// file's private imports.
+  ///
+  /// \param evaluator The request evaluator.
+  /// \param moduleOrFile The module or file unit to search, including imports.
+  /// \param name The name to look up.
+  /// \param lookupKind Whether this lookup is qualified or unqualified.
+  /// \param resolutionKind What sort of decl is expected.
+  /// \param moduleScopeContext The top-level context from which the lookup is
+  ///        being performed, for checking access. This must be either a
+  ///        FileUnit or a Module.
   llvm::Expected<QualifiedLookupResult>
   evaluate(Evaluator &evaluator, const DeclContext *moduleOrFile, DeclName name,
            NLKind lookupKind, namelookup::ResolutionKind resolutionKind,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -188,6 +188,9 @@ namespace swift {
     /// optimized custom allocator, so that memory debugging tools can be used.
     bool UseMalloc = false;
 
+    /// Enable experimental 'Module::name' syntax.
+    bool EnableExperimentalModuleSelector = false;
+
     /// Enable experimental #assert feature.
     bool EnableExperimentalStaticAssert = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -366,6 +366,10 @@ def enable_sil_opaque_values : Flag<["-"], "enable-sil-opaque-values">,
 def enable_large_loadable_types : Flag<["-"], "enable-large-loadable-types">,
   HelpText<"Enable Large Loadable types IRGen pass">;
 
+def enable_experimental_module_selector :
+  Flag<["-"], "enable-experimental-module-selector">,
+  HelpText<"Enable experimental 'Module::name' syntax">;
+
 def enable_experimental_static_assert :
   Flag<["-"], "enable-experimental-static-assert">,
   HelpText<"Enable experimental #assert">;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -576,6 +576,21 @@ public:
              Context.getIdentifier(tok.getText()));
   }
 
+  /// If the next two tokens appear to form a module selector, consume them and
+  /// diagnose an error. Call this method before consuming an identifier that
+  /// should *not* have a module selector before it.
+  ///
+  /// \param KindName A string describing the name or declaration being written.
+  /// \param IsDef If \c true, the identifier defines a declaration's name, and
+  /// \p KindName should be a string describing the declaration; if \c false,
+  /// the identifier does something else, and \p KindName should be a more
+  /// complete string.
+  ///
+  /// \returns true if a module selector was consumed and an error was diagnosed;
+  /// false otherwise.
+  bool
+  diagnoseAndConsumeIfModuleSelector(StringRef KindName, bool IsDef = true);
+
   /// Retrieve the location just past the end of the previous
   /// source location.
   SourceLoc getEndOfPreviousLoc() const;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1478,6 +1478,10 @@ public:
     /// not ordinary identifiers.
     AllowKeywordsUsingSpecialNames = AllowKeywords | 1 << 2,
 
+    /// If passed, a module selector (ModuleName::) is permitted before the base
+    /// name.
+    AllowModuleSelector = 1 << 3,
+
     /// If passed, compound names with argument lists are allowed, unless they
     /// have empty argument lists.
     AllowCompoundNames = 1 << 4,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -737,6 +737,17 @@ public:
   consumeStartingCharacterOfCurrentToken(tok Kind = tok::oper_binary_unspaced,
                                          size_t Len = 1);
 
+  /// If the next token is \c tok::colon, consume it; if the next token is
+  /// \c tok::colon_colon, split it into two \c tok::colons and consume the
+  /// first; otherwise, do nothing and return false.
+  bool consumeIfColonSplittingDoubles() {
+    if (!Tok.isAny(tok::colon, tok::colon_colon))
+      return false;
+
+    consumeStartingCharacterOfCurrentToken(tok::colon);
+    return true;
+  }
+
   swift::ScopeInfo &getScopeInfo() { return State->getScopeInfo(); }
 
   /// Add the given Decl to the current scope.

--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -167,6 +167,11 @@ inline ValueDecl *ScopeInfo::lookupValueName(DeclNameRef Name) {
   if (!CurScope)
     return nullptr;
 
+  // If the name has a module selector, by definition it can only match a
+  // top-level declaration.
+  if (Name.hasModuleSelector())
+    return nullptr;
+
   assert(CurScope && "no scope");
   // If we found nothing, or we found a decl at the top-level, return nothing.
   // We ignore results at the top-level because we may have overloading that

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -60,8 +60,9 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
 
   auto *const fileScope = sourceFile->getScope().impl;
   // Parser may have added decls to source file, since previous lookup
-  if (name.isOperator())
-    return fileScope; // operators always at file scope
+  if (name.isOperator() || name.hasModuleSelector())
+    // operators and module-selector names always at file scope
+    return fileScope;
 
   const auto *innermost = fileScope->findInnermostEnclosingScope(loc, nullptr);
   ASTScopeAssert(innermost->getWasExpanded(),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1873,6 +1873,14 @@ SourceRange IfConfigDecl::getSourceRange() const {
   return SourceRange(getLoc(), EndLoc);
 }
 
+DeclNameRef ValueDecl::createNameRef(bool moduleSelector) const {
+  if (moduleSelector)
+    return DeclNameRef(getASTContext(), getModuleContext()->getName(),
+                       getFullName());
+
+  return DeclNameRef(getFullName());
+}
+
 static bool isPolymorphic(const AbstractStorageDecl *storage) {
   if (storage->isObjCDynamic())
     return true;

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -52,6 +52,8 @@ void swift::simple_display(llvm::raw_ostream &out, DeclName name) {
 }
 
 raw_ostream &llvm::operator<<(raw_ostream &OS, DeclNameRef I) {
+  if (I.hasModuleSelector())
+    OS << I.getModuleSelector() << "::";
   OS << I.getFullName();
   return OS;
 }
@@ -203,17 +205,27 @@ void DeclNameRef::dump() const {
 }
 
 StringRef DeclNameRef::getString(llvm::SmallVectorImpl<char> &scratch,
-                             bool skipEmptyArgumentNames) const {
-  return FullName.getString(scratch, skipEmptyArgumentNames);
+                                 bool skipEmptyArgumentNames) const {
+  {
+    llvm::raw_svector_ostream out(scratch);
+    print(out, skipEmptyArgumentNames);
+  }
+
+  return StringRef(scratch.data(), scratch.size());
 }
 
-llvm::raw_ostream &DeclNameRef::print(llvm::raw_ostream &os,
-                                  bool skipEmptyArgumentNames) const {
-  return FullName.print(os, skipEmptyArgumentNames);
+llvm::raw_ostream &
+DeclNameRef::print(llvm::raw_ostream &os,
+                   bool skipEmptyArgumentNames) const {
+  if (hasModuleSelector())
+    os << getModuleSelector() << "::";
+  return getFullName().print(os, skipEmptyArgumentNames);
 }
 
 llvm::raw_ostream &DeclNameRef::printPretty(llvm::raw_ostream &os) const {
-  return FullName.printPretty(os);
+  if (hasModuleSelector())
+    os << getModuleSelector() << "::";
+  return getFullName().printPretty(os);
 }
 
 ObjCSelector::ObjCSelector(ASTContext &ctx, unsigned numArgs,

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -1038,6 +1038,8 @@ void UnqualifiedLookupFactory::recordDependencyOnTopLevelName(
 }
 
 void UnqualifiedLookupFactory::addImportedResults(DeclContext *const dc) {
+  assert(dc);
+
   using namespace namelookup;
   SmallVector<ValueDecl *, 8> CurModuleResults;
   auto resolutionKind = isOriginallyTypeLookup ? ResolutionKind::TypesOnly
@@ -1049,6 +1051,10 @@ void UnqualifiedLookupFactory::addImportedResults(DeclContext *const dc) {
     // We'd need a new ResolutionKind.
     moduleToLookIn =
         dc->getASTContext().getLoadedModule(Name.getModuleSelector());
+  
+  // If we didn't find the module, it obviously can't have any results.
+  if (!moduleToLookIn)
+    return;
 
   lookupInModule(moduleToLookIn, Name.getFullName(), CurModuleResults,
                  NLKind::UnqualifiedLookup, resolutionKind, dc);

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -1042,8 +1042,16 @@ void UnqualifiedLookupFactory::addImportedResults(DeclContext *const dc) {
   SmallVector<ValueDecl *, 8> CurModuleResults;
   auto resolutionKind = isOriginallyTypeLookup ? ResolutionKind::TypesOnly
                                                : ResolutionKind::Overloadable;
-  lookupInModule(dc, Name.getFullName(), CurModuleResults, NLKind::UnqualifiedLookup,
-                 resolutionKind, dc);
+
+  auto moduleToLookIn = dc;
+  if (Name.hasModuleSelector())
+    // FIXME: Should we look this up relative to dc?
+    // We'd need a new ResolutionKind.
+    moduleToLookIn =
+        dc->getASTContext().getLoadedModule(Name.getModuleSelector());
+
+  lookupInModule(moduleToLookIn, Name.getFullName(), CurModuleResults,
+                 NLKind::UnqualifiedLookup, resolutionKind, dc);
 
   // Always perform name shadowing for type lookup.
   if (options.contains(Flags::TypeLookup)) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2173,7 +2173,8 @@ namespace {
       auto found = Impl.MembersForNominal.find(subject);
       if (found != Impl.MembersForNominal.end()) {
         lookup.append(found->second.begin(), found->second.end());
-        namelookup::pruneLookupResultSet(dc, NL_QualifiedDefault, lookup);
+        namelookup::pruneLookupResultSet(dc, NL_QualifiedDefault,
+            /*moduleSelector=*/Identifier(), lookup);
       }
 
       for (auto *&result : lookup) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -284,6 +284,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DiagnosticsEditorMode |= Args.hasArg(OPT_diagnostics_editor_mode,
                                             OPT_serialize_diagnostics_path);
 
+  Opts.EnableExperimentalModuleSelector |=
+    Args.hasArg(OPT_enable_experimental_module_selector);
+
   Opts.EnableExperimentalStaticAssert |=
     Args.hasArg(OPT_enable_experimental_static_assert);
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -284,7 +284,7 @@ static void collectPossibleCalleesByQualifiedLookup(
 
   SmallVector<ValueDecl *, 2> decls;
   if (!DC.lookupQualified(baseTy->getMetatypeInstanceType(),
-                          name.withoutArgumentLabels(),
+                          name.withoutArgumentLabels(DC.getASTContext()),
                           NL_QualifiedDefault | NL_ProtocolMembers,
                           decls))
     return;

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2397,8 +2397,14 @@ void Lexer::lexImpl() {
 
   case ',': return formToken(tok::comma, TokStart);
   case ';': return formToken(tok::semi, TokStart);
-  case ':': return formToken(tok::colon, TokStart);
   case '\\': return formToken(tok::backslash, TokStart);
+
+  case ':':
+    if (CurPtr[0] == ':') {
+      CurPtr++;
+      return formToken(tok::colon_colon, TokStart);
+    }
+    return formToken(tok::colon, TokStart);
 
   case '#':
     if (unsigned CustomDelimiterLen = advanceIfCustomDelimiter(CurPtr, Diags))

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1277,11 +1277,10 @@ void Parser::parseObjCSelector(SmallVector<Identifier, 4> &Names,
     SyntaxParsingContext SelectorPieceContext(SyntaxContext,
                                               SyntaxKind::ObjCSelectorPiece);
     // Empty selector piece.
-    if (Tok.is(tok::colon)) {
+    if (consumeIfColonSplittingDoubles()) {
       Names.push_back(Identifier());
-      NameLocs.push_back(Tok.getLoc());
+      NameLocs.push_back(PreviousLoc);
       IsNullarySelector = false;
-      consumeToken();
       continue;
     }
 
@@ -1292,8 +1291,7 @@ void Parser::parseObjCSelector(SmallVector<Identifier, 4> &Names,
       consumeToken();
 
       // If we have a colon, consume it.
-      if (Tok.is(tok::colon)) {
-        consumeToken();
+      if (consumeIfColonSplittingDoubles()) {
         IsNullarySelector = false;
         continue;
       }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4086,7 +4086,9 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
     if (parseAnyIdentifier(ImportPath.back().first,
                            diag::expected_identifier_in_decl, "import"))
       return nullptr;
-    HasNext = consumeIf(tok::period);
+    HasNext = consumeIf(tok::period) ||
+        (Context.LangOpts.EnableExperimentalModuleSelector &&
+         consumeIf(tok::colon_colon));
   } while (HasNext);
 
   // Collect all access path components to an access path.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1015,7 +1015,8 @@ bool Parser::parseDifferentiableAttributeArguments(
     Diagnostic funcDiag(diag::attr_differentiable_expected_function_name.ID,
                         { label });
     result.Name = parseDeclNameRef(result.Loc, funcDiag,
-        DeclNameFlag::AllowZeroArgCompoundNames | DeclNameFlag::AllowOperators);
+        DeclNameFlag::AllowZeroArgCompoundNames | DeclNameFlag::AllowOperators |
+        DeclNameFlag::AllowModuleSelector);
     // If no trailing comma or 'where' clause, terminate parsing arguments.
     if (Tok.isNot(tok::comma, tok::kw_where))
       terminateParsingArgs = true;
@@ -1123,7 +1124,8 @@ static bool parseQualifiedDeclName(Parser &P, Diag<> nameParseError,
       original.Loc, nameParseError,
       Parser::DeclNameFlag::AllowZeroArgCompoundNames |
       Parser::DeclNameFlag::AllowKeywordsUsingSpecialNames |
-      Parser::DeclNameFlag::AllowOperators);
+      Parser::DeclNameFlag::AllowOperators |
+      Parser::DeclNameFlag::AllowModuleSelector);
   // The base type is optional, but the final unqualified declaration name is
   // not. If name could not be parsed, return true for error.
   return !original.Name;
@@ -2178,7 +2180,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
             diag::attr_dynamic_replacement_expected_function,
             DeclNameFlag::AllowZeroArgCompoundNames |
             DeclNameFlag::AllowKeywordsUsingSpecialNames |
-            DeclNameFlag::AllowOperators);
+            DeclNameFlag::AllowOperators |
+            DeclNameFlag::AllowModuleSelector);
       }
     }
 
@@ -2394,10 +2397,14 @@ static PatternBindingInitializer *findAttributeInitContent(
 /// but rejected since they have context-sensitive keywords.
 ///
 ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc) {
+  bool hasModuleSelector = Context.LangOpts.EnableExperimentalModuleSelector &&
+                               peekToken().is(tok::colon_colon);
+
   // If this not an identifier, the attribute is malformed.
   if (Tok.isNot(tok::identifier) &&
       Tok.isNot(tok::kw_in) &&
-      Tok.isNot(tok::kw_inout)) {
+      Tok.isNot(tok::kw_inout) &&
+      !hasModuleSelector) {
 
     if (Tok.is(tok::code_complete)) {
       if (CodeCompletion) {
@@ -2417,13 +2424,16 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
 
   // If the attribute follows the new representation, switch
   // over to the alternate parsing path.
-  DeclAttrKind DK = DeclAttribute::getAttrKindFromString(Tok.getText());
+  // All module-selected names are custom attributes, so we always use DAK_Count
+  // if a module selector is present.
+  DeclAttrKind DK = hasModuleSelector ? DAK_Count :
+      DeclAttribute::getAttrKindFromString(Tok.getText());
   
   auto checkInvalidAttrName = [&](StringRef invalidName,
                                   StringRef correctName,
                                   DeclAttrKind kind,
                                   Optional<Diag<StringRef, StringRef>> diag = None) {
-    if (DK == DAK_Count && Tok.getText() == invalidName) {
+    if (DK == DAK_Count && !hasModuleSelector && Tok.getText() == invalidName) {
       DK = kind;
 
       if (diag) {
@@ -2458,7 +2468,8 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
   checkInvalidAttrName("_propertyWrapper", "propertyWrapper",
                        DAK_PropertyWrapper, diag::attr_renamed_warning);
 
-  if (DK == DAK_Count && Tok.getText() == "warn_unused_result") {
+  if (DK == DAK_Count && !hasModuleSelector &&
+      Tok.getText() == "warn_unused_result") {
     // The behavior created by @warn_unused_result is now the default. Emit a
     // Fix-It to remove.
     SourceLoc attrLoc = consumeToken();
@@ -2499,9 +2510,10 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
     return makeParserSuccess();
   }
 
-  if (TypeAttributes::getAttrKindFromString(Tok.getText()) != TAK_Count)
+  if (!hasModuleSelector &&
+      TypeAttributes::getAttrKindFromString(Tok.getText()) != TAK_Count)
     diagnose(Tok, diag::type_attribute_applied_to_decl);
-  else if (Tok.isContextualKeyword("unknown")) {
+  else if (!hasModuleSelector && Tok.isContextualKeyword("unknown")) {
     diagnose(Tok, diag::unknown_attribute, "unknown");
   } else {
     // Change the context to create a custom attribute syntax.
@@ -2700,7 +2712,8 @@ bool Parser::parseConventionAttributeInternal(
 
     DeclNameLoc unusedLoc;
     convention.WitnessMethodProtocol = parseDeclNameRef(unusedLoc,
-        diag::convention_attribute_witness_method_expected_protocol, {});
+        diag::convention_attribute_witness_method_expected_protocol,
+        DeclNameFlag::AllowModuleSelector);
   }
   
   // Parse the ')'.  We can't use parseMatchingToken if we're in

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1133,7 +1133,8 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
                      ? diag::expected_identifier_after_super_dot_expr
                      : diag::expected_member_name;
       auto Name = parseDeclNameRef(NameLoc, D,
-          DeclNameFlag::AllowKeywords | DeclNameFlag::AllowCompoundNames);
+          DeclNameFlag::AllowKeywords | DeclNameFlag::AllowCompoundNames |
+          DeclNameFlag::AllowModuleSelector);
       if (!Name)
         return nullptr;
       SyntaxContext->createNodeInPlace(SyntaxKind::MemberAccessExpr);
@@ -1584,7 +1585,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
     }
 
     Name = parseDeclNameRef(NameLoc, diag::expected_identifier_after_dot_expr,
-        DeclNameFlag::AllowKeywords | DeclNameFlag::AllowCompoundNames);
+        DeclNameFlag::AllowKeywords | DeclNameFlag::AllowCompoundNames |
+        DeclNameFlag::AllowModuleSelector);
     if (!Name) return nullptr;
     SyntaxContext->createNodeInPlace(SyntaxKind::MemberAccessExpr);
 
@@ -2178,6 +2180,33 @@ static bool tryParseArgLabelList(Parser &P, Parser::DeclNameOptions flags,
 DeclNameRef Parser::parseDeclNameRef(DeclNameLoc &loc,
                                      const Diagnostic &diag,
                                      DeclNameOptions flags) {
+  // Consume the module name, if present.
+  SourceLoc moduleSelectorLoc;
+  Identifier moduleSelector;
+  if (Context.LangOpts.EnableExperimentalModuleSelector &&
+      peekToken().is(tok::colon_colon)) {
+    // FIXME: libSyntax
+
+    if (Tok.is(tok::identifier)) { // FIXME: tok::dollarident?
+      moduleSelectorLoc = consumeIdentifier(&moduleSelector);
+    }
+    else {
+      diagnose(Tok, diag::expected_identifier_in_module_selector);
+      moduleSelector = Identifier();
+      moduleSelectorLoc = consumeToken();
+    }
+
+    // Diagnose if we don't allow a module selector here.
+    if (!flags.contains(DeclNameFlag::AllowModuleSelector)) {
+      diagnose(Tok, diag::module_selector_not_allowed_here)
+          .fixItRemove({moduleSelectorLoc, Tok.getLoc()});
+      moduleSelector = Identifier();
+      moduleSelectorLoc = SourceLoc();
+    }
+
+    consumeToken(tok::colon_colon);
+  }
+
   // Consume the base name.
   DeclBaseName baseName;
   SourceLoc baseNameLoc;
@@ -2246,7 +2275,8 @@ Expr *Parser::parseExprIdentifier() {
   // Parse the unqualified-decl-name.
   DeclNameLoc loc;
   DeclNameRef name = parseDeclNameRef(loc, diag::expected_expr,
-                                      DeclNameFlag::AllowCompoundNames);
+                                      DeclNameFlag::AllowCompoundNames |
+                                      DeclNameFlag::AllowModuleSelector);
 
   SmallVector<TypeRepr*, 8> args;
   SourceLoc LAngleLoc, RAngleLoc;
@@ -3079,8 +3109,11 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
       SyntaxParsingContext operatorContext(SyntaxContext,
                                            SyntaxKind::IdentifierExpr);
       DeclNameLoc Loc;
+      // FIXME: We would like to allow module selectors on binary operators, but
+      // the condition above won't let us reach this code.
       auto OperName = parseDeclNameRef(Loc, diag::expected_operator_ref,
-                                       DeclNameFlag::AllowOperators);
+                                       DeclNameFlag::AllowOperators |
+                                       DeclNameFlag::AllowModuleSelector);
       if (!OperName) {
         return makeParserError();
       }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1500,6 +1500,10 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
         // call pattern.
         peekToken().isNot(tok::period, tok::period_prefix, tok::l_paren)) {
       DeferringContextRAII Deferring(*SyntaxContext);
+
+      diagnoseAndConsumeIfModuleSelector(InVarOrLetPattern != IVOLP_InVar
+                                         ? "constant" : "variable");
+
       Identifier name;
       SourceLoc loc = consumeIdentifier(&name, /*allowDollarIdentifier=*/true);
       auto introducer = (InVarOrLetPattern != IVOLP_InVar
@@ -2495,9 +2499,23 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
 
       // Okay, we have a closure signature.
     } else if (Tok.isIdentifierOrUnderscore()) {
-      // Parse identifier (',' identifier)*
+      // Parse module-selector? identifier (',' module-selector? identifier)*
+      // The module selectors aren't legal, but we want to diagnose them if
+      // they're present.
+      if (Context.LangOpts.EnableExperimentalModuleSelector &&
+          peekToken().is(tok::colon_colon)) {
+        consumeToken();
+        consumeToken(tok::colon_colon);
+      }
+
       consumeToken();
       while (consumeIf(tok::comma)) {
+        if (Context.LangOpts.EnableExperimentalModuleSelector &&
+            peekToken().is(tok::colon_colon)) {
+          consumeToken();
+          consumeToken(tok::colon_colon);
+        }
+
         if (Tok.isIdentifierOrUnderscore()) {
           consumeToken();
           continue;
@@ -2568,8 +2586,11 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
             diagnose(Tok, diag::attr_unowned_expected_rparen);
         }
       } else if (Tok.isAny(tok::identifier, tok::kw_self) &&
-                 peekToken().isAny(tok::equal, tok::comma, tok::r_square)) {
+                 peekToken().isAny(tok::equal, tok::comma, tok::r_square,
+                                   tok::colon_colon)) {
         // "x = 42", "x," and "x]" are all strong captures of x.
+        // "x::" is not permitted, but we want to diagnose it as though it were
+        // a strong capture.
       } else {
         diagnose(Tok, diag::expected_capture_specifier);
         skipUntil(tok::comma, tok::r_square);
@@ -2587,10 +2608,17 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
 
       // The thing being capture specified is an identifier, or as an identifier
       // followed by an expression.
+
       Expr *initializer;
       Identifier name;
       SourceLoc nameLoc = Tok.getLoc();
       SourceLoc equalLoc;
+
+      // FIXME: It'd be nice to be able to capture with a module selector, but
+      // define a local name; however, that would complicate the equals check
+      // here.
+      diagnoseAndConsumeIfModuleSelector("captured variable");
+
       if (peekToken().isNot(tok::equal)) {
         // If this is the simple case, then the identifier is both the name and
         // the expression to capture.
@@ -2677,6 +2705,9 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
       bool HasNext;
       do {
         SyntaxParsingContext ClParamCtx(SyntaxContext, SyntaxKind::ClosureParam);
+
+        diagnoseAndConsumeIfModuleSelector("parameter");
+
         if (Tok.isNot(tok::identifier, tok::kw__)) {
           diagnose(Tok, diag::expected_closure_parameter_name);
           invalid = true;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2257,15 +2257,15 @@ DeclNameRef Parser::parseDeclNameRef(DeclNameLoc &loc,
                                          rparenLoc);
 
   if (argumentLabelLocs.empty() || !hadArgList)
-    loc = DeclNameLoc(baseNameLoc);
+    loc = DeclNameLoc(Context, moduleSelectorLoc, baseNameLoc);
   else
-    loc = DeclNameLoc(Context, baseNameLoc, lparenLoc, argumentLabelLocs,
-                      rparenLoc);
+    loc = DeclNameLoc(Context, moduleSelectorLoc, baseNameLoc,
+                      lparenLoc, argumentLabelLocs, rparenLoc);
 
   if (!hadArgList)
-    return DeclNameRef(baseName);
+    return DeclNameRef(Context, moduleSelector, baseName);
 
-  return DeclNameRef({ Context, baseName, argumentLabels });
+  return DeclNameRef(Context, moduleSelector, baseName, argumentLabels);
 }
 
 ///   expr-identifier:

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -67,6 +67,8 @@ Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
       attributes.add(new (Context) RawDocCommentAttr(Tok.getCommentRange()));
     parseDeclAttributeList(attributes);
 
+    diagnoseAndConsumeIfModuleSelector("generic parameter");
+
     // Parse the name of the parameter.
     Identifier Name;
     SourceLoc NameLoc;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -185,6 +185,12 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
          rightParenLoc.isInvalid() && "Must start with empty state");
   SyntaxParsingContext ParamClauseCtx(SyntaxContext, SyntaxKind::ParameterClause);
 
+  // Operators and closures cannot have API names. Enum elements cannot have
+  // internal names.
+  bool canHaveLabels = !(paramContext == ParameterContextKind::Operator ||
+                         paramContext == ParameterContextKind::Closure);
+  bool canHaveInternalName = paramContext != ParameterContextKind::EnumElement;
+
   // Consume the starting '(';
   leftParenLoc = consumeToken(tok::l_paren);
 
@@ -279,21 +285,24 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       diagnose(Tok, diag::parameter_let_var_as_attr, Tok.getText())
         .fixItReplace(Tok.getLoc(), "`" + Tok.getText().str() + "`");
     }
+
+    diagnoseAndConsumeIfModuleSelector(
+        canHaveLabels ? "argument label" : "parameter",
+        /*isDef=*/!canHaveLabels);
     
     if (startsParameterName(*this, isClosure)) {
       // identifier-or-none for the first name
       param.FirstNameLoc = consumeArgumentLabel(param.FirstName);
 
+      diagnoseAndConsumeIfModuleSelector("parameter");
+
       // identifier-or-none? for the second name
       if (Tok.canBeArgumentLabel())
         param.SecondNameLoc = consumeArgumentLabel(param.SecondName);
 
-      // Operators, closures, and enum elements cannot have API names.
-      if ((paramContext == ParameterContextKind::Operator ||
-           paramContext == ParameterContextKind::Closure ||
-           paramContext == ParameterContextKind::EnumElement) &&
-          !param.FirstName.empty() &&
-          param.SecondNameLoc.isValid()) {
+      // Do we have two names in a parameter that can't have both?
+      if (!(canHaveLabels && canHaveInternalName) &&
+          !param.FirstName.empty() && param.SecondNameLoc.isValid()) {
         enum KeywordArgumentDiagnosticContextKind {
           Operator    = 0,
           Closure     = 1,
@@ -952,6 +961,12 @@ ParserResult<Pattern> Parser::parsePattern() {
   auto introducer = (InVarOrLetPattern != IVOLP_InVar
                      ? VarDecl::Introducer::Let
                      : VarDecl::Introducer::Var);
+  StringRef declNameKind = introducer == VarDecl::Introducer::Let
+                         ? "constant" : "variable";
+
+  // If there's a module selector here, consume and remove it.
+  diagnoseAndConsumeIfModuleSelector(declNameKind);
+
   switch (Tok.getKind()) {
   case tok::l_paren:
     return parsePatternTuple();
@@ -971,19 +986,17 @@ ParserResult<Pattern> Parser::parsePattern() {
     }
     PatternCtx.setCreateSyntax(SyntaxKind::WildcardPattern);
     return makeParserResult(new (Context) AnyPattern(consumeToken(tok::kw__)));
-    
+
   case tok::identifier: {
     PatternCtx.setCreateSyntax(SyntaxKind::IdentifierPattern);
     Identifier name;
     SourceLoc loc = consumeIdentifier(&name);
     if (Tok.isIdentifierOrUnderscore() && !Tok.isContextualDeclKeyword())
-      diagnoseConsecutiveIDs(name.str(), loc,
-                             introducer == VarDecl::Introducer::Let
-                             ? "constant" : "variable");
+      diagnoseConsecutiveIDs(name.str(), loc, declNameKind);
 
     return makeParserResult(createBindingFromPattern(loc, name, introducer));
   }
-    
+
   case tok::code_complete:
     if (!CurDeclContext->isTypeContext()) {
       // This cannot be an overridden property, so just eat the token. We cannot
@@ -1019,7 +1032,7 @@ ParserResult<Pattern> Parser::parsePattern() {
     return makeParserResult(new (Context) VarPattern(varLoc, isLet,
                                                      subPattern.get()));
   }
-      
+
   default:
     if (Tok.isKeyword() &&
         (peekToken().is(tok::colon) || peekToken().is(tok::equal))) {
@@ -1052,6 +1065,10 @@ Parser::parsePatternTupleElement() {
   // If this element has a label, parse it.
   Identifier Label;
   SourceLoc LabelLoc;
+
+  StringRef declNameKind = InVarOrLetPattern != IVOLP_InVar
+                         ? "constant" : "variable";
+  diagnoseAndConsumeIfModuleSelector(declNameKind);
 
   // If the tuple element has a label, parse it.
   if (Tok.is(tok::identifier) && peekToken().is(tok::colon)) {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -674,7 +674,8 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
   while (true) {
     DeclNameLoc Loc;
     DeclNameRef Name =
-        parseDeclNameRef(Loc, diag::expected_identifier_in_dotted_type, {});
+        parseDeclNameRef(Loc, diag::expected_identifier_in_dotted_type,
+                         DeclNameFlag::AllowModuleSelector);
     if (!Name)
       Status.setIsParseError();
 

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -903,9 +903,8 @@ private:
       }
       SmallVector<ValueDecl *, 1> decls;
       declContext->lookupQualified(declContext->getParentModule(),
-                                   renamedDeclName.withoutArgumentLabels(),
-                                   NL_OnlyTypes,
-                                   decls);
+          renamedDeclName.withoutArgumentLabels(astContext), NL_OnlyTypes,
+          decls);
       if (decls.size() == 1)
         return decls[0];
       return nullptr;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3162,7 +3162,8 @@ bool MissingMemberFailure::diagnoseAsError() {
       auto &cs = getConstraintSystem();
 
       auto result = cs.performMemberLookup(
-          ConstraintKind::ValueMember, getName().withoutArgumentLabels(),
+          ConstraintKind::ValueMember,
+          getName().withoutArgumentLabels(getASTContext()),
           metatypeTy, FunctionRefKind::DoubleApply, getLocator(),
           /*includeInaccessibleMembers=*/true);
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -116,7 +116,7 @@ static EnumElementDecl *
 lookupUnqualifiedEnumMemberElement(DeclContext *DC, DeclNameRef name,
                                    SourceLoc UseLoc) {
   // FIXME: We should probably pay attention to argument labels someday.
-  name = name.withoutArgumentLabels();
+  name = name.withoutArgumentLabels(DC->getASTContext());
 
   auto lookupOptions = defaultUnqualifiedLookupOptions;
   lookupOptions |= NameLookupFlags::KnownPrivate;
@@ -134,7 +134,7 @@ lookupEnumMemberElement(DeclContext *DC, Type ty,
     return nullptr;
 
   // FIXME: We should probably pay attention to argument labels someday.
-  name = name.withoutArgumentLabels();
+  name = name.withoutArgumentLabels(DC->getASTContext());
 
   // Look up the case inside the enum.
   // FIXME: We should be able to tell if this is a private lookup.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -919,7 +919,7 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
   lookupValueWitnessesViaImplementsAttr(req, witnesses);
 
   auto reqName = req->createNameRef();
-  auto reqBaseName = reqName.withoutArgumentLabels();
+  auto reqBaseName = reqName.withoutArgumentLabels(DC->getASTContext());
 
   if (req->isOperator()) {
     // Operator lookup is always global.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 531; // function parameter noDerivative
+const uint16_t SWIFTMODULE_VERSION_MINOR = 532; // DeclNameRef ModuleSelector fields
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1774,8 +1774,10 @@ namespace decls_block {
     Differentiable_DECL_ATTR,
     BCFixed<1>, // Implicit flag.
     BCFixed<1>, // Linear flag.
+    IdentifierIDField, // JVP module selector.
     IdentifierIDField, // JVP name.
     DeclIDField, // JVP function declaration.
+    IdentifierIDField, // VJP module selector.
     IdentifierIDField, // VJP name.
     DeclIDField, // VJP function declaration.
     GenericSignatureIDField, // Derivative generic signature.
@@ -1785,6 +1787,7 @@ namespace decls_block {
   using DerivativeDeclAttrLayout = BCRecordLayout<
     Derivative_DECL_ATTR,
     BCFixed<1>, // Implicit flag.
+    IdentifierIDField, // Original module selector.
     IdentifierIDField, // Original name.
     DeclIDField, // Original function declaration.
     AutoDiffDerivativeFunctionKindField, // Derivative function kind.
@@ -1810,7 +1813,7 @@ namespace decls_block {
     DynamicReplacement_DECL_ATTR,
     BCFixed<1>, // implicit flag
     DeclIDField, // replaced function
-    BCVBR<4>,   // # of arguments (+1) or zero if no name
+    BCVBR<4>,   // # of arguments (+2) or zero if no name
     BCArray<IdentifierIDField>
   >;
 

--- a/test/NameBinding/Inputs/ModuleSelectorTestingKit.swiftinterface
+++ b/test/NameBinding/Inputs/ModuleSelectorTestingKit.swiftinterface
@@ -1,0 +1,40 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name ModuleSelectorTestingKit -swift-version 5
+
+import Swift
+
+// These types are identical; we just use them to test with different scope
+// selectors.
+
+public struct A {
+  public init(value: Swift.Int)
+  public dynamic mutating func negate()
+  public var magnitude: Swift.UInt
+}
+
+public struct B {
+  public init(value: Swift.Int)
+  public dynamic mutating func negate()
+  public var magnitude: Swift.UInt
+}
+
+public struct C {
+  public init(value: Int)
+  public dynamic mutating func negate()
+  public var magnitude: Swift.UInt
+}
+
+public struct D {
+  public init(value: Int)
+  public dynamic mutating func negate()
+  public var magnitude: Swift.UInt
+}
+
+@propertyWrapper
+public struct available {
+  public init() {}
+  public var wrappedValue: Int { 0 }
+}
+
+@_functionBuilder
+public struct MyBuilder {}

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -13,6 +13,40 @@ import struct ModuleSelectorTestingKit::A
 
 let magnitude: Never = fatalError()
 
+// Test correct code using `A`
+
+extension ModuleSelectorTestingKit::A: Swift::Equatable {
+  @_implements(Swift::Equatable, ==(_:_:))
+  public static func equals(_: ModuleSelectorTestingKit::A, _: ModuleSelectorTestingKit::A) -> Swift::Bool {
+    Swift::fatalError()
+  }
+
+  // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
+  // @_derivative(of:)
+
+  @_dynamicReplacement(for: ModuleSelectorTestingKit::negate())
+  mutating func myNegate() {
+    let fn: (Swift::Int, Swift::Int) -> Swift::Int =
+      (+)
+      // FIXME: it'd be nice to handle module selectors on operators.
+
+    let magnitude: Int.Swift::Magnitude = main::magnitude
+    // FIXME incorrect: expected-error@-1 {{variable used within its own initial value}}
+    // expected-EVENTUALLY-error@-1 {{something about type mismatch between 'Never' and 'Int.Swift::Magnitude'}}
+
+    if Swift::Bool.Swift::random() {
+      self.ModuleSelectorTestingKit::negate()
+    }
+    else {
+      self = ModuleSelectorTestingKit::A(value: .Swift::min)
+    }
+
+    self.main::myNegate()
+  }
+
+  // FIXME: Can we test @convention(witness_method:)?
+}
+
 // Test resolution of main:: using `B`
 
 extension main::B {}

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -6,6 +6,15 @@
 // Make sure the lack of the experimental flag disables the feature:
 // RUN: not %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs 2>/dev/null
 
+// FIXME: This test doesn't really cover:
+//
+// * Whether X::foo finds foos in X's re-exports
+// * Whether we handle access paths correctly
+// * Interaction with ClangImporter
+// * Cross-module overlays, when those happen
+//
+// It also might not cover all combinations of name lookup paths and inputs.
+
 import ModuleSelectorTestingKit
 
 import ctypes::bits

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -21,6 +21,7 @@ extension main::B: main::Equatable {
   // @_derivative(of:)
   
   @_dynamicReplacement(for: main::negate())
+  // FIXME improve: expected-error@-1 {{replaced function 'main::negate()' could not be found}}
   mutating func myNegate() {
     let fn: (main::Int, main::Int) -> main::Int =
     // FIXME:
@@ -30,11 +31,12 @@ extension main::B: main::Equatable {
       // expected-error@-3 {{expected expression after operator}}
 
     let magnitude: main::Int.main::Magnitude = main::magnitude
-    // expected-EVENTUALLY-error@-1 {{a type mismatch with 'Never'}}
-    // FIXME: expected-error@-2 {{variable used within its own initial value}}
+    // expected-EVENTUALLY-error@-1 {{can't find 'Int'}}
+    // FIXME improve: expected-error@-2 {{type alias 'Magnitude' is not a member type of 'Int'}}
+    // FIXME: expected-error@-3 {{variable used within its own initial value}}
     if main::Bool.main::random() {
       main::negate()
-      // expected-EVENTUALLY-error@-1 {{something about not finding 'negate' because we didn't look in self}}
+      // FIXME improve: expected-error@-1 {{use of unresolved identifier 'main::negate'}}
     }
     else {
       self = main::B(value: .main::min)
@@ -66,7 +68,8 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
       // expected-error@-3 {{expected expression after operator}}
     let magnitude: ModuleSelectorTestingKit::Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
     // expected-EVENTUALLY-error@-1 {{something about not finding 'magnitude' because we didn't look in self}}
-    // FIXME: expected-error@-2 {{variable used within its own initial value}}
+    // FIXME improve: expected-error@-2 {{type alias 'Magnitude' is not a member type of 'Int'}}
+    // FIXME: expected-error@-3 {{variable used within its own initial value}}
     if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
       ModuleSelectorTestingKit::negate()
       // expected-EVENTUALLY-error@-1 {{something about not finding 'negate' because we didn't look in self}}
@@ -94,6 +97,7 @@ extension Swift::D: Swift::Equatable {
   // @_derivative(of:)
   
   @_dynamicReplacement(for: Swift::negate())
+  // FIXME improve: expected-error@-1 {{replaced function 'Swift::negate()' could not be found}}
   mutating func myNegate() {
     let fn: (Swift::Int, Swift::Int) -> Swift::Int =
     // FIXME:
@@ -106,7 +110,7 @@ extension Swift::D: Swift::Equatable {
     // FIXME: expected-error@-2 {{variable used within its own initial value}}
     if Swift::Bool.Swift::random() {
       Swift::negate()
-      // expected-EVENTUALLY-error@-1 {{something about not finding 'negate' because we didn't look in self}}
+      // FIXME improve: expected-error@-1 {{use of unresolved identifier 'Swift::negate'}}
     }
     else {
       self = Swift::D(value: .ModuleSelectorTestingKit::min)

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -15,7 +15,10 @@ let magnitude: Never = fatalError()
 
 // Test resolution of main:: using `B`
 
-extension main::B: main::Equatable {
+extension main::B {}
+// FIXME improve: expected-error@-1 {{use of undeclared type 'main::B'}}
+
+extension B: main::Equatable {
   @_implements(main::Equatable, main::==(_:_:))
   // expected-error@-1 {{name cannot be qualified with module selector here}} {{33-39=}}
   public static func equals(_: main::B, _: main::B) -> main::Bool { main::fatalError() }
@@ -33,7 +36,7 @@ extension main::B: main::Equatable {
       // expected-error@-2 {{expected expression}}
       // expected-error@-3 {{expected expression after operator}}
 
-    let magnitude: main::Int.main::Magnitude = main::magnitude
+    let magnitude: Int.main::Magnitude = main::magnitude
     // expected-EVENTUALLY-error@-1 {{can't find 'Int'}}
     // FIXME improve: expected-error@-2 {{type alias 'Magnitude' is not a member type of 'Int'}}
     // FIXME: expected-error@-3 {{variable used within its own initial value}}
@@ -53,27 +56,33 @@ extension main::B: main::Equatable {
 
 // Test resolution of ModuleSelectorTestingKit:: using `C`
 
+extension C {}
+
 extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
+// FIXME improve: expected-error@-1 {{use of undeclared type 'ModuleSelectorTestingKit::Equatable'}}
   @_implements(ModuleSelectorTestingKit::Equatable, ModuleSelectorTestingKit::==(_:_:))
-  // expected-error@-1 {{name cannot be qualified with module selector here}} {{52-77=}}
+  // FIXME improve: expected-error@-1 {{use of undeclared type 'ModuleSelectorTestingKit::Equatable'}}
+  // expected-error@-2 {{name cannot be qualified with module selector here}} {{52-77=}}
   public static func equals(_: ModuleSelectorTestingKit::C, _: ModuleSelectorTestingKit::C) -> ModuleSelectorTestingKit::Bool { ModuleSelectorTestingKit::fatalError() }
-  
+  // FIXME improve: expected-error@-1 {{use of undeclared type 'ModuleSelectorTestingKit::Bool'}}
+
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
   // @_derivative(of:)
   
   @_dynamicReplacement(for: ModuleSelectorTestingKit::negate())
   mutating func myNegate() {
     let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
+    // FIXME improve: expected-error@-1 3{{use of undeclared type 'ModuleSelectorTestingKit::Int'}}
     // FIXME:
       (ModuleSelectorTestingKit::+)
-      // expected-error@-1 {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}}
-      // expected-error@-2 {{expected expression}}
-      // expected-error@-3 {{expected expression after operator}}
-    let magnitude: ModuleSelectorTestingKit::Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
+      // expected-error@-1 {{expected expression}}
+      // expected-error@-2 {{expected expression after operator}}
+    let magnitude: Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
     // expected-EVENTUALLY-error@-1 {{something about not finding 'magnitude' because we didn't look in self}}
     // FIXME improve: expected-error@-2 {{type alias 'Magnitude' is not a member type of 'Int'}}
     // FIXME: expected-error@-3 {{variable used within its own initial value}}
     if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
+    // FIXME improve: expected-error@-1 {{use of unresolved identifier 'ModuleSelectorTestingKit::Bool'}}
       ModuleSelectorTestingKit::negate()
       // FIXME improve, suggest adding 'self.': expected-error@-1 {{use of unresolved identifier 'ModuleSelectorTestingKit::negate'}}
     }
@@ -91,7 +100,10 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
 // Test resolution of Swift:: using `D`
 // FIXME: Many more of these should fail once the feature is actually implemented.
 
-extension Swift::D: Swift::Equatable {
+extension Swift::D {}
+// FIXME improve: expected-error@-1 {{use of undeclared type 'Swift::D'}}
+
+extension D: Swift::Equatable {
   @_implements(Swift::Equatable, Swift::==(_:_:))
   // expected-error@-1 {{name cannot be qualified with module selector here}} {{34-41=}}
   public static func equals(_: Swift::D, _: Swift::D) -> Swift::Bool { Swift::fatalError() }
@@ -108,7 +120,7 @@ extension Swift::D: Swift::Equatable {
       // expected-error@-1 {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}}
       // expected-error@-2 {{expected expression}}
       // expected-error@-3 {{expected expression after operator}}
-    let magnitude: Swift::Int.Swift::Magnitude = Swift::magnitude
+    let magnitude: Int.Swift::Magnitude = Swift::magnitude
     // expected-EVENTUALLY-error@-1 {{something about not finding 'magnitude' because we didn't look in self}}
     // FIXME: expected-error@-2 {{variable used within its own initial value}}
     if Swift::Bool.Swift::random() {
@@ -130,15 +142,25 @@ struct AvailableUser {
   @available(macOS 10.15, *) var use1: String { "foo" }
 
   @main::available() var use2
+  // FIXME improve: expected-error@-1 {{unknown attribute 'available'}}
+  // FIXME suppress: expected-error@-2 {{type annotation missing in pattern}}
+
   @ModuleSelectorTestingKit::available() var use4
+  // no-error
+
   @Swift::available() var use5
-  // expected-EVENTUALLY-error@-1 {{can't find because not in 'Swift'}}
+  // FIXME improve: expected-error@-1 {{unknown attribute 'available'}}
+  // FIXME suppress: expected-error@-2 {{type annotation missing in pattern}}
 }
 
 func builderUser2(@main::MyBuilder fn: () -> Void) {}
+// FIXME improve: expected-error@-1 {{unknown attribute 'MyBuilder'}}
+
 func builderUser3(@ModuleSelectorTestingKit::MyBuilder fn: () -> Void) {}
+// no-error
+
 func builderUser4(@Swift::MyBuilder fn: () -> Void) {}
-// expected-EVENTUALLY-error@-1 {{can't find because not in 'Swift'}}
+// FIXME improve: expected-error@-1 {{unknown attribute 'MyBuilder'}}
 
 func whitespace() {
   Swift::print
@@ -181,10 +203,13 @@ func main::decl1(
   // expected-error@-1 {{name of function declaration cannot be qualified with module selector}}
   main::p1: main::A,
   // expected-error@-1 {{argument label cannot be qualified with module selector}}
+  // FIXME access path: expected-error@-2 {{use of undeclared type 'main::A'}}
   main::label p2: main::A,
   // expected-error@-1 {{argument label cannot be qualified with module selector}}
+  // FIXME access path: expected-error@-2 {{use of undeclared type 'main::A'}}
   label main::p3: main::A
   // expected-error@-1 {{name of parameter declaration cannot be qualified with module selector}}
+  // FIXME access path: expected-error@-2 {{use of undeclared type 'main::A'}}
 ) {
   let main::decl1a = "a"
   // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
@@ -268,6 +293,7 @@ class main::decl4<main::T> {}
 
 typealias main::decl5 = main::Bool
 // expected-error@-1 {{name of typealias declaration cannot be qualified with module selector}}
+// FIXME improve: expected-error@-2 {{use of undeclared type 'main::Bool'}}
 
 protocol main::decl6 {
   // expected-error@-1 {{name of protocol declaration cannot be qualified with module selector}}
@@ -308,6 +334,7 @@ struct Parent {
 
   typealias main::decl5 = main::Bool
   // expected-error@-1 {{name of typealias declaration cannot be qualified with module selector}}
+  // FIXME improve: expected-error@-2 {{use of undeclared type 'main::Bool'}}
 }
 
 @_swift_native_objc_runtime_base(main::BaseClass)

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -125,3 +125,81 @@ func whitespace() {
   ::
   print // expected-error{{expression resolves to an unused function}}
 }
+
+// Error cases
+
+func main::decl1( // expected-error {{name of function declaration cannot be qualified with module selector}}
+  main::p1: main::A, // expected-error {{argument label cannot be qualified with module selector}}
+  main::label p2: main::A, // expected-error {{argument label cannot be qualified with module selector}}
+  label main::p3: main::A // expected-error {{name of parameter declaration cannot be qualified with module selector}}
+) {
+  let main::decl1a = "a" // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+  var main::decl1b = "b" // expected-error {{name of variable declaration cannot be qualified with module selector}} expected-warning {{never used}}
+  let (main::decl1c, main::decl1d) = ("c", "d") // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning 2{{never used}}
+
+  if let (main::decl1e, main::decl1f) = Optional(("e", "f")) {} // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning 2{{never used}}
+  guard let (main::decl1g, main::decl1h) = Optional(("g", "h")) else { return }  // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+
+  switch Optional(main::decl1g) { // FIXME expecting an error later
+  case Optional.some(let main::decl1i): // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+    break
+  case .none:
+    break
+  }
+
+  switch Optional(main::decl1g) { // FIXME expecting an error later
+  case let Optional.some(main::decl1j): // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+    break
+  case .none:
+    break
+  }
+
+  switch Optional(main::decl1g) {
+  case let main::decl1k?: // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+    break
+  case .none:
+    break
+  }
+
+  for main::decl1l in "lll" {} // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+
+  "lll".forEach { [main::magnitude] // expected-error {{name of captured variable declaration cannot be qualified with module selector}} expected-warning {{never used}}
+    main::elem in print(elem) // expected-error {{name of parameter declaration cannot be qualified with module selector}}
+  }
+  "lll".forEach { (main::elem) in print(elem) } // expected-error {{name of parameter declaration cannot be qualified with module selector}}
+  "lll".forEach { (main::elem) -> Void in print(elem) } // expected-error {{name of parameter declaration cannot be qualified with module selector}}
+  "lll".forEach { (main::elem: Character) -> Void in print(elem) } // expected-error {{name of parameter declaration cannot be qualified with module selector}}
+}
+enum main::decl2 { // expected-error {{name of enum declaration cannot be qualified with module selector}}
+  case main::decl2a // expected-error {{name of enum 'case' declaration cannot be qualified with module selector}}
+}
+struct main::decl3 {} // expected-error {{name of struct declaration cannot be qualified with module selector}}
+class main::decl4<main::T> {} // expected-error {{name of class declaration cannot be qualified with module selector}} expected-error {{name of generic parameter declaration cannot be qualified with module selector}}
+typealias main::decl5 = main::Bool // expected-error {{name of typealias declaration cannot be qualified with module selector}}
+protocol main::decl6 { // expected-error {{name of protocol declaration cannot be qualified with module selector}}
+  associatedtype main::decl6a // expected-error {{name of associatedtype declaration cannot be qualified with module selector}}
+}
+let main::decl7 = 7 // expected-error {{name of constant declaration cannot be qualified with module selector}}
+var main::decl8 = 8 { // expected-error {{name of variable declaration cannot be qualified with module selector}}
+  willSet(main::newValue) {} // expected-error {{name of accessor parameter declaration cannot be qualified with module selector}}
+  didSet(main::oldValue) {} // expected-error {{name of accessor parameter declaration cannot be qualified with module selector}}
+}
+
+struct Parent {
+  func main::decl1() {} // expected-error {{name of function declaration cannot be qualified with module selector}}
+  enum main::decl2 { // expected-error {{name of enum declaration cannot be qualified with module selector}}
+    case main::decl2a // expected-error {{name of enum 'case' declaration cannot be qualified with module selector}}
+  }
+  struct main::decl3 {} // expected-error {{name of struct declaration cannot be qualified with module selector}}
+  class main::decl4 {} // expected-error {{name of class declaration cannot be qualified with module selector}}
+  typealias main::decl5 = main::Bool // expected-error {{name of typealias declaration cannot be qualified with module selector}}
+}
+
+@_swift_native_objc_runtime_base(main::BaseClass) // expected-error {{Objective-C class name in @_swift_native_objc_runtime_base}}
+class C1 {}
+
+infix operator <<<<< : Swift::AdditionPrecedence // expected-error {{precedence group specifier cannot be qualified with module selector}}
+
+precedencegroup main::PG1 { // expected-error {{name of precedence group declaration cannot be qualified with module selector}}
+  higherThan: Swift::AdditionPrecedence // expected-error {{precedence group specifier cannot be qualified with module selector}}
+}

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -68,7 +68,7 @@ extension B: main::Equatable {
   // expected-error@-4 {{type 'Bool' is not imported through module 'main'}}
   // expected-note@-5 {{did you mean module 'Swift'?}} {{56-60=Swift}}
     main::fatalError()
-    // expected-EVENTUALLY-error@-1 {{type 'fatalError' is not imported through module 'main'}}
+    // expected-EVENTUALLY-error@-1 {{declaration 'fatalError' is not imported through module 'main'}}
     // expected-EVENTUALLY-note@-2 {{did you mean module 'Swift'?}} {{4-8=Swift}}
   }
 
@@ -139,6 +139,8 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
   
   @_dynamicReplacement(for: ModuleSelectorTestingKit::negate())
   mutating func myNegate() {
+  // FIXME improve: expected-note@-1 {{did you mean 'myNegate'?}}
+
     let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
     // expected-error@-1 3{{type 'Int' is not imported through module 'ModuleSelectorTestingKit'}}
     // expected-note@-2 {{did you mean module 'Swift'?}} {{14-37=Swift}}
@@ -164,10 +166,11 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
     }
     else {
       self = ModuleSelectorTestingKit::C(value: .ModuleSelectorTestingKit::min)
+      // FIXME improve: expected-error@-1 {{type 'Int' has no member 'ModuleSelectorTestingKit::min'}}
     }
     
     self.ModuleSelectorTestingKit::myNegate()
-    // expected-EVENTUALLY-error@-2 {{can't find 'myNegate' in ModuleSelectorTestingKit}}
+    // FIXME improve: expected-error@-1 {{value of type 'C' has no member 'ModuleSelectorTestingKit::myNegate'}}
   }
 
   // FIXME: Can we test @convention(witness_method:)?
@@ -181,7 +184,7 @@ extension Swift::D {}
 // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{11-16=ModuleSelectorTestingKit}}
 
 extension D: Swift::Equatable {
-// FIXME wat: expected-error@-1 {{implementation of 'Equatable' cannot be automatically synthesized in an extension in a different file to the type}}
+// FIXME wat: expected-error@-1 *{{implementation of 'Equatable' cannot be automatically synthesized in an extension in a different file to the type}}
 
   @_implements(Swift::Equatable, Swift::==(_:_:))
   // expected-error@-1 {{name cannot be qualified with module selector here}} {{34-41=}}
@@ -199,6 +202,8 @@ extension D: Swift::Equatable {
   @_dynamicReplacement(for: Swift::negate())
   // FIXME improve: expected-error@-1 {{replaced function 'Swift::negate()' could not be found}}
   mutating func myNegate() {
+  // FIXME improve: expected-note@-1 {{did you mean 'myNegate'?}}
+
     let fn: (Swift::Int, Swift::Int) -> Swift::Int =
     // FIXME:
       (Swift::+)
@@ -220,7 +225,7 @@ extension D: Swift::Equatable {
     }
     
     self.Swift::myNegate()
-    // expected-EVENTUALLY-error@-1 {{can't find 'myNegate' in Swift}}
+    // FIXME improve: expected-error@-1 {{value of type 'D' has no member 'Swift::myNegate'}}
   }
 
   // FIXME: Can we test @convention(witness_method:)?

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -448,3 +448,19 @@ precedencegroup main::PG1 {
   higherThan: Swift::AdditionPrecedence
   // expected-error@-1 {{precedence group specifier cannot be qualified with module selector}}
 }
+
+func badModuleNames() {
+  NonexistentModule::print()
+  // expected-error@-1 {{declaration 'print' is not imported through module 'NonexistentModule'}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{3-20=Swift}}
+  // FIXME redundant: expected-note@-3  {{did you mean module 'Swift'?}}
+
+  _ = "foo".NonexistentModule::count
+  // FIXME improve: expected-error@-1 {{value of type 'String' has no member 'NonexistentModule::count'}}
+
+  let x: NonexistentModule::MyType = NonexistentModule::MyType()
+  // expected-error@-1 {{use of undeclared type 'NonexistentModule::MyType'}}
+
+  let y: A.NonexistentModule::MyChildType = fatalError()
+  // expected-error@-1 {{'NonexistentModule::MyChildType' is not a member type of 'A'}}
+}

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -94,14 +94,17 @@ extension B: main::Equatable {
     // FIXME incorrect: expected-error@-3 {{variable used within its own initial value}}
 
     if main::Bool.main::random() {
-    // FIXME improve: expected-error@-1 {{use of unresolved identifier 'main::Bool'}}
+    // expected-error@-1 {{declaration 'Bool' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{8-12=Swift}}
 
       main::negate()
-      // FIXME improve, suggest adding 'self.': expected-error@-1 {{use of unresolved identifier 'main::negate'}}
+      // expected-error@-1 {{declaration 'negate' is not imported through module 'main'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{7-11=self.ModuleSelectorTestingKit}}
     }
     else {
       self = main::B(value: .main::min)
-      // FIXME improve: expected-error@-1 {{use of unresolved identifier 'main::B'}}
+      // expected-error@-1 {{declaration 'B' is not imported through module 'main'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{14-18=ModuleSelectorTestingKit}}
     }
     
     self.main::myNegate()
@@ -152,10 +155,12 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
     // FIXME incorrect: expected-error@-3 {{variable used within its own initial value}}
 
     if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
-    // FIXME improve: expected-error@-1 {{use of unresolved identifier 'ModuleSelectorTestingKit::Bool'}}
+    // expected-error@-1 {{declaration 'Bool' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{8-31=Swift}}
 
       ModuleSelectorTestingKit::negate()
-      // FIXME improve, suggest adding 'self.': expected-error@-1 {{use of unresolved identifier 'ModuleSelectorTestingKit::negate'}}
+      // expected-error@-1 {{declaration 'negate' is not imported through module 'ModuleSelectorTestingKit'}}
+      // expected-note@-2 {{did you mean the member of 'self'?}} {{7-7=self.}}
     }
     else {
       self = ModuleSelectorTestingKit::C(value: .ModuleSelectorTestingKit::min)
@@ -176,7 +181,7 @@ extension Swift::D {}
 // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{11-16=ModuleSelectorTestingKit}}
 
 extension D: Swift::Equatable {
-// FIXME wat: expected-error@-1 2{{implementation of 'Equatable' cannot be automatically synthesized in an extension in a different file to the type}}
+// FIXME wat: expected-error@-1 {{implementation of 'Equatable' cannot be automatically synthesized in an extension in a different file to the type}}
 
   @_implements(Swift::Equatable, Swift::==(_:_:))
   // expected-error@-1 {{name cannot be qualified with module selector here}} {{34-41=}}
@@ -205,11 +210,13 @@ extension D: Swift::Equatable {
     // FIXME: expected-error@-2 {{variable used within its own initial value}}
     if Swift::Bool.Swift::random() {
       Swift::negate()
-      // FIXME improve: expected-error@-1 {{use of unresolved identifier 'Swift::negate'}}
+      // expected-error@-1 {{declaration 'negate' is not imported through module 'Swift'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{7-12=self.ModuleSelectorTestingKit}}
     }
     else {
       self = Swift::D(value: .ModuleSelectorTestingKit::min)
-      // FIXME improve: expected-error@-1 {{use of unresolved identifier 'Swift::D'}}
+      // expected-error@-1 {{declaration 'D' is not imported through module 'Swift'}}
+      // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{14-19=ModuleSelectorTestingKit}}
     }
     
     self.Swift::myNegate()
@@ -314,10 +321,10 @@ func main::decl1(
   // expected-error@-2 {{name of constant declaration cannot be qualified with module selector}}
 
   // From uses in the switch statements below:
-  // expected-note@-5 3{{did you mean 'decl1g'?}}
+  // expected-note@-5 3{{did you mean the local declaration?}}
 
   switch Optional(main::decl1g) {
-  // expected-error@-1 {{use of unresolved identifier 'main::decl1g'}}
+  // expected-error@-1 {{declaration 'decl1g' is not imported through module 'main'}}
   case Optional.some(let main::decl1i):
     // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
     break
@@ -326,7 +333,7 @@ func main::decl1(
   }
 
   switch Optional(main::decl1g) {
-  // expected-error@-1 {{use of unresolved identifier 'main::decl1g'}}
+  // expected-error@-1 {{declaration 'decl1g' is not imported through module 'main'}}
   case let Optional.some(main::decl1j):
     // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
     break
@@ -335,7 +342,7 @@ func main::decl1(
   }
 
   switch Optional(main::decl1g) {
- // expected-error@-1 {{use of unresolved identifier 'main::decl1g'}}
+ // expected-error@-1 {{declaration 'decl1g' is not imported through module 'main'}}
  case let main::decl1k?:
     // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
     break

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -1,9 +1,12 @@
-// RUN: %target-typecheck-verify-swift -module-name main -I %S/Inputs -enable-experimental-module-selector
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs -enable-experimental-module-selector
 
 // Make sure the lack of the experimental flag disables the feature:
-// RUN: not %target-typecheck-verify-swift -module-name main -I %S/Inputs 2>/dev/null
+// RUN: not %target-typecheck-verify-swift -sdk %clang-importer-sdk -module-name main -I %S/Inputs 2>/dev/null
 
 import ModuleSelectorTestingKit
+
+import ctypes::bits
+import struct ModuleSelectorTestingKit::A
 
 let magnitude: Never = fatalError()
 

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -1,0 +1,1 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-module-selector %s

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -119,16 +119,16 @@ extension C {}
 
 extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
 // expected-error@-1 {{type 'Equatable' is not imported through module 'ModuleSelectorTestingKit'}}
-// expected-note@-2 {{did you mean module 'Swift'?}} {{39-62=Swift}}
+// expected-note@-2 {{did you mean module 'Swift'?}} {{40-64=Swift}}
 
   @_implements(ModuleSelectorTestingKit::Equatable, ModuleSelectorTestingKit::==(_:_:))
-  // expected-error@-1 {{name cannot be qualified with module selector here}} {{52-77=}}
+  // expected-error@-1 {{name cannot be qualified with module selector here}} {{53-79=}}
   // expected-error@-2 {{type 'Equatable' is not imported through module 'ModuleSelectorTestingKit'}}
-  // expected-note@-3 {{did you mean module 'Swift'?}} {{16-39=Swift}}
+  // expected-note@-3 {{did you mean module 'Swift'?}} {{16-40=Swift}}
 
   public static func equals(_: ModuleSelectorTestingKit::C, _: ModuleSelectorTestingKit::C) -> ModuleSelectorTestingKit::Bool {
   // expected-error@-1 {{type 'Bool' is not imported through module 'ModuleSelectorTestingKit'}}
-  // expected-note@-2 {{did you mean module 'Swift'?}} {{94-117=Swift}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{96-120=Swift}}
     ModuleSelectorTestingKit::fatalError()
     // expected-EVENTUALLY-error@-1 {{type 'fatalError' is not imported through module 'main'}}
     // expected-EVENTUALLY-note@-2 {{did you mean module 'Swift'?}} {{4-8=Swift}}
@@ -143,9 +143,9 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
 
     let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
     // expected-error@-1 3{{type 'Int' is not imported through module 'ModuleSelectorTestingKit'}}
-    // expected-note@-2 {{did you mean module 'Swift'?}} {{14-37=Swift}}
-    // expected-note@-3 {{did you mean module 'Swift'?}} {{44-67=Swift}}
-    // expected-note@-4 {{did you mean module 'Swift'?}} {{77-100=Swift}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{14-38=Swift}}
+    // expected-note@-3 {{did you mean module 'Swift'?}} {{45-69=Swift}}
+    // expected-note@-4 {{did you mean module 'Swift'?}} {{79-103=Swift}}
       (ModuleSelectorTestingKit::+)
       // FIXME: it'd be nice to handle module selectors on operators.
       // expected-error@-2 {{expected expression}}
@@ -153,12 +153,12 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
 
     let magnitude: Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
     // expected-error@-1 {{type 'Magnitude' is not imported through module 'ModuleSelectorTestingKit'}}
-    // expected-note@-2 {{did you mean module 'Swift'?}} {{24-47=Swift}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{24-48=Swift}}
     // FIXME incorrect: expected-error@-3 {{variable used within its own initial value}}
 
     if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
     // expected-error@-1 {{declaration 'Bool' is not imported through module 'ModuleSelectorTestingKit'}}
-    // expected-note@-2 {{did you mean module 'Swift'?}} {{8-31=Swift}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{8-32=Swift}}
 
       ModuleSelectorTestingKit::negate()
       // expected-error@-1 {{declaration 'negate' is not imported through module 'ModuleSelectorTestingKit'}}

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -16,13 +16,28 @@ let magnitude: Never = fatalError()
 // Test resolution of main:: using `B`
 
 extension main::B {}
-// FIXME improve: expected-error@-1 {{use of undeclared type 'main::B'}}
+// expected-error@-1 {{type 'B' is not imported through module 'main'}}
+// expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{11-15=ModuleSelectorTestingKit}}
 
 extension B: main::Equatable {
+  // expected-error@-1 {{type 'Equatable' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{14-18=Swift}}
+
   @_implements(main::Equatable, main::==(_:_:))
   // expected-error@-1 {{name cannot be qualified with module selector here}} {{33-39=}}
-  public static func equals(_: main::B, _: main::B) -> main::Bool { main::fatalError() }
-  
+  // expected-error@-2 {{type 'Equatable' is not imported through module 'main'}}
+  // expected-note@-3 {{did you mean module 'Swift'?}} {{16-20=Swift}}
+  public static func equals(_: main::B, _: main::B) -> main::Bool {
+  // expected-error@-1 2{{type 'B' is not imported through module 'main'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{32-36=ModuleSelectorTestingKit}}
+  // expected-note@-3 {{did you mean module 'ModuleSelectorTestingKit'?}} {{44-48=ModuleSelectorTestingKit}}
+  // expected-error@-4 {{type 'Bool' is not imported through module 'main'}}
+  // expected-note@-5 {{did you mean module 'Swift'?}} {{56-60=Swift}}
+    main::fatalError()
+    // expected-EVENTUALLY-error@-1 {{type 'fatalError' is not imported through module 'main'}}
+    // expected-EVENTUALLY-note@-2 {{did you mean module 'Swift'?}} {{4-8=Swift}}
+  }
+
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
   // @_derivative(of:)
   
@@ -30,22 +45,29 @@ extension B: main::Equatable {
   // FIXME improve: expected-error@-1 {{replaced function 'main::negate()' could not be found}}
   mutating func myNegate() {
     let fn: (main::Int, main::Int) -> main::Int =
-    // FIXME:
+    // expected-error@-1 3{{type 'Int' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{14-18=Swift}}
+    // expected-note@-3 {{did you mean module 'Swift'?}} {{25-29=Swift}}
+    // expected-note@-4 {{did you mean module 'Swift'?}} {{39-43=Swift}}
       (main::+)
-      // expected-error@-1 {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}}
+      // FIXME: it'd be nice to handle module selectors on operators.
       // expected-error@-2 {{expected expression}}
       // expected-error@-3 {{expected expression after operator}}
 
     let magnitude: Int.main::Magnitude = main::magnitude
-    // expected-EVENTUALLY-error@-1 {{can't find 'Int'}}
-    // FIXME improve: expected-error@-2 {{type alias 'Magnitude' is not a member type of 'Int'}}
-    // FIXME: expected-error@-3 {{variable used within its own initial value}}
+    // expected-error@-1 {{type 'Magnitude' is not imported through module 'main'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{24-28=Swift}}
+    // FIXME incorrect: expected-error@-3 {{variable used within its own initial value}}
+
     if main::Bool.main::random() {
+    // FIXME improve: expected-error@-1 {{use of unresolved identifier 'main::Bool'}}
+
       main::negate()
-      // FIXME improve: expected-error@-1 {{use of unresolved identifier 'main::negate'}}
+      // FIXME improve, suggest adding 'self.': expected-error@-1 {{use of unresolved identifier 'main::negate'}}
     }
     else {
       self = main::B(value: .main::min)
+      // FIXME improve: expected-error@-1 {{use of unresolved identifier 'main::B'}}
     }
     
     self.main::myNegate()
@@ -59,12 +81,21 @@ extension B: main::Equatable {
 extension C {}
 
 extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
-// FIXME improve: expected-error@-1 {{use of undeclared type 'ModuleSelectorTestingKit::Equatable'}}
+// expected-error@-1 {{type 'Equatable' is not imported through module 'ModuleSelectorTestingKit'}}
+// expected-note@-2 {{did you mean module 'Swift'?}} {{39-62=Swift}}
+
   @_implements(ModuleSelectorTestingKit::Equatable, ModuleSelectorTestingKit::==(_:_:))
-  // FIXME improve: expected-error@-1 {{use of undeclared type 'ModuleSelectorTestingKit::Equatable'}}
-  // expected-error@-2 {{name cannot be qualified with module selector here}} {{52-77=}}
-  public static func equals(_: ModuleSelectorTestingKit::C, _: ModuleSelectorTestingKit::C) -> ModuleSelectorTestingKit::Bool { ModuleSelectorTestingKit::fatalError() }
-  // FIXME improve: expected-error@-1 {{use of undeclared type 'ModuleSelectorTestingKit::Bool'}}
+  // expected-error@-1 {{name cannot be qualified with module selector here}} {{52-77=}}
+  // expected-error@-2 {{type 'Equatable' is not imported through module 'ModuleSelectorTestingKit'}}
+  // expected-note@-3 {{did you mean module 'Swift'?}} {{16-39=Swift}}
+
+  public static func equals(_: ModuleSelectorTestingKit::C, _: ModuleSelectorTestingKit::C) -> ModuleSelectorTestingKit::Bool {
+  // expected-error@-1 {{type 'Bool' is not imported through module 'ModuleSelectorTestingKit'}}
+  // expected-note@-2 {{did you mean module 'Swift'?}} {{94-117=Swift}}
+    ModuleSelectorTestingKit::fatalError()
+    // expected-EVENTUALLY-error@-1 {{type 'fatalError' is not imported through module 'main'}}
+    // expected-EVENTUALLY-note@-2 {{did you mean module 'Swift'?}} {{4-8=Swift}}
+  }
 
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
   // @_derivative(of:)
@@ -72,17 +103,23 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
   @_dynamicReplacement(for: ModuleSelectorTestingKit::negate())
   mutating func myNegate() {
     let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
-    // FIXME improve: expected-error@-1 3{{use of undeclared type 'ModuleSelectorTestingKit::Int'}}
-    // FIXME:
+    // expected-error@-1 3{{type 'Int' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{14-37=Swift}}
+    // expected-note@-3 {{did you mean module 'Swift'?}} {{44-67=Swift}}
+    // expected-note@-4 {{did you mean module 'Swift'?}} {{77-100=Swift}}
       (ModuleSelectorTestingKit::+)
-      // expected-error@-1 {{expected expression}}
-      // expected-error@-2 {{expected expression after operator}}
+      // FIXME: it'd be nice to handle module selectors on operators.
+      // expected-error@-2 {{expected expression}}
+      // expected-error@-3 {{expected expression after operator}}
+
     let magnitude: Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
-    // expected-EVENTUALLY-error@-1 {{something about not finding 'magnitude' because we didn't look in self}}
-    // FIXME improve: expected-error@-2 {{type alias 'Magnitude' is not a member type of 'Int'}}
-    // FIXME: expected-error@-3 {{variable used within its own initial value}}
+    // expected-error@-1 {{type 'Magnitude' is not imported through module 'ModuleSelectorTestingKit'}}
+    // expected-note@-2 {{did you mean module 'Swift'?}} {{24-47=Swift}}
+    // FIXME incorrect: expected-error@-3 {{variable used within its own initial value}}
+
     if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
     // FIXME improve: expected-error@-1 {{use of unresolved identifier 'ModuleSelectorTestingKit::Bool'}}
+
       ModuleSelectorTestingKit::negate()
       // FIXME improve, suggest adding 'self.': expected-error@-1 {{use of unresolved identifier 'ModuleSelectorTestingKit::negate'}}
     }
@@ -101,13 +138,22 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
 // FIXME: Many more of these should fail once the feature is actually implemented.
 
 extension Swift::D {}
-// FIXME improve: expected-error@-1 {{use of undeclared type 'Swift::D'}}
+// expected-error@-1 {{type 'D' is not imported through module 'Swift'}}
+// expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{11-16=ModuleSelectorTestingKit}}
 
 extension D: Swift::Equatable {
+// FIXME wat: expected-error@-1 2{{implementation of 'Equatable' cannot be automatically synthesized in an extension in a different file to the type}}
+
   @_implements(Swift::Equatable, Swift::==(_:_:))
   // expected-error@-1 {{name cannot be qualified with module selector here}} {{34-41=}}
-  public static func equals(_: Swift::D, _: Swift::D) -> Swift::Bool { Swift::fatalError() }
-  
+
+  public static func equals(_: Swift::D, _: Swift::D) -> Swift::Bool {
+  // expected-error@-1 2{{type 'D' is not imported through module 'Swift'}}
+  // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{32-37=ModuleSelectorTestingKit}}
+  // expected-note@-3 {{did you mean module 'ModuleSelectorTestingKit'?}} {{45-50=ModuleSelectorTestingKit}}
+    Swift::fatalError()
+  }
+
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
   // @_derivative(of:)
   
@@ -129,6 +175,7 @@ extension D: Swift::Equatable {
     }
     else {
       self = Swift::D(value: .ModuleSelectorTestingKit::min)
+      // FIXME improve: expected-error@-1 {{use of unresolved identifier 'Swift::D'}}
     }
     
     self.Swift::myNegate()
@@ -203,13 +250,16 @@ func main::decl1(
   // expected-error@-1 {{name of function declaration cannot be qualified with module selector}}
   main::p1: main::A,
   // expected-error@-1 {{argument label cannot be qualified with module selector}}
-  // FIXME access path: expected-error@-2 {{use of undeclared type 'main::A'}}
+  // FIXME access path: expected-error@-2 {{type 'A' is not imported through module 'main'}}
+  // FIXME access path: expected-note@-3 {{did you mean module 'ModuleSelectorTestingKit'?}} {{13-17=ModuleSelectorTestingKit}}
   main::label p2: main::A,
   // expected-error@-1 {{argument label cannot be qualified with module selector}}
-  // FIXME access path: expected-error@-2 {{use of undeclared type 'main::A'}}
+  // FIXME access path: expected-error@-2 {{type 'A' is not imported through module 'main'}}
+  // FIXME access path: expected-note@-3 {{did you mean module 'ModuleSelectorTestingKit'?}} {{19-23=ModuleSelectorTestingKit}}
   label main::p3: main::A
   // expected-error@-1 {{name of parameter declaration cannot be qualified with module selector}}
-  // FIXME access path: expected-error@-2 {{use of undeclared type 'main::A'}}
+  // FIXME access path: expected-error@-2 {{type 'A' is not imported through module 'main'}}
+  // FIXME access path: expected-note@-3 {{did you mean module 'ModuleSelectorTestingKit'?}} {{19-23=ModuleSelectorTestingKit}}
 ) {
   let main::decl1a = "a"
   // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
@@ -293,7 +343,8 @@ class main::decl4<main::T> {}
 
 typealias main::decl5 = main::Bool
 // expected-error@-1 {{name of typealias declaration cannot be qualified with module selector}}
-// FIXME improve: expected-error@-2 {{use of undeclared type 'main::Bool'}}
+// expected-error@-2 {{type 'Bool' is not imported through module 'main'}}
+// expected-note@-3 {{did you mean module 'Swift'?}} {{25-29=Swift}}
 
 protocol main::decl6 {
   // expected-error@-1 {{name of protocol declaration cannot be qualified with module selector}}
@@ -334,7 +385,8 @@ struct Parent {
 
   typealias main::decl5 = main::Bool
   // expected-error@-1 {{name of typealias declaration cannot be qualified with module selector}}
-  // FIXME improve: expected-error@-2 {{use of undeclared type 'main::Bool'}}
+  // expected-error@-2 {{type 'Bool' is not imported through module 'main'}}
+  // expected-note@-3 {{did you mean module 'Swift'?}} {{27-31=Swift}}
 }
 
 @_swift_native_objc_runtime_base(main::BaseClass)

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -1,1 +1,127 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-module-selector %s
+// RUN: %target-typecheck-verify-swift -module-name main -I %S/Inputs -enable-experimental-module-selector
+
+// Make sure the lack of the experimental flag disables the feature:
+// RUN: not %target-typecheck-verify-swift -module-name main -I %S/Inputs 2>/dev/null
+
+import ModuleSelectorTestingKit
+
+let magnitude: Never = fatalError()
+
+// Test resolution of main:: using `B`
+
+extension main::B: main::Equatable {
+  @_implements(main::Equatable, main::==(_:_:)) // expected-error {{name cannot be qualified with module selector here}} {{33-39=}}
+  public static func equals(_: main::B, _: main::B) -> main::Bool { main::fatalError() }
+  
+  // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
+  // @_derivative(of:)
+  
+  @_dynamicReplacement(for: main::negate())
+  mutating func myNegate() {
+    let fn: (main::Int, main::Int) -> main::Int =
+    // FIXME:
+      (main::+) // expected-error {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}} expected-error {{expected expression}} expected-error {{expected expression after operator}}
+    let magnitude: main::Int.main::Magnitude = main::magnitude // expected-EVENTUALLY-error {{a type mismatch with 'Never'}} FIXME: expected-error {{variable used within its own initial value}}
+    if main::Bool.main::random() {
+      main::negate() // expected-EVENTUALLY-error {{something about not finding 'negate' because we didn't look in self}}
+    }
+    else {
+      self = main::B(value: .main::min)
+    }
+    
+    self.main::myNegate()
+  }
+
+  // FIXME: Can we test @convention(witness_method:)?
+}
+
+// Test resolution of ModuleSelectorTestingKit:: using `C`
+
+extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
+  @_implements(ModuleSelectorTestingKit::Equatable, ModuleSelectorTestingKit::==(_:_:)) // expected-error {{name cannot be qualified with module selector here}} {{52-77=}}
+  public static func equals(_: ModuleSelectorTestingKit::C, _: ModuleSelectorTestingKit::C) -> ModuleSelectorTestingKit::Bool { ModuleSelectorTestingKit::fatalError() }
+  
+  // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
+  // @_derivative(of:)
+  
+  @_dynamicReplacement(for: ModuleSelectorTestingKit::negate())
+  mutating func myNegate() {
+    let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
+    // FIXME:
+      (ModuleSelectorTestingKit::+) // expected-error {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}} expected-error {{expected expression}} expected-error {{expected expression after operator}}
+    let magnitude: ModuleSelectorTestingKit::Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude // expected-EVENTUALLY-error {{something about not finding 'magnitude' because we didn't look in self}} FIXME: expected-error {{variable used within its own initial value}}
+    if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
+      ModuleSelectorTestingKit::negate() // expected-EVENTUALLY-error {{something about not finding 'negate' because we didn't look in self}}
+    }
+    else {
+      self = ModuleSelectorTestingKit::C(value: .ModuleSelectorTestingKit::min)
+    }
+    
+    self.ModuleSelectorTestingKit::myNegate() // expected-EVENTUALLY-error {{can't find 'myNegate' in ModuleSelectorTestingKit}}
+  }
+
+  // FIXME: Can we test @convention(witness_method:)?
+}
+
+// Test resolution of Swift:: using `D`
+// FIXME: Many more of these should fail once the feature is actually implemented.
+
+extension Swift::D: Swift::Equatable {
+  @_implements(Swift::Equatable, Swift::==(_:_:)) // expected-error {{name cannot be qualified with module selector here}} {{34-41=}}
+  public static func equals(_: Swift::D, _: Swift::D) -> Swift::Bool { Swift::fatalError() }
+  
+  // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
+  // @_derivative(of:)
+  
+  @_dynamicReplacement(for: Swift::negate())
+  mutating func myNegate() {
+    let fn: (Swift::Int, Swift::Int) -> Swift::Int =
+    // FIXME:
+      (Swift::+) // expected-error {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}} expected-error {{expected expression}} expected-error {{expected expression after operator}}
+    let magnitude: Swift::Int.Swift::Magnitude = Swift::magnitude // expected-EVENTUALLY-error {{something about not finding 'magnitude' because we didn't look in self}} FIXME: expected-error {{variable used within its own initial value}}
+    if Swift::Bool.Swift::random() {
+      Swift::negate() // expected-EVENTUALLY-error {{something about not finding 'negate' because we didn't look in self}}
+    }
+    else {
+      self = Swift::D(value: .ModuleSelectorTestingKit::min)
+    }
+    
+    self.Swift::myNegate() // expected-EVENTUALLY-error {{can't find 'myNegate' in Swift}}
+  }
+
+  // FIXME: Can we test @convention(witness_method:)?
+}
+
+struct AvailableUser {
+  @available(macOS 10.15, *) var use1: String { "foo" }
+
+  @main::available() var use2
+  @ModuleSelectorTestingKit::available() var use4
+  @Swift::available() var use5 // expected-EVENTUALLY-error {{can't find because not in 'Swift'}}
+}
+
+func builderUser2(@main::MyBuilder fn: () -> Void) {}
+func builderUser3(@ModuleSelectorTestingKit::MyBuilder fn: () -> Void) {}
+func builderUser4(@Swift::MyBuilder fn: () -> Void) {} // expected-EVENTUALLY-error {{can't find because not in 'Swift'}}
+
+func whitespace() {
+  Swift::print // expected-error{{expression resolves to an unused function}}
+
+  Swift :: print // expected-error{{expression resolves to an unused function}}
+
+  Swift::
+  print // expected-error{{expression resolves to an unused function}}
+
+  Swift
+  ::print // expected-error{{expression resolves to an unused function}}
+
+  Swift ::
+  print // expected-error{{expression resolves to an unused function}}
+
+  Swift
+  :: print // expected-error{{expression resolves to an unused function}}
+
+  Swift
+  ::
+  print // expected-error{{expression resolves to an unused function}}
+}

--- a/test/NameBinding/module_selector.swift
+++ b/test/NameBinding/module_selector.swift
@@ -13,7 +13,8 @@ let magnitude: Never = fatalError()
 // Test resolution of main:: using `B`
 
 extension main::B: main::Equatable {
-  @_implements(main::Equatable, main::==(_:_:)) // expected-error {{name cannot be qualified with module selector here}} {{33-39=}}
+  @_implements(main::Equatable, main::==(_:_:))
+  // expected-error@-1 {{name cannot be qualified with module selector here}} {{33-39=}}
   public static func equals(_: main::B, _: main::B) -> main::Bool { main::fatalError() }
   
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
@@ -23,10 +24,17 @@ extension main::B: main::Equatable {
   mutating func myNegate() {
     let fn: (main::Int, main::Int) -> main::Int =
     // FIXME:
-      (main::+) // expected-error {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}} expected-error {{expected expression}} expected-error {{expected expression after operator}}
-    let magnitude: main::Int.main::Magnitude = main::magnitude // expected-EVENTUALLY-error {{a type mismatch with 'Never'}} FIXME: expected-error {{variable used within its own initial value}}
+      (main::+)
+      // expected-error@-1 {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}}
+      // expected-error@-2 {{expected expression}}
+      // expected-error@-3 {{expected expression after operator}}
+
+    let magnitude: main::Int.main::Magnitude = main::magnitude
+    // expected-EVENTUALLY-error@-1 {{a type mismatch with 'Never'}}
+    // FIXME: expected-error@-2 {{variable used within its own initial value}}
     if main::Bool.main::random() {
-      main::negate() // expected-EVENTUALLY-error {{something about not finding 'negate' because we didn't look in self}}
+      main::negate()
+      // expected-EVENTUALLY-error@-1 {{something about not finding 'negate' because we didn't look in self}}
     }
     else {
       self = main::B(value: .main::min)
@@ -41,7 +49,8 @@ extension main::B: main::Equatable {
 // Test resolution of ModuleSelectorTestingKit:: using `C`
 
 extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
-  @_implements(ModuleSelectorTestingKit::Equatable, ModuleSelectorTestingKit::==(_:_:)) // expected-error {{name cannot be qualified with module selector here}} {{52-77=}}
+  @_implements(ModuleSelectorTestingKit::Equatable, ModuleSelectorTestingKit::==(_:_:))
+  // expected-error@-1 {{name cannot be qualified with module selector here}} {{52-77=}}
   public static func equals(_: ModuleSelectorTestingKit::C, _: ModuleSelectorTestingKit::C) -> ModuleSelectorTestingKit::Bool { ModuleSelectorTestingKit::fatalError() }
   
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
@@ -51,16 +60,23 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
   mutating func myNegate() {
     let fn: (ModuleSelectorTestingKit::Int, ModuleSelectorTestingKit::Int) -> ModuleSelectorTestingKit::Int =
     // FIXME:
-      (ModuleSelectorTestingKit::+) // expected-error {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}} expected-error {{expected expression}} expected-error {{expected expression after operator}}
-    let magnitude: ModuleSelectorTestingKit::Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude // expected-EVENTUALLY-error {{something about not finding 'magnitude' because we didn't look in self}} FIXME: expected-error {{variable used within its own initial value}}
+      (ModuleSelectorTestingKit::+)
+      // expected-error@-1 {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}}
+      // expected-error@-2 {{expected expression}}
+      // expected-error@-3 {{expected expression after operator}}
+    let magnitude: ModuleSelectorTestingKit::Int.ModuleSelectorTestingKit::Magnitude = ModuleSelectorTestingKit::magnitude
+    // expected-EVENTUALLY-error@-1 {{something about not finding 'magnitude' because we didn't look in self}}
+    // FIXME: expected-error@-2 {{variable used within its own initial value}}
     if ModuleSelectorTestingKit::Bool.ModuleSelectorTestingKit::random() {
-      ModuleSelectorTestingKit::negate() // expected-EVENTUALLY-error {{something about not finding 'negate' because we didn't look in self}}
+      ModuleSelectorTestingKit::negate()
+      // expected-EVENTUALLY-error@-1 {{something about not finding 'negate' because we didn't look in self}}
     }
     else {
       self = ModuleSelectorTestingKit::C(value: .ModuleSelectorTestingKit::min)
     }
     
-    self.ModuleSelectorTestingKit::myNegate() // expected-EVENTUALLY-error {{can't find 'myNegate' in ModuleSelectorTestingKit}}
+    self.ModuleSelectorTestingKit::myNegate()
+    // expected-EVENTUALLY-error@-2 {{can't find 'myNegate' in ModuleSelectorTestingKit}}
   }
 
   // FIXME: Can we test @convention(witness_method:)?
@@ -70,7 +86,8 @@ extension ModuleSelectorTestingKit::C: ModuleSelectorTestingKit::Equatable {
 // FIXME: Many more of these should fail once the feature is actually implemented.
 
 extension Swift::D: Swift::Equatable {
-  @_implements(Swift::Equatable, Swift::==(_:_:)) // expected-error {{name cannot be qualified with module selector here}} {{34-41=}}
+  @_implements(Swift::Equatable, Swift::==(_:_:))
+  // expected-error@-1 {{name cannot be qualified with module selector here}} {{34-41=}}
   public static func equals(_: Swift::D, _: Swift::D) -> Swift::Bool { Swift::fatalError() }
   
   // FIXME: Add tests with autodiff @_differentiable(jvp:vjp:) and
@@ -80,16 +97,23 @@ extension Swift::D: Swift::Equatable {
   mutating func myNegate() {
     let fn: (Swift::Int, Swift::Int) -> Swift::Int =
     // FIXME:
-      (Swift::+) // expected-error {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}} expected-error {{expected expression}} expected-error {{expected expression after operator}}
-    let magnitude: Swift::Int.Swift::Magnitude = Swift::magnitude // expected-EVENTUALLY-error {{something about not finding 'magnitude' because we didn't look in self}} FIXME: expected-error {{variable used within its own initial value}}
+      (Swift::+)
+      // expected-error@-1 {{cannot convert value of type '()' to specified type '(Int, Int) -> Int'}}
+      // expected-error@-2 {{expected expression}}
+      // expected-error@-3 {{expected expression after operator}}
+    let magnitude: Swift::Int.Swift::Magnitude = Swift::magnitude
+    // expected-EVENTUALLY-error@-1 {{something about not finding 'magnitude' because we didn't look in self}}
+    // FIXME: expected-error@-2 {{variable used within its own initial value}}
     if Swift::Bool.Swift::random() {
-      Swift::negate() // expected-EVENTUALLY-error {{something about not finding 'negate' because we didn't look in self}}
+      Swift::negate()
+      // expected-EVENTUALLY-error@-1 {{something about not finding 'negate' because we didn't look in self}}
     }
     else {
       self = Swift::D(value: .ModuleSelectorTestingKit::min)
     }
     
-    self.Swift::myNegate() // expected-EVENTUALLY-error {{can't find 'myNegate' in Swift}}
+    self.Swift::myNegate()
+    // expected-EVENTUALLY-error@-1 {{can't find 'myNegate' in Swift}}
   }
 
   // FIXME: Can we test @convention(witness_method:)?
@@ -100,109 +124,199 @@ struct AvailableUser {
 
   @main::available() var use2
   @ModuleSelectorTestingKit::available() var use4
-  @Swift::available() var use5 // expected-EVENTUALLY-error {{can't find because not in 'Swift'}}
+  @Swift::available() var use5
+  // expected-EVENTUALLY-error@-1 {{can't find because not in 'Swift'}}
 }
 
 func builderUser2(@main::MyBuilder fn: () -> Void) {}
 func builderUser3(@ModuleSelectorTestingKit::MyBuilder fn: () -> Void) {}
-func builderUser4(@Swift::MyBuilder fn: () -> Void) {} // expected-EVENTUALLY-error {{can't find because not in 'Swift'}}
+func builderUser4(@Swift::MyBuilder fn: () -> Void) {}
+// expected-EVENTUALLY-error@-1 {{can't find because not in 'Swift'}}
 
 func whitespace() {
-  Swift::print // expected-error{{expression resolves to an unused function}}
+  Swift::print
+  // expected-error@-1 {{expression resolves to an unused function}}
 
-  Swift :: print // expected-error{{expression resolves to an unused function}}
+  Swift:: print
+  // expected-error@-1 {{expression resolves to an unused function}}
+
+  Swift ::print
+  // expected-error@-1 {{expression resolves to an unused function}}
+
+  Swift :: print
+  // expected-error@-1 {{expression resolves to an unused function}}
 
   Swift::
-  print // expected-error{{expression resolves to an unused function}}
+  print
+  // expected-error@-1 {{expression resolves to an unused function}}
 
   Swift
-  ::print // expected-error{{expression resolves to an unused function}}
+  ::print
+  // expected-error@-1 {{expression resolves to an unused function}}
 
   Swift ::
-  print // expected-error{{expression resolves to an unused function}}
+  print
+  // expected-error@-1 {{expression resolves to an unused function}}
 
   Swift
-  :: print // expected-error{{expression resolves to an unused function}}
+  :: print
+  // expected-error@-1 {{expression resolves to an unused function}}
 
   Swift
   ::
-  print // expected-error{{expression resolves to an unused function}}
+  print
+  // expected-error@-1 {{expression resolves to an unused function}}
 }
 
 // Error cases
 
-func main::decl1( // expected-error {{name of function declaration cannot be qualified with module selector}}
-  main::p1: main::A, // expected-error {{argument label cannot be qualified with module selector}}
-  main::label p2: main::A, // expected-error {{argument label cannot be qualified with module selector}}
-  label main::p3: main::A // expected-error {{name of parameter declaration cannot be qualified with module selector}}
+func main::decl1(
+  // expected-error@-1 {{name of function declaration cannot be qualified with module selector}}
+  main::p1: main::A,
+  // expected-error@-1 {{argument label cannot be qualified with module selector}}
+  main::label p2: main::A,
+  // expected-error@-1 {{argument label cannot be qualified with module selector}}
+  label main::p3: main::A
+  // expected-error@-1 {{name of parameter declaration cannot be qualified with module selector}}
 ) {
-  let main::decl1a = "a" // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
-  var main::decl1b = "b" // expected-error {{name of variable declaration cannot be qualified with module selector}} expected-warning {{never used}}
-  let (main::decl1c, main::decl1d) = ("c", "d") // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning 2{{never used}}
+  let main::decl1a = "a"
+  // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
+  // expected-warning@-2 {{never used}}
 
-  if let (main::decl1e, main::decl1f) = Optional(("e", "f")) {} // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning 2{{never used}}
-  guard let (main::decl1g, main::decl1h) = Optional(("g", "h")) else { return }  // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+  var main::decl1b = "b"
+  // expected-error@-1 {{name of variable declaration cannot be qualified with module selector}}
+  // expected-warning@-2 {{never used}}
+
+  let (main::decl1c, main::decl1d) = ("c", "d")
+  // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
+  // expected-error@-2 {{name of constant declaration cannot be qualified with module selector}}
+  // expected-warning@-3 2{{never used}}
+
+  if let (main::decl1e, main::decl1f) = Optional(("e", "f")) {}
+  // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
+  // expected-error@-2 {{name of constant declaration cannot be qualified with module selector}}
+  // expected-warning@-3 2{{never used}}
+
+  guard let (main::decl1g, main::decl1h) = Optional(("g", "h")) else { return }
+  // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
+  // expected-error@-2 {{name of constant declaration cannot be qualified with module selector}}
+  // expected-warning@-3 {{never used}}
 
   switch Optional(main::decl1g) { // FIXME expecting an error later
-  case Optional.some(let main::decl1i): // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+  case Optional.some(let main::decl1i):
+    // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
+    // expected-warning@-2 {{never used}}
     break
   case .none:
     break
   }
 
   switch Optional(main::decl1g) { // FIXME expecting an error later
-  case let Optional.some(main::decl1j): // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+  case let Optional.some(main::decl1j):
+    // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
+    // expected-warning@-2 {{never used}}
     break
   case .none:
     break
   }
 
   switch Optional(main::decl1g) {
-  case let main::decl1k?: // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+  case let main::decl1k?:
+    // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
+    // expected-warning@-2 {{never used}}
     break
   case .none:
     break
   }
 
-  for main::decl1l in "lll" {} // expected-error {{name of constant declaration cannot be qualified with module selector}} expected-warning {{never used}}
+  for main::decl1l in "lll" {}
+  // expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
+  // expected-warning@-2 {{never used}}
 
-  "lll".forEach { [main::magnitude] // expected-error {{name of captured variable declaration cannot be qualified with module selector}} expected-warning {{never used}}
-    main::elem in print(elem) // expected-error {{name of parameter declaration cannot be qualified with module selector}}
+  "lll".forEach { [main::magnitude]
+    // expected-error@-1 {{name of captured variable declaration cannot be qualified with module selector}}
+    // expected-warning@-2 {{never used}}
+    main::elem in print(elem)
+    // expected-error@-1 {{name of parameter declaration cannot be qualified with module selector}}
   }
-  "lll".forEach { (main::elem) in print(elem) } // expected-error {{name of parameter declaration cannot be qualified with module selector}}
-  "lll".forEach { (main::elem) -> Void in print(elem) } // expected-error {{name of parameter declaration cannot be qualified with module selector}}
-  "lll".forEach { (main::elem: Character) -> Void in print(elem) } // expected-error {{name of parameter declaration cannot be qualified with module selector}}
+
+  "lll".forEach { (main::elem) in print(elem) }
+  // expected-error@-1 {{name of parameter declaration cannot be qualified with module selector}}
+
+  "lll".forEach { (main::elem) -> Void in print(elem) }
+  // expected-error@-1 {{name of parameter declaration cannot be qualified with module selector}}
+
+  "lll".forEach { (main::elem: Character) -> Void in print(elem) }
+  // expected-error@-1 {{name of parameter declaration cannot be qualified with module selector}}
 }
-enum main::decl2 { // expected-error {{name of enum declaration cannot be qualified with module selector}}
-  case main::decl2a // expected-error {{name of enum 'case' declaration cannot be qualified with module selector}}
+enum main::decl2 {
+  // expected-error@-1 {{name of enum declaration cannot be qualified with module selector}}
+
+  case main::decl2a
+  // expected-error@-1 {{name of enum 'case' declaration cannot be qualified with module selector}}
 }
-struct main::decl3 {} // expected-error {{name of struct declaration cannot be qualified with module selector}}
-class main::decl4<main::T> {} // expected-error {{name of class declaration cannot be qualified with module selector}} expected-error {{name of generic parameter declaration cannot be qualified with module selector}}
-typealias main::decl5 = main::Bool // expected-error {{name of typealias declaration cannot be qualified with module selector}}
-protocol main::decl6 { // expected-error {{name of protocol declaration cannot be qualified with module selector}}
-  associatedtype main::decl6a // expected-error {{name of associatedtype declaration cannot be qualified with module selector}}
+
+struct main::decl3 {}
+// expected-error@-1 {{name of struct declaration cannot be qualified with module selector}}
+
+class main::decl4<main::T> {}
+// expected-error@-1 {{name of class declaration cannot be qualified with module selector}}
+// expected-error@-2 {{name of generic parameter declaration cannot be qualified with module selector}}
+
+typealias main::decl5 = main::Bool
+// expected-error@-1 {{name of typealias declaration cannot be qualified with module selector}}
+
+protocol main::decl6 {
+  // expected-error@-1 {{name of protocol declaration cannot be qualified with module selector}}
+
+  associatedtype main::decl6a
+  // expected-error@-1 {{name of associatedtype declaration cannot be qualified with module selector}}
 }
-let main::decl7 = 7 // expected-error {{name of constant declaration cannot be qualified with module selector}}
-var main::decl8 = 8 { // expected-error {{name of variable declaration cannot be qualified with module selector}}
-  willSet(main::newValue) {} // expected-error {{name of accessor parameter declaration cannot be qualified with module selector}}
-  didSet(main::oldValue) {} // expected-error {{name of accessor parameter declaration cannot be qualified with module selector}}
+
+let main::decl7 = 7
+// expected-error@-1 {{name of constant declaration cannot be qualified with module selector}}
+
+var main::decl8 = 8 {
+// expected-error@-1 {{name of variable declaration cannot be qualified with module selector}}
+
+  willSet(main::newValue) {}
+  // expected-error@-1 {{name of accessor parameter declaration cannot be qualified with module selector}}
+
+  didSet(main::oldValue) {}
+  // expected-error@-1 {{name of accessor parameter declaration cannot be qualified with module selector}}
 }
 
 struct Parent {
-  func main::decl1() {} // expected-error {{name of function declaration cannot be qualified with module selector}}
-  enum main::decl2 { // expected-error {{name of enum declaration cannot be qualified with module selector}}
-    case main::decl2a // expected-error {{name of enum 'case' declaration cannot be qualified with module selector}}
+  func main::decl1() {}
+  // expected-error@-1 {{name of function declaration cannot be qualified with module selector}}
+
+  enum main::decl2 {
+  // expected-error@-1 {{name of enum declaration cannot be qualified with module selector}}
+
+    case main::decl2a
+    // expected-error@-1 {{name of enum 'case' declaration cannot be qualified with module selector}}
   }
-  struct main::decl3 {} // expected-error {{name of struct declaration cannot be qualified with module selector}}
-  class main::decl4 {} // expected-error {{name of class declaration cannot be qualified with module selector}}
-  typealias main::decl5 = main::Bool // expected-error {{name of typealias declaration cannot be qualified with module selector}}
+
+  struct main::decl3 {}
+  // expected-error@-1 {{name of struct declaration cannot be qualified with module selector}}
+
+  class main::decl4 {}
+  // expected-error@-1 {{name of class declaration cannot be qualified with module selector}}
+
+  typealias main::decl5 = main::Bool
+  // expected-error@-1 {{name of typealias declaration cannot be qualified with module selector}}
 }
 
-@_swift_native_objc_runtime_base(main::BaseClass) // expected-error {{Objective-C class name in @_swift_native_objc_runtime_base}}
+@_swift_native_objc_runtime_base(main::BaseClass)
+// expected-error@-1 {{Objective-C class name in @_swift_native_objc_runtime_base}}
 class C1 {}
 
-infix operator <<<<< : Swift::AdditionPrecedence // expected-error {{precedence group specifier cannot be qualified with module selector}}
+infix operator <<<<< : Swift::AdditionPrecedence
+// expected-error@-1 {{precedence group specifier cannot be qualified with module selector}}
 
-precedencegroup main::PG1 { // expected-error {{name of precedence group declaration cannot be qualified with module selector}}
-  higherThan: Swift::AdditionPrecedence // expected-error {{precedence group specifier cannot be qualified with module selector}}
+precedencegroup main::PG1 {
+// expected-error@-1 {{name of precedence group declaration cannot be qualified with module selector}}
+
+  higherThan: Swift::AdditionPrecedence
+  // expected-error@-1 {{precedence group specifier cannot be qualified with module selector}}
 }

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -224,6 +224,7 @@ SYNTAX_TOKENS = [
     Punctuator('Comma', 'comma', text=',', serialization_code=84),
     Punctuator('Ellipsis', 'ellipsis', text='...', serialization_code=118),
     Punctuator('Colon', 'colon', text=':', serialization_code=82),
+    Punctuator('ColonColon', 'colon_colon', text='::', serialization_code=122),
     Punctuator('Semicolon', 'semi', text=';', serialization_code=83),
     Punctuator('Equal', 'equal', text='=', serialization_code=86),
     Punctuator('AtSign', 'at_sign', text='@', classification='Attribute',


### PR DESCRIPTION
This pull request begins to implement "module selectors", which allow references to declarations to be unambiguously prefixed with a module they can be found through:

```
class MyClass: ObjectiveC::NSObject {}  // OK, ObjectiveC defines NSObject
class MyClass: Foundation::NSObject {}  // OK, Foundation re-exports NSObject
class MyClass: Swift::NSObject {}       // error, Swift does not re-export or define NSObject
class MyClass: MyModule::NSObject {}    // error, MyModule does not re-export or define NSObject
```

This PR parses module selectors and partially implements lookup and diagnostics for them. The new functionality is hidden behind an `-enable-experimental-module-selector` frontend flag. There is one diagnostic regression with that flag enabled, but I've made sure that it keeps working when the diagnostic is disabled.

I will need to switch to other tasks soon, so I plan to merge this work in its current incomplete state to keep it from rotting in a branch.

Makes progress on rdar://problem/19481048.