### PR TITLE
Unrevert EscapeAnalysis commits

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -43,18 +43,20 @@
 ///   return a
 ///
 /// Generates the following connection graph, where 'a' is in the SILValue %0:
-///   Val %0 Esc: R, Succ: (%0.1) // Represents 'a', and points to 'a's content
-///   Con %0.1 Esc: G, Succ:      // Represents the content of 'a'
-///   Ret  Esc: R, Succ: %0       // The returned value, aliased with 'a'
+///   Val [ref] %1 Esc: R, Succ: (%1)   // Reference 'a'; points to 'a's object
+///   Con [int] %2 Esc: R, Succ: (%2.1) // Object pointed to by 'a'
+///   Con %2.1 Esc: G, Succ:            // Fields in the object
+///   Ret  Esc: R, Succ: %0             // The returned value, aliased with 'a'
 ///
 /// Each node has an escaping state: None, (R)eturn, (A)rguments, or (G)lobal.
 /// These states form a lattice in which None is the most refined, or top, state
 /// and Global is the least refined, or bottom, state. Merging nodes performs a
-/// meet operation on their escaping states. At a call site, the callee graph is
-/// merged with the callee graph by merging the respective call argument
-/// nodes. A node has a "Return" escaping state if it only escapes by being
-/// returned from the current function. A node has an "Argument" escaping state
-/// if only escapes by being passed as an incoming argument to this function.
+/// meet operation on their escaping states, moving the state down in the
+/// lattice. At a call site, the callee graph is merged with the caller graph by
+/// merging the respective call argument nodes. A node has a "Return" escaping
+/// state if it only escapes by being returned from the current function. A node
+/// has an "Argument" escaping state if only escapes by being passed as an
+/// incoming argument to this function.
 ///
 /// A directed edge between two connection graph nodes indicates that the memory
 /// represented by the destination node memory is reachable via an address
@@ -81,30 +83,37 @@
 ///
 /// Generates the following connection graph, where the alloc_stack for variable
 /// 'a' is in the SILValue %0 and class allocation returns SILValue %3.
-///   Val %0 Esc: G, Succ: (%0.1)
-///   Con %0.1 Esc: G, Succ: %3
-///   Val %3 Esc: G, Succ: (%3.1)
-///   Con %3.1 Esc: G, Succ:
-///   Ret  Esc: R, Succ: %3
+///
+///   Val %0 Esc: , Succ: (%0.1)        // Stack address of 'a'
+///   Con [ref] %0.1 Esc: , Succ: %3    // Local reference 'a', aliased with %3
+///   Val [ref] %3 Esc: , Succ: (%4)    // Local instance 'a', stored in %0.1
+///   Con [int] %4 Esc: G, Succ: (%4.1) // Object, escapes
+///   Con %4.1 Esc: G, Succ:            // Fields, escapes
+///   Ret  Esc: , Succ: (%4), %3
 ///
 /// The value node for variable 'a' now points to local variable storage
 /// (%0.1). That local variable storage contains a reference. Assignment into
 /// that reference creates a defer edge to the allocated reference (%3). The
-/// allocated reference in turn points to the object storage (%3.1).
+/// allocated reference in turn points to the object storage (%4).
 ///
-/// Note that a variable holding a single class reference and a variable
-/// holding a non-trivial struct has the same graph representation. The
-/// variable's content node only represents the value of the references, not the
-/// memory pointed-to by the reference.
+/// Note that a variable holding a single class reference and a variable holding
+/// a non-trivial struct will have the same graph representation. A '[ref]' flag
+/// on a node indicates that the all pointer-type fields that may be stored
+/// inside the memory represented by that node are references. This allows alias
+/// analysis to assume the object the node points to will not be released when
+/// the node's memory is released as long as there are subsequent accesses to
+/// the object accessed via a different path in the connection graph.
 ///
 /// A pointsTo edge does not necessarily indicate pointer indirection. It may
-/// simply represent a derived address within the same object. This allows
-/// escape analysis to view an object's memory in layers, each with separate
-/// escaping properties. For example, a class object's first-level content node
-/// represents the object header including the metadata pointer and reference
-/// count. An object's second level content node only represents the
-/// reference-holding fields within that object. Consider the connection graph
-/// for a class with properties:
+/// simply represent a derived address within the same object. A node that
+/// points to the same logical object must be flagged as an interior node
+/// ('[int]'). Interior nodes always have pointsTo content representing the rest
+/// of the object. This allows escape analysis to view an object's memory in
+/// layers, each with separate escaping properties. For example, a class
+/// object's first-level content node represents the object header including the
+/// metadata pointer and reference count. An object's second level content node
+/// only represents the reference-holding fields within that object. Consider
+/// the connection graph for a class with properties:
 ///
 ///   class HasObj {
 ///     var obj: AnyObject
@@ -114,35 +123,37 @@
 ///   }
 ///
 /// Which generates this graph where the argument 'h' is %0, and 'o' is %1:
-///   Arg %0 Esc: A, Succ: (%0.1)
-///   Con %0.1 Esc: A, Succ: (%0.2)
-///   Con %0.2 Esc: A, Succ: %1
-///   Arg %1 Esc: A, Succ: (%1.1)
-///   Con %1.1 Esc: A, Succ: (%1.2)
-///   Con %1.2 Esc: G, Succ:
 ///
-/// Node %0.1 represents the header of 'h', including reference count and
-/// metadata pointer. This node points to %0.2 which represents the 'obj'
-/// property. The assignment 'h.obj = o' creates a defer edge from %0.2 to
-/// %1. Similarly, %1.1 represents the header of 'o', and %1.2 represents any
-/// potential nontrivial properties in 'o' which may have escaped globally when
-/// 'o' was released.
+///   Arg [ref] %0 Esc: A, Succ: (%6)     // 'h'
+///   Arg [ref] %1 Esc: A, Succ: (%1.1)   // 'o'
+///   Con [int] %1.1 Esc: A, Succ: (%1.2) // 'o' object
+///   Con %1.2 Esc: A, Succ: (%1.3)       // 'o' fields
+///   Con %1.3 Esc: G, Succ:              // memory 'h.obj' may point to
+///   Con [int] %6 Esc: A, Succ: (%7)     // 'h' object
+///   Con %7 Esc: A, Succ: %1             // 'h.obj'
+///
+/// Node %1.1 represents the header of 'o', including reference count and
+/// metadata pointer. This node points to %1.2 which represents the 'obj'
+/// property. '%1.3' represents any potential nontrivial properties in 'o' which
+/// may have escaped globally when 'o' was released. '%6' is a ref_element_addr
+/// accessing 'h.obj'. '%7' is a load of 'h.obj'. The assignment 'h.obj = o'
+/// creates a defer edge from '%7' to '%1'.
 ///
 /// The connection graph is constructed by summarizing all memory operations in
 /// a flow-insensitive way. Hint: ConGraph->viewCG() displays the Dot-formatted
 /// connection graph.
 ///
-/// In addition to the connection graph, EscapeAnalysis stores information about
-/// "use points". Each release operation is a use points. These instructions are
-/// recorded in a table and given an ID. Each connection graph node stores a
-/// bitset indicating the use points reachable via the CFG by that node. This
-/// provides some flow-sensitive information on top of the otherwise flow
-/// insensitive connection graph.
-///
-/// Note: storing bitsets in each node may be unnecessary overhead since the
-/// same information can be obtained with a graph traversal, typically of only
-/// 1-3 hops.
-// ===---------------------------------------------------------------------===//
+/// In addition to the connection graph, EscapeAnalysis caches information about
+/// "use points". Each release operation in which the released reference can be
+/// identified is a considered a use point. The use point instructions are
+/// recorded in a table and given an ID. Each connection graph content node
+/// stores a bitset indicating the use points that may release references that
+/// point to by that content node. Correctness relies on an invariant: for each
+/// reference-type value in the function, all points in the function which may
+/// release the reference must be identified as use points of the node that the
+/// value points to. If the reference-type value may be released any other
+/// way, then its content node must be marked escaping.
+/// ===---------------------------------------------------------------------===//
 
 #ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ESCAPEANALYSIS_H_
 #define SWIFT_SILOPTIMIZER_ANALYSIS_ESCAPEANALYSIS_H_
@@ -234,6 +245,13 @@ class EscapeAnalysis : public BottomUpIPAnalysis {
     Global
   };
 
+  // Must be ordered from most precise to least precise. A meet across memory
+  // locations (such as aggregate fields) always moves down.
+  enum PointerKind { NoPointer, ReferenceOnly, AnyPointer };
+  static bool canOnlyContainReferences(PointerKind pointerKind) {
+    return pointerKind <= ReferenceOnly;
+  }
+
 public:
   class CGNode;
   class ConnectionGraph;
@@ -320,25 +338,52 @@ public:
     /// is completely unlinked from the graph,
     bool isMerged = false;
 
-    /// True if this is a content node that owns a reference count. Such a
-    /// content node necessarilly keeps alive all content it points to until it
-    /// is released. This can be conservatively false.
-    bool hasRC = false;
+    /// True if this node's pointsTo content is part of the same object with
+    /// respect to SIL memory access. When this is true, then this node must
+    /// have a content node.
+    ///
+    /// When this flag is false, it provides a "separate access guarantee" for
+    /// stronger analysis. If the base object for a SIL memory access is mapped
+    /// to this node, then the accessed memory must have the same escaping
+    /// properties as the base object. In contrast, when this is true, the
+    /// connection graph may model the escaping properties of the base object
+    /// separately from the accessed memory.
+    bool isInteriorFlag;
+
+    /// True if this node can only point to other nodes via a reference, not an
+    /// address or raw pointer.
+    ///
+    /// When this flag is true, it provides a "separate lifetime guarantee". Any
+    /// reference modeled by this node keeps alive all pointsTo content until
+    /// it is released. e.g. Given two nodes that both pointTo the same
+    /// content, releasing the value associated one node cannot free that
+    /// content as long as the released node is reference-only and the value
+    /// associated with the other node is accessed later.
+    ///
+    /// Note that an object field may contain a raw pointer which could point
+    /// anywhere, even back into the same object. In that case
+    /// hasReferenceOnlyFlag must be false.
+    ///
+    /// Typically, when this is true, the node represents at least one
+    /// reference, however, a return node may be created even when the return
+    /// type is NoPointer.
+    bool hasReferenceOnlyFlag;
 
     /// The type of the node (mainly distinguishes between content and value
     /// nodes).
     NodeType Type;
     
     /// The constructor.
-    CGNode(ValueBase *V, NodeType Type, bool hasRC)
-        : mappedValue(V), UsePoints(0), hasRC(hasRC), Type(Type) {
+    CGNode(ValueBase *V, NodeType Type, bool isInterior, bool hasReferenceOnly)
+        : mappedValue(V), UsePoints(0), isInteriorFlag(isInterior),
+          hasReferenceOnlyFlag(hasReferenceOnly), Type(Type) {
       switch (Type) {
       case NodeType::Argument:
       case NodeType::Value:
-        assert(V);
+        assert(V && !isInteriorFlag);
         break;
       case NodeType::Return:
-        assert(!V);
+        assert(!V && !isInteriorFlag);
         break;
       case NodeType::Content:
         // A content node representing the returned value has no associated
@@ -359,6 +404,8 @@ public:
       UsePoints |= RHS->UsePoints;
       return Changed;
     }
+
+    void mergeFlags(bool isInterior, bool hasReferenceOnly);
 
     // Merge the properties of \p fromNode into this node.
     void mergeProperties(CGNode *fromNode);
@@ -454,10 +501,18 @@ public:
     /// Return true if this node represents content.
     bool isContent() const { return Type == NodeType::Content; }
 
-    /// Return true if this node represents an entire reference counted object.
-    bool hasRefCount() const { return hasRC; }
+    /// Return true if this node pointsTo the same object.
+    bool isInterior() const { return isInteriorFlag; }
 
-    void setRefCount(bool rc) { hasRC = rc; }
+    void setInterior(bool isInterior) { isInteriorFlag = isInterior; }
+
+    /// Return true if this node can only point to another node via a reference,
+    /// as opposed to an address or raw pointer.
+    bool hasReferenceOnly() const { return hasReferenceOnlyFlag; }
+
+    void setHasReferenceOnly(bool hasReferenceOnly) {
+      hasReferenceOnlyFlag = hasReferenceOnly;
+    }
 
     /// Returns the escape state.
     EscapeState getEscapeState() const { return State; }
@@ -614,11 +669,13 @@ public:
 
     /// Allocates a node of a given type.
     ///
-    /// hasRC is set for Content nodes based on the type and origin of
-    /// the pointer.
-    CGNode *allocNode(ValueBase *V, NodeType Type, bool hasRC = false) {
-      assert(Type == NodeType::Content || !hasRC);
-      CGNode *Node = new (NodeAllocator.Allocate()) CGNode(V, Type, hasRC);
+    /// isInterior is always false for non-content nodes and is set for content
+    /// nodes based on the type and origin of the pointer.
+    CGNode *allocNode(ValueBase *V, NodeType Type, bool isInterior,
+                      bool isReference) {
+      assert((Type == NodeType::Content) || !isInterior);
+      CGNode *Node = new (NodeAllocator.Allocate())
+          CGNode(V, Type, isInterior, isReference);
       Nodes.push_back(Node);
       return Node;
     }
@@ -665,6 +722,9 @@ public:
       }
     }
 
+    // Helper for getNode and getValueContent.
+    CGNode *getOrCreateNode(ValueBase *V, PointerKind pointerKind);
+
     /// Gets or creates a node for a value \p V.
     /// If V is a projection(-path) then the base of the projection(-path) is
     /// taken. This means the node is always created for the "outermost" value
@@ -672,9 +732,14 @@ public:
     /// Returns null, if V is not a "pointer".
     CGNode *getNode(ValueBase *V, bool createIfNeeded = true);
 
-    /// Helper to create and return a content node with the given \p hasRC
-    /// flag. \p addrNode will gain a points-to edge to the new content node.
-    CGNode *createContentNode(CGNode *addrNode, bool hasRC);
+    // Helper for getValueContent to create and return a content node with the
+    // given \p isInterior and \p hasReferenceOnly flags. \p addrNode
+    // will gain a points-to edge to the new content node.
+    CGNode *createContentNode(CGNode *addrNode, bool isInterior,
+                              bool hasReferenceOnly);
+
+    CGNode *getOrCreateContentNode(CGNode *addrNode, bool isInterior,
+                                   bool hasReferenceOnly);
 
     /// Create a new content node based on an existing content node to support
     /// graph merging.
@@ -683,18 +748,33 @@ public:
     /// state will be initialized based on the \p srcContent node.
     CGNode *createMergedContent(CGNode *destAddrNode, CGNode *srcContent);
 
-    /// Get a node represnting the field data within the given RC node.
-    CGNode *getFieldContent(CGNode *rcNode);
+    // Helper for getValueContent to get the content node for an address, which
+    // may be variable content or field content.
+    CGNode *getOrCreateAddressContent(SILValue addrVal, CGNode *addrNode);
+
+    // Helper for getValueContent to get the content representing a referenced
+    // object. \p refVal's type may or may not have reference semantics. The
+    // caller must knows based on the operand using \p refVal that it contains a
+    // reference.
+    CGNode *getOrCreateReferenceContent(SILValue refVal, CGNode *refNode);
+
+    // Helper for getValueContent to get the content node for an unknown pointer
+    // value. This is useful to determine whether multiple nodes are in the same
+    // defer web, but is otherwise conservative.
+    CGNode *getOrCreateUnknownContent(CGNode *addrNode);
+
+    /// Get a node representing the field data within the given object node.
+    /// If objNode was a recognized reference-only value, then it's content node
+    /// will already be initialized according to the reference type. Otherwise,
+    /// return null.
+    CGNode *getFieldContent(CGNode *objNode) {
+      if (!objNode->isInterior())
+        return nullptr;
+      return objNode->getContentNodeOrNull();
+    }
 
     /// Get or creates a pseudo node for the function return value.
-    CGNode *getReturnNode() {
-      if (!ReturnNode) {
-        ReturnNode = allocNode(nullptr, NodeType::Return);
-        if (!isSummaryGraph)
-          ReturnNode->mergeEscapeState(EscapeState::Return);
-      }
-      return ReturnNode;
-    }
+    CGNode *getReturnNode();
 
     /// Returns the node for the function return value if present.
     CGNode *getReturnNodeOrNull() const {
@@ -731,6 +811,21 @@ public:
       assert(UsePoints.size() == UsePointTable.size());
       Node->setUsePointBit(Idx);
       return Idx;
+    /// If \p pointer is a pointer, set it's content to global escaping.
+    ///
+    /// Only mark the content node as escaping. Marking a pointer node as
+    /// escaping would generally be meaningless because it may have aliases or
+    /// defer edges. Marking the pointer node as escaping would also be too
+    /// conservative because, when the pointer is mapped to a content node, it
+    /// would behave as if the memory containing the pointer also escaped.
+    ///
+    /// If the pointer is mapped to a node, then calling setEscapesGlobal must
+    /// ensure that it points to a content node. Even if we could mark the
+    /// pointer node as escaping, it would be insufficient because only content
+    /// nodes are merged into the caller graph.
+    void setEscapesGlobal(SILValue pointer) {
+      if (CGNode *content = getValueContent(pointer))
+        content->markEscaping();
     }
 
     void escapeContentsOf(CGNode *Node) {
@@ -805,6 +900,14 @@ public:
     /// where V is contained.
     /// Returns null, if V is not a "pointer".
     CGNode *getNodeOrNull(ValueBase *V) { return getNode(V, false); }
+
+    /// Get the content node pointed to by \p ptrVal.
+    ///
+    /// If \p ptrVal cannot be mapped to a node, return nullptr.
+    ///
+    /// If \p ptrVal is mapped to a node, return a non-null node representing
+    /// the content that \p ptrVal points to.
+    CGNode *getValueContent(SILValue ptrVal);
 
     /// Returns the number of use-points of a node.
     int getNumUsePoints(CGNode *Node) {
@@ -901,6 +1004,8 @@ private:
     MaxGraphMerges = 4
   };
 
+  using PointerKindCache = llvm::DenseMap<SILType, PointerKind>;
+
   /// The connection graphs for all functions (does not include external
   /// functions).
   llvm::DenseMap<SILFunction *, FunctionInfo *> Function2Info;
@@ -909,7 +1014,7 @@ private:
   llvm::SpecificBumpPtrAllocator<FunctionInfo> Allocator;
 
   /// Cache for isPointer().
-  llvm::DenseMap<SILType, bool> isPointerCache;
+  PointerKindCache pointerKindCache;
 
   SILModule *M;
 
@@ -918,10 +1023,6 @@ private:
 
   /// Callee analysis, used for determining the callees at call sites.
   BasicCalleeAnalysis *BCA;
-
-  /// Returns true if \p V may encapsulate a "pointer" value.
-  /// See EscapeAnalysis::NodeType::Value.
-  bool isPointer(ValueBase *V) const;
 
   /// If EscapeAnalysis should consider the given value to be a derived address
   /// or pointer based on one of its address or pointer operands, then return
@@ -933,23 +1034,14 @@ private:
   /// value.
   SILValue getPointerRoot(SILValue value) const;
 
-  /// If \p pointer is a pointer, set it to global escaping.
-  void setEscapesGlobal(ConnectionGraph *conGraph, ValueBase *pointer) {
-    CGNode *Node = conGraph->getNode(pointer);
-    if (!Node)
-      return;
+  PointerKind findRecursivePointerKind(SILType Ty, const SILFunction &F) const;
 
-    if (Node->isContent()) {
-      Node->markEscaping();
-      return;
-    }
-    Node->mergeEscapeState(EscapeState::Global);
+  PointerKind findCachedPointerKind(SILType Ty, const SILFunction &F) const;
 
-    // Make sure to have a content node. Otherwise we may end up not merging
-    // the global-escape state into a caller graph (only content nodes are
-    // merged). Either the node itself is a content node or we let the node
-    // point to one.
-    conGraph->escapeContentsOf(Node);
+  // Returns true if the type \p Ty must be a reference or must transitively
+  // contain a reference and no other pointer or address type.
+  bool hasReferenceOnly(SILType Ty, const SILFunction &F) const {
+    return findCachedPointerKind(Ty, F) <= ReferenceOnly;
   }
 
   /// Gets or creates FunctionEffects for \p F.
@@ -959,15 +1051,6 @@ private:
       FInfo = new (Allocator.Allocate()) FunctionInfo(F, this);
     return FInfo;
   }
-
-  /// Get or create the node representing the memory pointed to by \p
-  /// addrVal. If \p addrVal is an address, then return the content node for the
-  /// variable's memory. Otherwise, \p addrVal may contain a reference, so
-  /// return the content node for the referenced heap object.
-  ///
-  /// Note that \p addrVal cannot be an address within a heap object, such as
-  /// an address from ref_element_addr or project_box.
-  CGNode *getValueContent(ConnectionGraph *conGraph, SILValue addrVal);
 
   /// Build a connection graph for reach callee from the callee list.
   bool buildConnectionGraphForCallees(SILInstruction *Caller,
@@ -989,6 +1072,9 @@ private:
   /// reaches MaxRecursionDepth.
   void buildConnectionGraph(FunctionInfo *FInfo, FunctionOrder &BottomUpOrder,
                             int RecursionDepth);
+
+  bool createArrayUninitializedSubgraph(FullApplySite apply,
+                                        ConnectionGraph *conGraph);
 
   /// Updates the graph by analyzing instruction \p I.
   /// Visited callees are added to \p BottomUpOrder until \p RecursionDepth
@@ -1046,6 +1132,19 @@ public:
     return &FInfo->Graph;
   }
 
+  /// Return \p value's PointerKind.
+  PointerKind getPointerKind(ValueBase *value) const {
+    auto *f = value->getFunction();
+    // The function can be null, e.g. if V is an undef.
+    if (!f)
+      return NoPointer;
+
+    return findCachedPointerKind(value->getType(), *f);
+  }
+  /// Returns true if \p V may encapsulate a "pointer" value.
+  /// See EscapeAnalysis::NodeType::Value.
+  bool isPointer(ValueBase *V) const { return getPointerKind(V) > NoPointer; }
+
   /// Returns true if the value \p V can escape to the function call \p FAS.
   /// This means that the called function may access the value \p V.
   /// If \p V has reference semantics, this function returns false if only the
@@ -1062,14 +1161,6 @@ public:
   /// This means that either \p To is the same as \p V or contains a reference
   /// to \p V.
   bool canEscapeToValue(SILValue V, SILValue To);
-
-  /// Returns true if the parameter with index \p ParamIdx can escape in the
-  /// called function of apply site \p FAS.
-  /// If it is an indirect parameter and \p checkContentOfIndirectParam is true
-  /// then the escape status is not checked for the address itself but for the
-  /// referenced pointer (if the referenced type is a pointer).
-  bool canParameterEscape(FullApplySite FAS, int ParamIdx,
-                          bool checkContentOfIndirectParam);
 
   /// Returns true if the pointers \p V1 and \p V2 can possibly point to the
   /// same memory.

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -737,8 +737,8 @@ bool AliasAnalysis::mayValueReleaseInterfereWithInstruction(SILInstruction *User
   // The most important check: does the object escape the current function?
   auto LO = getUnderlyingObject(V);
   auto *ConGraph = EA->getConnectionGraph(User->getFunction());
-  auto *Node = ConGraph->getNodeOrNull(LO);
-  if (Node && !Node->escapes())
+  auto *Content = ConGraph->getValueContent(LO);
+  if (Content && !Content->escapes())
     return false;
 
   // This is either a non-local allocation or a scoped allocation that escapes.

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -826,15 +826,6 @@ void EscapeAnalysis::ConnectionGraph::computeUsePoints() {
 #endif
   // First scan the whole function and add relevant instructions as use-points.
   for (auto &BB : *F) {
-    for (SILArgument *BBArg : BB.getArguments()) {
-      /// In addition to releasing instructions (see below) we also add block
-      /// arguments as use points. In case of loops, block arguments can
-      /// "extend" the liferange of a reference in upward direction.
-      if (CGNode *ArgNode = lookupNode(BBArg)) {
-        addUsePoint(ArgNode, BBArg);
-      }
-    }
-
     for (auto &I : BB) {
       switch (I.getKind()) {
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -30,120 +30,91 @@ static llvm::cl::opt<bool> EnableInternalVerify(
     llvm::cl::desc("Enable internal verification of escape analysis"),
     llvm::cl::init(false));
 
-// Returns true if \p Ty recursively contains a reference.  If \p mustBeRef is
-// true, only return true if the type is guaranteed to hold a reference. If \p
-// mustBeRef is false, only return false if the type is guaranteed not to hold a
-// reference.
-//
-// If \p Ty is itself an address, return false.
-static bool findRecursiveRefType(SILType Ty, const SILFunction &F,
-                                 bool mustBeRef) {
-  if (mustBeRef) {
-    // An address *may* be converted into a reference via something like
-    // raw_pointer_to_ref. However, addresses don't normally refer to the head
-    // of a reference counted object.
-    //
-    // The check for trivial types catches types that have AST "reference
-    // semantics", but are determined by type lowering to be trivial, such as
-    // noescape function types.
-    if (Ty.isAddress() || Ty.isTrivial(F))
-      return false;
-  }
+// Returns the kind of pointer that \p Ty recursively contains.
+EscapeAnalysis::PointerKind
+EscapeAnalysis::findRecursivePointerKind(SILType Ty,
+                                         const SILFunction &F) const {
+  // An address may be converted into a reference via something like
+  // raw_pointer_to_ref, but in general we don't know what kind of pointer it
+  // is.
+  if (Ty.isAddress())
+    return EscapeAnalysis::AnyPointer;
 
-  if (!mustBeRef) {
-    // Opaque types may contain a reference. Speculatively track them too.
-    //
-    // 1. It may be possible to optimize opaque values based on known mutation
-    // points.
-    //
-    // 2. A specialized function may call a generic function passing a concrete
-    // reference type via incomplete specialization.
-    //
-    // 3. A generic function may call a specialized function taking a concrete
-    // reference type via devirtualization.
-    if (Ty.isAddressOnly(F))
-      return true;
+  // Opaque types may contain a reference. Speculatively track them too.
+  //
+  // 1. It may be possible to optimize opaque values based on known mutation
+  // points.
+  //
+  // 2. A specialized function may call a generic function passing a concrete
+  // reference type via incomplete specialization.
+  //
+  // 3. A generic function may call a specialized function taking a concrete
+  // reference type via devirtualization.
+  if (Ty.isAddressOnly(F))
+    return EscapeAnalysis::AnyPointer;
 
-    if (Ty.getASTType() == F.getModule().getASTContext().TheRawPointerType)
-      return true;
-  }
+  // A raw pointer definitely does not have a reference, but could point
+  // anywhere. We do track these because critical stdlib data structures often
+  // use raw pointers under the hood.
+  if (Ty.getASTType() == F.getModule().getASTContext().TheRawPointerType)
+    return EscapeAnalysis::AnyPointer;
 
   if (Ty.hasReferenceSemantics())
-    return true;
+    return EscapeAnalysis::ReferenceOnly;
 
-  auto &Mod = F.getModule();
+  auto &M = F.getModule();
 
+  // Start with the most precise pointer kind
+  PointerKind aggregateKind = NoPointer;
+  auto meetAggregateKind = [&](PointerKind otherKind) {
+    if (otherKind > aggregateKind)
+      aggregateKind = otherKind;
+  };
   if (auto *Str = Ty.getStructOrBoundGenericStruct()) {
     for (auto *Field : Str->getStoredProperties()) {
-      if (findRecursiveRefType(
-              Ty.getFieldType(Field, Mod, F.getTypeExpansionContext()), F,
-              mustBeRef))
-        return true;
+      SILType fieldTy = Ty.getFieldType(Field, M, F.getTypeExpansionContext());
+      meetAggregateKind(findCachedPointerKind(fieldTy, F));
     }
-    return false;
+    return aggregateKind;
   }
   if (auto TT = Ty.getAs<TupleType>()) {
     for (unsigned i = 0, e = TT->getNumElements(); i != e; ++i) {
-      if (findRecursiveRefType(Ty.getTupleElementType(i), F, mustBeRef))
-        return true;
+      meetAggregateKind(findCachedPointerKind(Ty.getTupleElementType(i), F));
     }
-    return false;
+    return aggregateKind;
   }
   if (auto En = Ty.getEnumOrBoundGenericEnum()) {
     for (auto *ElemDecl : En->getAllElements()) {
-      if (ElemDecl->hasAssociatedValues() &&
-          findRecursiveRefType(
-              Ty.getEnumElementType(ElemDecl, Mod, F.getTypeExpansionContext()),
-              F, mustBeRef))
-        return true;
+      if (!ElemDecl->hasAssociatedValues())
+        continue;
+      SILType eltTy =
+          Ty.getEnumElementType(ElemDecl, M, F.getTypeExpansionContext());
+      meetAggregateKind(findCachedPointerKind(eltTy, F));
     }
-    return false;
+    return aggregateKind;
   }
-  // FIXME: without a covered switch, this is not robust for mayContainReference
-  // in the event that new reference-holding AST types are invented.
-  return false;
+  // FIXME: without a covered switch, this is not robust in the event that new
+  // reference-holding AST types are invented.
+  return NoPointer;
 }
 
-// Returns true if the type \p Ty is a reference or may transitively contain
-// a reference. If \p Ty is itself an address, return false.
-//
-// An address may contain a reference because addresses can be cast into
-// reference types.
-static bool mayContainReference(SILType Ty, const SILFunction &F) {
-  if (Ty.isAddress())
-    return true;
-  return findRecursiveRefType(Ty, F, false);
-}
+// Returns the kind of pointer that \p Ty recursively contains.
+EscapeAnalysis::PointerKind
+EscapeAnalysis::findCachedPointerKind(SILType Ty, const SILFunction &F) const {
+  auto iter = pointerKindCache.find(Ty);
+  if (iter != pointerKindCache.end())
+    return iter->second;
 
-// Returns true if the type \p Ty must be a reference or must transitively
-// contain a reference. If \p Ty is itself an address, return false.
-static bool mustContainReference(SILType Ty, const SILFunction &F) {
-  return findRecursiveRefType(Ty, F, true);
-}
-
-bool EscapeAnalysis::isPointer(ValueBase *V) const {
-  auto *F = V->getFunction();
-
-  // The function can be null, e.g. if V is an undef.
-  if (!F)
-    return false;
-
-  SILType Ty = V->getType();
-  auto Iter = isPointerCache.find(Ty);
-  if (Iter != isPointerCache.end())
-    return Iter->second;
-
-  bool IP = mayContainReference(Ty, *F);
-  const_cast<EscapeAnalysis *>(this)->isPointerCache[Ty] = IP;
-  return IP;
+  PointerKind pointerKind = findRecursivePointerKind(Ty, F);
+  const_cast<EscapeAnalysis *>(this)->pointerKindCache[Ty] = pointerKind;
+  return pointerKind;
 }
 
 static bool isExtractOfArrayUninitializedPointer(TupleExtractInst *TEI) {
-  if (TEI->getFieldNo() == 1) {
-    if (auto apply = dyn_cast<ApplyInst>(TEI->getOperand()))
-      if (ArraySemanticsCall(apply, "array.uninitialized", false))
-        return true;
-  }
+  if (auto apply = dyn_cast<ApplyInst>(TEI->getOperand()))
+    if (ArraySemanticsCall(apply, "array.uninitialized", false))
+      return true;
+
   return false;
 }
 
@@ -362,15 +333,26 @@ EscapeAnalysis::CGNode::RepValue EscapeAnalysis::CGNode::getRepValue() const {
           depth};
 }
 
+void EscapeAnalysis::CGNode::mergeFlags(bool isInterior,
+                                        bool hasReferenceOnly) {
+  // isInterior is conservatively preserved from either node unless two content
+  // nodes are being merged and one is the interior node's content.
+  isInteriorFlag |= isInterior;
+
+  // hasReferenceOnly is always conservatively merged.
+  hasReferenceOnlyFlag &= hasReferenceOnly;
+}
+
 void EscapeAnalysis::CGNode::mergeProperties(CGNode *fromNode) {
-  // TODO: Optimistically merge hasRC. 'this' node can only be merged with
-  // `fromNode` if their pointer values are compatible. If `fromNode->hasRC` is
-  // true, then it is guaranteed to represent the head of a heap object. Thus,
-  // it can only be merged with 'this' when the pointer values that access
-  // 'this' are also references.
-  //
-  // For now, this is pessimistic until we understand performance implications.
-  hasRC &= fromNode->hasRC;
+  // isInterior is conservatively preserved from either node unless the other
+  // node is the interior node's content.
+  bool isInterior = fromNode->isInteriorFlag;
+  if (fromNode == pointsTo)
+    this->isInteriorFlag = isInterior;
+  else if (this == fromNode->pointsTo)
+    isInterior = this->isInteriorFlag;
+
+  mergeFlags(isInterior, fromNode->hasReferenceOnlyFlag);
 }
 
 template <typename Visitor>
@@ -413,15 +395,35 @@ void EscapeAnalysis::ConnectionGraph::clear() {
 }
 
 EscapeAnalysis::CGNode *
-EscapeAnalysis::ConnectionGraph::getNode(ValueBase *V, bool createIfNeeded) {
+EscapeAnalysis::ConnectionGraph::getOrCreateNode(ValueBase *V,
+                                                 PointerKind pointerKind) {
+  assert(pointerKind != EscapeAnalysis::NoPointer);
+
   if (isa<FunctionRefInst>(V) || isa<DynamicFunctionRefInst>(V) ||
       isa<PreviousDynamicFunctionRefInst>(V))
     return nullptr;
 
-  // In the case of a struct or tuple extract, 'V' may not be a pointer
-  // even if it's pointer root is a pointer. Bail first because we only expect
-  // graph nodes for pointer values.
-  if (!EA->isPointer(V))
+  CGNode * &Node = Values2Nodes[V];
+  // Nodes mapped to values must have an indirect pointsTo. Nodes that don't
+  // have an indirect pointsTo are imaginary nodes that don't directly represnt
+  // a SIL value.
+  bool hasReferenceOnly = canOnlyContainReferences(pointerKind);
+  if (!Node) {
+    if (isa<SILFunctionArgument>(V)) {
+      Node = allocNode(V, NodeType::Argument, false, hasReferenceOnly);
+      if (!isSummaryGraph)
+        Node->mergeEscapeState(EscapeState::Arguments);
+    } else {
+      Node = allocNode(V, NodeType::Value, false, hasReferenceOnly);
+    }
+  }
+  return Node->getMergeTarget();
+}
+
+EscapeAnalysis::CGNode *
+EscapeAnalysis::ConnectionGraph::getNode(ValueBase *V, bool createIfNeeded) {
+  PointerKind pointerKind = EA->getPointerKind(V);
+  if (pointerKind == EscapeAnalysis::NoPointer)
     return nullptr;
 
   // Look past address projections, pointer casts, and the like within the same
@@ -431,18 +433,28 @@ EscapeAnalysis::ConnectionGraph::getNode(ValueBase *V, bool createIfNeeded) {
 
   if (!createIfNeeded)
     return lookupNode(V);
-  
-  CGNode * &Node = Values2Nodes[V];
-  if (!Node) {
-    if (isa<SILFunctionArgument>(V)) {
-      Node = allocNode(V, NodeType::Argument);
-      if (!isSummaryGraph)
-        Node->mergeEscapeState(EscapeState::Arguments);
-    } else {
-      Node = allocNode(V, NodeType::Value);
-    }
-  }
-  return Node->getMergeTarget();
+
+  return getOrCreateNode(V, pointerKind);
+}
+
+/// Adds an argument/instruction in which the node's memory is released.
+int EscapeAnalysis::ConnectionGraph::addUsePoint(CGNode *Node,
+                                                 SILInstruction *User) {
+  // Use points are never consulted for escaping nodes, but still need to
+  // propagate to other nodes in a defer web. Even if this node is escaping,
+  // some defer predecessors may not be escaping. Only checking if this node has
+  // defer predecessors is insufficient because a defer successor of this node
+  // may have defer predecessors.
+  if (Node->getEscapeState() >= EscapeState::Global)
+    return -1;
+
+  int Idx = (int)UsePoints.size();
+  assert(UsePoints.count(User) == 0 && "value is already a use-point");
+  UsePoints[User] = Idx;
+  UsePointTable.push_back(User);
+  assert(UsePoints.size() == UsePointTable.size());
+  Node->setUsePointBit(Idx);
+  return Idx;
 }
 
 CGNode *EscapeAnalysis::ConnectionGraph::defer(CGNode *From, CGNode *To,
@@ -640,9 +652,9 @@ void EscapeAnalysis::ConnectionGraph::mergeAllScheduledNodes() {
         assert(To->pointsTo != From);
       } else {
         // If 'To' has no pointsTo at all, initialize its defer web.
-        if (!To->pointsTo) {
+        if (!To->pointsTo)
           initializePointsToEdge(To, redirectPointsTo(From->pointsTo));
-        } else {
+        else {
           // Upgrade 'To's pointsTo to an edge to preserve the fact that 'From'
           // had a pointsTo edge.
           To->pointsToIsEdge = true;
@@ -864,13 +876,28 @@ void EscapeAnalysis::ConnectionGraph::computeUsePoints() {
   } while (Changed);
 }
 
-CGNode *EscapeAnalysis::ConnectionGraph::createContentNode(CGNode *addrNode,
-                                                           bool hasRC) {
-  CGNode *newContent = allocNode(nullptr, NodeType::Content, hasRC);
+CGNode *EscapeAnalysis::ConnectionGraph::createContentNode(
+    CGNode *addrNode, bool isInterior, bool hasReferenceOnly) {
+  CGNode *newContent =
+      allocNode(nullptr, NodeType::Content, isInterior, hasReferenceOnly);
   initializePointsToEdge(addrNode, newContent);
   assert(ToMerge.empty()
          && "Initially setting pointsTo should not require any node merges");
   return newContent;
+}
+
+CGNode *EscapeAnalysis::ConnectionGraph::getOrCreateContentNode(
+    CGNode *addrNode, bool isInterior, bool hasReferenceOnly) {
+  if (CGNode *content = addrNode->getContentNodeOrNull()) {
+    content->mergeFlags(isInterior, hasReferenceOnly);
+    return content;
+  }
+  CGNode *content = createContentNode(addrNode, isInterior, hasReferenceOnly);
+  // getValueContent may be called after the graph is built and escape states
+  // are propagated. Keep the escape state and use points consistent here.
+  content->mergeEscapeState(addrNode->State);
+  content->mergeUsePoints(addrNode);
+  return content;
 }
 
 // Create a content node for merging based on an address node in the destination
@@ -881,19 +908,103 @@ EscapeAnalysis::ConnectionGraph::createMergedContent(CGNode *destAddrNode,
   // destAddrNode may itself be a content node, so its value may be null. Since
   // we don't have the original pointer value, build a new content node based
   // on the source content.
-  return createContentNode(destAddrNode, srcContent->hasRC);
+  CGNode *mergedContent = createContentNode(
+      destAddrNode, srcContent->isInterior(), srcContent->hasReferenceOnly());
+  return mergedContent;
 }
 
-// Get a node representing the field data within the given reference-counted
-// node. The caller has already determined that rcNode represents the head of a
-// heap object rather than field content or the address of a local variable or
-// argument.
-CGNode *EscapeAnalysis::ConnectionGraph::getFieldContent(CGNode *rcNode) {
-  assert(rcNode->isContent());
-  if (rcNode->pointsTo)
-    return rcNode->pointsTo;
+CGNode *
+EscapeAnalysis::ConnectionGraph::getOrCreateAddressContent(SILValue addrVal,
+                                                           CGNode *addrNode) {
+  assert(addrVal->getType().isAddress());
 
-  return createContentNode(rcNode, /*hasRC=*/false);
+  bool contentHasReferenceOnly =
+      EA->hasReferenceOnly(addrVal->getType().getObjectType(), *F);
+  // Address content always has an indirect pointsTo (only reference content can
+  // have a non-indirect pointsTo).
+  return getOrCreateContentNode(addrNode, false, contentHasReferenceOnly);
+}
+
+// refVal is allowed to be invalid so we can model escaping content for
+// secondary deinitializers of released objects.
+CGNode *
+EscapeAnalysis::ConnectionGraph::getOrCreateReferenceContent(SILValue refVal,
+                                                             CGNode *refNode) {
+  // The object node points to internal fields. It neither has indirect pointsTo
+  // nor reference-only pointsTo.
+  CGNode *objNode = getOrCreateContentNode(refNode, true, false);
+  if (!objNode->isInterior())
+    return objNode;
+
+  bool contentHasReferenceOnly = false;
+  if (refVal) {
+    SILType refType = refVal->getType();
+    if (auto *C = refType.getClassOrBoundGenericClass()) {
+      PointerKind aggregateKind = NoPointer;
+      for (auto *field : C->getStoredProperties()) {
+        SILType fieldType = refType.getFieldType(field, F->getModule(),
+                                                 F->getTypeExpansionContext());
+        PointerKind fieldKind = EA->findCachedPointerKind(fieldType, *F);
+        if (fieldKind > aggregateKind)
+          aggregateKind = fieldKind;
+      }
+      contentHasReferenceOnly = canOnlyContainReferences(aggregateKind);
+    }
+  }
+  getOrCreateContentNode(objNode, false, contentHasReferenceOnly);
+  return objNode;
+}
+
+CGNode *
+EscapeAnalysis::ConnectionGraph::getOrCreateUnknownContent(CGNode *addrNode) {
+  // We don't know if addrVal has been cast from a reference or raw
+  // pointer. More importantly, we don't know what memory contents it may
+  // point to. There's no need to consider it an "interior" node initially. If
+  // it's ever merged with another interior node (from ref_element_addr), then
+  // it will conservatively take on the interior flag at that time.
+  return getOrCreateContentNode(addrNode, false, false);
+}
+
+// If ptrVal is itself mapped to a node, then this must return a non-null
+// contentnode. Otherwise, setEscapesGlobal won't be able to represent escaping
+// memory.
+//
+// This may be called after the graph is built and all escape states and use
+// points are propagate. If a new content node is created, update its state
+// on-the-fly.
+EscapeAnalysis::CGNode *
+EscapeAnalysis::ConnectionGraph::getValueContent(SILValue ptrVal) {
+  // Look past address projections, pointer casts, and the like within the same
+  // object. Does not look past a dereference such as ref_element_addr, or
+  // project_box.
+  SILValue ptrBase = EA->getPointerRoot(ptrVal);
+
+  PointerKind pointerKind = EA->getPointerKind(ptrBase);
+  if (pointerKind == EscapeAnalysis::NoPointer)
+    return nullptr;
+
+  CGNode *addrNode = getOrCreateNode(ptrBase, pointerKind);
+  if (!addrNode)
+    return nullptr;
+
+  if (ptrBase->getType().isAddress())
+    return getOrCreateAddressContent(ptrBase, addrNode);
+
+  if (canOnlyContainReferences(pointerKind))
+    return getOrCreateReferenceContent(ptrBase, addrNode);
+
+  // The pointer value may contain raw pointers.
+  return getOrCreateUnknownContent(addrNode);
+}
+
+CGNode *EscapeAnalysis::ConnectionGraph::getReturnNode() {
+  if (!ReturnNode) {
+    SILType resultTy =
+        F->mapTypeIntoContext(F->getConventions().getSILResultType());
+    bool hasReferenceOnly = EA->hasReferenceOnly(resultTy, *F);
+    ReturnNode = allocNode(nullptr, NodeType::Return, false, hasReferenceOnly);
+  }
+  return ReturnNode;
 }
 
 bool EscapeAnalysis::ConnectionGraph::mergeFrom(ConnectionGraph *SourceGraph,
@@ -918,7 +1029,9 @@ bool EscapeAnalysis::ConnectionGraph::mergeFrom(ConnectionGraph *SourceGraph,
         // global escaping state set.
         // Just set global escaping in the caller node and that's it.
         Changed |= DestNd->mergeEscapeState(EscapeState::Global);
-        continue;
+        // If DestNd is an interior node, its content still needs to be created.
+        if (!DestNd->isInterior())
+          continue;
       }
 
       CGNode *SourcePT = SourceNd->pointsTo;
@@ -1208,7 +1321,7 @@ std::string CGForDotView::getNodeAttributes(const Node *Node) const {
   switch (Orig->Type) {
   case EscapeAnalysis::NodeType::Content:
     attr = "style=\"rounded";
-    if (Orig->hasRefCount()) {
+    if (Orig->isInterior()) {
       attr += ",filled";
     }
     attr += "\"";
@@ -1330,8 +1443,10 @@ void EscapeAnalysis::ConnectionGraph::dumpCG() const {
 
 void EscapeAnalysis::CGNode::dump() const {
   llvm::errs() << getTypeStr();
-  if (hasRefCount())
-    llvm::errs() << " [rc]";
+  if (isInterior())
+    llvm::errs() << " [int]";
+  if (hasReferenceOnly())
+    llvm::errs() << " [ref]";
 
   auto rep = getRepValue();
   if (rep.depth > 0)
@@ -1391,16 +1506,6 @@ void EscapeAnalysis::ConnectionGraph::print(llvm::raw_ostream &OS) const {
               });
   };
 
-  auto nodeStr = [&](CGNode *Nd) -> std::string {
-    std::string Str;
-    llvm::raw_string_ostream OS(Str);
-    if (Nd->hasRefCount())
-      OS << "[rc] ";
-    Nd->getRepValue().print(OS, InstToIDMap);
-    OS.flush();
-    return Str;
-  };
-
   llvm::SmallVector<CGNode *, 8> SortedNodes;
   for (CGNode *Nd : Nodes) {
     if (!Nd->isMerged)
@@ -1409,7 +1514,13 @@ void EscapeAnalysis::ConnectionGraph::print(llvm::raw_ostream &OS) const {
   sortNodes(SortedNodes);
 
   for (CGNode *Nd : SortedNodes) {
-    OS << "  " << Nd->getTypeStr() << ' ' << nodeStr(Nd) << " Esc: ";
+    OS << "  " << Nd->getTypeStr() << ' ';
+    if (Nd->isInterior())
+      OS << "[int] ";
+    if (Nd->hasReferenceOnly())
+      OS << "[ref] ";
+    Nd->getRepValue().print(OS, InstToIDMap);
+    OS << " Esc: ";
     switch (Nd->getEscapeState()) {
       case EscapeState::None: {
         const char *Separator = "";
@@ -1434,13 +1545,16 @@ void EscapeAnalysis::ConnectionGraph::print(llvm::raw_ostream &OS) const {
     OS << ", Succ: ";
     const char *Separator = "";
     if (CGNode *PT = Nd->getPointsToEdge()) {
-      OS << '(' << nodeStr(PT) << ')';
+      OS << '(';
+      PT->getRepValue().print(OS, InstToIDMap);
+      OS << ')';
       Separator = ", ";
     }
     llvm::SmallVector<CGNode *, 8> SortedDefers = Nd->defersTo;
     sortNodes(SortedDefers);
     for (CGNode *Def : SortedDefers) {
-      OS << Separator << nodeStr(Def);
+      OS << Separator;
+      Def->getRepValue().print(OS, InstToIDMap);
       Separator = ", ";
     }
     OS << '\n';
@@ -1476,10 +1590,11 @@ void EscapeAnalysis::ConnectionGraph::verify(bool allowMerge) const {
     // which consist of only defer-edges and a single trailing points-to edge
     // must lead to the same
     assert(Nd->matchPointToOfDefers(allowMerge));
-    if (Nd->hasRefCount()) {
-      SILValue v = Nd->getRepValue().getValue();
-      (void)v;
-      assert(!v || mayContainReference(v->getType(), *F));
+    if (Nd->mappedValue && !(allowMerge && Nd->isMerged)) {
+      assert(Nd == Values2Nodes.lookup(Nd->mappedValue));
+      assert(EA->isPointer(Nd->mappedValue));
+      // Nodes must always be mapped from the pointer root value.
+      assert(Nd->mappedValue == EA->getPointerRoot(Nd->mappedValue));
     }
   }
 #endif
@@ -1488,9 +1603,6 @@ void EscapeAnalysis::ConnectionGraph::verify(bool allowMerge) const {
 void EscapeAnalysis::ConnectionGraph::verifyStructure(bool allowMerge) const {
 #ifndef NDEBUG
   for (CGNode *Nd : Nodes) {
-    if (Nd->mappedValue && !(allowMerge && Nd->mergeTo))
-      assert(Nd == Values2Nodes.lookup(Nd->mappedValue));
-
     if (Nd->isMerged) {
       assert(Nd->mergeTo);
       assert(!Nd->pointsTo);
@@ -1517,6 +1629,8 @@ void EscapeAnalysis::ConnectionGraph::verifyStructure(bool allowMerge) const {
       assert(PT->Type == NodeType::Content);
       assert(PT->findPred(Predecessor(Nd, EdgeType::PointsTo)) != PT->Preds.end());
     }
+    if (Nd->isInterior())
+      assert(Nd->pointsTo && "Interior content node requires a pointsTo node");
   }
 #endif
 }
@@ -1546,45 +1660,6 @@ static bool linkBBArgs(SILBasicBlock *BB) {
       return false;
   }
   return true;
-}
-
-EscapeAnalysis::CGNode *
-EscapeAnalysis::getValueContent(ConnectionGraph *conGraph, SILValue addrVal) {
-  CGNode *addrNode = conGraph->getNode(addrVal);
-  if (!addrNode)
-    return nullptr;
-
-  if (CGNode *content = addrNode->getPointsToEdge())
-    return content;
-
-#ifndef NDEBUG
-  if (!addrNode->isContent()) {
-    if (SILValue addrNodeValue = addrNode->getRepValue().getValue()) {
-      assert(isPointer(addrNodeValue));
-      assert(addrNodeValue == getPointerRoot(addrVal));
-    }
-  }
-#endif
-  SILValue baseAddr = getPointerRoot(addrVal);
-  auto *F = addrVal->getFunction();
-  auto hasRC = [&](){
-    return mustContainReference(baseAddr->getType(), *F)
-      || mustContainReference(addrVal->getType(), *F);
-  };
-  // Have we already merged a content node for this address?
-  if (CGNode *content = addrNode->getContentNodeOrNull()) {
-    // TODO: Optimistically merge hasRC content. The original content might not
-    // have an RC if one of the values pointing to this content was cast to an
-    // unknown type. If any of the types must contain a reference, then the
-    // content should contain a reference.
-    //
-    // For now, conservatively merge the RC flag instead.
-    if (content->hasRefCount() && !hasRC())
-      content->setRefCount(false);
-
-    return content;
-  }
-  return conGraph->createContentNode(addrNode, hasRC());
 }
 
 void EscapeAnalysis::buildConnectionGraph(FunctionInfo *FInfo,
@@ -1632,7 +1707,7 @@ void EscapeAnalysis::buildConnectionGraph(FunctionInfo *FInfo,
       if (!BBArg->getSingleTerminatorOperands(Incoming)) {
         // We don't know where the block argument comes from -> treat it
         // conservatively.
-        setEscapesGlobal(ConGraph, BBArg);
+        ConGraph->setEscapesGlobal(BBArg);
         continue;
       }
       CGNode *ArgNode = ConGraph->getNode(BBArg);
@@ -1644,7 +1719,7 @@ void EscapeAnalysis::buildConnectionGraph(FunctionInfo *FInfo,
         if (SrcArg) {
           ArgNode = ConGraph->defer(ArgNode, SrcArg);
         } else {
-          setEscapesGlobal(ConGraph, BBArg);
+          ConGraph->setEscapesGlobal(BBArg);
           break;
         }
       }
@@ -1654,13 +1729,26 @@ void EscapeAnalysis::buildConnectionGraph(FunctionInfo *FInfo,
                           << FInfo->Graph.F->getName() << '\n');
 }
 
-/// Returns true if all uses of \p I are tuple_extract instructions.
-static bool onlyUsedInTupleExtract(SILValue V) {
+/// Returns the tuple extract for the first two fields if all uses of \p I are
+/// tuple_extract instructions.
+static std::pair<TupleExtractInst *, TupleExtractInst *>
+onlyUsedInTupleExtract(SILValue V) {
+  TupleExtractInst *field0 = nullptr;
+  TupleExtractInst *field1 = nullptr;
   for (Operand *Use : getNonDebugUses(V)) {
-    if (!isa<TupleExtractInst>(Use->getUser()))
-      return false;
+    if (auto *TEI = dyn_cast<TupleExtractInst>(Use->getUser())) {
+      if (TEI->getFieldNo() == 0) {
+        field0 = TEI;
+        continue;
+      }
+      if (TEI->getFieldNo() == 1) {
+        field1 = TEI;
+        continue;
+      }
+    }
+    return std::make_pair(nullptr, nullptr);
   }
-  return true;
+  return std::make_pair(field0, field1);
 }
 
 bool EscapeAnalysis::buildConnectionGraphForCallees(
@@ -1719,6 +1807,40 @@ bool EscapeAnalysis::buildConnectionGraphForDestructor(
                                         RecursionDepth);
 }
 
+// Handle array.uninitialized
+bool EscapeAnalysis::createArrayUninitializedSubgraph(
+    FullApplySite apply, ConnectionGraph *conGraph) {
+
+  // Check if the result is used in the usual way: extracting the
+  // array and the element pointer with tuple_extract.
+  TupleExtractInst *arrayStruct;
+  TupleExtractInst *arrayElementPtr;
+  std::tie(arrayStruct, arrayElementPtr) =
+      onlyUsedInTupleExtract(cast<ApplyInst>(apply.getInstruction()));
+  if (!arrayStruct || !arrayElementPtr)
+    return false;
+
+  // array.uninitialized may have a first argument which is the
+  // allocated array buffer. The call is like a struct(buffer)
+  // instruction.
+  CGNode *arrayRefNode = conGraph->getNode(apply.getArgument(0));
+  if (!arrayRefNode)
+    return false;
+
+  CGNode *arrayStructNode = conGraph->getNode(arrayStruct);
+  assert(arrayStructNode && "Array struct must have a node");
+
+  CGNode *arrayObjNode = conGraph->getValueContent(apply.getArgument(0));
+
+  // The reference argument is effectively stored inside the returned
+  // array struct.
+  conGraph->defer(arrayStructNode, arrayRefNode);
+
+  // Map the returned element pointer to the array object's field pointer.
+  conGraph->setNode(arrayElementPtr, arrayObjNode);
+  return true;
+}
+
 void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
                                         FunctionInfo *FInfo,
                                         FunctionOrder &BottomUpOrder,
@@ -1739,74 +1861,71 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         // These array semantics calls do not capture anything.
         return;
       case ArrayCallKind::kArrayUninitialized:
-        // Check if the result is used in the usual way: extracting the
-        // array and the element pointer with tuple_extract.
-        if (onlyUsedInTupleExtract(ASC.getCallResult())) {
-          // array.uninitialized may have a first argument which is the
-          // allocated array buffer. The call is like a struct(buffer)
-          // instruction.
-          if (CGNode *BufferNode = ConGraph->getNode(FAS.getArgument(0))) {
-            SILValue ArrayBase = ASC.getCallResult();
-            CGNode *ArrayContent = getValueContent(ConGraph, ArrayBase);
-            assert(ArrayContent && "Array base must have a node");
-            ConGraph->defer(ArrayContent, BufferNode);
-          }
+        if (createArrayUninitializedSubgraph(FAS, ConGraph))
           return;
-        }
         break;
       case ArrayCallKind::kGetElement:
-        if (CGNode *ArrayRefNode = getValueContent(ConGraph, ASC.getSelf())) {
+        if (CGNode *ArrayObjNode = ConGraph->getValueContent(ASC.getSelf())) {
           CGNode *LoadedElement = nullptr;
           // This is like a load from a ref_element_addr.
           if (ASC.hasGetElementDirectResult()) {
             LoadedElement = ConGraph->getNode(ASC.getCallResult());
           } else {
             // The content of the destination address.
-            LoadedElement = getValueContent(ConGraph, FAS.getArgument(0));
+            LoadedElement = ConGraph->getValueContent(FAS.getArgument(0));
             assert(LoadedElement && "indirect result must have node");
           }
           if (LoadedElement) {
-            CGNode *ArrayElementStorage =
-                ConGraph->getFieldContent(ArrayRefNode);
-            ConGraph->defer(LoadedElement, ArrayElementStorage);
-            return;
+            if (CGNode *arrayElementStorage =
+                    ConGraph->getFieldContent(ArrayObjNode)) {
+              ConGraph->defer(LoadedElement, arrayElementStorage);
+              return;
+            }
           }
         }
         break;
       case ArrayCallKind::kGetElementAddress:
-        // This is like a ref_element_addr.
-        if (CGNode *ArrayRefNode = getValueContent(ConGraph, ASC.getSelf())) {
-          ConGraph->defer(ConGraph->getNode(ASC.getCallResult()), ArrayRefNode);
+        // This is like a ref_element_addr. Both the object node and the
+        // returned address point to the same element storage.
+        if (CGNode *ArrayObjNode = ConGraph->getValueContent(ASC.getSelf())) {
+          CGNode *arrayElementAddress = ConGraph->getNode(ASC.getCallResult());
+          ConGraph->defer(arrayElementAddress, ArrayObjNode);
+          return;
         }
-        return;
+        break;
       case ArrayCallKind::kWithUnsafeMutableBufferPointer:
         // Model this like an escape of the elements of the array and a capture
         // of anything captured by the closure.
         // Self is passed inout.
-        if (CGNode *ArrayStructValue =
-                getValueContent(ConGraph, ASC.getSelf())) {
+        if (CGNode *ArrayStructNode =
+                ConGraph->getValueContent(ASC.getSelf())) {
+          // The first non indirect result is the closure.
+          auto Args = FAS.getArgumentsWithoutIndirectResults();
+          ConGraph->setEscapesGlobal(Args[0]);
 
           // One content node for going from the array buffer pointer to
           // the element address (like ref_element_addr).
-          CGNode *ArrayRefNode = ArrayStructValue->getContentNodeOrNull();
-          // TODO: If ArrayRefNode already exists, optimistically do
-          // ArrayRefNode->setRefCount(true).
-          if (!ArrayRefNode) {
-            ArrayRefNode = ConGraph->createContentNode(
-                ArrayStructValue, /*hasRC=*/true);
+          CGNode *ArrayObjNode =
+              ConGraph->getOrCreateContentNode(ArrayStructNode,
+                                               /*isInterior*/ true,
+                                               /*hasRefOnly*/ false);
+          // If ArrayObjNode was already potentially merged with its pointsTo,
+          // then conservatively mark the whole thing as escaping.
+          if (!ArrayObjNode->isInterior()) {
+            ArrayObjNode->markEscaping();
+            return;
           }
-          // Another content node for the element storage.
-          CGNode *ArrayElementStorage = ConGraph->getFieldContent(ArrayRefNode);
+          // Otherwise, create the content node for the element storage.
+          CGNode *ArrayElementStorage = ConGraph->getOrCreateContentNode(
+              ArrayObjNode, /*isInterior*/ false,
+              /*hasRefOnly*/ true);
           ArrayElementStorage->markEscaping();
-          // The first non indirect result is the closure.
-          auto Args = FAS.getArgumentsWithoutIndirectResults();
-          setEscapesGlobal(ConGraph, Args[0]);
           return;
         }
         break;
       default:
         break;
-    }
+      }
 
     if (FAS.getReferencedFunctionOrNull() &&
         FAS.getReferencedFunctionOrNull()->hasSemanticsAttr(
@@ -1819,7 +1938,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       // from the pointer.
       auto Args = FAS.getArgumentsWithoutIndirectResults();
       // The first not indirect result argument is the closure.
-      setEscapesGlobal(ConGraph, Args[0]);
+      ConGraph->setEscapesGlobal(Args[0]);
       return;
     }
 
@@ -1834,7 +1953,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       // from the pointer.
       auto Args = FAS.getArgumentsWithoutIndirectResults();
       // The second not indirect result argument is the closure.
-      setEscapesGlobal(ConGraph, Args[1]);
+      ConGraph->setEscapesGlobal(Args[1]);
       return;
     }
 
@@ -1916,86 +2035,117 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     case SILInstructionKind::StrongReleaseInst:
     case SILInstructionKind::ReleaseValueInst: {
       // A release instruction may deallocate the pointer operand. This may
-      // capture anything pointed to by the released object, but not the pointer
-      // to the object itself (because it will be a dangling pointer after
-      // deallocation).
+      // capture anything pointed to by the released object, but not the object
+      // itself (because it will be a dangling pointer after deallocation).
       SILValue OpV = I->getOperand(0);
-      CGNode *rcContent = getValueContent(ConGraph, OpV);
-      if (!rcContent)
+      CGNode *objNode = ConGraph->getValueContent(OpV);
+      if (!objNode)
         return;
 
-      // rcContent->hasRefCount() may or may not be true depending on whether
-      // the type could be analyzed. Either way, treat it structurally like a
-      // refcounted object.
-      CGNode *fieldContent = ConGraph->getFieldContent(rcContent);
-      if (!deinitIsKnownToNotCapture(OpV)) {
-        fieldContent->markEscaping();
+      CGNode *fieldNode = ConGraph->getFieldContent(objNode);
+      if (!fieldNode) {
+        // In the unexpected case that the object has no field content, create
+        // escaping unknown content.
+        ConGraph->getOrCreateUnknownContent(objNode)->markEscaping();
         return;
       }
-      // This deinit is known to not directly capture it's own field content,
-      // however, indirect deinitializers could still capture anything pointed
-      // to by those fields.
-      ConGraph->escapeContentsOf(fieldContent);
+      if (!deinitIsKnownToNotCapture(OpV)) {
+        ConGraph->getOrCreateUnknownContent(fieldNode)->markEscaping();
+        return;
+      }
+      // This deinit is known to not directly capture it's own field content;
+      // however, other secondary deinitializers could still capture anything
+      // pointed to by references within those fields. Since secondary
+      // deinitializers only apply to reference-type fields, not pointer-type
+      // fields, the "field" content can initially be considered an indirect
+      // reference. Unfortunately, we can't know all possible reference types
+      // that may eventually be associated with 'fieldContent', so we must
+      // assume here that 'fieldContent2' could hold raw pointers. This is
+      // implied by passing in invalid SILValue.
+      CGNode *objNode2 =
+          ConGraph->getOrCreateReferenceContent(SILValue(), fieldNode);
+      CGNode *fieldNode2 = objNode2->getContentNodeOrNull();
+      ConGraph->getOrCreateUnknownContent(fieldNode2)->markEscaping();
+      return;
+    }
+    case SILInstructionKind::DestroyAddrInst: {
+      SILValue addressVal = I->getOperand(0);
+      CGNode *valueNode = ConGraph->getValueContent(addressVal);
+      if (!valueNode)
+        return;
+
+      // The value's destructor may escape anything the value points to.
+      // This could be an object referenced by the value or the contents of an
+      // existential box.
+      if (CGNode *fieldNode = ConGraph->getFieldContent(valueNode)) {
+        ConGraph->getOrCreateUnknownContent(fieldNode)->markEscaping();
+        return;
+      }
+      ConGraph->getOrCreateUnknownContent(valueNode)->markEscaping();
       return;
     }
 
 #define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
     case SILInstructionKind::Load##Name##Inst:
 #include "swift/AST/ReferenceStorage.def"
-    case SILInstructionKind::LoadInst:
+    case SILInstructionKind::LoadInst: {
       assert(!cast<SingleValueInstruction>(I)->getType().isAddress());
-      LLVM_FALLTHROUGH;
+      // For loads, get the address-type operand and return the content node
+      // that the address directly points to. The load's address may itself come
+      // from a ref_element_addr, project_box or open_existential, in which
+      // case, the loaded content will be the field content, not the RC
+      // content.
+      auto SVI = cast<SingleValueInstruction>(I);
+      if (!isPointer(SVI))
+        return;
+
+      if (CGNode *PointsTo = ConGraph->getValueContent(SVI->getOperand(0))) {
+        ConGraph->setNode(SVI, PointsTo);
+        return;
+      }
+      // A load from an address we don't handle -> be conservative.
+      ConGraph->setEscapesGlobal(SVI);
+      break;
+    }
     case SILInstructionKind::RefElementAddrInst:
     case SILInstructionKind::RefTailAddrInst:
     case SILInstructionKind::ProjectBoxInst:
     case SILInstructionKind::InitExistentialAddrInst:
     case SILInstructionKind::OpenExistentialAddrInst: {
-      // Loads and projections into RC objects have a similar pattern:
-      //
-      // For RC object projections, get the non-address reference operand and
-      // return an RC content node that the reference directly points to. It is
-      // as-if the RC content node holds the pointer to the object fields.
-      //
-      // For loads, get the address-type operand and return the content node
-      // that the address directly points to. The load's address may itself come
-      // from a ref_element_addr, project_box or open_existential, in which
-      // case, the loaded content will be the field content, not the RC content.
+      // For projections into objects, get the non-address reference operand and
+      // return an interior content node that the reference points to.
       auto SVI = cast<SingleValueInstruction>(I);
-      if (!isPointer(SVI))
-        return;
-
-      SILValue pointerVal = SVI->getOperand(0);
-      if (CGNode *PointsTo = getValueContent(ConGraph, pointerVal)) {
+      if (CGNode *PointsTo = ConGraph->getValueContent(SVI->getOperand(0))) {
         ConGraph->setNode(SVI, PointsTo);
         return;
       }
       // A load or projection from an address we don't handle -> be
       // conservative.
-      setEscapesGlobal(ConGraph, SVI);
+      ConGraph->setEscapesGlobal(SVI);
       return;
     }
     case SILInstructionKind::CopyAddrInst: {
       // Be conservative if the dest may be the final release.
       if (!cast<CopyAddrInst>(I)->isInitializationOfDest()) {
         setAllEscaping(I, ConGraph);
-        break;
+        return;
       }
 
       // A copy_addr is like a 'store (load src) to dest'.
       SILValue srcAddr = I->getOperand(CopyAddrInst::Src);
-      CGNode *loadedContent = getValueContent(ConGraph, srcAddr);
+      CGNode *loadedContent = ConGraph->getValueContent(srcAddr);
       if (!loadedContent) {
         setAllEscaping(I, ConGraph);
         break;
       }
       SILValue destAddr = I->getOperand(CopyAddrInst::Dest);
       // Create a defer-edge from the store location to the loaded content.
-      if (CGNode *destContent = getValueContent(ConGraph, destAddr)) {
+      if (CGNode *destContent = ConGraph->getValueContent(destAddr)) {
         ConGraph->defer(destContent, loadedContent);
         return;
       }
       // A store to an address we don't handle -> be conservative.
-      setEscapesGlobal(ConGraph, srcAddr);
+      ConGraph->setEscapesGlobal(srcAddr);
       return;
     }
 
@@ -2016,13 +2166,13 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       // (via ref_element_addr, project_box, or open_existential_addr) where the
       // stored field content is chained one level below the RC content.
       SILValue destAddr = I->getOperand(StoreInst::Dest);
-      if (CGNode *pointsTo = getValueContent(ConGraph, destAddr)) {
+      if (CGNode *pointsTo = ConGraph->getValueContent(destAddr)) {
         // Create a defer-edge from the content to the stored value.
         ConGraph->defer(pointsTo, valueNode);
         return;
       }
       // A store to an address we don't handle -> be conservative.
-      setEscapesGlobal(ConGraph, srcVal);
+      ConGraph->setEscapesGlobal(srcVal);
       return;
     }
     case SILInstructionKind::PartialApplyInst: {
@@ -2062,15 +2212,14 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     case SILInstructionKind::TupleExtractInst: {
       // This is a tuple_extract which extracts the second result of an
       // array.uninitialized call (otherwise getPointerBase should have already
-      // looked through it). The first result is the array itself.
-      // The second result (which is a pointer to the array elements) must be
-      // the content node of the first result. It's just like a ref_element_addr
-      // instruction.
+      // looked through it). The first result is the array itself.  The second
+      // result (which is a pointer to the array elements) must be the content
+      // node of the first result. It's just like a ref_element_addr
+      // instruction. It is mapped to a node when processing
+      // array.uninitialized.
       auto *TEI = cast<TupleExtractInst>(I);
       assert(isExtractOfArrayUninitializedPointer(TEI)
              && "tuple_extract should be handled as projection");
-      if (CGNode *ArrayElements = getValueContent(ConGraph, TEI->getOperand()))
-        ConGraph->setNode(TEI, ArrayElements);
       return;
     }
     case SILInstructionKind::UncheckedRefCastAddrInst: {
@@ -2081,12 +2230,15 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       ConGraph->defer(DestNode, SrcNode);
       return;
     }
-    case SILInstructionKind::ReturnInst:
-      if (CGNode *ValueNd =
-              ConGraph->getNode(cast<ReturnInst>(I)->getOperand())) {
+    case SILInstructionKind::ReturnInst: {
+      SILValue returnVal = cast<ReturnInst>(I)->getOperand();
+      if (CGNode *ValueNd = ConGraph->getNode(returnVal)) {
         ConGraph->defer(ConGraph->getReturnNode(), ValueNd);
+        ConGraph->getValueContent(returnVal)->mergeEscapeState(
+            EscapeState::Return);
       }
       return;
+    }
     default:
       // We handle all other instructions conservatively.
       setAllEscaping(I, ConGraph);
@@ -2147,8 +2299,8 @@ bool EscapeAnalysis::deinitIsKnownToNotCapture(SILValue V) {
 void EscapeAnalysis::setAllEscaping(SILInstruction *I,
                                     ConnectionGraph *ConGraph) {
   if (auto *TAI = dyn_cast<TryApplyInst>(I)) {
-    setEscapesGlobal(ConGraph, TAI->getNormalBB()->getArgument(0));
-    setEscapesGlobal(ConGraph, TAI->getErrorBB()->getArgument(0));
+    ConGraph->setEscapesGlobal(TAI->getNormalBB()->getArgument(0));
+    ConGraph->setEscapesGlobal(TAI->getErrorBB()->getArgument(0));
   }
   // Even if the instruction does not write memory we conservatively set all
   // operands to escaping, because they may "escape" to the result value in
@@ -2157,12 +2309,12 @@ void EscapeAnalysis::setAllEscaping(SILInstruction *I,
   for (const Operand &Op : I->getAllOperands()) {
     SILValue OpVal = Op.get();
     if (!isNonWritableMemoryAddress(OpVal))
-      setEscapesGlobal(ConGraph, OpVal);
+      ConGraph->setEscapesGlobal(OpVal);
   }
   // Even if the instruction does not write memory it could e.g. return the
   // address of global memory. Therefore we have to define it as escaping.
   for (auto result : I->getResults())
-    setEscapesGlobal(ConGraph, result);
+    ConGraph->setEscapesGlobal(result);
 }
 
 void EscapeAnalysis::recompute(FunctionInfo *Initial) {
@@ -2481,35 +2633,6 @@ bool EscapeAnalysis::canPointToSameMemory(SILValue V1, SILValue V2) {
     return Content1 == Content2;
   }
   return true;
-}
-
-bool EscapeAnalysis::canParameterEscape(FullApplySite FAS, int ParamIdx,
-                                        bool checkContentOfIndirectParam) {
-  CalleeList Callees = BCA->getCalleeList(FAS);
-  if (!Callees.allCalleesVisible())
-    return true;
-
-  // Derive the connection graph of the apply from the known callees.
-  for (SILFunction *Callee : Callees) {
-    FunctionInfo *FInfo = getFunctionInfo(Callee);
-    if (!FInfo->isValid())
-      recompute(FInfo);
-
-    CGNode *Node =
-        FInfo->SummaryGraph.getNodeOrNull(Callee->getArgument(ParamIdx));
-    if (!Node)
-      return true;
-
-    if (checkContentOfIndirectParam) {
-      Node = Node->getContentNodeOrNull();
-      if (!Node)
-        continue;
-    }
-
-    if (Node->escapes())
-      return true;
-  }
-  return false;
 }
 
 void EscapeAnalysis::invalidate() {

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -2479,44 +2479,50 @@ bool EscapeAnalysis::mergeSummaryGraph(ConnectionGraph *SummaryGraph,
   return SummaryGraph->mergeFrom(Graph, Mapping);
 }
 
-bool EscapeAnalysis::canEscapeToUsePoint(SILValue V, SILNode *UsePoint,
-                                         ConnectionGraph *ConGraph) {
+// Return true if any content within the logical object pointed to by \p value
+// escapes.
+//
+// Get the value's content node and check the escaping flag on all nodes within
+// that object. An interior CG node points to content within the same object.
+bool EscapeAnalysis::canEscapeToUsePoint(SILValue value,
+                                         SILInstruction *usePoint,
+                                         ConnectionGraph *conGraph) {
 
-  assert((FullApplySite::isa(UsePoint) || isa<RefCountingInst>(UsePoint)) &&
-         "use points are only created for calls and refcount instructions");
+  assert((FullApplySite::isa(usePoint) || isa<RefCountingInst>(usePoint))
+         && "use points are only created for calls and refcount instructions");
 
-  CGNode *Node = ConGraph->getNodeOrNull(V);
-  if (!Node)
+  CGNode *node = conGraph->getValueContent(value);
+  if (!node)
     return true;
 
-  // First check if there are escape paths which we don't explicitly see
-  // in the graph.
-  if (Node->valueEscapesInsideFunction(V))
-    return true;
+  // Follow points-to edges and return true if the current 'node' may escape at
+  // 'usePoint'.
+  CGNodeWorklist worklist(conGraph);
+  while (node) {
+    // Merging arbitrary nodes is supported, which may lead to cycles of
+    // interior nodes. End the search.
+    if (!worklist.tryPush(node))
+      break;
 
-  // No hidden escapes: check if the Node is reachable from the UsePoint.
-  // Check if the object itself can escape to the called function.
-  if (ConGraph->isUsePoint(UsePoint, Node))
-    return true;
+    // First check if 'node' may escape in a way not represented by the
+    // connection graph, assuming that it may represent part of the object
+    // pointed to by 'value'. If 'node' happens to represent another object
+    // indirectly reachabe from 'value', then it cannot actually escape to this
+    // usePoint, so passing the original value is still conservatively correct.
+    if (node->valueEscapesInsideFunction(value))
+      return true;
 
-  assert(isPointer(V) && "should not have a node for a non-pointer");
+    // No hidden escapes; check if 'usePoint' may access memory at 'node'.
+    if (conGraph->isUsePoint(usePoint, node))
+      return true;
 
-  // Check if the object "content" can escape to the called function.
-  // This will catch cases where V is a reference and a pointer to a stored
-  // property escapes.
-  // It's also important in case of a pointer assignment, e.g.
-  //    V = V1
-  //    apply(V1)
-  // In this case the apply is only a use-point for V1 and V1's content node.
-  // As V1's content node is the same as V's content node, we also make the
-  // check for the content node.
-  CGNode *ContentNode = getValueContent(ConGraph, V);
-  if (ContentNode->valueEscapesInsideFunction(V))
-    return true;
+    if (!node->isInterior())
+      break;
 
-  if (ConGraph->isUsePoint(UsePoint, ContentNode))
-    return true;
-
+    // Continue to check for escaping content whenever 'content' may point to
+    // the same object as 'node'.
+    node = node->getContentNodeOrNull();
+  }
   return false;
 }
 

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -108,32 +108,20 @@ bool StackPromotion::tryPromoteAlloc(AllocRefInst *ARI, EscapeAnalysis *EA,
     return false;
 
   auto *ConGraph = EA->getConnectionGraph(ARI->getFunction());
-  auto *Node = ConGraph->getNodeOrNull(ARI);
-  if (!Node)
+  auto *contentNode = ConGraph->getValueContent(ARI);
+  if (!contentNode)
     return false;
 
   // The most important check: does the object escape the current function?
-  if (Node->escapes())
+  if (contentNode->escapes())
     return false;
 
   LLVM_DEBUG(llvm::dbgs() << "Promote " << *ARI);
 
   // Collect all use-points of the allocation. These are refcount instructions
   // and apply instructions.
-  llvm::SmallVector<SILNode *, 8> BaseUsePoints;
   llvm::SmallVector<SILInstruction *, 8> UsePoints;
-  ConGraph->getUsePoints(Node, BaseUsePoints);
-  for (SILNode *UsePoint : BaseUsePoints) {
-    if (SILInstruction *I = dyn_cast<SILInstruction>(UsePoint)) {
-      UsePoints.push_back(I);
-    } else {
-      // Also block arguments can be use points.
-      SILBasicBlock *UseBB = cast<SILPhiArgument>(UsePoint)->getParent();
-      // For simplicity we just add the first instruction of the block as use
-      // point.
-      UsePoints.push_back(&UseBB->front());
-    }
-  }
+  ConGraph->getUsePoints(contentNode, UsePoints);
 
   ValueLifetimeAnalysis VLA(ARI, UsePoints);
   // Check if there is a use point before the allocation (this can happen e.g.

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -77,8 +77,8 @@ struct FourFields {
 sil @take_indirect_tuple : $@convention(method) (@in (Int, ())) -> ()
 
 // CHECK-LABEL: CG of handle_undef
-// CHECK:         Val %2 Esc: G, Succ: (%2.1)
-// CHECK:         Con %2.1 Esc: G, Succ: 
+// CHECK:         Val %2 Esc: , Succ: (%2.1)
+// CHECK:         Con [ref] %2.1 Esc: G, Succ: 
 // CHECK:       End
 sil @handle_undef : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
@@ -96,11 +96,12 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: CG of test_simple
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%5)
-// CHECK-NEXT:    Arg %1 Esc: G, Succ:
-// CHECK-NEXT:    Val %2 Esc: A, Succ: ([rc] %3)
-// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%3.1)
-// CHECK-NEXT:    Con %3.1 Esc: G, Succ: %1
-// CHECK-NEXT:    Con %5 Esc: A, Succ: %2
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: (%1.1)
+// CHECK-NEXT:    Con %1.1 Esc: G, Succ:
+// CHECK-NEXT:    Val [ref] %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con [int] %3 Esc: A, Succ: (%3.1)
+// CHECK-NEXT:    Con %3.1 Esc: A, Succ: %1
+// CHECK-NEXT:    Con [ref] %5 Esc: A, Succ: %2
 // CHECK-NEXT:  End
 sil @test_simple : $@convention(thin) (@inout Y, @owned X) -> () {
 bb0(%0 : $*Y, %1 : $X):
@@ -117,12 +118,12 @@ bb0(%0 : $*Y, %1 : $X):
 // Test if a deferring edge is created for a block argument.
 
 // CHECK-LABEL: CG of deferringEdge
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %4)
-// CHECK-NEXT:    Arg %1 Esc: A, Succ:
-// CHECK-NEXT:    Val %3 Esc: %3, Succ: ([rc] %4), %0
-// CHECK-NEXT:    Con [rc] %4 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ:
+// CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%4), %0
+// CHECK-NEXT:    Con [int] %4 Esc: A, Succ: (%4.1)
 // CHECK-NEXT:    Con %4.1 Esc: A, Succ: %1
-// CHECK-NEXT:    Ret return Esc: R, Succ: %0
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @deferringEdge : $@convention(thin) (@owned LinkedNode, @owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode, %1 : $LinkedNode):
@@ -137,8 +138,10 @@ bb1(%3 : $LinkedNode):
 // Test a local object just escaping via return.
 
 // CHECK-LABEL: CG of escapes_via_return
-// CHECK-NEXT:    Val %0 Esc: R, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %0
+// CHECK-NEXT:    Val [ref] %0 Esc: , Succ:
+// CHECK-NEXT:    Con [int] %0.1 Esc: R, Succ: (%0.2)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: R, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @escapes_via_return : $@convention(thin) () -> @owned X {
 bb0:
@@ -149,14 +152,14 @@ bb0:
 // A linear chain of assignments is collapsed to a single node.
 
 // CHECK-LABEL: CG of test_linked_list
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %2)
-// CHECK-NEXT:    Val %1 Esc: A, Succ: ([rc] %2)
-// CHECK-NEXT:    Con [rc] %2 Esc: A, Succ: (%13)
-// CHECK-NEXT:    Val %4 Esc: A, Succ: ([rc] %2)
-// CHECK-NEXT:    Val %7 Esc: %11, Succ: ([rc] %2)
-// CHECK-NEXT:    Val %11 Esc: %11, Succ: ([rc] %2), %7, %13
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Val [ref] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con [int] %2 Esc: A, Succ: (%13)
+// CHECK-NEXT:    Val [ref] %4 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%2)
+// CHECK-NEXT:    Val [ref] %11 Esc: , Succ: (%2), %7, %13
 // CHECK-NEXT:    Con %13 Esc: A, Succ: %0, %1, %4
-// CHECK-NEXT:    Ret return Esc: R, Succ: %13
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %13
 // CHECK-NEXT:  End
 sil @test_linked_list : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -184,14 +187,14 @@ bb2:
 // The same example as above but distributed over two functions.
 
 // CHECK-LABEL: CG of create_chain
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %8)
-// CHECK-NEXT:    Val %1 Esc: A, Succ: ([rc] %8)
-// CHECK-NEXT:    Val %4 Esc: A, Succ: ([rc] %8)
-// CHECK-NEXT:    Val %7 Esc: %11, Succ: ([rc] %8)
-// CHECK-NEXT:    Con [rc] %8 Esc: A, Succ: (%8.1)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%8)
+// CHECK-NEXT:    Val [ref] %1 Esc: A, Succ: (%8)
+// CHECK-NEXT:    Val [ref] %4 Esc: A, Succ: (%8)
+// CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%8)
+// CHECK-NEXT:    Con [int] %8 Esc: A, Succ: (%8.1)
 // CHECK-NEXT:    Con %8.1 Esc: A, Succ: %0, %1, %4
-// CHECK-NEXT:    Val %11 Esc: R, Succ: ([rc] %8), %8.1
-// CHECK-NEXT:    Ret return Esc: R, Succ: %11
+// CHECK-NEXT:    Val [ref] %11 Esc: , Succ: (%8), %8.1
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %11
 // CHECK-NEXT:  End
 sil @create_chain : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -211,11 +214,11 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of loadNext
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %3)
-// CHECK-NEXT:    Val %2 Esc: %2, Succ: ([rc] %3), %0, %4
-// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%4)
-// CHECK-NEXT:    Con %4 Esc: A, Succ: ([rc] %3)
-// CHECK-NEXT:    Ret return Esc: R, Succ: %4
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%3), %0, %4
+// CHECK-NEXT:    Con [int] %3 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con %4 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @loadNext : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -233,15 +236,17 @@ bb2:
 // Content nodes in the callee are duplicated in the caller.
 
 // CHECK-LABEL: CG of call_load_next3
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %0.1)
-// CHECK-NEXT:    Con [rc] %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: ([rc] %0.3)
-// CHECK-NEXT:    Con [rc] %0.3 Esc: A, Succ: (%0.4)
-// CHECK-NEXT:    Con %0.4 Esc: A, Succ: ([rc] %0.5)
-// CHECK-NEXT:    Con [rc] %0.5 Esc: A, Succ: (%0.6)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.3)
+// CHECK-NEXT:    Con [int] %0.3 Esc: A, Succ: (%0.4)
+// CHECK-NEXT:    Con %0.4 Esc: A, Succ: (%0.5)
+// CHECK-NEXT:    Con [int] %0.5 Esc: A, Succ: (%0.6)
 // CHECK-NEXT:    Con %0.6 Esc: A, Succ:
-// CHECK-NEXT:    Val %2 Esc: R, Succ: %0.6
-// CHECK-NEXT:    Ret return Esc: R, Succ: %2
+// CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%2.1), %0.6
+// CHECK-NEXT:    Con [int] %2.1 Esc: A, Succ: (%2.2)
+// CHECK-NEXT:    Con %2.2 Esc: A, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %2
 // CHECK-NEXT:  End
 sil @call_load_next3 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -251,14 +256,16 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of load_next3
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
-// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: A, Succ: ([rc] %3)
-// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%4)
-// CHECK-NEXT:    Con %4 Esc: A, Succ: ([rc] %5)
-// CHECK-NEXT:    Con [rc] %5 Esc: A, Succ: (%6)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
+// CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con [int] %3 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con %4 Esc: A, Succ: (%5)
+// CHECK-NEXT:    Con [int] %5 Esc: A, Succ: (%6)
 // CHECK-NEXT:    Con %6 Esc: A, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %6
+// CHECK-NEXT:    Con [int] %6.1 Esc: A, Succ: (%6.2)
+// CHECK-NEXT:    Con %6.2 Esc: A, Succ:
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %6
 // CHECK-NEXT:  End
 sil @load_next3 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -277,10 +284,12 @@ sil_global @global_x : $X
 // The argument escapes because it is stored to a global variable in the callee.
 
 // CHECK-LABEL: CG of call_store_pointer
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: ([rc] %5)
-// CHECK-NEXT:    Con [rc] %5 Esc: G, Succ: (%6)
+// CHECK-NEXT:    Arg [ref] %0 Esc: G, Succ: (%5)
+// CHECK-NEXT:    Con [int] %5 Esc: G, Succ: (%6)
 // CHECK-NEXT:    Con %6 Esc: G, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %6
+// CHECK-NEXT:    Con [int] %6.1 Esc: G, Succ: (%6.2)
+// CHECK-NEXT:    Con [ref] %6.2 Esc: G, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %6
 // CHECK-NEXT:  End
 sil @call_store_pointer : $@convention(thin) (@owned Pointer) -> @owned X {
 bb0(%0 : $Pointer):
@@ -294,9 +303,9 @@ bb0(%0 : $Pointer):
 }
 
 // CHECK-LABEL: CG of store_pointer
-// CHECK-NEXT:    Arg %0 Esc: G, Succ:
-// CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ: %0
+// CHECK-NEXT:    Arg [ref] %0 Esc: G, Succ:
+// CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
+// CHECK-NEXT:    Con [ref] %1.1 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil  @store_pointer : $@convention(thin) (@owned Pointer) -> () {
 bb0(%0 : $Pointer):
@@ -310,10 +319,10 @@ bb0(%0 : $Pointer):
 // global variable in the callee.
 
 // CHECK-LABEL: CG of store_content
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %3)
-// CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ: %4
-// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
+// CHECK-NEXT:    Con [ref] %1.1 Esc: G, Succ: %4
+// CHECK-NEXT:    Con [int] %3 Esc: A, Succ: (%4)
 // CHECK-NEXT:    Con %4 Esc: G, Succ:
 // CHECK-NEXT:  End
 sil  @store_content : $@convention(thin) (@owned Pointer) -> () {
@@ -328,10 +337,12 @@ bb0(%0 : $Pointer):
 }
 
 // CHECK-LABEL: CG of call_store_content
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %4)
-// CHECK-NEXT:    Con [rc] %4 Esc: A, Succ: (%5)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con [int] %4 Esc: A, Succ: (%5)
 // CHECK-NEXT:    Con %5 Esc: G, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %5
+// CHECK-NEXT:    Con [int] %5.1 Esc: G, Succ: (%5.2)
+// CHECK-NEXT:    Con [ref] %5.2 Esc: G, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %5
 // CHECK-NEXT:  End
 sil @call_store_content : $@convention(thin) (@owned Pointer) -> @owned X {
 bb0(%0 : $Pointer):
@@ -345,9 +356,9 @@ bb0(%0 : $Pointer):
 
 // CHECK-LABEL: CG of copy_addr_content
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: %1.1
+// CHECK-NEXT:    Con [ref] %0.1 Esc: A, Succ: %1.1
 // CHECK-NEXT:    Arg %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ:
+// CHECK-NEXT:    Con [ref] %1.1 Esc: A, Succ:
 // CHECK-NEXT:  End
 sil @copy_addr_content : $@convention(thin) (@in_guaranteed Int32) -> @out Int32 {
 bb0(%0: $*Int32, %1: $*Int32):
@@ -358,9 +369,9 @@ bb0(%0: $*Int32, %1: $*Int32):
 
 // CHECK-LABEL: CG of copy_addr_take_content
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: %1.1
+// CHECK-NEXT:    Con [ref] %0.1 Esc: A, Succ: %1.1
 // CHECK-NEXT:    Arg %1 Esc: A, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: A, Succ:
+// CHECK-NEXT:    Con [ref] %1.1 Esc: A, Succ:
 // CHECK-NEXT:  End
 sil @copy_addr_take_content : $@convention(thin) (@in Int32) -> @out Int32 {
 bb0(%0: $*Int32, %1: $*Int32):
@@ -370,10 +381,10 @@ bb0(%0: $*Int32, %1: $*Int32):
 }
 
 // CHECK-LABEL: CG of copy_addr_noinit_content
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ:
-// CHECK-NEXT:    Arg %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ:
+// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [ref] %0.1 Esc: G, Succ:
+// CHECK-NEXT:    Arg %1 Esc: A, Succ: (%1.1)
+// CHECK-NEXT:    Con [ref] %1.1 Esc: G, Succ:
 // CHECK-NEXT:  End
 sil @copy_addr_noinit_content : $@convention(thin) (@in Int32) -> @out Int32 {
 bb0(%0: $*Int32, %1: $*Int32):
@@ -383,10 +394,10 @@ bb0(%0: $*Int32, %1: $*Int32):
 }
 
 // CHECK-LABEL: CG of call_copy_addr_content
-// CHECK-NEXT:    Val %0 Esc: %3, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: %3, Succ: %1.1
-// CHECK-NEXT:    Val %1 Esc: %3, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: %3, Succ:
+// CHECK-NEXT:    Val %0 Esc: , Succ: (%0.1)
+// CHECK-NEXT:    Con [ref] %0.1 Esc: %3, Succ: %1.1
+// CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
+// CHECK-NEXT:    Con [ref] %1.1 Esc: %3, Succ:
 // CHECK-NEXT:  End
 sil @call_copy_addr_content : $@convention(thin) () -> () {
   %0 = alloc_stack $Int32
@@ -404,14 +415,17 @@ sil @call_copy_addr_content : $@convention(thin) () -> () {
 // of Y's box _could_ capture Y.x in Y's deinit.
 
 // CHECK-LABEL: CG of test_partial_apply
-// CHECK-NEXT:    Arg %1 Esc: G, Succ:
-// CHECK-NEXT:    Arg %2 Esc: A, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: G, Succ:
-// CHECK-NEXT:    Val %3 Esc: %14,%15,%17, Succ: ([rc] %7)
-// CHECK-NEXT:    Val %6 Esc: %14,%15,%16, Succ: ([rc] %7)
-// CHECK-NEXT:    Con [rc] %7 Esc: %14,%15,%16,%17, Succ: (%7.1)
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %1.1 Esc: G, Succ: (%1.2)
+// CHECK-NEXT:    Con [ref] %1.2 Esc: G, Succ: 
+// CHECK-NEXT:    Arg [ref] %2 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:    Con [int] %2.1 Esc: A, Succ:
+// CHECK-NEXT:    Con %2.2 Esc: A, Succ: (%1.1), %1
+// CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%7)
+// CHECK-NEXT:    Val [ref] %6 Esc: , Succ: (%7)
+// CHECK-NEXT:    Con [int] %7 Esc: %14,%15,%16,%17, Succ: (%7.1)
 // CHECK-NEXT:    Con %7.1 Esc: %14,%15,%16,%17, Succ: %2
-// CHECK-NEXT:    Val %12 Esc: %14,%15, Succ: %3, %6
+// CHECK-NEXT:    Val [ref] %12 Esc: , Succ: %3, %6
 // CHECK-NEXT:  End
 sil @test_partial_apply : $@convention(thin) (Int64, @owned X, @owned Y) -> Int64 {
 bb0(%0 : $Int64, %1 : $X, %2 : $Y):
@@ -434,16 +448,21 @@ bb0(%0 : $Int64, %1 : $X, %2 : $Y):
 }
 
 // CHECK-LABEL: CG of closure1
-// CHECK-NEXT:    Arg %0 Esc: G, Succ:
-// CHECK-NEXT:    Arg %1 Esc: A, Succ: ([rc] %3)
-// CHECK-NEXT:    Arg %2 Esc: A, Succ: ([rc] %4)
-// CHECK-NEXT:    Con [rc] %3 Esc: A, Succ: (%3.1)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %0.1 Esc: G, Succ: (%0.2)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: G, Succ: 
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Arg [ref] %2 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con [int] %3 Esc: A, Succ: (%3.1)
 // CHECK-NEXT:    Con %3.1 Esc: A, Succ: (%3.2)
-// CHECK-NEXT:    Con %3.2 Esc: G, Succ:
-// CHECK-NEXT:    Con [rc] %4 Esc: A, Succ: (%4.1)
-// CHECK-NEXT:    Con %4.1 Esc: A, Succ: ([rc] %4.2)
-// CHECK-NEXT:    Con [rc] %4.2 Esc: G, Succ:
-// CHECK-NEXT:    Val %7 Esc: %8, Succ: %2
+// CHECK-NEXT:    Con [int] %3.2 Esc: A, Succ: (%3.3)
+// CHECK-NEXT:    Con %3.3 Esc: A, Succ: (%3.4)
+// CHECK-NEXT:    Con %3.4 Esc: G, Succ:
+// CHECK-NEXT:    Con [int] %4 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Con %4.1 Esc: A, Succ: (%4.2)
+// CHECK-NEXT:    Con [int] %4.2 Esc: A, Succ:
+// CHECK-NEXT:    Con %4.3 Esc: A, Succ: (%0.1), %0
+// CHECK-NEXT:    Val [ref] %7 Esc: , Succ: %2
 // CHECK-NEXT:  End
 sil @closure1 : $@convention(thin) (@owned X, @owned <τ_0_0> { var τ_0_0 } <Int64>, @owned <τ_0_0> { var τ_0_0 } <Y>) -> Int64 {
 bb0(%0 : $X, %1 : $<τ_0_0> { var τ_0_0 } <Int64>, %2 : $<τ_0_0> { var τ_0_0 } <Y>):
@@ -458,12 +477,13 @@ bb0(%0 : $X, %1 : $<τ_0_0> { var τ_0_0 } <Int64>, %2 : $<τ_0_0> { var τ_0_0 
 }
 
 // CHECK-LABEL: CG of closure2
-// CHECK-NEXT:    Arg %0 Esc: G, Succ:
-// CHECK-NEXT:    Arg %1 Esc: A, Succ: ([rc] %2)
-// CHECK-NEXT:    Con [rc] %2 Esc: A, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: A, Succ: ([rc] %4)
-// CHECK-NEXT:    Con [rc] %4 Esc: G, Succ: (%4.1)
-// CHECK-NEXT:    Con %4.1 Esc: G, Succ: %0
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Con %0.1 Esc: G, Succ: 
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con [int] %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: A, Succ: (%4)
+// CHECK-NEXT:    Con [int] %4 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Con %4.1 Esc: A, Succ: %0
 // CHECK-NEXT:  End
 sil @closure2 : $@convention(thin) (@owned X, @owned <τ_0_0> { var τ_0_0 } <Y>) -> () {
 bb0(%0 : $X, %1 : $<τ_0_0> { var τ_0_0 } <Y>):
@@ -479,11 +499,13 @@ bb0(%0 : $X, %1 : $<τ_0_0> { var τ_0_0 } <Y>):
 // Test partial_apply. The box escapes in the callee.
 
 // CHECK-LABEL: CG of test_escaped_box
-// CHECK-NEXT:    Val %1 Esc: G, Succ: ([rc] %2)
-// CHECK-NEXT:    Con [rc] %2 Esc: G, Succ: (%2.1)
+// CHECK-NEXT:    Val [ref] %1 Esc: , Succ: (%2)
+// CHECK-NEXT:    Con [int] %2 Esc: G, Succ: (%2.1)
 // CHECK-NEXT:    Con %2.1 Esc: G, Succ: (%2.2)
-// CHECK-NEXT:    Con %2.2 Esc: G, Succ:
-// CHECK-NEXT:    Val %6 Esc: G, Succ: %1
+// CHECK-NEXT:    Con [int] %2.2 Esc: G, Succ:
+// CHECK-NEXT:    Con %2.3 Esc: G, Succ:
+// CHECK-NEXT:    Con %2.4 Esc: G, Succ:
+// CHECK-NEXT:    Val [ref] %6 Esc: , Succ: %1
 // CHECK-NEXT:  End
 sil @test_escaped_box : $@convention(thin) (Int64) -> Int64 {
 bb0(%0 : $Int64):
@@ -502,10 +524,12 @@ bb0(%0 : $Int64):
 }
 
 // CHECK-LABEL: CG of let_box_escape
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: ([rc] %1)
-// CHECK-NEXT:    Con [rc] %1 Esc: G, Succ: (%1.1)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
+// CHECK-NEXT:    Con [int] %1 Esc: G, Succ: (%1.1)
 // CHECK-NEXT:    Con %1.1 Esc: G, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: G, Succ:
+// CHECK-NEXT:    Con [int] %1.2 Esc: G, Succ: (%1.3)
+// CHECK-NEXT:    Con %1.3 Esc: G, Succ: (%1.4)
+// CHECK-NEXT:    Con %1.4 Esc: G, Succ:
 // CHECK-NEXT:  End
 sil @let_box_escape : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int64>) -> Int64 {
 bb0(%0 : $<τ_0_0> { var τ_0_0 } <Int64>):
@@ -524,9 +548,10 @@ sil @takebox :  $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int64>) -> (
 // The partial_apply itself escapes and therefore also the box escapes.
 
 // CHECK-LABEL: CG of test_escaped_partial_apply
-// CHECK-NEXT:    Val %1 Esc: G, Succ: ([rc] %2)
-// CHECK-NEXT:    Con [rc] %2 Esc: G, Succ:
-// CHECK-NEXT:    Val %6 Esc: G, Succ: %1
+// CHECK-NEXT:    Val [ref] %1 Esc: , Succ: (%2)
+// CHECK-NEXT:    Con [int] %2 Esc: G, Succ:
+// CHECK-NEXT:    Con %2.1 Esc: G, Succ: 
+// CHECK-NEXT:    Val [ref] %6 Esc: , Succ: %1
 // CHECK-NEXT:  End
 sil @test_escaped_partial_apply : $@convention(thin) (Int64) -> () {
 bb0(%0 : $Int64):
@@ -544,10 +569,12 @@ bb0(%0 : $Int64):
 }
 
 // CHECK-LABEL: CG of closure3
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
-// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%1.1)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
+// CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%1.1)
 // CHECK-NEXT:    Con %1.1 Esc: A, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: G, Succ:
+// CHECK-NEXT:    Con [int] %1.2 Esc: A, Succ:
+// CHECK-NEXT:    Con %1.3 Esc: A, Succ: (%1.4)
+// CHECK-NEXT:    Con %1.4 Esc: G, Succ:
 // CHECK-NEXT:  End
 sil @closure3 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int64>) -> Int64 {
 bb0(%0 : $<τ_0_0> { var τ_0_0 } <Int64>):
@@ -564,11 +591,13 @@ sil @take_partial_apply : $@convention(thin) (@owned @callee_owned () -> Int64) 
 sil_global @global_ln : $LinkedNode
 
 // CHECK-LABEL: CG of load_next_recursive
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
-// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
+// CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%2)
 // CHECK-NEXT:    Con %2 Esc: G, Succ:
-// CHECK-NEXT:    Val %4 Esc: G, Succ: %2
-// CHECK-NEXT:    Ret return Esc: R, Succ: %4
+// CHECK-NEXT:    Val [ref] %4 Esc: , Succ: (%4.1), %2
+// CHECK-NEXT:    Con [int] %4.1 Esc: G, Succ: (%4.2)
+// CHECK-NEXT:    Con %4.2 Esc: G, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @load_next_recursive : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -580,12 +609,13 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of let_escape
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: ([rc] %0.1)
-// CHECK-NEXT:    Con [rc] %0.1 Esc: G, Succ:
-// CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ: %0
-// CHECK-NEXT:    Val %4 Esc: G, Succ: %0
-// CHECK-NEXT:    Ret return Esc: R, Succ: %4
+// CHECK-NEXT:    Arg [ref] %0 Esc: G, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: G, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: G, Succ:
+// CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
+// CHECK-NEXT:    Con [ref] %1.1 Esc: G, Succ: %0
+// CHECK-NEXT:    Val [ref] %4 Esc: , Succ: (%0.1), %0
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @let_escape : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -597,12 +627,12 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of return_same
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %3.1)
-// CHECK-NEXT:    Val %3 Esc: G, Succ: ([rc] %3.1), %3.2
-// CHECK-NEXT:    Con [rc] %3.1 Esc: G, Succ: (%3.2)
-// CHECK-NEXT:    Con %3.2 Esc: G, Succ: ([rc] %3.1)
-// CHECK-NEXT:    Val %5 Esc: R, Succ: %0, %3
-// CHECK-NEXT:    Ret return Esc: R, Succ: %5
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%5.1)
+// CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%5.1), %5.2
+// CHECK-NEXT:    Val [ref] %5 Esc: , Succ: (%5.1), %0, %3
+// CHECK-NEXT:    Con [int] %5.1 Esc: G, Succ: (%5.2)
+// CHECK-NEXT:    Con %5.2 Esc: G, Succ: (%5.1)
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %5
 // CHECK-NEXT:  End
 sil @return_same : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -620,15 +650,15 @@ bb2(%5 : $LinkedNode):
 // Another recursion test.
 
 // CHECK-LABEL: CG of loadNext2
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
-// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: A, Succ: ([rc] %2.1)
-// CHECK-NEXT:    Con [rc] %2.1 Esc: A, Succ: (%2.2)
-// CHECK-NEXT:    Con %2.2 Esc: A, Succ: ([rc] %2.3)
-// CHECK-NEXT:    Con [rc] %2.3 Esc: A, Succ: (%2.4)
-// CHECK-NEXT:    Con %2.4 Esc: A, Succ: ([rc] %2.3)
-// CHECK-NEXT:    Val %4 Esc: R, Succ: %2.2, %2.4
-// CHECK-NEXT:    Ret return Esc: R, Succ: %4
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
+// CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con %2 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:    Con [int] %2.1 Esc: A, Succ: (%2.2)
+// CHECK-NEXT:    Con %2.2 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Val [ref] %4 Esc: , Succ: (%4.1), %2.2, %4.2
+// CHECK-NEXT:    Con [int] %4.1 Esc: A, Succ: (%4.2)
+// CHECK-NEXT:    Con %4.2 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @loadNext2 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -640,14 +670,14 @@ bb0(%0 : $LinkedNode):
 }
 
 // CHECK-LABEL: CG of returnNext2
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %5)
-// CHECK-NEXT:    Val %3 Esc: R, Succ: ([rc] %3.1), %3.2
-// CHECK-NEXT:    Con [rc] %3.1 Esc: A, Succ: (%3.2)
-// CHECK-NEXT:    Con %3.2 Esc: A, Succ: ([rc] %3.1)
-// CHECK-NEXT:    Con [rc] %5 Esc: A, Succ: (%6)
-// CHECK-NEXT:    Con %6 Esc: A, Succ: ([rc] %3.1)
-// CHECK-NEXT:    Val %8 Esc: R, Succ: %3, %6
-// CHECK-NEXT:    Ret return Esc: R, Succ: %8
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%5)
+// CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%8.1), %8.2
+// CHECK-NEXT:    Con [int] %5 Esc: A, Succ: (%6)
+// CHECK-NEXT:    Con %6 Esc: A, Succ: (%8.1)
+// CHECK-NEXT:    Val [ref] %8 Esc: , Succ: (%8.1), %3, %6
+// CHECK-NEXT:    Con [int] %8.1 Esc: A, Succ: (%8.2)
+// CHECK-NEXT:    Con %8.2 Esc: A, Succ: (%8.1)
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %8
 // CHECK-NEXT:  End
 sil @returnNext2 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -670,12 +700,12 @@ bb3(%8 : $LinkedNode):
 // A single-cycle recursion test.
 
 // CHECK-LABEL: CG of single_cycle_recursion
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %2)
-// CHECK-NEXT:    Con [rc] %2 Esc: A, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: A, Succ: ([rc] %2)
-// CHECK-NEXT:    Val %5 Esc: R, Succ: ([rc] %2), %3
-// CHECK-NEXT:    Val %7 Esc: R, Succ: %0, %5
-// CHECK-NEXT:    Ret return Esc: R, Succ: %7
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con [int] %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con %3 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Val [ref] %5 Esc: , Succ: (%2), %3
+// CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%2), %0, %5
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %7
 // CHECK-NEXT:  End
 sil @single_cycle_recursion : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
 bb0(%0 : $LinkedNode):
@@ -695,9 +725,11 @@ bb2(%5 : $LinkedNode):
 // Test if a try_apply is represented correctly in the connection graph.
 
 // CHECK-LABEL: CG of call_throwing_func
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Val %3 Esc: R, Succ: %0
-// CHECK-NEXT:    Ret return Esc: R, Succ: %3
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: A, Succ: 
+// CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%0.1), %0
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %3
 // CHECK-NEXT:  End
 sil @call_throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error Error) {
 bb0(%0 : $X):
@@ -712,10 +744,12 @@ bb2(%5 : $Error):
 }
 
 // CHECK-LABEL: CG of throwing_func
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Val %3 Esc: G, Succ: (%3.1)
-// CHECK-NEXT:    Con %3.1 Esc: G, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %0
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: A, Succ: 
+// CHECK-NEXT:    Val %3 Esc: , Succ: (%3.1)
+// CHECK-NEXT:    Con [ref] %3.1 Esc: G, Succ:
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error Error) {
 bb0(%0 : $X):
@@ -735,11 +769,13 @@ bb2:
 // Test if a try_apply to an unknown function is handled correctly.
 
 // CHECK-LABEL: CG of call_unknown_throwing_func
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ:
-// CHECK-NEXT:    Val %3 Esc: G, Succ: (%3.1)
-// CHECK-NEXT:    Con %3.1 Esc: G, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %3
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: G, Succ: (%0.2)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: G, Succ: 
+// CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%3.1)
+// CHECK-NEXT:    Con [int] %3.1 Esc: G, Succ: (%3.2)
+// CHECK-NEXT:    Con [ref] %3.2 Esc: G, Succ:
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %3
 // CHECK-NEXT:  End
 sil @call_unknown_throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error Error) {
 bb0(%0 : $X):
@@ -758,12 +794,14 @@ sil @unknown_throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error 
 // Test that the deinit of a box itself does not capture anything.
 
 // CHECK-LABEL: CG of test_release_of_partial_apply_with_box
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ:
-// CHECK-NEXT:    Val %1 Esc: %6, Succ: ([rc] %2)
-// CHECK-NEXT:    Con [rc] %2 Esc: %6, Succ: (%2.1)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.3)
+// CHECK-NEXT:    Con %0.3 Esc: G, Succ: 
+// CHECK-NEXT:    Val [ref] %1 Esc: , Succ: (%2)
+// CHECK-NEXT:    Con [int] %2 Esc: %6, Succ: (%2.1)
 // CHECK-NEXT:    Con %2.1 Esc: %6, Succ: %0
-// CHECK-NEXT:    Val %5 Esc: %6, Succ: %1
+// CHECK-NEXT:    Val [ref] %5 Esc: , Succ: %1
 // CHECK-NEXT:  End
 sil @test_release_of_partial_apply_with_box : $@convention(thin) (@owned Y) -> () {
 bb0(%0 : $Y):
@@ -782,9 +820,9 @@ sil @take_y_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Y>) -> ()
 // Test is an unknown value is merged correctly into the caller graph.
 
 // CHECK-LABEL: CG of store_to_unknown_reference
-// CHECK-NEXT:    Arg %0 Esc: G, Succ:
-// CHECK-NEXT:    Val %2 Esc: G, Succ: ([rc] %3)
-// CHECK-NEXT:    Con [rc] %3 Esc: G, Succ: (%3.1)
+// CHECK-NEXT:    Arg [ref] %0 Esc: G, Succ:
+// CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%3)
+// CHECK-NEXT:    Con [int] %3 Esc: G, Succ: (%3.1)
 // CHECK-NEXT:    Con %3.1 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @store_to_unknown_reference : $@convention(thin) (@owned X) -> () {
@@ -798,9 +836,10 @@ bb0(%0 : $X):
 }
 
 // CHECK-LABEL: CG of get_reference
-// CHECK-NEXT:    Val %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %1
+// CHECK-NEXT:    Val [ref] %1 Esc: , Succ: (%1.1)
+// CHECK-NEXT:    Con [int] %1.1 Esc: G, Succ: (%1.2)
+// CHECK-NEXT:    Con %1.2 Esc: G, Succ: 
+ // CHECK-NEXT:   Ret [ref] return Esc: , Succ: %1
 // CHECK-NEXT:  End
 sil @get_reference : $@convention(thin) () -> @owned Y {
 bb0:
@@ -816,9 +855,11 @@ sil @unknown_get_reference : $@convention(thin) () -> @owned Y
 sil @unknown_set_y : $@convention(thin) () -> @out Y
 
 // CHECK-LABEL: CG of get_y
-// CHECK-NEXT:    Val %0 Esc: G, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: G, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %3
+// CHECK-NEXT:    Val %0 Esc: , Succ: (%3)
+// CHECK-NEXT:    Con [ref] %3 Esc: G, Succ:
+// CHECK-NEXT:    Con [int] %3.1 Esc: G, Succ: (%3.2)
+// CHECK-NEXT:    Con %3.2 Esc: G, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %3
 // CHECK-NEXT:  End
 sil @get_y : $@convention(thin) () -> @owned Y {
 bb0:
@@ -831,9 +872,9 @@ bb0:
 }
 
 // CHECK-LABEL: CG of create_and_store_x
-// CHECK-NEXT:    Val %0 Esc: G, Succ: 
-// CHECK-NEXT:    Val %2 Esc: G, Succ: ([rc] %3)
-// CHECK-NEXT:    Con [rc] %3 Esc: G, Succ: (%3.1)
+// CHECK-NEXT:    Val [ref] %0 Esc: G, Succ: 
+// CHECK-NEXT:    Val [ref] %2 Esc: G, Succ: (%3)
+// CHECK-NEXT:    Con [int] %3 Esc: G, Succ: (%3.1)
 // CHECK-NEXT:    Con %3.1 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @create_and_store_x : $@convention(thin) () -> () {
@@ -850,11 +891,13 @@ bb0:
 // Test types which are considered as pointers.
 
 // CHECK-LABEL: CG of pointer_types
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: 
-// CHECK-NEXT:    Arg %1 Esc: A, Succ: 
-// CHECK-NEXT:    Val %4 Esc: R, Succ: %0, %1
-// CHECK-NEXT:    Val %7 Esc: R, Succ: %4
-// CHECK-NEXT:    Ret return Esc: R, Succ: %7
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: 
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: 
+// CHECK-NEXT:    Val [ref] %4 Esc: , Succ: %0, %1
+// CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%7.1), %4
+// CHECK-NEXT:    Con [int] %7.1 Esc: A, Succ: (%7.2)
+// CHECK-NEXT:    Con %7.2 Esc: A, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %7
 // CHECK-NEXT:  End
 sil @pointer_types : $@convention(thin) (@owned Y, @owned Y) -> @owned Y {
 bb0(%0 : $Y, %1 : $Y):
@@ -873,9 +916,9 @@ bb1(%7 : $(Pointer, Pointer)):
 // CHECK-LABEL: CG of defer_edge_cycle
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%2)
 // CHECK-NEXT:    Arg %1 Esc: A, Succ: (%4)
-// CHECK-NEXT:    Con %2 Esc: A, Succ: ([rc] %6), %4
-// CHECK-NEXT:    Con %4 Esc: A, Succ: %2
-// CHECK-NEXT:    Con [rc] %6 Esc: A, Succ: (%7)
+// CHECK-NEXT:    Con [ref] %2 Esc: A, Succ: (%6), %4
+// CHECK-NEXT:    Con [ref] %4 Esc: A, Succ: %2
+// CHECK-NEXT:    Con [int] %6 Esc: A, Succ: (%7)
 // CHECK-NEXT:    Con %7 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @defer_edge_cycle : $@convention(thin) (@inout Y, @inout Y) -> () {
@@ -891,9 +934,10 @@ entry(%0 : $*Y, %1 : $*Y):
 }
 
 // CHECK-LABEL: CG of take_c_func
-// CHECK-NEXT:    Arg %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ: 
-// CHECK-NEXT:    Ret return Esc: R, Succ: %0
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: G, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @take_c_func : $@convention(thin) (@convention(c) () -> ()) -> @convention(c) () -> () {
 bb0(%0 : $@convention(c) () -> ()):
@@ -910,8 +954,9 @@ bb0:
 }
 
 // CHECK-LABEL: CG of pass_c_func
-// CHECK-NEXT:    Val %2 Esc: G, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: G, Succ:
+// CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%2.1)
+// CHECK-NEXT:    Con [int] %2.1 Esc: G, Succ:
+// CHECK-NEXT:    Con %2.2 Esc: G, Succ: 
 // CHECK-NEXT:  End
 sil @pass_c_func : $@convention(thin) () -> () {
 bb0:
@@ -924,12 +969,14 @@ bb0:
 
 
 // CHECK-LABEL: CG of test_select_enum
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Arg %1 Esc: A, Succ:
-// CHECK-NEXT:    Arg %2 Esc: A, Succ:
-// CHECK-NEXT:    Arg %3 Esc: A, Succ:
-// CHECK-NEXT:    Val %4 Esc: R, Succ: %1, %2, %3
-// CHECK-NEXT:    Ret return Esc: R, Succ: %4
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %2 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %3 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %3.1 Esc: A, Succ: (%3.2)
+// CHECK-NEXT:    Con [ref] %3.2 Esc: A, Succ: 
+// CHECK-NEXT:    Val [ref] %4 Esc: , Succ: %1, %2, %3
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @test_select_enum : $@convention(thin) (PointerEnum2, @owned X, @owned X, @owned X) -> @owned X {
 bb0(%0 : $PointerEnum2, %1 : $X, %2 : $X, %3 : $X):
@@ -939,11 +986,13 @@ bb0(%0 : $PointerEnum2, %1 : $X, %2 : $X, %3 : $X):
 
 // CHECK-LABEL: CG of test_select_enum_addr
 // CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Arg %1 Esc: A, Succ:
-// CHECK-NEXT:    Arg %2 Esc: A, Succ:
-// CHECK-NEXT:    Arg %3 Esc: A, Succ:
-// CHECK-NEXT:    Val %4 Esc: R, Succ: %1, %2, %3
-// CHECK-NEXT:    Ret return Esc: R, Succ: %4
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: (%3.1)
+// CHECK-NEXT:    Arg [ref] %2 Esc: A, Succ: (%3.1)
+// CHECK-NEXT:    Arg [ref] %3 Esc: A, Succ: (%3.1)
+// CHECK-NEXT:    Con [int] %3.1 Esc: A, Succ: (%3.2)
+// CHECK-NEXT:    Con [ref] %3.2 Esc: A, Succ: 
+// CHECK-NEXT:    Val [ref] %4 Esc: , Succ: %1, %2, %3
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @test_select_enum_addr : $@convention(thin) (@in PointerEnum2, @owned X, @owned X, @owned X) -> @owned X {
 bb0(%0 : $*PointerEnum2, %1 : $X, %2 : $X, %3 : $X):
@@ -952,11 +1001,13 @@ bb0(%0 : $*PointerEnum2, %1 : $X, %2 : $X, %3 : $X):
 }
 
 // CHECK-LABEL: CG of test_select_value
-// CHECK-NEXT:    Arg %1 Esc: A, Succ:
-// CHECK-NEXT:    Arg %2 Esc: A, Succ:
-// CHECK-NEXT:    Arg %3 Esc: A, Succ:
-// CHECK-NEXT:    Val %6 Esc: R, Succ: %1, %2, %3
-// CHECK-NEXT:    Ret return Esc: R, Succ: %6
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %2 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %3 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %3.1 Esc: A, Succ: (%3.2)
+// CHECK-NEXT:    Con [ref] %3.2 Esc: A, Succ: 
+// CHECK-NEXT:    Val [ref] %6 Esc: , Succ: %1, %2, %3
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %6
 // CHECK-NEXT:  End
 sil @test_select_value : $@convention(thin) (Builtin.Int64, @owned X, @owned X, @owned X) -> @owned X {
 bb0(%0 : $Builtin.Int64, %1 : $X, %2 : $X, %3 : $X):
@@ -967,10 +1018,10 @@ bb0(%0 : $Builtin.Int64, %1 : $X, %2 : $X, %3 : $X):
 }
 
 // CHECK-LABEL: CG of test_existential_addr
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: 
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: 
 // CHECK-NEXT:    Val %1 Esc: , Succ: (%2)
 // CHECK-NEXT:    Con %2 Esc: , Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: , Succ: %0
+// CHECK-NEXT:    Con [ref] %2.1 Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @test_existential_addr : $@convention(thin) (@owned Pointer) -> () {
 bb0(%0 : $Pointer):
@@ -985,7 +1036,7 @@ bb0(%0 : $Pointer):
 }
 
 // CHECK-LABEL: CG of test_existential_ref
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
 // CHECK-NEXT:  End
 sil @test_existential_ref : $@convention(thin) (@owned X) -> () {
 bb0(%0 : $X):
@@ -1000,9 +1051,9 @@ bb0(%0 : $X):
 // Check that we don't crash on this.
 
 // CHECK-LABEL: CG of test_unknown_store
-// CHECK-NEXT:    Arg %0 Esc: G, Succ:
-// CHECK-NEXT:    Val %2 Esc: G, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: G, Succ: %0
+// CHECK-NEXT:    Arg [ref] %0 Esc: G, Succ:
+// CHECK-NEXT:    Val %2 Esc: , Succ: (%2.1)
+// CHECK-NEXT:    Con [ref] %2.1 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @test_unknown_store : $@convention(thin) (@owned ErrorClass) -> () {
 bb0(%0 : $ErrorClass):
@@ -1014,8 +1065,10 @@ bb0(%0 : $ErrorClass):
 }
 
 // CHECK-LABEL: CG of test_raw_pointer_to_ref
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %0
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: A, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @test_raw_pointer_to_ref : $@convention(thin) (@owned X) -> @owned X {
 bb0(%0 : $X):
@@ -1025,8 +1078,10 @@ bb0(%0 : $X):
 }
 
 // CHECK-LABEL: CG of test_bridge_object_to_ref
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %0
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: A, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @test_bridge_object_to_ref : $@convention(thin) (@owned X, Builtin.Word) -> @owned X {
 bb0(%0 : $X, %1 : $Builtin.Word):
@@ -1037,8 +1092,8 @@ bb0(%0 : $X, %1 : $Builtin.Word):
 
 // CHECK-LABEL: CG of test_address_to_pointer
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: %1
-// CHECK-NEXT:    Arg %1 Esc: A, Succ:
+// CHECK-NEXT:    Con [ref] %0.1 Esc: A, Succ: %1
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ:
 // CHECK-NEXT:  End
 sil @test_address_to_pointer : $@convention(thin) (@owned X) -> @out X {
 bb0(%0 : $*X, %1 : $X):
@@ -1050,8 +1105,10 @@ bb0(%0 : $*X, %1 : $X):
 }
 
 // CHECK-LABEL: CG of test_casts
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
-// CHECK-NEXT:    Ret return Esc: R, Succ: %0
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: 
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @test_casts : $@convention(thin) (@owned AnyObject) -> @owned X {
 bb0(%0 : $AnyObject):
@@ -1074,10 +1131,10 @@ bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
 sil_global @global_y : $SomeData
 
 // CHECK-LABEL: CG of test_node_merge_during_struct_inst
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: (%8)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%8)
 // CHECK-NEXT:    Val %1 Esc: G, Succ: (%8)
 // CHECK-NEXT:    Val %4 Esc: , Succ: (%8)
-// CHECK-NEXT:    Con %8 Esc: G, Succ: (%8), %1
+// CHECK-NEXT:    Con [ref] %8 Esc: G, Succ: (%8), %1
 // CHECK-NEXT:    Val %10 Esc: , Succ: %0, %4, %8
 // CHECK-NEXT:  End
 sil @test_node_merge_during_struct_inst : $@convention(thin) (Y) -> () {
@@ -1104,7 +1161,9 @@ bb0(%0 : $Y):
 }
 
 // CHECK-LABEL: CG of arraysemantics_is_native_no_typecheck
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @arraysemantics_is_native_no_typecheck : $@convention(thin) (Array<X>) -> () {
 bb0(%0 : $Array<X>):
@@ -1116,7 +1175,9 @@ bb0(%0 : $Array<X>):
 }
 
 // CHECK-LABEL: CG of arraysemantics_check_subscript
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @arraysemantics_check_subscript : $@convention(thin) (Array<X>) -> () {
 bb0(%0 : $Array<X>):
@@ -1133,7 +1194,9 @@ bb0(%0 : $Array<X>):
 }
 
 // CHECK-LABEL: CG of arraysemantics_check_index
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @arraysemantics_check_index : $@convention(thin) (Array<X>) -> () {
 bb0(%0 : $Array<X>):
@@ -1149,9 +1212,9 @@ bb0(%0 : $Array<X>):
 
 // CHECK-LABEL: CG of arraysemantics_get_element
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: %1.2
-// CHECK-NEXT:    Arg %1 Esc: A, Succ: ([rc] %1.1)
-// CHECK-NEXT:    Con [rc] %1.1 Esc: A, Succ: (%1.2)
+// CHECK-NEXT:    Con [ref] %0.1 Esc: A, Succ: %1.2
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: (%1.1)
+// CHECK-NEXT:    Con [int] %1.1 Esc: A, Succ: (%1.2)
 // CHECK-NEXT:    Con %1.2 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @arraysemantics_get_element : $@convention(thin) (Array<X>) -> @out X {
@@ -1170,6 +1233,7 @@ bb0(%io : $*X, %1 : $Array<X>):
 
 // CHECK-LABEL: CG of arraysemantics_make_mutable
 // CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:    Con [ref] %0.1 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @arraysemantics_make_mutable : $@convention(thin) (@inout Array<X>) -> () {
 bb0(%0 : $*Array<X>):
@@ -1181,9 +1245,10 @@ bb0(%0 : $*Array<X>):
 }
 
 // CHECK-LABEL: CG of arraysemantics_get_element_address
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %0.1)
-// CHECK-NEXT:    Con [rc] %0.1 Esc: A, Succ: 
-// CHECK-NEXT:    Val %4 Esc: , Succ: [rc] %0.1
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: 
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: 
+// CHECK-NEXT:    Val %4 Esc: , Succ: %0.1
 // CHECK-NEXT:  End
 sil @arraysemantics_get_element_address : $@convention(thin) (Array<X>) -> () {
 bb0(%0 : $Array<X>):
@@ -1198,7 +1263,9 @@ bb0(%0 : $Array<X>):
 }
 
 // CHECK-LABEL: CG of arraysemantics_get_count
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @arraysemantics_get_count : $@convention(thin) (Array<X>) -> () {
 bb0(%0 : $Array<X>):
@@ -1211,7 +1278,9 @@ bb0(%0 : $Array<X>):
 }
 
 // CHECK-LABEL: CG of arraysemantics_get_capacity
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @arraysemantics_get_capacity : $@convention(thin) (Array<X>) -> () {
 bb0(%0 : $Array<X>):
@@ -1225,12 +1294,14 @@ bb0(%0 : $Array<X>):
 
 // CHECK-LABEL: CG of arraysemantics_withUnsafeMutableBufferPointer
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: A, Succ: ([rc] %0.2)
-// CHECK-NEXT:    Con [rc] %0.2 Esc: A, Succ: (%0.3)
-// CHECK-NEXT:    Con %0.3 Esc: G, Succ: 
-// CHECK-NEXT:    Arg %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:    Con %1.1 Esc: G, Succ: 
-// CHECK-NEXT:    Val %3 Esc: %4, Succ: 
+// CHECK-NEXT:    Con [ref] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con [int] %0.2 Esc: A, Succ: (%0.3)
+// CHECK-NEXT:    Con [ref] %0.3 Esc: G, Succ: 
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: (%1.1)
+// CHECK-NEXT:    Con [int] %1.1 Esc: G, Succ: (%1.2)
+// CHECK-NEXT:    Con %1.2 Esc: G, Succ: 
+// CHECK-NEXT:    Val %3 Esc: , Succ: (%3.1)
+// CHECK-NEXT:    Con [ref] %3.1 Esc: %4, Succ: 
 // CHECK-NEXT: End
 sil @arraysemantics_withUnsafeMutableBufferPointer : $@convention(thin) (@inout Array<X>, @owned @callee_owned (@inout X) -> (@out (), @error Error)) -> () {
 bb(%0 : $*Array<X>, %1 : $@callee_owned (@inout X) -> (@out (), @error Error)):
@@ -1245,12 +1316,12 @@ bb(%0 : $*Array<X>, %1 : $@callee_owned (@inout X) -> (@out (), @error Error)):
 }
 
 // CHECK-LABEL: CG of arraysemantics_createUninitialized
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: 
-// CHECK-NEXT:    Val %2 Esc: R, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: R, Succ: %0
-// CHECK-NEXT:    Val %4 Esc: R, Succ: ([rc] %6)
-// CHECK-NEXT:    Con [rc] %6 Esc: R, Succ: %2
-// CHECK-NEXT:    Ret return Esc: R, Succ: %4
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: 
+// CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%6)
+// CHECK-NEXT:    Val [ref] %5 Esc: , Succ: %2
+// CHECK-NEXT:    Con [int] %6 Esc: R, Succ: (%6.1)
+// CHECK-NEXT:    Con %6.1 Esc: R, Succ: %0
+// CHECK-NEXT:    Ret [ref] return Esc: , Succ: %5
 // CHECK-NEXT:  End
 sil @arraysemantics_createUninitialized : $@convention(thin) (@owned X) -> @owned Array<X> {
 bb0(%0 : $X):
@@ -1284,11 +1355,17 @@ sil [_semantics "array.uninitialized"] @createUninitialized : $@convention(metho
 sil @swift_bufferAllocate : $@convention(thin) () -> @owned AnyObject
 
 // CHECK-LABEL: CG of semantics_pair_no_escaping_closure
-// CHECK-NEXT:   Arg %0 Esc: A, Succ:
-// CHECK-NEXT:   Arg %1 Esc: A, Succ:
-// CHECK-NEXT:   Arg %2 Esc: G, Succ: (%2.1)
-// CHECK-NEXT:   Con %2.1 Esc: G, Succ:
-// CHECK-NEXT:   Val %4 Esc: %5, Succ:
+// CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:   Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:   Con [ref] %0.2 Esc: A, Succ: 
+// CHECK-NEXT:   Arg [ref] %1 Esc: A, Succ:
+// CHECK-NEXT:   Con [int] %1.1 Esc: A, Succ: (%1.2)
+// CHECK-NEXT:   Con [ref] %1.2 Esc: A, Succ: 
+// CHECK-NEXT:   Arg [ref] %2 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:   Con [int] %2.1 Esc: G, Succ: (%2.2)
+// CHECK-NEXT:   Con %2.2 Esc: G, Succ: 
+// CHECK-NEXT:   Val %4 Esc: , Succ: (%4.1)
+// CHECK-NEXT:   Con [ref] %4.1 Esc: %5, Succ: 
 // CHECK-NEXT: End
 sil @semantics_pair_no_escaping_closure : $@convention(thin) (@owned X, @guaranteed X, @owned @callee_owned (X, X) -> (@out X, @error Error)) -> () {
 bb(%0 : $X, %1 : $X, %2: $@callee_owned (X, X) -> (@out X, @error Error)):
@@ -1301,10 +1378,14 @@ bb(%0 : $X, %1 : $X, %2: $@callee_owned (X, X) -> (@out X, @error Error)):
 }
 
 // CHECK-LABEL: CG of semantics_self_no_escaping_closure
-// CHECK-NEXT:   Arg %0 Esc: A, Succ:
-// CHECK-NEXT:   Arg %1 Esc: G, Succ: (%1.1)
-// CHECK-NEXT:   Con %1.1 Esc: G, Succ:
-// CHECK-NEXT:   Val %3 Esc: %4, Succ:
+// CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:   Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:   Con [ref] %0.2 Esc: A, Succ: 
+// CHECK-NEXT:   Arg [ref] %1 Esc: A, Succ: (%1.1)
+// CHECK-NEXT:   Con [int] %1.1 Esc: G, Succ: (%1.2)
+// CHECK-NEXT:   Con %1.2 Esc: G, Succ: 
+// CHECK-NEXT:   Val %3 Esc: , Succ:
+// CHECK-NEXT:   Con [ref] %3.1 Esc: %4, Succ: 
 // CHECK-NEXT: End
 sil @semantics_self_no_escaping_closure : $@convention(thin) (@guaranteed X, @owned @callee_owned (X, X) -> (@out X, @error Error)) -> () {
 bb(%0 : $X, %1: $@callee_owned (X, X) -> (@out X, @error Error)):
@@ -1317,7 +1398,7 @@ bb(%0 : $X, %1: $@callee_owned (X, X) -> (@out X, @error Error)):
 }
 
 // CHECK-LABEL: CG of check_dealloc_ref
-// CHECK-NEXT:   Arg %0 Esc: A, Succ:
+// CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ:
 // CHECK-NEXT:  End
 sil @check_dealloc_ref : $@convention(thin) (@owned X) -> () {
 bb0(%0 : $X):
@@ -1327,7 +1408,7 @@ bb0(%0 : $X):
 }
 
 // CHECK-LABEL: CG of check_set_deallocating
-// CHECK-NEXT:   Arg %0 Esc: A, Succ:
+// CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ:
 // CHECK-NEXT:  End
 sil @check_set_deallocating : $@convention(thin) (@owned X) -> () {
 bb0(%0 : $X):
@@ -1340,7 +1421,9 @@ bb0(%0 : $X):
 // happen due to strong_release and figure out that the object will not
 // globally escape.
 // CHECK-LABEL: CG of check_non_escaping_implicit_destructor_invocation_via_strong_release
-// CHECK-NEXT:   Val %0 Esc: %1, Succ:
+// CHECK-NEXT:    Val [ref] %0 Esc: , Succ:
+// CHECK-NEXT:    Con [int] %0.1 Esc: %1, Succ: (%0.2)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: %1, Succ: 
 // CHECK-NEXT:  End
 sil @check_non_escaping_implicit_destructor_invocation_via_strong_release : $@convention(thin) () -> () {
 bb0:
@@ -1355,7 +1438,9 @@ bb0:
 // happen due to strong_release and figure out that the object will not
 // globally escape.
 // CHECK-LABEL: CG of check_non_escaping_implicit_destructor_invocation_via_release_value
-// CHECK-NEXT:   Val %0 Esc: %1, Succ:
+// CHECK-NEXT:   Val [ref] %0 Esc: , Succ: (%0.1)
+// CHECK-NEXT:   Con [int] %0.1 Esc: %1, Succ: (%0.2)
+// CHECK-NEXT:   Con [ref] %0.2 Esc: %1, Succ: 
 // CHECK-NEXT:  End
 sil @check_non_escaping_implicit_destructor_invocation_via_release_value : $@convention(thin) () -> () {
 bb0:
@@ -1370,8 +1455,8 @@ bb0:
 // happen due to strong_release and figure out that the object will
 // globally escape.
 // CHECK-LABEL: CG of check_escaping_implicit_destructor_invocation_via_strong_release
-// CHECK-NEXT:    Val %0 Esc: %1, Succ: ([rc] %0.1)
-// CHECK-NEXT:    Con [rc] %0.1 Esc: %1, Succ: (%0.2)
+// CHECK-NEXT:    Val [ref] %0 Esc: , Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: %1, Succ: (%0.2)
 // CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
 // CHECK-NEXT:  End
 sil @check_escaping_implicit_destructor_invocation_via_strong_release : $@convention(thin) () -> () {
@@ -1387,8 +1472,8 @@ bb0:
 // happen due to strong_release and figure out that the object will
 // globally escape.
 // CHECK-LABEL: CG of check_escaping_implicit_destructor_invocation_via_release_value
-// CHECK-NEXT:    Val %0 Esc: %1, Succ: ([rc] %0.1)
-// CHECK-NEXT:    Con [rc] %0.1 Esc: %1, Succ: (%0.2)
+// CHECK-NEXT:    Val [ref] %0 Esc: , Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: %1, Succ: (%0.2)
 // CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
 // CHECK-NEXT:  End
 sil @check_escaping_implicit_destructor_invocation_via_release_value : $@convention(thin) () -> () {
@@ -1406,9 +1491,11 @@ bb0:
 // invoked by strong_release it would also determine that these objects
 // do not escape from the function.
 // CHECK-LABEL: CG of check_is_local_object_through_bb_args
-// CHECK-LABEL:  Val %2 Esc: %6,%7, Succ:
-// CHECK-LABEL:  Val %4 Esc: %6,%7, Succ:
-// CHECK-LABEL:  Val %6 Esc: %6,%7, Succ: %2, %4
+// CHECK-LABEL:  Val [ref] %2 Esc: , Succ: (%2.1)
+// CHECK-LABEL:  Con [int] %2.1 Esc: %7, Succ: (%2.2)
+// CHECK-LABEL:  Con [ref] %2.2 Esc: %7, Succ: 
+// CHECK-LABEL:  Val [ref] %4 Esc: , Succ: (%2.1)
+// CHECK-LABEL:  Val [ref] %6 Esc: , Succ: %2, %4
 // CHECK-LABEL: End
 sil @check_is_local_object_through_bb_args: $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
@@ -1429,7 +1516,10 @@ bb3(%6: $X):
 }
 
 // CHECK-LABEL: CG of check_look_through_thin_to_thick
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
+// CHECK-NEXT:    Val [ref] %1 Esc: , Succ: (%1.1)
+// CHECK-NEXT:    Con [int] %1.1 Esc: %2, Succ: (%1.2)
+// CHECK-NEXT:    Con %1.2 Esc: %2, Succ: 
 // CHECK-NEXT:  End
 sil @check_look_through_thin_to_thick: $(@convention(thin) () -> ()) -> () {
 bb0(%0 : $@convention(thin) () -> ()):
@@ -1441,7 +1531,7 @@ bb0(%0 : $@convention(thin) () -> ()):
 
 // X.deinit
 // CHECK-LABEL: CG of $s4main1XCfD
-// CHECK-NEXT:    Arg %0 Esc: A, Succ:
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
 // CHECK-NEXT:  End
 sil @$s4main1XCfD: $@convention(method) (@owned X) -> () {
 bb0(%0 : $X):
@@ -1452,11 +1542,11 @@ bb0(%0 : $X):
 
 // Z.deinit
 // CHECK-LABEL: CG of $s4main1ZCfD
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %1)
-// CHECK-NEXT:    Con [rc] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
+// CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%2)
 // CHECK-NEXT:    Con %2 Esc: G, Succ: 
-// CHECK-NEXT:    Val %3 Esc: G, Succ: (%3.1)
-// CHECK-NEXT:    Con %3.1 Esc: G, Succ: %2
+// CHECK-NEXT:    Val %3 Esc: , Succ: (%3.1)
+// CHECK-NEXT:    Con [ref] %3.1 Esc: G, Succ: %2
 // CHECK-NEXT:  End
 sil @$s4main1ZCfD: $@convention(method) (@owned Z) -> () {
 bb0(%0 : $Z):
@@ -1485,8 +1575,9 @@ bb0(%0 : $X):
 }
 
 // CHECK-LABEL: CG of call_public_external_func
-// CHECK-NEXT:    Val %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ: 
+// CHECK-NEXT:    Val [ref] %0 Esc: , Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: G, Succ: (%0.2)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: G, Succ: 
 // CHECK-NEXT:  End
 sil @call_public_external_func : $@convention(thin) () -> () {
 bb0:
@@ -1515,12 +1606,13 @@ bb2:
 // begin_apply result) is just marked as escaping.
 
 // CHECK-LABEL: CG of call_coroutine
-// CHECK-NEXT:    Val %0 Esc: G, Succ: (%0.1)
-// CHECK-NEXT:    Con %0.1 Esc: G, Succ: (%0.2)
+// CHECK-NEXT:    Val [ref] %0 Esc: , Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: G, Succ: (%0.2)
 // CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
-// CHECK-NEXT:    Val %2 Esc: G, Succ: (%2.1)
-// CHECK-NEXT:    Con %2.1 Esc: G, Succ: %4
-// CHECK-NEXT:    Val %4 Esc: G, Succ: 
+// CHECK-NEXT:    Con %0.3 Esc: G, Succ: 
+// CHECK-NEXT:    Val %2 Esc: , Succ: (%2.1)
+// CHECK-NEXT:    Con [ref] %2.1 Esc: G, Succ: %4
+// CHECK-NEXT:    Val [ref] %4 Esc: G, Succ: 
 // CHECK-NEXT:  End
 sil @call_coroutine : $@convention(thin) () -> () {
 bb0:
@@ -1537,14 +1629,14 @@ bb0:
 
 // Test the absence of redundant pointsTo edges
 // CHECK-LABEL: CG of testInitializePointsToLeaf
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %0.1)
-// CHECK-NEXT:    Con [rc] %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: ([rc] %13)
-// CHECK-NEXT:    Val %2 Esc: %4, Succ: %0.2
-// CHECK-NEXT:    Val %4 Esc: %4, Succ: %2
-// CHECK-NEXT:    Val %7 Esc: %12, Succ: ([rc] %13), %0.2
-// CHECK-NEXT:    Val %12 Esc: %12, Succ: ([rc] %13), %7
-// CHECK-NEXT:    Con [rc] %13 Esc: A, Succ: (%14)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%13)
+// CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%13), %0.2
+// CHECK-NEXT:    Val [ref] %4 Esc: , Succ: %2
+// CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%13), %0.2
+// CHECK-NEXT:    Val [ref] %12 Esc: , Succ: (%13), %7
+// CHECK-NEXT:    Con [int] %13 Esc: A, Succ: (%14)
 // CHECK-NEXT:    Con %14 Esc: A, Succ: 
 // CHECK-LABEL: End
 class C {
@@ -1593,14 +1685,14 @@ bb10(%arg2 : $LinkedNode):
 // a defer edge from a node with uninitialized pointsTo to a node with
 // already-initialized pointsTo.
 // CHECK-LABEL: CG of testInitializePointsToRedundant
-// CHECK-NEXT:    Arg %0 Esc: A, Succ: ([rc] %2)
-// CHECK-NEXT:    Arg %1 Esc: A, Succ: ([rc] %2)
-// CHECK-NEXT:    Con [rc] %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con [int] %2 Esc: A, Succ: (%3)
 // CHECK-NEXT:    Con %3 Esc: A, Succ: 
-// CHECK-NEXT:    Val %7 Esc: %7,%18, Succ: %0
-// CHECK-NEXT:    Val %12 Esc: %12,%14,%18, Succ: %1
-// CHECK-NEXT:    Val %14 Esc: %18, Succ: ([rc] %2), %1, %12
-// CHECK-NEXT:    Val %18 Esc: %18, Succ: %7, %14
+// CHECK-NEXT:    Val [ref] %7 Esc: , Succ: %0
+// CHECK-NEXT:    Val [ref] %12 Esc: , Succ: %1
+// CHECK-NEXT:    Val [ref] %14 Esc: , Succ: (%2), %1, %12
+// CHECK-NEXT:    Val [ref] %18 Esc: , Succ: %7, %14
 // CHECK-LABEL: End
 sil @testInitializePointsToMerge : $@convention(method) (@guaranteed C, @guaranteed C) -> C {
 bb0(%0: $C, %1 : $C):
@@ -1654,4 +1746,74 @@ bb9:
 bb10(%arg3 : $C):
   %66 = tuple ()
   return %66 : $()
+}
+
+// Test canEscapeToUsePoint with defer edges between non-reference-type nodes.
+//
+// Unfortunately, the only way I can think of to create defer edges
+// between non-reference nodes is with address-type block arguments.
+// This will be banned soon, so the test will need to be disabled, but
+// this is still an important corner case in the EscapeAnalysis
+// logic. To keep the test working, and be able to test many more
+// important corner cases, we should introduce testing modes that
+// introduce spurious but predictable defer edges and node merges.
+//
+// Here, canEscapeTo is called on %bbarg (%5) whose node is not
+// marked escaping. But it does have a defer edge to the local address
+// (%0) which does cause the address to escape via the call site.
+//
+// CHECK-LABEL: CG of testDeferPointer
+// CHECK-NEXT:   Val %0 Esc: , Succ: (%0.1)
+// CHECK-NEXT:   Con [ref] %0.1 Esc: G, Succ:
+// CHECK-NEXT:   Val %1 Esc: , Succ: (%0.1)
+// CHECK-NEXT:   Val %5 Esc: , Succ: %0, %1
+// CHECK-LABEL: End
+// CHECK: MayEscape: %5 = argument of bb3 : $*Builtin.Int32
+// CHECK-NEXT:  to   %{{.*}} = apply %{{.*}}(%0) : $@convention(thin) (@inout Builtin.Int32) -> ()
+sil @takeAdr : $@convention(thin) (@inout Builtin.Int32) -> ()
+
+sil hidden @testDeferPointer : $@convention(thin) () -> () {
+bb0:
+  %iadr1 = alloc_stack $Builtin.Int32
+  %iadr2 = alloc_stack $Builtin.Int32
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%iadr1: $*Builtin.Int32)
+
+bb2:
+  br bb3(%iadr2: $*Builtin.Int32)
+
+bb3(%bbarg: $*Builtin.Int32):
+  %val = integer_literal $Builtin.Int32, 1
+  store %val to %bbarg : $*Builtin.Int32
+  %ftake = function_ref @takeAdr : $@convention(thin) (@inout Builtin.Int32) -> ()
+  %call = apply %ftake(%iadr1) : $@convention(thin) (@inout Builtin.Int32) -> ()
+  dealloc_stack %iadr2 : $*Builtin.Int32
+  dealloc_stack %iadr1 : $*Builtin.Int32
+  %z = tuple ()
+  return %z : $()
+}
+
+// Test interior node (self) cycles.
+
+class IntWrapper {
+  var property: Int64
+}
+
+// CHECK-LABEL: CG of testInteriorCycle
+// CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ: (%2)
+// CHECK-NEXT:   Con [int] %2 Esc: G, Succ: (%2)
+// CHECK-NEXT:   Val %6 Esc: , Succ: %0, %2
+// CHECK-NEXT:   Ret return Esc: , Succ: %6
+// CHECK-LABEL: End
+sil @testInteriorCycle : $@convention(thin) (@owned IntWrapper) -> (Builtin.BridgeObject, UnsafeMutablePointer<Int64>) {
+bb0(%0 : $IntWrapper):
+  %bridge = unchecked_ref_cast %0 : $IntWrapper to $Builtin.BridgeObject
+  %adr = ref_tail_addr %0 : $IntWrapper, $Int64
+  %ptr = address_to_pointer %adr : $*Int64 to $Builtin.RawPointer
+  %ump = struct $UnsafeMutablePointer<Int64> (%ptr : $Builtin.RawPointer)
+  strong_release %0 : $IntWrapper
+  %tuple = tuple (%bridge : $Builtin.BridgeObject, %ump : $UnsafeMutablePointer<Int64>)
+  return %tuple : $(Builtin.BridgeObject, UnsafeMutablePointer<Int64>)
 }

--- a/test/SILOptimizer/escape_analysis_dead_store.sil
+++ b/test/SILOptimizer/escape_analysis_dead_store.sil
@@ -1,0 +1,138 @@
+// RUN: %target-sil-opt %s -dead-store-elim -enable-sil-verify-all | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+final class X {
+  init()
+}
+
+public struct S {
+  @_hasStorage var x: X { get set }
+  @_hasStorage var i: Int { get set }
+  init(x: X, i: Int)
+}
+
+@_hasStorage @_hasInitialValue var gg: X { get set }
+
+@inline(never) func takex(_ x: X)
+
+sil [noinline] @takeX : $@convention(thin) (@guaranteed X) -> ()
+
+// Test that escape analysis does not consider an inout argument to
+// escape at a call site even though it's reference-type field does
+// escape. Dead store elimination asks MemoryBehaviorVisitor whether
+// the apply may read from the inout argument. This call into
+// canEscapeToUsePoint, which should return false because the inout
+// structure itself is not exposed to the call, only it's
+// reference-type field is.
+//
+// CHECK-LABEL: sil @testInoutNoEscape
+// CHECK-NOT: store
+// CHECK:     apply
+// CHECK:     store
+// CHECK-NOT: store
+// CHECK:    } // end sil function 'testInoutNoEscape'
+sil @testInoutNoEscape : $@convention(thin) (@inout S, @guaranteed S) -> () {
+bb0(%0 : $*S, %1 : $S):
+  %4 = struct_extract %1 : $S, #S.x
+  %5 = struct_element_addr %0 : $*S, #S.x
+  %6 = load %5 : $*X
+  strong_retain %4 : $X
+  strong_release %6 : $X
+  store %1 to %0 : $*S
+  %10 = function_ref @takeX : $@convention(thin) (@guaranteed X) -> ()
+  strong_retain %4 : $X
+  %12 = apply %10(%4) : $@convention(thin) (@guaranteed X) -> ()
+  release_value %1 : $S
+  store %1 to %0 : $*S
+  %15 = tuple ()
+  return %15 : $()
+}
+
+// =============================================================================
+// Test that a store writing back into a container is not eliminated
+// when the container's interior pointer later escapes into a function
+// that reads from the pointer.
+
+final internal class TestArrayContainer {
+  @_hasStorage @_hasInitialValue internal final var pointer: UnsafeMutablePointer<Int32> { get set }
+  @_hasStorage @_hasInitialValue internal final var storage: ContiguousArray<Int32> { get set }
+  @_optimize(none) @inline(never) internal final func append(_ arg: Int32)
+  internal final func va_list() -> UnsafeMutableRawPointer
+  init()
+}
+
+sil @UnsafeMutablePointer_load_Int64 : $@convention(method) (Int64, UnsafeMutableRawPointer) -> Optional<UnsafeMutablePointer<Int32>> // user: %5
+// ContiguousArray.append(_:)
+sil @$ss15ContiguousArrayV6appendyyxnF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout ContiguousArray<τ_0_0>) -> ()
+
+
+// Helper that reads from a raw pointer.
+sil hidden [noinline] @takeRawPtr : $@convention(thin) (UnsafeMutableRawPointer) -> Bool {
+bb0(%0 : $UnsafeMutableRawPointer):
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = struct $Int64 (%1 : $Builtin.Int64)
+  %3 = function_ref @UnsafeMutablePointer_load_Int64 : $@convention(method) (Int64, UnsafeMutableRawPointer) -> Optional<UnsafeMutablePointer<Int32>>
+  %4 = apply %3(%2, %0) : $@convention(method) (Int64, UnsafeMutableRawPointer) -> Optional<UnsafeMutablePointer<Int32>> // users: %18, %6
+  %5 = integer_literal $Builtin.Int1, -1
+  %6 = struct $Bool (%5 : $Builtin.Int1)
+  return %6 : $Bool
+}
+
+// TestArrayContainer.append(_:)
+// Helper that produces a nonempty array.
+sil hidden [noinline] [Onone] @TestArrayContainer_append : $@convention(method) (Int32, @guaranteed TestArrayContainer) -> () {
+bb0(%0 : $Int32, %1 : $TestArrayContainer):
+  %2 = alloc_stack $Int32
+  store %0 to %2 : $*Int32
+  %4 = ref_element_addr %1 : $TestArrayContainer, #TestArrayContainer.storage
+  %5 = function_ref @$ss15ContiguousArrayV6appendyyxnF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout ContiguousArray<τ_0_0>) -> ()
+  %6 = apply %5<Int32>(%2, %4) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout ContiguousArray<τ_0_0>) -> ()
+  dealloc_stack %2 : $*Int32
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil [noinline] @testContainerPointer : $@convention(thin) () -> Bool {
+// CHECK: [[ALLOC:%.*]] = alloc_ref [stack] $TestArrayContainer
+// CHECK: [[PTR:%.*]] = ref_element_addr %0 : $TestArrayContainer, #TestArrayContainer.pointer
+// CHECK: [[LOAD:%.*]] = load %{{.*}} : $*__ContiguousArrayStorageBase
+// CHECK: [[ELTS:%.*]] = ref_tail_addr [[LOAD]] : $__ContiguousArrayStorageBase, $Int32
+// CHECK: [[ELTPTR:%.*]] = address_to_pointer [[ELTS]] : $*Int32 to $Builtin.RawPointer
+// CHECK: [[UMP:%.*]] = struct $UnsafeMutablePointer<Int32> ([[ELTPTR]] : $Builtin.RawPointer)
+// CHECK: store [[UMP]] to [[PTR]] : $*UnsafeMutablePointer<Int32>
+// CHECK: [[F:%.*]] = function_ref @takeRawPtr : $@convention(thin) (UnsafeMutableRawPointer) -> Bool
+// CHECK: apply [[F]](%{{.*}}) : $@convention(thin) (UnsafeMutableRawPointer) -> Bool
+// CHECK: fix_lifetime %0 : $TestArrayContainer
+// CHECK-LABEL: } // end sil function 'testContainerPointer'
+sil [noinline] @testContainerPointer : $@convention(thin) () -> Bool {
+bb0:
+  %0 = alloc_ref [stack] $TestArrayContainer
+  %1 = ref_element_addr %0 : $TestArrayContainer, #TestArrayContainer.pointer
+  %2 = ref_element_addr %0 : $TestArrayContainer, #TestArrayContainer.storage
+  %3 = integer_literal $Builtin.Int32, 42
+  %4 = struct $Int32 (%3 : $Builtin.Int32)
+  %5 = function_ref @TestArrayContainer_append : $@convention(method) (Int32, @guaranteed TestArrayContainer) -> ()
+  %6 = apply %5(%4, %0) : $@convention(method) (Int32, @guaranteed TestArrayContainer) -> ()
+  %7 = struct_element_addr %2 : $*ContiguousArray<Int32>, #ContiguousArray._buffer
+  %8 = struct_element_addr %7 : $*_ContiguousArrayBuffer<Int32>, #_ContiguousArrayBuffer._storage
+  %9 = load %8 : $*__ContiguousArrayStorageBase
+  %10 = ref_tail_addr %9 : $__ContiguousArrayStorageBase, $Int32
+  %11 = address_to_pointer %10 : $*Int32 to $Builtin.RawPointer
+  %12 = struct $UnsafeMutablePointer<Int32> (%11 : $Builtin.RawPointer)
+  store %12 to %1 : $*UnsafeMutablePointer<Int32>
+  %14 = address_to_pointer %1 : $*UnsafeMutablePointer<Int32> to $Builtin.RawPointer
+  %15 = struct $UnsafeMutableRawPointer (%14 : $Builtin.RawPointer)
+  %16 = function_ref @takeRawPtr : $@convention(thin) (UnsafeMutableRawPointer) -> Bool
+  %17 = apply %16(%15) : $@convention(thin) (UnsafeMutableRawPointer) -> Bool
+  fix_lifetime %0 : $TestArrayContainer
+  set_deallocating %0 : $TestArrayContainer
+  strong_release %9 : $__ContiguousArrayStorageBase
+  dealloc_ref %0 : $TestArrayContainer
+  dealloc_ref [stack] %0 : $TestArrayContainer
+  return %17 : $Bool
+}

--- a/test/SILOptimizer/sil_combine_concrete_existential.swift
+++ b/test/SILOptimizer/sil_combine_concrete_existential.swift
@@ -101,7 +101,7 @@ struct SS: PPP {
 // CHECK-LABEL: } // end sil function '$s32sil_combine_concrete_existential37testWitnessReturnOptionalIndirectSelfyyF'
 public func testWitnessReturnOptionalIndirectSelf() {
   let p: PPP = S()
-  p.returnsOptionalIndirect()?.returnsOptionalIndirect()
+  _ = p.returnsOptionalIndirect()?.returnsOptionalIndirect()
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This is an obvious two line fix that I meant to get checked in before these commits were reverted. I'm including a SIL test case. It's unclear why source compat testing didn't catch the original PR.
