### PR TITLE
[AutoDiff] Fix transpose type checking.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3043,9 +3043,12 @@ ERROR(transpose_attr_overload_not_found,none,
 ERROR(transpose_attr_cannot_use_named_wrt_params,none,
       "cannot use named 'wrt' parameters in '@transpose(of:)' attribute, found "
       "%0", (Identifier))
-ERROR(transpose_attr_result_value_not_differentiable,none,
-      "'@transpose(of:)' attribute requires original function result %0 to "
-      "conform to 'Differentiable'", (Type))
+ERROR(transpose_func_wrt_self_must_be_static,none,
+     "the transpose of an instance method must be a 'static' method in the "
+     "same type when 'self' is a linearity parameter", ())
+NOTE(transpose_func_wrt_self_self_type_mismatch_note,none,
+     "the transpose is declared in %0 but the original function is declared in "
+     "%1", (Type, Type))
 
 // Automatic differentiation attributes
 ERROR(autodiff_attr_original_decl_invalid_kind,none,

--- a/test/AutoDiff/Serialization/transpose_attr.swift
+++ b/test/AutoDiff/Serialization/transpose_attr.swift
@@ -56,14 +56,14 @@ extension S {
 
   // CHECK: @transpose(of: instanceMethod, wrt: 0)
   @transpose(of: instanceMethod, wrt: 0)
-  func transposeInstanceMethod(v: S) -> (S, S) {
-    (v, v)
+  func transposeInstanceMethod(t: S) -> S {
+    self + t
   }
 
   // CHECK: @transpose(of: instanceMethod, wrt: self)
   @transpose(of: instanceMethod, wrt: self)
-  func transposeInstanceMethodWrtSelf(v: S) -> (S, S) {
-    (v, v)
+  static func transposeInstanceMethodWrtSelf(_ other: S, t: S) -> S {
+    other + t
   }
 }
 
@@ -76,8 +76,8 @@ extension S {
 
   // CHECK: @transpose(of: staticMethod, wrt: 0)
   @transpose(of: staticMethod, wrt: 0)
-  func transposeStaticMethod(_: S.Type) -> S {
-    self
+  static func transposeStaticMethod(t: S) -> S {
+    t
   }
 }
 
@@ -87,8 +87,8 @@ extension S {
 
   // CHECK: @transpose(of: computedProperty, wrt: self)
   @transpose(of: computedProperty, wrt: self)
-  func transposeProperty() -> Self {
-    self
+  static func transposeProperty(t: Self) -> Self {
+    t
   }
 }
 
@@ -98,7 +98,7 @@ extension S {
 
   // CHECK: @transpose(of: subscript, wrt: self)
   @transpose(of: subscript(_:), wrt: self)
-  func transposeSubscript<T: Differentiable>(x: T) -> Self {
-    self
+  static func transposeSubscript<T: Differentiable>(x: T, t: Self) -> Self {
+    t
   }
 }

--- a/test/AutoDiff/compiler_crashers/tf1063-transpose-attr-typechecking-static-method.swift
+++ b/test/AutoDiff/compiler_crashers/tf1063-transpose-attr-typechecking-static-method.swift
@@ -1,0 +1,28 @@
+// RUN: not --crash %target-swift-frontend-typecheck -primary-file %s
+// REQUIRES: asserts
+
+// TF-1063: `@transpose` attribute type-checking crash for static methods in
+// `AnyFunctionType::getTransposeOriginalFunctionType`.
+
+struct Struct: Differentiable & AdditiveArithmetic {
+  static func staticMethod(x: Struct) -> Struct {
+    x
+  }
+
+  @transpose(of: staticMethod, wrt: 0)
+  static func transposeStaticMethod() -> Struct {
+    self
+  }
+}
+
+// Assertion failed: (!empty()), function back, file llvm-project/llvm/include/llvm/ADT/ArrayRef.h, line 158.
+// Stack dump:
+// ...
+// 1.	Swift version 5.2-dev (Swift ace3925395)
+// 2.	While evaluating request TypeCheckSourceFileRequest(source_file "test/AutoDiff/compiler_crashers/tf1063-transpose-attr-typechecking-static-method.swift", 0)
+// 3.	While type-checking 'Struct' (at test/AutoDiff/compiler_crashers/tf1063-transpose-attr-typechecking-static-method.swift:6:1)
+// 4.	While type-checking 'transposeStaticMethod()' (at test/AutoDiff/compiler_crashers/tf1063-transpose-attr-typechecking-static-method.swift:12:3)
+// ...
+// 7  swiftc                   0x00000001111003c3 swift::AnyFunctionType::getTransposeOriginalFunctionType(swift::IndexSubset*, bool) (.cold.3) + 35
+// 8  swiftc                   0x000000010dbf68e0 swift::AnyFunctionType::getTransposeOriginalFunctionType(swift::IndexSubset*, bool) + 1904
+// 9  swiftc

--- a/test/AutoDiff/transpose_attr_type_checking.swift
+++ b/test/AutoDiff/transpose_attr_type_checking.swift
@@ -560,7 +560,7 @@ struct StoredProperty: Differentiable & AdditiveArithmetic {
   }
 }
 
-// Check that the self type of the method and the result type are the same when 
+// Check that the self type of the method and the result type are the same when
 // transposing WRT self. Needed to make sure they are defined within the same
 // context.
 

--- a/test/Serialization/transpose_attr.swift
+++ b/test/Serialization/transpose_attr.swift
@@ -52,8 +52,8 @@ extension S {
 
   // CHECK: @transpose(of: instanceMethod, wrt: self)
   @transpose(of: instanceMethod, wrt: self)
-  func transposeInstanceMethodWrtSelf(v: S) -> (S, S) {
-    (v, v)
+  static func transposeInstanceMethodWrtSelf(_ other: S, v: S) -> S {
+    v
   }
 }
 
@@ -64,11 +64,14 @@ extension S {
     x
   }
 
-  // CHECK: @transpose(of: staticMethod, wrt: 0)
+  // FIXME(TF-1063): `@transpose` type-checking crash for static methods.
+  // CHECK-FIXME: @transpose(of: staticMethod, wrt: 0)
+  /*
   @transpose(of: staticMethod, wrt: 0)
-  func transposeStaticMethod(_: S.Type) -> S {
+  static func transposeStaticMethod() -> S {
     self
   }
+  */
 }
 
 // Test computed properties.
@@ -77,8 +80,8 @@ extension S {
 
   // CHECK: @transpose(of: computedProperty, wrt: self)
   @transpose(of: computedProperty, wrt: self)
-  func transposeProperty() -> Self {
-    self
+  static func transposeProperty(v: Self) -> Self {
+    v
   }
 }
 
@@ -88,7 +91,7 @@ extension S {
 
   // CHECK: @transpose(of: subscript, wrt: self)
   @transpose(of: subscript(_:), wrt: self)
-  func transposeSubscript<T: Differentiable>(x: T) -> Self {
-    self
+  static func transposeSubscript<T: Differentiable>(x: T, v: Self) -> Self {
+    v
   }
 }


### PR DESCRIPTION
Fix `@transpose` attribute type-checking:

- TF-1060: fix `@transpose` typing rules for instance methods wrt `self`.
  - The transpose of an instance method wrt `self` is now a static method
    in the same type context.
  - Nice new invariant: transpose functions are always declared in the same type
    context as the original function.
- TF-997: support `@transpose` for initializer original declarations.

---

Naturally there was a lot of tests to fix. LMK if I captured all the rule changes especially when it comes to when stuff needs to have `T.TangentVector == T`.

One thing that can be improved is to better handle the following additional test case in the code:
```swift
// Check that the self type of the method and the result type are the same when 
// transposing WRT self. Needed to make sure they are defined within the same
// context.

extension Float {
  func convertToDouble() -> Double {
    Double(self)
  }

   // Ok
  @transpose(of: convertToDouble, wrt: self)
  static func t1(t: Double) -> Float {
    Float(t)
  }
}
extension Double {
  // expected-error @+1 {{the static self type of the transpose must equal the self type of the original function: Double != Float.}}
  @transpose(of: Float.convertToDouble, wrt: self)
  static func t1(t: Double) -> Float {
    Float(t)
  }
}
```

Currently, I created a helper function `AnyFunctionType::transposeSelfTypesMatch` which makes sure the static type that the transpose is defined on matches the original expected `self` type. However, I'm guessing there might be a way to simplify the helper by using the type context of the transpose possibly?