### PR TITLE
[Parse]: Separate do and while blocks diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1037,7 +1037,11 @@ ERROR(expected_expr_repeat_while,PointsToFirstBadToken,
       "expected expression in 'repeat-while' condition", ())
 
 ERROR(do_while_now_repeat_while,none,
-      "'do-while' statement is not allowed; use 'repeat-while' instead", ())
+      "'do-while' statement is not allowed", ())
+NOTE(do_while_expected_repeat_while, none,
+      "did you mean 'repeat-while' statement?", ())
+NOTE(do_while_expected_separate_stmt, none,
+      "did you mean separate 'do' and 'while' statements?", ())
 
 // Do/Catch Statement
 ERROR(expected_lbrace_after_do,PointsToFirstBadToken,

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -235,9 +235,21 @@ func DoStmt() {
   }
 }
 
-func DoWhileStmt() {
-  do { // expected-error {{'do-while' statement is not allowed; use 'repeat-while' instead}} {{3-5=repeat}}
+
+func DoWhileStmt1() {
+  do { // expected-error {{'do-while' statement is not allowed}}
+  // expected-note@-1 {{did you mean 'repeat-while' statement?}} {{3-5=repeat}}
+  // expected-note@-2 {{did you mean separate 'do' and 'while' statements?}} {{5-5=\n}}
   } while true
+}
+
+func DoWhileStmt2() {
+  do {
+
+  }
+  while true {
+
+  }
 }
 
 //===--- Repeat-while statement.


### PR DESCRIPTION
SR-11148: Separate do and while blocks generate error from legacy diagnostic

Taking new line into account if there is a while token after stmt.
Updated diagnostic to provide new line separator.
More information in ticket https://bugs.swift.org/browse/SR-11148.

@CodaFi, @rintaro I had to recreate pull request to this ticket https://github.com/apple/swift/pull/28632 because of failed rebase. I addressed previous comments (added tests, and emit two separate diagnostics).
