### PR TITLE
[gardening] Remove some dead variables and be more defensive around uninitialized memory.

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -827,12 +827,10 @@ ManagedValue SILGenFunction::emitExistentialErasure(
           loc, SILType::getPrimitiveObjectType(anyObjectTy), concreteFormalType,
           concreteValue, {});
     };
-    
-    auto concreteTLPtr = &concreteTL;
+
     if (this->F.getLoweredFunctionType()->isPseudogeneric()) {
       if (anyObjectTy && concreteFormalType->is<ArchetypeType>()) {
         concreteFormalType = anyObjectTy;
-        concreteTLPtr = &getTypeLowering(anyObjectTy);
         F = eraseToAnyObject;
       }
     }

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -322,7 +322,6 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
   SILModule &M = F->getModule();
   auto &Ctx = M.getASTContext();
   GenericSignature NewGenericSig;
-  GenericEnvironment *NewGenericEnv;
 
   /// If the original function is generic, then maintain the same.
   auto OrigGenericSig = FTy->getInvocationGenericSignature();
@@ -340,8 +339,6 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
         OrigGenericSig.getPointer(), std::move(GenericParams),
         std::move(Requirements)},
       GenericSignature());
-
-  NewGenericEnv = NewGenericSig->getGenericEnvironment();
 
   /// Create a lambda for GenericParams.
   auto getCanonicalType = [&](Type t) -> CanType {

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -567,7 +567,7 @@ static SILFunction *genGetterFromInit(SILOptFunctionBuilder &FunctionBuilder,
   // Find the store instruction
   auto *BB = GetterF->getEntryBlock();
   SILValue Val;
-  SILInstruction *Store;
+  SILInstruction *Store = nullptr;
   for (auto II = BB->begin(), E = BB->end(); II != E;) {
     auto &I = *II++;
     if (isa<AllocGlobalInst>(&I)) {
@@ -586,6 +586,7 @@ static SILFunction *genGetterFromInit(SILOptFunctionBuilder &FunctionBuilder,
       B.createReturn(RI->getLoc(), Val);
       eraseUsesOfInstruction(RI);
       recursivelyDeleteTriviallyDeadInstructions(RI, true);
+      assert(Store && "Did not find a store?!");
       recursivelyDeleteTriviallyDeadInstructions(Store, true);
       return GetterF;
     }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -164,11 +164,13 @@ visitPointerToAddressInst(PointerToAddressInst *PTAI) {
   //   %addr = pointer_to_address %ptr, [strict] $T
   //   %result = index_addr %addr, %distance
   //
-  BuiltinInst *Bytes;
+  BuiltinInst *Bytes = nullptr;
   if (match(PTAI->getOperand(),
             m_IndexRawPointerInst(
                 m_ValueBase(),
                 m_TupleExtractOperation(m_BuiltinInst(Bytes), 0)))) {
+    assert(Bytes != nullptr &&
+           "Bytes should have been assigned a non-null value");
     if (match(Bytes, m_ApplyInst(BuiltinValueKind::SMulOver, m_ValueBase(),
                                  m_ApplyInst(BuiltinValueKind::Strideof,
                                              m_MetatypeInst(Metatype)),


### PR DESCRIPTION
Found by using clang-tidy via the static analyzer on my local machine.