### PR TITLE
[CMake] Add missing dependency

### DIFF
--- a/unittests/ClangImporter/CMakeLists.txt
+++ b/unittests/ClangImporter/CMakeLists.txt
@@ -7,4 +7,5 @@ target_link_libraries(SwiftClangImporterTests
     swiftClangImporter
     swiftParse
     swiftAST
+    LLVMBitstreamReader
 )


### PR DESCRIPTION
Found via LLVM's BUILD_SHARED_LIBS build option.