### PR TITLE
[CSDiag] NFC: Remove obsolete `CalleeListener` callback

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1615,47 +1615,6 @@ bool FailureDiagnosis::visitSubscriptExpr(SubscriptExpr *SE) {
   return diagnoseSubscriptErrors(SE, /* inAssignmentDestination = */ false);
 }
 
-namespace {
-  /// Type checking listener for pattern binding initializers.
-  class CalleeListener : public ExprTypeCheckListener {
-    Type contextualType;
-  public:
-    explicit CalleeListener(Type contextualType)
-      : contextualType(contextualType) { }
-
-    bool builtConstraints(ConstraintSystem &cs, Expr *expr) override {
-      // If we have no contextual type, there is nothing to do.
-      if (!contextualType)
-        return false;
-
-      // If the expression is obviously something that produces a metatype,
-      // then don't put a constraint on it.
-      auto semExpr = expr->getValueProvidingExpr();
-      if (isa<TypeExpr>(semExpr))
-        return false;
-
-      auto resultLocator =
-        cs.getConstraintLocator(expr, ConstraintLocator::FunctionResult);
-      auto resultType = cs.createTypeVariable(resultLocator,
-                                              TVO_CanBindToLValue |
-                                              TVO_CanBindToNoEscape);
-
-      auto locator = cs.getConstraintLocator(expr);
-      cs.addConstraint(ConstraintKind::FunctionResult,
-                       cs.getType(expr),
-                       resultType,
-                       locator);
-
-      cs.addConstraint(ConstraintKind::Conversion,
-                       resultType,
-                       contextualType,
-                       locator);
-
-      return false;
-    }
-  };
-} // end anonymous namespace
-
 // Check if there is a structural problem in the function expression
 // by performing type checking with the option to allow unresolved
 // type variables. If that is going to produce a function type with


### PR DESCRIPTION
Since closure handling has been ported to new diagnostic framework
`CalleeListener` callback is no longer used.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
