### PR TITLE
[sil] Add a new builder for Arguments called SILArgumentBuilder and use that in SILBasicBlock to create arguments instead of doing it manually.

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -21,6 +21,7 @@
 namespace swift {
 
 class SILBasicBlock;
+class SILArgumentBuilder;
 class SILModule;
 class SILUndef;
 
@@ -62,7 +63,7 @@ struct SILArgumentKind {
 };
 
 class SILArgument : public ValueBase {
-  friend class SILBasicBlock;
+  friend class SILArgumentBuilder;
 
   SILBasicBlock *parentBlock;
   const ValueDecl *decl;
@@ -185,7 +186,7 @@ protected:
 };
 
 class SILPhiArgument : public SILArgument {
-  friend class SILBasicBlock;
+  friend class SILArgumentBuilder;
 
   SILPhiArgument(SILBasicBlock *parentBlock, SILType type,
                  ValueOwnershipKind ownershipKind,
@@ -272,7 +273,7 @@ public:
 };
 
 class SILFunctionArgument : public SILArgument {
-  friend class SILBasicBlock;
+  friend class SILArgumentBuilder;
 
   SILFunctionArgument(SILBasicBlock *parentBlock, SILType type,
                       ValueOwnershipKind ownershipKind,

--- a/include/swift/SIL/SILArgumentBuilder.h
+++ b/include/swift/SIL/SILArgumentBuilder.h
@@ -1,0 +1,120 @@
+//===--- SILArgumentBuilder.h --------------------------------*- c++ -*----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILARGUMENTBUILDER_H
+#define SWIFT_SIL_SILARGUMENTBUILDER_H
+
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILBasicBlock.h"
+
+namespace swift {
+
+class SILPhiArgument;
+struct ValueOwnershipKind;
+class ValueDecl;
+class SILType;
+
+class SILArgumentBuilder {
+  SILBasicBlock *block;
+  bool disableEntryBlockVerification;
+
+public:
+  SILArgumentBuilder(SILBasicBlock *block,
+                     bool disableEntryBlockVerification = false)
+      : block(block),
+        disableEntryBlockVerification(disableEntryBlockVerification) {}
+
+  using arg_iterator = SILBasicBlock::arg_iterator;
+
+  // Creation routines for non function arguments.
+#define ARGUMENT_BOILERPLATE(CLASSNAME, PRETTYNAME)                            \
+  CLASSNAME *replace##PRETTYNAME(unsigned i, SILType type,                     \
+                                 ValueOwnershipKind kind,                      \
+                                 const ValueDecl *decl = nullptr) {            \
+    auto *newArg =                                                             \
+        replaceArgument(SILArgumentKind::CLASSNAME, i, type, kind, decl);      \
+    return cast<CLASSNAME>(newArg);                                            \
+  }                                                                            \
+  CLASSNAME *replace##PRETTYNAME##AndReplaceAllUses(                           \
+      unsigned i, SILType type, ValueOwnershipKind kind,                       \
+      const ValueDecl *decl = nullptr) {                                       \
+    auto *newArg = replaceArgumentAndReplaceAllUses(                           \
+        SILArgumentKind::CLASSNAME, i, type, kind, decl);                      \
+    return cast<CLASSNAME>(newArg);                                            \
+  }                                                                            \
+  CLASSNAME *create##PRETTYNAME(SILType type,                                  \
+                                ValueOwnershipKind ownershipKind,              \
+                                const ValueDecl *decl = nullptr) {             \
+    auto *newArg =                                                             \
+        createArgument(SILArgumentKind::CLASSNAME, type, ownershipKind, decl); \
+    return cast<CLASSNAME>(newArg);                                            \
+  }                                                                            \
+  CLASSNAME *insert##PRETTYNAME(arg_iterator insertPt, SILType type,           \
+                                ValueOwnershipKind ownershipKind,              \
+                                const ValueDecl *decl = nullptr) {             \
+    auto *newArg = insertArgument(SILArgumentKind::CLASSNAME, insertPt, type,  \
+                                  ownershipKind, decl);                        \
+    return cast<CLASSNAME>(newArg);                                            \
+  }                                                                            \
+  CLASSNAME *insert##PRETTYNAME(unsigned index, SILType type,                  \
+                                ValueOwnershipKind ownershipKind,              \
+                                const ValueDecl *decl = nullptr) {             \
+    arg_iterator insertPt = std::next(block->args_begin(), index);             \
+    return insert##PRETTYNAME(insertPt, type, ownershipKind, decl);            \
+  }
+  ARGUMENT_BOILERPLATE(SILFunctionArgument, FunctionArgument)
+  ARGUMENT_BOILERPLATE(SILPhiArgument, PhiArgument)
+#undef ARGUMENT_BOILERPLATE
+
+private:
+  //===---
+  // PImpl Declarations for non function arguments
+  //
+
+  /// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and
+  /// ValueDecl \p D.
+  ///
+  /// NOTE: This assumes that the current argument in position \p i has had its
+  /// uses eliminated. To replace/replace all uses with, use
+  /// replaceArgumentAndRAUW.
+  SILArgument *replaceArgument(SILArgumentKind argKind, unsigned i,
+                               SILType type, ValueOwnershipKind kind,
+                               const ValueDecl *decl = nullptr);
+
+  /// Replace phi argument \p i and RAUW all uses.
+  SILArgument *
+  replaceArgumentAndReplaceAllUses(SILArgumentKind argKind, unsigned i,
+                                   SILType type, ValueOwnershipKind kind,
+                                   const ValueDecl *decl = nullptr);
+
+  /// Allocate a new argument of type \p Ty and append it to the argument
+  /// list. Optionally you can pass in a value decl parameter.
+  SILArgument *createArgument(SILArgumentKind argKind, SILType type,
+                              ValueOwnershipKind ownershipKind,
+                              const ValueDecl *decl = nullptr);
+
+  /// Insert a new SILArgument with type \p Ty and \p Decl at
+  /// position \p Pos.
+  SILArgument *insertArgument(SILArgumentKind argKind, arg_iterator insertPt,
+                              SILType type, ValueOwnershipKind ownershipKind,
+                              const ValueDecl *decl = nullptr);
+
+  template <typename... ArgTys>
+  SILArgument *constructArgumentInternal(SILArgumentKind argKind,
+                                         ArgTys &&... argTys);
+
+  void validateEntryBlock(SILArgumentKind kind) const;
+};
+
+} // namespace swift
+
+#endif

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -19,6 +19,7 @@ add_swift_host_library(swiftSIL STATIC
   Projection.cpp
   SIL.cpp
   SILArgument.cpp
+  SILArgumentBuilder.cpp
   SILBasicBlock.cpp
   SILBuilder.cpp
   SILConstants.cpp

--- a/lib/SIL/SILArgumentBuilder.cpp
+++ b/lib/SIL/SILArgumentBuilder.cpp
@@ -1,0 +1,127 @@
+//===--- SILArgumentBuilder.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILArgumentBuilder.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILUndef.h"
+
+using namespace swift;
+
+void SILArgumentBuilder::validateEntryBlock(SILArgumentKind kind) const {
+  if (disableEntryBlockVerification)
+    return;
+
+  assert((kind != SILArgumentKind::SILFunctionArgument ||
+          disableEntryBlockVerification || block->isEntry()) &&
+         "Function Arguments can only be in the entry block");
+  assert((kind == SILArgumentKind::SILFunctionArgument || !block->isEntry()) &&
+         "Non function arguments can not be in the entry block");
+}
+
+/// A helper routine that dispatches a constructor call to the appropriate
+/// non-function argument constructor.
+template <typename... ArgTys>
+SILArgument *
+SILArgumentBuilder::constructArgumentInternal(SILArgumentKind argKind,
+                                              ArgTys &&... argTys) {
+  auto &mod = block->getModule();
+  switch (argKind) {
+  case SILArgumentKind::SILPhiArgument:
+    return new (mod) SILPhiArgument(std::forward<ArgTys>(argTys)...);
+  case SILArgumentKind::SILFunctionArgument:
+    return new (mod)
+        SILFunctionArgument(std::forward<ArgTys>(argTys)...);
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
+}
+
+/// Replace the \p{i}th BB arg with a new BBArg with SILType \p Ty and
+/// ValueDecl \p D.
+///
+/// NOTE: This assumes that the current argument in position \p i has had its
+/// uses eliminated. To replace/replace all uses with, use
+/// replacePhiArgumentAndRAUW.
+SILArgument *SILArgumentBuilder::replaceArgument(
+    SILArgumentKind argKind, unsigned i, SILType type,
+    ValueOwnershipKind ownershipKind, const ValueDecl *decl) {
+  validateEntryBlock(argKind);
+
+  if (type.isTrivial(*block->getParent()))
+    ownershipKind = ValueOwnershipKind::None;
+
+  SILModule &mod = block->getModule();
+
+  auto argIter = std::next(block->args_begin(), i);
+  assert((*argIter)->use_empty() && "Expected no uses of the old BB arg!");
+
+  // Notify the delete handlers that this argument is being deleted.
+  mod.notifyDeleteHandlers(*argIter);
+
+  auto *newArg = constructArgumentInternal(argKind, type, ownershipKind, decl);
+  newArg->setParent(block);
+
+  // TODO: When we switch to malloc/free allocation we'll be leaking memory
+  // here.
+  *argIter = newArg;
+
+  return newArg;
+}
+
+/// Replace phi argument \p i and RAUW all uses.
+SILArgument *SILArgumentBuilder::replaceArgumentAndReplaceAllUses(
+    SILArgumentKind argKind, unsigned i, SILType type,
+    ValueOwnershipKind ownershipKind, const ValueDecl *decl) {
+  // Put in an undef placeholder before we do the replacement since
+  // replacePhiArgument() expects the replaced argument to not have
+  // any uses.
+  SmallVector<Operand *, 16> operands;
+  SILValue undef = SILUndef::get(type, *block->getParent());
+  for (auto *use : block->getArgument(i)->getUses()) {
+    use->set(undef);
+    operands.push_back(use);
+  }
+
+  // Perform the replacement.
+  auto *newArg = replaceArgument(argKind, i, type, ownershipKind, decl);
+
+  // Wire back up the uses.
+  while (!operands.empty()) {
+    operands.pop_back_val()->set(newArg);
+  }
+
+  return newArg;
+}
+
+/// Allocate a new argument of type \p Ty and append it to the argument
+/// list. Optionally you can pass in a value decl parameter.
+SILArgument *
+SILArgumentBuilder::createArgument(SILArgumentKind argKind, SILType type,
+                                   ValueOwnershipKind ownershipKind,
+                                   const ValueDecl *decl) {
+  validateEntryBlock(argKind);
+  if (type.isTrivial(*block->getParent()))
+    ownershipKind = ValueOwnershipKind::None;
+  return constructArgumentInternal(argKind, block, type, ownershipKind, decl);
+}
+
+/// Insert a new SILPhiArgument with type \p Ty and \p Decl at position \p
+/// Pos.
+SILArgument *SILArgumentBuilder::insertArgument(
+    SILArgumentKind argKind, arg_iterator insertPt, SILType type,
+    ValueOwnershipKind ownershipKind, const ValueDecl *decl) {
+  validateEntryBlock(argKind);
+  if (type.isTrivial(*block->getParent()))
+    ownershipKind = ValueOwnershipKind::None;
+  return constructArgumentInternal(argKind, block, insertPt, type, ownershipKind,
+                                   decl);
+}


### PR DESCRIPTION
With time, we are going to move to a world where SILBasicBlock is not in the
business of constructing SILArguments. With that in mind, this commit refactors
the impl in SILBasicBlock to use this builder instead. Naturally, this means
that SILBasicBlock is no longer a friend class of SILArgument, eliminating an
abstraction leak!

That being said, there are a ton of call sites that call these
SILBasicBlock::*Argument methods that we will need to fix over time and until
that happens, we can not eliminate the old method. This commit at least allows
us to stauch the bleeding and ensures that I can put create methods for some of
the new arguments I am adding, only onto the arg builder class.

Should be NFC.
