### PR TITLE
build: remove workaround for CMake 3.4.0

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -573,26 +573,12 @@ function set_build_options_for_host() {
                 -DLLVM_ENABLE_MODULES:BOOL="$(true_false ${LLVM_ENABLE_MODULES})"
             )
             if [[ $(is_llvm_lto_enabled) == "TRUE" ]]; then
-                if [[ $(cmake_needs_to_specify_standard_computed_defaults) == "TRUE" ]]; then
-                    llvm_cmake_options+=(
-                        "-DCMAKE_C_STANDARD_COMPUTED_DEFAULT=AppleClang"
-                        "-DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT=AppleClang"
-                    )
-                fi
-
                 llvm_cmake_options+=(
                     "-DLLVM_PARALLEL_LINK_JOBS=${LLVM_NUM_PARALLEL_LTO_LINK_JOBS}"
                 )
             fi
 
             if [[ $(is_swift_lto_enabled) == "TRUE" ]]; then
-                if [[ $(cmake_needs_to_specify_standard_computed_defaults) = "TRUE" ]]; then
-                    swift_cmake_options+=(
-                        "-DCMAKE_C_STANDARD_COMPUTED_DEFAULT=AppleClang"
-                        "-DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT=AppleClang"
-                    )
-                fi
-
                 llvm_cmake_options+=(
                     -DLLVM_ENABLE_MODULE_DEBUGGING:BOOL=NO
                 )
@@ -912,14 +898,6 @@ function false_true() {
 
 function cmake_version() {
     "${CMAKE}" --version | grep "cmake version" | cut -f 3 -d " "
-}
-
-function cmake_needs_to_specify_standard_computed_defaults() {
-    if [[ $(cmake_version) = "3.4.0" ]]; then
-        echo "TRUE"
-    else
-        echo "FALSE"
-    fi
 }
 
 # Sanitize the list of cross-compilation targets.


### PR DESCRIPTION
With the dependencies now requiring CMake 3.15, everything is built with
a newer CMake.  This removes the workaround for the 3.4 CMake release.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
