### PR TITLE
[AutoDiff] forbid @derivative of protocol req

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3473,10 +3473,12 @@ void AttributeChecker::visitDerivativeAttr(DerivativeAttr *attr) {
       };
 
   auto isValidOriginal = [&](AbstractFunctionDecl *originalCandidate) {
-    return checkFunctionSignature(
-        cast<AnyFunctionType>(originalFnType->getCanonicalType()),
-        originalCandidate->getInterfaceType()->getCanonicalType(),
-        checkGenericSignatureSatisfied);
+    // TODO(TF-982): Allow derivatives on protocol requirements.
+    return !isa<ProtocolDecl>(originalCandidate->getDeclContext()) &&
+           checkFunctionSignature(
+               cast<AnyFunctionType>(originalFnType->getCanonicalType()),
+               originalCandidate->getInterfaceType()->getCanonicalType(),
+               checkGenericSignatureSatisfied);
   };
 
   auto noneValidDiagnostic = [&]() {

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -186,6 +186,11 @@ protocol StaticMethod: Differentiable {
 }
 
 extension StaticMethod {
+  static func foo(_ x: Float) -> Float { x }
+  static func generic<T: Differentiable>(_ x: T) -> T { x }
+}
+
+extension StaticMethod {
   @derivative(of: foo)
   static func jvpFoo(x: Float) -> (value: Float, differential: (Float) -> Float)
   {
@@ -214,11 +219,17 @@ extension StaticMethod {
 // Test instance methods.
 
 protocol InstanceMethod: Differentiable {
-  // expected-note @+1 {{'foo' defined here}}
   func foo(_ x: Self) -> Self
 
-  // expected-note @+1 {{'generic' defined here}}
   func generic<T: Differentiable>(_ x: T) -> Self
+}
+
+extension InstanceMethod {
+  // expected-note @+1 {{'foo' defined here}}
+  func foo(_ x: Self) -> Self { self }
+
+  // expected-note @+1 {{'generic' defined here}}
+  func generic<T: Differentiable>(_ x: T) -> Self { self }
 }
 
 extension InstanceMethod {
@@ -499,27 +510,15 @@ extension HasStoredProperty {
 
 // Test cross-file derivative registration. Currently unsupported.
 // TODO(TF-1021): Lift this restriction.
-
-extension AdditiveArithmetic where Self: Differentiable {
+extension FloatingPoint where Self: Differentiable {
   // expected-error @+1 {{derivative not in the same file as the original function}}
-  @derivative(of: +)
-  static func vjpPlus(x: Self, y: Self) -> (
-    value: Self,
-    pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
-  ) {
-    return (x + y, { v in (v, v) })
+  @derivative(of: rounded)
+  func vjpRounded() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+    fatalError()
   }
 }
 
-extension FloatingPoint where Self: Differentiable, Self == Self.TangentVector {
-  // expected-error @+1 {{derivative not in the same file as the original function}}
-  @derivative(of: +)
-  static func vjpPlus(x: Self, y: Self) -> (
-    value: Self, pullback: (Self) -> (Self, Self)
-  ) {
-    return (x + y, { v in (v, v) })
-  }
-}
+// Test static methods.
 
 extension Differentiable where Self: AdditiveArithmetic {
   // expected-error @+1 {{'+' is not defined in the current type context}}
@@ -540,5 +539,31 @@ where Self: Differentiable, Self == Self.TangentVector {
     value: Self, pullback: (Self) -> (Self, Self)
   ) {
     return (x + y, { v in (v, v) })
+  }
+}
+
+// Test derivatives of default implementations.
+protocol HasADefaultImplementation {
+  func req(_ x: Float) -> Float
+}
+extension HasADefaultImplementation {
+  func req(_ x: Float) -> Float { x }
+  // ok
+  @derivative(of: req)
+  func req(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    (x, { 10 * $0 })
+  }
+}
+
+// Test default derivatives of requirements.
+protocol HasADefaultDerivative {
+  func req(_ x: Float) -> Float
+}
+extension HasADefaultDerivative {
+  // TODO(TF-982): Make this ok.
+  // expected-error @+1 {{could not find function 'req'}}
+  @derivative(of: req)
+  func req(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    (x, { 10 * $0 })
   }
 }

--- a/test/AutoDiff/compiler_crashers_fixed/tf1039-cloned-curry-thunk-verification.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1039-cloned-curry-thunk-verification.swift
@@ -9,12 +9,6 @@ protocol P {
   @differentiable
   func foo(_ x: Float) -> Float
 }
-extension P {
-  @derivative(of: foo)
-  func vjpFoo(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
-    return (x, { $0 })
-  }
-}
 struct S: P {
   @differentiable
   func foo(_ x: Float) -> Float { x }

--- a/test/AutoDiff/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/derivative_attr_type_checking.swift
@@ -151,23 +151,17 @@ func vjpFooExtraGenericRequirements<T : FloatingPoint & Differentiable & BinaryI
   return (x, { $0 })
 }
 
+// Test cross-file derivative registration. Currently unsupported.
+// TODO(TF-1021): Lift this restriction.
+extension FloatingPoint where Self: Differentiable {
+  // expected-error @+1 {{derivative not in the same file as the original function}}
+  @derivative(of: rounded)
+  func vjpRounded() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+    fatalError()
+  }
+}
+
 // Test static methods.
-
-extension AdditiveArithmetic where Self : Differentiable {
-  // expected-error @+1 {{derivative not in the same file as the original function}}
-  @derivative(of: +)
-  static func vjpPlus(x: Self, y: Self) -> (value: Self, pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)) {
-    return (x + y, { v in (v, v) })
-  }
-}
-
-extension FloatingPoint where Self : Differentiable, Self == Self.TangentVector {
-  // expected-error @+1 {{derivative not in the same file as the original function}}
-  @derivative(of: +)
-  static func vjpPlus(x: Self, y: Self) -> (value: Self, pullback: (Self) -> (Self, Self)) {
-    return (x + y, { v in (v, v) })
-  }
-}
 
 extension Differentiable where Self : AdditiveArithmetic {
   // expected-error @+1 {{'+' is not defined in the current type context}}
@@ -188,12 +182,19 @@ extension AdditiveArithmetic where Self : Differentiable, Self == Self.TangentVe
 // Test instance methods.
 
 protocol InstanceMethod : Differentiable {
-  // expected-note @+1 {{'foo' defined here}}
   func foo(_ x: Self) -> Self
   func foo2(_ x: Self) -> Self
-  // expected-note @+1 {{'bar' defined here}}
   func bar<T : Differentiable>(_ x: T) -> Self
   func bar2<T : Differentiable>(_ x: T) -> Self
+}
+
+extension InstanceMethod {
+  // expected-note @+1 {{'foo' defined here}}
+  func foo(_ x: Self) -> Self { self }
+  func foo2(_ x: Self) -> Self { self }
+  // expected-note @+1 {{'bar' defined here}}
+  func bar<T : Differentiable>(_ x: T) -> Self { self }
+  func bar2<T : Differentiable>(_ x: T) -> Self { self}
 }
 
 extension InstanceMethod {
@@ -262,6 +263,10 @@ protocol GenericInstanceMethod : Differentiable where Self == Self.TangentVector
 }
 
 extension GenericInstanceMethod {
+  func instanceMethod<T : Differentiable>(_ x: T) -> T { x }
+}
+
+extension GenericInstanceMethod {
   @derivative(of: instanceMethod)
   func jvpInstanceMethod<T : Differentiable>(_ x: T) -> (value: T, differential: (Self, T.TangentVector) -> (T.TangentVector)) {
     return (x, { (dself, dx) in dx })
@@ -297,6 +302,9 @@ func vjpBaz<T : Differentiable, U : Differentiable>(_ x: T, _ y: U)
 protocol InstanceMethodProto {
   func bar() -> Float
 }
+extension InstanceMethodProto {
+  func bar() -> Float { 0 }
+}
 extension InstanceMethodProto where Self : Differentiable {
   @derivative(of: bar)
   func vjpBar() -> (value: Float, pullback: (Float) -> TangentVector) {
@@ -318,6 +326,9 @@ protocol Protocol: Differentiable {
   func requirementOverlapping() -> Self
 }
 extension Protocol {
+  @differentiable
+  func requirementOverlapping() -> Self { self }
+
   func nonRequirementOnlyDerivativeAttr() -> Self { self }
 
   @differentiable

--- a/test/AutoDiff/derivative_registration.swift
+++ b/test/AutoDiff/derivative_registration.swift
@@ -176,4 +176,21 @@ DerivativeRegistrationTests.testWithLeakChecking("NonCanonicalizedGenericSignatu
   expectEqual(0, dx)
 }
 
+// Test derivatives of default implementations.
+protocol HasADefaultImplementation {
+  func req(_ x: Tracked<Float>) -> Tracked<Float>
+}
+extension HasADefaultImplementation {
+  func req(_ x: Tracked<Float>) -> Tracked<Float> { x }
+  @derivative(of: req)
+  func req(_ x: Tracked<Float>) -> (value: Tracked<Float>, pullback: (Tracked<Float>) -> Tracked<Float>) {
+    (x, { 10 * $0 })
+  }
+}
+struct StructConformingToHasADefaultImplementation : HasADefaultImplementation {}
+DerivativeRegistrationTests.testWithLeakChecking("DerivativeOfDefaultImplementation") {
+  let dx = gradient(at: Tracked<Float>(0)) { StructConformingToHasADefaultImplementation().req($0) }
+  expectEqual(Tracked<Float>(10), dx)
+}
+
 runAllTests()

--- a/test/Serialization/derivative_attr.swift
+++ b/test/Serialization/derivative_attr.swift
@@ -37,6 +37,10 @@ protocol InstanceMethod : Differentiable {
   func bar<T : Differentiable>(_ x: T) -> Self
 }
 extension InstanceMethod {
+  func foo(_ x: Self) -> Self { self }
+  func bar<T : Differentiable>(_ x: T) -> Self { self }
+}
+extension InstanceMethod {
   // CHECK: @derivative(of: foo, wrt: (self, x))
   @derivative(of: foo)
   func vjpFoo(x: Self) -> (value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)) {


### PR DESCRIPTION
Until TF-982 is implemented, `@derivative`s of protocol requirements don't do anything. Therefore, this PR forbids them and adds a test that they are forbidden.

I am doing this because it fixes a problem that prevents me from removing `vjp:` from [`FloatingPoint.squareRoot`](https://github.com/apple/swift/blob/7d3ae09cf161f69e9ece497392e78b6aabc11fa3/stdlib/public/core/FloatingPoint.swift#L1686). The problem is that you get an "ambiguous reference" error because it can't tell if you want the `@derivative` on the requirement or the default implementation. This PR also adds a test that this problem is fixed (`protocol HasADefaultImplementation`).

The portions of this PR in code that have been upstreamed should be upstreamed. I will do this in a separate PR after merging this PR, because I want to run this PR through our full `tensorflow`-specific test suite.