### PR TITLE
AST: remove invalid `static_assert`

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -200,24 +200,12 @@ void *ProtocolConformance::operator new(size_t bytes, ASTContext &context,
 #define CONFORMANCE_SUBCLASS_DISPATCH(Method, Args)                          \
 switch (getKind()) {                                                         \
   case ProtocolConformanceKind::Normal:                                      \
-    static_assert(&ProtocolConformance::Method !=                            \
-                    &NormalProtocolConformance::Method,                      \
-                  "Must override NormalProtocolConformance::" #Method);      \
     return cast<NormalProtocolConformance>(this)->Method Args;               \
   case ProtocolConformanceKind::Self:                                        \
-    static_assert(&ProtocolConformance::Method !=                            \
-                    &SelfProtocolConformance::Method,                        \
-                  "Must override SelfProtocolConformance::" #Method);        \
     return cast<SelfProtocolConformance>(this)->Method Args;                 \
   case ProtocolConformanceKind::Specialized:                                 \
-    static_assert(&ProtocolConformance::Method !=                            \
-                    &SpecializedProtocolConformance::Method,                 \
-                  "Must override SpecializedProtocolConformance::" #Method); \
     return cast<SpecializedProtocolConformance>(this)->Method Args;          \
   case ProtocolConformanceKind::Inherited:                                   \
-    static_assert(&ProtocolConformance::Method !=                            \
-                    &InheritedProtocolConformance::Method,                   \
-                  "Must override InheritedProtocolConformance::" #Method);   \
     return cast<InheritedProtocolConformance>(this)->Method Args;            \
 }                                                                            \
 llvm_unreachable("bad ProtocolConformanceKind");
@@ -225,14 +213,8 @@ llvm_unreachable("bad ProtocolConformanceKind");
 #define ROOT_CONFORMANCE_SUBCLASS_DISPATCH(Method, Args)                     \
 switch (getKind()) {                                                         \
   case ProtocolConformanceKind::Normal:                                      \
-    static_assert(&RootProtocolConformance::Method !=                        \
-                    &NormalProtocolConformance::Method,                      \
-                  "Must override NormalProtocolConformance::" #Method);      \
     return cast<NormalProtocolConformance>(this)->Method Args;               \
   case ProtocolConformanceKind::Self:                                        \
-    static_assert(&RootProtocolConformance::Method !=                        \
-                    &SelfProtocolConformance::Method,                        \
-                  "Must override SelfProtocolConformance::" #Method);        \
     return cast<SelfProtocolConformance>(this)->Method Args;                 \
   case ProtocolConformanceKind::Specialized:                                 \
   case ProtocolConformanceKind::Inherited:                                   \


### PR DESCRIPTION
This removes a set of static assertions that did not do what they were
supposed to do.

The static assertions were attempting to ensure that the functions are
different.  However, the address of a function is *not* a constant
expression and cannot be used in a static assertion.

Furthermore, the static assert is either tautologically true or will be
caught as a compile error on the dispatch.    The methods being checked
here are non-virtual.  The PFN that was being computed is tautologically
different as there is no virtuality and the two methods must be
different (barring any ICF coalescing that may be performed by the
linker or by LTO).  The method must exist, otherwise, the dispatch
itself will trigger a resolution failure.

Effectively, the static assertionss did not compute anything as a
result:
- the method's existence is checked by the dispatch
- the address of the function is always different

This was identified by building with GCC 7.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
