### PR TITLE
Sema: Don't mark property wrapper 'modify' accessors transparent

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2009,22 +2009,22 @@ IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
     // Getters and setters for lazy properties are not @_transparent.
     if (storage->getAttrs().hasAttribute<LazyAttr>())
       return false;
+  }
 
-    // Getters/setters for a property with a wrapper are not @_transparent if
-    // the backing variable has more-restrictive access than the original
-    // property. The same goes for its storage wrapper.
-    if (auto var = dyn_cast<VarDecl>(storage)) {
-      if (auto backingVar = var->getPropertyWrapperBackingProperty()) {
-        if (backingVar->getFormalAccess() < var->getFormalAccess())
-          return false;
-      }
+  // Accessors for a property with a wrapper are not @_transparent if
+  // the backing variable has more-restrictive access than the original
+  // property. The same goes for its storage wrapper.
+  if (auto var = dyn_cast<VarDecl>(storage)) {
+    if (auto backingVar = var->getPropertyWrapperBackingProperty()) {
+      if (backingVar->getFormalAccess() < var->getFormalAccess())
+        return false;
+    }
 
-      if (auto original = var->getOriginalWrappedProperty(
-              PropertyWrapperSynthesizedPropertyKind::StorageWrapper)) {
-        auto backingVar = original->getPropertyWrapperBackingProperty();
-        if (backingVar->getFormalAccess() < var->getFormalAccess())
-          return false;
-      }
+    if (auto original = var->getOriginalWrappedProperty(
+            PropertyWrapperSynthesizedPropertyKind::StorageWrapper)) {
+      auto backingVar = original->getPropertyWrapperBackingProperty();
+      if (backingVar->getFormalAccess() < var->getFormalAccess())
+        return false;
     }
   }
 

--- a/test/SILGen/property_wrapper_coroutine.swift
+++ b/test/SILGen/property_wrapper_coroutine.swift
@@ -34,7 +34,7 @@ _ = state1.someValues
 
 // >> Check that the _modify coroutine is synthesized properly
 
-// CHECK-LABEL: sil hidden [transparent] [ossa] @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String> {
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String> {
 // CHECK: bb0([[STATE:%.*]] : $*State):
 // CHECK:  debug_value_addr [[STATE]] : $*State, var, name "self", argno {{.*}}
 // CHECK:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [unknown] [[STATE]] : $*State

--- a/test/SILGen/property_wrapper_coroutine_public.swift
+++ b/test/SILGen/property_wrapper_coroutine_public.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// Makes sure the modify coroutine is not @_transparent, since it references
+// private properties.
+
+public class Store {
+  @Published public var state: Any
+  init() {}
+}
+
+@propertyWrapper public struct Published<Value> {
+  public init(wrappedValue: Value) {}
+  public var wrappedValue: Value {
+    get {}
+    set {}
+  }
+  public static subscript<EnclosingSelf>(
+        _enclosingInstance object: EnclosingSelf,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Published<Value>>)
+      -> Value where EnclosingSelf : AnyObject {
+    get {}
+    set {}
+  }
+  public struct Publisher {}
+  public var projectedValue: Publisher {
+    mutating get {}
+  }
+}
+
+// CHECK-LABEL: sil [ossa] @$s33property_wrapper_coroutine_public5StoreC5stateypvM : $@yield_once @convention(method) (@guaranteed Store) -> @yields @inout Any {
+// CHECK: keypath $ReferenceWritableKeyPath<Store, Any>, (root $Store; settable_property $Any,  id #Store.state!getter.1 : (Store) -> () -> Any, getter @$s33property_wrapper_coroutine_public5StoreC5stateypvpACTK : $@convention(thin) (@in_guaranteed Store) -> @out Any, setter @$s33property_wrapper_coroutine_public5StoreC5stateypvpACTk : $@convention(thin) (@in_guaranteed Any, @in_guaranteed Store) -> ())
+// CHECK: keypath $ReferenceWritableKeyPath<Store, Published<Any>>, (root $Store; stored_property #Store._state : $Published<Any>)


### PR DESCRIPTION
There are certain conditions that cause them to reference
non-public properties, in particular if the property
wrapper is implemented via a subscript taking a keypath.

Instead of trying to detect this specific case though (and
possibly missing others), I'm just going to decree that
'modify' is never going to be transparent for property
wrappers.

Fixes <rdar://problem/57609867>.