### PR TITLE
[MSVC] Evaluate parameters in the right order.

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2483,8 +2483,9 @@ parseClosureSignatureIfPresent(SourceRange &bracketRange,
     
     SyntaxParsingContext CaptureCtx(SyntaxContext,
                                     SyntaxKind::ClosureCaptureSignature);
-    bracketRange = SourceRange(consumeToken(tok::l_square),
-                               consumeToken(tok::r_square));
+    SourceLoc lBracketLoc = consumeToken(tok::l_square);
+    SourceLoc rBracketLoc = consumeToken(tok::r_square);
+    bracketRange = SourceRange(lBracketLoc, rBracketLoc);
   } else if (Tok.is(tok::l_square) && !peekToken().is(tok::r_square)) {
     SyntaxParsingContext CaptureCtx(SyntaxContext,
                                     SyntaxKind::ClosureCaptureSignature);


### PR DESCRIPTION
Parameter evaluation order is unspecified, and MSVC happens to do it in
the opposite order than Clang.

Move the evaluation of the parameters outside the invocation, so the
order is clear, and the token consuming happens in the right order.

