### PR TITLE
[AutoDiff] Array literal differentiation fixes.

### DIFF
--- a/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
@@ -274,6 +274,20 @@ private:
   void addToAdjointBuffer(SILBasicBlock *origBB, SILValue originalBuffer,
                           SILValue rhsBufferAccess, SILLocation loc);
 
+  /// Given the adjoint value of an array initialized from an
+  /// `array.uninitialized_intrinsic` application and an array element index,
+  /// returns an `alloc_stack` containing the adjoint value of the array element
+  /// at the given index by applying `Array.TangentVector.subscript`.
+  AllocStackInst *getArrayAdjointElementBuffer(SILValue arrayAdjoint,
+                                               int eltIndex, SILLocation loc);
+
+  /// Given the adjoint value of an array initialized from an
+  /// `array.uninitialized_intrinsic` application, accumulate the adjoint
+  /// value's elements into the adjoint buffers of its element addresses.
+  void accumulateArrayLiteralElementAddressAdjoints(
+      SILBasicBlock *origBB, SILValue originalValue,
+      AdjointValue arrayAdjointValue, SILLocation loc);
+
   //--------------------------------------------------------------------------//
   // CFG mapping
   //--------------------------------------------------------------------------//
@@ -321,25 +335,6 @@ public:
   void visit(SILInstruction *inst);
 
   void visitSILInstruction(SILInstruction *inst);
-
-  /// Given an array adjoint value, array element index and element tangent
-  /// type, returns an `alloc_stack` containing the array element adjoint value.
-  AllocStackInst *getArrayAdjointElementBuffer(SILValue arrayAdjoint,
-                                               int eltIndex, SILType eltTanType,
-                                               SILLocation loc);
-
-  /// Accumulate array element adjoint buffer into `store` source.
-  void accumulateArrayElementAdjointDirect(StoreInst *si,
-                                           AllocStackInst *eltAdjBuffer);
-
-  /// Accumulate array element adjoint buffer into `copy_addr` source.
-  void accumulateArrayElementAdjointIndirect(CopyAddrInst *cai,
-                                             AllocStackInst *eltAdjBuffer);
-
-  /// Given a `store` or `copy_addr` instruction whose destination is an element
-  /// address from an `array.uninitialized_intrinsic` application, accumulate
-  /// array element adjoint into the source's adjoint.
-  void accumulateArrayElementAdjoint(SILInstruction *inst);
 
   void visitApplyInst(ApplyInst *ai);
 

--- a/test/AutoDiff/activity_analysis.swift
+++ b/test/AutoDiff/activity_analysis.swift
@@ -217,36 +217,36 @@ func testArrayUninitializedIntrinsicNested(_ x: Float, _ y: Float) -> [Float] {
   return [array[0], array[1]]
 }
 // CHECK-LABEL: [AD] Activity info for ${{.*}}testArrayUninitializedIntrinsicNested{{.*}} at (source=0 parameters=(0 1))
-// CHECK: [VARIED] %0 = argument of bb0 : $Float
-// CHECK: [VARIED] %1 = argument of bb0 : $Float
-// CHECK: [NONE]   %4 = integer_literal $Builtin.Word, 2
+// CHECK: [ACTIVE] %0 = argument of bb0 : $Float
+// CHECK: [ACTIVE] %1 = argument of bb0 : $Float
+// CHECK: [USEFUL]   %4 = integer_literal $Builtin.Word, 2
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
-// CHECK: [VARIED]   %6 = apply %5<Float>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-// CHECK: [VARIED] (**%7**, %8) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
+// CHECK: [ACTIVE]   %6 = apply %5<Float>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float
 // CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
-// CHECK: [VARIED]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
+// CHECK: [ACTIVE]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
 // CHECK: [USEFUL]   %15 = integer_literal $Builtin.Word, 2
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [ACTIVE]   %17 = apply %16<Float>(%15) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%18**, %19) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [VARIED] (%18, **%19**) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED]   %20 = pointer_to_address %19 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [VARIED]   %21 = begin_borrow %7 : $Array<Float>
-// CHECK: [NONE]   %22 = integer_literal $Builtin.IntLiteral, 0
-// CHECK: [NONE]   %23 = metatype $@thin Int.Type
+// CHECK: [ACTIVE]   %20 = pointer_to_address %19 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [ACTIVE]   %21 = begin_borrow %7 : $Array<Float>
+// CHECK: [USEFUL]   %22 = integer_literal $Builtin.IntLiteral, 0
+// CHECK: [USEFUL]   %23 = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [NONE]   %25 = apply %24(%22, %23) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [USEFUL]   %25 = apply %24(%22, %23) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [NONE]   // function_ref Array.subscript.getter
 // CHECK: [NONE]   %27 = apply %26<Float>(%20, %25, %21) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
 // CHECK: [VARIED]   %28 = integer_literal $Builtin.Word, 1
-// CHECK: [VARIED]   %29 = index_addr %20 : $*Float, %28 : $Builtin.Word
-// CHECK: [VARIED]   %30 = begin_borrow %7 : $Array<Float>
-// CHECK: [NONE]   %31 = integer_literal $Builtin.IntLiteral, 1
-// CHECK: [NONE]   %32 = metatype $@thin Int.Type
+// CHECK: [ACTIVE]   %29 = index_addr %20 : $*Float, %28 : $Builtin.Word
+// CHECK: [ACTIVE]   %30 = begin_borrow %7 : $Array<Float>
+// CHECK: [USEFUL]   %31 = integer_literal $Builtin.IntLiteral, 1
+// CHECK: [USEFUL]   %32 = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [NONE]   %34 = apply %33(%31, %32) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [USEFUL]   %34 = apply %33(%31, %32) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [NONE]   // function_ref Array.subscript.getter
 // CHECK: [NONE]   %36 = apply %35<Float>(%29, %34, %30) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
 
@@ -260,22 +260,22 @@ func testArrayUninitializedIntrinsicApplyIndirectResult<T>(_ x: T, _ y: T) -> [W
   return [Wrapper(value: x), Wrapper(value: y)]
 }
 // CHECK-LABEL: [AD] Activity info for ${{.*}}testArrayUninitializedIntrinsicApplyIndirectResult{{.*}} at (source=0 parameters=(0 1))
-// CHECK: [VARIED] %0 = argument of bb0 : $*T
-// CHECK: [VARIED] %1 = argument of bb0 : $*T
+// CHECK: [ACTIVE] %0 = argument of bb0 : $*T
+// CHECK: [ACTIVE] %1 = argument of bb0 : $*T
 // CHECK: [USEFUL]   %4 = integer_literal $Builtin.Word, 2
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
 // CHECK: [ACTIVE]   %6 = apply %5<Wrapper<T>>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<Wrapper<T>>, Builtin.RawPointer)
 // CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<Wrapper<T>>, Builtin.RawPointer)
-// CHECK: [VARIED]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Wrapper<T>
-// CHECK: [NONE]   %10 = metatype $@thin Wrapper<T>.Type
-// CHECK: [VARIED]   %11 = alloc_stack $T
+// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Wrapper<T>
+// CHECK: [USEFUL]   %10 = metatype $@thin Wrapper<T>.Type
+// CHECK: [ACTIVE]   %11 = alloc_stack $T
 // CHECK: [NONE]   // function_ref Wrapper.init(value:)
 // CHECK: [NONE]   %14 = apply %13<T>(%9, %11, %10) : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in τ_0_0, @thin Wrapper<τ_0_0>.Type) -> @out Wrapper<τ_0_0>
 // CHECK: [VARIED]   %16 = integer_literal $Builtin.Word, 1
-// CHECK: [VARIED]   %17 = index_addr %9 : $*Wrapper<T>, %16 : $Builtin.Word
-// CHECK: [NONE]   %18 = metatype $@thin Wrapper<T>.Type
-// CHECK: [VARIED]   %19 = alloc_stack $T
+// CHECK: [ACTIVE]   %17 = index_addr %9 : $*Wrapper<T>, %16 : $Builtin.Word
+// CHECK: [USEFUL]   %18 = metatype $@thin Wrapper<T>.Type
+// CHECK: [ACTIVE]   %19 = alloc_stack $T
 // CHECK: [NONE]   // function_ref Wrapper.init(value:)
 // CHECK: [NONE]   %22 = apply %21<T>(%17, %19, %18) : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in τ_0_0, @thin Wrapper<τ_0_0>.Type) -> @out Wrapper<τ_0_0>
 


### PR DESCRIPTION
Activity analysis:
- Mark array literal element addresses (`pointer_to_address` and `index_addr`
  instructions) as useful. These addresses legitimately need a derivative.
- Propagate usefulness through array literal element addresses that are `apply`
  indirect results to the `apply` arguments.

Pullback generation:
- Add special case for array literal element addresses to
  `PullbackEmitter::getAdjointProjection`. The adjoint projection is a local
  allocation initialized from the array literal's adjoint value by applying
  `Array.TangentVector.subscript`.
  - This generalizes the old logic in `PullbackEmitter::visit{Store,CopyAddr}Inst`
    for handling array literal element addresses, which is now removed.
- When an array literal's adjoint value is updated via
  `PullbackEmitter::addAdjointValue`, accumulate the array literal's adjoint
  value into the adjoint buffers of its element addresses.

Resolves cleanup task: TF-976.
Fixes correctness issues:
- TF-975: nested array literals.
- TF-978: array literal element addresses initialized as `apply` indirect result.

Update activity analysis and derivative correctness tests.

---

Examples:

```swift
// TF-975: nested array literals.
func TF_975(_ x: Float, _ y: Float) -> [Float] {
  let array = [x, y]
  return [array[0], array[1]]
}
let (value, pb) = valueWithPullback(at: 3, 4, in: TF_975)
print(value) // [3.0, 4.0]
print(pb([Float].TangentVector([1, 1])))
// Before: (0.0, 0.0)
//  After: (1.0, 1.0)
```

```swift
// TF-978: array literal element addresses initialized as `apply` indirect result.
struct Struct<T> {
  var x, y: T
}
extension Struct: Differentiable where T: Differentiable {}

func applyIndirectResult<T>(_ x: T, _ y: T) -> [Struct<T>] {
  return [Struct(x: x, y: y), Struct(x: x, y: y)]
}
let (value, pb) = valueWithPullback(at: 3, 4, in: { applyIndirectResult($0, $1) })
print(value) // [Struct<Double>(x: 3.0, y: 4.0), Struct<Double>(x: 3.0, y: 4.0)]
let v = Struct<Double>.TangentVector(x: 1, y: 1)
print(pb(.init([v, v])))
// Before: (0.0, 0.0)
//  After: (2.0, 2.0)
```
