### PR TITLE
DeserializeSIL: Fix two places where we want the SILType inside of the current function according to the TypeExpansionContext

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1429,7 +1429,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     // two values in the list are the basic block identifiers.
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);
-    SILType FnTy = getSILType(Ty, SILValueCategory::Object, nullptr);
+    SILType FnTy = getSILType(Ty, SILValueCategory::Object, Fn);
     SILType SubstFnTy = getSILType(Ty2, SILValueCategory::Object, Fn);
 
     SILBasicBlock *errorBB = getBBForReference(Fn, ListOfValues.back());
@@ -1455,7 +1455,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   case SILInstructionKind::PartialApplyInst: {
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);
-    SILType FnTy = getSILType(Ty, SILValueCategory::Object, nullptr);
+    SILType FnTy = getSILType(Ty, SILValueCategory::Object, Fn);
     SILType closureTy = getSILType(Ty2, SILValueCategory::Object, Fn);
 
     SubstitutionMap Substitutions = MF->getSubstitutionMap(NumSubs);

--- a/test/Serialization/Inputs/opaque_types_inlineable_2.swift
+++ b/test/Serialization/Inputs/opaque_types_inlineable_2.swift
@@ -1,0 +1,18 @@
+public protocol P {}
+
+public struct M<T : P> : P {
+  public init(t: T) {}
+}
+extension Int : P {}
+
+extension P {
+ @inlinable
+ public func o<T : P>(_ t: T) -> some P {
+   return M<T>(t: t)
+ }
+
+ @inlinable
+ public func p() throws -> some P {
+   return Int()
+ }
+}

--- a/test/Serialization/opaque_types_inlineable.swift
+++ b/test/Serialization/opaque_types_inlineable.swift
@@ -1,0 +1,29 @@
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking  -module-name A -emit-module %s %S/Inputs/opaque_types_inlineable_2.swift
+
+// This test case use to crash in the merge modules phase when the two partial
+// modules are merged as one deserializing the module for this file now has
+// access to opaque types in the other file (opaque_types_inlineable_2.swift).
+
+extension P {
+  @inlinable
+  public func r() -> some P {
+    return f { self.o(Q()) }
+  }
+
+  @inlinable
+  public func q() throws -> some P {
+    return try p()
+  }
+}
+
+public func f<T : P>(_ fn: () -> T) -> some P {
+  return K()
+}
+
+public struct K : P {
+  public init() {}
+}
+
+public struct Q : P {
+  public init() {}
+}


### PR DESCRIPTION

rdar://58095210