### PR TITLE
Revert "[test] Mark _Differentiable tests as unsupported in Swift-in-the-OS configurations"

### DIFF
--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -1,9 +1,6 @@
 // RUN: %target-swift-frontend-typecheck -enable-experimental-differentiable-programming -verify %s
 // REQUIRES: differentiable_programming
 
-// We currently lack availability information (rdar://57975086)
-// UNSUPPORTED: use_os_stdlib
-
 import _Differentiation
 
 // Test top-level functions.

--- a/test/AutoDiff/Serialization/derivative_attr.swift
+++ b/test/AutoDiff/Serialization/derivative_attr.swift
@@ -7,9 +7,6 @@
 
 // REQUIRES: differentiable_programming
 
-// We currently lack availability information (rdar://57975086)
-// UNSUPPORTED: use_os_stdlib
-
 import _Differentiation
 
 // Dummy `Differentiable`-conforming type.

--- a/test/AutoDiff/Serialization/differentiable_attr.swift
+++ b/test/AutoDiff/Serialization/differentiable_attr.swift
@@ -4,9 +4,6 @@
 // RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/differentiable_attr.swiftmodule -o - | %FileCheck %s
 // REQUIRES: differentiable_programming
 
-// We currently lack availability information (rdar://57975086)
-// UNSUPPORTED: use_os_stdlib
-
 // TODO(TF-836): Enable this test.
 // Blocked by TF-828: `@differentiable` attribute type-checking.
 // XFAIL: *

--- a/test/AutoDiff/Serialization/transpose_attr.swift
+++ b/test/AutoDiff/Serialization/transpose_attr.swift
@@ -6,9 +6,6 @@
 // BCANALYZER-NOT: UnknownCode
 // REQUIRES: differentiable_programming
 
-// We currently lack availability information (rdar://57975086)
-// UNSUPPORTED: use_os_stdlib
-
 // TODO(TF-838): Enable this test.
 // Blocked by TF-830: `@transpose` attribute type-checking.
 // XFAIL: *

--- a/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
+++ b/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
@@ -2,9 +2,6 @@
 // REQUIRES: executable_test
 // REQUIRES: differentiable_programming
 
-// We currently lack availability information (rdar://57975086)
-// UNSUPPORTED: use_os_stdlib
-
 import _Differentiation
 
 // Test `Differentiable` protocol conformances for stdlib types.


### PR DESCRIPTION
Reverts apple/swift#28882

The issue was due to a misconfiguration; these tests are already marked unsupported in back deployment setups.

rdar://57975086