### PR TITLE
[sil] Change TermInst::getSuccessorBlockArguments() to yield SILArguments instead of SILPhiArgument since I am going to be adding SwitchEnumResult (which the API can vend as well).

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7000,7 +7000,7 @@ public:
   }
 
   using SuccessorBlockArgumentListTy =
-      TransformRange<ConstSuccessorListTy, function_ref<SILPhiArgumentArrayRef(
+      TransformRange<ConstSuccessorListTy, function_ref<ArrayRef<SILArgument *>(
                                                const SILSuccessor &)>>;
 
   /// Return the range of Argument arrays for each successor of this

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -466,7 +466,7 @@ OperandOwnershipKindClassifier::visitSwitchEnumInst(SwitchEnumInst *sei) {
   // and merge them.
   auto mergedKind = ValueOwnershipKind::merge(makeTransformRange(
       sei->getSuccessorBlockArgumentLists(),
-      [&](SILPhiArgumentArrayRef array) -> ValueOwnershipKind {
+      [&](ArrayRef<SILArgument *> array) -> ValueOwnershipKind {
         // If the array is empty, we have a non-payloaded case. Return any.
         if (array.empty())
           return ValueOwnershipKind::None;
@@ -474,8 +474,7 @@ OperandOwnershipKindClassifier::visitSwitchEnumInst(SwitchEnumInst *sei) {
         // Otherwise, we should have a single element since a payload is
         // a tuple.
         assert(std::distance(array.begin(), array.end()) == 1);
-        SILPhiArgument *arg = array.front();
-        return arg->getOwnershipKind();
+        return array.front()->getOwnershipKind();
       }));
 
   // If we failed to merge, return an empty map so we will fail to pattern match

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1219,9 +1219,9 @@ bool TermInst::isProgramTerminating() const {
 
 TermInst::SuccessorBlockArgumentListTy
 TermInst::getSuccessorBlockArgumentLists() const {
-  function_ref<SILPhiArgumentArrayRef(const SILSuccessor &)> op;
-  op = [](const SILSuccessor &succ) -> SILPhiArgumentArrayRef {
-    return succ.getBB()->getSILPhiArguments();
+  function_ref<ArrayRef<SILArgument *>(const SILSuccessor &)> op;
+  op = [](const SILSuccessor &succ) -> ArrayRef<SILArgument *> {
+    return succ.getBB()->getArguments();
   };
   return SuccessorBlockArgumentListTy(getSuccessors(), op);
 }

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -143,8 +143,8 @@ cleanupDeadTrivialPhiArgs(SILValue initialValue,
   if (ReverseInitialWorklist) {
     std::reverse(insertedPhis.begin(), insertedPhis.end());
   }
-  SmallVector<SILPhiArgument *, 8> worklist(insertedPhis.begin(),
-                                            insertedPhis.end());
+  SmallVector<SILArgument *, 8> worklist(insertedPhis.begin(),
+                                         insertedPhis.end());
   sortUnique(insertedPhis);
   SmallVector<SILValue, 8> incomingValues;
 
@@ -189,7 +189,7 @@ cleanupDeadTrivialPhiArgs(SILValue initialValue,
       auto *termInst = cast<TermInst>(user);
       for (auto succBlockArgList : termInst->getSuccessorBlockArgumentLists()) {
         llvm::copy_if(succBlockArgList, std::back_inserter(worklist),
-                      [&](SILPhiArgument *succArg) -> bool {
+                      [&](SILArgument *succArg) -> bool {
                         auto it = lower_bound(insertedPhis, succArg);
                         return it != insertedPhis.end() && *it == succArg;
                       });

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -935,8 +935,9 @@ static bool
 terminatorHasAnyKnownPhis(TermInst *ti,
                           ArrayRef<SILPhiArgument *> insertedPhiNodesSorted) {
   for (auto succArgList : ti->getSuccessorBlockArgumentLists()) {
-    if (llvm::any_of(succArgList, [&](SILPhiArgument *arg) {
-          return binary_search(insertedPhiNodesSorted, arg);
+    if (llvm::any_of(succArgList, [&](SILArgument *arg) {
+          return binary_search(insertedPhiNodesSorted,
+                               cast<SILPhiArgument>(arg));
         })) {
       return true;
     }


### PR DESCRIPTION
Title says it all.
