### PR TITLE
[AutoDiff] Change `TangentVector` memberwise initializer access level.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -282,10 +282,11 @@ ConstructorDecl *swift::createMemberwiseImplicitConstructor(
 ConstructorDecl *swift::getOrCreateEffectiveMemberwiseInitializer(
     ASTContext &ctx, NominalTypeDecl *nominal) {
   // Compute the access level for the memberwise initializer: the minimum of:
-  // - The access level of the nominal type declaration itself.
+  // - Public, by default. This enables public nominal types to have public
+  //   memberwise initializers.
   // - The access level of each memberwise-initialized property in the nominal
   //   type declaration.
-  auto accessLevel = std::min(AccessLevel::Public, nominal->getFormalAccess());
+  auto accessLevel = AccessLevel::Public;
   for (auto *member : nominal->getMembers()) {
     auto var = dyn_cast<VarDecl>(member);
     if (!var ||

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -278,6 +278,32 @@ ConstructorDecl *swift::createMemberwiseImplicitConstructor(
                                    ctx);
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+ConstructorDecl *swift::getOrCreateEffectiveMemberwiseInitializer(
+    ASTContext &ctx, NominalTypeDecl *nominal) {
+  // Compute the access level for the memberwise initializer: the minimum of:
+  // - The access level of the nominal type declaration itself.
+  // - The access level of each memberwise-initialized property in the nominal
+  //   type declaration.
+  auto accessLevel = std::min(AccessLevel::Public, nominal->getFormalAccess());
+  for (auto *member : nominal->getMembers()) {
+    auto var = dyn_cast<VarDecl>(member);
+    if (!var ||
+        !var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
+      continue;
+    accessLevel = std::min(accessLevel, var->getFormalAccess());
+  }
+  if (auto *initDecl = nominal->getEffectiveMemberwiseInitializer()) {
+    initDecl->overwriteAccess(accessLevel);
+    return initDecl;
+  }
+  auto *initDecl = createMemberwiseImplicitConstructor(ctx, nominal);
+  initDecl->overwriteAccess(accessLevel);
+  nominal->addMember(initDecl);
+  return initDecl;
+}
+// SWIFT_ENABLE_TENSORFLOW END
+
 /// Create a stub body that emits a fatal error message.
 static std::pair<BraceStmt *, bool>
 synthesizeStubBody(AbstractFunctionDecl *fn, void *) {

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -65,6 +65,18 @@ Expr *buildArgumentForwardingExpr(ArrayRef<ParamDecl*> params,
 
 ConstructorDecl *createMemberwiseImplicitConstructor(ASTContext &ctx,
                                                      NominalTypeDecl *decl);
+
+// SWIFT_ENABLE_TENSORFLOW
+// Get the effective memberwise initializer of the given nominal type, or create
+// it if it does not exist.
+// Sets the access level of the memberwise initializer to the minimum of:
+// - The access level of the nominal type declaration itself.
+// - The access level of each memberwise-initialized property in the nominal
+//   type declaration.
+ConstructorDecl *getOrCreateEffectiveMemberwiseInitializer(
+    ASTContext &ctx, NominalTypeDecl *nominal);
+// SWIFT_ENABLE_TENSORFLOW END
+
 } // end namespace swift
 
 #endif

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -70,7 +70,12 @@ ConstructorDecl *createMemberwiseImplicitConstructor(ASTContext &ctx,
 // Get the effective memberwise initializer of the given nominal type, or create
 // it if it does not exist.
 // Sets the access level of the memberwise initializer to the minimum of:
-// - The access level of the nominal type declaration itself.
+// - Public, by default. This enables public nominal types to have public
+//   memberwise initializers.
+//   - NOTE(TF-1077): The `public` default is important for `TangentVector`
+//     structs synthesized during `Differentiable` derived conformances.
+//     Manually extending `TangentVector` structs to define a public
+//     memberwise initializer causes a redeclaration error.
 // - The access level of each memberwise-initialized property in the nominal
 //   type declaration.
 ConstructorDecl *getOrCreateEffectiveMemberwiseInitializer(

--- a/lib/Sema/DerivedConformanceElementaryFunctions.cpp
+++ b/lib/Sema/DerivedConformanceElementaryFunctions.cpp
@@ -100,17 +100,6 @@ static ValueDecl *getElementaryFunctionRequirement(
   }
 }
 
-// Get the effective memberwise initializer of the given nominal type, or create
-// it if it does not exist.
-static ConstructorDecl *getOrCreateEffectiveMemberwiseInitializer(
-    ASTContext &ctx, NominalTypeDecl *nominal) {
-  if (auto *initDecl = nominal->getEffectiveMemberwiseInitializer())
-    return initDecl;
-  auto *initDecl = createMemberwiseImplicitConstructor(ctx, nominal);
-  nominal->addMember(initDecl);
-  return initDecl;
-}
-
 bool DerivedConformance::canDeriveElementaryFunctions(NominalTypeDecl *nominal,
                                                       DeclContext *DC) {
   // Nominal type must be a struct. (Zero stored properties is okay.)

--- a/lib/Sema/DerivedConformanceRingMathProtocols.cpp
+++ b/lib/Sema/DerivedConformanceRingMathProtocols.cpp
@@ -75,18 +75,6 @@ static ValueDecl *getProtocolRequirement(ProtocolDecl *proto, Identifier name) {
   return lookup.front();
 }
 
-// Get the effective memberwise initializer of the given nominal type, or create
-// it if it does not exist.
-static ConstructorDecl *getOrCreateEffectiveMemberwiseInitializer(
-    ASTContext &ctx, NominalTypeDecl *nominal) {
-  if (auto *initDecl = nominal->getEffectiveMemberwiseInitializer())
-    return initDecl;
-  auto *initDecl = createMemberwiseImplicitConstructor(
-      ctx, nominal);
-  nominal->addMember(initDecl);
-  return initDecl;
-}
-
 // Return true if given nominal type has a `let` stored with an initial value.
 // TODO: Move function to shared place for use with other derived conformances.
 static bool hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {

--- a/test/Sema/differentiable_access_level.swift
+++ b/test/Sema/differentiable_access_level.swift
@@ -19,14 +19,14 @@ private struct PrivateStruct: Differentiable {}
 // CHECK-LABEL: internal struct InternalStruct : Differentiable {
 // CHECK:   internal init()
 // CHECK:   internal struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
-// CHECK:     internal init()
+// CHECK:     public init()
 // CHECK:   }
 // CHECK: }
 
 // CHECK-LABEL: private struct PrivateStruct : Differentiable {
 // CHECK:   internal init()
 // CHECK:   fileprivate struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
-// CHECK:     fileprivate init()
+// CHECK:     public init()
 // CHECK:   }
 // CHECK: }
 
@@ -44,13 +44,13 @@ private class PrivateClass: Differentiable {}
 // CHECK-LABEL: internal class InternalClass : Differentiable {
 // CHECK:   internal init()
 // CHECK:   internal struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
-// CHECK:     internal init()
+// CHECK:     public init()
 // CHECK:   }
 // CHECK: }
 
 // CHECK-LABEL: private class PrivateClass : Differentiable {
 // CHECK:   internal init()
 // CHECK:   fileprivate struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
-// CHECK:     fileprivate init()
+// CHECK:     public init()
 // CHECK:   }
 // CHECK: }

--- a/test/Sema/differentiable_access_level.swift
+++ b/test/Sema/differentiable_access_level.swift
@@ -1,0 +1,56 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %target-swift-frontend -print-ast %s | %FileCheck %s
+
+// Test `Differentiable` derived conformances.
+// Verify access levels of synthesized `TangentVector` types and their memberwise initializers.
+// `TangentVector` memberwise initializer access level should match `TangentVector` access level.
+
+public struct PublicStruct: Differentiable {}
+internal struct InternalStruct: Differentiable {}
+private struct PrivateStruct: Differentiable {}
+
+// CHECK-LABEL: public struct PublicStruct : Differentiable {
+// CHECK:   internal init()
+// CHECK:   public struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
+// CHECK:     public init()
+// CHECK:   }
+// CHECK: }
+
+// CHECK-LABEL: internal struct InternalStruct : Differentiable {
+// CHECK:   internal init()
+// CHECK:   internal struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
+// CHECK:     internal init()
+// CHECK:   }
+// CHECK: }
+
+// CHECK-LABEL: private struct PrivateStruct : Differentiable {
+// CHECK:   internal init()
+// CHECK:   fileprivate struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
+// CHECK:     fileprivate init()
+// CHECK:   }
+// CHECK: }
+
+public class PublicClass: Differentiable {}
+internal class InternalClass: Differentiable {}
+private class PrivateClass: Differentiable {}
+
+// CHECK-LABEL: public class PublicClass : Differentiable {
+// CHECK:   internal init()
+// CHECK:   public struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
+// CHECK:     public init()
+// CHECK:   }
+// CHECK: }
+
+// CHECK-LABEL: internal class InternalClass : Differentiable {
+// CHECK:   internal init()
+// CHECK:   internal struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
+// CHECK:     internal init()
+// CHECK:   }
+// CHECK: }
+
+// CHECK-LABEL: private class PrivateClass : Differentiable {
+// CHECK:   internal init()
+// CHECK:   fileprivate struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative, ElementaryFunctions {
+// CHECK:     fileprivate init()
+// CHECK:   }
+// CHECK: }

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -414,7 +414,7 @@ extension NoMemberwiseInitializerExtended: Differentiable
 extension NoMemberwiseInitializerExtended: EuclideanDifferentiable
   where T : Differentiable & AdditiveArithmetic {}
 
-// Test derived conformances in disallowed contexts.
+// Verify that cross-file derived conformances are disallowed.
 
 // expected-error @+2 {{type 'OtherFileNonconforming' does not conform to protocol 'Differentiable'}}
 // expected-error @+1 {{implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type}}


### PR DESCRIPTION
Previously, memberwise initializers of synthesized `TangentVector` structs were
internal by default. Now, they are public by default, improving usability.

Note that public synthesized memberwise initializers have no precedent in
Swift. For normal public structs, it's possible to manually define a public
memberwise initializer, skipping synthesis. However, since `TangentVector`
structs are always synthesized with a memberwise initializer, manually defining
a public memberwise initializer in an extension leads to a redeclaration error.

A broader discussion on memberwise initializer access levels may be
worthwhile.

Resolves TF-1077.
Note that public synthesized memberwise initializers have no precedent in
Swift. For normal public structs, it's possible to manually define a public
memberwise initializer, skipping synthesis. However, since `TangentVector`
structs are always synthesized with a memberwise initializer, manually defining
a public memberwise initializer in an extension leads to a redeclaration error:

```console
$ cat foo.swift
public struct Foo: Differentiable {}
extension Foo.TangentVector {
  public init() {}
}

$ swift foo.swift
foo.swift:3:10: error: invalid redeclaration of synthesized memberwise 'init()'
  public init() {}
         ^
```

A broader discussion on memberwise initializer access levels may be
worthwhile.

Resolves TF-1077. Unblocks a [concrete use case](https://github.com/tensorflow/swift-models/pull/231#discussion_r360560878): cc @eaplatanios.