### PR TITLE
build: improve libedit handling for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -924,14 +924,11 @@ else()
   find_package(LibXml2)
 endif()
 
-# You need libedit linked in order to check if you have el_wgets.
-cmake_push_check_state()
-list(APPEND CMAKE_REQUIRED_LIBRARIES "edit")
-check_symbol_exists(el_wgets "histedit.h" HAVE_EL_WGETS)
-if(HAVE_EL_WGETS)
-  set(HAVE_UNICODE_LIBEDIT 1)
+if(LLVM_ENABLE_LIBEDIT)
+  find_package(LibEdit REQUIRED)
+else()
+  find_package(LibEdit)
 endif()
-cmake_pop_check_state()
 
 check_symbol_exists(wait4 "sys/wait.h" HAVE_WAIT4)
 

--- a/cmake/modules/FindLibEdit.cmake
+++ b/cmake/modules/FindLibEdit.cmake
@@ -1,0 +1,61 @@
+#.rst:
+# FindLibEdit
+# -----------
+#
+# Find libedit library and headers
+#
+# The module defines the following variables:
+#
+# ::
+#
+#   libedit_FOUND         - true if libedit was found
+#   libedit_INCLUDE_DIRS  - include search path
+#   libedit_LIBRARIES     - libraries to link
+#   libedit_VERSION       - version number
+
+if(libedit_INCLUDE_DIRS AND libedit_LIBRARIES)
+  set(libedit_FOUND TRUE)
+else()
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_LIBEDIT QUIET libedit)
+
+  find_path(libedit_INCLUDE_DIRS
+            NAMES
+              histedit.h
+            HINTS
+              ${PC_LIBEDIT_INCLUDEDIR}
+              ${PC_LIBEDIT_INCLUDE_DIRS}
+              ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+  find_library(libedit_LIBRARIES
+               NAMES
+                 edit libedit
+               HINTS
+                 ${PC_LIBEDIT_LIBDIR}
+                 ${PC_LIBEDIT_LIBRARY_DIRS}
+                 ${CMAKE_INSTALL_FULL_LIBDIR})
+
+   if(libedit_INCLUDE_DIRS AND EXISTS "${libedit_INCLUDE_DIRS}/histedit.h")
+    file(STRINGS "${libedit_INCLUDE_DIRS}/histedit.h"
+         libedit_major_version_str
+         REGEX "^#define[ \t]+LIBEDIT_MAJOR[ \t]+[0-9]+")
+    string(REGEX REPLACE "^#define[ \t]+LIBEDIT_MAJOR[ \t]+([0-9]+)" "\\1"
+           LIBEDIT_MAJOR_VERSION "${libedit_major_version_str}")
+
+     file(STRINGS "${libedit_INCLUDE_DIRS}/histedit.h"
+         libedit_minor_version_str
+         REGEX "^#define[ \t]+LIBEDIT_MINOR[ \t]+[0-9]+")
+    string(REGEX REPLACE "^#define[ \t]+LIBEDIT_MINOR[ \t]+([0-9]+)" "\\1"
+           LIBEDIT_MINOR_VERSION "${libedit_minor_version_str}")
+
+     set(libedit_VERSION_STRING "${libedit_major_version}.${libedit_minor_version}")
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(libedit
+                                    REQUIRED_VARS
+                                      libedit_INCLUDE_DIRS
+                                      libedit_LIBRARIES
+                                    VERSION_VAR
+                                      libedit_VERSION_STRING)
+  mark_as_advanced(libedit_INCLUDE_DIRS libedit_LIBRARIES)
+endif()

--- a/include/swift/Config.h.in
+++ b/include/swift/Config.h.in
@@ -6,8 +6,6 @@
 
 #cmakedefine SWIFT_HAVE_WORKING_STD_REGEX 1
 
-#cmakedefine HAVE_UNICODE_LIBEDIT 1
-
 #cmakedefine HAVE_WAIT4 1
 
 #cmakedefine HAVE_PROC_PID_RUSAGE 1

--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -12,7 +12,9 @@ target_link_libraries(swiftImmediate PRIVATE
   swiftIRGen
   swiftSILGen
   swiftSILOptimizer)
-
-if(HAVE_UNICODE_LIBEDIT)
-  target_link_libraries(swiftImmediate PRIVATE edit)
+if(libedit_FOUND)
+  target_compile_definitions(swiftImmediate PRIVATE
+    HAVE_LIBEDIT)
+  target_link_libraries(swiftImmediate PRIVATE
+    ${libedit_LIBRARIES})
 endif()

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -37,7 +37,7 @@
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Process.h"
 
-#if HAVE_UNICODE_LIBEDIT
+#if HAVE_LIBEDIT
 #include <histedit.h>
 #include <wchar.h>
 #endif
@@ -120,8 +120,8 @@ public:
 };
 
 using Convert = ConvertForWcharSize<sizeof(wchar_t)>;
-  
-#if HAVE_UNICODE_LIBEDIT
+
+#if HAVE_LIBEDIT
 static void convertFromUTF8(llvm::StringRef utf8,
                             llvm::SmallVectorImpl<wchar_t> &out) {
   size_t reserve = out.size() + utf8.size();
@@ -135,7 +135,7 @@ static void convertFromUTF8(llvm::StringRef utf8,
   (void)res;
   out.set_size(wide_begin - out.begin());
 }
-  
+
 static void convertToUTF8(llvm::ArrayRef<wchar_t> wide,
                           llvm::SmallVectorImpl<char> &out) {
   size_t reserve = out.size() + wide.size()*4;
@@ -153,7 +153,7 @@ static void convertToUTF8(llvm::ArrayRef<wchar_t> wide,
 
 } // end anonymous namespace
 
-#if HAVE_UNICODE_LIBEDIT
+#if HAVE_LIBEDIT
 
 static ModuleDecl *
 typeCheckREPLInput(ModuleDecl *MostRecentModule, StringRef Name,

--- a/tools/SourceKit/tools/CMakeLists.txt
+++ b/tools/SourceKit/tools/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(
 
 add_swift_lib_subdirectory(sourcekitd)
 add_swift_tool_subdirectory(sourcekitd-test)
-if(HAVE_UNICODE_LIBEDIT)
+if(libedit_FOUND)
   add_swift_tool_subdirectory(sourcekitd-repl)
 endif()
 add_swift_tool_subdirectory(complete-test)

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -1,36 +1,34 @@
-set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} edit)
-check_symbol_exists(el_wgets "histedit.h" HAVE_UNICODE_LIBEDIT)
-
-if(HAVE_UNICODE_LIBEDIT)
-  add_sourcekit_executable(sourcekitd-repl
-    sourcekitd-repl.cpp
-    LLVM_LINK_COMPONENTS coverage lto
-  )
-  target_link_libraries(sourcekitd-repl PRIVATE edit)
-  if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
-    target_link_libraries(sourcekitd-repl PRIVATE sourcekitdInProc)
-  else()
-    target_link_libraries(sourcekitd-repl PRIVATE sourcekitd)
-  endif()
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    target_link_libraries(sourcekitd-repl PRIVATE
-      dispatch
-      BlocksRuntime)
-  endif()
-
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set_target_properties(sourcekitd-repl
-      PROPERTIES
-      LINK_FLAGS "-Wl,-rpath -Wl,@executable_path/../lib")
-  endif()
-  if(SWIFT_ANALYZE_CODE_COVERAGE)
-    set_property(TARGET sourcekitd-repl APPEND_STRING PROPERTY
-      LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
-  endif()
-
-  add_dependencies(tools sourcekitd-repl)
-  swift_install_in_component(TARGETS sourcekitd-repl
-                             RUNTIME
-                               DESTINATION bin
-                               COMPONENT tools)
+add_sourcekit_executable(sourcekitd-repl
+  sourcekitd-repl.cpp
+  LLVM_LINK_COMPONENTS coverage lto
+)
+if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
+  target_link_libraries(sourcekitd-repl PRIVATE sourcekitdInProc)
+else()
+  target_link_libraries(sourcekitd-repl PRIVATE sourcekitd)
 endif()
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(sourcekitd-repl PRIVATE
+    dispatch
+    BlocksRuntime)
+endif()
+target_include_directories(sourcekitd-repl PRIVATE
+  ${libedit_INCLUDE_DIRS})
+target_link_libraries(sourcekitd-repl PRIVATE
+  ${libedit_LIBRARIES})
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set_target_properties(sourcekitd-repl
+    PROPERTIES
+    LINK_FLAGS "-Wl,-rpath -Wl,@executable_path/../lib")
+endif()
+if(SWIFT_ANALYZE_CODE_COVERAGE)
+  set_property(TARGET sourcekitd-repl APPEND_STRING PROPERTY
+    LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
+endif()
+
+add_dependencies(tools sourcekitd-repl)
+swift_install_in_component(TARGETS sourcekitd-repl
+                           RUNTIME
+                             DESTINATION bin
+                             COMPONENT tools)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -9,9 +9,6 @@ target_link_libraries(swift
                       PRIVATE
                         swiftDriver
                         swiftFrontendTool)
-if(HAVE_UNICODE_LIBEDIT)
-  target_link_libraries(swift PRIVATE edit)
-endif()
 
 swift_create_post_build_symlink(swift
   SOURCE "swift${CMAKE_EXECUTABLE_SUFFIX}"

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -7,9 +7,6 @@ target_link_libraries(swift-remoteast-test
                         swiftFrontendTool
                         swiftRemoteAST)
 set_target_properties(swift-remoteast-test PROPERTIES ENABLE_EXPORTS 1)
-if(HAVE_UNICODE_LIBEDIT)
-  target_link_libraries(swift-remoteast-test PRIVATE edit)
-endif()
 
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)


### PR DESCRIPTION
Use the FindLibEdit.cmake module from LLDB to properly control where
the libedit libraries are searched for and linked from as well as where
the headers come from. This uses the standard mechanisms which allows
users to control where libedit is pulled from (which is important for
cross-compilation).

This second version is more aggressive about pruning the libedit
handling.  The Ubuntu 14.04 version of libedit does not have
`histedit.h`, and the intent is to rely on that to determine if we have
unicode support or not.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
