### PR TITLE
[AutoDiff] Fix build error.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3555,7 +3555,7 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
     baseType = resolution.resolveType(baseTypeRepr, options);
   }
   if (baseType && baseType->hasError())
-    return;
+    return true;
   auto lookupOptions = attr->getBaseTypeRepr()
                            ? defaultMemberLookupOptions
                            : defaultUnqualifiedLookupOptions;


### PR DESCRIPTION
Fix build error introduced in https://github.com/apple/swift/pull/28892: https://ci.swift.org//job/oss-swift-incremental-RA-osx/9984

```
/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/swift/lib/Sema/TypeCheckAttr.cpp:3558:5: error: non-void function 'typeCheckDerivativeAttr' should return a value [-Wreturn-type]
00:03:51     return;
00:03:51     ^
```

Caused by not re-running CI after https://github.com/apple/swift/pull/28879 was merged, sorry about that.