### PR TITLE
_isOptional(type(of:)) Does Not Do What You Think It Does

### DIFF
--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -384,7 +384,9 @@ internal func _print_unlocked<T, TargetStream: TextOutputStream>(
   // string. Check for Optional first, before checking protocol
   // conformance below, because an Optional value is convertible to a
   // protocol if its wrapped type conforms to that protocol.
-  if _isOptional(type(of: value)) {
+  // Note: _isOptional doesn't work here when T == Any, hence we
+  // use a more elaborate formulation:
+  if _openExistential(type(of: value as Any), do: _isOptional) {
     let debugPrintable = value as! CustomDebugStringConvertible
     debugPrintable.debugDescription.write(to: &target)
     return


### PR DESCRIPTION
In particular, if value is `Any` in a generic context, then `type(of: value)` is `Any.Protocol` which is never considered optional.  As a result, the first clause here (that provided special handling for printing optionals) was never actually being used for `print()` or other similar paths. (Curiously, it _was_ used for string interpolation.)

Fortunately? `print()` was producing the right results for optionals because of a dynamic cast bug that failed to unwrap optionals in these same contexts.

Resolves rdar://58302667
