### PR TITLE
[Driver] Add unversioned triple to the output of -print-target-info.

### DIFF
--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -91,7 +91,9 @@ namespace swift {
   /// llvm::Triple::normalize() would not affect it.
   llvm::Triple getTargetSpecificModuleTriple(const llvm::Triple &triple);
   
-  
+  /// Computes the target triple without version information.
+  llvm::Triple getUnversionedTriple(const llvm::Triple &triple);
+
   /// Get the Swift runtime version to deploy back to, given a deployment target expressed as an
   /// LLVM target triple.
   Optional<llvm::VersionTuple>

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -342,6 +342,20 @@ llvm::Triple swift::getTargetSpecificModuleTriple(const llvm::Triple &triple) {
   return triple;
 }
 
+llvm::Triple swift::getUnversionedTriple(const llvm::Triple &triple) {
+  StringRef unversionedOSName = triple.getOSName().take_until(llvm::isDigit);
+  if (triple.getEnvironment()) {
+    StringRef environment =
+        llvm::Triple::getEnvironmentTypeName(triple.getEnvironment());
+
+    return llvm::Triple(triple.getArchName(), triple.getVendorName(),
+                        unversionedOSName, environment);
+  }
+
+  return llvm::Triple(triple.getArchName(), triple.getVendorName(),
+                      unversionedOSName);
+}
+
 Optional<llvm::VersionTuple>
 swift::getSwiftRuntimeCompatibilityVersionForTarget(
     const llvm::Triple &Triple) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1880,6 +1880,10 @@ static void printTargetInfo(CompilerInvocation &invocation,
   out.write_escaped(langOpts.Target.getTriple());
   out << "\",\n";
 
+  out << "    \"unversionedTriple\": \"";
+  out.write_escaped(getUnversionedTriple(langOpts.Target).getTriple());
+  out << "\",\n";
+
   out << "    \"moduleTriple\": \"";
   out.write_escaped(getTargetSpecificModuleTriple(langOpts.Target).getTriple());
   out << "\",\n";

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -6,6 +6,7 @@
 
 // CHECK-IOS:   "target": {
 // CHECK-IOS:     "triple": "arm64-apple-ios12.0",
+// CHECK-IOS:     "unversionedTriple": "arm64-apple-ios",
 // CHECK-IOS:     "moduleTriple": "arm64-apple-ios",
 // CHECK-IOS:     "swiftRuntimeCompatibilityVersion": "5.0",
 // CHECK-IOS:     "librariesRequireRPath": true

--- a/test/Driver/print_target_info_macos.swift
+++ b/test/Driver/print_target_info_macos.swift
@@ -7,4 +7,5 @@
 
 // REQUIRES: OS=macosx
 
-// CHECK: "triple": "x86_64-apple-macosx
+// CHECK: "triple": "x86_64-apple-macosx10
+// CHECK: "unversionedTriple": "x86_64-apple-macosx"


### PR DESCRIPTION
SwiftPM wants to use the unversioned triple to know where to put
results. Vend this as part of `-print-target-info`. It'll come out as something like:

     "unversionedTriple": "x86_64-apple-macosx"

