### PR TITLE
[MSVC] Create empty file more explicitely.

### DIFF
--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -2049,6 +2049,8 @@ void Compilation::addDependencyPathOrCreateDummy(
     HaveAlreadyAddedDependencyPath = true;
   } else if (!depPath.empty()) {
     // Create dummy empty file
-    std::ofstream(depPath.str().c_str());
+    std::ofstream empty;
+    empty.open(depPath.str());
+    empty.close();
   }
 }


### PR DESCRIPTION
It might happen that MSVC doesn't create the file with the constructor,
so use a more manual approach of creating a variable and using
open/close explicitely.
