### PR TITLE
Revert "[ClangImporter] Hash content for validation when using clang …

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1076,10 +1076,6 @@ ClangImporter::create(ASTContext &ctx, const ClangImporterOptions &importerOpts,
   // read them later.
   instance.getLangOpts().NeededByPCHOrCompilationUsesPCH = true;
 
-  // Make sure to not trigger extra rebuilds on identical files with mismatching
-  // timestamps.
-  instance.getHeaderSearchOpts().ValidateASTInputFilesContent = true;
-
   if (importerOpts.Mode == ClangImporterOptions::Modes::PrecompiledModule)
     return importer;
 


### PR DESCRIPTION
…modules"

This reverts commit c362e925af7ff948be704c55cb4406a05f5d13b7.

This might be causing hard to reproduce issues. Taking it out until
we have further investigation.

rdar://problem/57964637