### PR TITLE
[stdlib] Fix a LLVM assert on *BSD.

### DIFF
--- a/stdlib/public/SwiftShims/LibcOverlayShims.h
+++ b/stdlib/public/SwiftShims/LibcOverlayShims.h
@@ -52,7 +52,7 @@ static inline int _swift_stdlib_fcntlPtr(int fd, int cmd, void* ptr) {
 #endif
 
 // Environment
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 static inline char * _Nullable * _Null_unspecified _swift_stdlib_getEnviron() {
   extern char **environ;
   return environ;


### PR DESCRIPTION
When building Glibc.o, LLVM asserts in CodeGenModule::EmitGlobal
with "Cannot emit local var decl as global.". This appears to be
because of the way _swift_stdlib_getEnviron is written for the BSDs
as an extern local, since moving the extern declaration to global scope
seems to avoid the problem.

(Note: this is tested on a WIP OpenBSD port, but not on FreeBSD proper; nevertheless, I think the FreeBSD port is probably broken and this will likely fix the problem on both platforms. However, I'm happy to go back and create distinct ifdefs for FreeBSD and OpenBSD separately if there's a concern.)