### PR TITLE
SwiftShims: unify assertion paths (NFC)

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -1475,25 +1475,13 @@ HeapObject* RefCounts<SideTableRefCountBits>::getHeapObject() {
 // for use by SWIFT_HEAPOBJECT_NON_OBJC_MEMBERS
 typedef swift::InlineRefCounts InlineRefCounts;
 
-// __cplusplus
-#endif
-
 // These assertions apply to both the C and the C++ declarations.
-#if defined(_MSC_VER) && !defined(__clang__)
 static_assert(sizeof(InlineRefCounts) == sizeof(InlineRefCountsPlaceholder),
               "InlineRefCounts and InlineRefCountsPlaceholder must match");
 static_assert(sizeof(InlineRefCounts) == sizeof(__swift_uintptr_t),
               "InlineRefCounts must be pointer-sized");
 static_assert(__alignof(InlineRefCounts) == __alignof(__swift_uintptr_t),
               "InlineRefCounts must be pointer-aligned");
-#else
-_Static_assert(sizeof(InlineRefCounts) == sizeof(InlineRefCountsPlaceholder),
-  "InlineRefCounts and InlineRefCountsPlaceholder must match");
-_Static_assert(sizeof(InlineRefCounts) == sizeof(__swift_uintptr_t),
-  "InlineRefCounts must be pointer-sized");
-_Static_assert(_Alignof(InlineRefCounts) == _Alignof(__swift_uintptr_t),
-  "InlineRefCounts must be pointer-aligned");
-#endif
 
 #if defined(_WIN32) && defined(_M_ARM64)
 #if defined(__cplusplus)
@@ -1507,5 +1495,7 @@ inline void _Atomic_storage<swift::SideTableRefCountBits, 16>::_Unlock() const n
 }
 #endif
 #endif
+
+#endif // !defined(__swift__)
 
 #endif


### PR DESCRIPTION
Use the C++ spelling for the static assertions.  This is a C11
extension, but GCC and MSVC both object to the reserved spelling
(`_Static_assert`).  Use the compatibility spelling of `static_assert`
on all targets instead.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
