### PR TITLE
build: synchronise with LLDB's version of FindLibEdit

### DIFF
--- a/cmake/modules/FindLibEdit.cmake
+++ b/cmake/modules/FindLibEdit.cmake
@@ -8,25 +8,25 @@
 #
 # ::
 #
-#   libedit_FOUND         - true if libedit was found
-#   libedit_INCLUDE_DIRS  - include search path
-#   libedit_LIBRARIES     - libraries to link
-#   libedit_VERSION       - version number
+#   LibEdit_FOUND          - true if libedit was found
+#   LibEdit_INCLUDE_DIRS   - include search path
+#   LibEdit_LIBRARIES      - libraries to link
+#   LibEdit_VERSION_STRING - version number
 
-if(libedit_INCLUDE_DIRS AND libedit_LIBRARIES)
-  set(libedit_FOUND TRUE)
+if(LibEdit_INCLUDE_DIRS AND LibEdit_LIBRARIES)
+  set(LibEdit_FOUND TRUE)
 else()
   find_package(PkgConfig QUIET)
   pkg_check_modules(PC_LIBEDIT QUIET libedit)
 
-  find_path(libedit_INCLUDE_DIRS
+  find_path(LibEdit_INCLUDE_DIRS
             NAMES
               histedit.h
             HINTS
               ${PC_LIBEDIT_INCLUDEDIR}
               ${PC_LIBEDIT_INCLUDE_DIRS}
               ${CMAKE_INSTALL_FULL_INCLUDEDIR})
-  find_library(libedit_LIBRARIES
+  find_library(LibEdit_LIBRARIES
                NAMES
                  edit libedit
                HINTS
@@ -34,28 +34,31 @@ else()
                  ${PC_LIBEDIT_LIBRARY_DIRS}
                  ${CMAKE_INSTALL_FULL_LIBDIR})
 
-   if(libedit_INCLUDE_DIRS AND EXISTS "${libedit_INCLUDE_DIRS}/histedit.h")
-    file(STRINGS "${libedit_INCLUDE_DIRS}/histedit.h"
+  if(LibEdit_INCLUDE_DIRS AND EXISTS "${LibEdit_INCLUDE_DIRS}/histedit.h")
+    file(STRINGS "${LibEdit_INCLUDE_DIRS}/histedit.h"
          libedit_major_version_str
          REGEX "^#define[ \t]+LIBEDIT_MAJOR[ \t]+[0-9]+")
     string(REGEX REPLACE "^#define[ \t]+LIBEDIT_MAJOR[ \t]+([0-9]+)" "\\1"
            LIBEDIT_MAJOR_VERSION "${libedit_major_version_str}")
 
-     file(STRINGS "${libedit_INCLUDE_DIRS}/histedit.h"
+    file(STRINGS "${LibEdit_INCLUDE_DIRS}/histedit.h"
          libedit_minor_version_str
          REGEX "^#define[ \t]+LIBEDIT_MINOR[ \t]+[0-9]+")
     string(REGEX REPLACE "^#define[ \t]+LIBEDIT_MINOR[ \t]+([0-9]+)" "\\1"
            LIBEDIT_MINOR_VERSION "${libedit_minor_version_str}")
 
-     set(libedit_VERSION_STRING "${libedit_major_version}.${libedit_minor_version}")
+    set(LibEdit_VERSION_STRING "${libedit_major_version}.${libedit_minor_version}")
   endif()
 
   include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(libedit
+  find_package_handle_standard_args(LibEdit
+                                    FOUND_VAR
+                                      LibEdit_FOUND
                                     REQUIRED_VARS
-                                      libedit_INCLUDE_DIRS
-                                      libedit_LIBRARIES
+                                      LibEdit_INCLUDE_DIRS
+                                      LibEdit_LIBRARIES
                                     VERSION_VAR
-                                      libedit_VERSION_STRING)
-  mark_as_advanced(libedit_INCLUDE_DIRS libedit_LIBRARIES)
+                                      LibEdit_VERSION_STRING)
+  mark_as_advanced(LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES)
 endif()
+

--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -12,9 +12,9 @@ target_link_libraries(swiftImmediate PRIVATE
   swiftIRGen
   swiftSILGen
   swiftSILOptimizer)
-if(libedit_FOUND)
+if(LibEdit_FOUND)
   target_compile_definitions(swiftImmediate PRIVATE
     HAVE_LIBEDIT)
   target_link_libraries(swiftImmediate PRIVATE
-    ${libedit_LIBRARIES})
+    ${LibEdit_LIBRARIES})
 endif()

--- a/tools/SourceKit/tools/CMakeLists.txt
+++ b/tools/SourceKit/tools/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(
 
 add_swift_lib_subdirectory(sourcekitd)
 add_swift_tool_subdirectory(sourcekitd-test)
-if(libedit_FOUND)
+if(LibEdit_FOUND)
   add_swift_tool_subdirectory(sourcekitd-repl)
 endif()
 add_swift_tool_subdirectory(complete-test)

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -13,9 +13,9 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     BlocksRuntime)
 endif()
 target_include_directories(sourcekitd-repl PRIVATE
-  ${libedit_INCLUDE_DIRS})
+  ${LibEdit_INCLUDE_DIRS})
 target_link_libraries(sourcekitd-repl PRIVATE
-  ${libedit_LIBRARIES})
+  ${LibEdit_LIBRARIES})
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set_target_properties(sourcekitd-repl


### PR DESCRIPTION
The current FOUND_VAR for FindLibEdit is libedit_FOUND but wasn't set by
find_package_handle_standard_args. However this isn't valid for the
package name.

  The argument for FOUND_VAR is "libedit_FOUND", but only
  "LibEdit_FOUND" and "LIBEDIT_FOUND" are valid names.

This fixes all the variables set by FindLibEdit to match the desired
naming scheme.

Thanks to Jonas for fixing the variable names!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
