### PR TITLE
[Clang importer] objc_direct methods/properties are unavailable in Swift

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7555,6 +7555,15 @@ void ClangImporter::Implementation::importAttributes(
     }
   }
 
+  if (auto method = dyn_cast<clang::ObjCMethodDecl>(ClangDecl)) {
+    if (method->isDirectMethod() && !AnyUnavailable) {
+      auto attr = AvailableAttr::createPlatformAgnostic(
+          C, "", "", PlatformAgnosticAvailabilityKind::UnavailableInSwift);
+      MappedDecl->getAttrs().add(attr);
+      AnyUnavailable = true;
+    }
+  }
+
   // If the declaration is unavailable, we're done.
   if (AnyUnavailable)
     return;

--- a/test/ClangImporter/Inputs/objc_direct.h
+++ b/test/ClangImporter/Inputs/objc_direct.h
@@ -1,0 +1,12 @@
+@interface Bar
+@property (readonly, direct, nonatomic) int directProperty;
+- (void)directMethod __attribute__((objc_direct));
++ (void)directClassMethod __attribute__((objc_direct));
+@end
+
+__attribute__((objc_direct_members))
+@interface Bar ()
+@property (readonly, nonatomic) int directProperty2;
+- (void)directMethod2;
++ (void)directClassMethod2;
+@end

--- a/test/ClangImporter/objc_direct.swift
+++ b/test/ClangImporter/objc_direct.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend-verify -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/objc_direct.h -verify-ignore-unknown
+
+// REQUIRES: objc_interop
+
+func callThingsOnBar(_ x: Bar) {
+  let _ = x.directProperty  // expected-error {{getter for 'directProperty' is unavailable in Swift}}
+  let _ = x.directProperty2 // expected-error {{getter for 'directProperty2' is unavailable in Swift}}
+
+  x.directMethod() // expected-error {{'directMethod()' is unavailable in Swift}}
+  x.directMethod2() // expected-error {{'directMethod2()' is unavailable in Swift}}
+
+  Bar.directClassMethod() // expected-error {{'directClassMethod()' is unavailable in Swift}}
+  Bar.directClassMethod2() // expected-error {{'directClassMethod2()' is unavailable in Swift}}
+}


### PR DESCRIPTION
`objc_direct` methods and properties cannot be used from Swift, so mark them
as unavailable in the importer.

Fixes rdar://problem/57287895
