### PR TITLE
[SE-0280] Enum cases as protocol witnesses

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2108,6 +2108,9 @@ NOTE(protocol_witness_throws_conflict,none,
      "candidate throws, but protocol does not allow it", ())
 NOTE(protocol_witness_not_objc,none,
      "candidate is explicitly '@nonobjc'", ())
+NOTE(protocol_witness_enum_case_payload, none,
+     "candidate is an enum case with associated values, "
+     "but protocol does not allow it", ())
 
 NOTE(protocol_witness_type,none,
      "possibly intended match", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1881,8 +1881,9 @@ ERROR(requirement_restricts_self,none,
       "'Self'",
       (DescriptiveDeclKind, DeclName, StringRef, unsigned, StringRef))
 ERROR(witness_argument_name_mismatch,none,
-      "%select{method|initializer}0 %1 has different argument labels from those "
-      "required by protocol %2 (%3)", (bool, DeclName, Type, DeclName))
+      "%0 %1 has different argument labels "
+      "from those required by protocol %2 (%3)",
+			(DescriptiveDeclKind, DeclName, Type, DeclName))
 ERROR(witness_initializer_not_required,none,
       "initializer requirement %0 can only be satisfied by a 'required' "
       "initializer in%select{| the definition of}1 non-final class %2",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1883,7 +1883,7 @@ ERROR(requirement_restricts_self,none,
 ERROR(witness_argument_name_mismatch,none,
       "%0 %1 has different argument labels "
       "from those required by protocol %2 (%3)",
-			(DescriptiveDeclKind, DeclName, Type, DeclName))
+      (DescriptiveDeclKind, DeclName, Type, DeclName))
 ERROR(witness_initializer_not_required,none,
       "initializer requirement %0 can only be satisfied by a 'required' "
       "initializer in%select{| the definition of}1 non-final class %2",

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -499,6 +499,10 @@ bool calleesAreStaticallyKnowable(SILModule &module, SILDeclRef decl);
 /// be reached by calling the function represented by Decl?
 bool calleesAreStaticallyKnowable(SILModule &module, AbstractFunctionDecl *afd);
 
+/// Do we have enough information to determine all callees that could
+/// be reached by calling the function represented by Decl?
+bool calleesAreStaticallyKnowable(SILModule &module, EnumElementDecl *eed);
+
 // Attempt to get the instance for , whose static type is the same as
 // its exact dynamic type, returning a null SILValue() if we cannot find it.
 // The information that a static type is the same as the exact dynamic,

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -335,11 +335,6 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
     }
   }
 
-  // Enum constructors are emitted on-demand
-  if (isa<EnumElementDecl>(d)) {
-    limit = Limit::OnDemand;
-  }
-
   auto effectiveAccess = d->getEffectiveAccess();
   
   // Private setter implementations for an internal storage declaration should

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -334,7 +334,12 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
       limit = Limit::OnDemand;
     }
   }
-  
+
+  // Enum constructors are emitted on-demand
+  if (isa<EnumElementDecl>(d)) {
+    limit = Limit::OnDemand;
+  }
+
   auto effectiveAccess = d->getEffectiveAccess();
   
   // Private setter implementations for an internal storage declaration should

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1992,6 +1992,7 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
   // captured functions.
   auto captureInfo = TC.getLoweredLocalCaptures(constant);
 
+  // FIXME: Why do we end up here when witness is case-with-payload?
   if (!constant.getAnyFunctionRef().hasValue()) {
     auto *vd = constant.loc.dyn_cast<ValueDecl *>();
     auto funcTy =

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1992,6 +1992,16 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
   // captured functions.
   auto captureInfo = TC.getLoweredLocalCaptures(constant);
 
+  if (!constant.getAnyFunctionRef().hasValue()) {
+    auto *vd = constant.loc.dyn_cast<ValueDecl *>();
+    auto funcTy =
+        cast<AnyFunctionType>(vd->getInterfaceType()->getCanonicalType());
+    auto sig = vd->getDeclContext()->getGenericSignatureOfContext();
+    return CanAnyFunctionType::get(getCanonicalSignatureOrNull(sig),
+                                   funcTy->getParams(), funcTy.getResult(),
+                                   funcTy->getExtInfo());
+  }
+
   // Capture generic parameters from the enclosing context if necessary.
   auto closure = *constant.getAnyFunctionRef();
   auto genericSig = getEffectiveGenericSignature(closure, captureInfo);

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1992,17 +1992,6 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
   // captured functions.
   auto captureInfo = TC.getLoweredLocalCaptures(constant);
 
-  // FIXME: Why do we end up here when witness is case-with-payload?
-  if (!constant.getAnyFunctionRef().hasValue()) {
-    auto *vd = constant.loc.dyn_cast<ValueDecl *>();
-    auto funcTy =
-        cast<AnyFunctionType>(vd->getInterfaceType()->getCanonicalType());
-    auto sig = vd->getDeclContext()->getGenericSignatureOfContext();
-    return CanAnyFunctionType::get(getCanonicalSignatureOrNull(sig),
-                                   funcTy->getParams(), funcTy.getResult(),
-                                   funcTy->getExtInfo());
-  }
-
   // Capture generic parameters from the enclosing context if necessary.
   auto closure = *constant.getAnyFunctionRef();
   auto genericSig = getEffectiveGenericSignature(closure, captureInfo);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -406,6 +406,15 @@ public:
     if (!witness)
       return asDerived().addMissingMethod(requirementRef);
 
+    // An enum case can witness a static get-only Self property requirement
+    if (auto EED = dyn_cast<EnumElementDecl>(witness.getDecl())) {
+      assert(!EED->hasAssociatedValues() && "cases with payload not supported");
+      return addMethodImplementation(
+          requirementRef,
+          SILDeclRef(witness.getDecl(), SILDeclRef::Kind::EnumElement),
+          witness);
+    }
+
     auto witnessStorage = cast<AbstractStorageDecl>(witness.getDecl());
     if (reqAccessor->isSetter() && !witnessStorage->supportsMutation())
       return asDerived().addMissingMethod(requirementRef);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -408,7 +408,8 @@ public:
 
     // An enum case can witness a static get-only Self property requirement
     if (auto EED = dyn_cast<EnumElementDecl>(witness.getDecl())) {
-      assert(!EED->hasAssociatedValues() && "cases with payload not supported");
+      // assert(!EED->hasAssociatedValues() && "cases with payload not
+      // supported");
       return addMethodImplementation(
           requirementRef,
           SILDeclRef(witness.getDecl(), SILDeclRef::Kind::EnumElement),

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -744,6 +744,12 @@ SILFunction *SILGenModule::emitProtocolWitness(
   if (witnessRef.isAlwaysInline())
     InlineStrategy = AlwaysInline;
 
+  // If the witness is an enum case, we need to emit the constructor
+  // unconditionally.
+  if (isa<EnumElementDecl>(witness.getDecl())) {
+    emitEnumConstructor(cast<EnumElementDecl>(witness.getDecl()));
+  }
+
   SILGenFunctionBuilder builder(*this);
   auto *f = builder.createFunction(
       linkage, nameBuffer, witnessSILFnType, genericEnv,

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -406,10 +406,13 @@ public:
     if (!witness)
       return asDerived().addMissingMethod(requirementRef);
 
-    // An enum case can witness a static get-only Self property requirement
+    // An enum case can witness:
+    // 1. A static get-only property requirement, as long as the property's
+    //    type is `Self` or it matches the type of the enum explicitly.
+    // 2. A static function requirement, if the enum case has a payload
+    //    and the payload types and labels match the function and the
+    //    function returns `Self` or the type of the enum.
     if (auto EED = dyn_cast<EnumElementDecl>(witness.getDecl())) {
-      // assert(!EED->hasAssociatedValues() && "cases with payload not
-      // supported");
       return addMethodImplementation(
           requirementRef,
           SILDeclRef(witness.getDecl(), SILDeclRef::Kind::EnumElement),

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1852,6 +1852,7 @@ bool swift::calleesAreStaticallyKnowable(SILModule &module,
 
 /// Are the callees that could be called through Decl statically
 /// knowable based on the Decl and the compilation mode?
+// FIXME: Merge this with calleesAreStaticallyKnowable above
 bool swift::calleesAreStaticallyKnowable(SILModule &module,
                                          EnumElementDecl *eed) {
   const DeclContext *assocDC = module.getAssociatedContext();

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1797,6 +1797,11 @@ bool swift::calleesAreStaticallyKnowable(SILModule &module, SILDeclRef decl) {
   if (decl.isForeign)
     return false;
 
+  if (decl.isEnumElement()) {
+    return calleesAreStaticallyKnowable(module,
+                                        cast<EnumElementDecl>(decl.getDecl()));
+  }
+
   auto *afd = decl.getAbstractFunctionDecl();
   assert(afd && "Expected abstract function decl!");
   return calleesAreStaticallyKnowable(module, afd);
@@ -1835,6 +1840,40 @@ bool swift::calleesAreStaticallyKnowable(SILModule &module,
         return false;
     }
     LLVM_FALLTHROUGH;
+  case AccessLevel::Internal:
+    return module.isWholeModule();
+  case AccessLevel::FilePrivate:
+  case AccessLevel::Private:
+    return true;
+  }
+
+  llvm_unreachable("Unhandled access level in switch.");
+}
+
+/// Are the callees that could be called through Decl statically
+/// knowable based on the Decl and the compilation mode?
+bool swift::calleesAreStaticallyKnowable(SILModule &module,
+                                         EnumElementDecl *eed) {
+  const DeclContext *assocDC = module.getAssociatedContext();
+  if (!assocDC)
+    return false;
+
+  // Only handle members defined within the SILModule's associated context.
+  if (!eed->isChildContextOf(assocDC))
+    return false;
+
+  if (eed->isDynamic()) {
+    return false;
+  }
+
+  if (!eed->hasAccess())
+    return false;
+
+  // Only consider 'private' members, unless we are in whole-module compilation.
+  switch (eed->getEffectiveAccess()) {
+  case AccessLevel::Open:
+    return false;
+  case AccessLevel::Public:
   case AccessLevel::Internal:
     return module.isWholeModule();
   case AccessLevel::FilePrivate:

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -211,6 +211,10 @@ enum class MatchKind : uint8_t {
 
   /// The witness is missing a `@differentiable` attribute from the requirement.
   MissingDifferentiableAttr,
+  
+  /// The witness did not match because it is an enum case with
+  /// associated values.
+  EnumCaseWithAssociatedValues,
 };
 
 /// Describes the kind of optional adjustment performed when
@@ -436,7 +440,12 @@ struct RequirementMatch {
     case MatchKind::RethrowsConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
+<<<<<<< HEAD
     case MatchKind::MissingDifferentiableAttr:
+=======
+    case MatchKind::DifferentiableConflict:
+    case MatchKind::EnumCaseWithAssociatedValues:
+>>>>>>> [Typechecker] Allow enum cases without payload to witness a static get-only property with Self type protocol requirement
       return false;
     }
 
@@ -466,7 +475,12 @@ struct RequirementMatch {
     case MatchKind::RethrowsConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
+<<<<<<< HEAD
     case MatchKind::MissingDifferentiableAttr:
+=======
+    case MatchKind::DifferentiableConflict:
+    case MatchKind::EnumCaseWithAssociatedValues:
+>>>>>>> [Typechecker] Allow enum cases without payload to witness a static get-only property with Self type protocol requirement
       return false;
     }
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -440,12 +440,8 @@ struct RequirementMatch {
     case MatchKind::RethrowsConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
-<<<<<<< HEAD
     case MatchKind::MissingDifferentiableAttr:
-=======
-    case MatchKind::DifferentiableConflict:
     case MatchKind::EnumCaseWithAssociatedValues:
->>>>>>> [Typechecker] Allow enum cases without payload to witness a static get-only property with Self type protocol requirement
       return false;
     }
 
@@ -475,12 +471,8 @@ struct RequirementMatch {
     case MatchKind::RethrowsConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
-<<<<<<< HEAD
     case MatchKind::MissingDifferentiableAttr:
-=======
-    case MatchKind::DifferentiableConflict:
     case MatchKind::EnumCaseWithAssociatedValues:
->>>>>>> [Typechecker] Allow enum cases without payload to witness a static get-only property with Self type protocol requirement
       return false;
     }
 

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -494,21 +494,23 @@ void TBDGenVisitor::addConformances(DeclContext *DC) {
       }
     };
 
-    rootConformance->forEachValueWitness(
-        [&](ValueDecl *valueReq, Witness witness) {
-          auto witnessDecl = witness.getDecl();
-          if (isa<AbstractFunctionDecl>(valueReq)) {
-            addSymbolIfNecessary(valueReq, witnessDecl);
-          } else if (auto *storage = dyn_cast<AbstractStorageDecl>(valueReq)) {
-            auto witnessStorage = cast<AbstractStorageDecl>(witnessDecl);
-            storage->visitOpaqueAccessors([&](AccessorDecl *reqtAccessor) {
-              auto witnessAccessor =
-                witnessStorage->getSynthesizedAccessor(
-                  reqtAccessor->getAccessorKind());
-              addSymbolIfNecessary(reqtAccessor, witnessAccessor);
-            });
-          }
-        });
+    rootConformance->forEachValueWitness([&](ValueDecl *valueReq,
+                                             Witness witness) {
+      auto witnessDecl = witness.getDecl();
+      if (isa<AbstractFunctionDecl>(valueReq)) {
+        addSymbolIfNecessary(valueReq, witnessDecl);
+      } else if (auto *storage = dyn_cast<AbstractStorageDecl>(valueReq)) {
+        if (auto witnessStorage = dyn_cast<AbstractStorageDecl>(witnessDecl)) {
+          storage->visitOpaqueAccessors([&](AccessorDecl *reqtAccessor) {
+            auto witnessAccessor = witnessStorage->getSynthesizedAccessor(
+                reqtAccessor->getAccessorKind());
+            addSymbolIfNecessary(reqtAccessor, witnessAccessor);
+          });
+        } else if (isa<EnumElementDecl>(witnessDecl)) {
+          addSymbolIfNecessary(valueReq, witnessDecl);
+        }
+      }
+    });
   }
 }
 

--- a/test/SILGen/protocol_enum_witness.swift
+++ b/test/SILGen/protocol_enum_witness.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+protocol Foo {
+  static var button: Self { get }
+}
+
+enum Bar: Foo {
+  case button
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW : $@convention(witness_method: Foo) (@thick Bar.Type) -> @out Bar {
+// CHECK-NEXT: bb0([[BAR:%.*]] : $*Bar, [[BAR_TYPE:%.*]] : $@thick Bar.Type):
+// CHECK-NEXT: [[META_TYPE:%.*]] = metatype $@thin Bar.Type
+// CHECK-NEXT: [[REF:%.*]] = function_ref @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[REF]]([[META_TYPE]]) : $@convention(method) (@thin Bar.Type) -> Bar
+// CHECK-NEXT store [[RESULT]] to [trivial] [[BAR]] : $*Bar
+// CHECK-NEXT: [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT: return [[TUPLE]] : $()
+// CHECK-END: }
+
+// CHECK-LABEL: sil shared [transparent] [ossa] @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar {
+// CHECK-NEXT: bb0({{%.*}} : $@thin Bar.Type):
+// CHECK-NEXT: [[CASE:%.*]] = enum $Bar, #Bar.button!enumelt
+// CHECK-NEXT: return [[CASE]] : $Bar
+// CHECK-END: }
+
+// CHECK-LABEL: sil_witness_table hidden Bar: Foo module protocol_enum_witness {
+// CHECK: method #Foo.button!getter.1: <Self where Self : Foo> (Self.Type) -> () -> Self : @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW

--- a/test/SILGen/protocol_enum_witness.swift
+++ b/test/SILGen/protocol_enum_witness.swift
@@ -8,6 +8,14 @@ enum Bar: Foo {
   case button
 }
 
+protocol AnotherFoo {
+  static func bar(arg: Int) -> Self
+}
+
+enum AnotherBar: AnotherFoo {
+  case bar(arg: Int)
+}
+
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW : $@convention(witness_method: Foo) (@thick Bar.Type) -> @out Bar {
 // CHECK-NEXT: bb0([[BAR:%.*]] : $*Bar, [[BAR_TYPE:%.*]] : $@thick Bar.Type):
 // CHECK-NEXT: [[META_TYPE:%.*]] = metatype $@thin Bar.Type
@@ -24,5 +32,18 @@ enum Bar: Foo {
 // CHECK-NEXT: return [[CASE]] : $Bar
 // CHECK-END: }
 
+// CHECK-LABEL: sil private [transparent] [thunk] @$s21protocol_enum_witness10AnotherBarOAA0B3FooA2aDP3bar3argxSi_tFZTW : $@convention(witness_method: AnotherFoo) (Int, @thick AnotherBar.Type) -> @out AnotherBar {
+// CHECK-NEXT: bb0([[ANOTHER_BAR:%.*]] : $*AnotherBar, [[INT_ARG:%.*]] : $Int, [[ANOTHER_BAR_TYPE:%.*]] : $@thick AnotherBar.Type):
+// CHECK-NEXT: [[META_TYPE:%.*]] = metatype $@thin AnotherBar.Type
+// CHECK-NEXT: [[REF:%.*]] = function_ref @$s21protocol_enum_witness10AnotherBarO3baryACSi_tcACmF : $@convention(method) (Int, @thin AnotherBar.Type) -> AnotherBar
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[REF]]([[INT_ARG]], [[META_TYPE]]) : $@convention(method) (Int, @thin AnotherBar.Type) -> AnotherBar
+// CHECK-NEXT: store [[RESULT]] to [[ANOTHER_BAR]] : $*AnotherBar
+// CHECK-NEXT: [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT: return [[TUPLE]] : $()
+// CHECK-END: }
+
 // CHECK-LABEL: sil_witness_table hidden Bar: Foo module protocol_enum_witness {
 // CHECK: method #Foo.button!getter.1: <Self where Self : Foo> (Self.Type) -> () -> Self : @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW
+
+// CHECK-LABEL: sil_witness_table hidden AnotherBar: AnotherFoo module protocol_enum_witness {
+// CHECK: method #AnotherFoo.bar!1: <Self where Self : AnotherFoo> (Self.Type) -> (Int) -> Self : @$s21protocol_enum_witness10AnotherBarOAA0B3FooA2aDP3bar3argxSi_tFZTW

--- a/test/SILGen/protocol_enum_witness.swift
+++ b/test/SILGen/protocol_enum_witness.swift
@@ -17,33 +17,33 @@ enum AnotherBar: AnotherFoo {
 }
 
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW : $@convention(witness_method: Foo) (@thick Bar.Type) -> @out Bar {
-// CHECK-NEXT: bb0([[BAR:%.*]] : $*Bar, [[BAR_TYPE:%.*]] : $@thick Bar.Type):
+// CHECK: bb0([[BAR:%.*]] : $*Bar, [[BAR_TYPE:%.*]] : $@thick Bar.Type):
 // CHECK-NEXT: [[META_TYPE:%.*]] = metatype $@thin Bar.Type
-// CHECK-NEXT: [[REF:%.*]] = function_ref @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar
+// CHECK: [[REF:%.*]] = function_ref @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[REF]]([[META_TYPE]]) : $@convention(method) (@thin Bar.Type) -> Bar
-// CHECK-NEXT store [[RESULT]] to [trivial] [[BAR]] : $*Bar
+// CHECK-NEXT: store [[RESULT]] to [trivial] [[BAR]] : $*Bar
 // CHECK-NEXT: [[TUPLE:%.*]] = tuple ()
 // CHECK-NEXT: return [[TUPLE]] : $()
 // CHECK-END: }
 
-// CHECK-LABEL: sil shared [transparent] [ossa] @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar {
-// CHECK-NEXT: bb0({{%.*}} : $@thin Bar.Type):
+// CHECK-LABEL: sil hidden [transparent] [ossa] @$s21protocol_enum_witness3BarO6buttonyA2CmF : $@convention(method) (@thin Bar.Type) -> Bar {
+// CHECK: bb0({{%.*}} : $@thin Bar.Type):
 // CHECK-NEXT: [[CASE:%.*]] = enum $Bar, #Bar.button!enumelt
 // CHECK-NEXT: return [[CASE]] : $Bar
 // CHECK-END: }
 
-// CHECK-LABEL: sil private [transparent] [thunk] @$s21protocol_enum_witness10AnotherBarOAA0B3FooA2aDP3bar3argxSi_tFZTW : $@convention(witness_method: AnotherFoo) (Int, @thick AnotherBar.Type) -> @out AnotherBar {
-// CHECK-NEXT: bb0([[ANOTHER_BAR:%.*]] : $*AnotherBar, [[INT_ARG:%.*]] : $Int, [[ANOTHER_BAR_TYPE:%.*]] : $@thick AnotherBar.Type):
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s21protocol_enum_witness10AnotherBarOAA0D3FooA2aDP3bar3argxSi_tFZTW : $@convention(witness_method: AnotherFoo) (Int, @thick AnotherBar.Type) -> @out AnotherBar {
+// CHECK: bb0([[ANOTHER_BAR:%.*]] : $*AnotherBar, [[INT_ARG:%.*]] : $Int, [[ANOTHER_BAR_TYPE:%.*]] : $@thick AnotherBar.Type):
 // CHECK-NEXT: [[META_TYPE:%.*]] = metatype $@thin AnotherBar.Type
-// CHECK-NEXT: [[REF:%.*]] = function_ref @$s21protocol_enum_witness10AnotherBarO3baryACSi_tcACmF : $@convention(method) (Int, @thin AnotherBar.Type) -> AnotherBar
+// CHECK: [[REF:%.*]] = function_ref @$s21protocol_enum_witness10AnotherBarO3baryACSi_tcACmF : $@convention(method) (Int, @thin AnotherBar.Type) -> AnotherBar
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[REF]]([[INT_ARG]], [[META_TYPE]]) : $@convention(method) (Int, @thin AnotherBar.Type) -> AnotherBar
-// CHECK-NEXT: store [[RESULT]] to [[ANOTHER_BAR]] : $*AnotherBar
+// CHECK-NEXT: store [[RESULT]] to [trivial] [[ANOTHER_BAR]] : $*AnotherBar
 // CHECK-NEXT: [[TUPLE:%.*]] = tuple ()
 // CHECK-NEXT: return [[TUPLE]] : $()
 // CHECK-END: }
 
 // CHECK-LABEL: sil_witness_table hidden Bar: Foo module protocol_enum_witness {
-// CHECK: method #Foo.button!getter.1: <Self where Self : Foo> (Self.Type) -> () -> Self : @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW
+// CHECK: method #Foo.button!getter: <Self where Self : Foo> (Self.Type) -> () -> Self : @$s21protocol_enum_witness3BarOAA3FooA2aDP6buttonxvgZTW
 
 // CHECK-LABEL: sil_witness_table hidden AnotherBar: AnotherFoo module protocol_enum_witness {
-// CHECK: method #AnotherFoo.bar!1: <Self where Self : AnotherFoo> (Self.Type) -> (Int) -> Self : @$s21protocol_enum_witness10AnotherBarOAA0B3FooA2aDP3bar3argxSi_tFZTW
+// CHECK: method #AnotherFoo.bar: <Self where Self : AnotherFoo> (Self.Type) -> (Int) -> Self : @$s21protocol_enum_witness10AnotherBarOAA0D3FooA2aDP3bar3argxSi_tFZTW

--- a/test/decl/protocol/protocol_enum_witness.swift
+++ b/test/decl/protocol/protocol_enum_witness.swift
@@ -1,0 +1,75 @@
+// RUN: %target-typecheck-verify-swift
+
+// Requirement is settable, so witness cannot satisfy it //
+
+protocol Foo1 {
+  static var bar: Self { get set } // expected-note {{protocol requires property 'bar' with type 'Bar1'; do you want to add a stub?}}
+}
+
+enum Bar1: Foo1 { // expected-error {{type 'Bar1' does not conform to protocol 'Foo1'}}
+  case bar // expected-note {{candidate is not settable, but protocol requires it}}
+}
+
+// Witness has associated values, which is unsupported //
+
+protocol Foo2 {
+  static var bar: Self { get set } // expected-note {{protocol requires property 'bar' with type 'Bar2'; do you want to add a stub?}}
+}
+
+enum Bar2: Foo2 { // expected-error {{type 'Bar2' does not conform to protocol 'Foo2'}}
+  case bar(Int) // expected-note {{candidate is an enum case with associated values, but protocol does not allow it}}
+}
+
+protocol Foo3 {
+  static var bar: Self { get } // expected-note {{protocol requires property 'bar' with type 'Bar3'; do you want to add a stub?}}
+}
+
+enum Bar3: Foo3 { // expected-error {{type 'Bar3' does not conform to protocol 'Foo3'}}
+  case bar(Int) // expected-note {{candidate is an enum case with associated values, but protocol does not allow it}}
+}
+
+// Requirement is not static, so it cannot be witnessed by the enum case //
+
+protocol Foo4 {
+  var bar: Self { get } // expected-note {{protocol requires property 'bar' with type 'Bar4'; do you want to add a stub?}}
+}
+
+enum Bar4: Foo4 { // expected-error {{type 'Bar4' does not conform to protocol 'Foo4'}}
+  case bar // expected-note {{candidate operates on a type, not an instance as required}}
+}
+
+protocol Foo5 {
+  var bar: Self { get set } // expected-note {{protocol requires property 'bar' with type 'Bar5'; do you want to add a stub?}}
+}
+
+enum Bar5: Foo5 { // expected-error {{type 'Bar5' does not conform to protocol 'Foo5'}}
+  case bar // expected-note {{candidate operates on a type, not an instance as required}}
+}
+
+// Requirement does not have Self type, so it cannot be witnessed by the enum case //
+
+protocol Foo6 {
+  static var bar: Int { get } // expected-note {{protocol requires property 'bar' with type 'Int'; do you want to add a stub?}}
+}
+
+enum Bar6: Foo6 { // expected-error {{type 'Bar6' does not conform to protocol 'Foo6'}}
+  case bar // expected-note {{candidate has non-matching type '(Bar6.Type) -> Bar6'}}
+}
+
+// Valid cases
+
+protocol Foo7 {
+  static var bar: Self { get }
+}
+
+enum Bar7: Foo7 {
+  case bar // Okay
+}
+
+protocol Foo8 {
+  static var bar: Bar8 { get }
+}
+
+enum Bar8: Foo8 {
+  case bar // Okay
+}

--- a/test/decl/protocol/protocol_enum_witness.swift
+++ b/test/decl/protocol/protocol_enum_witness.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
+////// WITNESS MATCHING FOR PAYLOAD-LESS ENUMS //////
+
 // Requirement is settable, so witness cannot satisfy it //
 
 protocol Foo1 {
@@ -72,4 +74,58 @@ protocol Foo8 {
 
 enum Bar8: Foo8 {
   case bar // Okay
+}
+
+////// WITNESS MATCHING FOR PAYLOAD ENUMS //////
+
+// Witness does not have argument label, but requirement does
+
+protocol Foo9 {
+  static func bar(f: Int) -> Self // expected-note {{protocol requires function 'bar(f:)' with type '(Int) -> Bar9'; do you want to add a stub?}}
+}
+
+enum Bar9: Foo9 { // expected-error {{type 'Bar9' does not conform to protocol 'Foo9'}}
+  case bar(_ f: Int) // expected-note {{candidate has non-matching type '(Bar9.Type) -> (Int) -> Bar9'}}
+}
+
+// Witness does not have any labels, but requirement does
+
+protocol Foo10 {
+  static func bar(g: Int) -> Self // expected-note {{protocol requires function 'bar(g:)' with type '(Int) -> Bar10'; do you want to add a stub?}}
+}
+
+enum Bar10: Foo10 { // expected-error {{type 'Bar10' does not conform to protocol 'Foo10'}}
+  case bar(Int) // expected-note {{candidate has non-matching type '(Bar10.Type) -> (Int) -> Bar10'}}
+}
+
+// Witness does not have a payload, but requirement is a function
+
+protocol Foo11 {
+  static func bar(h: Int) -> Self // expected-note {{protocol requires function 'bar(h:)' with type '(Int) -> Bar11'; do you want to add a stub?}}
+}
+
+enum Bar11: Foo11 { // expected-error {{type 'Bar11' does not conform to protocol 'Foo11'}}
+  case bar // expected-note {{candidate has non-matching type '(Bar11.Type) -> Bar11'}}
+}
+
+// Witness is static, but requirement is not
+
+protocol Foo12 {
+  func bar(i: Int) -> Self // expected-note {{protocol requires function 'bar(i:)' with type '(Int) -> Bar12'; do you want to add a stub?}}
+}
+
+enum Bar12: Foo12 { // expected-error {{type 'Bar12' does not conform to protocol 'Foo12'}}
+  case bar // expected-note {{candidate operates on a type, not an instance as required}}
+}
+
+// Valid cases
+
+protocol Foo13 {
+  static func bar(j: Int) -> Self
+  static func baz(_ k: String) -> Bar13
+}
+
+enum Bar13: Foo13 {
+  case bar(j: Int) // Okay
+  case baz(_ k: String) // Okay
 }

--- a/test/decl/protocol/req/name_mismatch.swift
+++ b/test/decl/protocol/req/name_mismatch.swift
@@ -54,7 +54,7 @@ protocol P3 {
 }
 
 class MislabeledSubscript : P3 {
-  subscript(val: String, label: String) -> Int { // expected-error{{method 'subscript(_:_:)' has different argument labels from those required by protocol 'P3' ('subscript(_:label:)')}}
+  subscript(val: String, label: String) -> Int { // expected-error{{subscript 'subscript(_:_:)' has different argument labels from those required by protocol 'P3' ('subscript(_:label:)')}}
     return 1
   }
 }


### PR DESCRIPTION
Allow enum cases to witness static protocol requirements. For example:

```swift
protocol Foo {
  static var bar: Self { get }
  static func baz(arg: Int) -> Self
}

enum SomeEnum: Foo {
  case bar // Okay
  case baz(arg: Int) // Okay
}
```

Swift-evolution thread: https://forums.swift.org/t/pitch-enum-cases-as-protocol-witnesses/32753

Resolves SR-3170, SR-3510, SR-9099