### PR TITLE
Emit swiftmodule as intermediate file even if it's top level output

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2437,9 +2437,15 @@ static StringRef getOutputFilename(Compilation &C,
   const OutputInfo &OI = C.getOutputInfo();
   const llvm::opt::DerivedArgList &Args = C.getArgs();
 
+  // When emit output file as top level, we should use output file name
+  // specified by -o option.
   bool ShouldUseDefaultFileName = AtTopLevel;
 
   if (isa<MergeModuleJobAction>(JA)) {
+    // For merge-module action, we should respect how module output should
+    // be treated. When there is no -emit-module-path option and driver
+    // requests not to treat module as top level output, we should compute
+    // output file name from BaseName.
     ShouldUseDefaultFileName = OI.ShouldTreatModuleAsTopLevelOutput;
     auto optFilename = getOutputFilenameFromPathArgOrAsTopLevel(
         OI, Args, options::OPT_emit_module_path, file_types::TY_SwiftModuleFile,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2418,7 +2418,7 @@ static StringRef getOutputFilename(Compilation &C,
                                    const JobAction *JA,
                                    const TypeToPathMap *OutputMap,
                                    StringRef workingDirectory,
-                                   bool AtTopLevel,
+                                   const bool AtTopLevel,
                                    StringRef BaseInput,
                                    StringRef PrimaryInput,
                                    llvm::SmallString<128> &Buffer) {
@@ -2437,7 +2437,10 @@ static StringRef getOutputFilename(Compilation &C,
   const OutputInfo &OI = C.getOutputInfo();
   const llvm::opt::DerivedArgList &Args = C.getArgs();
 
+  bool ShouldUseDefaultFileName = AtTopLevel;
+
   if (isa<MergeModuleJobAction>(JA)) {
+    ShouldUseDefaultFileName = OI.ShouldTreatModuleAsTopLevelOutput;
     auto optFilename = getOutputFilenameFromPathArgOrAsTopLevel(
         OI, Args, options::OPT_emit_module_path, file_types::TY_SwiftModuleFile,
         OI.ShouldTreatModuleAsTopLevelOutput, workingDirectory, Buffer);
@@ -2464,7 +2467,7 @@ static StringRef getOutputFilename(Compilation &C,
 
   // We don't have an output from an Action-specific command line option,
   // so figure one out using the defaults.
-  if (AtTopLevel) {
+  if (ShouldUseDefaultFileName) {
     if (Arg *FinalOutput = Args.getLastArg(options::OPT_o))
       return FinalOutput->getValue();
     if (file_types::isTextual(JA->getType()))

--- a/test/Driver/merge-module.swift
+++ b/test/Driver/merge-module.swift
@@ -10,11 +10,13 @@
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix TWO-OUTPUTS %s < %t.complex.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -c %s -emit-objc-header -o sdk.foo.out 2>&1 > %t.complex.txt
+// RUN: %swiftc_driver -driver-print-jobs -c %s -emit-module -module-name sdk -emit-objc-header 2>&1 > %t.complex.txt
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix THREE-OUTPUTS %s < %t.complex.txt
 
 // RUN: %swiftc_driver -emit-module -driver-print-jobs -driver-filelist-threshold=0 %s %S/../Inputs/empty.swift -module-name main 2>&1 | %FileCheck -check-prefix FILELISTS %s
+
+// RUN: %swiftc_driver -emit-library -emit-module-interface -driver-print-jobs -static -o libModule.a %s | %FileCheck -check-prefix EMIT-LIBRARY %s
 
 // CHECK: {{bin(/|\\\\)swiftc?(\.exe)?"?}} -frontend
 // CHECK: -module-name {{[^ ]+}}
@@ -66,8 +68,8 @@
 // THREE-OUTPUTS: -o {{[^ ]*[/\\]}}merge-module-{{[^ ]*}}.o
 // THREE-OUTPUTS: {{bin(/|\\\\)swiftc?(\.exe)?"?}} -frontend
 // THREE-OUTPUTS: -emit-module [[MODULE]]
-// THREE-OUTPUTS: -emit-objc-header-path sdk.foo.h
-// THREE-OUTPUTS: -o sdk.foo.out
+// THREE-OUTPUTS: -emit-objc-header-path sdk.h
+// THREE-OUTPUTS: -o sdk.swiftmodule
 
 
 // FILELISTS: {{bin(/|\\\\)swiftc?(\.exe)?"?}} -frontend
@@ -78,6 +80,7 @@
 // FILELISTS-NOT: .swiftmodule
 // FILELISTS: -o {{[^ ]+}}
 
+// EMIT-LIBRARY-NOT: {{bin(/|\\\\)swiftc?(\.exe)?"?}} -frontend -merge-modules {{.*}} -o lib{{[^ ]*}}.a
 
 // RUN: %swiftc_driver -driver-print-jobs -emit-module %S/Inputs/main.swift %S/Inputs/lib.swift -module-name merge -o /tmp/modules > %t.complex.txt
 // RUN: %FileCheck %s < %t.complex.txt


### PR DESCRIPTION
`ShouldTreatModuleAsTopLevelOutput` is set to false when using `-emit-module-interface`, so we expect that the output file should be temporary.
But since the emit-module job is top level, `getOutputFilename` infers that the file is specified by `-o`. 
So I changed to infer the file name as temporary file if `ShouldTreatModuleAsTopLevelOutput` is false.


This bug can be problem when using `-static`, `-emit-module-interface`, `-emit-library` and `-o` on Linux.

```swift
$ touch Module.swift
$ swiftc Module.swift -static -emit-library -emit-module-interface -o libModule.a -v
Swift version 5.1-dev (LLVM c5340df2d1, Swift 768ac78cb0)
Target: x86_64-unknown-linux-gnu
/home/katei/swift-source/build/Ninja-DebugAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file Module.swift -emit-module-path /tmp/Module-67124f.swiftmodule -emit-module-doc-path /tmp/Module-67124f.swiftdoc -target x86_64-unknown-linux-gnu -disable-objc-interop -color-diagnostics -static -parse-as-library -module-name Module -o /tmp/Module-67124f.o
/home/katei/swift-source/build/Ninja-DebugAssert/swift-linux-x86_64/bin/swift -frontend -merge-modules -emit-module /tmp/Module-67124f.swiftmodule -parse-as-library -sil-merge-partial-modules -disable-diagnostic-passes -disable-sil-perf-optzns -target x86_64-unknown-linux-gnu -disable-objc-interop -color-diagnostics -static -emit-module-doc-path libModule.swiftdoc -emit-module-interface-path Module.swiftinterface -module-name Module -o libModule.a
<unknown>:0: warning: module interfaces are only supported with -enable-library-evolution
/home/katei/swift-source/build/Ninja-DebugAssert/swift-linux-x86_64/bin/swift-autolink-extract /tmp/Module-67124f.o -o /tmp/Module-16bebe.autolink
/usr/bin/ar crs libModule.a /tmp/Module-67124f.o
/usr/bin/ar: libModule.a: file format not recognized
<unknown>:0: error: static-link command failed with exit code 1 (use -v to see invocation)

```

