### PR TITLE
[Experiment] Redo Globals As Member Tables

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1229,7 +1229,8 @@ private:
   /// forEachDistinctName's callback.
   bool addMemberAndAlternatesToExtension(
       clang::NamedDecl *decl, importer::ImportedName newName,
-      importer::ImportNameVersion nameVersion, ExtensionDecl *ext);
+      importer::ImportNameVersion nameVersion, ExtensionDecl *ext,
+      SmallPtrSetImpl<Decl *> &addedMembers);
 
 public:
   void

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -13,8 +13,7 @@ import ImportAsMember
 // CHECK:        radius:
 // CHECK-NEXT:     IAMStruct1: IAMStruct1GetRadius, IAMStruct1SetRadius
 
-// CHECK: Globals-as-members mapping:
-// CHECK-NEXT: IAMStruct1: IAMStruct1GlobalVar, IAMStruct1CreateSimple, IAMStruct1CreateSpecialLabel, IAMStruct1Invert, IAMStruct1InvertInPlace, IAMStruct1Rotate, IAMStruct1Scale, IAMStruct1GetRadius, IAMStruct1SetRadius, IAMStruct1GetAltitude, IAMStruct1SetAltitude, IAMStruct1GetMagnitude, IAMStruct1StaticMethod, IAMStruct1StaticGetProperty, IAMStruct1StaticSetProperty, IAMStruct1StaticGetOnlyProperty, IAMStruct1SelfComesLast, IAMStruct1SelfComesThird, IAMStruct1StaticVar1, IAMStruct1StaticVar2, IAMStruct1CreateFloat, IAMStruct1GetZeroStruct1
+// CHECK-LABEL: Globals-as-members mapping:
 
 // CHECK-LABEL: <<Bridging header lookup table>>
 // CHECK-NEXT:      Base name -> entry mappings:
@@ -62,4 +61,17 @@ import ImportAsMember
 
 
 // CHECK-NEXT: Globals-as-members mapping:
-// CHECK-NEXT:   SNSomeStruct: DefaultXValue, SNAdding, SNCreate, SNSomeStructGetDefault, SNSomeStructSetDefault, SNSomeStructGetFoo, SNSomeStructSetFoo
+// CHECK: adding:
+// CHECK-NEXT:   SNSomeStruct: SNAdding
+//
+// CHECK: defaultValue:
+// CHECK-NEXT:   SNSomeStruct: SNSomeStructGetDefault, SNSomeStructSetDefault
+//
+// CHECK: defaultX:
+// CHECK-NEXT:   SNSomeStruct: DefaultXValue
+//
+// CHECK: foo:
+// CHECK-NEXT:   SNSomeStruct: SNSomeStructGetFoo, SNSomeStructSetFoo
+//
+// CHECK: init:
+// CHECK-NEXT:   SNSomeStruct: SNCreate

--- a/test/IDE/import_as_member.swift
+++ b/test/IDE/import_as_member.swift
@@ -21,21 +21,21 @@
 // PRINT-NOT: static var static1: Double
 
 // PRINT:      extension Struct1 {
-// PRINT-NEXT:   static var globalVar: Double
-// PRINT-NEXT:   init(value value: Double)
-// PRINT-NEXT:   init(specialLabel specialLabel: ())
-// PRINT-NEXT:   func inverted() -> Struct1
-// PRINT-NEXT:   mutating func invert()
-// PRINT-NEXT:   func translate(radians radians: Double) -> Struct1
-// PRINT-NEXT:   func scale(_ radians: Double) -> Struct1
-// PRINT-NEXT:   var radius: Double { get nonmutating set }
-// PRINT-NEXT:   var altitude: Double{{$}}
-// PRINT-NEXT:   var magnitude: Double { get }
-// PRINT-NEXT:   static func staticMethod() -> Int32
-// PRINT-NEXT:   static var property: Int32
-// PRINT-NEXT:   static var getOnlyProperty: Int32 { get }
-// PRINT-NEXT:   func selfComesLast(x x: Double)
-// PRINT-NEXT:   func selfComesThird(a a: Int32, b b: Float, x x: Double)
+// PRINT-NEXT: var altitude: Double
+// PRINT-NEXT: static var getOnlyProperty: Int32 { get }
+// PRINT-NEXT: static var globalVar: Double
+// PRINT-NEXT: init(value value: Double)
+// PRINT-NEXT: init(specialLabel specialLabel: ())
+// PRINT-NEXT: mutating func invert()
+// PRINT-NEXT: func inverted() -> Struct1
+// PRINT-NEXT: var magnitude: Double { get }
+// PRINT-NEXT: static var property: Int32
+// PRINT-NEXT: var radius: Double { get nonmutating set }
+// PRINT-NEXT: func scale(_ radians: Double) -> Struct1
+// PRINT-NEXT: func selfComesLast(x x: Double)
+// PRINT-NEXT: func selfComesThird(a a: Int32, b b: Float, x x: Double)
+// PRINT-NEXT: static func staticMethod() -> Int32
+// PRINT-NEXT: func translate(radians radians: Double) -> Struct1
 // PRINT-NEXT: }
 // PRINT-NOT: static var static1: Double
 
@@ -44,9 +44,9 @@
 // PRINTB-NOT: static var globalVar: Double
 
 // PRINTB:      extension Struct1 {
-// PRINTB:        static var static1: Double
-// PRINTB-NEXT:   static var static2: Float
 // PRINTB-NEXT:   init(float value: Float)
+// PRINTB-NEXT:   static var static1: Double
+// PRINTB-NEXT:   static var static2: Float
 // PRINTB-NEXT:   static var zero: Struct1 { get }
 // PRINTB-NEXT: }
 
@@ -56,21 +56,6 @@
 
 // PRINT-APINOTES-3:      @available(swift, obsoleted: 3, renamed: "Struct1.oldApiNoteVar")
 // PRINT-APINOTES-3-NEXT: var IAMStruct1APINoteVar: Double
-// PRINT-APINOTES-3:      extension Struct1 {
-// PRINT-APINOTES-3-NEXT:   var oldApiNoteVar: Double
-// PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4.2, renamed: "Struct1.oldApiNoteVar")
-// PRINT-APINOTES-3-NEXT:   var newApiNoteVar: Double
-// PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4.2, renamed: "IAMStruct1APINoteVarInSwift4")
-// PRINT-APINOTES-3-NEXT:   var apiNoteVarInSwift4: Double
-// PRINT-APINOTES-3-NEXT:   static func oldApiNoteMethod()
-// PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4.2, renamed: "Struct1.oldApiNoteMethod()")
-// PRINT-APINOTES-3-NEXT:   static func newApiNoteMethod()
-// PRINT-APINOTES-3-NEXT:   init(oldLabel _: Int32)
-// PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4.2, renamed: "Struct1.init(oldLabel:)")
-// PRINT-APINOTES-3-NEXT:   init(newLabel _: Int32)
-// PRINT-APINOTES-3-NEXT:   typealias OldApiNoteType = Struct1.NewApiNoteType
-// PRINT-APINOTES-3-NEXT:   typealias NewApiNoteType = Double
-// PRINT-APINOTES-3-NEXT: }
 // PRINT-APINOTES-3-NOT: @available
 // PRINT-APINOTES-3:     var IAMStruct1APINoteVarInSwift4: Double
 // PRINT-APINOTES-3:     @available(swift, obsoleted: 3, renamed: "Struct1.oldApiNoteMethod()")
@@ -79,24 +64,24 @@
 // PRINT-APINOTES-3-NEXT: func IAMStruct1APINoteCreateFunction(_ _: Int32) -> Struct1
 // PRINT-APINOTES-3:      @available(swift, obsoleted: 3, renamed: "Struct1.OldApiNoteType")
 // PRINT-APINOTES-3-NEXT: typealias IAMStruct1APINoteType = Struct1.OldApiNoteType
+// PRINT-APINOTES-3:      extension Struct1 {
+// PRINT-APINOTES-3-NEXT:   typealias OldApiNoteType = Struct1.NewApiNoteType
+// PRINT-APINOTES-3-NEXT:   typealias NewApiNoteType = Double
+// PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4.2, renamed: "IAMStruct1APINoteVarInSwift4")
+// PRINT-APINOTES-3-NEXT:   var apiNoteVarInSwift4: Double
+// PRINT-APINOTES-3-NEXT:   init(oldLabel _: Int32)
+// PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4.2, renamed: "Struct1.init(oldLabel:)")
+// PRINT-APINOTES-3-NEXT:   init(newLabel _: Int32)
+// PRINT-APINOTES-3-NEXT:   static func oldApiNoteMethod()
+// PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4.2, renamed: "Struct1.oldApiNoteMethod()")
+// PRINT-APINOTES-3-NEXT:   static func newApiNoteMethod()
+// PRINT-APINOTES-3-NEXT:   var oldApiNoteVar: Double
+// PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4.2, renamed: "Struct1.oldApiNoteVar")
+// PRINT-APINOTES-3-NEXT:   var newApiNoteVar: Double
+// PRINT-APINOTES-3-NEXT: }
 
 // PRINT-APINOTES-4:      @available(swift, obsoleted: 3, renamed: "Struct1.newApiNoteVar")
 // PRINT-APINOTES-4-NEXT: var IAMStruct1APINoteVar: Double
-// PRINT-APINOTES-4:      extension Struct1 {
-// PRINT-APINOTES-4-NEXT:   var newApiNoteVar: Double
-// PRINT-APINOTES-4-NEXT:   @available(swift, obsoleted: 4.2, renamed: "Struct1.newApiNoteVar")
-// PRINT-APINOTES-4-NEXT:   var oldApiNoteVar: Double
-// PRINT-APINOTES-4-NEXT:   var apiNoteVarInSwift4: Double
-// PRINT-APINOTES-4-NEXT:   static func newApiNoteMethod()
-// PRINT-APINOTES-4-NEXT:   @available(swift, obsoleted: 4.2, renamed: "Struct1.newApiNoteMethod()")
-// PRINT-APINOTES-4-NEXT:   static func oldApiNoteMethod()
-// PRINT-APINOTES-4-NEXT:   init(newLabel _: Int32)
-// PRINT-APINOTES-4-NEXT:   @available(swift, obsoleted: 4.2, renamed: "Struct1.init(newLabel:)")
-// PRINT-APINOTES-4-NEXT:   init(oldLabel _: Int32)
-// PRINT-APINOTES-4-NEXT:   typealias NewApiNoteType = Double
-// PRINT-APINOTES-4-NEXT:   @available(swift, obsoleted: 4.2, renamed: "Struct1.NewApiNoteType")
-// PRINT-APINOTES-4-NEXT:   typealias OldApiNoteType = Struct1.NewApiNoteType
-// PRINT-APINOTES-4-NEXT: }
 // PRINT-APINOTES-4:      @available(swift, obsoleted: 4.2, renamed: "Struct1.apiNoteVarInSwift4")
 // PRINT-APINOTES-4-NEXT: var IAMStruct1APINoteVarInSwift4: Double
 // PRINT-APINOTES-4:     @available(swift, obsoleted: 3, renamed: "Struct1.newApiNoteMethod()")
@@ -105,6 +90,21 @@
 // PRINT-APINOTES-4-NEXT: func IAMStruct1APINoteCreateFunction(_ _: Int32) -> Struct1
 // PRINT-APINOTES-4:      @available(swift, obsoleted: 3, renamed: "Struct1.NewApiNoteType")
 // PRINT-APINOTES-4-NEXT: typealias IAMStruct1APINoteType = Struct1.NewApiNoteType
+// PRINT-APINOTES-4:      extension Struct1 {
+// PRINT-APINOTES-4-NEXT:   typealias NewApiNoteType = Double
+// PRINT-APINOTES-4-NEXT:   @available(swift, obsoleted: 4.2, renamed: "Struct1.NewApiNoteType")
+// PRINT-APINOTES-4-NEXT:   typealias OldApiNoteType = Struct1.NewApiNoteType
+// PRINT-APINOTES-4-NEXT:   var apiNoteVarInSwift4: Double
+// PRINT-APINOTES-4-NEXT:   init(newLabel _: Int32)
+// PRINT-APINOTES-4-NEXT:   @available(swift, obsoleted: 4.2, renamed: "Struct1.init(newLabel:)")
+// PRINT-APINOTES-4-NEXT:   init(oldLabel _: Int32)
+// PRINT-APINOTES-4-NEXT:   static func newApiNoteMethod()
+// PRINT-APINOTES-4-NEXT:   @available(swift, obsoleted: 4.2, renamed: "Struct1.newApiNoteMethod()")
+// PRINT-APINOTES-4-NEXT:   static func oldApiNoteMethod()
+// PRINT-APINOTES-4-NEXT:   var newApiNoteVar: Double
+// PRINT-APINOTES-4-NEXT:   @available(swift, obsoleted: 4.2, renamed: "Struct1.newApiNoteVar")
+// PRINT-APINOTES-4-NEXT:   var oldApiNoteVar: Double
+// PRINT-APINOTES-4-NEXT: }
 
 import ImportAsMember.A
 import ImportAsMember.B

--- a/test/IDE/import_as_member_cf.swift
+++ b/test/IDE/import_as_member_cf.swift
@@ -4,15 +4,6 @@
 
 // RUN: %FileCheck %s -check-prefix=PRINTC -strict-whitespace < %t.printed.C.txt
 
-// PRINTC:      extension CCPowerSupply {
-// PRINTC-NEXT:   /*not inherited*/ init(watts watts: Double)
-// PRINTC-NEXT:   class let semiModular: CCPowerSupply!
-// PRINTC-NEXT:   /*not inherited*/ init(dangerous dangerous: ())
-// PRINTC-NEXT:   class let defaultPower: Double
-// PRINTC-NEXT:   class let AC: CCPowerSupply
-// PRINTC-NEXT:   class let DC: CCPowerSupply?
-// PRINTC-NEXT: }
-
 // PRINTC:      extension CCRefrigerator {
 // PRINTC-NEXT:   /*not inherited*/ init(powerSupply power: CCPowerSupply)
 // PRINTC-NEXT:   func open()
@@ -21,6 +12,15 @@
 
 // PRINTC:      extension CCMutableRefrigerator {
 // PRINTC-NEXT:   /*not inherited*/ init(powerSupply power: CCPowerSupply)
+// PRINTC-NEXT: }
+
+// PRINTC:      extension CCPowerSupply {
+// PRINTC-NEXT:   class let AC: CCPowerSupply
+// PRINTC-NEXT:   class let DC: CCPowerSupply?
+// PRINTC-NEXT:   class let defaultPower: Double
+// PRINTC-NEXT:   /*not inherited*/ init(watts watts: Double)
+// PRINTC-NEXT:   /*not inherited*/ init(dangerous dangerous: ())
+// PRINTC-NEXT:   class let semiModular: CCPowerSupply!
 // PRINTC-NEXT: }
 
 // RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules

--- a/test/IDE/import_as_member_objc.swift
+++ b/test/IDE/import_as_member_objc.swift
@@ -2,22 +2,22 @@
 
 // RUN: %FileCheck %s -check-prefix=PRINT-CLASS -strict-whitespace < %t.printed.Class.txt
 
-// PRINT-CLASS-LABEL: class SomeClass : NSObject {
-// PRINT-CLASS-NEXT:   init()
-// PRINT-CLASS-NEXT: }
-// PRINT-CLASS-NEXT: extension SomeClass {
-// PRINT-CLASS-NEXT:   /*not inherited*/ init(value x: Double)
-// PRINT-CLASS-NEXT:   func applyOptions(_ options: SomeClass.Options)
-// PRINT-CLASS-NEXT:   func doIt()
+// PRINT-CLASS-LABEL: extension SomeClass {
 // PRINT-CLASS-NEXT:   struct Options : OptionSet {
 // PRINT-CLASS-NEXT:     init(rawValue rawValue: Int)
 // PRINT-CLASS-NEXT:     let rawValue: Int
 // PRINT-CLASS-NEXT:     typealias RawValue = Int
-// PRINT-CLASS-NEXT:     typealias Element = SomeClass
-// PRINT-CLASS-NEXT:     typealias ArrayLiteralElement = SomeClass
+// PRINT-CLASS-NEXT:     typealias Element = SomeClass.Options
+// PRINT-CLASS-NEXT:     typealias ArrayLiteralElement = SomeClass.Options
 // PRINT-CLASS-NEXT:     static var fuzzyDice: SomeClass.Options { get }
 // PRINT-CLASS-NEXT:     static var spoiler: SomeClass.Options { get }
 // PRINT-CLASS-NEXT:   }
+// PRINT-CLASS-NEXT:   func applyOptions(_ options: SomeClass.Options)
+// PRINT-CLASS-NEXT:   func doIt()
+// PRINT-CLASS-NEXT:   /*not inherited*/ init(value x: Double)
+// PRINT-CLASS-NEXT: }
+// PRINT-CLASS-LABEL: class SomeClass : NSObject {
+// PRINT-CLASS-NEXT:   init()
 // PRINT-CLASS-NEXT: }
 
 // RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules

--- a/test/IDE/infer_import_as_member.swift
+++ b/test/IDE/infer_import_as_member.swift
@@ -20,65 +20,63 @@ let _ = mine.getCollisionNonProperty(1)
 // PRINT-NEXT:  }
 
 // PRINT-LABEL: extension IAMStruct1 {
-// PRINT-NEXT:    static var globalVar: Double
+// PRINT-NEXT:  var altitude: Double
+// PRINT-NEXT:  func getCollisionNonProperty(_ _: Int32) -> Float
+// PRINT-NEXT:  func getNonPropertyNoSelf() -> Float
 //
-// PRINT-LABEL:   /// Init
-// PRINT-NEXT:    init(copyIn in: IAMStruct1)
-// PRINT-NEXT:    init(simpleValue value: Double)
-// PRINT-NEXT:    init(redundant redundant: Double)
-// PRINT-NEXT:    init(specialLabel specialLabel: ())
+// PRINT-LABEL:  /// Various instance functions that can't quite be imported as properties.
+// PRINT-NEXT:  func getNonPropertyNumParams() -> Float
+// PRINT-NEXT:  func getNonPropertyType() -> Float
+// PRINT-NEXT:  static var globalVar: Double
 //
-// PRINT-LABEL:   /// Methods
-// PRINT-NEXT:    func invert() -> IAMStruct1
-// PRINT-NEXT:    mutating func invertInPlace()
-// PRINT-NEXT:    func rotate(radians radians: Double) -> IAMStruct1
-// PRINT-NEXT:    func selfComesLast(x x: Double)
-// PRINT-NEXT:    func selfComesThird(a a: Double, b b: Float, x x: Double)
+// PRINT-LABEL:  /// Init
+// PRINT-NEXT:  init(copyIn in: IAMStruct1)
+// PRINT-NEXT:  init(simpleValue value: Double)
+// PRINT-NEXT:  init(redundant redundant: Double)
+// PRINT-NEXT:  init(specialLabel specialLabel: ())
 //
-// PRINT-LABEL:   /// Properties
-// PRINT-NEXT:    var radius: Double { get nonmutating set }
-// PRINT-NEXT:    var altitude: Double
-// PRINT-NEXT:    var magnitude: Double { get }
-// PRINT-NEXT:    var length: Double
+// PRINT-LABEL:  /// Fuzzy
+// PRINT-NEXT:  init(fuzzy fuzzy: ())
+// PRINT-NEXT:  init(fuzzyWithFuzzyName fuzzyWithFuzzyName: ())
+// PRINT-NEXT:  init(fuzzyName fuzzyName: ())
 //
-// PRINT-LABEL:   /// Various instance functions that can't quite be imported as properties.
-// PRINT-NEXT:    func getNonPropertyNumParams() -> Float
-// PRINT-NEXT:    func setNonPropertyNumParams(a a: Float, b b: Float)
-// PRINT-NEXT:    func getNonPropertyType() -> Float
-// PRINT-NEXT:    func setNonPropertyType(x x: Double)
-// PRINT-NEXT:    func getNonPropertyNoSelf() -> Float
-// PRINT-NEXT:    static func setNonPropertyNoSelf(x x: Double, y y: Double)
-// PRINT-NEXT:    func setNonPropertyNoGet(x x: Double)
-// PRINT-NEXT:    func setNonPropertyExternalCollision(x x: Double)
+// PRINT-LABEL:  /// Methods
+// PRINT-NEXT:  func invert() -> IAMStruct1
+// PRINT-NEXT:  mutating func invertInPlace()
+// PRINT-NEXT:  var length: Double
+// PRINT-NEXT:  var magnitude: Double { get }
 //
-// PRINT-LABEL:   /// Various static functions that can't quite be imported as properties.
-// PRINT-NEXT:    static func staticGetNonPropertyNumParams() -> Float
-// PRINT-NEXT:    static func staticSetNonPropertyNumParams(a a: Float, b b: Float)
-// PRINT-NEXT:    static func staticGetNonPropertyNumParamsGetter(d d: Double)
-// PRINT-NEXT:    static func staticGetNonPropertyType() -> Float
-// PRINT-NEXT:    static func staticSetNonPropertyType(x x: Double)
-// PRINT-NEXT:    static func staticGetNonPropertyNoSelf() -> Float
-// PRINT-NEXT:    static func staticSetNonPropertyNoSelf(x x: Double, y y: Double)
-// PRINT-NEXT:    static func staticSetNonPropertyNoGet(x x: Double)
+// PRINT-LABEL:  /// Omit needless words
+// PRINT-NEXT:  static func onwNeedlessTypeArgLabel(_ Double: Double) -> Double
 //
-// PRINT-LABEL:   /// Static method
-// PRINT-NEXT:    static func staticMethod() -> Double
-// PRINT-NEXT:    static func tlaThreeLetterAcronym() -> Double
+// PRINT-LABEL:  /// Properties
+// PRINT-NEXT:  var radius: Double { get nonmutating set }
+// PRINT-NEXT:  func rotate(radians radians: Double) -> IAMStruct1
+// PRINT-NEXT:  func selfComesLast(x x: Double)
+// PRINT-NEXT:  func selfComesThird(a a: Double, b b: Float, x x: Double)
+// PRINT-NEXT:  func setNonPropertyExternalCollision(x x: Double)
+// PRINT-NEXT:  func setNonPropertyNoGet(x x: Double)
+// PRINT-NEXT:  static func setNonPropertyNoSelf(x x: Double, y y: Double)
+// PRINT-NEXT:  func setNonPropertyNumParams(a a: Float, b b: Float)
+// PRINT-NEXT:  func setNonPropertyType(x x: Double)
+// PRINT-NEXT:  static func staticGetNonPropertyNoSelf() -> Float
+// :
+// PRINT-LABEL:  /// Various static functions that can't quite be imported as properties.
+// PRINT-NEXT:  static func staticGetNonPropertyNumParams() -> Float
+// PRINT-NEXT:  static func staticGetNonPropertyNumParamsGetter(d d: Double)
+// PRINT-NEXT:  static func staticGetNonPropertyType() -> Float
 //
-// PRINT-LABEL:   /// Static computed properties
-// PRINT-NEXT:    static var staticProperty: Double
-// PRINT-NEXT:    static var staticOnlyProperty: Double { get }
+// PRINT-LABEL:  /// Static method
+// PRINT-NEXT:  static func staticMethod() -> Double
+// PRINT-NEXT:  static var staticOnlyProperty: Double { get }
 //
-// PRINT-LABEL:   /// Omit needless words
-// PRINT-NEXT:    static func onwNeedlessTypeArgLabel(_ Double: Double) -> Double
-//
-// PRINT-LABEL:   /// Fuzzy
-// PRINT-NEXT:    init(fuzzy fuzzy: ())
-// PRINT-NEXT:    init(fuzzyWithFuzzyName fuzzyWithFuzzyName: ())
-// PRINT-NEXT:    init(fuzzyName fuzzyName: ())
-//
-// PRINT-NEXT:    func getCollisionNonProperty(_ _: Int32) -> Float
-//
+// PRINT-LABEL:  /// Static computed properties
+// PRINT-NEXT:  static var staticProperty: Double
+// PRINT-NEXT:  static func staticSetNonPropertyNoGet(x x: Double)
+// PRINT-NEXT:  static func staticSetNonPropertyNoSelf(x x: Double, y y: Double)
+// PRINT-NEXT:  static func staticSetNonPropertyNumParams(a a: Float, b b: Float)
+// PRINT-NEXT:  static func staticSetNonPropertyType(x x: Double)
+// PRINT-NEXT:  static func tlaThreeLetterAcronym() -> Double
 // PRINT-NEXT:  }
 //
 // PRINT-NEXT:  func __IAMStruct1IgnoreMe(_ s: IAMStruct1) -> Double
@@ -88,9 +86,9 @@ let _ = mine.getCollisionNonProperty(1)
 // PRINT-NEXT:    init()
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension IAMMutableStruct1 {
+// PRINT-NEXT:    func doSomething()
 // PRINT-NEXT:    init(with withIAMStruct1: IAMStruct1)
 // PRINT-NEXT:    init(url url: UnsafePointer<Int8>!)
-// PRINT-NEXT:    func doSomething()
 // PRINT-NEXT:  }
 //
 // PRINT-LABEL: struct TDStruct {
@@ -107,9 +105,9 @@ let _ = mine.getCollisionNonProperty(1)
 // PRINT-NEXT:  }
 // PRINT-NEXT:  typealias IAMOtherName = IAMClass
 // PRINT-NEXT:  extension IAMClass {
-// PRINT-NEXT:    class var typeID: UInt32 { get }
 // PRINT-NEXT:    init!(i i: Double)
 // PRINT-NEXT:    class func invert(_ iamOtherName: IAMOtherName!)
+// PRINT-NEXT:    class var typeID: UInt32 { get }
 // PRINT-NEXT:  }
 //
 // PRINT-LABEL: struct IAMPointerStruct {

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -6,55 +6,55 @@
 // REQUIRES: objc_interop
 
 // PRINT-LABEL: struct ErrorDomain : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
-// PRINT-NEXT:    init(_ rawValue: String)
-// PRINT-NEXT:    init(rawValue: String)
-// PRINT-NEXT:    var rawValue: String { get }
-// PRINT-NEXT:    typealias RawValue = String
-// PRINT-NEXT:    typealias _ObjectiveCType = NSString
-// PRINT-NEXT:  }
-// PRINT-NEXT:  extension ErrorDomain {
-// PRINT-NEXT:    func process()
-// PRINT-NEXT:    static let one: ErrorDomain
-// PRINT-NEXT:    static let errTwo: ErrorDomain
-// PRINT-NEXT:    static let three: ErrorDomain
-// PRINT-NEXT:    static let fourErrorDomain: ErrorDomain
-// PRINT-NEXT:    static let stillAMember: ErrorDomain
-// PRINT-NEXT:  }
-// PRINT-NEXT:  struct Food {
-// PRINT-NEXT:    init()
-// PRINT-NEXT:  }
-// PRINT-NEXT:  extension Food {
-// PRINT-NEXT:    static let err: ErrorDomain
-// PRINT-NEXT:  }
-// PRINT-NEXT:  struct ClosedEnum : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
-// PRINT-NEXT:    init(rawValue: String)
-// PRINT-NEXT:    var rawValue: String { get }
-// PRINT-NEXT:    typealias RawValue = String
-// PRINT-NEXT:    typealias _ObjectiveCType = NSString
-// PRINT-NEXT:  }
-// PRINT-NEXT:  extension ClosedEnum {
-// PRINT-NEXT:    static let firstClosedEntryEnum: ClosedEnum
-// PRINT-NEXT:    static let secondEntry: ClosedEnum
-// PRINT-NEXT:    static let thirdEntry: ClosedEnum
-// PRINT-NEXT:  }
-// PRINT-NEXT:  struct IUONewtype : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
-// PRINT-NEXT:    init(_ rawValue: String)
-// PRINT-NEXT:    init(rawValue: String)
-// PRINT-NEXT:    var rawValue: String { get }
-// PRINT-NEXT:    typealias RawValue = String
-// PRINT-NEXT:    typealias _ObjectiveCType = NSString
-// PRINT-NEXT:  }
-// PRINT-NEXT:  struct MyFloat : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
-// PRINT-NEXT:    init(_ rawValue: Float)
-// PRINT-NEXT:    init(rawValue: Float)
-// PRINT-NEXT:    let rawValue: Float
-// PRINT-NEXT:    typealias RawValue = Float
-// PRINT-NEXT:  }
-// PRINT-NEXT:  extension MyFloat {
-// PRINT-NEXT:    static let globalFloat: MyFloat{{$}}
-// PRINT-NEXT:    static let PI: MyFloat{{$}}
-// PRINT-NEXT:    static let version: MyFloat{{$}}
-// PRINT-NEXT:  }
+// PRINT-NEXT:   init(_ rawValue: String)
+// PRINT-NEXT:   init(rawValue: String)
+// PRINT-NEXT:   var rawValue: String { get }
+// PRINT-NEXT:   typealias RawValue = String
+// PRINT-NEXT:   typealias _ObjectiveCType = NSString
+// PRINT-NEXT: }
+// PRINT-NEXT: struct Food {
+// PRINT-NEXT:   init()
+// PRINT-NEXT: }
+// PRINT-NEXT: extension ErrorDomain {
+// PRINT-NEXT:   static let errTwo: ErrorDomain
+// PRINT-NEXT:   static let fourErrorDomain: ErrorDomain
+// PRINT-NEXT:   static let one: ErrorDomain
+// PRINT-NEXT:   func process()
+// PRINT-NEXT:   static let stillAMember: ErrorDomain
+// PRINT-NEXT:   static let three: ErrorDomain
+// PRINT-NEXT: }
+// PRINT-NEXT: extension Food {
+// PRINT-NEXT:   static let err: ErrorDomain
+// PRINT-NEXT: }
+// PRINT-NEXT: struct ClosedEnum : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT:   init(rawValue: String)
+// PRINT-NEXT:   var rawValue: String { get }
+// PRINT-NEXT:   typealias RawValue = String
+// PRINT-NEXT:   typealias _ObjectiveCType = NSString
+// PRINT-NEXT: }
+// PRINT-NEXT: extension ClosedEnum {
+// PRINT-NEXT:   static let firstClosedEntryEnum: ClosedEnum
+// PRINT-NEXT:   static let secondEntry: ClosedEnum
+// PRINT-NEXT:   static let thirdEntry: ClosedEnum
+// PRINT-NEXT: }
+// PRINT-NEXT: struct IUONewtype : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT:   init(_ rawValue: String)
+// PRINT-NEXT:   init(rawValue: String)
+// PRINT-NEXT:   var rawValue: String { get }
+// PRINT-NEXT:   typealias RawValue = String
+// PRINT-NEXT:   typealias _ObjectiveCType = NSString
+// PRINT-NEXT: }
+// PRINT-NEXT: struct MyFloat : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT:   init(_ rawValue: Float)
+// PRINT-NEXT:   init(rawValue: Float)
+// PRINT-NEXT:   let rawValue: Float
+// PRINT-NEXT:   typealias RawValue = Float
+// PRINT-NEXT: }
+// PRINT-NEXT: extension MyFloat {
+// PRINT-NEXT:   static let PI: MyFloat
+// PRINT-NEXT:   static let globalFloat: MyFloat
+// PRINT-NEXT:   static let version: MyFloat
+// PRINT-NEXT: }
 //
 // PRINT-LABEL: struct MyInt : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: Int32)
@@ -63,21 +63,21 @@
 // PRINT-NEXT:    typealias RawValue = Int32
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension MyInt {
-// PRINT-NEXT:    static let zero: MyInt{{$}}
 // PRINT-NEXT:    static let one: MyInt{{$}}
+// PRINT-NEXT:    static let zero: MyInt{{$}}
 // PRINT-NEXT:  }
 // PRINT-NEXT:  let kRawInt: Int32
 // PRINT-NEXT:  func takesMyInt(_: MyInt)
 //
 // PRINT-LABEL: extension NSURLResourceKey {
-// PRINT-NEXT:    static let isRegularFileKey: NSURLResourceKey
 // PRINT-NEXT:    static let isDirectoryKey: NSURLResourceKey
+// PRINT-NEXT:    static let isRegularFileKey: NSURLResourceKey
 // PRINT-NEXT:    static let localizedNameKey: NSURLResourceKey
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension NSNotification.Name {
 // PRINT-NEXT:    static let Foo: NSNotification.Name
-// PRINT-NEXT:    static let bar: NSNotification.Name
 // PRINT-NEXT:    static let NSWibble: NSNotification.Name
+// PRINT-NEXT:    static let bar: NSNotification.Name
 // PRINT-NEXT:  }
 // PRINT-NEXT:  let kNotification: String
 // PRINT-NEXT:  let Notification: String
@@ -91,8 +91,8 @@
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension CFNewType {
 // PRINT-NEXT:    static let MyCFNewTypeValue: CFNewType
-// PRINT-NEXT:    static let MyCFNewTypeValueUnauditedButConst: CFNewType
 // PRINT-NEXT:    static var MyCFNewTypeValueUnaudited: Unmanaged<CFString>
+// PRINT-NEXT:    static let MyCFNewTypeValueUnauditedButConst: CFNewType
 // PRINT-NEXT:  }
 // PRINT-NEXT:  func FooAudited() -> CFNewType
 // PRINT-NEXT:  func FooUnaudited() -> Unmanaged<CFString>
@@ -162,8 +162,8 @@
 // PRINT-NEXT: func destroy_T(_: TRef!)
 // PRINT-NEXT: func destroy_ConstT(_: ConstTRef!)
 // PRINT-NEXT: extension TRef {
-// PRINT-NEXT:   func mutatePointee()
 // PRINT-NEXT:   mutating func mutate()
+// PRINT-NEXT:   func mutatePointee()
 // PRINT-NEXT: }
 // PRINT-NEXT: extension ConstTRef {
 // PRINT-NEXT:   func use()
@@ -186,8 +186,8 @@
 // PRINT-NEXT: func destroy_TRef(_: TRefRef!)
 // PRINT-NEXT: func destroy_ConstTRef(_: ConstTRefRef!)
 // PRINT-NEXT: extension TRefRef {
-// PRINT-NEXT:   func mutatePointee()
 // PRINT-NEXT:   mutating func mutate()
+// PRINT-NEXT:   func mutatePointee()
 // PRINT-NEXT: }
 // PRINT-NEXT: extension ConstTRefRef {
 // PRINT-NEXT:   func use()

--- a/test/IDE/print_clang_decls_AppKit.swift
+++ b/test/IDE/print_clang_decls_AppKit.swift
@@ -41,7 +41,7 @@
 // APPKIT-NEXT: var action: Selector
 // APPKIT: {{^}}}{{$}}
 // APPKIT: extension NSNotification.Name {
-// APPKIT:   static let NSViewFrameDidChange: NSNotification.Name
 // APPKIT:   static let NSViewFocusDidChange: NSNotification.Name
+// APPKIT:   static let NSViewFrameDidChange: NSNotification.Name
 // APPKIT: }
 


### PR DESCRIPTION
⚠️  DO NOT MERGE ⚠️ 

Globals-as-members has an antagonistic relationship with lazy member
loading. The old PCM extension filed them away indexed by context, which
was super efficient for the general case of "just import this entire
extension", but ridiculously inefficient for the specific case of "just
load this one member for me".

Instead, store the table in named order.  Switch over all the callers
and unblock lazy member loading.

This naturally changes the order things are printed in, but does not
change their contents.

