### PR TITLE
Rewrite AliasAnalysis may-release/may-decrement queries.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -194,10 +194,10 @@ public:
     return alias(V1, V2, TBAAType1, TBAAType2) == AliasResult::MayAlias;
   }
 
-  /// \returns True if the release of the \p Ptr can access memory accessed by
-  /// \p User.
+  /// \returns True if the release of the \p releasedReference can access or
+  /// free memory accessed by \p User.
   bool mayValueReleaseInterfereWithInstruction(SILInstruction *User,
-                                               SILValue Ptr);
+                                               SILValue releasedReference);
 
   /// Use the alias analysis to determine the memory behavior of Inst with
   /// respect to V.

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -72,7 +72,8 @@ EscapeAnalysis::findRecursivePointerKind(SILType Ty,
   };
   if (auto *Str = Ty.getStructOrBoundGenericStruct()) {
     for (auto *Field : Str->getStoredProperties()) {
-      SILType fieldTy = Ty.getFieldType(Field, M, F.getTypeExpansionContext());
+      SILType fieldTy = Ty.getFieldType(Field, M, F.getTypeExpansionContext())
+                            .getObjectType();
       meetAggregateKind(findCachedPointerKind(fieldTy, F));
     }
     return aggregateKind;
@@ -925,8 +926,10 @@ EscapeAnalysis::ConnectionGraph::getOrCreateReferenceContent(SILValue refVal,
     if (auto *C = refType.getClassOrBoundGenericClass()) {
       PointerKind aggregateKind = NoPointer;
       for (auto *field : C->getStoredProperties()) {
-        SILType fieldType = refType.getFieldType(field, F->getModule(),
-                                                 F->getTypeExpansionContext());
+        SILType fieldType = refType
+                                .getFieldType(field, F->getModule(),
+                                              F->getTypeExpansionContext())
+                                .getObjectType();
         PointerKind fieldKind = EA->findCachedPointerKind(fieldType, *F);
         if (fieldKind > aggregateKind)
           aggregateKind = fieldKind;
@@ -1161,19 +1164,6 @@ bool EscapeAnalysis::ConnectionGraph::forwardTraverseDefer(
   return true;
 }
 
-bool EscapeAnalysis::ConnectionGraph::mayReach(CGNode *pointer,
-                                               CGNode *pointee) {
-  if (pointer == pointee)
-    return true;
-
-  // This query is successful when the traversal halts and returns false.
-  return !backwardTraverse(pointee, [pointer](Predecessor pred) {
-    if (pred.getPredNode() == pointer)
-      return Traversal::Halt;
-    return Traversal::Follow;
-  });
-}
-
 void EscapeAnalysis::ConnectionGraph::removeFromGraph(ValueBase *V) {
   CGNode *node = Values2Nodes.lookup(V);
   if (!node)
@@ -1193,10 +1183,7 @@ void EscapeAnalysis::ConnectionGraph::removeFromGraph(ValueBase *V) {
 /// This makes iterating over the edges easier.
 struct CGForDotView {
 
-  enum EdgeTypes {
-    PointsTo,
-    Deferred
-  };
+  enum EdgeTypes { PointsTo, Reference, Deferred };
 
   struct Node {
     EscapeAnalysis::CGNode *OrigNode;
@@ -1248,7 +1235,10 @@ CGForDotView::CGForDotView(const EscapeAnalysis::ConnectionGraph *CG) :
     Nd.OrigNode = OrigNode;
     if (auto *PT = OrigNode->getPointsToEdge()) {
       Nd.Children.push_back(Orig2Node[PT]);
-      Nd.ChildrenTypes.push_back(PointsTo);
+      if (OrigNode->hasReferenceOnly())
+        Nd.ChildrenTypes.push_back(Reference);
+      else
+        Nd.ChildrenTypes.push_back(PointsTo);
     }
     for (auto *Def : OrigNode->defersTo) {
       Nd.Children.push_back(Orig2Node[Def]);
@@ -1396,8 +1386,12 @@ namespace llvm {
                                          const CGForDotView *Graph) {
       unsigned ChildIdx = I - Node->Children.begin();
       switch (Node->ChildrenTypes[ChildIdx]) {
-        case CGForDotView::PointsTo: return "";
-        case CGForDotView::Deferred: return "color=\"gray\"";
+      case CGForDotView::PointsTo:
+        return "";
+      case CGForDotView::Reference:
+        return "color=\"green\"";
+      case CGForDotView::Deferred:
+        return "color=\"gray\"";
       }
 
       llvm_unreachable("Unhandled CGForDotView in switch.");
@@ -2570,24 +2564,6 @@ static SILFunction *getCommonFunction(SILValue V1, SILValue V2) {
   return F;
 }
 
-bool EscapeAnalysis::canEscapeToValue(SILValue V, SILValue To) {
-  if (!isUniquelyIdentified(V))
-    return true;
-
-  SILFunction *F = getCommonFunction(V, To);
-  if (!F)
-    return true;
-  auto *ConGraph = getConnectionGraph(F);
-
-  CGNode *valueContent = ConGraph->getValueContent(V);
-  if (!valueContent)
-    return true;
-  CGNode *userContent = ConGraph->getValueContent(To);
-  if (!userContent)
-    return true;
-  return ConGraph->mayReach(userContent, valueContent);
-}
-
 bool EscapeAnalysis::canPointToSameMemory(SILValue V1, SILValue V2) {
   // At least one of the values must be a non-escaping local object.
   bool isUniq1 = isUniquelyIdentified(V1);
@@ -2640,6 +2616,99 @@ bool EscapeAnalysis::canPointToSameMemory(SILValue V1, SILValue V2) {
     return Content1 == Content2;
   }
   return true;
+}
+
+// Return true if deinitialization of \p releasedReference may release memory
+// directly pointed to by \p accessAddress.
+//
+// Note that \p accessedAddress could be a reference itself, an address of a
+// local/argument that contains a reference, or even a pointer to the middle of
+// an object (even if it is an exclusive argument).
+//
+// This is almost the same as asking "is the content node for accessedAddress
+// reachable via releasedReference", with three subtle differences:
+//
+// (1) A locally referenced object can only be freed when deinitializing
+// releasedReference if it is the same object. Indirect references will be kept
+// alive by their distinct local references--ARC can't remove those without
+// inserting a mark_dependence/end_dependence scope.
+//
+// (2) the content of exclusive arguments may be indirectly reachable via
+// releasedReference, but the exclusive argument must have it's own reference
+// count, so cannot be freed via the locally released reference.
+//
+// (3) Objects may contain raw pointers into themselves or into other
+// objects. Any access to the raw pointer is not considered a use of the object
+// because that access must be "guarded" by a fix_lifetime or
+// mark_dependence/end_dependence that acts as a placeholder.
+//
+// There are two interesting cases in which a connection graph query can
+// determine that the accessed memory cannot be released:
+//
+// Case #1: accessedAddress points to a uniquely identified object that does not
+// escape within this function.
+//
+// Note: A "uniquely identified object" is either a locally allocated object,
+// which is obviously not reachable outside this function, or an exclusive
+// address argument, which *is* reachable outside this function, but must
+// have its own reference count so cannot be released locally.
+//
+// Case #2: The released reference points to a local object and no connection
+// graph path exists from the referenced object to a global-escaping or
+// argument-escaping node without traversing a non-interior edge.
+//
+// In both cases, the connection graph is sufficient to determine if the
+// accessed content may be released. To prove that the accessed memory is
+// distinct from any released memory it is now sufficient to check that no
+// connection graph path exists from the released object's node to the accessed
+// content node without traversing a non-interior edge.
+bool EscapeAnalysis::mayReleaseContent(SILValue releasedReference,
+                                       SILValue accessedAddress) {
+  assert(!releasedReference->getType().isAddress()
+         && "an address is never a reference");
+
+  SILFunction *f = getCommonFunction(releasedReference, accessedAddress);
+  if (!f)
+    return true;
+
+  auto *conGraph = getConnectionGraph(f);
+
+  CGNode *addrContentNode = conGraph->getValueContent(accessedAddress);
+  if (!addrContentNode)
+    return true;
+
+  // Case #1: Unique accessedAddress whose content does not escape.
+  bool isAccessUniq =
+      isUniquelyIdentified(accessedAddress)
+      && !addrContentNode->valueEscapesInsideFunction(accessedAddress);
+
+  // Case #2: releasedReference points to a local object.
+  if (!isAccessUniq && !pointsToLocalObject(releasedReference))
+    return true;
+
+  CGNode *releasedObjNode = conGraph->getValueContent(releasedReference);
+  // Make sure we have at least one value CGNode for releasedReference.
+  if (!releasedObjNode)
+    return true;
+
+  // Check for reachability from releasedObjNode to addrContentNode.
+  // A pointsTo cycle is equivalent to a null pointsTo.
+  CGNodeWorklist worklist(conGraph);
+  for (CGNode *releasedNode = releasedObjNode;
+       releasedNode && worklist.tryPush(releasedNode);
+       releasedNode = releasedNode->getContentNodeOrNull()) {
+    // A path exists from released content to accessed content.
+    if (releasedNode == addrContentNode)
+      return true;
+
+    // A path exists to an escaping node.
+    if (!isAccessUniq && releasedNode->escapesInsideFunction())
+      return true;
+
+    if (!releasedNode->isInterior())
+      break;
+  }
+  return false; // no path to escaping memory that may be freed.
 }
 
 void EscapeAnalysis::invalidate() {

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -571,10 +571,16 @@ bb0(%0 : $Cls):
   return %r : $()
 }
 
-// CHECK-LABEL: sil @dont_remove_as_local_object_indirectly_escapes_to_callee
-// CHECK: retain_value
-// CHECK: release_value
-sil @dont_remove_as_local_object_indirectly_escapes_to_callee : $@convention(thin) (Cls) -> () {
+// Remove a retain release "pair" for the local reference if a child object.
+//
+// The local 'Cls' reference is now effectively "moved" into the parent
+// 'Container' object, so the child will be destroyed with the parent.
+// The original SIL already has an over-release of the parent.
+//
+// CHECK-LABEL: sil @remove_as_local_object_indirectly_escapes_to_callee
+// CHECK-NOT: retain_value
+// CHECK-NOT: release_value
+sil @remove_as_local_object_indirectly_escapes_to_callee : $@convention(thin) (Cls) -> () {
 bb0(%0 : $Cls):
   %1 = alloc_ref $Cls
   %2 = alloc_ref $Container
@@ -589,9 +595,41 @@ bb0(%0 : $Cls):
   return %r : $()
 }
 
+// Remove a retain release "pair" for the local reference if a child object.
+//
+// The local 'Cls' reference is now effectively "moved" into the parent
+// 'Container' object, so the child will be destroyed with the parent.
+//
+// CHECK-LABEL: sil @local_object_indirectly_escapes_to_use_and_owned_arg
+// CHECK-NOT: retain_value
+// CHECK-NOT: release_value
+sil @local_object_indirectly_escapes_to_use_and_owned_arg : $@convention(thin) (Cls) -> () {
+bb0(%0 : $Cls):
+  %1 = alloc_ref $Cls
+  %2 = alloc_ref $Container
+  %3 = ref_element_addr %2 : $Container, #Container.c
+  store %1 to %3 : $*Cls
+  retain_value %1 : $Cls
+  %f1 = function_ref @use_container : $@convention(thin) (@guaranteed Container) -> ()
+  apply %f1 (%2) : $@convention(thin) (@guaranteed Container) -> ()
+  %f2 = function_ref @release_container : $@convention(thin) (Container) -> ()
+  apply %f2 (%2) : $@convention(thin) (Container) -> ()
+  release_value %1 : $Cls
+  %r = tuple()
+  return %r : $()
+}
+
 sil @release_arg1 : $@convention(thin) (Cls, Cls) -> () {
 bb0(%0 : $Cls, %1 : $Cls):
   strong_release %1 : $Cls
+  %r = tuple()
+  return %r : $()
+}
+
+sil @use_container : $@convention(thin) (@guaranteed Container) -> () {
+bb0(%0 : $Container):
+  %1 = ref_element_addr %0 : $Container, #Container.c
+  %2 = load %1 : $*Cls
   %r = tuple()
   return %r : $()
 }

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -100,7 +100,7 @@ bb0(%0 : $Int):
 // CHECK-NEXT:    Con %1.1 Esc: G, Succ:
 // CHECK-NEXT:    Val [ref] %2 Esc: A, Succ: (%3)
 // CHECK-NEXT:    Con [int] %3 Esc: A, Succ: (%3.1)
-// CHECK-NEXT:    Con %3.1 Esc: A, Succ: %1
+// CHECK-NEXT:    Con [ref] %3.1 Esc: A, Succ: %1
 // CHECK-NEXT:    Con [ref] %5 Esc: A, Succ: %2
 // CHECK-NEXT:  End
 sil @test_simple : $@convention(thin) (@inout Y, @owned X) -> () {
@@ -122,7 +122,7 @@ bb0(%0 : $*Y, %1 : $X):
 // CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ:
 // CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%4), %0
 // CHECK-NEXT:    Con [int] %4 Esc: A, Succ: (%4.1)
-// CHECK-NEXT:    Con %4.1 Esc: A, Succ: %1
+// CHECK-NEXT:    Con [ref] %4.1 Esc: A, Succ: %1
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @deferringEdge : $@convention(thin) (@owned LinkedNode, @owned LinkedNode) -> @owned LinkedNode {
@@ -158,7 +158,7 @@ bb0:
 // CHECK-NEXT:    Val [ref] %4 Esc: A, Succ: (%2)
 // CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%2)
 // CHECK-NEXT:    Val [ref] %11 Esc: , Succ: (%2), %7, %13
-// CHECK-NEXT:    Con %13 Esc: A, Succ: %0, %1, %4
+// CHECK-NEXT:    Con [ref] %13 Esc: A, Succ: %0, %1, %4
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %13
 // CHECK-NEXT:  End
 sil @test_linked_list : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -192,7 +192,7 @@ bb2:
 // CHECK-NEXT:    Val [ref] %4 Esc: A, Succ: (%8)
 // CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%8)
 // CHECK-NEXT:    Con [int] %8 Esc: A, Succ: (%8.1)
-// CHECK-NEXT:    Con %8.1 Esc: A, Succ: %0, %1, %4
+// CHECK-NEXT:    Con [ref] %8.1 Esc: A, Succ: %0, %1, %4
 // CHECK-NEXT:    Val [ref] %11 Esc: , Succ: (%8), %8.1
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %11
 // CHECK-NEXT:  End
@@ -217,7 +217,7 @@ bb0(%0 : $LinkedNode):
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%3)
 // CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%3), %0, %4
 // CHECK-NEXT:    Con [int] %3 Esc: A, Succ: (%4)
-// CHECK-NEXT:    Con %4 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con [ref] %4 Esc: A, Succ: (%3)
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @loadNext : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -238,14 +238,14 @@ bb2:
 // CHECK-LABEL: CG of call_load_next3
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
 // CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%0.3)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: A, Succ: (%0.3)
 // CHECK-NEXT:    Con [int] %0.3 Esc: A, Succ: (%0.4)
-// CHECK-NEXT:    Con %0.4 Esc: A, Succ: (%0.5)
+// CHECK-NEXT:    Con [ref] %0.4 Esc: A, Succ: (%0.5)
 // CHECK-NEXT:    Con [int] %0.5 Esc: A, Succ: (%0.6)
-// CHECK-NEXT:    Con %0.6 Esc: A, Succ:
+// CHECK-NEXT:    Con [ref] %0.6 Esc: A, Succ:
 // CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%2.1), %0.6
 // CHECK-NEXT:    Con [int] %2.1 Esc: A, Succ: (%2.2)
-// CHECK-NEXT:    Con %2.2 Esc: A, Succ: 
+// CHECK-NEXT:    Con [ref] %2.2 Esc: A, Succ: 
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %2
 // CHECK-NEXT:  End
 sil @call_load_next3 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -258,13 +258,13 @@ bb0(%0 : $LinkedNode):
 // CHECK-LABEL: CG of load_next3
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
 // CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: A, Succ: (%3)
+// CHECK-NEXT:    Con [ref] %2 Esc: A, Succ: (%3)
 // CHECK-NEXT:    Con [int] %3 Esc: A, Succ: (%4)
-// CHECK-NEXT:    Con %4 Esc: A, Succ: (%5)
+// CHECK-NEXT:    Con [ref] %4 Esc: A, Succ: (%5)
 // CHECK-NEXT:    Con [int] %5 Esc: A, Succ: (%6)
-// CHECK-NEXT:    Con %6 Esc: A, Succ:
+// CHECK-NEXT:    Con [ref] %6 Esc: A, Succ:
 // CHECK-NEXT:    Con [int] %6.1 Esc: A, Succ: (%6.2)
-// CHECK-NEXT:    Con %6.2 Esc: A, Succ:
+// CHECK-NEXT:    Con [ref] %6.2 Esc: A, Succ:
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %6
 // CHECK-NEXT:  End
 sil @load_next3 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -593,10 +593,10 @@ sil_global @global_ln : $LinkedNode
 // CHECK-LABEL: CG of load_next_recursive
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
 // CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: G, Succ:
+// CHECK-NEXT:    Con [ref] %2 Esc: G, Succ:
 // CHECK-NEXT:    Val [ref] %4 Esc: , Succ: (%4.1), %2
 // CHECK-NEXT:    Con [int] %4.1 Esc: G, Succ: (%4.2)
-// CHECK-NEXT:    Con %4.2 Esc: G, Succ: 
+// CHECK-NEXT:    Con [ref] %4.2 Esc: G, Succ: 
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @load_next_recursive : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -611,7 +611,7 @@ bb0(%0 : $LinkedNode):
 // CHECK-LABEL: CG of let_escape
 // CHECK-NEXT:    Arg [ref] %0 Esc: G, Succ: (%0.1)
 // CHECK-NEXT:    Con [int] %0.1 Esc: G, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ:
+// CHECK-NEXT:    Con [ref] %0.2 Esc: G, Succ:
 // CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
 // CHECK-NEXT:    Con [ref] %1.1 Esc: G, Succ: %0
 // CHECK-NEXT:    Val [ref] %4 Esc: , Succ: (%0.1), %0
@@ -631,7 +631,7 @@ bb0(%0 : $LinkedNode):
 // CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%5.1), %5.2
 // CHECK-NEXT:    Val [ref] %5 Esc: , Succ: (%5.1), %0, %3
 // CHECK-NEXT:    Con [int] %5.1 Esc: G, Succ: (%5.2)
-// CHECK-NEXT:    Con %5.2 Esc: G, Succ: (%5.1)
+// CHECK-NEXT:    Con [ref] %5.2 Esc: G, Succ: (%5.1)
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %5
 // CHECK-NEXT:  End
 sil @return_same : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -652,12 +652,12 @@ bb2(%5 : $LinkedNode):
 // CHECK-LABEL: CG of loadNext2
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
 // CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:    Con [ref] %2 Esc: A, Succ: (%2.1)
 // CHECK-NEXT:    Con [int] %2.1 Esc: A, Succ: (%2.2)
-// CHECK-NEXT:    Con %2.2 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Con [ref] %2.2 Esc: A, Succ: (%4.1)
 // CHECK-NEXT:    Val [ref] %4 Esc: , Succ: (%4.1), %2.2, %4.2
 // CHECK-NEXT:    Con [int] %4.1 Esc: A, Succ: (%4.2)
-// CHECK-NEXT:    Con %4.2 Esc: A, Succ: (%4.1)
+// CHECK-NEXT:    Con [ref] %4.2 Esc: A, Succ: (%4.1)
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @loadNext2 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -673,10 +673,10 @@ bb0(%0 : $LinkedNode):
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%5)
 // CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%8.1), %8.2
 // CHECK-NEXT:    Con [int] %5 Esc: A, Succ: (%6)
-// CHECK-NEXT:    Con %6 Esc: A, Succ: (%8.1)
+// CHECK-NEXT:    Con [ref] %6 Esc: A, Succ: (%8.1)
 // CHECK-NEXT:    Val [ref] %8 Esc: , Succ: (%8.1), %3, %6
 // CHECK-NEXT:    Con [int] %8.1 Esc: A, Succ: (%8.2)
-// CHECK-NEXT:    Con %8.2 Esc: A, Succ: (%8.1)
+// CHECK-NEXT:    Con [ref] %8.2 Esc: A, Succ: (%8.1)
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %8
 // CHECK-NEXT:  End
 sil @returnNext2 : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -702,7 +702,7 @@ bb3(%8 : $LinkedNode):
 // CHECK-LABEL: CG of single_cycle_recursion
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%2)
 // CHECK-NEXT:    Con [int] %2 Esc: A, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: A, Succ: (%2)
+// CHECK-NEXT:    Con [ref] %3 Esc: A, Succ: (%2)
 // CHECK-NEXT:    Val [ref] %5 Esc: , Succ: (%2), %3
 // CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%2), %0, %5
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %7
@@ -823,7 +823,7 @@ sil @take_y_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Y>) -> ()
 // CHECK-NEXT:    Arg [ref] %0 Esc: G, Succ:
 // CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%3)
 // CHECK-NEXT:    Con [int] %3 Esc: G, Succ: (%3.1)
-// CHECK-NEXT:    Con %3.1 Esc: G, Succ: %0
+// CHECK-NEXT:    Con [ref] %3.1 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @store_to_unknown_reference : $@convention(thin) (@owned X) -> () {
 bb0(%0 : $X):
@@ -838,7 +838,7 @@ bb0(%0 : $X):
 // CHECK-LABEL: CG of get_reference
 // CHECK-NEXT:    Val [ref] %1 Esc: , Succ: (%1.1)
 // CHECK-NEXT:    Con [int] %1.1 Esc: G, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: G, Succ: 
+// CHECK-NEXT:    Con [ref] %1.2 Esc: G, Succ: 
  // CHECK-NEXT:   Ret [ref] return Esc: , Succ: %1
 // CHECK-NEXT:  End
 sil @get_reference : $@convention(thin) () -> @owned Y {
@@ -858,7 +858,7 @@ sil @unknown_set_y : $@convention(thin) () -> @out Y
 // CHECK-NEXT:    Val %0 Esc: , Succ: (%3)
 // CHECK-NEXT:    Con [ref] %3 Esc: G, Succ:
 // CHECK-NEXT:    Con [int] %3.1 Esc: G, Succ: (%3.2)
-// CHECK-NEXT:    Con %3.2 Esc: G, Succ: 
+// CHECK-NEXT:    Con [ref] %3.2 Esc: G, Succ: 
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %3
 // CHECK-NEXT:  End
 sil @get_y : $@convention(thin) () -> @owned Y {
@@ -875,7 +875,7 @@ bb0:
 // CHECK-NEXT:    Val [ref] %0 Esc: G, Succ: 
 // CHECK-NEXT:    Val [ref] %2 Esc: G, Succ: (%3)
 // CHECK-NEXT:    Con [int] %3 Esc: G, Succ: (%3.1)
-// CHECK-NEXT:    Con %3.1 Esc: G, Succ: %0
+// CHECK-NEXT:    Con [ref] %3.1 Esc: G, Succ: %0
 // CHECK-NEXT:  End
 sil @create_and_store_x : $@convention(thin) () -> () {
 bb0:
@@ -919,7 +919,7 @@ bb1(%7 : $(Pointer, Pointer)):
 // CHECK-NEXT:    Con [ref] %2 Esc: A, Succ: (%6), %4
 // CHECK-NEXT:    Con [ref] %4 Esc: A, Succ: %2
 // CHECK-NEXT:    Con [int] %6 Esc: A, Succ: (%7)
-// CHECK-NEXT:    Con %7 Esc: A, Succ: 
+// CHECK-NEXT:    Con [ref] %7 Esc: A, Succ: 
 // CHECK-NEXT:  End
 sil @defer_edge_cycle : $@convention(thin) (@inout Y, @inout Y) -> () {
 entry(%0 : $*Y, %1 : $*Y):
@@ -1457,7 +1457,7 @@ bb0:
 // CHECK-LABEL: CG of check_escaping_implicit_destructor_invocation_via_strong_release
 // CHECK-NEXT:    Val [ref] %0 Esc: , Succ: (%0.1)
 // CHECK-NEXT:    Con [int] %0.1 Esc: %1, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
+// CHECK-NEXT:    Con [ref] %0.2 Esc: G, Succ: 
 // CHECK-NEXT:  End
 sil @check_escaping_implicit_destructor_invocation_via_strong_release : $@convention(thin) () -> () {
 bb0:
@@ -1474,7 +1474,7 @@ bb0:
 // CHECK-LABEL: CG of check_escaping_implicit_destructor_invocation_via_release_value
 // CHECK-NEXT:    Val [ref] %0 Esc: , Succ: (%0.1)
 // CHECK-NEXT:    Con [int] %0.1 Esc: %1, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
+// CHECK-NEXT:    Con [ref] %0.2 Esc: G, Succ: 
 // CHECK-NEXT:  End
 sil @check_escaping_implicit_destructor_invocation_via_release_value : $@convention(thin) () -> () {
 bb0:
@@ -1544,7 +1544,7 @@ bb0(%0 : $X):
 // CHECK-LABEL: CG of $s4main1ZCfD
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
 // CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%2)
-// CHECK-NEXT:    Con %2 Esc: G, Succ: 
+// CHECK-NEXT:    Con [ref] %2 Esc: G, Succ: 
 // CHECK-NEXT:    Val %3 Esc: , Succ: (%3.1)
 // CHECK-NEXT:    Con [ref] %3.1 Esc: G, Succ: %2
 // CHECK-NEXT:  End
@@ -1608,7 +1608,7 @@ bb2:
 // CHECK-LABEL: CG of call_coroutine
 // CHECK-NEXT:    Val [ref] %0 Esc: , Succ: (%0.1)
 // CHECK-NEXT:    Con [int] %0.1 Esc: G, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: G, Succ: 
+// CHECK-NEXT:    Con [ref] %0.2 Esc: G, Succ: 
 // CHECK-NEXT:    Con %0.3 Esc: G, Succ: 
 // CHECK-NEXT:    Val %2 Esc: , Succ: (%2.1)
 // CHECK-NEXT:    Con [ref] %2.1 Esc: G, Succ: %4
@@ -1631,13 +1631,13 @@ bb0:
 // CHECK-LABEL: CG of testInitializePointsToLeaf
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
 // CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: (%13)
+// CHECK-NEXT:    Con [ref] %0.2 Esc: A, Succ: (%13)
 // CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%13), %0.2
 // CHECK-NEXT:    Val [ref] %4 Esc: , Succ: %2
 // CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%13), %0.2
 // CHECK-NEXT:    Val [ref] %12 Esc: , Succ: (%13), %7
 // CHECK-NEXT:    Con [int] %13 Esc: A, Succ: (%14)
-// CHECK-NEXT:    Con %14 Esc: A, Succ: 
+// CHECK-NEXT:    Con [ref] %14 Esc: A, Succ: 
 // CHECK-LABEL: End
 class C {
   var c: C
@@ -1688,7 +1688,7 @@ bb10(%arg2 : $LinkedNode):
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%2)
 // CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: (%2)
 // CHECK-NEXT:    Con [int] %2 Esc: A, Succ: (%3)
-// CHECK-NEXT:    Con %3 Esc: A, Succ: 
+// CHECK-NEXT:    Con [ref] %3 Esc: A, Succ: 
 // CHECK-NEXT:    Val [ref] %7 Esc: , Succ: %0
 // CHECK-NEXT:    Val [ref] %12 Esc: , Succ: %1
 // CHECK-NEXT:    Val [ref] %14 Esc: , Succ: (%2), %1, %12
@@ -1833,7 +1833,7 @@ sil [_semantics "array.uninitialized"] @init_any_array_with_buffer : $@conventio
 // CHECK-LABEL: CG of testBadArrayUninit
 // CHECK-NEXT:  Val [ref] %2 Esc: , Succ: (%2.1)
 // CHECK-NEXT:  Con [int] %2.1 Esc: G, Succ: (%2.2)
-// CHECK-NEXT:  Con %2.2 Esc: G, Succ:
+// CHECK-NEXT:  Con [ref] %2.2 Esc: G, Succ:
 // CHECK-NEXT:  Val %5 Esc: , Succ: (%5.1)
 // CHECK-NEXT:  Con %5.1 Esc: G, Succ: %10
 // CHECK-NEXT:  Val [ref] %10 Esc: G, Succ: (%10.1)

--- a/test/SILOptimizer/late_release_hoisting.sil
+++ b/test/SILOptimizer/late_release_hoisting.sil
@@ -1,0 +1,234 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -late-release-hoisting %s | %FileCheck %s
+
+import Builtin
+import Swift
+
+sil_stage canonical
+
+//===----------------------------------------------------------------------===//
+// Unit tests for reachability to and from local objects.
+//===----------------------------------------------------------------------===//
+
+class HasObj {
+  var o : AnyObject
+}
+
+class HasInt64 {
+  var i : Int64
+}
+
+class HasHasObj {
+  var ho : HasObj
+}
+
+// The release of %lo can be hoisted over the load because it does not
+// point to any escaping references.
+//
+// CHECK-LABEL: sil @testLocalNotReachesEscaped : $@convention(thin) (Int64, @owned HasObj) -> AnyObject {
+// CHECK: bb0(%0 : $Int64, %1 : $HasObj):
+// CHECK:   [[LO:%.*]] = alloc_ref $HasInt
+// CHECK:   [[IADR:%.*]] = ref_element_addr [[LO]] : $HasInt64, #HasInt64.i
+// CHECK:   store %0 to [[IADR]] : $*Int64
+// CHECK:   strong_release [[LO]] : $HasInt
+// CHECK:   [[OADR:%.*]] = ref_element_addr %1 : $HasObj, #HasObj.o
+// CHECK:   [[O:%.*]] = load [[OADR]] : $*AnyObject
+// CHECK:   return [[O]] : $AnyObject
+// CHECK-LABEL: } // end sil function 'testLocalNotReachesEscaped'
+sil @testLocalNotReachesEscaped : $@convention(thin) (Int64, @owned HasObj) -> AnyObject {
+bb0(%0 : $Int64, %1 : $HasObj):
+  %lo = alloc_ref $HasInt64
+  %iadr = ref_element_addr %lo : $HasInt64, #HasInt64.i
+  store %0 to %iadr : $*Int64
+
+  %oadr = ref_element_addr %1 : $HasObj, #HasObj.o
+  %o = load %oadr : $*AnyObject
+  strong_release %lo : $HasInt64
+  return %o : $AnyObject
+}
+
+// The release of %lo cannot be hoisted over the load.
+//
+// CHECK-LABEL: sil @testLocalReachesEscaped : $@convention(thin) (@owned AnyObject) -> AnyObject {
+// CHECK: bb0(%0 : $AnyObject):
+// CHECK:   [[LO:%.*]] = alloc_ref $HasObj
+// CHECK:   [[IADR:%.*]] = ref_element_addr [[LO]] : $HasObj, #HasObj.o
+// CHECK:   store %0 to [[IADR]] : $*AnyObject
+// CHECK:   [[OADR:%.*]] = ref_element_addr [[LO]] : $HasObj, #HasObj.o
+// CHECK:   [[O:%.*]] = load [[OADR]] : $*AnyObject
+// CHECK:   strong_release [[LO]] : $HasObj
+// CHECK:   return [[O]] : $AnyObject
+// CHECK-LABEL: } // end sil function 'testLocalReachesEscaped'
+sil @testLocalReachesEscaped : $@convention(thin) (@owned AnyObject) -> AnyObject {
+bb0(%0 : $AnyObject):
+  %lo = alloc_ref $HasObj
+  %iadr = ref_element_addr %lo : $HasObj, #HasObj.o
+  store %0 to %iadr : $*AnyObject
+
+  %oadr = ref_element_addr %lo : $HasObj, #HasObj.o
+  %o = load %oadr : $*AnyObject
+  strong_release %lo : $HasObj
+  return %o : $AnyObject
+}
+
+// The release of %lo can be hoisted above the load from %oadr.  There
+// is a points-to relation between %lo and %oadr. However, the
+// points-to path from %lo to %oadr reaches another reference counted
+// object before reaching $oadr.
+//
+// CHECK-LABEL: sil @testLocalReachesRCEscaped : $@convention(thin) (@owned HasObj) -> AnyObject {
+// CHECK: bb0(%0 : $HasObj):
+// CHECK:   [[LO:%.*]] = alloc_ref $HasHasObj
+// CHECK:   [[HOADR:%.*]] = ref_element_addr [[LO]] : $HasHasObj, #HasHasObj.ho
+// CHECK:   strong_retain %0 : $HasObj
+// CHECK:   store %0 to [[HOADR]] : $*HasObj
+// CHECK:   [[HO:%.*]] = load [[HOADR]] : $*HasObj
+// CHECK:   strong_release [[LO]] : $HasHasObj
+// CHECK:   [[OADR:%.*]] = ref_element_addr [[HO]] : $HasObj, #HasObj.o
+// CHECK:   [[O:%.*]] = load [[OADR]] : $*AnyObject
+// CHECK:   return [[O]] : $AnyObject
+// CHECK-LABEL: } // end sil function 'testLocalReachesRCEscaped'
+sil @testLocalReachesRCEscaped : $@convention(thin) (@owned HasObj) -> AnyObject {
+bb0(%0 : $HasObj):
+  %lo = alloc_ref $HasHasObj
+  %hoadr = ref_element_addr %lo : $HasHasObj, #HasHasObj.ho
+  strong_retain %0 : $HasObj
+  store %0 to %hoadr : $*HasObj
+  %ho = load %hoadr : $*HasObj
+  %oadr = ref_element_addr %ho : $HasObj, #HasObj.o
+  %o = load %oadr : $*AnyObject
+  // Normally a retain of %o would precede this release of %c. But
+  // let's assume some aggressive optimization happened.
+  strong_release %lo : $HasHasObj
+  return %o : $AnyObject
+}
+
+// Two local references, one reachable from the other.
+//
+// TODO: We do not currently hoist strong_release %hho above
+// strong_retain %o because %hho is marked as escaping. However, it is
+// only stored to another local object, so in theory it does not need
+// to be marked escaping.
+//
+// CHECK-LABEL: sil @testLocalReachesEscapingLocal : $@convention(thin) (AnyObject) -> AnyObject {
+// CHECK: bb0(%0 : $AnyObject):
+// CHECK: [[LO:%.*]] = alloc_ref $HasObj
+// CHECK: [[OADR:%.*]] = ref_element_addr %1 : $HasObj, #HasObj.o
+// CHECK: strong_retain %0 : $AnyObject
+// CHECK: store %0 to [[OADR]] : $*AnyObject
+// CHECK: [[HHO:%.*]] = alloc_ref $HasHasObj
+// CHECK: [[HOADR:%.*]] = ref_element_addr [[HHO]] : $HasHasObj, #HasHasObj.ho
+// CHECK: store [[LO]] to [[HOADR]] : $*HasObj
+// CHECK: [[HO:%.*]] = load [[HOADR]] : $*HasObj
+// CHECK: [[OADR2:%.*]] = ref_element_addr [[HO]] : $HasObj, #HasObj.o
+// CHECK: [[O:%.*]] = load [[OADR2]] : $*AnyObject
+// CHECK: strong_retain [[O]] : $AnyObject
+// CHECK: strong_release [[HHO]] : $HasHasObj
+// CHECK: return [[O]] : $AnyObject
+// CHECK-LABEL: } // end sil function 'testLocalReachesEscapingLocal'
+sil @testLocalReachesEscapingLocal : $@convention(thin) (AnyObject) -> AnyObject {
+bb0(%0 : $AnyObject):
+  %ho = alloc_ref $HasObj
+  %oadr = ref_element_addr %ho : $HasObj, #HasObj.o
+  strong_retain %0 : $AnyObject
+  store %0 to %oadr : $*AnyObject
+
+  %hho = alloc_ref $HasHasObj
+  %hoadr = ref_element_addr %hho : $HasHasObj, #HasHasObj.ho
+  store %ho to %hoadr : $*HasObj
+
+  %ho2 = load %hoadr : $*HasObj
+  %oadr2 = ref_element_addr %ho2 : $HasObj, #HasObj.o
+  %o = load %oadr2 : $*AnyObject
+  strong_retain %o : $AnyObject
+  strong_release %hho : $HasHasObj
+  return %o : $AnyObject
+}
+
+// Two local references, one reachable from the other. We assume that
+// the reachable one has its own reference count and hoist
+// strong_release %hho above load %oadr.
+//
+// CHECK-LABEL: sil @testLocalReachesRCLocal : $@convention(thin) (AnyObject) -> AnyObject {
+// CHECK: bb0(%0 : $AnyObject):
+// CHECK: [[LO:%.*]] = alloc_ref $HasObj
+// CHECK: [[OADR:%.*]] = ref_element_addr %1 : $HasObj, #HasObj.o
+// CHECK: strong_retain %0 : $AnyObject
+// CHECK: store %0 to [[OADR]] : $*AnyObject
+// CHECK: [[HHO:%.*]] = alloc_ref $HasHasObj
+// CHECK: [[HOADR:%.*]] = ref_element_addr [[HHO]] : $HasHasObj, #HasHasObj.ho
+// CHECK: store [[LO]] to [[HOADR]] : $*HasObj
+// CHECK: [[HO:%.*]] = load [[HOADR]] : $*HasObj
+// CHECK: strong_release [[HHO]] : $HasHasObj
+// CHECK: [[OADR2:%.*]] = ref_element_addr [[HO]] : $HasObj, #HasObj.o
+// CHECK: [[O:%.*]] = load [[OADR2]] : $*AnyObject
+// CHECK: strong_retain [[O]] : $AnyObject
+// CHECK: return [[O]] : $AnyObject
+// CHECK-LABEL: } // end sil function 'testLocalReachesRCLocal'
+sil @testLocalReachesRCLocal : $@convention(thin) (AnyObject) -> AnyObject {
+bb0(%0 : $AnyObject):
+  %ho = alloc_ref $HasObj
+  %oadr = ref_element_addr %ho : $HasObj, #HasObj.o
+  strong_retain %0 : $AnyObject
+  store %0 to %oadr : $*AnyObject
+
+  %hho = alloc_ref $HasHasObj
+  %hoadr = ref_element_addr %hho : $HasHasObj, #HasHasObj.ho
+  store %ho to %hoadr : $*HasObj
+
+  %ho2 = load %hoadr : $*HasObj
+  %oadr2 = ref_element_addr %ho2 : $HasObj, #HasObj.o
+  %o = load %oadr2 : $*AnyObject
+  strong_release %hho : $HasHasObj
+  strong_retain %o : $AnyObject
+  return %o : $AnyObject
+}
+
+// Hoist the release of an escaping object above memory operations on
+// a local object that never escapes.
+//
+// CHECK-LABEL: sil @testEscapeNotReachesLocal : $@convention(thin) (Int64, @owned HasObj) -> Int64 {
+// CHECK: bb0(%0 : $Int64, %1 : $HasObj):
+// CHECK:   strong_release %1 : $HasObj
+// CHECK:   [[LO:%.*]] = alloc_ref $HasInt64
+// CHECK:   [[IADR:%.*]] = ref_element_addr [[LO]] : $HasInt64, #HasInt64.i
+// CHECK:   store %0 to [[IADR]] : $*Int64
+// CHECK:   [[I:%.*]] = load [[IADR]] : $*Int64
+// CHECK:   return [[I]] : $Int64
+// CHECK-LABEL: } // end sil function 'testEscapeNotReachesLocal'
+sil @testEscapeNotReachesLocal : $@convention(thin) (Int64, @owned HasObj) -> Int64 {
+bb0(%0 : $Int64, %1 : $HasObj):
+  %lo = alloc_ref $HasInt64
+  %iadr = ref_element_addr %lo : $HasInt64, #HasInt64.i
+  store %0 to %iadr : $*Int64
+  %i = load %iadr : $*Int64
+  strong_release %1 : $HasObj
+  return %i : $Int64
+}
+
+// EscapeAnalysis must consider the local object %lo as globally
+// escaping because it is stored into an object that escapes via an
+// incoming argument. This creates an aliasing relationship preventing
+// the strong_release from being hoisted.
+//
+// CHECK-LABEL: sil @testEscapeReachesLocal : $@convention(thin) (@owned AnyObject, @owned HasHasObj) -> AnyObject {
+// CHECK: bb0(%0 : $AnyObject, %1 : $HasHasObj):
+// CHECK:   [[LO:%.*]] = alloc_ref $HasObj
+// CHECK:   [[OADR:%.*]] = ref_element_addr [[LO]] : $HasObj, #HasObj.o
+// CHECK:   store %0 to [[OADR]] : $*AnyObject
+// CHECK:   [[HOADR:%.*]] = ref_element_addr %1 : $HasHasObj, #HasHasObj.ho
+// CHECK:   store [[LO]] to [[HOADR]] : $*HasObj
+// CHECK:   [[O:%.*]] = load [[OADR]] : $*AnyObject
+// CHECK:   strong_release %1 : $HasHasObj
+// CHECK:   return [[O]] : $AnyObject
+// CHECK-LABEL: } // end sil function 'testEscapeReachesLocal'
+sil @testEscapeReachesLocal : $@convention(thin) (@owned AnyObject, @owned HasHasObj) -> AnyObject {
+bb0(%0 : $AnyObject, %1 : $HasHasObj):
+  %lo = alloc_ref $HasObj
+  %oadr = ref_element_addr %lo : $HasObj, #HasObj.o
+  store %0 to %oadr : $*AnyObject
+  %hoadr = ref_element_addr %1 : $HasHasObj, #HasHasObj.ho
+  store %lo to %hoadr : $*HasObj
+  %o = load %oadr : $*AnyObject
+  strong_release %1 : $HasHasObj
+  return %o : $AnyObject
+}


### PR DESCRIPTION
Use the new EscapeAnalysis infrastructure to make ARC code motion and
ARC sequence opts much more powerful and fix a latent bug in
AliasAnalysis.

Adds a new API `EscapeAnalysis::mayReleaseContent()`. This replaces
all uses if `EscapeAnalysis::canEscapeValueTo()`, which affects
`AliasAnalysis::can[Apply|Builtin]DecrementRefCount()`.

Also rewrite `AliasAnalysis::mayValueReleaseInterferWithInstruction` to
directly use `EscapeAnalysis::mayReleaseContent`.

The new implementation in `EscapeAnalysis::mayReleaseContent()`
generalizes the logic to handle more cases while avoiding an incorrect
assumption in the prior code. In particular, it adds support for
disambiguating local references from accessed addresses. This helps
handle cases in which inlining was defeating ARC optimization. The
incorrect assumption was that a non-escaping address is never
reachable via a reference. However, if a reference does not escape,
then an address into its object also does not escape.

The bug in `AliasAnalysis::mayValueReleaseInterfereWithInstruction()`
appears not to have broken anything yet because it is always called by
`AliasAnalysis::mayHaveSymmetricInteference()`, which later checks
whether the accessed address may alias with the released reference
using a separate query, `EscapeAnalysis::canPointToSameMemory()`. This
happens to work because an address into memory that is directly
released when destroying a reference necesasarilly points to the same
memory object. For this reason, I couldn't figure out a simple way to
hand-code SIL tests to expose this bug.

The changes in diff order:

Replace EscapeAnalysis `canEscapeToValue` with `mayReleaseContent` to
make the semantics clear. It queries: "Can the given reference release
the content pointed to the given address".

Change `AliasAnalysis::canApplyDecrementRefCount` to use
`mayReleaseContent` instead if 'canEscapeToValue'.

Change `AliasAnalysis::mayValueReleaseInterferWithInstruction`: after
getting the memory address accessed by the instruction, simply call
`EscapeAnalysis::mayReleaseContent`, which now implements all the
logic. This avoids the bad assumption made by AliasAnalysis.

Handle two cases in mayReleaseContent: non-escaping instruction
addresses and non-escaping referenecs. Fix the non-escaping address
case by following all content nodes to determine whether the address
is reachable from the released reference. Introduce a new optimization
for the case in which the reference being released is allocated
locally.

The following test case is now optimized in arcsequenceopts.sil:
remove_as_local_object_indirectly_escapes_to_callee. It was trying to
test that ARC optimization was not too aggressive when it removed a
retain/release of a child object whose parent container is still in
use. But the retain/release should be removed. The original example
already over-releases the parent object.

Add new unit tests to late_release_hoisting.sil.

