### PR TITLE
[AutoDiff] Fix `@differentiable(linear)` type-checking.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4094,13 +4094,16 @@ ERROR(attr_only_on_parameters_of_differentiable,none,
       "'%0' may only be used on parameters of '@differentiable' function "
       "types", (StringRef))
 // SWIFT_ENABLE_TENSORFLOW
-ERROR(autodiff_attr_argument_not_differentiable,none,
-      "argument is not differentiable, but the enclosing function type is "
-      "marked '@differentiable'; did you want to add '@noDerivative' to this "
-      "argument?", ())
-ERROR(autodiff_attr_result_not_differentiable,none,
-      "result is not differentiable, but the function type is marked "
-      "'@differentiable'", ())
+ERROR(differentiable_function_type_invalid_parameter,none,
+      "parameter type '%0' does not conform to 'Differentiable'"
+      "%select{| and satisfy '%0 == %0.TangentVector'}1, but the enclosing "
+      "function type is '@differentiable%select{|(linear)}1'; did you want to "
+      "add '@noDerivative' to this parameter?", (StringRef, bool))
+ERROR(differentiable_function_type_invalid_result,none,
+      "result type '%0' does not conform to 'Differentiable'"
+      "%select{| and satisfy '%0 == %0.TangentVector'}1, but the enclosing "
+      "function type is '@differentiable%select{|(linear)}1'",
+      (StringRef, bool))
 ERROR(attr_differentiable_no_vjp_or_jvp_when_linear,none,
       "cannot specify 'vjp:' or 'jvp:' for linear functions; use "
       "'transpose:' instead", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4097,8 +4097,10 @@ ERROR(attr_only_on_parameters_of_differentiable,none,
 ERROR(differentiable_function_type_invalid_parameter,none,
       "parameter type '%0' does not conform to 'Differentiable'"
       "%select{| and satisfy '%0 == %0.TangentVector'}1, but the enclosing "
-      "function type is '@differentiable%select{|(linear)}1'; did you want to "
-      "add '@noDerivative' to this parameter?", (StringRef, bool))
+      "function type is '@differentiable%select{|(linear)}1'"
+      "%select{|; did you want to add '@noDerivative' to this parameter?}2",
+      (StringRef, /*tangentVectorEqualsSelf*/ bool,
+       /*hasValidDifferentiabilityParameter*/ bool))
 ERROR(differentiable_function_type_invalid_result,none,
       "result type '%0' does not conform to 'Differentiable'"
       "%select{| and satisfy '%0 == %0.TangentVector'}1, but the enclosing "

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -776,7 +776,7 @@ extension TF_521 where T: Differentiable, T == T.TangentVector {
     return (TF_521(real: real, imaginary: imaginary), { ($0.real, $0.imaginary) })
   }
 }
-// expected-error @+1 {{result is not differentiable, but the function type is marked '@differentiable'}}
+// expected-error @+1 {{result type 'TF_521<Float>' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
 let _: @differentiable(Float, Float) -> TF_521<Float> = { r, i in
   TF_521(real: r, imaginary: i)
 }

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -9,9 +9,9 @@ let _: @differentiable (Float) throws -> Float
 
 struct NonDiffType { var x: Int }
 // FIXME: Properly type-check parameters and the result's differentiability
-// expected-error @+1 {{argument is not differentiable, but the enclosing function type is marked '@differentiable'}} {{25-25=@noDerivative }}
+// expected-error @+1 {{parameter type 'NonDiffType' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'; did you want to add '@noDerivative' to this parameter?}} {{25-25=@noDerivative }}
 let _: @differentiable (NonDiffType) -> Float
-// expected-error @+1 {{result is not differentiable, but the function type is marked '@differentiable'}}
+// expected-error @+1 {{result type 'NonDiffType' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
 let _: @differentiable (Float) -> NonDiffType
 
 let _: @differentiable(linear) (Float) -> Float
@@ -80,10 +80,10 @@ func foo<T: Differentiable, U: Differentiable>(x: T) -> U {
 
 func test1<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> @differentiable (U) -> Float) {}
 func test2<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> (U) -> Float) {}
-// expected-error @+2 {{result is not differentiable, but the function type is marked '@differentiable'}}
-// expected-error @+1 {{result is not differentiable, but the function type is marked '@differentiable'}}
+// expected-error @+2 {{result type 'Int' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
+// expected-error @+1 {{result type '@differentiable (U) -> Int' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
 func test3<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> @differentiable (U) -> Int) {}
-// expected-error @+1 {{result is not differentiable, but the function type is marked '@differentiable'}}
+// expected-error @+1 {{result type '(U) -> Int' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
 func test4<T: Differentiable, U: Differentiable>(_: @differentiable (T) -> (U) -> Int) {}
 
 let diffFunc: @differentiable (Float) -> Float
@@ -107,23 +107,56 @@ struct Vector<T> {
   var x, y: T
 }
 extension Vector: Equatable where T: Equatable {}
-extension Vector: Differentiable where T: Differentiable {}
 extension Vector: AdditiveArithmetic where T: AdditiveArithmetic {}
+extension Vector: Differentiable where T: Differentiable {}
 
-// expected-note @+1 {{where 'T' = 'Int'}}
+// expected-note @+1 2 {{where 'T' = 'Int'}}
 func inferredConformancesGeneric<T, U>(_: @differentiable (Vector<T>) -> Vector<U>) {}
 
-// expected-note @+1 {{where 'T' = 'Int'}}
+// expected-error @+5 {{generic signature requires types 'Vector<T>' and 'Vector<T>.TangentVector' to be the same}}
+// expected-error @+4 {{generic signature requires types 'Vector<U>' and 'Vector<U>.TangentVector' to be the same}}
+// expected-error @+3 {{parameter type 'Vector<T>' does not conform to 'Differentiable' and satisfy 'Vector<T> == Vector<T>.TangentVector', but the enclosing function type is '@differentiable(linear)'; did you want to add '@noDerivative' to this parameter?}}
+// expected-error @+2 {{result type 'Vector<U>' does not conform to 'Differentiable' and satisfy 'Vector<U> == Vector<U>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+// expected-note @+1 2 {{where 'T' = 'Int'}}
 func inferredConformancesGenericLinear<T, U>(_: @differentiable(linear) (Vector<T>) -> Vector<U>) {}
 
-func nondiffVectorFunc(x: Vector<Int>) -> Vector<Int> {}
+func nondiff(x: Vector<Int>) -> Vector<Int> {}
 // expected-error @+1 {{global function 'inferredConformancesGeneric' requires that 'Int' conform to 'Differentiable}}
-inferredConformancesGeneric(nondiffVectorFunc)
+inferredConformancesGeneric(nondiff)
 // expected-error @+1 {{global function 'inferredConformancesGenericLinear' requires that 'Int' conform to 'Differentiable}}
-inferredConformancesGenericLinear(nondiffVectorFunc)
+inferredConformancesGenericLinear(nondiff)
 
-func diffVectorFunc(x: Vector<Float>) -> Vector<Float> {}
-inferredConformancesGeneric(diffVectorFunc) // okay!
+func diff(x: Vector<Float>) -> Vector<Float> {}
+inferredConformancesGeneric(diff) // okay!
 
 func inferredConformancesGenericResult<T, U>() -> @differentiable (Vector<T>) -> Vector<U> {}
+// expected-error @+4 {{generic signature requires types 'Vector<T>' and 'Vector<T>.TangentVector' to be the same}}
+// expected-error @+3 {{generic signature requires types 'Vector<U>' and 'Vector<U>.TangentVector' to be the same}}
+// expected-error @+2 {{parameter type 'Vector<T>' does not conform to 'Differentiable' and satisfy 'Vector<T> == Vector<T>.TangentVector', but the enclosing function type is '@differentiable(linear)'; did you want to add '@noDerivative' to this parameter?}}
+// expected-error @+1 {{result type 'Vector<U>' does not conform to 'Differentiable' and satisfy 'Vector<U> == Vector<U>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
 func inferredConformancesGenericResultLinear<T, U>() -> @differentiable(linear) (Vector<T>) -> Vector<U> {}
+
+struct Linear<T> {
+  var x, y: T
+}
+extension Linear: Equatable where T: Equatable {}
+extension Linear: AdditiveArithmetic where T: AdditiveArithmetic {}
+extension Linear: Differentiable where T: Differentiable, T == T.TangentVector {
+  typealias TangentVector = Self
+}
+
+func inferredConformancesGeneric<T, U>(_: @differentiable (Linear<T>) -> Linear<U>) {}
+
+func inferredConformancesGenericLinear<T, U>(_: @differentiable(linear) (Linear<T>) -> Linear<U>) {}
+
+func nondiff(x: Linear<Int>) -> Linear<Int> {}
+// expected-error @+1 {{global function 'inferredConformancesGeneric' requires that 'Int' conform to 'Differentiable}}
+inferredConformancesGeneric(nondiff)
+// expected-error @+1 {{global function 'inferredConformancesGenericLinear' requires that 'Int' conform to 'Differentiable}}
+inferredConformancesGenericLinear(nondiff)
+
+func diff(x: Linear<Float>) -> Linear<Float> {}
+inferredConformancesGeneric(diff) // okay!
+
+func inferredConformancesGenericResult<T, U>() -> @differentiable (Linear<T>) -> Linear<U> {}
+func inferredConformancesGenericResultLinear<T, U>() -> @differentiable(linear) (Linear<T>) -> Linear<U> {}

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -8,11 +8,27 @@ let _: @differentiable (Float) throws -> Float
 //===----------------------------------------------------------------------===//
 
 struct NonDiffType { var x: Int }
+
 // FIXME: Properly type-check parameters and the result's differentiability
-// expected-error @+1 {{parameter type 'NonDiffType' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'; did you want to add '@noDerivative' to this parameter?}} {{25-25=@noDerivative }}
+// expected-error @+1 {{parameter type 'NonDiffType' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
 let _: @differentiable (NonDiffType) -> Float
+
+// Emit `@noDerivative` fixit iff there is at least one valid differentiability parameter.
+// expected-error @+1 {{parameter type 'NonDiffType' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'; did you want to add '@noDerivative' to this parameter?}} {{32-32=@noDerivative }}
+let _: @differentiable (Float, NonDiffType) -> Float
+
+// expected-error @+1 {{result type 'NonDiffType' does not conform to 'Differentiable' and satisfy 'NonDiffType == NonDiffType.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+let _: @differentiable(linear) (Float) -> NonDiffType
+
+// Emit `@noDerivative` fixit iff there is at least one valid linearity parameter.
+// expected-error @+1 {{parameter type 'NonDiffType' does not conform to 'Differentiable' and satisfy 'NonDiffType == NonDiffType.TangentVector', but the enclosing function type is '@differentiable(linear)'; did you want to add '@noDerivative' to this parameter?}} {{40-40=@noDerivative }}
+let _: @differentiable(linear) (Float, NonDiffType) -> Float
+
 // expected-error @+1 {{result type 'NonDiffType' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
 let _: @differentiable (Float) -> NonDiffType
+
+// expected-error @+1 {{result type 'NonDiffType' does not conform to 'Differentiable' and satisfy 'NonDiffType == NonDiffType.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
+let _: @differentiable(linear) (Float) -> NonDiffType
 
 let _: @differentiable(linear) (Float) -> Float
 
@@ -115,7 +131,7 @@ func inferredConformancesGeneric<T, U>(_: @differentiable (Vector<T>) -> Vector<
 
 // expected-error @+5 {{generic signature requires types 'Vector<T>' and 'Vector<T>.TangentVector' to be the same}}
 // expected-error @+4 {{generic signature requires types 'Vector<U>' and 'Vector<U>.TangentVector' to be the same}}
-// expected-error @+3 {{parameter type 'Vector<T>' does not conform to 'Differentiable' and satisfy 'Vector<T> == Vector<T>.TangentVector', but the enclosing function type is '@differentiable(linear)'; did you want to add '@noDerivative' to this parameter?}}
+// expected-error @+3 {{parameter type 'Vector<T>' does not conform to 'Differentiable' and satisfy 'Vector<T> == Vector<T>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
 // expected-error @+2 {{result type 'Vector<U>' does not conform to 'Differentiable' and satisfy 'Vector<U> == Vector<U>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
 // expected-note @+1 2 {{where 'T' = 'Int'}}
 func inferredConformancesGenericLinear<T, U>(_: @differentiable(linear) (Vector<T>) -> Vector<U>) {}
@@ -132,7 +148,7 @@ inferredConformancesGeneric(diff) // okay!
 func inferredConformancesGenericResult<T, U>() -> @differentiable (Vector<T>) -> Vector<U> {}
 // expected-error @+4 {{generic signature requires types 'Vector<T>' and 'Vector<T>.TangentVector' to be the same}}
 // expected-error @+3 {{generic signature requires types 'Vector<U>' and 'Vector<U>.TangentVector' to be the same}}
-// expected-error @+2 {{parameter type 'Vector<T>' does not conform to 'Differentiable' and satisfy 'Vector<T> == Vector<T>.TangentVector', but the enclosing function type is '@differentiable(linear)'; did you want to add '@noDerivative' to this parameter?}}
+// expected-error @+2 {{parameter type 'Vector<T>' does not conform to 'Differentiable' and satisfy 'Vector<T> == Vector<T>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
 // expected-error @+1 {{result type 'Vector<U>' does not conform to 'Differentiable' and satisfy 'Vector<U> == Vector<U>.TangentVector', but the enclosing function type is '@differentiable(linear)'}}
 func inferredConformancesGenericResultLinear<T, U>() -> @differentiable(linear) (Vector<T>) -> Vector<U> {}
 


### PR DESCRIPTION
For all non-`@noDerivative` parameter and result types, `@differentiable(linear)` function types should require and imply `T: Differentiable`, `T == T.TangentVector` requirements instead of `T: Differentiable & AdditiveArithmetic`.

Update tests.

---

Type-checking example:

```swift
// linear.swift
struct D: Differentiable {}
// `D` does not conform to `AdditiveArithmetic`.
// `D` is not equal to `D.TangentVector`.
func test(_: @differentiable(linear) (D) -> D) {}
```

Before:
```console
$ swift linear.swift
# Missing error.
```

After:
```console
$ swift linear.swift
linear.swift:5:39: error: parameter type 'D' does not conform to 'Differentiable' and satisfy 'D == D.TangentVector', but the enclosing function type is '@differentiable(linear)'; did you want to add '@noDerivative' to this parameter?
func test(_: @differentiable(linear) (D) -> D) {}
                                      ^
                                      @noDerivative
linear.swift:5:45: error: result type 'D' does not conform to 'Differentiable' and satisfy 'D == D.TangentVector', but the enclosing function type is '@differentiable(linear)'
func test(_: @differentiable(linear) (D) -> D) {}
                                            ^
```

---

Inference example:

```swift
func inferred<T, U>(_: @differentiable(linear) (T) -> U) {}
```

Before:
```console
$ swiftc -print-ast linear.swift
internal func inferred<T, U>(_: @differentiable(linear) (T) -> U) where T : AdditiveArithmetic, T : Differentiable, U : AdditiveArithmetic, U : Differentiable
```

After:
```console
$ swiftc -print-ast linear.swift
internal func inferred<T, U>(_: @differentiable(linear) (T) -> U) where T : Differentiable, T == T.TangentVector, U : Differentiable, U == U.TangentVector
```