### PR TITLE
[sil] Rename TermInst::{getSuccessorBlockArguments,getSuccessorBlockArgumentLists}()

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6998,13 +6998,13 @@ public:
     });
   }
 
-  using SuccessorBlockArgumentsListTy =
+  using SuccessorBlockArgumentListTy =
       TransformRange<ConstSuccessorListTy, function_ref<SILPhiArgumentArrayRef(
                                                const SILSuccessor &)>>;
 
   /// Return the range of Argument arrays for each successor of this
   /// block.
-  SuccessorBlockArgumentsListTy getSuccessorBlockArguments() const;
+  SuccessorBlockArgumentListTy getSuccessorBlockArgumentLists() const;
 
   using SuccessorBlockListTy =
       TransformRange<SuccessorListTy,

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -455,7 +455,7 @@ OperandOwnershipKindClassifier::visitSwitchEnumInst(SwitchEnumInst *sei) {
   // Otherwise, go through the ownership constraints of our successor arguments
   // and merge them.
   auto mergedKind = ValueOwnershipKind::merge(makeTransformRange(
-      sei->getSuccessorBlockArguments(),
+      sei->getSuccessorBlockArgumentLists(),
       [&](SILPhiArgumentArrayRef array) -> ValueOwnershipKind {
         // If the array is empty, we have a non-payloaded case. Return any.
         if (array.empty())
@@ -485,7 +485,7 @@ OperandOwnershipKindClassifier::visitCheckedCastBranchInst(
     CheckedCastBranchInst *ccbi) {
   // TODO: Simplify this using ValueOwnershipKind::merge.
   Optional<OperandOwnershipKindMap> map;
-  for (auto argArray : ccbi->getSuccessorBlockArguments()) {
+  for (auto argArray : ccbi->getSuccessorBlockArgumentLists()) {
     assert(!argArray.empty());
 
     auto argOwnershipKind = argArray[getOperandIndex()]->getOwnershipKind();

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1217,13 +1217,13 @@ bool TermInst::isProgramTerminating() const {
   llvm_unreachable("Unhandled TermKind in switch.");
 }
 
-TermInst::SuccessorBlockArgumentsListTy
-TermInst::getSuccessorBlockArguments() const {
+TermInst::SuccessorBlockArgumentListTy
+TermInst::getSuccessorBlockArgumentLists() const {
   function_ref<SILPhiArgumentArrayRef(const SILSuccessor &)> op;
   op = [](const SILSuccessor &succ) -> SILPhiArgumentArrayRef {
     return succ.getBB()->getSILPhiArguments();
   };
-  return SuccessorBlockArgumentsListTy(getSuccessors(), op);
+  return SuccessorBlockArgumentListTy(getSuccessors(), op);
 }
 
 YieldInst *YieldInst::create(SILDebugLocation loc,

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -187,7 +187,7 @@ cleanupDeadTrivialPhiArgs(SILValue initialValue,
         continue;
 
       auto *termInst = cast<TermInst>(user);
-      for (auto succBlockArgList : termInst->getSuccessorBlockArguments()) {
+      for (auto succBlockArgList : termInst->getSuccessorBlockArgumentLists()) {
         llvm::copy_if(succBlockArgList, std::back_inserter(worklist),
                       [&](SILPhiArgument *succArg) -> bool {
                         auto it = lower_bound(insertedPhis, succArg);

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -934,7 +934,7 @@ static SILInstruction *getNonPhiBlockIncomingValueDef(SILValue incomingValue,
 static bool
 terminatorHasAnyKnownPhis(TermInst *ti,
                           ArrayRef<SILPhiArgument *> insertedPhiNodesSorted) {
-  for (auto succArgList : ti->getSuccessorBlockArguments()) {
+  for (auto succArgList : ti->getSuccessorBlockArgumentLists()) {
     if (llvm::any_of(succArgList, [&](SILPhiArgument *arg) {
           return binary_search(insertedPhiNodesSorted, arg);
         })) {

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -292,7 +292,7 @@ struct SemanticARCOptVisitor
 
 #define FORWARDING_TERM(NAME)                                                  \
   bool visit##NAME##Inst(NAME##Inst *cls) {                                    \
-    for (auto succValues : cls->getSuccessorBlockArguments()) {                \
+    for (auto succValues : cls->getSuccessorBlockArgumentLists()) {            \
       for (SILValue v : succValues) {                                          \
         worklist.insert(v);                                                    \
       }                                                                        \


### PR DESCRIPTION
This method returns argument lists, not arguments! We should add in the future
an additional API that returns a flap mapped range over all such argument lists
to cleanup some of this code. But at least now the name is more accurate.
