### PR TITLE
[Type checker] Make typeCheckPattern() a functional request

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -20,6 +20,7 @@
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Evaluator.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/SimpleRequest.h"
 #include "swift/AST/TypeResolutionStage.h"
 #include "swift/Basic/AnyValue.h"
@@ -33,6 +34,7 @@ namespace swift {
 class AbstractStorageDecl;
 class AccessorDecl;
 enum class AccessorKind;
+class ContextualPattern;
 class DefaultArgumentExpr;
 class GenericParamList;
 class PrecedenceGroupDecl;
@@ -1988,6 +1990,32 @@ public:
     // the constraint system that created them.
     auto ty = std::get<0>(getStorage());
     return !ty->hasTypeVariable();
+  }
+};
+
+/// Determines the type of a given pattern.
+///
+/// Note that this returns the "raw" pattern type, which can involve
+/// unresolved types and unbound generic types where type inference is
+/// allowed.
+class PatternTypeRequest
+    : public SimpleRequest<PatternTypeRequest, Type(ContextualPattern),
+                           CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<Type> evaluate(
+      Evaluator &evaluator, ContextualPattern pattern) const;
+
+public:
+  bool isCached() const { return true; }
+
+  SourceLoc getNearestLoc() const {
+    return std::get<0>(getStorage()).getPattern()->getLoc();
   }
 };
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -216,3 +216,6 @@ SWIFT_REQUEST(TypeChecker, TypeWitnessRequest,
 SWIFT_REQUEST(TypeChecker, ValueWitnessRequest,
               Witness(NormalProtocolConformance *, ValueDecl *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, PatternTypeRequest,
+              Type(ContextualPattern),
+              Cached, HasNearestLocation)

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -496,3 +496,33 @@ const UnifiedStatsReporter::TraceFormatter*
 FrontendStatsTracer::getTraceFormatter<const Pattern *>() {
   return &TF;
 }
+
+
+ContextualPattern ContextualPattern::forPatternBindingDecl(
+    PatternBindingDecl *pbd, unsigned index) {
+  return ContextualPattern(
+      pbd->getPattern(index), /*isTopLevel=*/true, pbd, index);
+}
+
+DeclContext *ContextualPattern::getDeclContext() const {
+  if (auto pbd = getPatternBindingDecl())
+    return pbd->getDeclContext();
+
+  return declOrContext.get<DeclContext *>();
+}
+
+PatternBindingDecl *ContextualPattern::getPatternBindingDecl() const {
+  return declOrContext.dyn_cast<PatternBindingDecl *>();
+}
+
+bool ContextualPattern::allowsInference() const {
+  if (auto pbd = getPatternBindingDecl())
+    return pbd->isInitialized(index);
+
+  return true;
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const ContextualPattern &pattern) {
+  out << "(pattern @ " << pattern.getPattern() << ")";
+}

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2159,9 +2159,9 @@ namespace {
 
       case PatternKind::Typed: {
         // FIXME: Need a better locator for a pattern as a base.
-        TypeResolutionOptions options(TypeResolverContext::InExpression);
-        options |= TypeResolutionFlags::AllowUnboundGenerics;
-        Type type = TypeChecker::typeCheckPattern(pattern, CurDC, options);
+        auto contextualPattern =
+            ContextualPattern::forRawPattern(pattern, CurDC);
+        Type type = TypeChecker::typeCheckPattern(contextualPattern);
         Type openedType = CS.openUnboundGenericType(type, locator);
 
         // For a typed pattern, simply return the opened type of the pattern.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2158,10 +2158,11 @@ namespace {
       }
 
       case PatternKind::Typed: {
-        auto typedPattern = cast<TypedPattern>(pattern);
         // FIXME: Need a better locator for a pattern as a base.
-        Type openedType = CS.openUnboundGenericType(typedPattern->getType(),
-                                                    locator);
+        TypeResolutionOptions options(TypeResolverContext::InExpression);
+        options |= TypeResolutionFlags::AllowUnboundGenerics;
+        Type type = TypeChecker::typeCheckPattern(pattern, CurDC, options);
+        Type openedType = CS.openUnboundGenericType(type, locator);
 
         // For a typed pattern, simply return the opened type of the pattern.
         // FIXME: Error recovery if the type is an error type?

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2864,10 +2864,8 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
     if (pattern->hasType())
       patternType = pattern->getType();
     else {
-      TypeResolutionOptions options(TypeResolverContext::InExpression);
-      options |= TypeResolutionFlags::AllowUnspecifiedTypes;
-      options |= TypeResolutionFlags::AllowUnboundGenerics;
-      patternType = typeCheckPattern(pattern, DC, options);
+      auto contextualPattern = ContextualPattern::forRawPattern(pattern, DC);
+      patternType = typeCheckPattern(contextualPattern);
     }
 
     if (patternType->hasError()) {
@@ -2995,11 +2993,9 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
         return true;
       }
 
-      TypeResolutionOptions options(TypeResolverContext::InExpression);
-      options |= TypeResolutionFlags::AllowUnspecifiedTypes;
-      options |= TypeResolutionFlags::AllowUnboundGenerics;
-      Type patternType = TypeChecker::typeCheckPattern(
-          Stmt->getPattern(), DC, options);
+      auto contextualPattern =
+          ContextualPattern::forRawPattern(Stmt->getPattern(), DC);
+      Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
       if (patternType->hasError()) {
         // FIXME: Handle errors better.
         Stmt->getPattern()->setType(ErrorType::get(ctx));
@@ -3221,10 +3217,8 @@ bool TypeChecker::typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
 
     // Check the pattern, it allows unspecified types because the pattern can
     // provide type information.
-    TypeResolutionOptions options(TypeResolverContext::InExpression);
-    options |= TypeResolutionFlags::AllowUnspecifiedTypes;
-    options |= TypeResolutionFlags::AllowUnboundGenerics;
-    Type patternType = TypeChecker::typeCheckPattern(pattern, dc, options);
+    auto contextualPattern = ContextualPattern::forRawPattern(pattern, dc);
+    Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
     if (patternType->hasError()) {
       typeCheckPatternFailed();
       continue;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2566,7 +2566,8 @@ TypeChecker::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
 }
 
 bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
-                                   DeclContext *DC) {
+                                   DeclContext *DC,
+                                   Type patternType) {
 
   /// Type checking listener for pattern binding initializers.
   class BindingListener : public ExprTypeCheckListener {
@@ -2763,8 +2764,10 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
   // if there's an error we can use that information to inform diagnostics.
   contextualPurpose = CTP_Initialization;
 
-  if (pattern->hasType()) {
-    contextualType = TypeLoc::withoutLoc(pattern->getType());
+  if (isa<OptionalSomePattern>(pattern)) {
+    flags |= TypeCheckExprFlags::ExpressionTypeMustBeOptional;
+  } else if (patternType && !patternType->isEqual(Context.TheUnresolvedType)) {
+    contextualType = TypeLoc::withoutLoc(patternType);
 
     // If we already had an error, don't repeat the problem.
     if (contextualType.getType()->hasError())
@@ -2772,7 +2775,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
     
     // Allow the initializer expression to establish the underlying type of an
     // opaque type.
-    if (auto opaqueType = pattern->getType()->getAs<OpaqueTypeArchetypeType>()){
+    if (auto opaqueType = patternType->getAs<OpaqueTypeArchetypeType>()){
       flags |= TypeCheckExprFlags::ConvertTypeIsOpaqueReturnType;
       flags -= TypeCheckExprFlags::ConvertTypeIsOnlyAHint;
     }
@@ -2780,11 +2783,12 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
     // Only provide a TypeLoc if it makes sense to allow diagnostics.
     if (auto *typedPattern = dyn_cast<TypedPattern>(pattern)) {
       const Pattern *inner = typedPattern->getSemanticsProvidingPattern();
-      if (isa<NamedPattern>(inner) || isa<AnyPattern>(inner))
+      if (isa<NamedPattern>(inner) || isa<AnyPattern>(inner)) {
         contextualType = typedPattern->getTypeLoc();
+        if (!contextualType.getType())
+          contextualType.setType(patternType);
+      }
     }
-  } else if (isa<OptionalSomePattern>(pattern)) {
-    flags |= TypeCheckExprFlags::ExpressionTypeMustBeOptional;
   }
     
   // Type-check the initializer.
@@ -2797,6 +2801,8 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
         ? TypeResolverContext::EditorPlaceholderExpr
         : TypeResolverContext::InExpression;
     options |= TypeResolutionFlags::OverrideType;
+    options |= TypeResolutionFlags::AllowUnspecifiedTypes;
+    options |= TypeResolutionFlags::AllowUnboundGenerics;
 
     // FIXME: initTy should be the same as resultTy; now that typeCheckExpression()
     // returns a Type and not bool, we should be able to simplify the listener
@@ -2819,7 +2825,8 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
   // and its variables, to prevent it from being referenced by the constraint
   // system.
   if (!resultTy &&
-      (!pattern->hasType() || pattern->getType()->hasUnboundGenericType())) {
+      (patternType->hasUnresolvedType() ||
+       patternType->hasUnboundGenericType())) {
     pattern->setType(ErrorType::get(Context));
     pattern->forEachVariable([&](VarDecl *var) {
       // Don't change the type of a variable that we've been able to
@@ -2837,7 +2844,8 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 }
 
 bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
-                                          unsigned patternNumber) {
+                                          unsigned patternNumber,
+                                          Type patternType) {
   Pattern *pattern = PBD->getPattern(patternNumber);
   Expr *init = PBD->getInit(patternNumber);
 
@@ -2851,7 +2859,24 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
       DC = initContext;
   }
 
-  bool hadError = TypeChecker::typeCheckBinding(pattern, init, DC);
+  // If we weren't given a pattern type, compute one now.
+  if (!patternType) {
+    if (pattern->hasType())
+      patternType = pattern->getType();
+    else {
+      TypeResolutionOptions options(TypeResolverContext::InExpression);
+      options |= TypeResolutionFlags::AllowUnspecifiedTypes;
+      options |= TypeResolutionFlags::AllowUnboundGenerics;
+      patternType = typeCheckPattern(pattern, DC, options);
+    }
+
+    if (patternType->hasError()) {
+      PBD->setInvalid();
+      return true;
+    }
+  }
+
+  bool hadError = TypeChecker::typeCheckBinding(pattern, init, DC, patternType);
   if (!init) {
     PBD->setInvalid();
     return true;
@@ -2973,7 +2998,9 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
       TypeResolutionOptions options(TypeResolverContext::InExpression);
       options |= TypeResolutionFlags::AllowUnspecifiedTypes;
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (TypeChecker::typeCheckPattern(Stmt->getPattern(), DC, options)) {
+      Type patternType = TypeChecker::typeCheckPattern(
+          Stmt->getPattern(), DC, options);
+      if (patternType->hasError()) {
         // FIXME: Handle errors better.
         Stmt->getPattern()->setType(ErrorType::get(ctx));
         return true;
@@ -3040,6 +3067,8 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
       Pattern *pattern = Stmt->getPattern();
       TypeResolutionOptions options(TypeResolverContext::ForEachStmt);
       options |= TypeResolutionFlags::OverrideType;
+      options |= TypeResolutionFlags::AllowUnboundGenerics;
+      options |= TypeResolutionFlags::AllowUnspecifiedTypes;
       if (TypeChecker::coercePatternToType(pattern,
                                            TypeResolution::forContextual(DC),
                                            InitType, options)) {
@@ -3195,7 +3224,8 @@ bool TypeChecker::typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
     TypeResolutionOptions options(TypeResolverContext::InExpression);
     options |= TypeResolutionFlags::AllowUnspecifiedTypes;
     options |= TypeResolutionFlags::AllowUnboundGenerics;
-    if (TypeChecker::typeCheckPattern(pattern, dc, options)) {
+    Type patternType = TypeChecker::typeCheckPattern(pattern, dc, options);
+    if (patternType->hasError()) {
       typeCheckPatternFailed();
       continue;
     }
@@ -3203,7 +3233,7 @@ bool TypeChecker::typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
     // If the pattern didn't get a type, it's because we ran into some
     // unknown types along the way. We'll need to check the initializer.
     auto init = elt.getInitializer();
-    hadError |= TypeChecker::typeCheckBinding(pattern, init, dc);
+    hadError |= TypeChecker::typeCheckBinding(pattern, init, dc, patternType);
     elt.setPattern(pattern);
     elt.setInitializer(init);
     hadAnyFalsable |= pattern->isRefutablePattern();

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include <utility>
 using namespace swift;
@@ -704,6 +705,14 @@ static Type validateTypedPattern(TypeResolution resolution,
 }
 
 Type TypeChecker::typeCheckPattern(ContextualPattern pattern) {
+  DeclContext *dc = pattern.getDeclContext();
+  ASTContext &ctx = dc->getASTContext();
+  return evaluateOrDefault(
+      ctx.evaluator, PatternTypeRequest{pattern}, ErrorType::get(ctx));
+}
+
+llvm::Expected<Type> PatternTypeRequest::evaluate(
+    Evaluator &evaluator, ContextualPattern pattern) const {
   Pattern *P = pattern.getPattern();
   DeclContext *dc = pattern.getDeclContext();
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -256,9 +256,11 @@ PatternBindingEntryRequest::evaluate(Evaluator &eval,
     }
   } else {
     // Coerce the pattern to the computed type.
-    auto resolution = TypeResolution::forContextual(binding->getDeclContext());
-    if (TypeChecker::coercePatternToType(pattern, resolution,
-                                         patternType, options)) {
+    if (auto newPattern = TypeChecker::coercePatternToType(
+            contextualPattern, patternType,
+            TypeResolverContext::PatternBindingDecl)) {
+      pattern = newPattern;
+    } else {
       binding->setInvalid();
       pattern->setType(ErrorType::get(Context));
       return &pbe;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -206,6 +206,8 @@ PatternBindingEntryRequest::evaluate(Evaluator &eval,
   // In particular, it's /not/ correct to check the PBD's DeclContext because
   // top-level variables in a script file are accessible from other files,
   // even though the PBD is inside a TopLevelCodeDecl.
+  auto contextualPattern =
+      ContextualPattern::forPatternBindingDecl(binding, entryNumber);
   TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
 
   if (binding->isInitialized(entryNumber)) {
@@ -214,8 +216,7 @@ PatternBindingEntryRequest::evaluate(Evaluator &eval,
     options |= TypeResolutionFlags::AllowUnboundGenerics;
   }
 
-  Type patternType = TypeChecker::typeCheckPattern(
-      pattern, binding->getDeclContext(), options);
+  Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
   if (patternType->hasError()) {
     swift::setBoundVarsTypeError(pattern, Context);
     binding->setInvalid();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1003,8 +1003,11 @@ public:
   /// \param dc The context in which type checking occurs.
   /// \param options Options that control type resolution.
   ///
-  /// \returns true if any errors occurred during type checking.
-  static bool typeCheckPattern(Pattern *P, DeclContext *dc,
+  /// \returns the type of the pattern, which may be an error type if an
+  /// unrecoverable error occurred. If the options permit it, the type may
+  /// involve \c UnresolvedType (for patterns with no type information) and
+  /// unbound generic types.
+  static Type typeCheckPattern(Pattern *P, DeclContext *dc,
                                TypeResolutionOptions options);
 
   static bool typeCheckCatchPattern(CatchStmt *S, DeclContext *dc);
@@ -1029,8 +1032,11 @@ public:
                                         AnyFunctionType *FN);
   
   /// Type-check an initialized variable pattern declaration.
-  static bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC);
-  static bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber);
+  static bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC,
+                               Type patternType);
+  static bool typeCheckPatternBinding(PatternBindingDecl *PBD,
+                                      unsigned patternNumber,
+                                      Type patternType = Type());
 
   /// Type-check a for-each loop's pattern binding and sequence together.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1009,15 +1009,14 @@ public:
 
   /// Coerce a pattern to the given type.
   ///
-  /// \param P The pattern, which may be modified by this coercion.
-  /// \param resolution The type resolution.
+  /// \param pattern The contextual pattern.
   /// \param type the type to coerce the pattern to.
-  /// \param options Options describing how to perform this coercion.
+  /// \param options Options that control the coercion.
   ///
-  /// \returns true if an error occurred, false otherwise.
-  static bool coercePatternToType(Pattern *&P, TypeResolution resolution, Type type,
-                                  TypeResolutionOptions options,
-                                  TypeLoc tyLoc = TypeLoc());
+  /// \returns the coerced pattern, or nullptr if the coercion failed.
+  static Pattern *coercePatternToType(ContextualPattern pattern, Type type,
+                                      TypeResolutionOptions options,
+                                      TypeLoc tyLoc = TypeLoc());
   static bool typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
                                    Type type);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -999,16 +999,11 @@ public:
 
   /// Type check the given pattern.
   ///
-  /// \param P The pattern to type check.
-  /// \param dc The context in which type checking occurs.
-  /// \param options Options that control type resolution.
-  ///
   /// \returns the type of the pattern, which may be an error type if an
   /// unrecoverable error occurred. If the options permit it, the type may
   /// involve \c UnresolvedType (for patterns with no type information) and
   /// unbound generic types.
-  static Type typeCheckPattern(Pattern *P, DeclContext *dc,
-                               TypeResolutionOptions options);
+  static Type typeCheckPattern(ContextualPattern pattern);
 
   static bool typeCheckCatchPattern(CatchStmt *S, DeclContext *dc);
 

--- a/test/Parse/ConditionalCompilation/switch_case.swift
+++ b/test/Parse/ConditionalCompilation/switch_case.swift
@@ -209,6 +209,7 @@ func foo(x: E, intVal: Int) {
       fallthrough // expected-error {{'fallthrough' from a case which doesn't bind variable 'val'}}
 #if ENABLE_C
     case let val:
+      _ = val
       break
 #endif
     case 2:

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -333,6 +333,6 @@ case (_?)?: break // expected-warning {{case is already handled by previous patt
 let (responseObject: Int?) = op1
 // expected-error @-1 {{expected ',' separator}} {{25-25=,}}
 // expected-error @-2 {{expected pattern}}
-// expected-error @-3 {{expression type 'Int?' is ambiguous without more context}}
+// expected-error @-3 {{cannot convert value of type 'Int?' to specified type '(responseObject: _)'}}
 
 

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -96,7 +96,7 @@ func tuplePatternDestructuring(_ x : Int, y : Int) {
   _ = i+j
 
   // <rdar://problem/20395243> QoI: type variable reconstruction failing for tuple types
-  let (x: g1, a: h1) = (b: x, a: y)  // expected-error {{tuple type '(b: Int, a: Int)' is not convertible to tuple type '(x: Int, a: Int)'}}
+  let (x: g1, a: h1) = (b: x, a: y)  // expected-error {{cannot convert value of type '(b: Int, a: Int)' to specified type '(x: Int, a: Int)'}}
 }
 
 // <rdar://problem/21057425> Crash while compiling attached test-app.

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -133,14 +133,14 @@ func testForEachInference() {
   // Generic sequence resolved contextually
   for i: Int in getGenericSeq() { }
   for d: Double in getGenericSeq() { }
-  
+
   // Inference of generic arguments in the element type from the
   // sequence.
-  for x: X in getXIntSeq() { 
+  for x: X in getXIntSeq() {
     let z = x.value + 1
   }
 
-  for x: X in getOvlSeq() { 
+  for x: X in getOvlSeq() {
     let z = x.value + 1
   }
 


### PR DESCRIPTION
Rework `typeCheckPattern` to be functional, so that it never writes a type into the pattern it operates on. Capture this functional operation in a new request, simplifying the interface so we don't have to deal with quite so many options in quite so many places and to make it easier to cache.

Write types into patterns with the "coerce pattern to type" operation, which has been reworked
to produce a Pattern (which might be a new pattern) rather than mutating its arguments in place.
It's not strictly functional (because it mutates the given pattern), but could be made so and
callers wouldn't notice.