### PR TITLE
[ConstraintSystem] Delay constraint generation for single-statement closure body

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3318,7 +3318,6 @@ END_CAN_TYPE_WRAPPER(FunctionType, AnyFunctionType)
 /// has a default argument.
 struct ParameterListInfo {
   SmallBitVector defaultArguments;
-  std::vector<Type> functionBuilderTypes;
 
 public:
   ParameterListInfo() { }
@@ -3336,9 +3335,6 @@ public:
 
   /// Retrieve the number of parameters for which we have information.
   unsigned size() const { return defaultArguments.size(); }
-
-  /// Retrieve the function builder type for the given parameter.
-  Type getFunctionBuilderType(unsigned paramIdx) const;
 };
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -818,7 +818,6 @@ ParameterListInfo::ParameterListInfo(
     const ValueDecl *paramOwner,
     bool skipCurriedSelf) {
   defaultArguments.resize(params.size());
-  functionBuilderTypes.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -863,22 +862,12 @@ ParameterListInfo::ParameterListInfo(
     if (param->isDefaultArgument()) {
       defaultArguments.set(i);
     }
-
-    if (Type functionBuilderType = param->getFunctionBuilderType()) {
-      functionBuilderTypes[i] = functionBuilderType;
-    }
   }
 }
 
 bool ParameterListInfo::hasDefaultArgument(unsigned paramIdx) const {
   return paramIdx < defaultArguments.size() ? defaultArguments[paramIdx]
       : false;
-}
-
-Type ParameterListInfo::getFunctionBuilderType(unsigned paramIdx) const {
-  return paramIdx < functionBuilderTypes.size()
-      ? functionBuilderTypes[paramIdx]
-      : Type();
 }
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -615,13 +615,6 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionBuilder(
   assert(builder && "Bad function builder type");
   assert(builder->getAttrs().hasAttribute<FunctionBuilderAttr>());
 
-  // FIXME: Right now, single-expression closures suppress the function
-  // builder translation.
-  if (auto closure = fn.getAbstractClosureExpr()) {
-    if (closure->hasSingleExpressionBody())
-      return getTypeMatchSuccess();
-  }
-
   // Pre-check the body: pre-check any expressions in it and look
   // for return statements.
   auto request = PreCheckFunctionBuilderRequest{fn};

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -709,6 +709,12 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionBuilder(
         fn,
         AppliedBuilderTransform{builderType, singleExpr, bodyResultType}));
 
+  // If builder is applied to the closure expression then
+  // `closure body` to `closure result` matching should
+  // use special locator.
+  if (auto *closure = fn.getAbstractClosureExpr())
+    locator = getConstraintLocator(closure, ConstraintLocator::ClosureResult);
+
   // Bind the body result type to the type of the transformed expression.
   addConstraint(bodyResultConstraintKind, transformedType, bodyResultType,
                 locator);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -157,7 +157,11 @@ ConstraintLocator *Solution::getCalleeLocator(ConstraintLocator *locator,
   auto &cs = getConstraintSystem();
   return cs.getCalleeLocator(
       locator, lookThroughApply,
-      [&](const Expr *expr) -> Type { return getType(expr); });
+      [&](const Expr *expr) -> Type { return getType(expr); },
+      [&](Type type) -> Type { return simplifyType(type)->getRValueType(); },
+      [&](ConstraintLocator *locator) -> Optional<SelectedOverload> {
+        return getOverloadChoiceIfAvailable(locator);
+      });
 }
 
 /// Return the implicit access kind for a MemberRefExpr with the

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -347,6 +347,11 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
 
     result.InvolvesTypeVariables = true;
 
+    if (constraint->getKind() == ConstraintKind::Subtype &&
+        kind == AllowedBindingKind::Subtypes) {
+      result.SubtypeOf.insert(bindingTypeVar);
+    }
+
     // If we've already set addOptionalSupertypeBindings, or we aren't
     // allowing supertype bindings, we're done.
     if (addOptionalSupertypeBindings || kind != AllowedBindingKind::Supertypes)

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -206,6 +206,22 @@ bool ConstraintSystem::PotentialBindings::isViable(
   return true;
 }
 
+bool ConstraintSystem::PotentialBindings::favoredOverDisjunction() const {
+  if (IsHole || FullyBound)
+    return false;
+
+  // If this bindings are for a closure and there are no holes,
+  // it shouldn't matter whether it there are any type variables
+  // or not because e.g. parameter type can have type variables,
+  // but we still want to resolve closure body early (instead of
+  // attempting any disjunction) to gain additional contextual
+  // information.
+  if (TypeVar->getImpl().isClosureType())
+    return true;
+
+  return !InvolvesTypeVariables;
+}
+
 static bool hasNilLiteralConstraint(TypeVariableType *typeVar,
                                     const ConstraintSystem &CS) {
   // Look for a literal-conformance constraint on the type variable.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2061,8 +2061,7 @@ namespace {
 
           Type externalType;
           if (param->getTypeRepr()) {
-            auto declaredTy =
-                closure->mapTypeIntoContext(param->getInterfaceType());
+            auto declaredTy = param->getType();
             externalType = CS.openUnboundGenericType(declaredTy, paramLoc);
           } else {
             externalType = CS.createTypeVariable(

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3662,20 +3662,16 @@ namespace {
         }
       }
 
-      // For closures containing only a single expression, the body participates
-      // in type checking.
+      // Both multi- and single-statement closures now behave the same way
+      // when it comes to constraint generation.
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         auto &CS = CG.getConstraintSystem();
-        if (closure->hasSingleExpressionBody()) {
-          auto closureType = CG.visitClosureExpr(closure);
-          if (!closureType)
-            return {false, nullptr};
+        auto closureType = CG.visitClosureExpr(closure);
+        if (!closureType)
+          return {false, nullptr};
 
-          CS.setType(expr, closureType);
-          return {false, expr};
-        }
-
-        return { true, expr };
+        CS.setType(expr, closureType);
+        return {false, expr};
       }
 
       // Don't visit CoerceExpr with an empty sub expression. They may occur
@@ -3733,12 +3729,6 @@ namespace {
 
             return DSE;
           }
-        }
-      }
-
-      if (auto closure = dyn_cast<ClosureExpr>(expr)) {
-        if (closure->hasSingleExpressionBody()) {
-          return expr;
         }
       }
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1080,6 +1080,21 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
       continue;
     }
 
+    // With introduction of holes it's currently possible to form solutions
+    // with UnresolvedType bindings, we need to account for that in
+    // ranking. If one solution has a hole for a given type variable
+    // it's always worse than any non-hole type other solution might have.
+    if (type1->is<UnresolvedType>() || type2->is<UnresolvedType>()) {
+      if (type1->is<UnresolvedType>()) {
+        ++score2;
+      } else {
+        ++score1;
+      }
+
+      identical = false;
+      continue;
+    }
+
     // If one type is a subtype of the other, but not vice-versa,
     // we prefer the system with the more-constrained type.
     // FIXME: Collapse this check into the second check.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6531,6 +6531,10 @@ static Type getFunctionBuilderTypeFor(ConstraintSystem &cs, unsigned paramIdx,
     return Type();
 
   auto *choice = selectedOverload->choice.getDecl();
+  bool skipCurriedSelf = hasAppliedSelf(cs, selectedOverload->choice);
+
+  if (choice->hasCurriedSelf() && !skipCurriedSelf)
+    return Type();
 
   if (!choice->hasParameterList())
     return Type();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2358,6 +2358,12 @@ ConstraintSystem::matchTypesBindTypeVar(
     });
   }
 
+  if (typeVar->getImpl().isClosureType()) {
+    return resolveClosure(typeVar, type, locator)
+               ? getTypeMatchSuccess()
+               : getTypeMatchFailure(locator);
+  }
+
   assignFixedType(typeVar, type);
 
   return getTypeMatchSuccess();

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1694,6 +1694,7 @@ void ConstraintSystem::ArgumentInfoCollector::walk(Type argType) {
       case ConstraintKind::ConformsTo:
       case ConstraintKind::Defaultable:
       case ConstraintKind::OneWayEqual:
+      case ConstraintKind::DefaultClosureType:
         break;
       }
     }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -335,6 +335,13 @@ void truncate(llvm::SmallSetVector<T, N> &vec, unsigned newSize) {
     vec.pop_back();
 }
 
+template <typename K, typename V>
+void truncate(llvm::MapVector<K, V> &map, unsigned newSize) {
+  assert(newSize <= map.size() && "Not a truncation!");
+  for (unsigned i = 0, n = map.size() - newSize; i != n; ++i)
+    map.pop_back();
+}
+
 } // end anonymous namespace
 
 ConstraintSystem::SolverState::SolverState(
@@ -438,6 +445,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numFavoredConstraints = cs.solverState->getNumFavoredConstraints();
   numFunctionBuilderTransformed = cs.functionBuilderTransformed.size();
   numResolvedOverloads = cs.ResolvedOverloads.size();
+  numInferredClosureTypes = cs.ClosureTypes.size();
 
   PreviousScore = cs.CurrentScore;
 
@@ -450,8 +458,7 @@ ConstraintSystem::SolverScope::~SolverScope() {
   while (cs.TypeVariables.size() > numTypeVariables)
     cs.TypeVariables.pop_back();
 
-  while (cs.ResolvedOverloads.size() > numResolvedOverloads)
-    cs.ResolvedOverloads.pop_back();
+  truncate(cs.ResolvedOverloads, numResolvedOverloads);
 
   // Restore bindings.
   cs.restoreTypeVariableBindings(cs.solverState->savedBindings.size() -
@@ -504,6 +511,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   /// Remove any builder transformed closures.
   truncate(cs.functionBuilderTransformed, numFunctionBuilderTransformed);
+
+  // Remove any inferred closure types (e.g. used in function builder body).
+  truncate(cs.ClosureTypes, numInferredClosureTypes);
 
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -329,9 +329,8 @@ StepResult ComponentStep::take(bool prevFailed) {
   auto *disjunction = CS.selectDisjunction();
   auto bestBindings = CS.determineBestBindings();
 
-  if (bestBindings && (!disjunction || (!bestBindings->IsHole &&
-                                        !bestBindings->InvolvesTypeVariables &&
-                                        !bestBindings->FullyBound))) {
+  if (bestBindings &&
+      (!disjunction || bestBindings->favoredOverDisjunction())) {
     // Produce a type variable step.
     return suspend(
         llvm::make_unique<TypeVariableStep>(CS, *bestBindings, Solutions));

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -608,13 +608,16 @@ bool Constraint::isExplicitConversion() const {
 
 Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind, 
                                Type first, Type second,
-                               ConstraintLocator *locator) {
+                               ConstraintLocator *locator,
+                               ArrayRef<TypeVariableType *> extraTypeVars) {
   // Collect type variables.
   SmallVector<TypeVariableType *, 4> typeVars;
   if (first->hasTypeVariable())
     first->getTypeVariables(typeVars);
   if (second && second->hasTypeVariable())
     second->getTypeVariables(typeVars);
+
+  typeVars.append(extraTypeVars.begin(), extraTypeVars.end());
   uniqueTypeVariables(typeVars);
 
   // Conformance constraints expect an existential on the right-hand side.

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -81,6 +81,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
     llvm_unreachable("Wrong constructor for member constraint");
 
   case ConstraintKind::Defaultable:
+  case ConstraintKind::DefaultClosureType:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -137,6 +138,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
   case ConstraintKind::OneWayEqual:
+  case ConstraintKind::DefaultClosureType:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -263,6 +265,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
   case ConstraintKind::OneWayEqual:
+  case ConstraintKind::DefaultClosureType:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::BindOverload:
@@ -345,6 +348,9 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
   case ConstraintKind::EscapableFunctionOf: Out << " @escaping type of "; break;
   case ConstraintKind::OpenedExistentialOf: Out << " opened archetype of "; break;
   case ConstraintKind::OneWayEqual: Out << " one-way bind to "; break;
+  case ConstraintKind::DefaultClosureType:
+    Out << " closure can default to ";
+    break;
   case ConstraintKind::KeyPath:
       Out << " key path from ";
       Out << getSecondType()->getString(PO);
@@ -561,6 +567,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
   case ConstraintKind::OneWayEqual:
+  case ConstraintKind::DefaultClosureType:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -161,6 +161,9 @@ enum class ConstraintKind : char {
   /// type). At that point, this constraint will be treated like an `Equal`
   /// constraint.
   OneWayEqual,
+  /// If there are no contextual types e.g. `_ = { 42 }` default first type
+  /// to a second type (inferred closure type).
+  DefaultClosureType,
 };
 
 /// Classification of the different kinds of constraints.
@@ -540,6 +543,7 @@ public:
     case ConstraintKind::OptionalObject:
     case ConstraintKind::OpaqueUnderlyingType:
     case ConstraintKind::OneWayEqual:
+    case ConstraintKind::DefaultClosureType:
       return ConstraintClassification::Relational;
 
     case ConstraintKind::ValueMember:

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -161,8 +161,14 @@ enum class ConstraintKind : char {
   /// type). At that point, this constraint will be treated like an `Equal`
   /// constraint.
   OneWayEqual,
-  /// If there are no contextual types e.g. `_ = { 42 }` default first type
-  /// to a second type (inferred closure type).
+  /// If there is no contextual info e.g. `_ = { 42 }` default first type
+  /// to a second type (inferred closure type). This is effectively a
+  /// `Defaultable` constraint which a couple of differences:
+  ///
+  /// - References inferred closure type and all of the outer parameters
+  ///   referenced by closure body.
+  /// - Handled specially by binding inference, specifically contributes
+  ///   to the bindings only if there are no contextual types available.
   DefaultClosureType,
 };
 
@@ -409,9 +415,9 @@ class Constraint final : public llvm::ilist_node<Constraint>,
 
 public:
   /// Create a new constraint.
-  static Constraint *create(ConstraintSystem &cs, ConstraintKind Kind, 
-                            Type First, Type Second,
-                            ConstraintLocator *locator);
+  static Constraint *create(ConstraintSystem &cs, ConstraintKind Kind,
+                            Type First, Type Second, ConstraintLocator *locator,
+                            ArrayRef<TypeVariableType *> extraTypeVars = {});
 
   /// Create a new constraint.
   static Constraint *create(ConstraintSystem &cs, ConstraintKind Kind, 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1266,6 +1266,10 @@ private:
   /// type in a disjunction constraint.
   llvm::DenseMap<Expr *, TypeBase *> FavoredTypes;
 
+  /// Maps discovered closures to their types inferred
+  /// from declared parameters/result and body.
+  llvm::MapVector<const ClosureExpr *, FunctionType *> ClosureTypes;
+
   /// Maps expression types used within all portions of the constraint
   /// system, instead of directly using the types on the expression
   /// nodes themselves. This allows us to typecheck an expression and
@@ -1854,6 +1858,9 @@ public:
     /// The length of \c ResolvedOverloads.
     unsigned numResolvedOverloads;
 
+    /// The length of \c ClosureTypes.
+    unsigned numInferredClosureTypes;
+
     /// The previous score.
     Score PreviousScore;
 
@@ -1988,6 +1995,19 @@ public:
   /// the moment.
   bool isActiveTypeVariable(TypeVariableType *typeVar) const {
     return TypeVariables.count(typeVar) > 0;
+  }
+
+  void setClosureType(const ClosureExpr *closure, FunctionType *type) {
+    assert(closure);
+    assert(type && "Expected non-null type");
+    assert(ClosureTypes.count(closure) == 0 && "Cannot reset closure type");
+    ClosureTypes.insert({closure, type});
+  }
+
+  FunctionType *getClosureType(const ClosureExpr *closure) const {
+    auto result = ClosureTypes.find(closure);
+    assert(result != ClosureTypes.end());
+    return result->second;
   }
 
   TypeBase* getFavoredType(Expr *E) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2731,10 +2731,12 @@ public:
   /// closure expression.
   /// \param contextualType The contextual type this closure would be
   /// converted to.
+  /// \param locator The locator associated with contextual type.
   ///
   /// \returns `true` if it was possible to generate constraints for
   /// the body and assign fixed type to the closure, `false` otherwise.
-  bool resolveClosure(TypeVariableType *typeVar, Type contextualType);
+  bool resolveClosure(TypeVariableType *typeVar, Type contextualType,
+                      ConstraintLocatorBuilder locator);
 
   /// Assign a fixed type to the given type variable.
   ///

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -297,6 +297,9 @@ public:
   /// Retrieve the generic parameter opened by this type variable.
   GenericTypeParamType *getGenericParameter() const;
 
+  /// Determine whether this type variable represents a closure type.
+  bool isClosureType() const;
+
   /// Determine whether this type variable represents a closure result type.
   bool isClosureResultType() const;
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2973,6 +2973,11 @@ public:
     return allocateCopy(vec.begin(), vec.end());
   }
 
+  /// Generate constraints for the body of the given single-statement closure.
+  ///
+  /// \returns a possibly-sanitized expression, or null if an error occurred.
+  Expr *generateConstraints(ClosureExpr *closure);
+
   /// Generate constraints for the given (unchecked) expression.
   ///
   /// \returns a possibly-sanitized expression, or null if an error occurred.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3757,6 +3757,10 @@ private:
       return false;
     }
 
+    /// Check if this binding is favored over a disjunction e.g.
+    /// if it has only concrete types or would resolve a closure.
+    bool favoredOverDisjunction() const;
+
     void dump(llvm::raw_ostream &out,
               unsigned indent = 0) const LLVM_ATTRIBUTE_USED {
       out.indent(indent);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -936,22 +936,9 @@ public:
     SmallVector<OverloadChoice, 2> choices;
   };
 
-  /// A difference between two type variable bindings.
-  struct TypeBindingDiff {
-    /// The type variable.
-    TypeVariableType *typeVar;
-
-    /// The bindings that each solution made.
-    SmallVector<Type, 2> bindings;
-  };
-
   /// The differences between the overload choices between the
   /// solutions.
   SmallVector<OverloadDiff, 4> overloads;
-
-  /// The differences between the type variable bindings of the
-  /// solutions.
-  SmallVector<TypeBindingDiff, 4> typeBindings;
 
   /// Compute the differences between the given set of solutions.
   ///

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3481,10 +3481,15 @@ private:
       ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify the given defaultable constraint.
-  SolutionKind simplifyDefaultableConstraint(ConstraintKind kind,
-                                             Type first, Type second,
+  SolutionKind simplifyDefaultableConstraint(Type first, Type second,
                                              TypeMatchOptions flags,
                                              ConstraintLocatorBuilder locator);
+
+  /// Attempt to simplify the given defaultable closure type constraint.
+  SolutionKind simplifyDefaultClosureTypeConstraint(
+      Type closureType, Type inferredType,
+      ArrayRef<TypeVariableType *> referencedOuterParameters,
+      TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify a one-way constraint.
   SolutionKind simplifyOneWayConstraint(ConstraintKind kind,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3479,7 +3479,8 @@ private:
       ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify the given defaultable constraint.
-  SolutionKind simplifyDefaultableConstraint(Type first, Type second,
+  SolutionKind simplifyDefaultableConstraint(ConstraintKind kind,
+                                             Type first, Type second,
                                              TypeMatchOptions flags,
                                              ConstraintLocatorBuilder locator);
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2722,6 +2722,20 @@ public:
   static bool typeVarOccursInType(TypeVariableType *typeVar, Type type,
                                   bool *involvesOtherTypeVariables = nullptr);
 
+  /// Given the fact that contextual type is now available for the type
+  /// variable representing one of the closures, let's set pre-determined
+  /// closure type and generate constraints for its body, iff it's a
+  /// single-statement closure.
+  ///
+  /// \param typeVar The type variable representing a function type of the
+  /// closure expression.
+  /// \param contextualType The contextual type this closure would be
+  /// converted to.
+  ///
+  /// \returns `true` if it was possible to generate constraints for
+  /// the body and assign fixed type to the closure, `false` otherwise.
+  bool resolveClosure(TypeVariableType *typeVar, Type contextualType);
+
   /// Assign a fixed type to the given type variable.
   ///
   /// \param typeVar The type variable to bind.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -83,6 +83,13 @@ TypeVariableType::Implementation::getGenericParameter() const {
   return locator ? locator->getGenericParameter() : nullptr;
 }
 
+bool TypeVariableType::Implementation::isClosureType() const {
+  if (!(locator && locator->getAnchor()))
+    return false;
+
+  return isa<ClosureExpr>(locator->getAnchor()) && locator->getPath().empty();
+}
+
 bool TypeVariableType::Implementation::isClosureResultType() const {
   if (!(locator && locator->getAnchor()))
     return false;

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -186,7 +186,7 @@ func testMap() {
 }
 
 // <rdar://problem/22414757> "UnresolvedDot" "in wrong phase" assertion from verifier
-[].reduce { $0 + $1 }  // expected-error {{cannot invoke 'reduce' with an argument list of type '(@escaping (_, _) -> _)'}}
+[].reduce { $0 + $1 }  // expected-error {{cannot invoke 'reduce' with an argument list of type '(_)'}}
 
 
 
@@ -371,7 +371,7 @@ func someGeneric19997471<T>(_ x: T) {
 func rdar21078316() {
   var foo : [String : String]?
   var bar : [(String, String)]?
-  bar = foo.map { ($0, $1) }  // expected-error {{contextual closure type '([String : String]) throws -> U' expects 1 argument, but 2 were used in closure body}}
+  bar = foo.map { ($0, $1) }  // expected-error {{contextual closure type '(Dictionary<String, String>) throws -> (Dictionary<String, String>, _)' expects 1 argument, but 2 were used in closure body}}
 }
 
 

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -216,6 +216,7 @@ func rdar_50668864() {
   struct Foo {
     init(anchors: [Int]) { // expected-note {{'init(anchors:)' declared here}}
       self = .init { _ in [] } // expected-error {{trailing closure passed to parameter of type '[Int]' that does not accept a closure}}
+      // expected-error@-1 {{generic parameter 'Element' could not be inferred}}
     }
   }
 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -251,8 +251,7 @@ struct Toe {
   let toenail: Nail // expected-error {{use of undeclared type 'Nail'}}
 
   func clip() {
-    // FIXME: We shouldn't report this because toenail.inspect is a hole
-    toenail.inspect { x in // expected-error {{unable to infer closure return type; add explicit type to disambiguate}}
+    toenail.inspect { x in
       toenail.inspect { y in }
     }
   }
@@ -290,7 +289,6 @@ func r18800223(_ i : Int) {
   
   var buttonTextColor: String?
   _ = (buttonTextColor != nil) ? 42 : {$0}; // expected-error {{result values in '? :' expression have mismatching types 'Int' and '(_) -> _'}}
-  // expected-error@-1 {{unable to infer closure return type; add explicit type to disambiguate}}
 }
 
 // <rdar://problem/21883806> Bogus "'_' can only appear in a pattern or on the left side of an assignment" is back

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -409,3 +409,18 @@ testForEach1.show()
 
 // CHECK: ("testForEach1", main.Either<(Swift.String, Swift.Bool), (Swift.Bool, Swift.String)>.first("begin", true))
 // CHECK: ("testForEach1", main.Either<(Swift.String, Swift.Bool), (Swift.Bool, Swift.String)>.second(true, "end"))
+
+func test_single_stmt_closure_support() {
+  @_functionBuilder
+  struct MyBuilder {
+    static func buildBlock(_ numbers: Int...) -> Int {
+      return 42
+    }
+  }
+
+  func test(@MyBuilder builder: () -> Int) -> Int {
+    builder()
+  }
+
+  let _ = test { 0 } // ok
+}

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -211,7 +211,7 @@ func erroneousSR11350(x: Int) {
       if b {
         acceptInt(0) { }
       }
-    }).domap(0) // expected-error{{value of type 'Optional<()>' has no member 'domap'}}
+    }).domap(0) // expected-error{{value of type '()?' has no member 'domap'}}
   }
 }
 

--- a/test/Constraints/function_builder_one_way.swift
+++ b/test/Constraints/function_builder_one_way.swift
@@ -49,17 +49,17 @@ func tuplify<C: Collection, T>(_ collection: C, @TupleBuilder body: (C.Element) 
 }
 
 // CHECK: ---Connected components---
-// CHECK-NEXT: 0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T69 depends on 1
-// CHECK-NEXT: 1: $T9 $T11 $T16 $T30 $T62 $T63 $T64 $T65 $T66 $T67 $T68 depends on 2, 3, 4, 5
+// CHECK-NEXT: 0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T10 $T11 $T69 depends on 1
+// CHECK-NEXT: 1: $T12 $T14 $T19 $T30 $T62 $T63 $T64 $T65 $T66 $T67 $T68 depends on 2, 3, 4, 5
 // CHECK-NEXT: 5: $T32 $T43 $T44 $T45 $T46 $T47 $T57 $T58 $T59 $T60 $T61 depends on 6, 9
 // CHECK-NEXT: 9: $T48 $T54 $T55 $T56 depends on 10
 // CHECK-NEXT: 10: $T49 $T50 $T51 $T52 $T53
 // CHECK-NEXT: 6: $T33 $T35 $T39 $T40 $T41 $T42 depends on 7, 8
 // CHECK-NEXT: 8: $T36 $T37 $T38
 // CHECK-NEXT: 7: $T34
-// CHECK-NEXT: 4: $T17 $T18 $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28 $T29
-// CHECK-NEXT: 3: $T14 $T15
-// CHECK-NEXT: 2: $T10
+// CHECK-NEXT: 4: $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28 $T29
+// CHECK-NEXT: 3: $T17 $T18
+// CHECK-NEXT: 2: $T13
 let names = ["Alice", "Bob", "Charlie"]
 let b = true
 var number = 17

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1736,7 +1736,8 @@ func autoclosureSplat() {
   // wrap the closure in a function conversion.
 
   takeFn { (fn: @autoclosure () -> Int, x: Int) in }
-  // expected-error@-1 {{contextual closure type '(@escaping () -> Int) -> ()' expects 1 argument, but 2 were used in closure body}}
+  // expected-error@-1 {{contextual closure type '(() -> Int) -> ()' expects 1 argument, but 2 were used in closure body}}
+  // expected-error@-2 {{converting non-escaping value to 'T' may allow it to escape}}
 
   takeFn { (fn: @autoclosure @escaping () -> Int) in }
   // FIXME: It looks like matchFunctionTypes() does not check @autoclosure at all.

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar50869732.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar50869732.swift
@@ -10,7 +10,8 @@ struct Generic<T> {
 
 @_functionBuilder
 struct Builder {
-  static func buildBlock<C0, C1>(_ c0: C0, _ c1: C1) // expected-note {{where 'C0' = 'Empty'}} expected-note {{where 'C1' = 'Test<Empty>'}}
+  static func buildBlock<C0, C1>(_ c0: C0, _ c1: C1) // expected-note 2 {{where 'C0' = 'Empty'}} expected-note {{where 'C1' = 'Test<Generic<(Empty, _)>>'}}
+  // expected-note@-1 {{'buildBlock' declared here}}
            -> Generic<(C0, C1)> where C0 : P, C1 : P {
     return Generic((c0, c1))
   }
@@ -24,13 +25,16 @@ struct Empty {
   init() {}
 }
 
-struct Test<T> where T : P { // expected-note {{where 'T' = 'Empty'}}
+struct Test<T> where T : P { // expected-note {{where 'T' = 'Generic<(Empty, _)>'}}
   init(@Builder _: () -> T) {}
 }
 
 let x = G {
   // expected-error@-1 {{static method 'buildBlock' requires that 'Empty' conform to 'P'}}
-  // expected-error@-2 {{static method 'buildBlock' requires that 'Test<Empty>' conform to 'P'}}
+  // expected-error@-2 {{static method 'buildBlock' requires that 'Test<Generic<(Empty, _)>>' conform to 'P'}}
   Empty()
-  Test { Empty() } // expected-error {{generic struct 'Test' requires that 'Empty' conform to 'P'}}
+  Test { Empty() }
+  // expected-error@-1 {{static method 'buildBlock' requires that 'Empty' conform to 'P'}}
+  // expected-error@-2 {{missing argument for parameter #2 in call}}
+  // expected-error@-3 {{generic struct 'Test' requires that 'Generic<(Empty, _)>' conform to 'P'}}
 }

--- a/validation-test/Sema/type_checker_perf/fast/rdar20959612.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20959612.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 3 --end 7 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 3 --end 15 --step 1 --select NumLeafScopes %s
 // REQUIRES: asserts,no_asan
 
 func curry<T0

--- a/validation-test/Sema/type_checker_perf/slow/rdar22022980.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22022980.swift
@@ -2,3 +2,4 @@
 // REQUIRES: tools-release,no_asan
 
 _ = [1, 3, 5, 7, 11].filter{ $0 == 1 || $0 == 3 || $0 == 11 || $0 == 1 || $0 == 3 || $0 == 11 } == [ 1, 3, 11 ]
+// expected-error@-1 {{unable to type-check}}


### PR DESCRIPTION
Attempt to infer a closure type based on its parameters and body
and put it aside until contextual type becomes available or it
has been determined that there is no context.

Once all appropriate conditions are met, generate constraints for
the body of the closure and bind it the previously inferred type.

Doing so makes it possible to pass single-statement closures as
an argument to a function builder parameter.

Resolves: SR-11628
Resolves: rdar://problem/56340587

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
