### PR TITLE
[cmake] Add support for exporting frameworks/libraries into cmake export files.

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -198,6 +198,13 @@ macro(add_sourcekit_library name)
                              COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}")
   set_target_properties(${name} PROPERTIES FOLDER "SourceKit libraries")
   add_sourcekit_default_compiler_flags("${name}")
+
+  swift_is_installing_component("${SOURCEKITLIB_INSTALL_IN_COMPONENT}" is_installing)
+  if(NOT is_installing)
+    set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
+  else()
+    set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
+  endif()
 endmacro()
 
 # Add a new SourceKit executable.
@@ -324,7 +331,6 @@ macro(add_sourcekit_framework name)
     endif()
   endif()
 
-
   if (SOURCEKIT_DEPLOYMENT_OS MATCHES "^macosx")
     set_output_directory(${name}
         BINARY_DIR ${SOURCEKIT_RUNTIME_OUTPUT_INTDIR}
@@ -374,6 +380,14 @@ macro(add_sourcekit_framework name)
         COMMAND ${CMAKE_COMMAND} -E copy "${hdr}" "${framework_location}/Headers/${hdrname}")
     endforeach()
   endif()
+
+  swift_is_installing_component("${SOURCEKITFW_INSTALL_IN_COMPONENT}" is_installing)
+  if(NOT is_installing)
+    set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
+  else()
+    set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
+  endif()
+
   add_sourcekit_default_compiler_flags("${name}")
 endmacro(add_sourcekit_framework)
 


### PR DESCRIPTION
I think this was just an oversight. The new cmake 3.16 seems to choke if we do
not add SourceKit to the exports file since there are dependencies upon it in
other swift libraries.
