### PR TITLE
build: remove remnants of libdispatch staging (NFC)

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2135,18 +2135,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     LIBICU_BUILD_ARGS=()
                 fi
 
-                # Staging: require opt-in for building with dispatch
-                if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
-                    LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
-                    LIBDISPATCH_BUILD_ARGS=(
-                      -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=${LIBDISPATCH_SOURCE_DIR}
-                      -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=${LIBDISPATCH_BUILD_DIR}
-                      -Ddispatch_DIR=${LIBDISPATCH_BUILD_DIR}/cmake/modules
-                    )
-                else
-                    LIBDISPATCH_BUILD_ARGS=( -DFOUNDATION_ENABLE_LIBDISPATCH=NO )
-                fi
-
                 # FIXME: Always re-build XCTest on non-darwin platforms.
                 # The Swift project might have been changed, but CMake might
                 # not be aware and will not rebuild.
@@ -2169,7 +2157,10 @@ for host in "${ALL_HOSTS[@]}"; do
                   -DCMAKE_INSTALL_PREFIX:PATH=$(get_host_install_prefix ${host})
 
                   ${LIBICU_BUILD_ARGS[@]}
-                  ${LIBDISPATCH_BUILD_ARGS[@]}
+
+                  -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=${LIBDISPATCH_SOURCE_DIR}
+                  -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=$(build_directory ${host} libdispatch)
+                  -Ddispatch_DIR=$(build_directory ${host} libdispatch)/cmake/modules
 
                   # NOTE(compnerd) we disable tests because XCTest is not ready
                   # yet, but we will reconfigure when the time comes.
@@ -2605,16 +2596,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     LIBICU_BUILD_ARGS=()
                 fi
 
-                if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
-                    LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
-                    LIBDISPATCH_BUILD_ARGS=(
-                      -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=${LIBDISPATCH_SOURCE_DIR}
-                      -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=${LIBDISPATCH_BUILD_DIR}
-                      -Ddispatch_DIR=${LIBDISPATCH_BUILD_DIR}/cmake/modules
-                    )
-                else
-                    LIBDISPATCH_BUILD_ARGS=( -DFOUNDATION_ENABLE_LIBDISPATCH=NO )
-                fi
 
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
@@ -2629,7 +2610,10 @@ for host in "${ALL_HOSTS[@]}"; do
                   -DCMAKE_INSTALL_PREFIX:PATH=$(get_host_install_prefix ${host})
 
                   ${LIBICU_BUILD_ARGS[@]}
-                  ${LIBDISPATCH_BUILD_ARGS[@]}
+
+                  -DFOUNDATION_PATH_TO_LIBDISPATCH_SOURCE=${LIBDISPATCH_SOURCE_DIR}
+                  -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=$(build_directory ${host} libdispatch)
+                  -Ddispatch_DIR=$(build_directory ${host} libdispatch)/cmake/modules
 
                   -DENABLE_TESTING:BOOL=YES
                   -DXCTest_DIR=$(build_directory ${host} xctest)/cmake/modules


### PR DESCRIPTION
libdispatch is required by Foundation.  The
`FOUNDATION_ENABLE_LIBDISPATCH` flag was removed a while ago from
Foundation itself.  Remove the handling for this option and simplify the
flag handling.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
