### PR TITLE
[5.2] [IRGen] Canonicalize associated type witnesses.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -824,6 +824,7 @@ namespace {
         auto witness =
             entry.getAssociatedTypeWitness().Witness->mapTypeOutOfContext();
         return IGM.getAssociatedTypeWitness(witness,
+                                            Proto->getGenericSignature(),
                                             /*inProtocolContext=*/true);
       }
 
@@ -1593,8 +1594,7 @@ namespace {
       // TargetRelativeDirectPointer<Runtime, const char> SuperclassType;
       if (auto superclassType = getType()->getSuperclass()) {
         GenericSignature genericSig = getType()->getGenericSignature();
-        B.addRelativeAddress(IGM.getTypeRef(superclassType->getCanonicalType(),
-                                            genericSig,
+        B.addRelativeAddress(IGM.getTypeRef(superclassType, genericSig,
                                             MangledTypeRefRole::Metadata)
                                .first);
       } else {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1122,7 +1122,8 @@ public:
                                          CanGenericSignature genericSig);
 
   /// Produce an associated type witness that refers to the given type.
-  llvm::Constant *getAssociatedTypeWitness(Type type, bool inProtocolContext);
+  llvm::Constant *getAssociatedTypeWitness(Type type, GenericSignature sig,
+                                           bool inProtocolContext);
 
   void emitAssociatedTypeMetadataRecord(const RootProtocolConformance *C);
   void emitFieldDescriptor(const NominalTypeDecl *Decl);

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -133,6 +133,37 @@ struct UsesVoid : HasSimpleAssoc {
   typealias Assoc = ()
 }
 
+// SR-11642: Failure to canonicalize type in associated type witness.
+struct Validator<T> {
+  let validatorFailureType: Any.Type
+}
+
+
+protocol ValidatorType {
+  associatedtype Data
+  associatedtype Failure
+  func validator() -> Validator<Data>
+}
+
+
+extension ValidatorType {
+  func validator() -> Validator<Data> {
+    .init(validatorFailureType: Failure.self)
+  }
+}
+
+
+// MARK: Failing example
+extension Validator where T == String {
+  // GLOBAL: @"symbolic _____ySS__G 23associated_type_witness9ValidatorVAASSRszlE1VV7FailureV"
+  struct V: ValidatorType {
+    typealias Data = T // or String
+
+    struct Failure {}
+  }
+}
+
+
 //   Protocol conformance descriptor for Computed : Assocked.
 // GLOBAL-LABEL: @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAMc" = hidden constant
 // GLOBAL-SAME:    i16 4,


### PR DESCRIPTION
Associated type witnesses were not getting canonicalized with respect to
their appropriate generic signatures, causing types to be emitted into
the metadata that could not be properly demangled. Be consistent about
providing a generic signature for canonicalization.

Fixes SR-11642 / rdar://problem/56466693.
