### PR TITLE
[AutoDiff] Diagnose unsupported coroutine differentiation.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -541,6 +541,9 @@ NOTE(autodiff_control_flow_not_supported,none,
 // TODO(TF-645): Remove when differentiation supports `ref_element_addr`.
 NOTE(autodiff_class_property_not_supported,none,
      "differentiating class properties is not yet supported", ())
+// TODO(TF-1080): Remove when differentiation supports `begin_apply`.
+NOTE(autodiff_coroutines_not_supported,none,
+     "differentiation of coroutine calls is not yet supported", ())
 NOTE(autodiff_missing_return,none,
      "missing return for differentiation", ())
 

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -503,6 +503,19 @@ public:
     return getArguments().slice(getNumIndirectSILResults());
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  InoutArgumentRange getInoutArguments() const {
+    switch (getKind()) {
+    case FullApplySiteKind::ApplyInst:
+      return cast<ApplyInst>(getInstruction())->getInoutArguments();
+    case FullApplySiteKind::TryApplyInst:
+      return cast<TryApplyInst>(getInstruction())->getInoutArguments();
+    case FullApplySiteKind::BeginApplyInst:
+      return cast<BeginApplyInst>(getInstruction())->getInoutArguments();
+    }
+  }
+  // SWIFT_ENABLE_TENSORFLOW END
+
   /// Returns true if \p op is the callee operand of this apply site
   /// and not an argument operand.
   bool isCalleeOperand(const Operand &op) const {

--- a/include/swift/SILOptimizer/Utils/Differentiation/Common.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/Common.h
@@ -50,9 +50,9 @@ namespace autodiff {
 /// This is being used to print short debug messages within the AD pass.
 raw_ostream &getADDebugStream();
 
-/// Returns true if this is an `ApplyInst` with `array.uninitialized_intrinsic`
-/// semantics.
-bool isArrayLiteralIntrinsic(ApplyInst *ai);
+/// Returns true if this is an full apply site whose callee has
+/// `array.uninitialized_intrinsic` semantics.
+bool isArrayLiteralIntrinsic(FullApplySite applySite);
 
 /// If the given value `v` corresponds to an `ApplyInst` with
 /// `array.uninitialized_intrinsic` semantics, returns the corresponding
@@ -76,11 +76,22 @@ ApplyInst *getAllocateUninitializedArrayIntrinsicElementAddress(SILValue v);
 /// tuple-typed and such a user exists.
 DestructureTupleInst *getSingleDestructureTupleUser(SILValue value);
 
-/// Given an `apply` instruction, apply the given callback to each of its
-/// direct results. If the `apply` instruction has a single `destructure_tuple`
-/// user, apply the callback to the results of the `destructure_tuple` user.
+/// Given a full apply site, apply the given callback to each of its
+/// "direct results".
+///
+/// - `apply`
+/// Special case because `apply` returns a single (possibly tuple-typed) result
+/// instead of multiple results. If the `apply` has a single
+/// `destructure_tuple` user, treat the `destructure_tuple` results as the
+/// `apply` direct results.
+///
+/// - `begin_apply`
+/// Apply callback to each `begin_apply` direct result.
+///
+/// - `try_apply`
+/// Apply callback to each `try_apply` successor basic block argument.
 void forEachApplyDirectResult(
-    ApplyInst *ai, llvm::function_ref<void(SILValue)> resultCallback);
+    FullApplySite applySite, llvm::function_ref<void(SILValue)> resultCallback);
 
 /// Given a function, gathers all of its formal results (both direct and
 /// indirect) in an order defined by its result type. Note that "formal results"

--- a/include/swift/SILOptimizer/Utils/Differentiation/LinearMapInfo.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/LinearMapInfo.h
@@ -141,7 +141,7 @@ private:
                                              SILFunction *derivative);
 
 public:
-  bool shouldDifferentiateApplyInst(ApplyInst *ai);
+  bool shouldDifferentiateApplySite(FullApplySite applySite);
   bool shouldDifferentiateInstruction(SILInstruction *inst);
 
   LinearMapInfo(const LinearMapInfo &) = delete;

--- a/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
@@ -338,6 +338,8 @@ public:
 
   void visitApplyInst(ApplyInst *ai);
 
+  void visitBeginApplyInst(BeginApplyInst *bai);
+
   /// Handle `struct` instruction.
   ///   Original: y = struct (x0, x1, x2, ...)
   ///    Adjoint: adj[x0] += struct_extract adj[y], #x0

--- a/lib/SILOptimizer/Utils/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/Common.cpp
@@ -82,8 +82,8 @@ void forEachApplyDirectResult(
       return;
     }
     if (auto *dti = getSingleDestructureTupleUser(ai))
-      for (auto directtResult : dti->getResults())
-        resultCallback(directtResult);
+      for (auto directResult : dti->getResults())
+        resultCallback(directResult);
     break;
   }
   case FullApplySiteKind::BeginApplyInst: {

--- a/lib/SILOptimizer/Utils/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/Common.cpp
@@ -26,8 +26,9 @@ namespace autodiff {
 
 raw_ostream &getADDebugStream() { return llvm::dbgs() << "[AD] "; }
 
-bool isArrayLiteralIntrinsic(ApplyInst *ai) {
-  return ai->hasSemantics("array.uninitialized_intrinsic");
+bool isArrayLiteralIntrinsic(FullApplySite applySite) {
+  return doesApplyCalleeHaveSemantics(applySite.getCalleeOrigin(),
+                                      "array.uninitialized_intrinsic");
 }
 
 ApplyInst *getAllocateUninitializedArrayIntrinsic(SILValue v) {
@@ -71,14 +72,34 @@ DestructureTupleInst *getSingleDestructureTupleUser(SILValue value) {
 }
 
 void forEachApplyDirectResult(
-    ApplyInst *ai, llvm::function_ref<void(SILValue)> resultCallback) {
-  if (!ai->getType().is<TupleType>()) {
-    resultCallback(ai);
-    return;
+    FullApplySite applySite,
+    llvm::function_ref<void(SILValue)> resultCallback) {
+  switch (applySite.getKind()) {
+  case FullApplySiteKind::ApplyInst: {
+    auto *ai = cast<ApplyInst>(applySite.getInstruction());
+    if (!ai->getType().is<TupleType>()) {
+      resultCallback(ai);
+      return;
+    }
+    if (auto *dti = getSingleDestructureTupleUser(ai))
+      for (auto directtResult : dti->getResults())
+        resultCallback(directtResult);
+    break;
   }
-  if (auto *dti = getSingleDestructureTupleUser(ai))
-    for (auto result : dti->getResults())
-      resultCallback(result);
+  case FullApplySiteKind::BeginApplyInst: {
+    auto *bai = cast<BeginApplyInst>(applySite.getInstruction());
+    for (auto directResult : bai->getResults())
+      resultCallback(directResult);
+    break;
+  }
+  case FullApplySiteKind::TryApplyInst: {
+    auto *tai = cast<TryApplyInst>(applySite.getInstruction());
+    for (auto *succBB : tai->getSuccessorBlocks())
+      for (auto *arg : succBB->getArguments())
+        resultCallback(arg);
+    break;
+  }
+  }
 }
 
 void collectAllFormalResultsInTypeOrder(SILFunction &function,

--- a/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/JVPEmitter.cpp
@@ -746,7 +746,7 @@ CLONE_AND_EMIT_TANGENT(DestructureTuple, dti) {
 void JVPEmitter::emitTangentForApplyInst(
     ApplyInst *ai, SILAutoDiffIndices actualIndices,
     CanSILFunctionType originalDifferentialType) {
-  assert(differentialInfo.shouldDifferentiateApplyInst(ai));
+  assert(differentialInfo.shouldDifferentiateApplySite(ai));
   auto *bb = ai->getParent();
   auto loc = ai->getLoc();
   auto &diffBuilder = getDifferentialBuilder();
@@ -1184,7 +1184,7 @@ void JVPEmitter::visitInstructionsInBlock(SILBasicBlock *bb) {
 void JVPEmitter::visitApplyInst(ApplyInst *ai) {
   // If the function should not be differentiated or its the array literal
   // initialization intrinsic, just do standard cloning.
-  if (!differentialInfo.shouldDifferentiateApplyInst(ai) ||
+  if (!differentialInfo.shouldDifferentiateApplySite(ai) ||
       isArrayLiteralIntrinsic(ai)) {
     LLVM_DEBUG(getADDebugStream() << "No active results:\n" << *ai << '\n');
     TypeSubstCloner::visitApplyInst(ai);

--- a/lib/SILOptimizer/Utils/Differentiation/PullbackEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/PullbackEmitter.cpp
@@ -1078,7 +1078,7 @@ PullbackEmitter::getArrayAdjointElementBuffer(SILValue arrayAdjoint,
 }
 
 void PullbackEmitter::visitApplyInst(ApplyInst *ai) {
-  assert(getPullbackInfo().shouldDifferentiateApplyInst(ai));
+  assert(getPullbackInfo().shouldDifferentiateApplySite(ai));
   // Skip `array.uninitialized_intrinsic` intrinsic applications, which have
   // special `store` and `copy_addr` support.
   if (isArrayLiteralIntrinsic(ai))
@@ -1271,6 +1271,15 @@ void PullbackEmitter::visitStructInst(StructInst *si) {
                      "instructions");
   }
   }
+}
+
+void PullbackEmitter::visitBeginApplyInst(BeginApplyInst *bai) {
+  // Diagnose `begin_apply` instructions.
+  // Coroutine differentiation is not yet supported.
+  getContext().emitNondifferentiabilityError(
+      bai, getInvoker(), diag::autodiff_coroutines_not_supported);
+  errorOccurred = true;
+  return;
 }
 
 void PullbackEmitter::visitStructExtractInst(StructExtractInst *sei) {

--- a/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
@@ -430,7 +430,7 @@ void VJPEmitter::visitSwitchEnumInst(SwitchEnumInst *sei) {
 void VJPEmitter::visitApplyInst(ApplyInst *ai) {
   // If the function should not be differentiated or its the array literal
   // initialization intrinsic, just do standard cloning.
-  if (!pullbackInfo.shouldDifferentiateApplyInst(ai) ||
+  if (!pullbackInfo.shouldDifferentiateApplySite(ai) ||
       isArrayLiteralIntrinsic(ai)) {
     LLVM_DEBUG(getADDebugStream() << "No active results:\n" << *ai << '\n');
     TypeSubstCloner::visitApplyInst(ai);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3857,10 +3857,12 @@ DifferentiableAttributeParameterIndicesRequest::evaluate(
       original = nullptr;
     }
   }
-  // Setters are not yet supported.
-  // TODO(TF-129): Remove this when differentiation supports inout parameters.
+  // Non-`get` accessors are not yet supported: `set`, `read`, and `modify`.
+  // TODO(TF-129): Enable `set` when differentiation supports inout parameters.
+  // TODO(TF-1080): Enable `read` and `modify` when differentiation supports
+  // coroutines.
   if (auto *accessor = dyn_cast_or_null<AccessorDecl>(original))
-    if (accessor->isSetter())
+    if (!accessor->isGetter())
       original = nullptr;
 
   // Global immutable vars, for example, have no getter, and therefore trigger

--- a/test/AutoDiff/control_flow_diagnostics.swift
+++ b/test/AutoDiff/control_flow_diagnostics.swift
@@ -72,7 +72,18 @@ func nested_loop(_ x: Float) -> Float {
   return outer
 }
 
-// Test `try_apply`.
+// TF-433: Test throwing functions.
+
+func rethrowing(_ x: () throws -> Void) rethrows -> Void {}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func testTryApply(_ x: Float) -> Float {
+  // expected-note @+1 {{cannot differentiate unsupported control flow}}
+  rethrowing({})
+  return x
+}
 
 // expected-error @+1 {{function is not differentiable}}
 @differentiable

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -1053,3 +1053,25 @@ class Sub : Super {
   @differentiable(wrt: x, vjp: vjp)
   override func testSuperclassDerivatives(_ x: Float) -> Float { x }
 }
+
+// Test unsupported accessors: `set`, `_read`, `_modify`.
+
+struct UnsupportedAccessors: Differentiable {
+  var stored: Float
+  var computed: Float {
+    // `set` has an `inout` parameter: `(inout Self) -> (Float) -> ()`.
+    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable
+    set { stored = newValue }
+
+    // `_read` is a coroutine: `(Self) -> () -> ()`.
+    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable
+    _read { yield stored }
+
+    // `_modify` is a coroutine: `(inout Self) -> () -> ()`.
+    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable
+    _modify { yield &stored }
+  }
+}


### PR DESCRIPTION
Coroutines are functions that can yield values and suspend/resume execution.
[SIL has dedicated coroutine types.](https://github.com/apple/swift/blob/master/docs/SIL.rst#coroutine-types) Coroutines are applied via [`begin_apply`](https://github.com/apple/swift/blob/master/docs/SIL.rst#begin_apply).
The `read` and [`modify`](https://forums.swift.org/t/pitch-modify-accessors/31872) accessors are coroutines.

Coroutine differentiation requires extra support, so it should be diagnosed
for now.

---

Differentiation transform:
- Generalize differentiation utilities from `ApplyInst` to `FullApplySite`.
  - `bool isArrayLiteralIntrinsic(FullApplySite)`
  - `void forEachApplyDirectResult(FullApplySite, llvm::function_ref<...>)`
    - `apply`: direct result is the `apply` result, unless the `apply` result
      has tuple-type and a single `destructure_tuple` user. Then, direct results
      are the `destructure_tuple` results.
    - `begin_apply`: direct results are the `begin_apply` results.
    - `try_apply`: direct results are successor blocks' arguments.
  - `bool LinearMapInfo::shouldDifferentiateApplySite(FullApplySite)`
- Generalize activity analysis from `ApplyInst` to `FullApplySite`.
  - Propagate variedness for `FullApplySite` through direct/indirect results and
    `inout` arguments.
  - Propagate usefulness for `FullApplySite` through arguments.
- Diagnose `begin_apply` instructions with active arguments and results in
  `PullbackEmitter::visitBeginApplyInst`.

Sema:
- Diagnose `@differentiable` attribute on `read` and `modify` coroutines.

Resolves TF-1081.

TF-1080 tracks coroutine differentiation support.
TF-1083 tracks throwing function differentiation support.

---

Example:

```swift
@differentiable
func foo(array: [Float], x: Float) -> Float {
  var array = array
  // `read` and `modify` accessors are coroutines.
  // Array subscript assignment below calls `Array.subscript.modify`.
  array[0] = x * x
  return array[0]
}
print(valueWithGradient(at: [3, 4], 5, in: foo))

// Before: silently incorrect results.
// (value: 25.0, gradient: ([1.0, 0.0], 0.0)).

// After: diagnosed.
// coroutine.swift:1:2: error: function is not differentiable
// @differentiable
// ~^~~~~~~~~~~~~~
// coroutine.swift:2:6: note: when differentiating this function definition
// func foo(array: [Float], x: Float) -> Float {
//   ^
// coroutine.swift:5:12: note: differentiation of coroutine calls is not yet supported
//   array[0] = x * x
//     ^
```