### PR TITLE
[ownership] Allow mark_uninitialized to only take owned/none ownership parameters.

### DIFF
--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -333,7 +333,6 @@ FORWARD_ANY_OWNERSHIP_INST(ConvertFunction)
 FORWARD_ANY_OWNERSHIP_INST(RefToBridgeObject)
 FORWARD_ANY_OWNERSHIP_INST(BridgeObjectToRef)
 FORWARD_ANY_OWNERSHIP_INST(UnconditionalCheckedCast)
-FORWARD_ANY_OWNERSHIP_INST(MarkUninitialized)
 FORWARD_ANY_OWNERSHIP_INST(UncheckedEnumData)
 FORWARD_ANY_OWNERSHIP_INST(DestructureStruct)
 FORWARD_ANY_OWNERSHIP_INST(DestructureTuple)
@@ -355,6 +354,8 @@ FORWARD_ANY_OWNERSHIP_INST(DestructureTuple)
   }
 FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, MustBeLive, TupleExtract)
 FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, MustBeLive, StructExtract)
+FORWARD_CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, MustBeInvalidated,
+                                        MarkUninitialized)
 #undef CONSTANT_OR_NONE_OWNERSHIP_INST
 
 OperandOwnershipKindMap

--- a/lib/SIL/ValueOwnership.cpp
+++ b/lib/SIL/ValueOwnership.cpp
@@ -157,7 +157,8 @@ CONSTANT_OWNERSHIP_INST(Unowned, ValueToBridgeObject)
 #define CONSTANT_OR_NONE_OWNERSHIP_INST(OWNERSHIP, INST)                       \
   ValueOwnershipKind ValueOwnershipKindClassifier::visit##INST##Inst(          \
       INST##Inst *I) {                                                         \
-    if (I->getType().isTrivial(*I->getFunction())) {                           \
+    if (I->getType().isTrivial(*I->getFunction()) ||                           \
+        I->getType().isAddress()) {                                            \
       return ValueOwnershipKind::None;                                         \
     }                                                                          \
     return ValueOwnershipKind::OWNERSHIP;                                      \
@@ -173,6 +174,12 @@ CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, TupleExtract)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, OpenExistentialValue)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, OpenExistentialBoxValue)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, UnconditionalCheckedCastValue)
+
+// Given an owned value, mark_uninitialized always forwards an owned value since
+// we want to make sure that all destroys of that value must come through the
+// mark_uninitialized (which will happen due to mark_uninitialized consuming the
+// value).
+CONSTANT_OR_NONE_OWNERSHIP_INST(Owned, MarkUninitialized)
 
 // unchecked_bitwise_cast is a bitwise copy. It produces a trivial or unowned
 // result.
@@ -249,7 +256,6 @@ FORWARDING_OWNERSHIP_INST(Tuple)
 FORWARDING_OWNERSHIP_INST(UncheckedRefCast)
 FORWARDING_OWNERSHIP_INST(UnconditionalCheckedCast)
 FORWARDING_OWNERSHIP_INST(Upcast)
-FORWARDING_OWNERSHIP_INST(MarkUninitialized)
 FORWARDING_OWNERSHIP_INST(UncheckedEnumData)
 FORWARDING_OWNERSHIP_INST(SelectEnum)
 FORWARDING_OWNERSHIP_INST(Enum)

--- a/test/SIL/ownership-verifier/undef.sil
+++ b/test/SIL/ownership-verifier/undef.sil
@@ -20,9 +20,9 @@ struct MyInt {
 // CHECK-NEXT: Operand Ownership Map:
 // CHECK-NEXT: Op #: 0
 // CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
-// CHECK-NEXT: unowned:  Yes. Liveness: MustBeLive
-// CHECK-NEXT: owned: Yes. Liveness: MustBeLive
-// CHECK-NEXT: guaranteed:  Yes. Liveness: MustBeLive
+// CHECK-NEXT: unowned:  No.
+// CHECK-NEXT: owned: Yes. Liveness: MustBeInvalidated
+// CHECK-NEXT: guaranteed:  No.
 // CHECK-NEXT: any: Yes. Liveness: MustBeLive
 // CHECK: Visiting: {{.*}}%1 = mark_uninitialized [var] undef : $Klass
 // CHECK-NEXT: Operand Ownership Map:
@@ -36,9 +36,9 @@ struct MyInt {
 // CHECK-NEXT: Operand Ownership Map:
 // CHECK-NEXT: Op #: 0
 // CHECK-NEXT: Ownership Map: -- OperandOwnershipKindMap --
-// CHECK-NEXT: unowned:  Yes. Liveness: MustBeLive
-// CHECK-NEXT: owned: Yes. Liveness: MustBeLive
-// CHECK-NEXT: guaranteed:  Yes. Liveness: MustBeLive
+// CHECK-NEXT: unowned:  No.
+// CHECK-NEXT: owned: Yes. Liveness: MustBeInvalidated
+// CHECK-NEXT: guaranteed:  No.
 // CHECK-NEXT: any: Yes. Liveness: MustBeLive
 // CHECK: Visiting: {{.*}}%4 = struct $MyInt (undef : $Builtin.Int32)
 // CHECK-NEXT: Operand Ownership Map:


### PR DESCRIPTION
More explicitly, this disallows guaranteed values to be passed to
mark_uninitialized. From the perspective of OSSA, it only makes sense for
mark_uninitialized to consume its incoming parameter since we want the
underlying allocated value to have its "entire" lifetime "funnel" through the
mark_uninitialized.

Since if the input value is none, we still accept it, all mark_uninitialized on
pointers will not be affected by this.

NOTE: Today, mark_uninitialized can not even accept a borrow parameter (we
severely restrict what parameters it can take). So I can not actually even write
a test for this today since the verifier will run after parsing and assert. But
from a modeling perspective and from the perspective of not creating confusion,
specifying the ownership of mark_uninitialized more explicitly is good.

Given the note above this should actually be NFC since none of that specific set of instructions provide a guaranteed value. But future proofing/explicitness are overall good.
