### PR TITLE
Sema: Fix crash-on-invalid with 'enclosing self' property wrappers

### DIFF
--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -typecheck %s -verify -verify-ignore-unknown
+
+// FIXME: This should produce a diagnostic with a proper
+// source location. Right now, we just get three useless errors:
+
+// <unknown>:0: error: type of expression is ambiguous without more context
+// <unknown>:0: error: type of expression is ambiguous without more context
+// <unknown>:0: error: type of expression is ambiguous without more context
+
+// The actual problem is the type of the subscript declaration is wrong.
+
+public class Store {
+    @Published public var state: Any
+    init() {
+      self.state = 0
+    }
+}
+
+@propertyWrapper public struct Published<Value> {
+  public init(wrappedValue: Value) {}
+  public var wrappedValue: Value {
+    get { fatalError() }
+    set {}
+  }
+  public static subscript(_enclosingInstance object: Any,
+                          wrapped wrappedKeyPath: Any,
+                          storage storageKeyPath: Any)
+      -> Value {
+    get { fatalError() }
+    set {}
+  }
+  public struct Publisher {}
+  public var projectedValue: Publisher {
+    mutating get { fatalError() }
+  }
+}


### PR DESCRIPTION
The diagnostic is still terrible, but at least we shouldn't crash.

Fixes one manifestation of <rdar://problem/57726880>.

I also filed <https://bugs.swift.org/browse/SR-11989> to track improving
the diagnostic.