### PR TITLE
GSB: inline some trivial methods

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1687,6 +1687,21 @@ public:
   friend class GenericSignatureBuilder;
 };
 
+template <typename C>
+bool GenericSignatureBuilder::Constraint<C>::isSubjectEqualTo(Type T) const {
+  return getSubjectDependentType({ })->isEqual(T);
+}
+
+template <typename T>
+bool GenericSignatureBuilder::Constraint<T>::isSubjectEqualTo(const GenericSignatureBuilder::PotentialArchetype *PA) const {
+  return getSubjectDependentType({ })->isEqual(PA->getDependentType({ }));
+}
+
+template <typename T>
+bool GenericSignatureBuilder::Constraint<T>::hasSameSubjectAs(const GenericSignatureBuilder::Constraint<T> &C) const {
+  return getSubjectDependentType({ })->isEqual(C.getSubjectDependentType({ }));
+}
+
 /// Describes a requirement whose processing has been delayed for some reason.
 class GenericSignatureBuilder::DelayedRequirement {
 public:

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1712,22 +1712,6 @@ bool EquivalenceClass::recordConformanceConstraint(
   return inserted;
 }
 
-template<typename T>
-bool Constraint<T>::isSubjectEqualTo(Type type) const {
-  return getSubjectDependentType({ })->isEqual(type);
-}
-
-template<typename T>
-bool Constraint<T>::isSubjectEqualTo(const PotentialArchetype *pa) const {
-  return getSubjectDependentType({ })->isEqual(pa->getDependentType({ }));
-}
-
-template<typename T>
-bool Constraint<T>::hasSameSubjectAs(const Constraint<T> &other) const {
-  return getSubjectDependentType({ })
-    ->isEqual(other.getSubjectDependentType({ }));
-}
-
 Optional<ConcreteConstraint>
 EquivalenceClass::findAnyConcreteConstraintAsWritten(Type preferredType) const {
   // If we don't have a concrete type, there's no source.


### PR DESCRIPTION
This inlines the comparators since GCC 7 objects to the definition
(which is probably due to scoping).  However, these methods are
templates, which must be visible to the consumers, and should therefore
be in the header.  Given the size, it seems reasonable to just inline
them.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
