### PR TITLE
[semantic-arc-opts] Use the LiveRange abstraction to find destroys instead of iterating over direct uses so we handle forwarding uses.

### DIFF
--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -589,11 +589,8 @@ bb0(%x : @owned $ClassLet):
   return undef : $()
 }
 
-// We do not support this today, but we will once forwarding is ignored when
-// checking if the load [copy] is a dead live range.
-//
 // CHECK-LABEL: sil [ossa] @dont_copy_let_properties_with_borrowed_base_that_dominates_projtestcase :
-// CHECK: load [copy]
+// CHECK: load_borrow
 // CHECK: } // end sil function 'dont_copy_let_properties_with_borrowed_base_that_dominates_projtestcase'
 sil [ossa] @dont_copy_let_properties_with_borrowed_base_that_dominates_projtestcase : $@convention(thin) (@owned ClassLet) -> () {
 bb0(%x : @owned $ClassLet):
@@ -613,11 +610,8 @@ bb0(%x : @owned $ClassLet):
   return undef : $()
 }
 
-// We do not support this today, but we will once forwarding is ignored when
-// checking if the load [copy] is a dead live range.
-//
 // CHECK-LABEL: sil [ossa] @dont_copy_let_properties_with_borrowed_base_that_dominates_projtestcase_2 :
-// CHECK: load [copy]
+// CHECK: load_borrow
 // CHECK: } // end sil function 'dont_copy_let_properties_with_borrowed_base_that_dominates_projtestcase_2'
 sil [ossa] @dont_copy_let_properties_with_borrowed_base_that_dominates_projtestcase_2 : $@convention(thin) (@owned ClassLet) -> () {
 bb0(%x : @owned $ClassLet):


### PR DESCRIPTION
Previously, we were incorrectly handling these test cases since we weren't
properly finding destroys through forwarding instructions. I fixed that in a
previous commit by changing the code here to only support load [copy] without
forwarding instructions.

In this commit, I change the code to instead use the LiveRange abstraction. The
LiveRange abstraction already knows how to find destroys through forwarding
instructions and has this destroy array already computed for us!

So we get better runtime performance of code (due to the better opt) and better
compile time (since we aren't computing the destroy list twice)!

rdar://58289320
