### PR TITLE
[ConstraintSystem] Finish porting unresolved member reference failures.

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -472,14 +472,15 @@ UseSubscriptOperator *UseSubscriptOperator::create(ConstraintSystem &cs,
 bool DefineMemberBasedOnUse::diagnose(bool asNote) const {
   auto failure = MissingMemberFailure(getConstraintSystem(), BaseType,
                                       Name, getLocator());
-  return failure.diagnose(asNote);
+  return AlreadyDiagnosed || failure.diagnose(asNote);
 }
 
 DefineMemberBasedOnUse *
 DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
-                               DeclNameRef member, ConstraintLocator *locator) {
+                               DeclNameRef member, bool alreadyDiagnosed,
+                               ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      DefineMemberBasedOnUse(cs, baseType, member, locator);
+      DefineMemberBasedOnUse(cs, baseType, member, alreadyDiagnosed, locator);
 }
 
 AllowMemberRefOnExistential *

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -806,10 +806,19 @@ class DefineMemberBasedOnUse final : public ConstraintFix {
   Type BaseType;
   DeclNameRef Name;
 
+  /// Whether or not the member error is already diagnosed. This can happen
+  /// when referencing an erroneous member, and the error is diagnosed at the
+  /// member declaration.
+  ///
+  /// We still want to define erroneous members based on use in order to find
+  /// a solution through the new diagnostic infrastructure, but we don't
+  /// want to report a second error message.
+  bool AlreadyDiagnosed;
+
   DefineMemberBasedOnUse(ConstraintSystem &cs, Type baseType, DeclNameRef member,
-                         ConstraintLocator *locator)
+                         bool alreadyDiagnosed, ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::DefineMemberBasedOnUse, locator),
-        BaseType(baseType), Name(member) {}
+        BaseType(baseType), Name(member), AlreadyDiagnosed(alreadyDiagnosed) {}
 
 public:
   std::string getName() const override {
@@ -822,7 +831,7 @@ public:
   bool diagnose(bool asNote = false) const override;
 
   static DefineMemberBasedOnUse *create(ConstraintSystem &cs, Type baseType,
-                                        DeclNameRef member,
+                                        DeclNameRef member, bool alreadyDiagnosed,
                                         ConstraintLocator *locator);
 };
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -251,7 +251,8 @@ struct Toe {
   let toenail: Nail // expected-error {{use of undeclared type 'Nail'}}
 
   func clip() {
-    toenail.inspect { x in
+    // FIXME: We shouldn't report this because toenail.inspect is a hole
+    toenail.inspect { x in // expected-error {{unable to infer closure return type; add explicit type to disambiguate}}
       toenail.inspect { y in }
     }
   }

--- a/test/Constraints/rdar46377919.swift
+++ b/test/Constraints/rdar46377919.swift
@@ -9,5 +9,4 @@ class Foo {
 
 func foo() -> Foo {
   return Foo(lhs: 2, rhs: 2)
-  // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '<<error type>>'}}
 }


### PR DESCRIPTION
This covers member failures where the error is at the declaration, so the result of member lookup is "already diagnosed".

We record references to erroneous member declarations as a hole in order to allow the constraint solver to continue, and to suppress diagnostics at the site of the reference (since the error is already diagnosed at the declaration).

Note: We need to record and diagnose at least one fix in order to solve the constraint system in the new diagnostic infrastructure. For this reason, we record the `DefineMemberBasedOnUse` fix for erroneous members, but flag the fix as "already diagnosed" to suppress the error message.
