### PR TITLE
[NFC] Hide SourceFile::Decls

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -137,6 +137,16 @@ public:
     Decls.push_back(d);
   }
 
+  /// Prepends a declaration to the top-level decls list.
+  ///
+  /// FIXME: This entrypoint exists to support LLDB. Calls to this function are
+  /// always a mistake, and additional uses should not be added.
+  ///
+  /// See rdar://58355191
+  void prependTopLevelDecl(Decl *d) {
+    Decls.insert(Decls.begin(), d);
+  }
+
   /// Retrieves an immutable view of the list of top-level decls in this file.
   ArrayRef<Decl *> getTopLevelDecls() const {
     return Decls;

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -125,11 +125,28 @@ private:
   /// been validated.
   llvm::SetVector<ValueDecl *> UnvalidatedDeclsWithOpaqueReturnTypes;
 
+  /// The list of top-level declarations in the source file.
+  std::vector<Decl *> Decls;
+
   friend ASTContext;
   friend Impl;
+
 public:
-  /// The list of top-level declarations in the source file.
-  std::vector<Decl*> Decls;
+  /// Appends the given declaration to the end of the top-level decls list.
+  void addTopLevelDecl(Decl *d) {
+    Decls.push_back(d);
+  }
+
+  /// Retrieves an immutable view of the list of top-level decls in this file.
+  ArrayRef<Decl *> getTopLevelDecls() const {
+    return Decls;
+  }
+
+  /// Truncates the list of top-level decls so it contains \c count elements.
+  void truncateTopLevelDecls(unsigned count) {
+    assert(count <= Decls.size() && "Can only truncate top-level decls!");
+    Decls.resize(count);
+  }
 
   /// A cache of syntax nodes that can be reused when creating the syntax tree
   /// for this file.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -794,7 +794,7 @@ namespace {
       PrintWithColorRAII(OS, ASTNodeColor) << "source_file ";
       PrintWithColorRAII(OS, LocationColor) << '\"' << SF.getFilename() << '\"';
       
-      for (Decl *D : SF.Decls) {
+      for (Decl *D : SF.getTopLevelDecls()) {
         if (D->isImplicit())
           continue;
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1193,7 +1193,7 @@ AnnotatedInsertionPoint
 ASTSourceFileScope::expandAScopeThatCreatesANewInsertionPoint(
     ScopeCreator &scopeCreator) {
   ASTScopeAssert(SF, "Must already have a SourceFile.");
-  ArrayRef<Decl *> decls = SF->Decls;
+  ArrayRef<Decl *> decls = SF->getTopLevelDecls();
   // Assume that decls are only added at the end, in source order
   ArrayRef<Decl *> newDecls = decls.slice(numberOfDeclsAlreadySeen);
   std::vector<ASTNode> newNodes(newDecls.begin(), newDecls.end());
@@ -1865,10 +1865,10 @@ void ASTScopeImpl::beCurrent() {}
 bool ASTScopeImpl::isCurrentIfWasExpanded() const { return true; }
 
 void ASTSourceFileScope::beCurrent() {
-  numberOfDeclsAlreadySeen = SF->Decls.size();
+  numberOfDeclsAlreadySeen = SF->getTopLevelDecls().size();
 }
 bool ASTSourceFileScope::isCurrentIfWasExpanded() const {
-  return SF->Decls.size() == numberOfDeclsAlreadySeen;
+  return SF->getTopLevelDecls().size() == numberOfDeclsAlreadySeen;
 }
 
 void IterableTypeScope::beCurrent() { portion->beCurrent(this); }

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -284,12 +284,12 @@ SourceRange ASTSourceFileScope::getSourceRangeOfThisASTNode(
     return SourceRange(charRange.getStart(), charRange.getEnd());
   }
 
-  if (SF->Decls.empty())
+  if (SF->getTopLevelDecls().empty())
     return SourceRange();
 
   // Use the source ranges of the declarations in the file.
-  return SourceRange(SF->Decls.front()->getStartLoc(),
-                     SF->Decls.back()->getEndLoc());
+  return SourceRange(SF->getTopLevelDecls().front()->getStartLoc(),
+                     SF->getTopLevelDecls().back()->getEndLoc());
 }
 
 SourceRange GenericTypeOrExtensionScope::getSourceRangeOfThisASTNode(

--- a/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
+++ b/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
@@ -191,7 +191,7 @@ public:
   // clang-format off
     SourceFileDeclFinder(const SourceFile *const SF, const bool includePrivateDecls)
     : includePrivateDecls(includePrivateDecls) {
-      for (const Decl *const D : SF->Decls) {
+      for (const Decl *const D : SF->getTopLevelDecls()) {
         select<ExtensionDecl, DeclKind::Extension>(D, extensions, false) ||
         select<OperatorDecl, DeclKind::InfixOperator, DeclKind::PrefixOperator,
         DeclKind::PostfixOperator>(D, operators, false) ||

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -230,7 +230,7 @@ void SourceLookupCache::populateMemberCache(const SourceFile &SF) {
 
   FrontendStatsTracer tracer(SF.getASTContext().Stats,
                              "populate-source-file-class-member-cache");
-  addToMemberCache(SF.Decls);
+  addToMemberCache(SF.getTopLevelDecls());
   MemberCachePopulated = true;
 }
 
@@ -243,7 +243,7 @@ void SourceLookupCache::populateMemberCache(const ModuleDecl &Mod) {
 
   for (const FileUnit *file : Mod.getFiles()) {
     auto &SF = *cast<SourceFile>(file);
-    addToMemberCache(SF.Decls);
+    addToMemberCache(SF.getTopLevelDecls());
   }
 
   MemberCachePopulated = true;
@@ -275,7 +275,7 @@ void SourceLookupCache::addToMemberCache(Range decls) {
 SourceLookupCache::SourceLookupCache(const SourceFile &SF) {
   FrontendStatsTracer tracer(SF.getASTContext().Stats,
                              "source-file-populate-cache");
-  addToUnqualifiedLookupCache(SF.Decls, false);
+  addToUnqualifiedLookupCache(SF.getTopLevelDecls(), false);
 }
 
 SourceLookupCache::SourceLookupCache(const ModuleDecl &M) {
@@ -283,7 +283,7 @@ SourceLookupCache::SourceLookupCache(const ModuleDecl &M) {
                              "module-populate-cache");
   for (const FileUnit *file : M.getFiles()) {
     auto &SF = *cast<SourceFile>(file);
-    addToUnqualifiedLookupCache(SF.Decls, false);
+    addToUnqualifiedLookupCache(SF.getTopLevelDecls(), false);
   }
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2470,7 +2470,7 @@ void FindLocalVal::checkGenericParams(GenericParamList *Params) {
 }
 
 void FindLocalVal::checkSourceFile(const SourceFile &SF) {
-  for (Decl *D : SF.Decls)
+  for (Decl *D : SF.getTopLevelDecls())
     if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
       visitBraceStmt(TLCD->getBody(), /*isTopLevel=*/true);
 }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -984,13 +984,13 @@ void CompilerInstance::parseAndTypeCheckMainFileUpTo(
     // For SIL we actually have to interleave parsing and type checking
     // because the SIL parser expects to see fully type checked declarations.
     if (TheSILModule) {
-      if (Done || CurTUElem < MainFile.Decls.size()) {
+      if (Done || CurTUElem < MainFile.getTopLevelDecls().size()) {
         assert(mainIsPrimary);
         performTypeChecking(MainFile, CurTUElem);
       }
     }
 
-    CurTUElem = MainFile.Decls.size();
+    CurTUElem = MainFile.getTopLevelDecls().size();
   } while (!Done);
 
   if (!TheSILModule) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -667,7 +667,7 @@ static void countStatsOfSourceFile(UnifiedStatsReporter &Stats,
                                    SourceFile *SF) {
   auto &C = Stats.getFrontendCounters();
   auto &SM = Instance.getSourceMgr();
-  C.NumDecls += SF->Decls.size();
+  C.NumDecls += SF->getTopLevelDecls().size();
   C.NumLocalTypeDecls += SF->LocalTypeDecls.size();
   C.NumObjCMethods += SF->ObjCMethods.size();
   C.NumInfixOperators += SF->InfixOperators.size();

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -252,7 +252,7 @@ ProvidesEmitter::emitTopLevelNames() const {
   out << providesTopLevel << ":\n";
 
   CollectedDeclarations cpd;
-  for (const Decl *D : SF->Decls)
+  for (const Decl *D : SF->getTopLevelDecls())
     emitTopLevelDecl(D, cpd);
   for (auto *operatorFunction : cpd.memberOperatorDecls)
     out << "- \"" << escape(operatorFunction->getName()) << "\"\n";

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -88,7 +88,7 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
     auto *parentDC = newDC->getParent();
     unsigned N;
     if (auto parentSF = dyn_cast<SourceFile>(parentDC))
-      N = findIndexInRange(D, parentSF->Decls);
+      N = findIndexInRange(D, parentSF->getTopLevelDecls());
     else if (auto parentIDC =
                  dyn_cast<IterableDeclContext>(parentDC->getAsDecl()))
       N = findIndexInRange(D, parentIDC->getMembers());
@@ -114,7 +114,7 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
     auto N = IndexStack.pop_back_val();
     Decl *D;
     if (auto parentSF = dyn_cast<SourceFile>(newDC))
-      D = getElementAt(parentSF->Decls, N);
+      D = getElementAt(parentSF->getTopLevelDecls(), N);
     else if (auto parentIDC = dyn_cast<IterableDeclContext>(newDC->getAsDecl()))
       D = getElementAt(parentIDC->getMembers(), N);
     else

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -111,7 +111,7 @@ void swift::ide::typeCheckContextUntil(DeclContext *DC, SourceLoc Loc) {
     // Here, 'value' is '<error type>' unless we explicitly typecheck the
     // 'guard' statement.
     SourceFile *SF = DC->getParentSourceFile();
-    for (auto *D : SF->Decls) {
+    for (auto *D : SF->getTopLevelDecls()) {
       if (auto Code = dyn_cast<TopLevelCodeDecl>(D)) {
         typeCheckTopLevelCodeDecl(Code);
         if (Code == TLCD)

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -667,7 +667,7 @@ static SourceLoc getDeclStartPosition(SourceFile &File) {
     return false;
   };
 
-  for (auto D : File.Decls) {
+  for (auto D : File.getTopLevelDecls()) {
     if (tryUpdateStart(D->getStartLoc())) {
       tryUpdateStart(D->getAttrs().getStartLoc());
       auto RawComment = D->getRawComment();

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -205,7 +205,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   Ctx.SourceMgr.setCodeCompletionPoint(*BufferID, CodeCompletionOffset);
 
   // Parse, typecheck and temporarily insert the incomplete code into the AST.
-  const unsigned OriginalDeclCount = SF.Decls.size();
+  const unsigned OriginalDeclCount = SF.getTopLevelDecls().size();
 
   PersistentParserState PersistentState;
   bool Done;
@@ -218,7 +218,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
 
   // Now we are done with code completion.  Remove the declarations we
   // temporarily inserted.
-  SF.Decls.resize(OriginalDeclCount);
+  SF.truncateTopLevelDecls(OriginalDeclCount);
 
   // Reset the error state because it's only relevant to the code that we just
   // processed, which now gets thrown away.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -431,7 +431,7 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
   llvm::SaveAndRestore<SourceFile *> SetCurSourceFile(CurSourceFile, &SF);
 
   // Emit types and other global decls.
-  for (auto *decl : SF.Decls)
+  for (auto *decl : SF.getTopLevelDecls())
     emitGlobalDecl(decl);
   for (auto *localDecl : SF.LocalTypeDecls)
     emitGlobalDecl(localDecl);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -175,7 +175,7 @@ namespace {
       DebuggerClient *debug_client = getDebuggerClient();
       assert (debug_client);
       debug_client->didGlobalize(D);
-      SF->Decls.push_back(D);
+      SF->addTopLevelDecl(D);
       P.markWasHandled(D);
     }
   };
@@ -250,7 +250,7 @@ void Parser::parseTopLevel() {
   for (auto Item : Items) {
     if (auto *D = Item.dyn_cast<Decl*>()) {
       assert(!isa<AccessorDecl>(D) && "accessors should not be added here");
-      SF.Decls.push_back(D);
+      SF.addTopLevelDecl(D);
     }
   }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -182,7 +182,7 @@ void Parser::performCodeCompletionSecondPassImpl(
                 } else if (auto *ED = dyn_cast<ExtensionDecl>(DC)) {
                   ED->addMember(D);
                 } else if (auto *SF = dyn_cast<SourceFile>(DC)) {
-                  SF->Decls.push_back(D);
+                  SF->addTopLevelDecl(D);
                 } else {
                   llvm_unreachable("invalid decl context kind");
                 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1670,7 +1670,7 @@ public:
 void SILGenModule::emitSourceFile(SourceFile *sf) {
   SourceFileScope scope(*this, sf);
   FrontendStatsTracer StatsTracer(getASTContext().Stats, "SILgen-file", sf);
-  for (Decl *D : sf->Decls) {
+  for (Decl *D : sf->getTopLevelDecls()) {
     FrontendStatsTracer StatsTracer(getASTContext().Stats, "SILgen-decl", D);
     visit(D);
   }

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -261,11 +261,11 @@ void swift::performDebuggerTestingTransform(SourceFile &SF) {
   // Walk over all decls in the file to find the next available closure
   // discriminator.
   DiscriminatorFinder DF;
-  for (Decl *D : SF.Decls)
+  for (Decl *D : SF.getTopLevelDecls())
     D->walk(DF);
 
   // Instrument the decls with checkExpect() sanity-checks.
-  for (Decl *D : SF.Decls) {
+  for (Decl *D : SF.getTopLevelDecls()) {
     DebuggerTestingTransform Transform{D->getASTContext(), DF};
     D->walk(Transform);
     swift::verify(D);

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -402,7 +402,7 @@ void swift::performNameBinding(SourceFile &SF, unsigned StartElem) {
 
   // Make sure we skip adding the standard library imports if the
   // source file is empty.
-  if (SF.ASTStage == SourceFile::NameBound || SF.Decls.empty()) {
+  if (SF.ASTStage == SourceFile::NameBound || SF.getTopLevelDecls().empty()) {
     SF.ASTStage = SourceFile::NameBound;
     return;
   }
@@ -417,7 +417,7 @@ void swift::performNameBinding(SourceFile &SF, unsigned StartElem) {
 
   // Do a prepass over the declarations to find and load the imported modules
   // and map operator decls.
-  for (auto D : llvm::makeArrayRef(SF.Decls).slice(StartElem)) {
+  for (auto D : SF.getTopLevelDecls().slice(StartElem)) {
     if (auto *ID = dyn_cast<ImportDecl>(D)) {
       Binder.addImport(ImportedModules, ID);
     } else if (auto *OD = dyn_cast<PrefixOperatorDecl>(D)) {

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -705,7 +705,7 @@ void swift::performPCMacro(SourceFile &SF) {
   };
 
   ExpressionFinder EF;
-  for (Decl *D : SF.Decls) {
+  for (Decl *D : SF.getTopLevelDecls()) {
     D->walk(EF);
   }
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -604,7 +604,7 @@ void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF,
   // Build refinement contexts, if necessary, for all declarations starting
   // with StartElem.
   TypeRefinementContextBuilder Builder(RootTRC, Context);
-  for (auto D : llvm::makeArrayRef(SF.Decls).slice(StartElem)) {
+  for (auto D : SF.getTopLevelDecls().slice(StartElem)) {
     Builder.build(D);
   }
 }
@@ -904,8 +904,9 @@ static const Decl *findContainingDeclaration(SourceRange ReferenceRange,
   if (!SF)
     return nullptr;
 
-  auto BestTopLevelDecl = llvm::find_if(SF->Decls, ContainsReferenceRange);
-  if (BestTopLevelDecl != SF->Decls.end())
+  auto BestTopLevelDecl = llvm::find_if(SF->getTopLevelDecls(),
+                                        ContainsReferenceRange);
+  if (BestTopLevelDecl != SF->getTopLevelDecls().end())
     return *BestTopLevelDecl;
 
   return nullptr;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -263,7 +263,7 @@ static void bindExtensions(SourceFile &SF) {
       if (!SF)
         continue;
 
-      for (auto D : SF->Decls) {
+      for (auto D : SF->getTopLevelDecls()) {
         if (auto ED = dyn_cast<ExtensionDecl>(D))
           if (!tryBindExtension(ED))
             worklist.push_back(ED);
@@ -378,7 +378,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval,
     ::bindExtensions(*SF);
 
     // Type check the top-level elements of the source file.
-    for (auto D : llvm::makeArrayRef(SF->Decls).slice(StartElem)) {
+    for (auto D : SF->getTopLevelDecls().slice(StartElem)) {
       if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
         // Immediately perform global name-binding etc.
         TypeChecker::typeCheckTopLevelCodeDecl(TLCD);
@@ -465,7 +465,7 @@ void swift::checkInconsistentImplementationOnlyImports(ModuleDecl *MainModule) {
     if (!SF)
       continue;
 
-    for (auto *topLevelDecl : SF->Decls) {
+    for (auto *topLevelDecl : SF->getTopLevelDecls()) {
       auto *nextImport = dyn_cast<ImportDecl>(topLevelDecl);
       if (!nextImport)
         continue;

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -30,7 +30,7 @@ static void declareOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
   auto decl = new (ctx) EnumDecl(SourceLoc(), name, SourceLoc(),
                                  /*inherited*/{}, params, fileForLookups);
   wrapped->setDeclContext(decl);
-  fileForLookups->Decls.push_back(decl);
+  fileForLookups->addTopLevelDecl(decl);
 }
 
 TestContext::TestContext(ShouldDeclareOptionalTypes optionals)


### PR DESCRIPTION
In preparation for installing some stable paths infrastructure here,
hide access to the array of top-level decls.