### PR TITLE
[stdlib] Tweak IndexingIterator

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -123,10 +123,9 @@ extension IndexingIterator: IteratorProtocol, Sequence {
   @inlinable
   @inline(__always)
   public mutating func next() -> Elements.Element? {
-    if _position == _elements.endIndex { return nil }
-    let element = _elements[_position]
-    _elements.formIndex(after: &_position)
-    return element
+    guard _position < _elements.endIndex else { return nil }
+    defer { _elements.formIndex(after: &_position) }    
+    return _elements[_position]
   }
 }
 


### PR DESCRIPTION
This appears to generate better code in at least some situations (yes, even with the `defer`).

This was my test case:

```swift
extension Array where Element: SIMD {
    var flatCount: Int { count * Element.scalarCount }
    subscript(flatIdx i: Int) -> Element.Scalar {
        let (i0, i1) = i.quotientAndRemainder(dividingBy: Element.scalarCount)
        return self[i0][i1]
    }
}

@inline(never)
func blackHole(_ x: Float) {
    print(x)
}
func doTestRange(arr: Array<SIMD4<Float>>) {
    for x in 0..<arr.flatCount {
        let result = arr[flatIdx: x]
        blackHole(result)
    }
}
```

With the current implementation, I got this code being generated in the loop:

```asm
        mov     rcx, rax
        sar     rcx, 63
        shr     rcx, 62
        add     rcx, rax
        sar     rcx, 2
        lea     edx, [4*rcx]
        lea     rbx, [rax + 1]
        sub     eax, edx
        shl     rcx, 4
        add     rcx, r14
        cdqe
        movss   xmm0, dword ptr [rcx + 4*rax]
        call    (output.blackHole(Swift.Float) -> ())
        mov     rax, rbx
        cmp     r15, rbx
        jne     .LBB29_2
```

But by replacing it with a modified version of `IndexingIterator`, I got a much more pleasing result:

```asm
        mov     rcx, rax
        and     rcx, r15
        lea     rcx, [r14 + 4*rcx]
        lea     rbx, [rax + 1]
        and     eax, 3
        movss   xmm0, dword ptr [rcx + 4*rax]
        call    (output.blackHole(Swift.Float) -> ())
        mov     rax, rbx
        cmp     r12, rbx
        jne     .LBB31_2
```

Granted, this is a micro-optimisation, but given that it's part of the loop's hot-path for so many collections, it may add up to something noticeable 🤷‍♂ 

@lorentey Would you mind asking for benchmarks? I'm just curious.