### PR TITLE
[Driver] [SR11918] Reject the combination of -enable-testing and -enable-library-evolution

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -201,9 +201,9 @@ ERROR(error_darwin_static_stdlib_not_supported, none,
       "-static-stdlib is no longer supported on Apple platforms", ())
 
 WARNING(warn_library_evolution_test_mode_compatibility, none,
-       "'-enable-library-evolution' and '-enable-testing' together "
-       "can cause unexpected compatibility compilation and runtime errors", 
-       ())
+        "'-enable-library-evolution' and '-enable-testing' together "
+        "can cause unexpected compatibility compilation and runtime errors", 
+        ())
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -205,8 +205,9 @@ ERROR(error_darwin_static_stdlib_not_supported, none,
 
 WARNING(warn_library_evolution_test_mode_compatibility, none,
         "specifying '-enable-library-evolution' and '-enable-testing' "
-        "together will cause program instability", 
-        ())
+        "together will cause program instability; consider disabling the "
+        "'%0' flag", 
+        (StringRef))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -204,8 +204,8 @@ ERROR(error_darwin_static_stdlib_not_supported, none,
       "-static-stdlib is no longer supported on Apple platforms", ())
 
 WARNING(warn_library_evolution_test_mode_compatibility, none,
-        "'-enable-library-evolution' and '-enable-testing' together "
-        "can cause unexpected compatibility compilation and runtime errors", 
+        "specifying '-enable-library-evolution' and '-enable-testing' "
+        "together will cause program instability", 
         ())
 
 #ifndef DIAG_NO_UNDEF

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -183,22 +183,27 @@ WARNING(warn_use_filelists_deprecated, none,
         "'-driver-filelist-threshold=0' instead", ())
 
 WARNING(warn_unable_to_load_swift_ranges, none,
-"unable to load swift ranges file \"%0\", %1",
-(StringRef, StringRef))
+       "unable to load swift ranges file \"%0\", %1",
+       (StringRef, StringRef))
 
 WARNING(warn_unable_to_load_compiled_swift, none,
-"unable to load previously compiled swift file \"%0\", %1",
-(StringRef, StringRef))
+       "unable to load previously compiled swift file \"%0\", %1",
+       (StringRef, StringRef))
 
 WARNING(warn_unable_to_load_primary, none,
-"unable to load primary swift file \"%0\", %1",
-(StringRef, StringRef))
+       "unable to load primary swift file \"%0\", %1",
+       (StringRef, StringRef))
 
 ERROR(cannot_find_migration_script, none,
       "missing migration script from path '%0'", (StringRef))
 
 ERROR(error_darwin_static_stdlib_not_supported, none,
       "-static-stdlib is no longer supported on Apple platforms", ())
+
+WARNING(warn_library_evolution_test_mode_compatibility, none,
+       "'-enable-library-evolution' and '-enable-testing' together "
+       "can cause unexpected compatibility compilation and runtime errors", 
+       ())
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -108,7 +108,7 @@ WARNING(incremental_requires_build_record_entry,none,
         "entry (\"%0\" under \"\")", (StringRef))
 
 WARNING(unable_to_open_incremental_comparison_log,none,
-"unable to open incremental comparison log file '%0'", (StringRef))
+        "unable to open incremental comparison log file '%0'", (StringRef))
 
 ERROR(error_os_minimum_deployment,none,
       "Swift requires a minimum deployment target of %0", (StringRef))
@@ -164,35 +164,38 @@ WARNING(warn_opt_remark_disabled, none,
         "-whole-module-optimization flag", ())
 
 WARNING(warn_ignoring_batch_mode,none,
-"ignoring '-enable-batch-mode' because '%0' was also specified", (StringRef))
+        "ignoring '-enable-batch-mode' because '%0' was also specified", (StringRef))
 
 WARNING(warn_ignoring_wmo, none,
         "ignoring '-wmo' because '-dump-ast' was also specified", ())
 
 WARNING(warn_ignoring_source_range_dependencies,none,
-"ignoring '-enable-source-range-dependencies' because '%0' was also specified", (StringRef))
+        "ignoring '-enable-source-range-dependencies' because '%0' was also specified", 
+        (StringRef))
 
 WARNING(warn_bad_swift_ranges_header,none,
-"ignoring '-enable-source-range-dependencies' because of bad header in '%0'", (StringRef))
+        "ignoring '-enable-source-range-dependencies' because of bad header in '%0'", 
+        (StringRef))
 
 WARNING(warn_bad_swift_ranges_format,none,
-"ignoring '-enable-source-range-dependencies' because of bad format '%1' in '%0'", (StringRef, StringRef))
+        "ignoring '-enable-source-range-dependencies' because of bad format '%1' in '%0'", 
+        (StringRef, StringRef))
 
 WARNING(warn_use_filelists_deprecated, none,
         "the option '-driver-use-filelists' is deprecated; use "
         "'-driver-filelist-threshold=0' instead", ())
 
 WARNING(warn_unable_to_load_swift_ranges, none,
-       "unable to load swift ranges file \"%0\", %1",
-       (StringRef, StringRef))
+        "unable to load swift ranges file \"%0\", %1",
+        (StringRef, StringRef))
 
 WARNING(warn_unable_to_load_compiled_swift, none,
-       "unable to load previously compiled swift file \"%0\", %1",
-       (StringRef, StringRef))
+        "unable to load previously compiled swift file \"%0\", %1",
+        (StringRef, StringRef))
 
 WARNING(warn_unable_to_load_primary, none,
-       "unable to load primary swift file \"%0\", %1",
-       (StringRef, StringRef))
+        "unable to load primary swift file \"%0\", %1",
+        (StringRef, StringRef))
 
 ERROR(cannot_find_migration_script, none,
       "missing migration script from path '%0'", (StringRef))

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -226,6 +226,17 @@ static void validateAutolinkingArgs(DiagnosticEngine &diags,
                  forceLoadArg->getSpelling(), incrementalArg->getSpelling());
 }
 
+static void validateLibraryEvolutionInTestMode(DiagnosticEngine &diags,
+                                               const ArgList &args) {
+  // SR-11918: Testability and library evolution have compatibility issues so
+  // validating if we see -enable-testing and -enable-library-evolution together
+  if (args.hasArg(options::OPT_enable_testing) &&
+      args.hasArg(options::OPT_enable_library_evolution)) {
+    diags.diagnose(SourceLoc(),
+                   diag::warn_library_evolution_test_mode_compatibility);
+  }
+}
+
 /// Perform miscellaneous early validation of arguments.
 static void validateArgs(DiagnosticEngine &diags, const ArgList &args,
                          const llvm::Triple &T) {
@@ -236,6 +247,7 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &args,
   validateCompilationConditionArgs(diags, args);
   validateSearchPathArgs(diags, args);
   validateAutolinkingArgs(diags, args, T);
+  validateLibraryEvolutionInTestMode(diags, args);
 }
 
 std::unique_ptr<ToolChain>

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -232,8 +232,20 @@ static void validateLibraryEvolutionInTestMode(DiagnosticEngine &diags,
   // validating if we see -enable-testing and -enable-library-evolution together
   if (args.hasArg(options::OPT_enable_testing) &&
       args.hasArg(options::OPT_enable_library_evolution)) {
+
+    bool isReleaseCompilation = false;
+    if (const Arg *A = args.getLastArg(options::OPT_O_Group)) {
+      if (A->getOption().matches(options::OPT_O) ||
+          A->getOption().matches(options::OPT_Ounchecked) ||
+          A->getOption().matches(options::OPT_Osize)) {
+        isReleaseCompilation = true;
+      }
+    }
+
+    // Suggesting removing one of the flags based on Debug/Release configuration.
+    auto flag = isReleaseCompilation ? "-enable-testing" : "-enable-library-evolution";
     diags.diagnose(SourceLoc(),
-                   diag::warn_library_evolution_test_mode_compatibility);
+                   diag::warn_library_evolution_test_mode_compatibility, flag);
   }
 }
 

--- a/test/Driver/test_mode_library_evolution.swift
+++ b/test/Driver/test_mode_library_evolution.swift
@@ -1,0 +1,5 @@
+// RUN: %swiftc_driver -driver-print-jobs -enable-testing -enable-library-evolution %s 2>&1 | %FileCheck %s
+
+// CHECK: warning: '-enable-library-evolution' and '-enable-testing' together can cause unexpected compatibility compilation and runtime errors
+
+@testable import Module

--- a/test/Driver/test_mode_library_evolution.swift
+++ b/test/Driver/test_mode_library_evolution.swift
@@ -1,5 +1,14 @@
-// RUN: %swiftc_driver -driver-print-jobs -enable-testing -enable-library-evolution %s 2>&1 | %FileCheck %s
+// RUN: %swiftc_driver -driver-print-jobs -enable-testing -enable-library-evolution %s 2>&1 | %FileCheck --check-prefix NO_O %s
+// RUN: %swiftc_driver -driver-print-jobs -enable-testing -enable-library-evolution -Osize %s 2>&1 | %FileCheck --check-prefix O_SIZE %s
+// RUN: %swiftc_driver -driver-print-jobs -enable-testing -enable-library-evolution -Onone %s 2>&1 | %FileCheck --check-prefix O_NONE %s
+// RUN: %swiftc_driver -driver-print-jobs -enable-testing -enable-library-evolution -O %s 2>&1 | %FileCheck --check-prefix O %s
+// RUN: %swiftc_driver -driver-print-jobs -enable-testing -enable-library-evolution -Ounchecked %s 2>&1 | %FileCheck --check-prefix O_UNCHECKED %s
 
-// CHECK: warning: specifying '-enable-library-evolution' and '-enable-testing' together will cause program instability
+
+// NO_O: warning: specifying '-enable-library-evolution' and '-enable-testing' together will cause program instability; consider disabling the '-enable-library-evolution' flag
+// O_SIZE: warning: specifying '-enable-library-evolution' and '-enable-testing' together will cause program instability; consider disabling the '-enable-testing' flag
+// O_NONE: warning: specifying '-enable-library-evolution' and '-enable-testing' together will cause program instability; consider disabling the '-enable-library-evolution' flag
+// O: warning: specifying '-enable-library-evolution' and '-enable-testing' together will cause program instability; consider disabling the '-enable-testing' flag
+// O_UNCHECKED: warning: specifying '-enable-library-evolution' and '-enable-testing' together will cause program instability; consider disabling the '-enable-testing' flag
 
 @testable import Module

--- a/test/Driver/test_mode_library_evolution.swift
+++ b/test/Driver/test_mode_library_evolution.swift
@@ -1,5 +1,5 @@
 // RUN: %swiftc_driver -driver-print-jobs -enable-testing -enable-library-evolution %s 2>&1 | %FileCheck %s
 
-// CHECK: warning: '-enable-library-evolution' and '-enable-testing' together can cause unexpected compatibility compilation and runtime errors
+// CHECK: warning: specifying '-enable-library-evolution' and '-enable-testing' together will cause program instability
 
 @testable import Module


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adding warning when driver sees both -enable-testing and -enable-library-evolution arguments.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-11918.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
cc @brentdax @jrose-apple 