### PR TITLE
Basic: adjust aliasing annotation (NFCI)

### DIFF
--- a/lib/Basic/PrefixMap.cpp
+++ b/lib/Basic/PrefixMap.cpp
@@ -34,8 +34,8 @@ enum class ChildKind { Left, Right, Further, Root };
 // that's technically instantiation-specific.  Redefining the struct here
 // is technically an aliasing violation, but we can just tell the compilers
 // that actually use TBAA that this is okay.
-typedef struct _Node Node LLVM_MAY_ALIAS;
-struct _Node {
+typedef struct _Node Node;
+struct LLVM_MAY_ALIAS _Node {
   // If you change the layout in the header, you'll need to change it here.
   // (This comment is repeated there.)
   Node *Left, *Right, *Further;


### PR DESCRIPTION
GCC `-fpermissive` flagged this annotation as being discarded as it is
being applied after the definition.  Move the annotation to the
re-definition to which it appertains.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
