### PR TITLE
Adjust batch mode partition count calculation

### DIFF
--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1361,18 +1361,24 @@ namespace driver {
       // subprocesses than before. And significantly: it's doing so while
       // not exceeding the RAM of a typical 2-core laptop.
 
+      // An explanation of why the partition calculation isn't integer division.
+      // Using an example, a module of 26 files exceeds the limit of 25 and must
+      // be compiled in 2 batches. Integer division yields 26/25 = 1 batch, but
+      // a single batch of 26 exceeds the limit. The calculation must round up,
+      // which can be calculated using: `(x + y - 1) / y`
+      //
+      // Two key properties of this calculation are:
+      //   DivideUp(M*N, N) = M
+      //   DivideUp(M*N + 1, N) = M + 1
+      auto DivideUp = [](size_t Num, size_t Div) -> size_t {
+        return (Num + Div - 1) / Div;
+      };
+
       size_t DefaultSizeLimit = 25;
       size_t NumTasks = TQ->getNumberOfParallelTasks();
       size_t NumFiles = PendingExecution.size();
       size_t SizeLimit = Comp.getBatchSizeLimit().getValueOr(DefaultSizeLimit);
-
-      // An explanation of why the partition calculation isn't simple division.
-      // Using the default limit as an example, a module of 26 files must be
-      // compiled in 2 batches. Simple division yields 26/25 = 1 batch, but a
-      // single batch of 26 would exceed the limit of 25. To round up, the
-      // calculation is: `(x - 1) / y + 1`.
-      size_t NumPartitions = (NumFiles - 1) / SizeLimit + 1;
-      return std::max(NumTasks, NumPartitions);
+      return std::max(NumTasks, DivideUp(NumFiles, SizeLimit));
     }
 
     /// Select jobs that are batch-combinable from \c PendingExecution, combine

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1366,10 +1366,6 @@ namespace driver {
       // be compiled in 2 batches. Integer division yields 26/25 = 1 batch, but
       // a single batch of 26 exceeds the limit. The calculation must round up,
       // which can be calculated using: `(x + y - 1) / y`
-      //
-      // Two key properties of this calculation are:
-      //   DivideUp(M*N, N) = M
-      //   DivideUp(M*N + 1, N) = M + 1
       auto DivideUp = [](size_t Num, size_t Div) -> size_t {
         return (Num + Div - 1) / Div;
       };

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1366,7 +1366,7 @@ namespace driver {
       // be compiled in 2 batches. Integer division yields 26/25 = 1 batch, but
       // a single batch of 26 exceeds the limit. The calculation must round up,
       // which can be calculated using: `(x + y - 1) / y`
-      auto DivideUp = [](size_t Num, size_t Div) -> size_t {
+      auto DivideRoundingUp = [](size_t Num, size_t Div) -> size_t {
         return (Num + Div - 1) / Div;
       };
 
@@ -1374,7 +1374,7 @@ namespace driver {
       size_t NumTasks = TQ->getNumberOfParallelTasks();
       size_t NumFiles = PendingExecution.size();
       size_t SizeLimit = Comp.getBatchSizeLimit().getValueOr(DefaultSizeLimit);
-      return std::max(NumTasks, DivideUp(NumFiles, SizeLimit));
+      return std::max(NumTasks, DivideRoundingUp(NumFiles, SizeLimit));
     }
 
     /// Select jobs that are batch-combinable from \c PendingExecution, combine


### PR DESCRIPTION
While exploring how to optimize global build times, I noticed that the batch sizing logic wasn't producing multiple batches until a module had 50 files. Based on @graydon's [detailed batch calculation comment](https://github.com/apple/swift/blob/746b58e8e1c1ef1ac09d8031875fd2a08b65597c/lib/Driver/Compilation.cpp#L1269-L1362) (which says "cap the batch size ... at ... 25"), and based on the variable names ("`SizeLimit`"), I believe the batch calculation implementation is off.

The simple example is a module of 26 files. With the existing batch calculation, the result is a `26/25=1` batch. However this is larger than the `DefaultSizeLimit`. This calculation continues to yield `1` for modules up to 49 files. Only at modules of 50 files does the batch calculation produce two batches.

Here's a table showing the effects of the current partition count calculation:

| Num Files | Num Batches  | Min Batch Size | Max Batch Size |
| --- | --- | --- | --- |
| 1-49 | 1 | 1 | 49 |
| 50-74 | 2 | 25 | 37 |
| 75-99 | 3 | 25 | 33 |
| 100-124 | 4 | 25 | 31 |

This table shows that the max batch size is inversely proportional with the number of files. Smaller modules have a higher max batch size, and as a module gets larger, its max batch size trends toward 25. It also shows that after 50, the minimum batch size is consistently 25.

With this proposed change to the batch count calculation, the math is now:

| Num Files | Num Batches  | Min Batch Size | Max Batch Size |
| --- | --- | --- | --- |
| 1-25 | 1 | 1 | 25 |
| 26-50 | 2 | 13 | 25 |
| 51-75 | 3 | 17 | 25 |
| 76-100 | 4 | 19 | 25 |
| 101-125 | 5 | 21 | 25 |

This table shows that the batch size is in fact capped to 25, independent of how many files are in the module. It also show the minimum batch size increases with module size.
