### PR TITLE
[AutoDiff] factor derivative typechecking helper out of AttributeChecker

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -290,7 +290,7 @@ public:
   // derivative function configurations per original `AbstractFunctionDecl`.
   llvm::DenseMap<
       std::tuple<Decl *, IndexSubset *, AutoDiffDerivativeFunctionKind>,
-      DerivativeAttr *>
+      llvm::SmallPtrSet<DerivativeAttr *, 1>>
       DerivativeAttrs;
 
 private:


### PR DESCRIPTION
In order to allow a `@derivative` in one file to define the derivative of a function in another file, we nned to calculate the derivative configurations of all the `@derivative` attributes in the module, not just those in the primary file (see https://github.com/apple/swift/pull/28790 for a work in progress of this).

`AttributeChecker::visitDerivativeAttr` is the function that does the necessary calculation, so this PR factors it into a separate function that others can call to do the calculation. This PR makes a few changes to the logic:
* `ASTContext::DerivativeAttrs` now stores a set of all attributes per configuration, because otherwise you get buggy order-dependent behavior in the duplicate attr check when you call `typeCheckDerivativeAttr` multiple times per attribute.
* `typeCheckDerivativeAttr` returns a boolean indicating error instead of calling `attr->setInvalid()` so that non-`AttributeChecker` callers can leave `attr->setInvalid()` to the `AttributeChecker`.

Note: This PR makes the `AttributeChecker` no longer use `diagnoseAndRemoveAttr()`, so you don't get a "fixItRemove" on the diagnostics any more. Keeping it would make the refactoring a bit more complicated, and I don't think it's that valuable to keep, because in many of the error cases removing the attribute isn't really the right way to fix things.