### PR TITLE
ASTMangler: ignore original module name when DWARFMangling is enabled

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -499,6 +499,7 @@ std::string ASTMangler::mangleTypeAsUSR(Type Ty) {
 
 std::string ASTMangler::mangleDeclAsUSR(const ValueDecl *Decl,
                                         StringRef USRPrefix) {
+  DWARFMangling = true;
   beginManglingWithoutPrefix();
   llvm::SaveAndRestore<bool> allowUnnamedRAII(AllowNamelessEntities, true);
   Buffer << USRPrefix;
@@ -1790,7 +1791,12 @@ void ASTMangler::appendModule(const ModuleDecl *module,
     assert(useModuleName.empty());
     return appendOperator("SC");
   }
-  if (!useModuleName.empty())
+
+  // Enabling DWARFMangling indicate the mangled names are not part of the ABI,
+  // probably used by the debugger or IDE (USR). These mangled names will not be
+  // demangled successfully if we use the original module name instead of the
+  // actual module name.
+  if (!useModuleName.empty() && !DWARFMangling)
     appendIdentifier(useModuleName);
   else
     appendIdentifier(ModName);

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -247,3 +247,9 @@ private
 func patatino<T: Comparable>(_ vers1: T, _ vers2: T) -> Bool {
   return vers1 < vers2;
 }
+
+@available(OSX 10.9, *)
+@_originallyDefinedIn(module: "OtherModule", OSX 10.13)
+public struct MovedHere {
+  public func foo() {}
+}


### PR DESCRIPTION
Enabling DWARFMangling indicates the mangled name will be used by either
debugger or IDE. We could and should avoid using the original module name so
demangling will keep working.

rdar://58355404