### PR TITLE
[test] Mark _Differentiable tests as unsupported in Swift-in-the-OS configurations

### DIFF
--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend-typecheck -enable-experimental-differentiable-programming -verify %s
 // REQUIRES: differentiable_programming
 
+// We currently lack availability information (rdar://57975086)
+// UNSUPPORTED: use_os_stdlib
+
 import _Differentiation
 
 // Test top-level functions.

--- a/test/AutoDiff/Serialization/derivative_attr.swift
+++ b/test/AutoDiff/Serialization/derivative_attr.swift
@@ -7,6 +7,9 @@
 
 // REQUIRES: differentiable_programming
 
+// We currently lack availability information (rdar://57975086)
+// UNSUPPORTED: use_os_stdlib
+
 import _Differentiation
 
 // Dummy `Differentiable`-conforming type.

--- a/test/AutoDiff/Serialization/differentiable_attr.swift
+++ b/test/AutoDiff/Serialization/differentiable_attr.swift
@@ -4,6 +4,9 @@
 // RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/differentiable_attr.swiftmodule -o - | %FileCheck %s
 // REQUIRES: differentiable_programming
 
+// We currently lack availability information (rdar://57975086)
+// UNSUPPORTED: use_os_stdlib
+
 // TODO(TF-836): Enable this test.
 // Blocked by TF-828: `@differentiable` attribute type-checking.
 // XFAIL: *

--- a/test/AutoDiff/Serialization/transpose_attr.swift
+++ b/test/AutoDiff/Serialization/transpose_attr.swift
@@ -6,6 +6,9 @@
 // BCANALYZER-NOT: UnknownCode
 // REQUIRES: differentiable_programming
 
+// We currently lack availability information (rdar://57975086)
+// UNSUPPORTED: use_os_stdlib
+
 // TODO(TF-838): Enable this test.
 // Blocked by TF-830: `@transpose` attribute type-checking.
 // XFAIL: *

--- a/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
+++ b/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
@@ -2,6 +2,9 @@
 // REQUIRES: executable_test
 // REQUIRES: differentiable_programming
 
+// We currently lack availability information (rdar://57975086)
+// UNSUPPORTED: use_os_stdlib
+
 import _Differentiation
 
 // Test `Differentiable` protocol conformances for stdlib types.


### PR DESCRIPTION
The new _Differentiable module is not available in any shipping OS release, but its public API currently doesn’t have availability, either.

Temporarily disable tests that import it when we’re testing with OS-provided libraries.

The typecheck test test/AutoDiff/stdlib/differentiable_protocol.swift imports _Differentable but still somehow succeeds in these configs, so leave that one enabled.

rdar://57975086
