### PR TITLE
[CodeCompletion] Batch code completion test 

### DIFF
--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -1,404 +1,4 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_PROTOCOL_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_PROTOCOL < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNC_PARAM_GENERIC_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_FUNC_PARAM_GENERIC_1 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNC_PARAM_GENERIC_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_FUNC_PARAM_GENERIC_2 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNC_PARAM_GENERIC_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_FUNC_PARAM_GENERIC_3 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNC_PARAM_GENERIC_4 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_FUNC_PARAM_GENERIC_4 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNC_PARAM_GENERIC_5 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_FUNC_PARAM_GENERIC_5 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_1 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_2 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_3 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_RETURN_GEN_PARAM_NO_DUP > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_RETURN_GEN_PARAM_NO_DUP < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IVAR_GEN_PARAM_NO_DUP > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IVAR_GEN_PARAM_NO_DUP < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_SUBSCR_GEN_PARAM_NO_DUP > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_SUBSCR_GEN_PARAM_NO_DUP < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_2 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_IN_CONSTRUCTOR_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_LOCAL_VAR_IN_MEMBER_FUNC_1 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_IN_DESTRUCTOR_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_LOCAL_VAR_IN_MEMBER_FUNC_1 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_IN_INSTANCE_FUNC_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IN_LOCAL_VAR_IN_MEMBER_FUNC_1 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_GLOBAL_VAR_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_TYPEALIAS_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_TYPEALIAS_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_TYPEALIAS_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_ASSOC_TYPE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_ASSOC_TYPE_INHERITANCE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_EXTENSION_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_EXTENSION_INHERITANCE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_EXTENSION_INHERITANCE_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_EXTENSION_INHERITANCE_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_STRUCT_INHERITANCE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_STRUCT_INHERITANCE_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_STRUCT_INHERITANCE_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_STRUCT_INHERITANCE_4 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_STRUCT_INHERITANCE_5 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_STRUCT_INHERITANCE_6 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_STRUCT_INHERITANCE_7 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_STRUCT_INHERITANCE_8 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_CLASS_INHERITANCE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_CLASS_INHERITANCE_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_ENUM_INHERITANCE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_ENUM_INHERITANCE_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_PROTOCOL_INHERITANCE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_PROTOCOL_INHERITANCE_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_TUPLE_TYPE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_TUPLE_TYPE_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_TUPLE_TYPE_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_TUPLE_TYPE_4 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_TUPLE_TYPE_5 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_TUPLE_TYPE_6 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNCTION_TYPE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNCTION_TYPE_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNCTION_TYPE_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNCTION_TYPE_4 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNCTION_TYPE_5 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNCTION_TYPE_6 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_PROTOCOL_COMPOSITION_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_PROTOCOL_COMPOSITION_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_PROTOCOL_COMPOSITION_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNC_PARAM_NESTED_TYPES_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNC_PARAM_NESTED_TYPES_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNC_PARAM_NESTED_TYPES_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_DERIVED_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_FUNC_PARAM_NESTED_TYPES_4 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_DERIVED_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_INSTANCE_VAR_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_INSTANCE_VAR_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_INSTANCE_VAR_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_DERIVED_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_INSTANCE_VAR_4 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_DERIVED_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_DERIVED_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_4 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_DERIVED_1_TYPES_INCONTEXT < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_BASE_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_BASE_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_BASE_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_BASE_4 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_BASE_NO_DOT_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_NO_DOT_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_BASE_NO_DOT_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_NO_DOT_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_BASE_NO_DOT_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_BASE_1_NO_DOT_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_DERIVED_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_DERIVED_1_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_DERIVED_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_DERIVED_1_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_DERIVED_3 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=VAR_DERIVED_1_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_GENERIC_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IDENTIFIER_GENERIC_1 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_GENERIC_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IDENTIFIER_GENERIC_2 < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITHOUT_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_GENERIC_3 | %FileCheck %s -check-prefix=TYPE_IDENTIFIER_GENERIC_3
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IDENTIFIER_IRRELEVANT_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=TYPE_IDENTIFIER_IRRELEVANT_1 < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INSIDE_AS_CAST_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TYPEALIAS_1 | %FileCheck %s -check-prefix=GENERIC_TYPEALIAS_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TYPEALIAS_2 > %t.gentypealias.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.gentypealias.txt
-// RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.gentypealias.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_TOPLEVEL_VAR | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_TOPLEVEL_PARAM | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_TOPLEVEL_RETURN | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_MEMBER_VAR | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_MEMBER_PARAM | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_MEMBER_RETURN | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_LOCAL_VAR | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_LOCAL_PARAM | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_LOCAL_RETURN | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_DOT_1 | %FileCheck %s -check-prefix=PROTOCOL_DOT_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNBOUND_DOT | %FileCheck %s -check-prefix=UNBOUND_DOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNBOUND_DOT_2 | %FileCheck %s -check-prefix=UNBOUND_DOT_2
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
 
 //===--- Helper types that are used in this test
 
@@ -464,7 +64,7 @@ typealias FooTypealias = Int
 // TYPE_IN_PROTOCOL: End completions
 
 protocol TestSelf1 {
-  func instanceFunc() -> #^TYPE_IN_PROTOCOL_1^#
+  func instanceFunc() -> #^TYPE_IN_PROTOCOL_1?check=TYPE_IN_PROTOCOL;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 //===---
@@ -475,7 +75,7 @@ protocol TestSelf1 {
 func testTypeInParamGeneric1<
     GenericFoo : FooProtocol,
     GenericBar : FooProtocol & BarProtocol,
-    GenericBaz>(a: #^TYPE_IN_FUNC_PARAM_GENERIC_1^#
+    GenericBaz>(a: #^TYPE_IN_FUNC_PARAM_GENERIC_1?check=TYPE_IN_FUNC_PARAM_GENERIC_1;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 // TYPE_IN_FUNC_PARAM_GENERIC_1: Begin completions
 // Generic parameters of the function.
@@ -488,7 +88,7 @@ struct TestTypeInParamGeneric2<
     StructGenericFoo : FooProtocol,
     StructGenericBar : FooProtocol & BarProtocol,
     StructGenericBaz> {
-  func testTypeInParamGeneric2(a: #^TYPE_IN_FUNC_PARAM_GENERIC_2^#
+  func testTypeInParamGeneric2(a: #^TYPE_IN_FUNC_PARAM_GENERIC_2?check=TYPE_IN_FUNC_PARAM_GENERIC_2;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 // TYPE_IN_FUNC_PARAM_GENERIC_2: Begin completions
@@ -501,7 +101,7 @@ struct TestTypeInParamGeneric3 {
   func testTypeInParamGeneric3<
       GenericFoo : FooProtocol,
       GenericBar : FooProtocol & BarProtocol,
-      GenericBaz>(a: #^TYPE_IN_FUNC_PARAM_GENERIC_3^#
+      GenericBaz>(a: #^TYPE_IN_FUNC_PARAM_GENERIC_3?check=TYPE_IN_FUNC_PARAM_GENERIC_3;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 // TYPE_IN_FUNC_PARAM_GENERIC_3: Begin completions
@@ -517,7 +117,7 @@ struct TestTypeInParamGeneric4<
   func testTypeInParamGeneric4<
       GenericFoo : FooProtocol,
       GenericBar : FooProtocol & BarProtocol,
-      GenericBaz>(a: #^TYPE_IN_FUNC_PARAM_GENERIC_4^#
+      GenericBaz>(a: #^TYPE_IN_FUNC_PARAM_GENERIC_4?check=TYPE_IN_FUNC_PARAM_GENERIC_4;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 // TYPE_IN_FUNC_PARAM_GENERIC_4: Begin completions
@@ -534,7 +134,7 @@ struct TestTypeInParamGeneric4<
 struct TestTypeInParamGeneric5<StructGenericFoo> {
   struct TestTypeInParamGeneric5a<StructGenericBar> {
     struct TestTypeInParamGeneric5b<StructGenericBaz> {
-      func testTypeInParamGeneric5<GenericFoo>(a: #^TYPE_IN_FUNC_PARAM_GENERIC_5^#
+      func testTypeInParamGeneric5<GenericFoo>(a: #^TYPE_IN_FUNC_PARAM_GENERIC_5?check=TYPE_IN_FUNC_PARAM_GENERIC_5;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
     }
   }
 }
@@ -552,7 +152,7 @@ struct TestTypeInConstructorParamGeneric1<
     StructGenericFoo : FooProtocol,
     StructGenericBar : FooProtocol & BarProtocol,
     StructGenericBaz> {
-  init(a: #^TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_1^#
+  init(a: #^TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_1?check=TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_1;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 // TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_1: Begin completions
@@ -564,7 +164,7 @@ struct TestTypeInConstructorParamGeneric1<
 struct TestTypeInConstructorParamGeneric2 {
   init<GenericFoo : FooProtocol,
        GenericBar : FooProtocol & BarProtocol,
-       GenericBaz>(a: #^TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_2^#
+       GenericBaz>(a: #^TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_2?check=TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_2;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 // TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_2: Begin completions
@@ -579,7 +179,7 @@ struct TestTypeInConstructorParamGeneric3<
     StructGenericBaz> {
   init<GenericFoo : FooProtocol,
        GenericBar : FooProtocol & BarProtocol,
-       GenericBaz>(a: #^TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_3^#
+       GenericBaz>(a: #^TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_3?check=TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_3;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 // TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_3: Begin completions
@@ -628,7 +228,7 @@ class A<T> {
 //===---
 
 func testTypeInLocalVarInFreeFunc1() {
-  var localVar: #^TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_1^#
+  var localVar: #^TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInLocalVarInFreeFunc2() {
@@ -640,7 +240,7 @@ func testTypeInLocalVarInFreeFunc2() {
 
   typealias NestedTypealias = Int
 
-  var localVar: #^TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_2^#
+  var localVar: #^TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_2?check=TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_2;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 // TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_2: Begin completions
 // TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_2-DAG: Decl[Struct]/Local:    NestedStruct[#NestedStruct#]{{; name=.+$}}
@@ -659,15 +259,15 @@ class TestTypeInLocalVarInMemberFunc1 {
   typealias NestedTypealias = Int
 
   init() {
-    var localVar: #^TYPE_IN_LOCAL_VAR_IN_CONSTRUCTOR_1^#
+    var localVar: #^TYPE_IN_LOCAL_VAR_IN_CONSTRUCTOR_1?check=TYPE_IN_LOCAL_VAR_IN_MEMBER_FUNC_1;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
   }
 
   deinit {
-    var localVar: #^TYPE_IN_LOCAL_VAR_IN_DESTRUCTOR_1^#
+    var localVar: #^TYPE_IN_LOCAL_VAR_IN_DESTRUCTOR_1?check=TYPE_IN_LOCAL_VAR_IN_MEMBER_FUNC_1;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
   }
 
   func test() {
-    var localVar: #^TYPE_IN_LOCAL_VAR_IN_INSTANCE_FUNC_1^#
+    var localVar: #^TYPE_IN_LOCAL_VAR_IN_INSTANCE_FUNC_1?check=TYPE_IN_LOCAL_VAR_IN_MEMBER_FUNC_1;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
   }
 }
 // TYPE_IN_LOCAL_VAR_IN_MEMBER_FUNC_1: Begin completions
@@ -677,19 +277,19 @@ class TestTypeInLocalVarInMemberFunc1 {
 // TYPE_IN_LOCAL_VAR_IN_MEMBER_FUNC_1-DAG: Decl[TypeAlias]/CurrNominal: NestedTypealias[#Int#]{{; name=.+$}}
 // TYPE_IN_LOCAL_VAR_IN_MEMBER_FUNC_1: End completions
 
-var TypeInGlobalVar1: #^TYPE_IN_GLOBAL_VAR_1^#
+var TypeInGlobalVar1: #^TYPE_IN_GLOBAL_VAR_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 //===---
 //===--- Test that we can complete types in typealias declarations.
 //===---
 
-typealias TypeInTypealias1 = #^TYPE_IN_TYPEALIAS_1^#
+typealias TypeInTypealias1 = #^TYPE_IN_TYPEALIAS_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-typealias TypeInTypealias2 = (#^TYPE_IN_TYPEALIAS_2^#
+typealias TypeInTypealias2 = (#^TYPE_IN_TYPEALIAS_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 func resyncParser0() {}
 
-typealias TypeInTypealias3 = ((#^TYPE_IN_TYPEALIAS_3^#
+typealias TypeInTypealias3 = ((#^TYPE_IN_TYPEALIAS_3?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 func resyncParser1() {}
 
@@ -698,7 +298,7 @@ func resyncParser1() {}
 //===---
 
 protocol AssocType1 {
-  associatedtype AssocType = #^TYPE_IN_ASSOC_TYPE_1^#
+  associatedtype AssocType = #^TYPE_IN_ASSOC_TYPE_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 //===---
@@ -706,76 +306,76 @@ protocol AssocType1 {
 //===---
 
 protocol AssocType1 {
-  associatedtype AssocType : #^TYPE_IN_ASSOC_TYPE_INHERITANCE_1^#
+  associatedtype AssocType : #^TYPE_IN_ASSOC_TYPE_INHERITANCE_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 //===---
 //===--- Test that we can complete types in extension declarations.
 //===---
 
-extension #^TYPE_IN_EXTENSION_1^#
+extension #^TYPE_IN_EXTENSION_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 //===---
 //===--- Test that we can complete types in the extension inheritance clause.
 //===---
 
-extension TypeInExtensionInheritance1 : #^TYPE_IN_EXTENSION_INHERITANCE_1^#
+extension TypeInExtensionInheritance1 : #^TYPE_IN_EXTENSION_INHERITANCE_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-extension TypeInExtensionInheritance2 : #^TYPE_IN_EXTENSION_INHERITANCE_2^# {
+extension TypeInExtensionInheritance2 : #^TYPE_IN_EXTENSION_INHERITANCE_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^# {
 }
 
-extension TypeInExtensionInheritance3 : FooProtocol, #^TYPE_IN_EXTENSION_INHERITANCE_3^# {
+extension TypeInExtensionInheritance3 : FooProtocol, #^TYPE_IN_EXTENSION_INHERITANCE_3?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^# {
 }
 
 //===---
 //===--- Test that we can complete types in the struct inheritance clause.
 //===---
 
-struct TypeInStructInheritance1 : #^TYPE_IN_STRUCT_INHERITANCE_1^#
+struct TypeInStructInheritance1 : #^TYPE_IN_STRUCT_INHERITANCE_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-struct TypeInStructInheritance2 : , #^TYPE_IN_STRUCT_INHERITANCE_2^#
+struct TypeInStructInheritance2 : , #^TYPE_IN_STRUCT_INHERITANCE_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-struct TypeInStructInheritance3 : FooProtocol, #^TYPE_IN_STRUCT_INHERITANCE_3^#
+struct TypeInStructInheritance3 : FooProtocol, #^TYPE_IN_STRUCT_INHERITANCE_3?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-struct TypeInStructInheritance4 : FooProtocol., #^TYPE_IN_STRUCT_INHERITANCE_4^#
+struct TypeInStructInheritance4 : FooProtocol., #^TYPE_IN_STRUCT_INHERITANCE_4?check=WITH_GLOBAL_TYPES^#
 
-struct TypeInStructInheritance5 : #^TYPE_IN_STRUCT_INHERITANCE_5^# {
+struct TypeInStructInheritance5 : #^TYPE_IN_STRUCT_INHERITANCE_5?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^# {
 }
 
-struct TypeInStructInheritance6 : , #^TYPE_IN_STRUCT_INHERITANCE_6^# {
+struct TypeInStructInheritance6 : , #^TYPE_IN_STRUCT_INHERITANCE_6?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^# {
 }
 
-struct TypeInStructInheritance7 : FooProtocol, #^TYPE_IN_STRUCT_INHERITANCE_7^# {
+struct TypeInStructInheritance7 : FooProtocol, #^TYPE_IN_STRUCT_INHERITANCE_7?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^# {
 }
 
-struct TypeInStructInheritance8 : FooProtocol., #^TYPE_IN_STRUCT_INHERITANCE_8^# {
+struct TypeInStructInheritance8 : FooProtocol., #^TYPE_IN_STRUCT_INHERITANCE_8?check=WITH_GLOBAL_TYPES^# {
 }
 
 //===---
 //===--- Test that we can complete types in the class inheritance clause.
 //===---
 
-class TypeInClassInheritance1 : #^TYPE_IN_CLASS_INHERITANCE_1^# {
+class TypeInClassInheritance1 : #^TYPE_IN_CLASS_INHERITANCE_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^# {
 }
 
-class TypeInClassInheritance2 : #^TYPE_IN_CLASS_INHERITANCE_2^#
+class TypeInClassInheritance2 : #^TYPE_IN_CLASS_INHERITANCE_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 //===---
 //===--- Test that we can complete types in the enum inheritance clause.
 //===---
 
-enum TypeInEnumInheritance1 : #^TYPE_IN_ENUM_INHERITANCE_1^#
+enum TypeInEnumInheritance1 : #^TYPE_IN_ENUM_INHERITANCE_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-enum TypeInEnumInheritance2 : #^TYPE_IN_ENUM_INHERITANCE_2^# {
+enum TypeInEnumInheritance2 : #^TYPE_IN_ENUM_INHERITANCE_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^# {
 }
 
 //===---
 //===--- Test that we can complete types in the protocol inheritance clause.
 //===---
 
-protocol TypeInProtocolInheritance1 : #^TYPE_IN_PROTOCOL_INHERITANCE_1^#
+protocol TypeInProtocolInheritance1 : #^TYPE_IN_PROTOCOL_INHERITANCE_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-protocol TypeInProtocolInheritance2 : #^TYPE_IN_PROTOCOL_INHERITANCE_2^# {
+protocol TypeInProtocolInheritance2 : #^TYPE_IN_PROTOCOL_INHERITANCE_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^# {
 }
 
 //===---
@@ -783,31 +383,31 @@ protocol TypeInProtocolInheritance2 : #^TYPE_IN_PROTOCOL_INHERITANCE_2^# {
 //===---
 
 func testTypeInTupleType1() {
-  var localVar: (#^TYPE_IN_TUPLE_TYPE_1^#
+  var localVar: (#^TYPE_IN_TUPLE_TYPE_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInTupleType2() {
-  var localVar: (a: #^TYPE_IN_TUPLE_TYPE_2^#
+  var localVar: (a: #^TYPE_IN_TUPLE_TYPE_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInTupleType3() {
-  var localVar: (Int, #^TYPE_IN_TUPLE_TYPE_3^#
+  var localVar: (Int, #^TYPE_IN_TUPLE_TYPE_3?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInTupleType4() {
-  var localVar: (a: Int, #^TYPE_IN_TUPLE_TYPE_4^#
+  var localVar: (a: Int, #^TYPE_IN_TUPLE_TYPE_4?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInTupleType5() {
-  var localVar: (Int, a: #^TYPE_IN_TUPLE_TYPE_5^#
+  var localVar: (Int, a: #^TYPE_IN_TUPLE_TYPE_5?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInTupleType6() {
-  var localVar: (a:, #^TYPE_IN_TUPLE_TYPE_6^#
+  var localVar: (a:, #^TYPE_IN_TUPLE_TYPE_6?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInTupleType7() {
-  var localVar: (a: b: #^TYPE_IN_TUPLE_TYPE_7^#
+  var localVar: (a: b: #^TYPE_IN_TUPLE_TYPE_7?skip=FIXME^#
 }
 
 //===---
@@ -815,27 +415,27 @@ func testTypeInTupleType7() {
 //===---
 
 func testTypeInFunctionType1() {
-  var localVar: #^TYPE_IN_FUNCTION_TYPE_1^# ->
+  var localVar: #^TYPE_IN_FUNCTION_TYPE_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^# ->
 }
 
 func testTypeInFunctionType2() {
-  var localVar: (#^TYPE_IN_FUNCTION_TYPE_2^#) -> ()
+  var localVar: (#^TYPE_IN_FUNCTION_TYPE_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#) -> ()
 }
 
 func testTypeInFunctionType3() {
-  var localVar: () -> #^TYPE_IN_FUNCTION_TYPE_3^#
+  var localVar: () -> #^TYPE_IN_FUNCTION_TYPE_3?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInFunctionType4() {
-  var localVar: (Int) -> #^TYPE_IN_FUNCTION_TYPE_4^#
+  var localVar: (Int) -> #^TYPE_IN_FUNCTION_TYPE_4?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInFunctionType5() {
-  var localVar: (a: Int) -> #^TYPE_IN_FUNCTION_TYPE_5^#
+  var localVar: (a: Int) -> #^TYPE_IN_FUNCTION_TYPE_5?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInFunctionType6() {
-  var localVar: (a: Int, ) -> #^TYPE_IN_FUNCTION_TYPE_6^#
+  var localVar: (a: Int, ) -> #^TYPE_IN_FUNCTION_TYPE_6?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 //===---
@@ -843,15 +443,15 @@ func testTypeInFunctionType6() {
 //===---
 
 func testTypeInProtocolComposition1() {
-  var localVar: protocol<#^TYPE_IN_PROTOCOL_COMPOSITION_1^#
+  var localVar: protocol<#^TYPE_IN_PROTOCOL_COMPOSITION_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInProtocolComposition2() {
-  var localVar: protocol<, #^TYPE_IN_PROTOCOL_COMPOSITION_2^#
+  var localVar: protocol<, #^TYPE_IN_PROTOCOL_COMPOSITION_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 func testTypeInProtocolComposition3() {
-  var localVar: protocol<FooProtocol, #^TYPE_IN_PROTOCOL_COMPOSITION_3^#
+  var localVar: protocol<FooProtocol, #^TYPE_IN_PROTOCOL_COMPOSITION_3?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 //===---
@@ -859,12 +459,12 @@ func testTypeInProtocolComposition3() {
 //===---
 
 class VarBase1 {
-  var instanceVarBase1: #^TYPE_IN_INSTANCE_VAR_1^#
+  var instanceVarBase1: #^TYPE_IN_INSTANCE_VAR_1?check=VAR_BASE_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-  func paramNestedTypesBase1(a: #^TYPE_IN_FUNC_PARAM_NESTED_TYPES_1^#
+  func paramNestedTypesBase1(a: #^TYPE_IN_FUNC_PARAM_NESTED_TYPES_1?check=VAR_BASE_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
   func localVarBaseTest1() {
-    var localVar: #^TYPE_IN_LOCAL_VAR_1^#
+    var localVar: #^TYPE_IN_LOCAL_VAR_1?check=VAR_BASE_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
   }
 
   // Define types after all tests to test delayed parsing of decls.
@@ -879,12 +479,12 @@ class VarBase1 {
 }
 
 extension VarBase1 {
-  var instanceVarBaseExt1: #^TYPE_IN_INSTANCE_VAR_2^#
+  var instanceVarBaseExt1: #^TYPE_IN_INSTANCE_VAR_2?check=VAR_BASE_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-  func paramNestedTypesBaseExt1(a: #^TYPE_IN_FUNC_PARAM_NESTED_TYPES_2^#
+  func paramNestedTypesBaseExt1(a: #^TYPE_IN_FUNC_PARAM_NESTED_TYPES_2?check=VAR_BASE_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
   func localVarBaseExtTest1() {
-    var localVar: #^TYPE_IN_LOCAL_VAR_2^#
+    var localVar: #^TYPE_IN_LOCAL_VAR_2?check=VAR_BASE_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
   }
 
   // Define types after all tests to test delayed parsing of decls.
@@ -938,12 +538,12 @@ extension VarBase1 {
 // VAR_BASE_1_NO_DOT_TYPES: End completions
 
 class VarDerived1 : VarBase1 {
-  var instanceVarDerived1 : #^TYPE_IN_INSTANCE_VAR_3^#
+  var instanceVarDerived1 : #^TYPE_IN_INSTANCE_VAR_3?check=VAR_DERIVED_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-  func paramNestedTypesDerived1(a: #^TYPE_IN_FUNC_PARAM_NESTED_TYPES_3^#
+  func paramNestedTypesDerived1(a: #^TYPE_IN_FUNC_PARAM_NESTED_TYPES_3?check=VAR_DERIVED_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
   func localVarDerivedTest1() {
-    var localVar : #^TYPE_IN_LOCAL_VAR_3^#
+    var localVar : #^TYPE_IN_LOCAL_VAR_3?check=VAR_DERIVED_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
   }
 
   // Define types after all tests to test delayed parsing of decls.
@@ -958,12 +558,12 @@ class VarDerived1 : VarBase1 {
 }
 
 extension VarDerived1 {
-  var instanceVarDerivedExt1 : #^TYPE_IN_INSTANCE_VAR_4^#
+  var instanceVarDerivedExt1 : #^TYPE_IN_INSTANCE_VAR_4?check=VAR_DERIVED_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-  func paramNestedTypesDerivedExt1(a: #^TYPE_IN_FUNC_PARAM_NESTED_TYPES_4^#
+  func paramNestedTypesDerivedExt1(a: #^TYPE_IN_FUNC_PARAM_NESTED_TYPES_4?check=VAR_DERIVED_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
   func localVarDerivedExtTest1() {
-    var localVar : #^TYPE_IN_LOCAL_VAR_4^#
+    var localVar : #^TYPE_IN_LOCAL_VAR_4?check=VAR_DERIVED_1_TYPES_INCONTEXT;check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
   }
 
   // Define types after all tests to test delayed parsing of decls.
@@ -1027,30 +627,30 @@ extension VarDerived1 {
 //===--- Test that we can complete based on user-provided type-identifier.
 //===---
 
-func testTypeIdentifierBase1(a: VarBase1.#^TYPE_IDENTIFIER_BASE_1^#
-func testTypeIdentifierBase2(a: Int, b: VarBase1.#^TYPE_IDENTIFIER_BASE_2^#
-func testTypeIdentifierBase3(a: unknown_type, b: VarBase1.#^TYPE_IDENTIFIER_BASE_3^#
-func testTypeIdentifierBase4(a: , b: VarBase1.#^TYPE_IDENTIFIER_BASE_4^#
+func testTypeIdentifierBase1(a: VarBase1.#^TYPE_IDENTIFIER_BASE_1?check=VAR_BASE_1_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
+func testTypeIdentifierBase2(a: Int, b: VarBase1.#^TYPE_IDENTIFIER_BASE_2?check=VAR_BASE_1_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
+func testTypeIdentifierBase3(a: unknown_type, b: VarBase1.#^TYPE_IDENTIFIER_BASE_3?check=VAR_BASE_1_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
+func testTypeIdentifierBase4(a: , b: VarBase1.#^TYPE_IDENTIFIER_BASE_4?check=VAR_BASE_1_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-func testTypeIdentifierBaseNoDot1(a: VarBase1#^TYPE_IDENTIFIER_BASE_NO_DOT_1^#
+func testTypeIdentifierBaseNoDot1(a: VarBase1#^TYPE_IDENTIFIER_BASE_NO_DOT_1?check=VAR_BASE_1_NO_DOT_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 func testTypeIdentifierBaseNoDot2() {
-  var localVar : protocol<VarBase1#^TYPE_IDENTIFIER_BASE_NO_DOT_2^#
+  var localVar : protocol<VarBase1#^TYPE_IDENTIFIER_BASE_NO_DOT_2?check=VAR_BASE_1_NO_DOT_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
-typealias testTypeIdentifierBaseNoDot3 = VarBase1#^TYPE_IDENTIFIER_BASE_NO_DOT_3^#
+typealias testTypeIdentifierBaseNoDot3 = VarBase1#^TYPE_IDENTIFIER_BASE_NO_DOT_3?check=VAR_BASE_1_NO_DOT_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
-func testTypeIdentifierDerived1(a: VarDerived1.#^TYPE_IDENTIFIER_DERIVED_1^#
+func testTypeIdentifierDerived1(a: VarDerived1.#^TYPE_IDENTIFIER_DERIVED_1?check=VAR_DERIVED_1_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 func testTypeIdentifierDerived2() {
-  var localVar : protocol<VarDerived1.#^TYPE_IDENTIFIER_DERIVED_2^#
+  var localVar : protocol<VarDerived1.#^TYPE_IDENTIFIER_DERIVED_2?check=VAR_DERIVED_1_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
-typealias testTypeIdentifierDerived3 = VarDerived1.#^TYPE_IDENTIFIER_DERIVED_3^#
+typealias testTypeIdentifierDerived3 = VarDerived1.#^TYPE_IDENTIFIER_DERIVED_3?check=VAR_DERIVED_1_TYPES;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 func testTypeIdentifierGeneric1<
     GenericFoo : FooProtocol
-    >(a: GenericFoo.#^TYPE_IDENTIFIER_GENERIC_1^#
+    >(a: GenericFoo.#^TYPE_IDENTIFIER_GENERIC_1?check=TYPE_IDENTIFIER_GENERIC_1;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 // TYPE_IDENTIFIER_GENERIC_1: Begin completions
 // TYPE_IDENTIFIER_GENERIC_1-NEXT: Decl[AssociatedType]/CurrNominal: FooTypeAlias1{{; name=.+$}}
@@ -1059,7 +659,7 @@ func testTypeIdentifierGeneric1<
 
 func testTypeIdentifierGeneric2<
     GenericFoo : FooProtocol & BarProtocol
-    >(a: GenericFoo.#^TYPE_IDENTIFIER_GENERIC_2^#
+    >(a: GenericFoo.#^TYPE_IDENTIFIER_GENERIC_2?check=TYPE_IDENTIFIER_GENERIC_2;check=WITHOUT_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 
 // TYPE_IDENTIFIER_GENERIC_2: Begin completions
 // TYPE_IDENTIFIER_GENERIC_2-NEXT: Decl[AssociatedType]/CurrNominal: BarTypeAlias1{{; name=.+$}}
@@ -1089,7 +689,7 @@ func testTypeIdentifierIrrelevant1() {
 //===---
 
 func testAsCast1(a: Int) {
-  a as #^INSIDE_AS_CAST_1^#
+  a as #^INSIDE_AS_CAST_1?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#
 }
 
 //===---
@@ -1104,23 +704,23 @@ func testGenericTypealias1() {
 // GENERIC_TYPEALIAS_1: Decl[TypeAlias]/Local: MyPair[#(T, T)#];
 func testGenericTypealias2() {
   typealias MyPair<T> = (T, T)
-  let x: MyPair<#^GENERIC_TYPEALIAS_2^#>
+  let x: MyPair<#^GENERIC_TYPEALIAS_2?check=WITH_GLOBAL_TYPES;check=GLOBAL_NEGATIVE^#>
 }
 
 // In generic argument
 struct GenStruct<T> { }
-let a : GenStruct<#^GENERIC_ARGS_TOPLEVEL_VAR^#
-func foo1(x: GenStruct<#^GENERIC_ARGS_TOPLEVEL_PARAM^#
-func foo2() -> GenStruct<#^GENERIC_ARGS_TOPLEVEL_RETURN^#
+let a : GenStruct<#^GENERIC_ARGS_TOPLEVEL_VAR?check=WITH_GLOBAL_TYPES^#
+func foo1(x: GenStruct<#^GENERIC_ARGS_TOPLEVEL_PARAM?check=WITH_GLOBAL_TYPES^#
+func foo2() -> GenStruct<#^GENERIC_ARGS_TOPLEVEL_RETURN?check=WITH_GLOBAL_TYPES^#
 class _TestForGenericArg_ {
-  let a : GenStruct<#^GENERIC_ARGS_MEMBER_VAR^#
-  func foo1(x: GenStruct<#^GENERIC_ARGS_MEMBER_PARAM^#
-  func foo2() -> GenStruct<#^GENERIC_ARGS_MEMBER_RETURN^#
+  let a : GenStruct<#^GENERIC_ARGS_MEMBER_VAR?check=WITH_GLOBAL_TYPES^#
+  func foo1(x: GenStruct<#^GENERIC_ARGS_MEMBER_PARAM?check=WITH_GLOBAL_TYPES^#
+  func foo2() -> GenStruct<#^GENERIC_ARGS_MEMBER_RETURN?check=WITH_GLOBAL_TYPES^#
 }
 func _testForGenericArg_() {
-  let a : GenStruct<#^GENERIC_ARGS_LOCAL_VAR^#
-  func foo1(x: GenStruct<#^GENERIC_ARGS_LOCAL_PARAM^#
-  func foo2() -> GenStruct<#^GENERIC_ARGS_LOCAL_RETURN^#
+  let a : GenStruct<#^GENERIC_ARGS_LOCAL_VAR?check=WITH_GLOBAL_TYPES^#
+  func foo1(x: GenStruct<#^GENERIC_ARGS_LOCAL_PARAM?check=WITH_GLOBAL_TYPES^#
+  func foo2() -> GenStruct<#^GENERIC_ARGS_LOCAL_RETURN?check=WITH_GLOBAL_TYPES^#
 }
 
 func testProtocol() {
@@ -1148,8 +748,8 @@ extension Task.Inner {
     fatalError()
   }
 }
-extension Task.Inner.#^UNBOUND_DOT^# {}
-func testUnbound(x: Task.Inner.#^UNBOUND_DOT^#) {}
+extension Task.Inner.#^UNBOUND_DOT_1?check=UNBOUND_DOT^# {}
+func testUnbound(x: Task.Inner.#^UNBOUND_DOT_2?check=UNBOUND_DOT^#) {}
 // UNBOUND_DOT: Begin completions
 // UNBOUND_DOT-DAG: Decl[TypeAlias]/CurrNominal:        Failure[#Int#]; name=Failure
 // UNBOUND_DOT-DAG: Keyword/None:                       Type[#Task.Inner.Type#]; name=Type
@@ -1161,7 +761,7 @@ struct OuterStruct<U>  {
   class Inner<V>: MyProtocol {}
 }
 
-func testUnbound2(x: OuterStruct<Int>.Inner.#^UNBOUND_DOT_2^#) {}
-// UNBOUND_DOT_2: Begin completions
-// UNBOUND_DOT_2-DAG: Keyword/None:                       Type[#OuterStruct<Int>.Inner.Type#]; name=Type
-// UNBOUND_DOT_2: End completions
+func testUnbound2(x: OuterStruct<Int>.Inner.#^UNBOUND_DOT_3^#) {}
+// UNBOUND_DOT_3: Begin completions
+// UNBOUND_DOT_3-DAG: Keyword/None:                       Type[#OuterStruct<Int>.Inner.Type#]; name=Type
+// UNBOUND_DOT_3: End completions

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -58,13 +58,16 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/Program.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/ManagedStatic.h"
 #include <system_error>
 
+#include <random>
 #include <string>
+#include <chrono>
 
 using namespace swift;
 using namespace ide;
@@ -74,6 +77,7 @@ namespace {
 
 enum class ActionType {
   None,
+  BatchCodeCompletion,
   CodeCompletion,
   REPLCodeCompletion,
   DumpCompletionCache,
@@ -158,6 +162,8 @@ static llvm::cl::opt<ActionType>
 Action(llvm::cl::desc("Mode:"), llvm::cl::init(ActionType::None),
        llvm::cl::cat(Category),
        llvm::cl::values(
+           clEnumValN(ActionType::BatchCodeCompletion,
+                      "batch-code-completion", "Perform code completion in batch mode"),
            clEnumValN(ActionType::CodeCompletion,
                       "code-completion", "Perform code completion"),
            clEnumValN(ActionType::REPLCodeCompletion,
@@ -402,6 +408,29 @@ DebugForbidTypecheckPrefix("debug-forbid-typecheck-prefix",
   llvm::cl::desc("Triggers llvm fatal_error if typechecker tries to typecheck "
                  "a decl with the provided prefix name"),
   llvm::cl::cat(Category));
+
+// '-batch-code-completion' options.
+
+static llvm::cl::opt<uint64_t>
+RandomSeed("random-seed", llvm::cl::value_desc("seed"),
+                    llvm::cl::desc("Seed for the random number generator"),
+                    llvm::cl::cat(Category),
+                    llvm::cl::init(0));
+
+
+static llvm::cl::opt<std::string>
+CompletionOutputDir("completion-output-dir", llvm::cl::value_desc("path"),
+                    llvm::cl::desc("Directory for completion output"),
+                    llvm::cl::cat(Category));
+
+static llvm::cl::opt<std::string>
+FileCheckPath("filecheck", llvm::cl::value_desc("path"),
+                           llvm::cl::desc("Path to 'FileCheck' utility"),
+                           llvm::cl::cat(Category));
+
+static llvm::cl::opt<bool>
+SkipFileCheck("skip-filecheck", llvm::cl::desc("Skip 'FileCheck' checking"),
+                                llvm::cl::cat(Category));
 
 // '-code-completion' options.
 
@@ -874,6 +903,397 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
   return doCodeCompletionImpl(callbacksFactory.get(), InitInvok, SourceFilename,
                               SecondSourceFileName, CodeCompletionToken,
                               CodeCompletionDiagnostics);
+}
+
+namespace {
+struct CompletionTestToken {
+  unsigned Line;
+  unsigned Column;
+  unsigned Offset;
+  StringRef Name;
+  SmallVector<StringRef, 1> CheckPrefixes;
+  StringRef Skip;
+  Optional<bool> IncludeKeywords = None;
+  Optional<bool> IncludeComments = None;
+
+  CompletionTestToken(unsigned Line, unsigned Column, unsigned Offset)
+      : Line(Line), Column(Column), Offset(Offset){};
+
+  static bool isStartOfToken(const char *Ptr) {
+    return Ptr[0] == '#' && Ptr[1] == '^';
+  }
+
+  static bool isEndOfToken(const char *Ptr) {
+    return Ptr[0] == '^' && Ptr[1] == '#';
+  }
+
+  static bool isValidTokenChar(char Chr) {
+    return (Chr >= 'A' && Chr <= 'Z') || (Chr >= 'a' && Chr <= 'z') ||
+           (Chr >= '0' && Chr <= '9') || Chr == '_' || Chr == '-' || Chr == '.';
+  }
+
+  static bool parseBooleanValue(StringRef Value, bool &Result,
+                                std::string &Error) {
+    if (Value.empty() || Value == "true" || Value == "1") {
+      Result = true;
+      return false;
+    }
+    if (Value == "false" || Value == "0") {
+      Result = false;
+      return false;
+    }
+
+    Error = "invalid value for keywords";
+    return true;
+  }
+
+  // #^TOKEN_NAME?check-prefix=CHECK1,CHECK2&keywords=1&comments=true^#
+  static bool parse(const char *&InputPtr, CompletionTestToken &Result,
+                    std::string &Error) {
+    auto Ptr = InputPtr;
+    assert(isStartOfToken(Ptr));
+    Ptr += 2;
+
+    // Parse the token name.
+    auto NameStart = Ptr;
+    while (isValidTokenChar(*Ptr)) { ++Ptr; }
+    Result.Name = StringRef(NameStart, Ptr - NameStart);
+
+    // Parse optional query string.
+    if (*Ptr == '?') {
+      ++Ptr;
+      auto QueryStart = Ptr;
+      while (!isEndOfToken(Ptr) && *Ptr != 0 && *Ptr != '\n' && *Ptr != '\r')
+        ++Ptr;
+      StringRef QueryString(QueryStart, Ptr - QueryStart);
+
+      while (!QueryString.empty()) {
+        StringRef Query, Key, Value;
+        std::tie(Query, QueryString) = QueryString.split(';');
+        std::tie(Key, Value) = Query.split('=');
+
+        if (Key == "check") {
+          // This value is passed to 'FileCheck --check-prefixes' as is.
+          Result.CheckPrefixes.push_back(Value);
+          continue;
+        }
+        if (Key == "keywords") {
+          Result.IncludeKeywords.emplace();
+          if (parseBooleanValue(Value, *Result.IncludeKeywords, Error))
+            return true;
+          continue;
+        }
+        if (Key == "comments") {
+          Result.IncludeComments.emplace();
+          if (parseBooleanValue(Value, *Result.IncludeComments, Error))
+            return true;
+          continue;
+        }
+        if (Key == "skip") {
+          Result.Skip = Value;
+          continue;
+        }
+        Error = "unknown option (" + Key.str() + ") for token";
+        return true;
+      }
+    }
+
+    // Default check prefix is the token name.
+    if (Result.CheckPrefixes.empty())
+      Result.CheckPrefixes.push_back(Result.Name);
+
+    // Tokens must end with '^#'.
+    if (!isEndOfToken(Ptr)) {
+      Error = "expected '^#' at the end of completion token";
+      return true;
+    }
+
+    InputPtr = Ptr + 2;
+    return false;;
+  }
+};
+
+static std::unique_ptr<llvm::MemoryBuffer>
+removeCodeCompletionTokens(llvm::MemoryBuffer *Input,
+                           SmallVectorImpl<CompletionTestToken> &Tokens,
+                           std::string &Error) {
+  const char *Start = Input->getBufferStart();
+  const char *End = Input->getBufferEnd();
+  assert(*End == 0 && "buffer must be nul terminated");
+
+  std::string Out;
+  Out.reserve(Input->getBufferSize());
+
+  llvm::StringSet<> seenTokenName;
+  const char *Ptr = Start;
+  const char *SegmentStart = Ptr;
+  unsigned Removed = 0;
+  unsigned Line = 1;
+  unsigned Column = 1;
+  while (Ptr != End) {
+    if (CompletionTestToken::isStartOfToken(Ptr)) {
+      Out.append(SegmentStart, Ptr - SegmentStart);
+
+      // Emplace a token with the offset, and parse it.
+      const char *TokenStart = Ptr;
+      Tokens.emplace_back(Line, Column, Ptr - Start - Removed);
+      if (CompletionTestToken::parse(Ptr, Tokens.back(), Error)) {
+        Error = "while parsing a token at " +
+                (llvm::utostr(Line) + ":" + llvm::utostr(Column)) + ": " +
+                Error;
+        return nullptr;
+      }
+
+      if (!seenTokenName.insert(Tokens.back().Name).second) {
+        Error = "Duplicated token name '" + Tokens.back().Name.str() +
+                "' at " + (llvm::utostr(Line) + ":" + llvm::utostr(Column));
+        return nullptr;
+      }
+
+      auto TokLen =  Ptr - TokenStart;
+      SegmentStart = Ptr;
+      Removed += TokLen;
+      Column += TokLen;
+      continue;
+    }
+    if (*Ptr == '\r' || *Ptr == '\n') {
+      Ptr += (Ptr[0] == '\r' && Ptr[1] == '\n') ? 2 : 1;
+      Line += 1;
+      Column = 1;
+      continue;
+    }
+    ++Ptr;
+    ++Column;
+  }
+  Out.append(SegmentStart, Ptr - SegmentStart);
+
+  return llvm::MemoryBuffer::getMemBufferCopy(Out,
+                                              Input->getBufferIdentifier());
+}
+
+} // namespace
+
+static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
+                                 StringRef SourceFilename,
+                                 bool CodeCompletionDiagnostics,
+                                 bool CodeCompletionKeywords,
+                                 bool CodeCompletionComments) {
+  auto FileBufOrErr = llvm::MemoryBuffer::getFile(SourceFilename);
+  if (!FileBufOrErr) {
+    llvm::errs() << "error opening input file: "
+                 << FileBufOrErr.getError().message() << '\n';
+    return 1;
+  }
+
+  // Completion results are output to
+  // '${OutputDir}/complete-{Token.Name}.result'.
+  SmallString<128> OutputDir;
+  if (!options::CompletionOutputDir.empty()) {
+    OutputDir = options::CompletionOutputDir;
+    if (auto result = llvm::sys::fs::create_directories(OutputDir))
+      return result.value();
+  } else if (!options::SkipFileCheck) {
+    llvm::errs() << "error: -completion-output-dir is needed unless "
+                    "-skip-filecheck is specified.\n";
+    return 1;
+  }
+
+  std::string Error;
+
+  llvm::SmallVector<CompletionTestToken, 0> CCTokens;
+  auto CleanFile =
+      removeCodeCompletionTokens(FileBufOrErr.get().get(), CCTokens, Error);
+  if (!CleanFile) {
+    llvm::errs() << "error: " << Error << "\n";
+    return 1;
+  }
+
+  if (!options::CodeCompletionToken.empty()) {
+    // If `-code-completion-token` is specified, test only that token.
+    // TODO: Multiple tokens.
+    StringRef TargetTokName = options::CodeCompletionToken;
+    Optional<CompletionTestToken> FoundTok;
+    for (auto Tok : CCTokens) {
+      if (Tok.Name == TargetTokName) {
+        FoundTok = Tok;
+        break;
+      }
+    }
+    if (FoundTok) {
+      CCTokens = {*FoundTok};
+    } else {
+      llvm::errs() << "error: could not find code completion token \""
+                   << TargetTokName << "\"\n";
+      return 1;
+    }
+  } else {
+    // Shuffle tokens to detect order-dependent bugs.
+    if (CCTokens.empty()) {
+      llvm::errs()
+          << "error: could not find any code completion tokens in input file\n";
+      return 1;
+    }
+    unsigned RandomSeed = options::RandomSeed;
+    if (RandomSeed == 0)
+      RandomSeed = std::chrono::system_clock::now().time_since_epoch().count();
+    llvm::errs() << "Use --random-seed=" << RandomSeed
+                 << " to reproduce the order of this run.\n";
+
+    std::shuffle(CCTokens.begin(), CCTokens.end(),
+                 std::default_random_engine(RandomSeed));
+  }
+
+  CompilerInvocation Invocation(InitInvok);
+  auto FileSystem = llvm::vfs::getRealFileSystem();
+
+  CompletionInstance CompletionInst;
+
+  std::unique_ptr<ide::OnDiskCodeCompletionCache> OnDiskCache;
+  if (!options::CompletionCachePath.empty())
+    OnDiskCache = std::make_unique<ide::OnDiskCodeCompletionCache>(
+        options::CompletionCachePath);
+  ide::CodeCompletionCache CompletionCache(OnDiskCache.get());
+
+  // Process tokens.
+  SmallVector<StringRef, 0> FailedTokens;
+  for (const auto &Token : CCTokens) {
+    if (!options::CodeCompletionToken.empty() &&
+        options::CodeCompletionToken != Token.Name)
+      continue;
+
+    llvm::errs() << "----\n";
+    llvm::errs() << "Token: " << Token.Name << "; offset=" << Token.Offset
+                 << "; pos=" << Token.Line << ":" << Token.Column;
+    for (auto Prefix : Token.CheckPrefixes) {
+      llvm::errs() << "; check=" << Prefix;
+    }
+    llvm::errs() << "\n";
+
+    // Skip tokens with '?skip=${reason}'.
+    if (!Token.Skip.empty()) {
+      llvm::errs() << "Skipped: " << Token.Skip << "\n";
+      continue;
+    }
+
+    auto IncludeKeywords = CodeCompletionKeywords;
+    if (Token.IncludeKeywords)
+      IncludeKeywords = *Token.IncludeKeywords;
+
+    auto IncludeComments = CodeCompletionComments;
+    if (Token.IncludeComments)
+      IncludeComments = *Token.IncludeComments;
+
+    // Store the result to a string.
+    std::string ResultStr;
+    llvm::raw_string_ostream OS(ResultStr);
+    OS << "// Token: "  << Token.Name << "\n";
+
+    auto Offset = Token.Offset;
+    auto completionBuffer = ide::makeCodeCompletionMemoryBuffer(
+        CleanFile.get(), Offset, CleanFile->getBufferIdentifier());
+
+    PrintingDiagnosticConsumer PrintDiags;
+    auto completionStart = std::chrono::high_resolution_clock::now();
+    bool isSuccess = CompletionInst.performOperation(
+        Invocation, /*Args=*/{}, FileSystem, completionBuffer.get(), Offset,
+        /*EnableASTCaching=*/true, Error,
+        CodeCompletionDiagnostics ? &PrintDiags : nullptr,
+        [&](CompilerInstance &CI, bool reusingASTContext) {
+          // Create a CodeCompletionConsumer.
+          std::unique_ptr<ide::CodeCompletionConsumer> Consumer(
+              new ide::PrintingCodeCompletionConsumer(OS, IncludeKeywords,
+                                                      IncludeComments));
+
+          // Create a factory for code completion callbacks that will feed the
+          // Consumer.
+          ide::CodeCompletionContext CompletionContext(CompletionCache);
+          std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
+              ide::makeCodeCompletionCallbacksFactory(CompletionContext,
+                                                      *Consumer));
+
+          auto *SF = CI.getCodeCompletionFile();
+          performCodeCompletionSecondPass(*SF, *callbacksFactory);
+        });
+    auto completionEnd = std::chrono::high_resolution_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        completionEnd - completionStart);
+    llvm::errs() << "Elapsed: " << elapsed.count() << " msec\n";
+    OS.flush();
+
+    if (OutputDir.empty()) {
+      // If output directory is not specified, print the results to STDOUT.
+      llvm::outs() << ResultStr;
+      continue;
+    }
+
+    // Print to '${OutputDir}/complete-{Token.Name}.result'.
+    int resultFD;
+    SmallString<128> resultFilename(OutputDir);
+    llvm::sys::path::append(resultFilename,
+                            "complete-" + Token.Name + ".result");
+    if (auto res = llvm::sys::fs::openFileForWrite(resultFilename, resultFD)) {
+      llvm::errs() << "error: failed to create output file: "
+                   << resultFilename << "\n";
+      return res.value();
+    }
+
+    llvm::raw_fd_ostream fileOut(resultFD, /*shouldClose=*/true);
+    fileOut << ResultStr;
+    fileOut.close();
+
+    if (!isSuccess) {
+      llvm::errs() << "error: " << Error << "\n";
+      return 1;
+    }
+
+    if (options::SkipFileCheck)
+      continue;
+
+    assert(!options::FileCheckPath.empty());
+
+    bool isFileCheckFailed = false;
+    for (auto Prefix : Token.CheckPrefixes) {
+      StringRef FileCheckArgs[] = {options::FileCheckPath, SourceFilename,
+                                   "--check-prefixes",     Prefix,
+                                   "--input-file",         resultFilename};
+
+      int result =
+          llvm::sys::ExecuteAndWait(options::FileCheckPath, FileCheckArgs,
+                                    /*Env=*/None,
+                                    /*Redirects=*/{},
+                                    /*SecondsToWait=*/0,
+                                    /*MemoryLimit=*/0,
+                                    /*ErrMsg=*/&Error);
+      if (result != 0) {
+        isFileCheckFailed = true;
+        if (!Error.empty())
+          llvm::errs() << "error: " << Error << "\n";
+
+        // Output the FileCheck invocation.
+        llvm::errs() << "+";
+        for (auto arg : FileCheckArgs)
+          llvm::errs() << " " << arg;
+        llvm::errs() << "\n";
+      }
+    }
+
+    if (isFileCheckFailed) {
+      FailedTokens.push_back(Token.Name);
+    } else {
+      // The result may be huge. Remove the result if it's succeeded.
+      llvm::sys::fs::remove(resultFilename);
+    }
+  }
+
+  if (!FailedTokens.empty()) {
+    llvm::errs() << "----\n";
+    llvm::errs() << "Unexpected failures: ";
+    llvm::interleave(
+        FailedTokens, [&](StringRef name) { llvm::errs() << name; },
+        [&]() { llvm::errs() << ", "; });
+  }
+
+  return !FailedTokens.empty();
 }
 
 static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,
@@ -3525,6 +3945,19 @@ int main(int argc, char *argv[]) {
   case ActionType::DiffModuleAPI:
   case ActionType::DumpCompletionCache:
     llvm_unreachable("should be handled above");
+
+  case ActionType::BatchCodeCompletion:
+    if (options::FileCheckPath.empty() && !options::SkipFileCheck) {
+      llvm::errs() << "'FileCheck' path required or explicitly specify "
+                   << "'-skip-filecheck'\n";
+      return 1;
+    }
+    ExitCode = doBatchCodeCompletion(InitInvok,
+                                     options::SourceFilename,
+                                     options::CodeCompletionDiagnostics,
+                                     options::CodeCompletionKeywords,
+                                     options::CodeCompletionComments);
+    break;
 
   case ActionType::CodeCompletion:
     if (options::CodeCompletionToken.empty()) {


### PR DESCRIPTION
Utilize fast completion (reusing `CompilerInstance`) in libIDE code completion tests.

- Catch regressions in fast-completion
- Reduce the test execution time (e.g. 32sec -> approx. 2sec  for `complete_types.swift`)

Introduce `-batch-code-completion` mode. The typical usage is:
```
// RUN: %swift-ide-test -batch-code-completion \
// RUN:     -filecheck %raw-FileCheck \
// RUN:     -completion-output-dir %t \
// RUN:     -source-filename %s
```

This scans the source file for tokens (`#^NAME^#`), then performs code completion for each token in *random* order with `reuseastcontext` mode.

Options are:
* `-filecheck`: `FileCheck` command path. Completion results are checked with this `FileCheck`
* `-completion-output-dir`: Temporary file directory. Completion results are output with `${output dir}/complete-${token name}.result`
* `-random-seed`: By default, tokens are shuffled with random generated seed. Using `-random-seed` you can specify shuffle seed. This is convenient for reproducing order-dependent failures
* `-code-completion-token`: You can specify a specific token name to test, but in `batch-code-completion` mode

Each token can have several options (e.g. `#^NAME?check=GLOBAL;comments=true^#`):
* `check`: By default, the completion results are `FileCheck -check-prefixes=`ed with the token name. `check` can changes the `check-prefix` name. Also, you can specify multiple `check` to perform multiple `FileCheck`s with different prefixes
* `keywords`: equivalent to `-code-completion-keywords`
* `comments`: equivalent to `-code-completion-comments`
* `skip`: Tokens with `skip` are skipped

In this PR. Only migrate `test/IDE/complete_type.swift`. But I intend to migrate other test files in follow up PRs.


rdar://problem/16025703