### PR TITLE
[CodeCompletion] Always look into decls to find the parsed expression

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -161,8 +161,6 @@ public:
     return {isInterstingRange(S), S};
   }
 
-  bool walkToDeclPre(Decl *D) override { return isInterstingRange(D); }
-
   bool walkToTypeLocPre(TypeLoc &TL) override { return false; }
   bool walkToTypeReprPre(TypeRepr *T) override { return false; }
 };

--- a/test/SourceKit/CodeComplete/complete_sequence_bodyrange.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_bodyrange.swift
@@ -1,0 +1,57 @@
+class TestChain {
+  class Child {
+    var value: Struct1?
+  }
+  class Struct1 {
+    var value: Struct2
+  }
+  class Struct2 {
+    var prop1: Int
+    var prop2: Int
+  }
+
+  var child: Child!
+
+  func foo() {
+    let _ = child.value?.value.
+  }
+}
+
+// rdar://problem/58098222
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:32 %s -async -- %s | %FileCheck %s
+
+// CHECK-NOT: key.name: "prop1"
+// CHECK-NOT: key.name: "prop2"
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK: key.name: "prop1",
+// CHECK: key.name: "prop2",
+// CHECK-NOT: key.name: "prop1"
+// CHECK-NOT: key.name: "prop2"


### PR DESCRIPTION
In fast completion scenario, `AbstractFunctionDecl` may have the body from the different file than the decl itself. That may confuses source range checking.

As a workaround, always look into decls regardless of the range. This should not regress the speed of the searching much because statements/expressions (including the nested function bodies) in the decl is still skipped if they are outside the range.

rdar://problem/58098222