### PR TITLE
Remove re-entrancy assertion

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1135,8 +1135,6 @@ populateLookupTableEntryFromLazyIDCLoader(ASTContext &ctx,
                                           MemberLookupTable &LookupTable,
                                           DeclBaseName name,
                                           IterableDeclContext *IDC) {
-  assert(!IDC->isLoadingLazyMembers() &&
-         "Re-entrant member loading is not supported!");
   IDC->setLoadingLazyMembers(true);
   auto ci = ctx.getOrCreateLazyIterableContextData(IDC,
                                                    /*lazyLoader=*/nullptr);


### PR DESCRIPTION
This was just to confirm that the re-entrancy problem still exists on
the bots.  There's something OS-dependent (probably the SDKs) that
causes this to only reproduce on 10.14.5 and not 10.15.

rdar://58116531