### PR TITLE
Support whitespace and punctuation for escaped identifiers

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -96,6 +96,9 @@ public:
   /// isOperator - Return true if this identifier is an operator, false if it is
   /// a normal identifier.
   bool isOperator() const;
+    
+  /// isEscapedIdentifier - Return true if this identifier should be escaped
+  bool isEscapedIdentifier() const;
   
   /// isOperatorStartCodePoint - Return true if the specified code point is a
   /// valid start of an operator.
@@ -174,6 +177,7 @@ public:
 
 private:
   mutable Optional<bool> cachedIsOperator;
+  mutable Optional<bool> cachedIsEscapedIdentifier;
 };
   
 class DeclName;
@@ -290,6 +294,10 @@ public:
 
   bool isOperator() const {
     return !isSpecial() && getIdentifier().isOperator();
+  }
+    
+  bool isEscapedIdentifier() const {
+      return !isSpecial() && getIdentifier().isEscapedIdentifier();
   }
 
   bool isEditorPlaceholder() const {
@@ -509,6 +517,11 @@ public:
   bool isOperator() const {
     return getBaseName().isOperator();
   }
+    
+  /// True if this name is an escaped identifier.
+  bool isEscapedIdentifier() const {
+    return getBaseName().isEscapedIdentifier();
+  }
   
   /// True if this name should be found by a decl ref or member ref under the
   /// name specified by 'refName'.
@@ -664,6 +677,10 @@ public:
 
   bool isOperator() const {
     return FullName.isOperator();
+  }
+    
+  bool isEscapedIdentifier() const {
+      return FullName.isEscapedIdentifier();
   }
 
   bool isCompoundName() const {

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -95,18 +95,7 @@ public:
   
   /// isOperator - Return true if this identifier is an operator, false if it is
   /// a normal identifier.
-  /// FIXME: We should maybe cache this.
-  bool isOperator() const {
-    if (empty())
-      return false;
-    if (isEditorPlaceholder())
-      return false;
-    if ((unsigned char)Pointer[0] < 0x80)
-      return isOperatorStartCodePoint((unsigned char)Pointer[0]);
-
-    // Handle the high unicode case out of line.
-    return isOperatorSlow();
-  }
+  bool isOperator() const;
   
   /// isOperatorStartCodePoint - Return true if the specified code point is a
   /// valid start of an operator.
@@ -184,7 +173,7 @@ public:
   }
 
 private:
-  bool isOperatorSlow() const;
+  mutable Optional<bool> cachedIsOperator;
 };
   
 class DeclName;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -394,9 +394,9 @@ ASTPrinter &operator<<(ASTPrinter &printer, tok keyword) {
   return printer;
 }
 
-/// Determine whether to escape the given keyword in the given context.
-static bool escapeKeywordInContext(StringRef keyword, PrintNameContext context){
-
+/// Determine whether to escape the given identifier in the given context.
+static bool escapeIdentifierInContext(Identifier Name, PrintNameContext context){
+  StringRef keyword = Name.str();
   bool isKeyword = llvm::StringSwitch<bool>(keyword)
 #define KEYWORD(KW) \
       .Case(#KW, true)
@@ -406,7 +406,7 @@ static bool escapeKeywordInContext(StringRef keyword, PrintNameContext context){
   switch (context) {
   case PrintNameContext::Normal:
   case PrintNameContext::Attribute:
-    return isKeyword;
+    return isKeyword || Name.isEscapedIdentifier();
   case PrintNameContext::Keyword:
     return false;
 
@@ -435,12 +435,12 @@ void ASTPrinter::printName(Identifier Name, PrintNameContext Context) {
     return;
   }
 
-  bool shouldEscapeKeyword = escapeKeywordInContext(Name.str(), Context);
+  bool shouldEscapeIdentifier = escapeIdentifierInContext(Name, Context);
 
-  if (shouldEscapeKeyword)
+  if (shouldEscapeIdentifier)
     *this << "`";
   *this << Name.str();
-  if (shouldEscapeKeyword)
+  if (shouldEscapeIdentifier)
     *this << "`";
 
   printNamePost(Context);

--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -84,6 +84,21 @@ bool Identifier::isOperator() const {
   return cachedIsOperator.getValue();
 }
 
+bool Identifier::isEscapedIdentifier() const {
+  if (!cachedIsEscapedIdentifier.hasValue()) {
+     cachedIsEscapedIdentifier =
+       !isOperator() && !Lexer::isIdentifier(str()) &&
+       str().front() != '$'; // a property wrapper does not need to be escaped
+     
+     // dollar sign must be escaped
+     if (str().equals("$")) {
+       cachedIsEscapedIdentifier = true;
+     }
+  }
+
+  return cachedIsEscapedIdentifier.getValue();
+}
+
 int Identifier::compare(Identifier other) const {
   // Handle empty identifiers.
   if (empty() || other.empty()) {

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -461,10 +461,18 @@ private:
     // report an occurrence of `foo` in `_foo` and '$foo').
     if (auto *VD = dyn_cast<VarDecl>(D)) {
       if (auto *Wrapped = VD->getOriginalWrappedProperty()) {
-        assert(Range.getByteLength() > 1 &&
-               (Range.str().front() == '_' || Range.str().front() == '$'));
-        auto AfterDollar = Loc.getAdvancedLoc(1);
-        reportRef(Wrapped, AfterDollar, Info, None);
+        assert(Range.getByteLength() > 1);
+        if (Range.str().front() == '`') {
+          assert(Range.getByteLength() > 3);
+          assert(Range.str().consume_front("`_") ||
+                 Range.str().consume_front("`$"));
+          auto AfterBacktick = Loc.getAdvancedLoc(2);
+          reportRef(Wrapped, AfterBacktick, Info, None);
+        } else {
+          assert(Range.str().front() == '_' || Range.str().front() == '$');
+          auto AfterDollar = Loc.getAdvancedLoc(1);
+          reportRef(Wrapped, AfterDollar, Info, None);
+        }
       }
     }
 

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -228,20 +228,21 @@ static void printValueDecl(ValueDecl *Decl, raw_ostream &OS) {
   } else if (Decl->isOperator()) {
     OS << '"' << Decl->getBaseName() << '"';
   } else {
-    bool shouldEscape = !Decl->getBaseName().isSpecial() &&
-        llvm::StringSwitch<bool>(Decl->getBaseName().userFacingName())
+    bool isKeyword = llvm::StringSwitch<bool>(Decl->getBaseName().userFacingName())
             // FIXME: Represent "init" by a special name and remove this case
             .Case("init", false)
 #define KEYWORD(kw) \
             .Case(#kw, true)
 #include "swift/Syntax/TokenKinds.def"
             .Default(false);
+    bool shouldEscapeIdentifier = !Decl->getBaseName().isSpecial() &&
+      (isKeyword || Decl->getBaseName().isEscapedIdentifier());
 
-    if (shouldEscape) {
-      OS << '`' << Decl->getBaseName().userFacingName() << '`';
-    } else {
-      OS << Decl->getBaseName().userFacingName();
-    }
+    if (shouldEscapeIdentifier)
+      OS << '`';
+    OS << Decl->getBaseName().userFacingName();
+    if (shouldEscapeIdentifier)
+      OS << '`';
   }
 }
 

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -83,6 +83,11 @@ _TF3foolp3barSi ---> foo.bar.nativePinningAddressor : Swift.Int
 _TF3foog3barSi ---> foo.bar.getter : Swift.Int
 _TF3foos3barSi ---> foo.bar.setter : Swift.Int
 _TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
+_$s4test3fooyyF ---> test.foo() -> ()
+_$s4test0014foospace_ntJBbyyF ---> test.foo space() -> ()
+_$s4test0012_3times_bpJCayyF ---> test.3 times() -> ()
+_$s4test0011test_DkJtFbyyF ---> test.test +() -> ()
+_$s4test0016pathfoo_yuEHaaCiyyF ---> test.path://foo() -> ()
 _TToFC3foo3bar3basfT3zimCS_3zim_T_ ---> {T:_TFC3foo3bar3basfT3zimCS_3zim_T_,C} @objc foo.bar.bas(zim: foo.zim) -> ()
 _TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 _T03foo3barC3basyAA3zimCAE_tFTo ---> {T:_T03foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -56,10 +56,9 @@ func escapedDollarFunc() {
 }
 
 func escapedDollarAnd() {
-  // FIXME: Bad diagnostics.
-  `$0` = 1 // expected-error {{expected expression}}
-  `$$` = 2
-  `$abc` = 3
+  `$0` = 1 // expected-error {{use of unresolved identifier '$0'}}
+  `$$` = 2 // expected-error {{use of unresolved identifier '$$'}}
+  `$abc` = 3 // expected-error {{use of unresolved identifier '$abc'}}
 }
 
 func $declareWithDollar() { // expected-error{{cannot declare entity named '$declareWithDollar'}}
@@ -70,3 +69,5 @@ func $declareWithDollar() { // expected-error{{cannot declare entity named '$dec
     $a: Int, // expected-error{{cannot declare entity named '$a'}}
     $b c: Int) { } // expected-error{{cannot declare entity named '$b'}}
 }
+
+func `$declareEscapedWithDollar`() { } // expected-error{{cannot declare entity named '$declareEscapedWithDollar'}}

--- a/test/Parse/escaped_identifiers.swift
+++ b/test/Parse/escaped_identifiers.swift
@@ -35,3 +35,5 @@ var `var with space and .:/` = `Class with space and .:/`.self
 enum `enum with space and .:/` {}
 
 typealias `Typealias with space and .:/` = Int
+
+func `+ start with operator`() {}

--- a/test/Parse/escaped_identifiers.swift
+++ b/test/Parse/escaped_identifiers.swift
@@ -23,3 +23,15 @@ var applyGet: Int {
 enum `switch` {}
 
 typealias `Self` = Int
+
+func `method with space and .:/`() {}
+
+`method with space and .:/`()
+
+class `Class with space and .:/` {}
+
+var `var with space and .:/` = `Class with space and .:/`.self
+
+enum `enum with space and .:/` {}
+
+typealias `Typealias with space and .:/` = Int

--- a/test/SIL/printer_include_decls.swift
+++ b/test/SIL/printer_include_decls.swift
@@ -51,3 +51,8 @@ extension Foo.E {
   func e(x: Foo.E) {}
 // CHECK: func e(x: Foo.E)
 }
+func `foo space`() { }
+// CHECK: func `foo space`()
+
+var `x space`: Int
+// CHECK: var `x space`: Int


### PR DESCRIPTION
Hello everyone 👋 
This is a working in progress prototype for a new evolution pitch about adding support for whitespace and punctuation for escaped identifiers.

In few words this would enable us to do something like:
```swift
func `test object returns true when validation succeed`() { ... }
```

For more details, the discussion is currently being held at: https://forums.swift.org/t/pre-pitch-whitespaces-and-punctuation-for-methods-declarations/32073