### PR TITLE
[Type checker] Stop devirtualizing the reference to IteratorProtocol.next()

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -489,6 +489,9 @@ public:
   /// Get the '+' function on two String.
   FuncDecl *getPlusFunctionOnString() const;
 
+  /// Get Sequence.makeIterator().
+  FuncDecl *getSequenceMakeIterator() const;
+
   /// Check whether the standard library provides all the correct
   /// intrinsic support for Optional<T>.
   ///

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3924,6 +3924,10 @@ public:
   /// value to be specified later.
   bool isPlaceholder() const { return Bits.OpaqueValueExpr.IsPlaceholder; }
 
+  void setIsPlaceholder(bool value) {
+    Bits.OpaqueValueExpr.IsPlaceholder = value;
+  }
+
   SourceRange getSourceRange() const { return Range; }
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -808,7 +808,6 @@ class ForEachStmt : public LabeledStmt {
 
   // Set by Sema:
   ProtocolConformanceRef sequenceConformance = ProtocolConformanceRef();
-  ConcreteDeclRef makeIterator;
   ConcreteDeclRef iteratorNext;
   VarDecl *iteratorVar = nullptr;
   Expr *iteratorVarRef = nullptr;
@@ -837,9 +836,6 @@ public:
 
   void setConvertElementExpr(Expr *expr) { convertElementExpr = expr; }
   Expr *getConvertElementExpr() const { return convertElementExpr; }
-
-  void setMakeIterator(ConcreteDeclRef declRef) { makeIterator = declRef; }
-  ConcreteDeclRef getMakeIterator() const { return makeIterator; }
 
   void setIteratorNext(ConcreteDeclRef declRef) { iteratorNext = declRef; }
   ConcreteDeclRef getIteratorNext() const { return iteratorNext; }

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -808,7 +808,6 @@ class ForEachStmt : public LabeledStmt {
 
   // Set by Sema:
   ProtocolConformanceRef sequenceConformance = ProtocolConformanceRef();
-  ConcreteDeclRef iteratorNext;
   VarDecl *iteratorVar = nullptr;
   Expr *iteratorVarRef = nullptr;
   OpaqueValueExpr *elementExpr = nullptr;
@@ -836,9 +835,6 @@ public:
 
   void setConvertElementExpr(Expr *expr) { convertElementExpr = expr; }
   Expr *getConvertElementExpr() const { return convertElementExpr; }
-
-  void setIteratorNext(ConcreteDeclRef declRef) { iteratorNext = declRef; }
-  ConcreteDeclRef getIteratorNext() const { return iteratorNext; }
 
   void setSequenceConformance(ProtocolConformanceRef conformance) {
     sequenceConformance = conformance;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -196,6 +196,9 @@ struct ASTContext::Implementation {
   /// The declaration of '+' function for two String.
   FuncDecl *PlusFunctionOnString = nullptr;
 
+  /// The declaration of 'Sequence.makeIterator()'.
+  FuncDecl *MakeIterator = nullptr;
+
   /// The declaration of Swift.Optional<T>.Some.
   EnumElementDecl *OptionalSomeDecl = nullptr;
 
@@ -708,6 +711,31 @@ FuncDecl *ASTContext::getPlusFunctionOnString() const {
     }
   }
   return getImpl().PlusFunctionOnString;
+}
+
+FuncDecl *ASTContext::getSequenceMakeIterator() const {
+  if (getImpl().MakeIterator) {
+    return getImpl().MakeIterator;
+  }
+
+  auto proto = getProtocol(KnownProtocolKind::Sequence);
+  if (!proto)
+    return nullptr;
+
+  for (auto result : proto->lookupDirect(Id_makeIterator)) {
+    if (result->getDeclContext() != proto)
+      continue;
+
+    if (auto func = dyn_cast<FuncDecl>(result)) {
+      if (func->getParameters()->size() != 0)
+        continue;
+
+      getImpl().MakeIterator = func;
+      return func;
+    }
+  }
+
+  return nullptr;
 }
 
 #define KNOWN_STDLIB_TYPE_DECL(NAME, DECL_CLASS, NUM_GENERIC_PARAMS) \

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1593,9 +1593,6 @@ public:
   }
   void visitForEachStmt(ForEachStmt *S) {
     printCommon(S, "for_each_stmt");
-    PrintWithColorRAII(OS, LiteralValueColor) << " make_generator=";
-    S->getMakeIterator().dump(
-        PrintWithColorRAII(OS, LiteralValueColor).getOS());
     PrintWithColorRAII(OS, LiteralValueColor) << " next=";
     S->getIteratorNext().dump(
         PrintWithColorRAII(OS, LiteralValueColor).getOS());

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1593,9 +1593,6 @@ public:
   }
   void visitForEachStmt(ForEachStmt *S) {
     printCommon(S, "for_each_stmt");
-    PrintWithColorRAII(OS, LiteralValueColor) << " next=";
-    S->getIteratorNext().dump(
-        PrintWithColorRAII(OS, LiteralValueColor).getOS());
     OS << '\n';
     printRec(S->getPattern());
     OS << '\n';

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -87,6 +87,7 @@ Solution::computeSubstitutions(GenericSignature sig,
       return ProtocolConformanceRef(protoType);
     }
 
+    // FIXME: Retrieve the conformance from the solution itself.
     return TypeChecker::conformsToProtocol(replacement, protoType,
                                            getConstraintSystem().DC,
                                            ConformanceCheckFlags::InExpression);
@@ -7343,6 +7344,37 @@ public:
   /// Ignore declarations.
   bool walkToDeclPre(Decl *decl) override { return false; }
 };
+}
+
+ProtocolConformanceRef Solution::resolveConformance(
+    ConstraintLocator *locator, ProtocolDecl *proto) {
+  for (const auto &conformance : Conformances) {
+    if (conformance.first != locator)
+      continue;
+    if (conformance.second.getRequirement() != proto)
+      continue;
+
+    // If the conformance doesn't require substitution, return it immediately.
+    auto conformanceRef = conformance.second;
+    if (conformanceRef.isAbstract())
+      return conformanceRef;
+
+    auto concrete = conformanceRef.getConcrete();
+    auto conformingType = concrete->getType();
+    if (!conformingType->hasTypeVariable())
+      return conformanceRef;
+
+    // Substitute into the conformance type, then look for a conformance
+    // again.
+    // FIXME: Should be able to perform the substitution using the Solution
+    // itself rather than another conforms-to-protocol check.
+    Type substConformingType = simplifyType(conformingType);
+    return TypeChecker::conformsToProtocol(
+        substConformingType, proto, constraintSystem->DC,
+        ConformanceCheckFlags::InExpression);
+  }
+
+  return ProtocolConformanceRef::forInvalid();
 }
 
 void Solution::setExprTypes(Expr *expr) const {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -610,6 +610,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
 
     case ConstraintKind::ValueMember:
     case ConstraintKind::UnresolvedValueMember:
+    case ConstraintKind::ValueWitness:
       // If our type variable shows up in the base type, there's
       // nothing to do.
       // FIXME: Can we avoid simplification here?

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1670,6 +1670,7 @@ void ConstraintSystem::ArgumentInfoCollector::walk(Type argType) {
 
       case ConstraintKind::BindToPointerType:
       case ConstraintKind::ValueMember:
+      case ConstraintKind::ValueWitness:
       case ConstraintKind::UnresolvedValueMember:
       case ConstraintKind::Disjunction:
       case ConstraintKind::CheckedCast:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -898,6 +898,11 @@ public:
     return None;
   }
 
+  /// Retrieve a fully-resolved protocol conformance at the given locator
+  /// and with the given protocol.
+  ProtocolConformanceRef resolveConformance(ConstraintLocator *locator,
+                                            ProtocolDecl *proto);
+
   void setExprTypes(Expr *expr) const;
 
   SWIFT_DEBUG_DUMP;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2367,6 +2367,26 @@ public:
     }
   }
 
+  /// Add a value witness constraint to the constraint system.
+  void addValueWitnessConstraint(
+      Type baseTy, ValueDecl *requirement, Type memberTy, DeclContext *useDC,
+      FunctionRefKind functionRefKind, ConstraintLocatorBuilder locator) {
+    assert(baseTy);
+    assert(memberTy);
+    assert(requirement);
+    assert(useDC);
+    switch (simplifyValueWitnessConstraint(
+        ConstraintKind::ValueWitness, baseTy, requirement, memberTy, useDC,
+        functionRefKind, TMF_GenerateConstraints, locator)) {
+    case SolutionKind::Unsolved:
+      llvm_unreachable("Unsolved result when generating constraints!");
+
+    case SolutionKind::Solved:
+    case SolutionKind::Error:
+      break;
+    }
+  }
+
   /// Add an explicit conversion constraint (e.g., \c 'x as T').
   void addExplicitConversionConstraint(Type fromType, Type toType,
                                        bool allowFixes,
@@ -3267,6 +3287,12 @@ private:
       DeclContext *useDC, FunctionRefKind functionRefKind,
       ArrayRef<OverloadChoice> outerAlternatives, TypeMatchOptions flags,
       ConstraintLocatorBuilder locator);
+
+  /// Attempt to simplify the given value witness constraint.
+  SolutionKind simplifyValueWitnessConstraint(
+      ConstraintKind kind, Type baseType, ValueDecl *member, Type memberType,
+      DeclContext *useDC, FunctionRefKind functionRefKind,
+      TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify the optional object constraint.
   SolutionKind simplifyOptionalObjectConstraint(

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2991,14 +2991,12 @@ auto TypeChecker::typeCheckForEachBinding(
       }
 
       // Reference the makeIterator witness.
-      // FIXME: Not tied to the actual witness.
       ASTContext &ctx = cs.getASTContext();
-      DeclName makeIteratorName(ctx, ctx.Id_makeIterator,
-                                ArrayRef<Identifier>());
+      FuncDecl *makeIterator = ctx.getSequenceMakeIterator();
       MakeIteratorType = cs.createTypeVariable(Locator, TVO_CanBindToNoEscape);
-      cs.addValueMemberConstraint(
-          LValueType::get(SequenceType), DeclNameRef(makeIteratorName),
-          MakeIteratorType, cs.DC, FunctionRefKind::Compound, { },
+      cs.addValueWitnessConstraint(
+          LValueType::get(SequenceType), makeIterator,
+          MakeIteratorType, cs.DC, FunctionRefKind::Compound,
           ContextualLocator);
 
       Stmt->setSequence(expr);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3040,17 +3040,15 @@ auto TypeChecker::typeCheckForEachBinding(
       Stmt->setPattern(pattern);
 
       // Get the conformance of the sequence type to the Sequence protocol.
-      // FIXME: Get this from the solution and substitute into that.
-      SequenceConformance = TypeChecker::conformsToProtocol(
-          SequenceType, SequenceProto, cs.DC,
-          ConformanceCheckFlags::InExpression,
-          expr->getLoc());
+      SequenceConformance = solution.resolveConformance(
+          ContextualLocator, SequenceProto);
       assert(!SequenceConformance.isInvalid() &&
              "Couldn't find sequence conformance");
       Stmt->setSequenceConformance(SequenceConformance);
 
       // Retrieve the conformance of the iterator type to IteratorProtocol.
-      // FIXME: Get this from the solution and substitute into that.
+      // FIXME: We probably don't even need this. If we do, get it from
+      // SequenceConformance instead.
       IteratorConformance = TypeChecker::conformsToProtocol(
           IteratorType, IteratorProto, cs.DC,
           ConformanceCheckFlags::InExpression,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3013,16 +3013,7 @@ auto TypeChecker::typeCheckForEachBinding(
 
       // Perform any necessary conversions of the sequence (e.g. [T]! -> [T]).
       expr = solution.coerceToType(expr, SequenceType, Locator);
-      
       if (!expr) return nullptr;
-
-      // Convert the sequence as appropriate for the makeIterator() call.
-      auto makeIteratorOverload = solution.getOverloadChoice(ContextualLocator);
-      auto makeIteratorSelfType = solution.simplifyType(
-          makeIteratorOverload.openedFullType
-        )->castTo<AnyFunctionType>()->getParams()[0].getPlainType();
-      expr = solution.coerceToType(expr, makeIteratorSelfType,
-                                   ContextualLocator);
 
       cs.cacheExprTypes(expr);
       Stmt->setSequence(expr);
@@ -3053,14 +3044,6 @@ auto TypeChecker::typeCheckForEachBinding(
           IteratorType, IteratorProto, cs.DC,
           ConformanceCheckFlags::InExpression,
           expr->getLoc());
-
-      // Record the makeIterator declaration we used.
-      auto makeIteratorDecl = makeIteratorOverload.choice.getDecl();
-      auto makeIteratorSubs = SequenceType->getMemberSubstitutionMap(
-          cs.DC->getParentModule(), makeIteratorDecl);
-      auto makeIteratorDeclRef =
-          ConcreteDeclRef(makeIteratorDecl, makeIteratorSubs);
-      Stmt->setMakeIterator(makeIteratorDeclRef);
 
       solution.setExprTypes(expr);
       return expr;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1037,7 +1037,6 @@ public:
     Type sequenceType;
     ProtocolConformanceRef sequenceConformance;
     Type iteratorType;
-    ProtocolConformanceRef iteratorConformance;
     Type elementType;
   };
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1032,8 +1032,20 @@ public:
   static bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC);
   static bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber);
 
+  /// Information about a type-checked for-each binding.
+  struct ForEachBinding {
+    Type sequenceType;
+    ProtocolConformanceRef sequenceConformance;
+    Type iteratorType;
+    ProtocolConformanceRef iteratorConformance;
+    Type elementType;
+  };
+
   /// Type-check a for-each loop's pattern binding and sequence together.
-  static bool typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt);
+  ///
+  /// \returns the binding, if successful.
+  static Optional<ForEachBinding> typeCheckForEachBinding(
+      DeclContext *dc, ForEachStmt *stmt);
 
   /// Compute the set of captures for the given function or closure.
   static void computeCaptures(AnyFunctionRef AFR);
@@ -1100,17 +1112,6 @@ public:
   /// \returns the default type, or null if there is no default type for
   /// this protocol.
   static Type getDefaultType(ProtocolDecl *protocol, DeclContext *dc);
-
-  /// Convert the given expression to the given type.
-  ///
-  /// \param expr The expression, which will be updated in place.
-  /// \param type The type to convert to.
-  /// \param typeFromPattern Optionally, the caller can specify the pattern
-  ///   from where the toType is derived, so that we can deliver better fixit.
-  ///
-  /// \returns true if an error occurred, false otherwise.
-  static bool convertToType(Expr *&expr, Type type, DeclContext *dc,
-                            Optional<Pattern*> typeFromPattern = None);
 
   /// Coerce the given expression to materializable type, if it
   /// isn't already.

--- a/test/Constraints/generic_protocol_witness.swift
+++ b/test/Constraints/generic_protocol_witness.swift
@@ -61,5 +61,4 @@ struct L<T>: Sequence {} // expected-error {{type 'L<T>' does not conform to pro
 func z(_ x: L<Int>) {
   for xx in x {}
   // expected-warning@-1{{immutable value 'xx' was never used; consider replacing with '_' or removing it}}
-  // expected-error@-2{{type 'L<Int>.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }

--- a/test/Constraints/generic_protocol_witness.swift
+++ b/test/Constraints/generic_protocol_witness.swift
@@ -59,5 +59,6 @@ func usesAGenericMethod<U : NeedsAGenericMethod>(_ x: U) {
 struct L<T>: Sequence {} // expected-error {{type 'L<T>' does not conform to protocol 'Sequence'}}
 
 func z(_ x: L<Int>) {
-  for xx in x {} // expected-warning {{immutable value 'xx' was never used; consider replacing with '_' or removing it}}
+  for xx in x {}
+  // expected-error@-1{{for-in loop requires 'L<Int>' to conform to 'Sequence'}}
 }

--- a/test/Constraints/generic_protocol_witness.swift
+++ b/test/Constraints/generic_protocol_witness.swift
@@ -60,5 +60,6 @@ struct L<T>: Sequence {} // expected-error {{type 'L<T>' does not conform to pro
 
 func z(_ x: L<Int>) {
   for xx in x {}
-  // expected-error@-1{{for-in loop requires 'L<Int>' to conform to 'Sequence'}}
+  // expected-warning@-1{{immutable value 'xx' was never used; consider replacing with '_' or removing it}}
+  // expected-error@-2{{type 'L<Int>.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -215,7 +215,7 @@ public func testGetFunc() {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$s22big_types_corner_cases7TestBigC5test2yyF"(%T22big_types_corner_cases7TestBigC* swiftself)
 // CHECK: [[CALL1:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSaySS2ID_y22big_types_corner_cases9BigStructVcSg7handlertGMD"
 // CHECK: [[CALL2:%.*]] = call i8** @"$sSaySS2ID_y22big_types_corner_cases9BigStructVcSg7handlertGSayxGSlsWl"
-// CHECK: call swiftcc void @"$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF"(%Ts16IndexingIteratorV* noalias nocapture sret {{.*}}, %swift.type* [[CALL1]], i8** [[CALL2]], %swift.opaque* noalias nocapture swiftself {{.*}})
+// CHECK: call swiftcc void @"$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF"(%Ts16IndexingIteratorV{{.*}}* noalias nocapture sret {{.*}}, %swift.type* [[CALL1]], i8** [[CALL2]], %swift.opaque* noalias nocapture swiftself {{.*}})
 // CHECK: ret void
 class TestBig {
     typealias Handler = (BigStruct) -> Void

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -115,8 +115,8 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[GET_ELT_STACK:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<Int>>
-// CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method)
-// CHECK:   apply [[FUNC_REF]]<Array<Int>>([[GET_ELT_STACK]], [[WRITE]])
+// CHECK:   [[FUNC_REF:%.*]] = witness_method $IndexingIterator<Array<Int>>, #IteratorProtocol.next!1 : <Self where Self : IteratorProtocol> (inout Self) -> () -> Self.Element? : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@inout τ_0_0) -> @out Optional<τ_0_0.Element>
+// CHECK:   apply [[FUNC_REF]]<IndexingIterator<Array<Int>>>([[GET_ELT_STACK]], [[WRITE]])
 // CHECK:   [[IND_VAR:%.*]] = load [trivial] [[GET_ELT_STACK]]
 // CHECK:   switch_enum [[IND_VAR]] : $Optional<Int>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
@@ -215,8 +215,8 @@ func existentialBreak(_ xx: [P]) {
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<P>>
-// CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method)
-// CHECK:   apply [[FUNC_REF]]<Array<P>>([[ELT_STACK]], [[WRITE]])
+// CHECK:   [[FUNC_REF:%.*]] = witness_method $IndexingIterator<Array<P>>, #IteratorProtocol.next!1 : <Self where Self : IteratorProtocol> (inout Self) -> () -> Self.Element? : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@inout τ_0_0) -> @out Optional<τ_0_0.Element>
+// CHECK:   apply [[FUNC_REF]]<IndexingIterator<Array<P>>>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<P>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[SOME_BB]]:
@@ -375,8 +375,8 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<GenericStruct<T>>>
-// CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method)
-// CHECK:   apply [[FUNC_REF]]<Array<GenericStruct<T>>>([[ELT_STACK]], [[WRITE]])
+// CHECK:   [[FUNC_REF:%.*]] = witness_method $IndexingIterator<Array<GenericStruct<T>>>, #IteratorProtocol.next!1 : <Self where Self : IteratorProtocol> (inout Self) -> () -> Self.Element? : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@inout τ_0_0) -> @out Optional<τ_0_0.Element>
+// CHECK:   apply [[FUNC_REF]]<IndexingIterator<Array<GenericStruct<T>>>>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<GenericStruct<T>>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[SOME_BB]]:

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -108,8 +108,8 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<Int>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<Int>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<Int>, #Sequence.makeIterator!1 : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[Int]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
@@ -208,8 +208,8 @@ func existentialBreak(_ xx: [P]) {
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<P>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<P>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<P>, #Sequence.makeIterator!1 : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[P]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<P>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
@@ -368,8 +368,8 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<GenericStruct<T>>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<GenericStruct<T>>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<GenericStruct<T>>, #Sequence.makeIterator!1 : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[GenericStruct<T>]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<GenericStruct<T>>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -167,8 +167,8 @@ func for_loops2() {
   // rdar://problem/19316670
   // CHECK: alloc_stack $Optional<MyClass>
   // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown]
-  // CHECK: [[NEXT:%[0-9]+]] = function_ref @$ss16IndexingIteratorV4next{{[_0-9a-zA-Z]*}}F
-  // CHECK-NEXT: apply [[NEXT]]<Array<MyClass>>
+  // CHECK: [[NEXT:%[0-9]+]] = witness_method $IndexingIterator<Array<MyClass>>, #IteratorProtocol.next!1 : <Self where Self : IteratorProtocol> (inout Self) -> () -> Self.Element? : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@inout τ_0_0) -> @out Optional<τ_0_0.Element>
+  // CHECK-NEXT: apply [[NEXT]]<IndexingIterator<Array<MyClass>>>
   // CHECK: class_method [[OBJ:%[0-9]+]] : $MyClass, #MyClass.foo!1
   let objects = [MyClass(), MyClass() ]
   for obj in objects {

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -15,6 +15,7 @@ struct BadContainer2 : Sequence { // expected-error{{type 'BadContainer2' does n
 func bad_containers_2(bc: BadContainer2) {
   for e in bc { }
   // expected-warning@-1 {{immutable value 'e' was never used; consider replacing with '_' or removing it}}
+  // expected-error@-2{{type 'BadContainer2.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }
 
 struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does not conform to protocol 'Sequence'}}
@@ -24,6 +25,7 @@ struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does n
 func bad_containers_3(bc: BadContainer3) {
   for e in bc { }
   // expected-warning@-1 {{immutable value 'e' was never used; consider replacing with '_' or removing it}}
+  // expected-error@-2{{type 'BadContainer3.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }
 
 struct BadIterator1 {}
@@ -36,6 +38,7 @@ struct BadContainer4 : Sequence { // expected-error{{type 'BadContainer4' does n
 func bad_containers_4(bc: BadContainer4) {
   for e in bc { }
   // expected-warning@-1 {{immutable value 'e' was never used; consider replacing with '_' or removing it}}
+  // expected-error@-2{{type 'BadContainer4.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }
 
 // Pattern type-checking

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -15,7 +15,6 @@ struct BadContainer2 : Sequence { // expected-error{{type 'BadContainer2' does n
 func bad_containers_2(bc: BadContainer2) {
   for e in bc { }
   // expected-warning@-1 {{immutable value 'e' was never used; consider replacing with '_' or removing it}}
-  // expected-error@-2{{type 'BadContainer2.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }
 
 struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does not conform to protocol 'Sequence'}}
@@ -25,7 +24,6 @@ struct BadContainer3 : Sequence { // expected-error{{type 'BadContainer3' does n
 func bad_containers_3(bc: BadContainer3) {
   for e in bc { }
   // expected-warning@-1 {{immutable value 'e' was never used; consider replacing with '_' or removing it}}
-  // expected-error@-2{{type 'BadContainer3.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }
 
 struct BadIterator1 {}
@@ -38,7 +36,6 @@ struct BadContainer4 : Sequence { // expected-error{{type 'BadContainer4' does n
 func bad_containers_4(bc: BadContainer4) {
   for e in bc { }
   // expected-warning@-1 {{immutable value 'e' was never used; consider replacing with '_' or removing it}}
-  // expected-error@-2{{type 'BadContainer4.Iterator' does not conform to protocol 'IteratorProtocol'}}
 }
 
 // Pattern type-checking


### PR DESCRIPTION
Rather than having the type checker look for the specific witness to
next() when type checking the for-each loop, which had the effect of
devirtualizing next() even when it shouldn't be, leave the formation
of the next() reference to SILGen. There, form it as a witness
reference, so that the SIL optimizer can choose whether to
devirtualization (or not).