### PR TITLE
[AutoDiff] Deprecate `@differentiable(jvp:vjp:)` arguments.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1573,10 +1573,12 @@ ERROR(attr_implements_expected_member_name,PointsToFirstBadToken,
       "expected a member name as second parameter in '_implements' attribute", ())
 
 // differentiable
+// TODO(TF-1001): Remove diagnostic when deprecated `jvp:`, `vjp:` are removed.
 ERROR(attr_differentiable_expected_function_name,PointsToFirstBadToken,
       "expected a %0 function name", (StringRef))
 ERROR(attr_differentiable_expected_parameter_list,PointsToFirstBadToken,
       "expected a list of parameters to differentiate with respect to", ())
+// TODO(TF-1001): Remove diagnostic when deprecated `jvp:`, `vjp:` are removed.
 ERROR(attr_differentiable_use_wrt_not_withrespectto,none,
       "use 'wrt:' to specify parameters to differentiate with respect to", ())
 ERROR(attr_differentiable_expected_label,none,
@@ -1586,6 +1588,11 @@ ERROR(differentiable_attribute_expected_rparen,none,
       "expected ')' in '@differentiable' attribute", ())
 ERROR(unexpected_argument_differentiable,none,
       "unexpected argument '%0' in '@differentiable' attribute", (StringRef))
+// TODO(TF-1001): Remove diagnostic when deprecated `jvp:`, `vjp:` are removed.
+WARNING(differentiable_attr_jvp_vjp_deprecated_warning,none,
+        "'jvp:' and 'vjp:' arguments in '@differentiable' attribute are "
+        "deprecated; use '@derivative' attribute for derivative registration "
+        "instead", ())
 
 // derivative
 WARNING(attr_differentiating_deprecated,PointsToFirstBadToken,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1021,6 +1021,13 @@ bool Parser::parseDifferentiableAttributeArguments(
                         { label });
     result.Name = parseDeclNameRef(result.Loc, funcDiag,
         DeclNameFlag::AllowZeroArgCompoundNames | DeclNameFlag::AllowOperators);
+    // Emit warning for deprecated `jvp:` and `vjp:` arguments.
+    // TODO(TF-1001): Remove deprecated `jvp:` and `vjp:` arguments.
+    if (result.Loc.isValid()) {
+      diagnose(result.Loc.getStartLoc(),
+               diag::differentiable_attr_jvp_vjp_deprecated_warning)
+          .highlight(result.Loc.getSourceRange());
+    }
     // If no trailing comma or 'where' clause, terminate parsing arguments.
     if (Tok.isNot(tok::comma, tok::kw_where))
       terminateParsingArgs = true;

--- a/test/AutoDiff/Inputs/silgen_thunking_other_module.swift
+++ b/test/AutoDiff/Inputs/silgen_thunking_other_module.swift
@@ -1,12 +1,13 @@
 struct TF_619: Differentiable {
   var p: Float = 1
 
-  @differentiable(vjp: vjpFoo)
+  @differentiable
   func foo(_ x: Float) -> Float {
     return p * x
   }
 
-  func vjpFoo(_ x: Float) -> (Float, (Float) -> (TangentVector, Float)) {
+  @derivative(of: foo)
+  func vjpFoo(_ x: Float) -> (value: Float, pullback: (Float) -> (TangentVector, Float)) {
     return (x, { v in (TangentVector(p: v * x), v * self.p) })
   }
 }

--- a/test/AutoDiff/Parse/differentiable_attr_parse.swift
+++ b/test/AutoDiff/Parse/differentiable_attr_parse.swift
@@ -7,21 +7,25 @@ struct Foo {
   var x: Float
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:)) // okay
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:) where T : FloatingPoint) // okay
 func bar<T : Numeric>(_ x: T, _: T) -> T {
     return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: (self, x, y), vjp: foo(_:_:)) // okay
 func bar(_ x: Float, _ y: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: (self, x, y), jvp: bar, vjp: foo(_:_:)) // okay
 func bar(_ x: Float, _ y: Float) -> Float {
   return 1 + x
@@ -55,6 +59,7 @@ func playWellWithOtherAttrs(_ x: Float, _: Float) -> Float {
 }
 
 @_transparent
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: (self), vjp: _vjpSquareRoot) // okay
 public func squareRoot() -> Self {
   var lhs = self
@@ -109,6 +114,7 @@ func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:), 3) // expected-error {{expected either 'wrt:' or a function specifier label, e.g. 'jvp:', or 'vjp:'}}
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
@@ -139,11 +145,13 @@ func two(x: Float, y: Float) -> Float {
   return x + y
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:) // expected-error {{expected ')' in 'differentiable' attribute}}
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:) where T) // expected-error {{expected ':' or '==' to indicate a conformance or same-type requirement}}
 func bar<T : Numeric>(_ x: T, _: T) -> T {
     return 1 + x
@@ -154,11 +162,13 @@ func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:),) // expected-error {{unexpected ',' separator}}
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:), where T) // expected-error {{unexpected ',' separator}}
 func bar<T : Numeric>(_ x: T, _: T) -> T {
     return 1 + x
@@ -174,6 +184,7 @@ func slope5(_ x: Float) -> Float {
   return 5 * x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: x, vjp: const6, linear) // expected-error {{expected either 'wrt:' or a function specifier label, e.g. 'jvp:', or 'vjp:'}}
 func slope5(_ x: Float) -> Float {
   return 6 * x

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -14,18 +14,13 @@ _ = gradient(at: 1.0, in: generic)
 
 // Test unmet generic requirements.
 
-@differentiable(
-  vjp: vjpWeirdExtraRequirements
-  where T : Differentiable & CaseIterable, T.AllCases : ExpressibleByStringLiteral
-)
 func weird<T>(_ x: T) -> T {
   return x
 }
-func vjpWeirdExtraRequirements<
-  T : Differentiable & CaseIterable
->(_ x: T) -> (T, (T.TangentVector) -> T.TangentVector)
-  where T.AllCases : ExpressibleByStringLiteral
-{
+@derivative(of: weird)
+func vjpWeirdExtraRequirements<T : Differentiable & CaseIterable>(_ x: T) -> (
+  value: T, pullback: (T.TangentVector) -> T.TangentVector
+) where T.AllCases : ExpressibleByStringLiteral {
   return (x, { $0 })
 }
 func weirdWrapper<T : Differentiable>(_ x: T) -> T {

--- a/test/AutoDiff/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/derivative_attr_type_checking.swift
@@ -389,6 +389,7 @@ extension Class {
 // both attributes register the same derivatives. This was previously valid
 // but is now rejected.
 
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated; use '@derivative' attribute for derivative registration instead}}
 @differentiable(jvp: jvpConsistent, vjp: vjpConsistent)
 func consistentSpecifiedDerivatives(_ x: Float) -> Float {
   return x

--- a/test/AutoDiff/differentiable_attr_access_control.swift
+++ b/test/AutoDiff/differentiable_attr_access_control.swift
@@ -4,22 +4,22 @@
 // its JVP/VJP must also be exported.
 
 // Ok: all public.
-@differentiable(vjp: dfoo1)
-public func foo1(_ x: Float) -> Float { return 1 }
-public func dfoo1(x: Float) -> (Float, (Float) -> Float) { return (1, {$0}) }
+public func foo1(_ x: Float) -> Float { x }
+@derivative(of: foo1)
+public func dfoo1(x: Float) -> (value: Float, pullback: (Float) -> Float) { fatalError() }
 
 // Ok: all internal.
 struct CheckpointsFoo {}
-@differentiable(vjp: dfoo2)
-func foo2(_ x: Float) -> Float { return 1 }
-func dfoo2(_ x: Float) -> (Float, (Float) -> Float) { return (1, {$0}) }
+func foo2(_ x: Float) -> Float { x }
+@derivative(of: foo2)
+func dfoo2(_ x: Float) -> (value: Float, pullback: (Float) -> Float) { fatalError() }
 
 // Ok: all private.
-@differentiable(vjp: dfoo3)
-private func foo3(_ x: Float) -> Float { return 1 }
-private func dfoo3(_ x: Float) -> (Float, (Float) -> Float) { return (1, {$0}) }
+private func foo3(_ x: Float) -> Float { x }
+@derivative(of: foo3)
+private func dfoo3(_ x: Float) -> (value: Float, pullback: (Float) -> Float) { fatalError() }
 
 // Error: vjp not exported.
-@differentiable(vjp: dbar1) // expected-error {{derivative function 'dbar1' is required to either be public or '@usableFromInline' because the original function 'bar1' is public or '@usableFromInline'}}
-public func bar1(_ x: Float) -> Float { return 1 }
-private func dbar1(_ x: Float) -> (Float, (Float) -> Float) { return (1, {$0}) }
+public func bar1(_ x: Float) -> Float { x }
+@derivative(of: bar1)
+private func dbar1(_ x: Float) -> (value: Float, pullback: (Float) -> Float) { fatalError() }

--- a/test/AutoDiff/differentiable_attr_parse.swift
+++ b/test/AutoDiff/differentiable_attr_parse.swift
@@ -7,21 +7,25 @@ struct Foo {
   var x: Float
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:)) // okay
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:) where T : FloatingPoint) // okay
 func bar<T : Numeric>(_ x: T, _: T) -> T {
     return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: (self, x, y), vjp: foo(_:_:)) // okay
 func bar(_ x: Float, _ y: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: (self, x, y), jvp: bar, vjp: foo(_:_:)) // okay
 func bar(_ x: Float, _ y: Float) -> Float {
   return 1 + x
@@ -55,6 +59,7 @@ func playWellWithOtherAttrs(_ x: Float, _: Float) -> Float {
 }
 
 @_transparent
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: (self), vjp: _vjpSquareRoot) // okay
 public func squareRoot() -> Self {
   var lhs = self
@@ -109,6 +114,7 @@ func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:), 3) // expected-error {{expected either 'wrt:' or a function specifier label, e.g. 'jvp:', or 'vjp:'}}
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
@@ -139,11 +145,13 @@ func two(x: Float, y: Float) -> Float {
   return x + y
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:) // expected-error {{expected ')' in 'differentiable' attribute}}
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:) where T) // expected-error {{expected ':' or '==' to indicate a conformance or same-type requirement}}
 func bar<T : Numeric>(_ x: T, _: T) -> T {
     return 1 + x
@@ -154,11 +162,13 @@ func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:),) // expected-error {{unexpected ',' separator}}
 func bar(_ x: Float, _: Float) -> Float {
   return 1 + x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: foo(_:_:), where T) // expected-error {{unexpected ',' separator}}
 func bar<T : Numeric>(_ x: T, _: T) -> T {
     return 1 + x
@@ -174,6 +184,7 @@ func slope5(_ x: Float) -> Float {
   return 5 * x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: x, vjp: const6, linear) // expected-error {{expected either 'wrt:' or a function specifier label, e.g. 'jvp:', or 'vjp:'}}
 func slope5(_ x: Float) -> Float {
   return 6 * x
@@ -185,6 +196,7 @@ func localDifferentiableDeclaration() {
   func foo1(_ x: Float) -> Float
 
   // Not okay. Derivative registration can only be non-local.
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{attribute '@differentiable(jvp:vjp:)' can only be used in a non-local scope}}
   @differentiable(vjp: dfoo2)
   func foo2(_ x: Float) -> Float

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -21,6 +21,7 @@ func testLocalVariables() {
   }
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: dfoo) // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
 protocol P {}
 
@@ -162,6 +163,7 @@ struct SubscriptMethod {
 
 // JVP
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(jvp: jvpSimpleJVP)
 func jvpSimple(x: Float) -> Float {
   return x
@@ -171,11 +173,13 @@ func jvpSimpleJVP(x: Float) -> (Float, ((Float) -> Float)) {
   return (x, { v in v })
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: y, jvp: jvpWrtSubsetJVP)
 func jvpWrtSubset1(x: Float, y: Float) -> Float {
   return x + y
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: (y), jvp: jvpWrtSubsetJVP)
 func jvpWrtSubset2(x: Float, y: Float) -> Float {
   return x + y
@@ -185,6 +189,7 @@ func jvpWrtSubsetJVP(x: Float, y: Float) -> (Float, (Float) -> Float) {
   return (x + y, { v in v })
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(jvp: jvp2ParamsJVP)
 func jvp2Params(x: Float, y: Float) -> Float {
   return x + y
@@ -206,6 +211,7 @@ func jvpParamOrderNotIncreasing(x: Float, y: Float) -> Float {
   return x * y
 }
 
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{'jvpWrongTypeJVP' does not have expected type '(Float) -> (Float, (Float.TangentVector) -> Float.TangentVector)' (aka '(Float) -> (Float, (Float) -> Float)'}}
 @differentiable(jvp: jvpWrongTypeJVP)
 func jvpWrongType(x: Float) -> Float {
@@ -216,24 +222,28 @@ func jvpWrongTypeJVP(x: Float) -> (Float, (Float) -> Int) {
   return (x, { v in Int(v) })
 }
 
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
 @differentiable(jvp: jvpSimpleJVP)
 func jvpNonDiffParam(x: Int) -> Float {
   return Float(x)
 }
 
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'Int' does not conform to 'Differentiable'}}
 @differentiable(jvp: jvpSimpleJVP)
 func jvpNonDiffResult(x: Float) -> Int {
   return Int(x)
 }
 
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but '(Float, Int)' does not conform to 'Differentiable'}}
 @differentiable(jvp: jvpSimpleJVP)
 func jvpNonDiffResult2(x: Float) -> (Float, Int) {
   return (x, Int(x))
 }
 
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{ambiguous reference to 'jvpAmbiguousVJP' in '@differentiable' attribute}}
 @differentiable(jvp: jvpAmbiguousVJP)
 func jvpAmbiguous(x: Float) -> Float {
@@ -258,6 +268,7 @@ struct JVPStruct {
   @differentiable
   let p: Float
 
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{'funcJVP' does not have expected type '(JVPStruct) -> () -> (Double, (JVPStruct.TangentVector) -> Double.TangentVector)' (aka '(JVPStruct) -> () -> (Double, (JVPStruct) -> Double)'}}
   @differentiable(wrt: (self), jvp: funcJVP)
   func funcWrongType() -> Double {
@@ -290,6 +301,7 @@ extension JVPStruct : Differentiable {
 }
 
 extension JVPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(wrt: x, jvp: wrtAllNonSelfJVP)
   func wrtAllNonSelf(x: Float) -> Float {
     return x + p
@@ -301,6 +313,7 @@ extension JVPStruct {
 }
 
 extension JVPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(wrt: (self, x), jvp: wrtAllJVP)
   func wrtAll(x: Float) -> Float {
     return x + p
@@ -312,18 +325,21 @@ extension JVPStruct {
 }
 
 extension JVPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(jvp: computedPropJVP)
   var computedPropOk1: Float {
     return 0
   }
 
   var computedPropOk2: Float {
+    // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
     @differentiable(jvp: computedPropJVP)
     get {
       return 0
     }
   }
 
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{'computedPropJVP' does not have expected type '(JVPStruct) -> () -> (Double, (JVPStruct.TangentVector) -> Double.TangentVector)' (aka '(JVPStruct) -> () -> (Double, (JVPStruct) -> Double)'}}
   @differentiable(jvp: computedPropJVP)
   var computedPropWrongType: Double {
@@ -334,6 +350,7 @@ extension JVPStruct {
     get {
       return 0
     }
+    // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
     // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
     @differentiable(jvp: computedPropJVP)
     set {
@@ -348,6 +365,7 @@ extension JVPStruct {
 
 // VJP
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: vjpSimpleVJP)
 func vjpSimple(x: Float) -> Float {
   return x
@@ -357,6 +375,7 @@ func vjpSimpleVJP(x: Float) -> (Float, ((Float) -> Float)) {
   return (x, { v in v })
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(wrt: (y), vjp: vjpWrtSubsetVJP)
 func vjpWrtSubset(x: Float, y: Float) -> Float {
   return x + y
@@ -366,6 +385,7 @@ func vjpWrtSubsetVJP(x: Float, y: Float) -> (Float, (Float) -> Float) {
   return (x + y, { v in v })
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(vjp: vjp2ParamsVJP)
 func vjp2Params(x: Float, y: Float) -> Float {
   return x + y
@@ -375,6 +395,7 @@ func vjp2ParamsVJP(x: Float, y: Float) -> (Float, (Float) -> (Float, Float)) {
   return (x + y, { v in (v, v) })
 }
 
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{'vjpWrongTypeVJP' does not have expected type '(Float) -> (Float, (Float.TangentVector) -> Float.TangentVector)' (aka '(Float) -> (Float, (Float) -> Float)'}}
 @differentiable(vjp: vjpWrongTypeVJP)
 func vjpWrongType(x: Float) -> Float {
@@ -385,18 +406,21 @@ func vjpWrongTypeVJP(x: Float) -> (Float, (Float) -> Int) {
   return (x, { v in Int(v) })
 }
 
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
 @differentiable(vjp: vjpSimpleVJP)
 func vjpNonDiffParam(x: Int) -> Float {
   return Float(x)
 }
 
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'Int' does not conform to 'Differentiable'}}
 @differentiable(vjp: vjpSimpleVJP)
 func vjpNonDiffResult(x: Float) -> Int {
   return Int(x)
 }
 
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but '(Float, Int)' does not conform to 'Differentiable'}}
 @differentiable(vjp: vjpSimpleVJP)
 func vjpNonDiffResult2(x: Float) -> (Float, Int) {
@@ -406,6 +430,7 @@ func vjpNonDiffResult2(x: Float) -> (Float, Int) {
 struct VJPStruct {
   let p: Float
 
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{'funcVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
   @differentiable(vjp: funcVJP)
   func funcWrongType() -> Double {
@@ -438,6 +463,7 @@ extension VJPStruct : Differentiable {
 }
 
 extension VJPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(wrt: x, vjp: wrtAllNonSelfVJP)
   func wrtAllNonSelf(x: Float) -> Float {
     return x + p
@@ -449,6 +475,7 @@ extension VJPStruct {
 }
 
 extension VJPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(wrt: (self, x), vjp: wrtAllVJP)
   func wrtAll(x: Float) -> Float {
     return x + p
@@ -460,18 +487,21 @@ extension VJPStruct {
 }
 
 extension VJPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(vjp: computedPropVJP)
   var computedPropOk1: Float {
     return 0
   }
 
   var computedPropOk2: Float {
+    // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
     @differentiable(vjp: computedPropVJP)
     get {
       return 0
     }
   }
 
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{'computedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
   @differentiable(vjp: computedPropVJP)
   var computedPropWrongType: Double {
@@ -482,6 +512,7 @@ extension VJPStruct {
     get {
       return 0
     }
+    // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
     // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
     @differentiable(vjp: computedPropVJP)
     set {
@@ -507,6 +538,7 @@ func nongenericWhereClause(x: Float) -> Float {
   return x
 }
 
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(jvp: jvpWhere1, vjp: vjpWhere1 where T : Differentiable)
 func where1<T>(x: T) -> T {
   return x
@@ -519,6 +551,7 @@ func vjpWhere1<T : Differentiable>(x: T) -> (T, (T.TangentVector) -> T.TangentVe
 }
 
 // Test derivative functions with result tuple type labels.
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(jvp: jvpResultLabels, vjp: vjpResultLabels)
 func derivativeResultLabels(_ x: Float) -> Float {
   return x
@@ -530,6 +563,7 @@ func vjpResultLabels(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   return (x, { $0 })
 }
 struct ResultLabelTest {
+  // expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(jvp: jvpResultLabels, vjp: vjpResultLabels)
   static func derivativeResultLabels(_ x: Float) -> Float {
     return x
@@ -541,6 +575,7 @@ struct ResultLabelTest {
     return (x, { $0 })
   }
 
+  // expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(jvp: jvpResultLabels, vjp: vjpResultLabels)
   func derivativeResultLabels(_ x: Float) -> Float {
     return x
@@ -555,12 +590,10 @@ struct ResultLabelTest {
 
 struct Tensor<Scalar> : AdditiveArithmetic {}
 extension Tensor : Differentiable where Scalar : Differentiable {}
-@differentiable(where Scalar : Differentiable)
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(jvp: jvpWhere2, vjp: vjpWhere2 where Scalar : Differentiable)
 func where2<Scalar : Numeric>(x: Tensor<Scalar>) -> Tensor<Scalar> {
   return x
-}
-func adjWhere2<Scalar : Numeric & Differentiable>(seed: Tensor<Scalar>, originalResult: Tensor<Scalar>, x: Tensor<Scalar>) -> Tensor<Scalar> {
-  return seed
 }
 func jvpWhere2<Scalar : Numeric & Differentiable>(x: Tensor<Scalar>) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
   return (x, { v in v })
@@ -584,7 +617,7 @@ extension FloatingPoint {
     return self
   }
 }
-
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 // expected-error @+1 {{'vjpNonvariadic' does not have expected type '(Float, Int32...) -> (Float, (Float.TangentVector) -> Float.TangentVector)' (aka '(Float, Int32...) -> (Float, (Float) -> Float)')}}
 @differentiable(wrt: x, vjp: vjpNonvariadic)
 func variadic(_ x: Float, indices: Int32...) -> Float {
@@ -758,6 +791,7 @@ struct TF_521<T: FloatingPoint> {
   var real: T
   var imaginary: T
 
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'TF_521<T>' does not conform to 'Differentiable'}}
   @differentiable(vjp: _vjpInit where T: Differentiable, T == T.TangentVector)
   init(real: T = 0, imaginary: T = 0) {
@@ -811,16 +845,19 @@ struct NonDiffableStruct {
   }
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(linear, wrt: x, vjp: const3) // expected-error {{cannot specify 'vjp:' or 'jvp:' for linear functions; use 'transpose:' instead}}
 func slope1(_ x: Float) -> Float {
   return 3 * x
 }
 
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(linear, wrt: x, jvp: const3) // expected-error {{cannot specify 'vjp:' or 'jvp:' for linear functions; use 'transpose:' instead}}
 func slope2(_ x: Float) -> Float {
   return 3 * x
 }
 
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
 @differentiable(linear, jvp: const3, vjp: const3) // expected-error {{cannot specify 'vjp:' or 'jvp:' for linear functions; use 'transpose:' instead}}
 func slope3(_ x: Float) -> Float {
   return 3 * x
@@ -828,6 +865,7 @@ func slope3(_ x: Float) -> Float {
 
 // Check that `@differentiable` attribute rejects stored properties.
 struct StoredProperty : Differentiable {
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{'@differentiable' attribute on stored property cannot specify 'jvp:' or 'vjp:'}}
   @differentiable(vjp: vjpStored)
   var stored: Float
@@ -839,6 +877,7 @@ struct StoredProperty : Differentiable {
 
 // Check that `@differentiable` attribute rejects non-`func` derivatives.
 struct Struct: Differentiable {
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{registered derivative 'computedPropertyVJP' must be a 'func' declaration}}
   @differentiable(vjp: computedPropertyVJP)
   func testComputedProperty() -> Float { 1 }
@@ -975,6 +1014,7 @@ protocol ProtocolRequirementUnsupported : Differentiable {
   @differentiable(where Scalar: Differentiable)
   func unsupportedWhereClause(value: Scalar) -> Float
 
+  // expected-warning @+2 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{'@differentiable' attribute on protocol requirement cannot specify 'jvp:' or 'vjp:'}}
   @differentiable(wrt: x, jvp: dfoo, vjp: dfoo)
   func unsupportedDerivatives(_ x: Float) -> Float
@@ -1013,10 +1053,12 @@ class Super : Differentiable {
   static func testStaticMethod(_ x: Float) -> Float { x }
 
   @differentiable(wrt: (self, x))
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(wrt: x, vjp: vjp)
   // expected-note @+1 2 {{overridden declaration is here}}
   func testMissingAttributes(_ x: Float) -> Float { x }
 
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   @differentiable(wrt: x, vjp: vjp)
   func testSuperclassDerivatives(_ x: Float) -> Float { x }
 
@@ -1031,6 +1073,7 @@ class Super : Differentiable {
   @differentiable(wrt: x)
   func instanceMethod<T>(_ x: Float, y: T) -> Float { x }
 
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{'@differentiable' attribute cannot be declared on class methods returning 'Self'}}
   @differentiable(vjp: vjpDynamicSelfResult)
   func dynamicSelfResult() -> Self { self }
@@ -1049,6 +1092,7 @@ class Sub : Super {
   // expected-error @+1 {{overriding declaration is missing attribute '@differentiable'}}
   override func testMissingAttributes(_ x: Float) -> Float { x }
 
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
   // expected-error @+1 {{'vjp' is not defined in the current type context}}
   @differentiable(wrt: x, vjp: vjp)
   override func testSuperclassDerivatives(_ x: Float) -> Float { x }

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -102,7 +102,6 @@ protocol TF_508_Proto {
 }
 extension TF_508_Proto where Scalar : FloatingPoint {
   @differentiable(
-    vjp: vjpAdd
     where Self : Differentiable, Scalar : Differentiable,
           // Conformance requirement with dependent member type.
           Self.TangentVector : TF_508_Proto
@@ -112,7 +111,6 @@ extension TF_508_Proto where Scalar : FloatingPoint {
   }
 
   @differentiable(
-    vjp: vjpSubtract
     where Self : Differentiable, Scalar : Differentiable,
           // Same-type requirement with dependent member type.
           Self.TangentVector == Float
@@ -124,16 +122,18 @@ extension TF_508_Proto where Scalar : FloatingPoint {
 extension TF_508_Proto where Self : Differentiable,
                              Scalar : FloatingPoint & Differentiable,
                              Self.TangentVector : TF_508_Proto {
+  @derivative(of: +)
   static func vjpAdd(lhs: Self, rhs: Self)
-      -> (Self, (TangentVector) -> (TangentVector, TangentVector)) {
+      -> (value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)) {
     return (lhs, { v in (v, v) })
   }
 }
 extension TF_508_Proto where Self : Differentiable,
                              Scalar : FloatingPoint & Differentiable,
                              Self.TangentVector == Float {
+  @derivative(of: -)
   static func vjpSubtract(lhs: Self, rhs: Self)
-      -> (Self, (TangentVector) -> (TangentVector, TangentVector)) {
+      -> (value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)) {
     return (lhs, { v in (v, v) })
   }
 }
@@ -190,7 +190,7 @@ struct TF_546<T: FloatingPoint>: AdditiveArithmetic {
   var real: T
   var imaginary: T
 
-  @differentiable(vjp: _vjpInit where T: Differentiable, T == T.TangentVector)
+  @differentiable(where T: Differentiable, T == T.TangentVector)
   init(real: T = 0, imaginary: T = 0) {
     self.real = real
     self.imaginary = imaginary
@@ -200,7 +200,8 @@ extension TF_546: Differentiable where T: Differentiable {
   typealias TangentVector = TF_546
 }
 extension TF_546 where T: Differentiable, T == T.TangentVector {
-  static func _vjpInit(real: T, imaginary: T) -> (TF_546, (TF_546) -> (T, T)) {
+  @derivative(of: init)
+  static func _vjpInit(real: T, imaginary: T) -> (value: TF_546, pullback: (TF_546) -> (T, T)) {
     return (TF_546(real: real, imaginary: imaginary), { ($0.real, $0.imaginary) })
   }
 }
@@ -228,7 +229,6 @@ protocol TF_682_Proto {
 }
 extension TF_682_Proto where Scalar : FloatingPoint {
   @differentiable(
-    vjp: vjpFoo
     where Self : Differentiable, Scalar : Differentiable,
           // Same-type requirement with dependent member type.
           Self.TangentVector == Float
@@ -240,8 +240,8 @@ extension TF_682_Proto where Scalar : FloatingPoint {
 extension TF_682_Proto where Self : Differentiable,
                              Scalar : FloatingPoint & Differentiable,
                              Self.TangentVector == Float {
-  func vjpFoo(lhs: Self)
-      -> (Self, (TangentVector) -> (TangentVector, TangentVector)) {
+  @derivative(of: foo)
+  func vjpFoo(lhs: Self) -> (value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)) {
     return (lhs, { v in (v, v) })
   }
 }

--- a/test/AutoDiff/silgen_thunking/main.swift
+++ b/test/AutoDiff/silgen_thunking/main.swift
@@ -11,11 +11,11 @@ import StdlibUnittest
 import DifferentiationUnittest
 
 // Verify that SILGen derivative thunks are never `[transparent]`.
-@differentiable(vjp: vjpNoReabstraction)
 func noReabstraction<T: Differentiable>(_ x: T) -> T {
   return x
 }
-func vjpNoReabstraction<T: Differentiable>(_ x: T) -> (T, (T.TangentVector) -> T.TangentVector) {
+@derivative(of: noReabstraction)
+func vjpNoReabstraction<T: Differentiable>(_ x: T) -> (value: T, pullback: (T.TangentVector) -> T.TangentVector) {
   return (x, { $0 })
 }
 // Find the non-`[transparent]` SILGen thunk.
@@ -38,22 +38,23 @@ struct SelfReordering : Differentiable & AdditiveArithmetic {
 
   // TF-742: Test method with three parameters (including `self`).
   // Note: pullback returns direct `Self.TangentVector`.
-  @differentiable(jvp: jvpThreeParameterMethod, vjp: vjpThreeParameterMethod)
   func threeParameterMethod(_: Self, _: Self) -> Self {
     return self
   }
-  func jvpThreeParameterMethod(_ x: Self, _ y: Self) -> (Self, (Self, Self, Self) -> Self) {
+  @derivative(of: threeParameterMethod)
+  func jvpThreeParameterMethod(_ x: Self, _ y: Self) -> (value: Self, differential: (Self, Self, Self) -> Self) {
     let value = threeParameterMethod(x, y)
     return (value, { dself, dx, dy in Self(dself.x + dx.x * 2 + dy.x * 3) })
   }
-  func vjpThreeParameterMethod(_ x: Self, _ y: Self) -> (Self, (Self) -> (Self, Self, Self)) {
+  @derivative(of: threeParameterMethod)
+  func vjpThreeParameterMethod(_ x: Self, _ y: Self) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
     let value = threeParameterMethod(x, y)
     return (value, { v in (Self(1), Self(2), Self(3)) })
   }
 
 // CHECK-LABEL: sil hidden [always_inline] [ossa] @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__jvp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> @owned SelfReordering)
 // CHECK: bb0([[X:%.*]] : @guaranteed $SelfReordering, [[Y:%.*]] : @guaranteed $SelfReordering, [[SELF:%.*]] : @guaranteed $SelfReordering):
-// CHECK: [[JVP:%.*]] = function_ref @$s4main14SelfReorderingV23jvpThreeParameterMethodyAC_A2C_A2CtctAC_ACtF
+// CHECK: [[JVP:%.*]] = function_ref @$s4main14SelfReorderingV23jvpThreeParameterMethodyAC5value_A2C_A2Ctc12differentialtAC_ACtF
 // CHECK: [[JVP_RESULT:%.*]] = apply [[JVP]]([[X]], [[Y]], [[SELF]])
 // CHECK: ([[JVP_ORIG_RESULT:%.*]], [[DF:%.*]]) = destructure_tuple [[JVP_RESULT]]
 // CHECK: [[DF_SELF_REORDER_THUNK:%.*]] = function_ref @AD__$s4main14SelfReorderingVA3CIeggggo_A4CIeggggo_TR_differential_self_reordering_thunk
@@ -68,7 +69,7 @@ struct SelfReordering : Differentiable & AdditiveArithmetic {
 
 // CHECK-LABEL: sil hidden [always_inline] [ossa] @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__vjp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering) -> (@owned SelfReordering, @owned SelfReordering, @owned SelfReordering))
 // CHECK: bb0([[X:%.*]] : @guaranteed $SelfReordering, [[Y:%.*]] : @guaranteed $SelfReordering, [[SELF:%.*]] : @guaranteed $SelfReordering):
-// CHECK: [[VJP:%.*]] = function_ref @$s4main14SelfReorderingV23vjpThreeParameterMethodyAC_AC_A2CtACctAC_ACtF
+// CHECK: [[VJP:%.*]] = function_ref @$s4main14SelfReorderingV23vjpThreeParameterMethodyAC5value_AC_A2CtACc8pullbacktAC_ACtF
 // CHECK: [[VJP_RESULT:%.*]] = apply [[VJP]]([[X]], [[Y]], [[SELF]])
 // CHECK: ([[VJP_ORIG_RESULT:%.*]], [[PB:%.*]]) = destructure_tuple [[VJP_RESULT]]
 // CHECK: [[PB_SELF_REORDER_THUNK:%.*]] = function_ref @AD__$s4main14SelfReorderingVA3CIeggooo_A4CIeggooo_TR_pullback_self_reordering_thunk
@@ -96,20 +97,21 @@ where Dummy: Differentiable & ExpressibleByIntegerLiteral {
 
   // TF-742: Test method with three parameters (including `self`).
   // Note: pullback returns indirect `Self.TangentVector`.
-  @differentiable(jvp: jvpThreeParameterMethod, vjp: vjpThreeParameterMethod)
   func threeParameterMethod<T: Differentiable, U: Differentiable>(_: T, _: U) -> Self
   where T.TangentVector: ExpressibleByFloatLiteral, U.TangentVector: ExpressibleByFloatLiteral {
     return self
   }
+  @derivative(of: threeParameterMethod)
   func jvpThreeParameterMethod<T: Differentiable, U: Differentiable>(_ x: T, _ y: U)
-    -> (Self, (Self.TangentVector, T.TangentVector, U.TangentVector) -> Self.TangentVector)
+    -> (value: Self, differential: (Self.TangentVector, T.TangentVector, U.TangentVector) -> Self.TangentVector)
   where T.TangentVector: ExpressibleByFloatLiteral, U.TangentVector: ExpressibleByFloatLiteral {
     let value = threeParameterMethod(x, y)
     // TODO: Make this test meaningful/robust.
     return (value, { dself, dx, dy in dself })
   }
+  @derivative(of: threeParameterMethod)
   func vjpThreeParameterMethod<T: Differentiable, U: Differentiable>(_ x: T, _ y: U)
-    -> (Self, (Self.TangentVector) -> (Self.TangentVector, T.TangentVector, U.TangentVector))
+    -> (value: Self, pullback: (Self.TangentVector) -> (Self.TangentVector, T.TangentVector, U.TangentVector))
   where T.TangentVector: ExpressibleByFloatLiteral, U.TangentVector: ExpressibleByFloatLiteral {
     let value = threeParameterMethod(x, y)
     return (value, { v in (v, 2.0, 3.0) })
@@ -117,7 +119,7 @@ where Dummy: Differentiable & ExpressibleByIntegerLiteral {
 
 // CHECK-LABEL: sil hidden [always_inline] [ossa] @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__jvp_src_0_wrt_0_1_2{{.*}} : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed τ_1_0.TangentVector, @in_guaranteed τ_1_1.TangentVector, @in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> @out SelfReorderingGeneric<τ_0_0>.TangentVector) {
 // CHECK: bb0([[JVP_RESULT:%.*]] : $*SelfReorderingGeneric<τ_0_0>, [[X:%.*]] : $*τ_1_0, [[Y:%.*]] : $*τ_1_1, [[SELF:%.*]] : $*SelfReorderingGeneric<τ_0_0>):
-// CHECK: [[JVP:%.*]] = function_ref @$s4main21SelfReorderingGenericV23jvpThreeParameterMethodyACyxG_AC13TangentVectorVyx_GAH_AFQyd__AFQyd_0_tctqd___qd_0_ts14DifferentiableRd__sAKRd_0_s25ExpressibleByFloatLiteralAIRQsAlJRQr0_lF
+// CHECK: [[JVP:%.*]] = function_ref @$s4main21SelfReorderingGenericV23jvpThreeParameterMethodyACyxG5value_AC13TangentVectorVyx_GAI_AGQyd__AGQyd_0_tc12differentialtqd___qd_0_ts14DifferentiableRd__sAMRd_0_s25ExpressibleByFloatLiteralAJRQsAnKRQr0_lF
 // CHECK: [[DF:%.*]] = apply [[JVP]]<τ_0_0, τ_1_0, τ_1_1>([[JVP_RESULT]], [[X]], [[Y]], [[SELF]])
 // CHECK: [[DF_SELF_REORDER_THUNK:%.*]] = function_ref @AD__$s4main21SelfReorderingGenericV13TangentVectorVyx_GADQyd__ADQyd_0_AFIegnnnr_Agh2FIegnnnr_s14DifferentiableRzs27ExpressibleByIntegerLiteralRzsAIRd__sAIRd_0_s0hi5FloatK0AGRQsAkHRQr_0_lTR_differential_self_reordering_thunk
 // CHECK: [[THUNKED_DF:%.*]] = partial_apply [callee_guaranteed] [[DF_SELF_REORDER_THUNK]]<τ_0_0, τ_1_0, τ_1_1>([[DF]])
@@ -131,7 +133,7 @@ where Dummy: Differentiable & ExpressibleByIntegerLiteral {
 
 // CHECK-LABEL: sil hidden [always_inline] [ossa] @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__vjp_src_0_wrt_0_1_2{{.*}} : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> (@out τ_1_0.TangentVector, @out τ_1_1.TangentVector, @out SelfReorderingGeneric<τ_0_0>.TangentVector)) {
 // CHECK: bb0([[VJP_RESULT:%.*]] : $*SelfReorderingGeneric<τ_0_0>, [[X:%.*]] : $*τ_1_0, [[Y:%.*]] : $*τ_1_1, [[SELF:%.*]] : $*SelfReorderingGeneric<τ_0_0>):
-// CHECK: [[VJP:%.*]] = function_ref @$s4main21SelfReorderingGenericV23vjpThreeParameterMethodyACyxG_AC13TangentVectorVyx_G_AFQyd__AFQyd_0_tAHctqd___qd_0_ts14DifferentiableRd__sAKRd_0_s25ExpressibleByFloatLiteralAIRQsAlJRQr0_lF
+// CHECK: [[VJP:%.*]] = function_ref @$s4main21SelfReorderingGenericV23vjpThreeParameterMethodyACyxG5value_AC13TangentVectorVyx_G_AGQyd__AGQyd_0_tAIc8pullbacktqd___qd_0_ts14DifferentiableRd__sAMRd_0_s25ExpressibleByFloatLiteralAJRQsAnKRQr0_lF
 // CHECK: [[PB:%.*]] = apply [[VJP]]<τ_0_0, τ_1_0, τ_1_1>([[VJP_RESULT]], [[X]], [[Y]], [[SELF]])
 // CHECK: [[PB_SELF_REORDER_THUNK:%.*]] = function_ref @AD__$s4main21SelfReorderingGenericV13TangentVectorVyx_GAfDQyd__ADQyd_0_Iegnrrr_AfghFIegnrrr_s14DifferentiableRzs27ExpressibleByIntegerLiteralRzsAIRd__sAIRd_0_s0hi5FloatK0AGRQsAkHRQr_0_lTR_pullback_self_reordering_thunk
 // CHECK: [[THUNKED_PB:%.*]] = partial_apply [callee_guaranteed] [[PB_SELF_REORDER_THUNK]]<τ_0_0, τ_1_0, τ_1_1>([[PB]])

--- a/test/AutoDiff/vtable_sil.swift
+++ b/test/AutoDiff/vtable_sil.swift
@@ -20,21 +20,11 @@ class Super : Differentiable {
     return (Super(base: base), { x in x.base })
   }
 
-  @differentiable(vjp: vjpProperty)
+  @differentiable
   var property: Float { base }
-  final func vjpProperty() -> (Float, (Float) -> TangentVector) {
+  @derivative(of: property)
+  final func vjpProperty() -> (value: Float, pullback: (Float) -> TangentVector) {
     return (property, { _ in .zero })
-  }
-
-  @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
-  func f(_ x: Float, _ y: Float) -> Float {
-    return x * y
-  }
-  final func jvpf(_ x: Float, _ y: Float) -> (Float, (Float) -> Float) {
-    return (f(x, y), { v in v * y })
-  }
-  final func vjpf(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float)) {
-    return (f(x, y), { v in v * y })
   }
 
   @differentiable(wrt: x where T: Differentiable)
@@ -42,9 +32,25 @@ class Super : Differentiable {
     return x
   }
 
-  @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
+  @differentiable(wrt: x)
+  func f(_ x: Float, _ y: Float) -> Float {
+    return x * y
+  }
+
+  @differentiable(wrt: x)
   subscript(_ x: Float, _ y: Float) -> Float {
     return x * y
+  }
+
+  @derivative(of: f, wrt: x)
+  @derivative(of: subscript, wrt: x)
+  final func jvpf(_ x: Float, _ y: Float) -> (value: Float, differential: (Float) -> Float) {
+    return (f(x, y), { v in v * y })
+  }
+  @derivative(of: f, wrt: x)
+  @derivative(of: subscript, wrt: x)
+  final func vjpf(_ x: Float, _ y: Float) -> (value: Float, pullback: (Float) -> (Float)) {
+    return (f(x, y), { v in v * y })
   }
 }
 
@@ -60,28 +66,34 @@ class Sub : Super {
     return (Sub(base: base), { x in x.base })
   }
 
-  @differentiable(vjp: vjpProperty2)
+  @differentiable
   override var property: Float { base }
-  final func vjpProperty2() -> (Float, (Float) -> TangentVector) {
+  @derivative(of: property)
+  final func vjpProperty2() -> (value: Float, pullback: (Float) -> TangentVector) {
     return (property, { _ in .zero })
   }
 
-  @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
+  @differentiable(wrt: x)
   // New `@differentiable` attribute.
   @differentiable(wrt: (x, y))
   override func f(_ x: Float, _ y: Float) -> Float {
     return x * y
   }
-  final func jvpf2(_ x: Float, _ y: Float) -> (Float, (Float) -> Float) {
-    return (f(x, y), { v in v * y })
-  }
-  final func vjpf2(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float)) {
-    return (f(x, y), { v in v * y })
-  }
 
-  @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
+  @differentiable(wrt: x)
   override subscript(_ x: Float, _ y: Float) -> Float {
     return x * y
+  }
+
+  @derivative(of: f, wrt: x)
+  @derivative(of: subscript, wrt: x)
+  final func jvpf2(_ x: Float, _ y: Float) -> (value: Float, differential: (Float) -> Float) {
+    return (f(x, y), { v in v * y })
+  }
+  @derivative(of: f, wrt: x)
+  @derivative(of: subscript, wrt: x)
+  final func vjpf2(_ x: Float, _ y: Float) -> (value: Float, pullback: (Float) -> (Float)) {
+    return (f(x, y), { v in v * y })
   }
 }
 
@@ -98,12 +110,12 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super.property!getter.1: (Super) -> () -> Float : @$s10vtable_sil5SuperC8propertySfvg
 // CHECK-NEXT:   #Super.property!getter.1.jvp.S: (Super) -> () -> Float : @AD__$s10vtable_sil5SuperC8propertySfvg__jvp_src_0_wrt_0_vtable_entry_thunk
 // CHECK-NEXT:   #Super.property!getter.1.vjp.S: (Super) -> () -> Float : @AD__$s10vtable_sil5SuperC8propertySfvg__vjp_src_0_wrt_0_vtable_entry_thunk
-// CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil5SuperC1fyS2f_SftF
-// CHECK-NEXT:   #Super.f!1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperC1fyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk
-// CHECK-NEXT:   #Super.f!1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperC1fyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk
 // CHECK-NEXT:   #Super.generic!1: <T> (Super) -> (T, T) -> T : @$s10vtable_sil5SuperC7genericyxx_xtlF
 // CHECK-NEXT:   #Super.generic!1.jvp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__jvp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk
 // CHECK-NEXT:   #Super.generic!1.vjp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__vjp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk
+// CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil5SuperC1fyS2f_SftF
+// CHECK-NEXT:   #Super.f!1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperC1fyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk
+// CHECK-NEXT:   #Super.f!1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperC1fyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk
 // CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil5SuperCyS2f_Sftcig
 // CHECK-NEXT:   #Super.subscript!getter.1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk
 // CHECK-NEXT:   #Super.subscript!getter.1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk
@@ -122,12 +134,12 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super.property!getter.1: (Super) -> () -> Float : @$s10vtable_sil3SubC8propertySfvg [override]
 // CHECK-NEXT:   #Super.property!getter.1.jvp.S: (Super) -> () -> Float : @AD__$s10vtable_sil3SubC8propertySfvg__jvp_src_0_wrt_0_vtable_entry_thunk [override]
 // CHECK-NEXT:   #Super.property!getter.1.vjp.S: (Super) -> () -> Float : @AD__$s10vtable_sil3SubC8propertySfvg__vjp_src_0_wrt_0_vtable_entry_thunk [override]
-// CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubC1fyS2f_SftF [override]
-// CHECK-NEXT:   #Super.f!1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk [override]
-// CHECK-NEXT:   #Super.f!1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk [override]
 // CHECK-NEXT:   #Super.generic!1: <T> (Super) -> (T, T) -> T : @$s10vtable_sil5SuperC7genericyxx_xtlF [inherited]
 // CHECK-NEXT:   #Super.generic!1.jvp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__jvp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.generic!1.vjp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__vjp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk [inherited]
+// CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubC1fyS2f_SftF [override]
+// CHECK-NEXT:   #Super.f!1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk [override]
+// CHECK-NEXT:   #Super.f!1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk [override]
 // CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubCyS2f_Sftcig [override]
 // CHECK-NEXT:   #Super.subscript!getter.1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk [override]
 // CHECK-NEXT:   #Super.subscript!getter.1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk [override]
@@ -148,12 +160,12 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super.property!getter.1: (Super) -> () -> Float : @$s10vtable_sil3SubC8propertySfvg [inherited]
 // CHECK-NEXT:   #Super.property!getter.1.jvp.S: (Super) -> () -> Float : @AD__$s10vtable_sil3SubC8propertySfvg__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.property!getter.1.vjp.S: (Super) -> () -> Float : @AD__$s10vtable_sil3SubC8propertySfvg__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]
-// CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubC1fyS2f_SftF [inherited]
-// CHECK-NEXT:   #Super.f!1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
-// CHECK-NEXT:   #Super.f!1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.generic!1: <T> (Super) -> (T, T) -> T : @$s10vtable_sil5SuperC7genericyxx_xtlF [inherited]
 // CHECK-NEXT:   #Super.generic!1.jvp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__jvp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.generic!1.vjp.SUU.<T where T : Differentiable>: <T> (Super) -> (T, T) -> T : @AD__$s10vtable_sil5SuperC7genericyxx_xtlF__vjp_src_0_wrt_0_s14DifferentiableRzl_vtable_entry_thunk [inherited]
+// CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubC1fyS2f_SftF [inherited]
+// CHECK-NEXT:   #Super.f!1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
+// CHECK-NEXT:   #Super.f!1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubCyS2f_Sftcig [inherited]
 // CHECK-NEXT:   #Super.subscript!getter.1.jvp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.subscript!getter.1.vjp.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]


### PR DESCRIPTION
Deprecate `@differentiable` attribute `jvp:` `vjp:` arguments for derivative
registration. `@derivative` attribute is the canonical way to register
derivatives.

Update tests.

TF-1001 tracks removing `@differentiable` attribute `jvp:` and `vjp:` arguments.
TF-1085 tracks removing `@differentiable(jvp:vjp:)` usages in the stdlib.

Todo: upstream this PR to `master`.

---

Example:
```swift
@differentiable(vjp: vjpFoo)
func foo(_ x: Float) -> Float { x }

func vjpFoo(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
  (x, { $0 })
}
```

```
test.swift:1:22: warning: 'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated; use '@derivative' attribute for derivative registration instead
@differentiable(vjp: vjpFoo)
                     ^~~~~~
```

I decided not to invest time writing fully-fledged fix-its for rewriting `@differentiable(jvp:vjp:)` usages to `@derivative` attribute, as it's slightly non-trivial. We can focus on retrodiff progress and manually rewriting `@differentiable(jvp:vjp:)` usages instead.