### PR TITLE
[Diagnostics] Emit a diagnostic if a function parameter is unused in the body

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4588,6 +4588,15 @@ WARNING(variable_never_read, none,
 WARNING(observe_keypath_property_not_objc_dynamic, none,
         "passing reference to non-'@objc dynamic' property %0 to KVO method %1 "
         "may lead to unexpected behavior or runtime trap", (DeclName, DeclName))
+WARNING(param_never_used, none,
+        "function parameter %0 was never used; "
+        "consider %select{replacing it with '_'|"
+        "replacing the whole parameter with '_'|removing it}1",
+        (Identifier, unsigned))
+NOTE(param_never_used_fixit_remove_only_param, none,
+     "replace %0 with '_' instead", (Identifier))
+NOTE(param_never_used_fixit_ignore_param, none,
+     "insert '_' to ignore %0 instead", (Identifier))
 
 //------------------------------------------------------------------------------
 // MARK: Debug diagnostics

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -98,6 +98,10 @@ namespace swift {
     /// human-readable string.
     bool EnableConcisePoundFile = false;
 
+    /// If false, we do not warn when function parameters are
+    /// unused.
+    bool WarnUnusedFunctionParams = false;
+
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -513,6 +513,10 @@ def save_optimization_record_path :
   Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Specify the file name of any generated YAML optimization record">;
 
+def warn_unused_function_params : Flag<["-"], "warn-unused-function-params">,
+  Flags<[FrontendOption]>,
+  HelpText<"Emit a warning when function parameters are not used in the body">;
+
 // Platform options.
 def enable_app_extension : Flag<["-"], "application-extension">,
   Flags<[FrontendOption, NoInteractiveOption]>,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -456,6 +456,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableConcisePoundFile =
       Args.hasArg(OPT_enable_experimental_concise_pound_file);
 
+  Opts.WarnUnusedFunctionParams = Args.hasArg(OPT_warn_unused_function_params);
+
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;
   if (const Arg *A = Args.getLastArg(OPT_target)) {

--- a/test/decl/func/warn_unused_function_params.swift
+++ b/test/decl/func/warn_unused_function_params.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift -warn-unused-function-params
+
+// SR-2849
+final class FooContainer {
+  func foo1(x: Int) { 
+    // expected-warning@-1:13 {{function parameter 'x' was never used; consider replacing it with '_'}} {{13-14=_}}
+    // expected-note@-2:13 {{insert '_' to ignore 'x' instead}} {{14-14= _}}
+    let array = [1, 2, 3]
+    print(array[0])
+  }
+
+  func foo2(_: Int) { // No warning
+    let array = [1, 2, 3]
+    print(array[0])
+  }
+
+  func foo3(_ y: Int) { // // expected-warning@:15 {{function parameter 'y' was never used; consider removing it}} {{14-16=}}
+    let array = [1, 2, 3]
+    print(array[0])
+  }
+
+  func foo4(_ y: Int) { // No warning as 'y' is used in the body
+    let array = [1, 2, 3]
+    print(array[y])
+  }
+
+  func foo5(x y: Int) {
+    // expected-warning@-1:15 {{function parameter 'y' was never used; consider replacing the whole parameter with '_'}} {{13-16=_}}
+    // expected-note@-2:15 {{replace 'y' with '_' instead}} {{15-16=_}}
+    let array = [1, 2, 3]
+    print(array[0])
+  }
+
+  func foo6(x _: Int) { // No warning
+    let array = [1, 2, 3]
+    print(array[0])
+  }
+
+  func foo7(x y: Int) { // No warning as 'y' is used in the body
+    let array = [1, 2, 3]
+    print(array[y])
+  }
+
+  // FIXME: Handle this as well
+  func foo8(x: Int = 0) {
+    let array = [1, 2, 3]
+    print(array[0])
+  }
+}


### PR DESCRIPTION
When a function parameter is not used in the body of the function, emit a warning. For example:

```swift
func foo(x: Int) { // warning + fix-it to replace 'x' with '_' OR insert '_' after 'x'
  print("I didn't use x!")
}

func bar(_ y: Int) { // warning + fix-it remove 'y'
  print("I didn't use y!")
}

func baz(x y: Int) { // warning + fix-it to replace entire parameter with '_' OR replace 'y' with '_'
  print("I didn't use y!")
}
```

This is hidden behind a frontend flag: `-warn-unused-function-params`. When this flag is passed, we emit the warnings, otherwise we don't. We probably also need a new Xcode build setting to conveniently allow the users to enable or disable this functionality, but that's not up to me.

In the future, we can extend this to work with closure parameters as well.

Resolves SR-2849
Resolves SR-6963
Resolves rdar://problem/31844597
Resolves rdar://problem/35534022
