### PR TITLE
remove VS2015 workaround (NFC)

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -927,7 +927,7 @@ public:
 
   // Make vanilla new/delete illegal for Decls.
   void *operator new(size_t Bytes) = delete;
-  void operator delete(void *Data) SWIFT_DELETE_OPERATOR_DELETED;
+  void operator delete(void *Data) = delete;
 
   // Only allow allocation of Decls using the allocator in ASTContext
   // or by doing a placement new.

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -109,7 +109,7 @@ public:
 
   /// Make vanilla new/delete illegal.
   void *operator new(size_t Bytes) = delete;
-  void operator delete(void *Data) SWIFT_DELETE_OPERATOR_DELETED;
+  void operator delete(void *Data) = delete;
 
   /// Only allow placement new.
   void *operator new(size_t Bytes, void *Mem) {

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -582,7 +582,7 @@ public:
 private:
   // Make placement new and vanilla new/delete illegal for Modules.
   void *operator new(size_t Bytes) throw() = delete;
-  void operator delete(void *Data) throw() SWIFT_DELETE_OPERATOR_DELETED;
+  void operator delete(void *Data) throw() = delete;
   void *operator new(size_t Bytes, void *Mem) throw() = delete;
 public:
   // Only allow allocation of Modules using the allocator in ASTContext

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -285,7 +285,7 @@ public:
 
   // Make vanilla new/delete illegal for protocol conformances.
   void *operator new(size_t bytes) = delete;
-  void operator delete(void *data) SWIFT_DELETE_OPERATOR_DELETED;
+  void operator delete(void *data) = delete;
 
   // Only allow allocation of protocol conformances using the allocator in
   // ASTContext or by doing a placement new.

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -27,15 +27,6 @@
 #define __has_attribute(x) 0
 #endif
 
-#if SWIFT_COMPILER_IS_MSVC && _MSC_VER < 1910
-// Work around MSVC bug: attempting to reference a deleted function
-// https://connect.microsoft.com/VisualStudio/feedback/details/3116505
-#define SWIFT_DELETE_OPERATOR_DELETED                                          \
-  { llvm_unreachable("Delete operator should not be called."); }
-#else
-#define SWIFT_DELETE_OPERATOR_DELETED = delete;
-#endif
-
 // __builtin_assume() is an optimization hint.
 #if __has_builtin(__builtin_assume)
 #define SWIFT_ASSUME(x) __builtin_assume(x)

--- a/include/swift/SIL/SILAllocated.h
+++ b/include/swift/SIL/SILAllocated.h
@@ -31,7 +31,7 @@ public:
   void *operator new[](size_t) = delete;
 
   /// Disable non-placement delete.
-  void operator delete(void *) SWIFT_DELETE_OPERATOR_DELETED;
+  void operator delete(void *) = delete;
   void operator delete[](void *) = delete;
 
   /// Custom version of 'new' that uses the SILModule's BumpPtrAllocator with

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -89,7 +89,7 @@ protected:
 
 public:
   void operator=(const SILArgument &) = delete;
-  void operator delete(void *, size_t) SWIFT_DELETE_OPERATOR_DELETED;
+  void operator delete(void *, size_t) = delete;
 
   ValueOwnershipKind getOwnershipKind() const {
     return static_cast<ValueOwnershipKind>(Bits.SILArgument.VOKind);

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -54,7 +54,7 @@ private:
   SILBasicBlock() : Parent(nullptr) {}
   void operator=(const SILBasicBlock &) = delete;
 
-  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED
+  void operator delete(void *Ptr, size_t) = delete;
 
   SILBasicBlock(SILFunction *F, SILBasicBlock *relativeToBB, bool after);
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -318,7 +318,7 @@ class SILInstruction
 
   SILInstruction() = delete;
   void operator=(const SILInstruction &) = delete;
-  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED
+  void operator delete(void *Ptr, size_t) = delete;
 
   /// Check any special state of instructions that are not represented in the
   /// instructions operands/type.
@@ -799,7 +799,7 @@ public:
   SILModule &getModule() const { return SILInstruction::getModule(); }
   SILInstructionKind getKind() const { return SILInstruction::getKind(); }
 
-  void operator delete(void *Ptr, size_t) SWIFT_DELETE_OPERATOR_DELETED
+  void operator delete(void *Ptr, size_t) = delete;
 
   ValueKind getValueKind() const {
     return ValueBase::getKind();
@@ -950,7 +950,7 @@ protected:
       : SILInstruction(kind, loc) {}
 
 public:
-  void operator delete(void *Ptr, size_t)SWIFT_DELETE_OPERATOR_DELETED;
+  void operator delete(void *Ptr, size_t) = delete;
 
   MultipleValueInstruction *clone(SILInstruction *insertPt = nullptr) {
     return cast<MultipleValueInstruction>(SILInstruction::clone(insertPt));

--- a/include/swift/SIL/SILUndef.h
+++ b/include/swift/SIL/SILUndef.h
@@ -29,7 +29,7 @@ class SILUndef : public ValueBase {
 
 public:
   void operator=(const SILArgument &) = delete;
-  void operator delete(void *, size_t) SWIFT_DELETE_OPERATOR_DELETED;
+  void operator delete(void *, size_t) = delete;
 
   static SILUndef *get(SILType ty, SILModule &m, ValueOwnershipKind ownershipKind);
   static SILUndef *get(SILType ty, const SILFunction &f);


### PR DESCRIPTION
VS2015 had an issue with the deletion of an operator.  Since VS2017 is
the minimum version that LLVM uses, we can assume that VS2017+ is in use
(_MSC_VER >= 1910).  Clean up the now defunct workaround.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
