### PR TITLE
[CodeCompletion] Evaluate 'PatternBindingEntryRequest' before checking the init

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -575,6 +575,8 @@ void swift::typeCheckPatternBinding(PatternBindingDecl *PBD,
   auto &Ctx = PBD->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
   (void)createTypeChecker(Ctx);
+  (void)evaluateOrDefault(
+      Ctx.evaluator, PatternBindingEntryRequest{PBD, bindingIndex}, nullptr);
   TypeChecker::typeCheckPatternBinding(PBD, bindingIndex);
 }
 

--- a/validation-test/IDE/crashers_2_fixed/rdar52105899.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar52105899.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: echo '//DUMMY' > %t/dummy.swift
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s %t/dummy.swift > /dev/null
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=B -source-filename=%s %t/dummy.swift > /dev/null
+
+struct MyStruct {
+  let _: Int = #^A^#
+}
+
+let _: Int = #^B^#


### PR DESCRIPTION
If a completion happens in a `PatternBindingInitializer` context for `TypedPattern` without any `VarDecl`, e.g.:

```swift
let _: Int = <HERE>
```

it crashes because `typeCheckPatternBinding()` requires that the `TypedPattern` has the type.

rdar://problem/52105899