### PR TITLE
[Foundation] Fix Data.count’s setter

### DIFF
--- a/stdlib/public/Darwin/Foundation/Data.swift
+++ b/stdlib/public/Darwin/Foundation/Data.swift
@@ -1402,7 +1402,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
                         if newValue == 0 {
                             return nil
                         } else if InlineData.canStore(count: newValue) {
-                            return .inline(InlineData())
+                            return .inline(InlineData(count: newValue))
                         } else if InlineSlice.canStore(count: newValue) {
                             return .slice(InlineSlice(count: newValue))
                         } else {

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -3836,6 +3836,53 @@ class TestData : TestDataSuper {
             }
         }
     }
+
+    func test_increaseCount() {
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+        let initials: [Range<UInt8>] = [
+            0..<0,
+            0..<2,
+            0..<4,
+            0..<8,
+            0..<16,
+            0..<32,
+            0..<64
+        ]
+        let diffs = [0, 1, 2, 4, 8, 16, 32]
+        for initial in initials {
+            for diff in diffs {
+                var data = Data(initial)
+                data.count += diff
+                expectEqualSequence(
+                    Array(initial) + Array(repeating: 0, count: diff),
+                    data)
+            }
+        }
+    }
+
+    func test_decreaseCount() {
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+        let initials: [Range<UInt8>] = [
+            0..<0,
+            0..<2,
+            0..<4,
+            0..<8,
+            0..<16,
+            0..<32,
+            0..<64
+        ]
+        let diffs = [0, 1, 2, 4, 8, 16, 32]
+        for initial in initials {
+            for diff in diffs {
+                guard initial.count >= diff else { continue }
+                var data = Data(initial)
+                data.count -= diff
+                expectEqualSequence(
+                    initial.dropLast(diff),
+                    data)
+            }
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -4159,6 +4206,9 @@ if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
     DataTests.test("test_nsdataSequence") { TestData().test_nsdataSequence() }
     DataTests.test("test_dispatchSequence") { TestData().test_dispatchSequence() }
 }
+DataTests.test("test_increaseCount") { TestData().test_increaseCount() }
+DataTests.test("test_decreaseCount") { TestData().test_decreaseCount() }
+
 
 // XCTest does not have a crash detection, whereas lit does
 DataTests.test("bounding failure subdata") {


### PR DESCRIPTION
`Data` provides a settable `count` property. Its expected behavior is undocumented, but based on the implementation, it is intended to zero-extend (or truncate) the collection to the specified length.

This does not work correctly if we start with an empty `Data` and we try to increase the count by a small integer:

```
import Foundation

var d = Data()
d.count = 2
print(d.count) // ⟹ 0 ⁉️

d.count = 100
print(d.count) // ⟹ 100 ✓
```

It looks like this bug was introduced with the `Data` overhaul that shipped in Swift 5.

(This issue was uncovered by https://github.com/apple/swift/pull/28918.)

rdar://58134026
