### PR TITLE
SIL: explicitly instantiate the `Operand` move ctor

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -587,6 +587,7 @@ public:
   Operand &operator=(const Operand &use) = delete;
 
   Operand(Operand &&) = default;
+  Operand &operator=(Operand &&) = default;
 
   /// Return the current value being used by this operand.
   SILValue get() const { return TheValue; }

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -586,6 +586,8 @@ public:
   Operand(const Operand &use) = delete;
   Operand &operator=(const Operand &use) = delete;
 
+  Operand(Operand &&) = default;
+
   /// Return the current value being used by this operand.
   SILValue get() const { return TheValue; }
 


### PR DESCRIPTION
GCC 7 does not like the missing move constructor and does not implicitly
synthesize one.  Explicitly indicate that this should be synthesized.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
