### PR TITLE
Fix macOS toolchains with Xcode new build system.

### DIFF
--- a/utils/build-toolchain-tensorflow
+++ b/utils/build-toolchain-tensorflow
@@ -127,6 +127,7 @@ set -x
 YEAR=$(date +"%Y")
 MONTH=$(date +"%m")
 DAY=$(date +"%d")
+TOOLCHAIN_VERSION_DATE="5.0.${YEAR}${MONTH}${DAY}"
 TOOLCHAIN_VERSION="swift-tensorflow-LOCAL-${YEAR}-${MONTH}-${DAY}-a"
 ARCHIVE="${TOOLCHAIN_VERSION}-${HOST}.tar.gz"
 SYM_ARCHIVE="${TOOLCHAIN_VERSION}-osx-symbols.tar.gz"
@@ -159,6 +160,6 @@ fi
         darwin_toolchain_display_name="${DISPLAY_NAME}" \
         darwin_toolchain_display_name_short="${DISPLAY_NAME_SHORT}" \
         darwin_toolchain_xctoolchain_name="${TOOLCHAIN_NAME}" \
-        darwin_toolchain_version="${TOOLCHAIN_VERSION}" \
+        darwin_toolchain_version="${TOOLCHAIN_VERSION_DATE}" \
         darwin_toolchain_alias="Swift for TensorFlow" \
         ${INSTALLER_PACKAGE}


### PR DESCRIPTION
Xcode's new build system requires the `Version` entry in Info.plist to have a
particular date-based format.

Resolves https://github.com/tensorflow/swift/issues/350:
```
2019-12-24 15:47:16.618 XCBBuildService[75398:12495542] /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2019-12-12-a.xctoolchain: warning: failed to load toolchain: 'Version' parse error: Could not parse version component from: 'swift-tensorflow-DEVELOPMENT-2019-12-12-a'
```

Swift for TensorFlow macOS toolchain working with Xcode new build system:
![image](https://user-images.githubusercontent.com/5590046/71424986-c6f94a00-2665-11ea-82d2-7485884250bc.png)
