### PR TITLE
[Serialization] Recover from deserializing an enum from a missing module

### DIFF
--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -913,6 +913,11 @@ public:
   /// Returns the decl context with the given ID, deserializing it if needed.
   DeclContext *getDeclContext(serialization::DeclContextID DID);
 
+  /// Returns the decl context with the given ID, deserializing it if needed,
+  /// or the first error.
+  llvm::Expected<DeclContext *>
+  getDeclContextChecked(serialization::DeclContextID DCID);
+
   /// Returns the local decl context with the given ID, deserializing it if needed.
   DeclContext *getLocalDeclContext(serialization::LocalDeclContextID DID);
 


### PR DESCRIPTION
This is a quick fix for a deserialization failure of an enum defined behind an `@_implementationOnly` import. The failure was trigger in a lookup path, so dropping the enum shouldn't be an issue.

I'm still working on the reproducer to see if there would be other similar cases.

rdar://problem/58022345