### PR TITLE
build: simplify handling for static variants (NFC)

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1400,18 +1400,7 @@ for host in "${ALL_HOSTS[@]}"; do
     fi
 
     for product in "${PRODUCTS[@]}"; do
-        # Check if we should perform this action.
-        tmp_product=${product}
-        if [[ ${tmp_product} == "libdispatch_static" ]]; then
-            tmp_product=libdispatch
-            LIBDISPATCH_STATIC_CMAKE_OPTIONS=${LIBDISPATCH_CMAKE_OPTIONS[@]}
-        fi
-        if [[ ${tmp_product} == "foundation_static" ]]; then
-            tmp_product=foundation
-        fi
-        if ! [[ $(should_execute_action "${host}-${tmp_product}-build") ]]; then
-            continue
-        fi
+        [[ $(should_execute_action "${host}-${product/_static}-build") ]] || continue
 
         unset skip_build
         source_dir_var="$(toupper ${product})_SOURCE_DIR"
@@ -2627,17 +2616,7 @@ for host in "${ALL_HOSTS[@]}"; do
     set_build_options_for_host $host
 
     for product in "${PRODUCTS[@]}"; do
-        # Check if we should perform this action.
-        tmp_product=${product}
-        if [[ ${tmp_product} == "libdispatch_static" ]]; then
-            tmp_product=libdispatch
-        fi
-        if [[ ${tmp_product} == "foundation_static" ]]; then
-            tmp_product=foundation
-        fi
-        if ! [[ $(should_execute_action "${host}-${tmp_product}-install") ]]; then
-            continue
-        fi
+        [[ $(should_execute_action "${host}-${product/_static}-install") ]] || continue
         if [[ -z "${INSTALL_DESTDIR}" ]] ; then
             echo "--install-destdir is required to install products."
             exit 1


### PR DESCRIPTION
There is no need to special case the products for the static build.
This handles `libdispatch_static` and `foundation_static` more
generically.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
