### PR TITLE
[Incremental] Dependency fixes in preparation for fine-grained dependencies

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -325,7 +325,7 @@ private:
 /// Write out the .swiftdeps file for a frontend compilation of a primary file.
 bool emitReferenceDependencies(DiagnosticEngine &diags, SourceFile *SF,
                                const DependencyTracker &depTracker,
-                               StringRef outputPath);
+                               StringRef outputPath, bool alsoEmitDotFile);
 //==============================================================================
 // MARK: Enums
 //==============================================================================
@@ -438,8 +438,8 @@ public:
         name() {}
 
   /// For constructing a key in the frontend.
-  DependencyKey(NodeKind kind, DeclAspect aspect, std::string context,
-                std::string name)
+  DependencyKey(NodeKind kind, DeclAspect aspect, const std::string &context,
+                const std::string &name)
       : kind(kind), aspect(aspect), context(context), name(name) {
     assert(verify());
   }
@@ -449,7 +449,7 @@ public:
   StringRef getContext() const { return context; }
   StringRef getName() const { return name; }
 
-  StringRef getSwiftDepsFromSourceFileProvide() const {
+  StringRef getSwiftDepsFromASourceFileProvideNodeKey() const {
     assert(getKind() == NodeKind::sourceFileProvide &&
            "Receiver must be sourceFileProvide.");
     return getName();
@@ -494,10 +494,18 @@ public:
   static std::string computeNameForProvidedEntity(Entity);
 
   /// Given some type of depended-upon entity create the key.
-  template <NodeKind kind, typename Entity>
-  static DependencyKey createDependedUponKey(const Entity &);
+  static DependencyKey createDependedUponKey(StringRef mangledHolderName,
+                                             StringRef memberBaseName);
+
+  template <NodeKind kind>
+  static DependencyKey createDependedUponKey(StringRef);
+
+  static DependencyKey
+  createTransitiveKeyForWholeSourceFile(StringRef swiftDeps);
 
   std::string humanReadableName() const;
+
+  StringRef aspectName() const { return DeclAspectNames[size_t(aspect)]; }
 
   void dump(llvm::raw_ostream &os) const { os << asString() << "\n"; }
   SWIFT_DEBUG_DUMP { dump(llvm::errs()); }
@@ -534,6 +542,13 @@ struct std::hash<typename swift::fine_grained_dependencies::DeclAspect> {
     return size_t(aspect);
   }
 };
+
+namespace swift {
+namespace fine_grained_dependencies {
+using ContextNameFingerprint =
+    std::tuple<std::string, std::string, Optional<std::string>>;
+}
+} // namespace swift
 
 //==============================================================================
 // MARK: DepGraphNode
@@ -684,6 +699,9 @@ public:
   }
 
   /// Record the sequence number, \p n, of another use.
+  /// The relationship between an interface and its implementation is NOT
+  /// included here. See \c
+  /// SourceFileDepGraph::findExistingNodePairOrCreateAndAddIfNew.
   void addDefIDependUpon(size_t n) {
     if (n != getSequenceNumber())
       defsIDependUpon.insert(n);
@@ -727,6 +745,25 @@ public:
   SourceFileDepGraph(const SourceFileDepGraph &g) = delete;
   SourceFileDepGraph(SourceFileDepGraph &&g) = default;
 
+  /// Simulate loading for unit testing:
+  /// \param swiftDepsFileName The name of the swiftdeps file of the phony job
+  /// \param includePrivateDeps Whether the graph includes intra-file arcs
+  /// \param hadCompilationError Simulate a compilation error
+  /// \param interfaceHash The interface hash of the simulated graph
+  /// \param simpleNamesByRDK A map of vectors of names keyed by reference
+  /// dependency key \param compoundNamesByRDK A map of (mangledHolder,
+  /// baseName) pairs keyed by reference dependency key. For single-name
+  /// dependencies, an initial underscore indicates that the name does not
+  /// cascade. For compound names, it is the first name, the holder which
+  /// indicates non-cascading. For member names, an initial underscore indicates
+  /// file-privacy.
+  static SourceFileDepGraph
+  simulateLoad(std::string swiftDepsFileName, const bool includePrivateDeps,
+               const bool hadCompilationError, std::string interfaceHash,
+               llvm::StringMap<std::vector<std::string>> simpleNamesByRDK,
+               llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
+                   compoundNamesByRDK);
+
   /// Nodes are owned by the graph.
   ~SourceFileDepGraph() {
     forEachNode([&](SourceFileDepGraphNode *n) { delete n; });
@@ -746,7 +783,7 @@ public:
   InterfaceAndImplementationPair<SourceFileDepGraphNode>
   getSourceFileNodePair() const;
 
-  StringRef getSwiftDepsFromSourceFileProvide() const;
+  StringRef getSwiftDepsOfJobThatProducedThisGraph() const;
 
   std::string getGraphID() const {
     return getSourceFileNodePair().getInterface()->getKey().humanReadableName();
@@ -770,12 +807,13 @@ public:
   /// The frontend creates a pair of nodes for every tracked Decl and the source
   /// file itself.
   InterfaceAndImplementationPair<SourceFileDepGraphNode>
-  findExistingNodePairOrCreateAndAddIfNew(NodeKind k, StringRef context,
-                                          StringRef name,
-                                          Optional<std::string> fingerprint);
+  findExistingNodePairOrCreateAndAddIfNew(
+      NodeKind k, const ContextNameFingerprint &contextNameFingerprint);
 
-  SourceFileDepGraphNode *findExistingNodeOrCreateIfNew(
-      DependencyKey key, Optional<std::string> fingerprint, bool isProvides);
+  SourceFileDepGraphNode *
+  findExistingNodeOrCreateIfNew(DependencyKey key,
+                                const Optional<std::string> &fingerprint,
+                                bool isProvides);
 
   /// \p Use is the Node that must be rebuilt when \p def changes.
   /// Record that fact in the graph.
@@ -892,7 +930,7 @@ private:
   }
   void emitArcs() {
     g.forEachArc([&](const NodeT *def, const NodeT *use) {
-      if (includeGraphArc(use, def))
+      if (includeGraphArc(def, use))
         emitGraphArc(def, use);
     });
   }

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -282,10 +282,14 @@ namespace swift {
     /// Whether to verify the parsed syntax tree and emit related diagnostics.
     bool VerifySyntaxTree = false;
 
-    /// Scaffolding to permit experimentation with finer-grained dependencies
-    /// and faster rebuilds.
+    /// Emit the newer, finer-grained swiftdeps file. Eventually will support
+    /// faster rebuilds.
     bool EnableFineGrainedDependencies = false;
-    
+
+    /// When using fine-grained dependencies, emit dot files for every swiftdeps
+    /// file.
+    bool EmitFineGrainedDependencySourcefileDotFiles = false;
+
     /// To mimic existing system, set to false.
     /// To experiment with including file-private and private dependency info,
     /// set to true.

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -168,6 +168,26 @@ public:
   static bool classof(const Action *A) {
     return A->getKind() == Action::Kind::CompileJob;
   }
+
+  /// Return a _single_ TY_Swift InputAction, if one exists;
+  /// if 0 or >1 such inputs exist, return nullptr.
+  const InputAction *findSingleSwiftInput() const {
+    auto Inputs = getInputs();
+    const InputAction *IA = nullptr;
+    for (auto const *I : Inputs) {
+      if (auto const *S = dyn_cast<InputAction>(I)) {
+        if (S->getType() == file_types::TY_Swift) {
+          if (IA == nullptr) {
+            IA = S;
+          } else {
+            // Already found one, two is too many.
+            return nullptr;
+          }
+        }
+      }
+    }
+    return IA;
+  }
 };
 
 class InterpretJobAction : public JobAction {

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -173,20 +173,17 @@ public:
   /// if 0 or >1 such inputs exist, return nullptr.
   const InputAction *findSingleSwiftInput() const {
     auto Inputs = getInputs();
-    const InputAction *IA = nullptr;
-    for (auto const *I : Inputs) {
-      if (auto const *S = dyn_cast<InputAction>(I)) {
-        if (S->getType() == file_types::TY_Swift) {
-          if (IA == nullptr) {
-            IA = S;
-          } else {
-            // Already found one, two is too many.
-            return nullptr;
-          }
-        }
-      }
-    }
-    return IA;
+    auto isSwiftInput = [](const Action *A) -> const InputAction* {
+      if (auto const *S = dyn_cast<InputAction>(A))
+        return S->getType() == file_types::TY_Swift ? S : nullptr;
+      return nullptr;
+    };
+    const auto loc1 = std::find_if(Inputs.begin(), Inputs.end(), isSwiftInput);
+    if (loc1 == Inputs.end())
+      return nullptr; // none found
+    // Ensure uniqueness
+    const auto loc2 = std::find_if(loc1 + 1, Inputs.end(), isSwiftInput);
+    return loc2 == Inputs.end() ? dyn_cast<InputAction>(*loc1) : nullptr;
   }
 };
 

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -521,6 +521,18 @@ public:
   /// How many .swift input files?
   unsigned countSwiftInputs() const;
 
+  /// Unfortunately the success or failure of a Swift compilation is currently
+  /// sensitive to the order in which files are processed, at least in terms of
+  /// the order of processing extensions (and likely other ways we haven't
+  /// discovered yet). So long as this is true, we need to make sure any batch
+  /// job we build names its inputs in an order that's a subsequence of the
+  /// sequence of inputs the driver was initially invoked with.
+  ///
+  /// Also use to write out information in a consistent order.
+  void sortJobsToMatchCompilationInputs(
+      ArrayRef<const Job *> unsortedJobs,
+      SmallVectorImpl<const Job *> &sortedJobs) const;
+
 private:
   /// Perform all jobs.
   ///

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -48,9 +48,9 @@ namespace fine_grained_dependencies {
 /// Keep separate type from Node for type-checking.
 class ModuleDepGraphNode : public DepGraphNode {
 
-  /// The swiftDeps file that holds this entity.
+  /// The swiftDeps file that holds this entity iff this is a provides node.
   /// If more than one source file has the same DependencyKey, then there
-  /// will be one node for each in the driver.
+  /// will be one node for each in the driver, distinguished by this field.
   Optional<std::string> swiftDeps;
 
 public:
@@ -76,26 +76,18 @@ public:
 
   const Optional<std::string> &getSwiftDeps() const { return swiftDeps; }
 
-  bool assertImplementationMustBeInAFile() const {
-    assert((getSwiftDeps().hasValue() || !getKey().isImplementation()) &&
-           "Implementations must be in some file.");
-    return true;
+  std::string getSwiftDepsOrEmpty() const {
+    return getSwiftDeps().getValueOr(std::string());
   }
 
-  std::string humanReadableName() const {
-    StringRef where =
-        !getSwiftDeps().hasValue()
-            ? ""
-            : llvm::sys::path::filename(getSwiftDeps().getValue());
-    return DepGraphNode::humanReadableName(where);
+  std::string getSwiftDepsForMapKey() const {
+    // Use the empty string for nodes whose source file is unknown,
+    // i.e. depends. (Known depends are represented by arcs, not nodes.)
+    return getSwiftDepsOrEmpty();
   }
 
-  SWIFT_DEBUG_DUMP;
-
-  bool assertProvidedEntityMustBeInAFile() const {
-    assert((getSwiftDeps().hasValue() || !getKey().isImplementation()) &&
-           "Implementations must be in some file.");
-    return true;
+  const std::string &getSwiftDepsOfProvides() const {
+    return getSwiftDeps().getValue();
   }
 
   /// Nodes can move from file to file when the driver reads the result of a
@@ -103,15 +95,28 @@ public:
   void setSwiftDeps(Optional<std::string> s) { swiftDeps = s; }
 
   bool getIsProvides() const { return getSwiftDeps().hasValue(); }
-};
 
-/// A placeholder allowing the experimental system to fit into the driver
-/// without changing as much code.
-class CoarseGrainedDependencyGraphImpl {
-public:
-  /// Use the status quo LoadResult for now.
-  using LoadResult =
-      typename swift::CoarseGrainedDependencyGraphImpl::LoadResult;
+  /// Return true if this node describes a definition for which the job is known
+  bool isDefinedInAKnownFile() const { return getIsProvides(); }
+
+  bool doesNodeProvideAnInterface() const {
+    return getKey().isInterface() && getIsProvides();
+  }
+
+  bool assertImplementationMustBeInAFile() const {
+    assert((isDefinedInAKnownFile() || !getKey().isImplementation()) &&
+           "Implementations must be in some file.");
+    return true;
+  }
+
+  std::string humanReadableName() const {
+    StringRef where = !getIsProvides()
+                          ? ""
+                          : llvm::sys::path::filename(getSwiftDepsOfProvides());
+    return DepGraphNode::humanReadableName(where);
+  }
+
+  SWIFT_DEBUG_DUMP;
 };
 
 //==============================================================================
@@ -159,18 +164,10 @@ class ModuleDepGraph {
   std::unordered_set<std::string> externalDependencies;
 
   /// The new version of "Marked."
-  /// Record cascading jobs by swiftDepsFilename because that's what
-  /// nodes store directly.
-  ///
-  /// The status quo system uses "cascade" for the following:
-  /// Def1 -> def2 -> def3, where arrows are uses, so 3 depends on 2 which
-  /// depends on 1. The first use is said to "cascade" if when def1 changes,
-  /// def3 is dirtied.
-  /// TODO: Move cascadingJobs out of the graph, ultimately.
-  /// If marked, any Job that depends on me must be rebuilt after compiling me
-  /// if I have changed.
-
-  std::unordered_set<std::string> cascadingJobs;
+  /// Aka "isMarked". Holds the swiftDeps paths for jobs the driver has or will
+  /// schedule.
+  /// TODO: Move scheduledJobs out of the graph, ultimately.
+  std::unordered_set<std::string> swiftDepsOfJobsThatNeedRunning;
 
   /// Keyed by swiftdeps filename, so we can get back to Jobs.
   std::unordered_map<std::string, const driver::Job *> jobsBySwiftDeps;
@@ -190,10 +187,12 @@ class ModuleDepGraph {
   const bool verifyFineGrainedDependencyGraphAfterEveryImport;
   const bool emitFineGrainedDependencyDotFileAfterEveryImport;
 
-  /// If tracing dependencies, holds the current node traversal path
+  /// If tracing dependencies, holds a vector used to hold the current path
+  /// def - use/def - use/def - ...
   Optional<std::vector<const ModuleDepGraphNode *>> currentPathIfTracing;
 
-  /// If tracing dependencies, record the node sequence
+  /// If tracing dependencies, holds the sequence of defs used to get to the job
+  /// that is the key
   std::unordered_multimap<const driver::Job *,
                           std::vector<const ModuleDepGraphNode *>>
       dependencyPathsToJobs;
@@ -204,7 +203,7 @@ class ModuleDepGraph {
   /// Encapsulate the invariant between where the node resides in
   /// nodesBySwiftDepsFile and the swiftDeps node instance variable here.
   void addToMap(ModuleDepGraphNode *n) {
-    nodeMap.insert(n->getSwiftDeps().getValueOr(std::string()), n->getKey(), n);
+    nodeMap.insert(n->getSwiftDepsForMapKey(), n->getKey(), n);
   }
 
   /// When integrating a SourceFileDepGraph, there might be a node representing
@@ -223,13 +222,34 @@ class ModuleDepGraph {
   /// Remove node from nodeMap, check invariants.
   ModuleDepGraphNode *eraseNodeFromMap(ModuleDepGraphNode *nodeToErase) {
     ModuleDepGraphNode *nodeActuallyErased = nodeMap.findAndErase(
-        nodeToErase->getSwiftDeps().getValueOr(std::string()),
-        nodeToErase->getKey());
+        nodeToErase->getSwiftDepsForMapKey(), nodeToErase->getKey());
     (void)nodeActuallyErased;
     assert(
         nodeToErase == nodeActuallyErased ||
         mapCorruption("Node found from key must be same as node holding key."));
     return nodeToErase;
+  }
+
+  void eraseNodeFromUsesByDef(ModuleDepGraphNode *nodeToErase) {
+    for (auto &defAndUses : usesByDef)
+      defAndUses.second.erase(nodeToErase);
+  }
+
+  void eraseNodeFromCurrentPathIfTracing(ModuleDepGraphNode *nodeToErase) {
+    if (currentPathIfTracing)
+      eraseNodeFromVector(currentPathIfTracing.getValue(), nodeToErase);
+  }
+
+  void eraseNodeFromDependencyPathToJobs(ModuleDepGraphNode *nodeToErase) {
+    for (auto &jobAndPath : dependencyPathsToJobs)
+      eraseNodeFromVector(jobAndPath.second, nodeToErase);
+  }
+
+  static void eraseNodeFromVector(std::vector<const ModuleDepGraphNode *> &v,
+                                  const ModuleDepGraphNode *n) {
+    const auto where = std::find(v.begin(), v.end(), n);
+    if (where != v.end())
+      v.erase(where);
   }
 
   static StringRef getSwiftDeps(const driver::Job *cmd) {
@@ -268,12 +288,21 @@ public:
     assert(verify() && "ModuleDepGraph should be fine when created");
   }
 
+  ModuleDepGraph() : ModuleDepGraph(false, false, false, nullptr) {}
+
   /// Unlike the standard \c CoarseGrainedDependencyGraph, returns \c
   /// CoarseGrainedDependencyGraphImpl::LoadResult::AffectsDownstream when
   /// loading a new file, i.e. when determining the initial set. Caller
   /// compensates.
   CoarseGrainedDependencyGraphImpl::LoadResult
   loadFromPath(const driver::Job *, StringRef, DiagnosticEngine &);
+
+  CoarseGrainedDependencyGraphImpl::LoadResult
+  loadFromString(const driver::Job *cmd, StringRef data);
+
+  CoarseGrainedDependencyGraphImpl::LoadResult
+  loadFromSourceFileDepGraph(const driver::Job *cmd,
+                             const SourceFileDepGraph &);
 
   /// For the dot file.
   std::string getGraphID() const { return "driver"; }
@@ -302,8 +331,12 @@ public:
   /// 1. Return value (via visited) is the set of jobs needing recompilation
   /// after this one, and
   /// 2. Jobs not previously known to need dependencies reexamined after they
-  /// are recompiled. Such jobs are added to the \ref cascadingJobs set, and
+  /// are recompiled. Such jobs are added to the \ref scheduledJobs set, and
   /// accessed via \ref isMarked.
+  ///
+  /// Only return jobs marked that were previously unmarked. Not required for
+  /// the driver because it won't run a job twice, but required for the unit
+  /// test.
   std::vector<const driver::Job*> markTransitive(
       const driver::Job *jobToBeRecompiled, const void *ignored = nullptr);
 
@@ -315,6 +348,8 @@ public:
 
   std::vector<StringRef> getExternalDependencies() const;
 
+  /// Find jobs that were previously not known to need compilation but that
+  /// depend on \c externalDependency.
   std::vector<const driver::Job*> markExternal(StringRef externalDependency);
 
   void forEachUnmarkedJobDirectlyDependentOnExternalSwiftdeps(
@@ -428,14 +463,14 @@ private:
   /// Given a definition node, and a list of already found dependents,
   /// recursively add transitive closure of dependents of the definition
   /// into the already found dependents.
-  /// Also record any dependents that "cascade", i.e. whose dependencies must be
-  /// recomputed after recompilation so that its dependents can be recompiled.
-  void findDependentNodesAndRecordCascadingOnes(
+  void findDependentNodes(
       std::unordered_set<const ModuleDepGraphNode *> &foundDependents,
       const ModuleDepGraphNode *definition);
 
-  std::vector<const driver::Job*> computeUniqueJobsFromNodes(
-      const std::unordered_set<const ModuleDepGraphNode *> &nodes);
+  /// Givien a set of nodes, return the set of swiftDeps for the jobs those
+  /// nodes are in.
+  llvm::StringSet<> computeSwiftDepsFromInterfaceNodes(
+      ArrayRef<const ModuleDepGraphNode *> nodes);
 
   /// Record a visit to this node for later dependency printing
   size_t traceArrival(const ModuleDepGraphNode *visitedNode);
@@ -447,9 +482,9 @@ private:
       const std::vector<const ModuleDepGraphNode *> &pathToJob,
       const driver::Job *dependentJob);
 
-  /// Return true if job did not cascade before
-  bool rememberThatJobCascades(StringRef swiftDeps) {
-    return cascadingJobs.insert(swiftDeps).second;
+  /// Return true if job was not scheduled before
+  bool recordJobNeedsRunning(StringRef swiftDeps) {
+    return swiftDepsOfJobsThatNeedRunning.insert(swiftDeps).second;
   }
 
   /// For debugging, write out the graph to a dot file.
@@ -469,6 +504,13 @@ public:
   void printPath(raw_ostream &out, const driver::Job *node) const;
 
 private:
+  /// Get a printable filename, given a node's swiftDeps.
+  StringRef getProvidingFilename(Optional<std::string> swiftDeps) const;
+
+  /// Print one node on the dependency path.
+  static void printOneNodeOfPath(raw_ostream &out, const DependencyKey &key,
+                                 const StringRef filename);
+
   bool isCurrentPathForTracingEmpty() const {
     return !currentPathIfTracing.hasValue() || currentPathIfTracing->empty();
   }

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -487,7 +487,7 @@ private:
     return swiftDepsOfJobsThatNeedRunning.insert(swiftDeps).second;
   }
 
-  /// For debugging, write out the graph to a dot file.
+  /// For debugging and visualization, write out the graph to a dot file.
   /// \p diags may be null if no diagnostics are needed.
   void emitDotFileForJob(DiagnosticEngine &, const driver::Job *);
   void emitDotFile(DiagnosticEngine &, StringRef baseName);

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -150,6 +150,9 @@ class CommandOutput {
 public:
   CommandOutput(file_types::ID PrimaryOutputType, OutputFileMap &Derived);
 
+  /// For testing dependency graphs that use Jobs
+  CommandOutput(StringRef dummyBaseName, OutputFileMap &);
+
   /// Return the primary output type for this CommandOutput.
   file_types::ID getPrimaryOutputType() const;
 
@@ -318,6 +321,12 @@ public:
         Executable(Executable), Arguments(std::move(Arguments)),
         ExtraEnvironment(std::move(ExtraEnvironment)),
         FilelistFileInfos(std::move(Infos)), ResponseFile(ResponseFile) {}
+
+  /// For testing dependency graphs that use Jobs
+  Job(OutputFileMap &OFM, StringRef dummyBaseName)
+      : Job(CompileJobAction(file_types::TY_Object),
+            SmallVector<const Job *, 4>(),
+            std::make_unique<CommandOutput>(dummyBaseName, OFM), nullptr, {}) {}
 
   virtual ~Job();
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -137,7 +137,11 @@ def driver_always_rebuild_dependents :
 
 def enable_fine_grained_dependencies :
 Flag<["-"], "enable-fine-grained-dependencies">, Flags<[FrontendOption, HelpHidden]>,
-HelpText<"Experimental work-in-progress to be more selective about incremental recompilation">;
+HelpText<"Be more selective about incremental recompilation">;
+
+def disable_fine_grained_dependencies :
+Flag<["-"], "disable-fine-grained-dependencies">, Flags<[FrontendOption, HelpHidden]>,
+HelpText<"Don't be more selective about incremental recompilation">;
 
 
 def enable_only_one_dependency_file :
@@ -182,6 +186,11 @@ def fine_grained_dependency_include_intrafile :
 Flag<["-"], "fine-grained-dependency-include-intrafile">,
 InternalDebugOpt,
 HelpText<"Include within-file dependencies.">;
+
+def emit_fine_grained_dependency_sourcefile_dot_files :
+Flag<["-"], "emit-fine-grained-dependency-sourcefile-dot-files">,
+InternalDebugOpt,
+HelpText<"Emit dot files for every source file.">;
 
 def driver_mode : Joined<["--"], "driver-mode=">, Flags<[HelpHidden]>,
   HelpText<"Set the driver mode to either 'swift' or 'swiftc'">;

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -57,11 +57,11 @@ SourceFileDepGraph::getSourceFileNodePair() const {
                                                                 getNode(1));
 }
 
-StringRef SourceFileDepGraph::getSwiftDepsFromSourceFileProvide() const {
+StringRef SourceFileDepGraph::getSwiftDepsOfJobThatProducedThisGraph() const {
   return getSourceFileNodePair()
       .getInterface()
       ->getKey()
-      .getSwiftDepsFromSourceFileProvide();
+      .getSwiftDepsFromASourceFileProvideNodeKey();
 }
 
 void SourceFileDepGraph::forEachArc(
@@ -77,8 +77,11 @@ void SourceFileDepGraph::forEachArc(
 
 InterfaceAndImplementationPair<SourceFileDepGraphNode>
 SourceFileDepGraph::findExistingNodePairOrCreateAndAddIfNew(
-    NodeKind k, StringRef context, StringRef name,
-    Optional<std::string> fingerprint) {
+    NodeKind k, const ContextNameFingerprint &contextNameFingerprint) {
+  const std::string &context = std::get<0>(contextNameFingerprint);
+  const std::string &name = std::get<1>(contextNameFingerprint);
+  const Optional<std::string> &fingerprint =
+      std::get<2>(contextNameFingerprint);
   InterfaceAndImplementationPair<SourceFileDepGraphNode> nodePair{
       findExistingNodeOrCreateIfNew(
           DependencyKey(k, DeclAspect::interface, context, name), fingerprint,
@@ -86,13 +89,16 @@ SourceFileDepGraph::findExistingNodePairOrCreateAndAddIfNew(
       findExistingNodeOrCreateIfNew(
           DependencyKey(k, DeclAspect::implementation, context, name),
           fingerprint, true /* = isProvides */)};
-  // if interface changes, have to rebuild implementation
-  addArc(nodePair.getInterface(), nodePair.getImplementation());
+  // if interface changes, have to rebuild implementation.
+  // But, if an arc is added for this, then *any* change that causes
+  // a same-named interface to be dirty will dirty this implementation,
+  // even if that interface is in another file.
+  // So, make the interface->implementation arc implicit.
   return nodePair;
 }
 
 SourceFileDepGraphNode *SourceFileDepGraph::findExistingNodeOrCreateIfNew(
-    DependencyKey key, Optional<std::string> fingerprint,
+    DependencyKey key, const Optional<std::string> &fingerprint,
     const bool isProvides) {
   SourceFileDepGraphNode *result = memoizedNodes.findExistingOrCreateIfNew(
       key, [&](DependencyKey key) -> SourceFileDepGraphNode * {
@@ -101,16 +107,39 @@ SourceFileDepGraphNode *SourceFileDepGraph::findExistingNodeOrCreateIfNew(
         addNode(n);
         return n;
       });
+  assert(result->getKey() == key && "Keys must match.");
+  if (!isProvides)
+    return result;
   // If have provides and depends with same key, result is one node that
   // isProvides
-  if (isProvides)
+  if (!result->getIsProvides() && fingerprint) {
     result->setIsProvides();
-  assert(result->getKey() == key && "Keys must match.");
+    assert(!result->getFingerprint() && "Depends should not have fingerprints");
+    result->setFingerprint(fingerprint);
+    return result;
+  }
+  // If there are two Decls with same base name but differ only in fingerprint,
+  // since we won't be able to tell which Decl is depended-upon (is this right?)
+  // just use the one node, but erase its print:
+  if (fingerprint != result->getFingerprint())
+    result->setFingerprint(None);
   return result;
 }
 
 std::string DependencyKey::demangleTypeAsContext(StringRef s) {
   return swift::Demangle::demangleTypeAsString(s.str());
+}
+
+DependencyKey DependencyKey::createTransitiveKeyForWholeSourceFile(
+    const StringRef swiftDeps) {
+  assert(!swiftDeps.empty());
+  const auto context = DependencyKey::computeContextForProvidedEntity<
+      NodeKind::sourceFileProvide>(swiftDeps);
+  const auto name =
+      DependencyKey::computeNameForProvidedEntity<NodeKind::sourceFileProvide>(
+          swiftDeps);
+  return DependencyKey(NodeKind::sourceFileProvide, DeclAspect::interface,
+                       context, name);
 }
 
 //==============================================================================
@@ -175,9 +204,8 @@ std::string DependencyKey::humanReadableName() const {
 }
 
 std::string DependencyKey::asString() const {
-  return NodeKindNames[size_t(kind)] + " " +
-         "aspect: " + DeclAspectNames[size_t(aspect)] + ", " +
-         humanReadableName();
+  return NodeKindNames[size_t(kind)] + " " + "aspect: " + aspectName().str() +
+         ", " + humanReadableName();
 }
 
 /// Needed for TwoStageMap::verify:

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -90,10 +90,19 @@ SourceFileDepGraph::findExistingNodePairOrCreateAndAddIfNew(
           DependencyKey(k, DeclAspect::implementation, context, name),
           fingerprint, true /* = isProvides */)};
   // if interface changes, have to rebuild implementation.
+  // This dependency used to be represented by
+  // addArc(nodePair.getInterface(), nodePair.getImplementation());
+  // However, recall that the dependency scheme as of 1/2020 chunks
+  // declarations together by base name.
+  // So if the arc were added, a dirtying of a same-based-named interface
+  // in a different file would dirty the implementation in this file,
+  // causing the needless recompilation of this file.
   // But, if an arc is added for this, then *any* change that causes
   // a same-named interface to be dirty will dirty this implementation,
   // even if that interface is in another file.
-  // So, make the interface->implementation arc implicit.
+  // Therefor no such arc is added here, and any dirtying of either
+  // the interface or implementation of this declaration will cause
+  // the driver to recompile this source file.
   return nodePair;
 }
 

--- a/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
+++ b/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
@@ -361,6 +361,12 @@ std::string DependencyKey::computeContextForProvidedEntity<
   return mangleTypeAsContext(holderAndMember.first);
 }
 
+// Linux compiler requires the following:
+template
+std::string
+DependencyKey::computeContextForProvidedEntity<NodeKind::sourceFileProvide,
+                                               StringRef>(StringRef);
+
 //==============================================================================
 // MARK: computeNameForProvidedEntity
 //==============================================================================

--- a/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
+++ b/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
@@ -647,10 +647,10 @@ private:
   namesForProvidersOfAGivenType(std::vector<ContentsT> &contentsVec) {
     std::vector<ContextNameFingerprint> result;
     for (const auto declOrPair : contentsVec)
-      result.push_back(
-          {DependencyKey::computeContextForProvidedEntity<kind>(declOrPair),
-           DependencyKey::computeNameForProvidedEntity<kind>(declOrPair),
-           Optional<std::string>()});
+      result.push_back(ContextNameFingerprint(
+          DependencyKey::computeContextForProvidedEntity<kind>(declOrPair),
+          DependencyKey::computeNameForProvidedEntity<kind>(declOrPair),
+          Optional<std::string>()));
     return result;
   }
 
@@ -733,11 +733,11 @@ void SourceFileDepGraphConstructor::addAllDependenciesFrom(
 void SourceFileDepGraphConstructor::addSourceFileNodesToGraph() {
   g.findExistingNodePairOrCreateAndAddIfNew(
       NodeKind::sourceFileProvide,
-      {DependencyKey::computeContextForProvidedEntity<
-           NodeKind::sourceFileProvide>(swiftDeps),
-       DependencyKey::computeNameForProvidedEntity<NodeKind::sourceFileProvide>(
-           swiftDeps),
-       getSourceFileFingerprint()});
+      ContextNameFingerprint(DependencyKey::computeContextForProvidedEntity<
+                                 NodeKind::sourceFileProvide>(swiftDeps),
+                             DependencyKey::computeNameForProvidedEntity<
+                                 NodeKind::sourceFileProvide>(swiftDeps),
+                             getSourceFileFingerprint()));
 }
 
 void SourceFileDepGraphConstructor::addProviderNodesToGraph() {
@@ -824,7 +824,7 @@ static std::vector<ContextNameFingerprint>
 getBaseNameProvides(ArrayRef<std::string> simpleNames) {
   std::vector<ContextNameFingerprint> result;
   for (StringRef n : simpleNames)
-    result.push_back({"", n.str(), None});
+    result.push_back(ContextNameFingerprint("", n.str(), None));
   return result;
 }
 
@@ -832,7 +832,7 @@ static std::vector<ContextNameFingerprint>
 getMangledHolderProvides(ArrayRef<std::string> simpleNames) {
   std::vector<ContextNameFingerprint> result;
   for (StringRef n : simpleNames)
-    result.push_back({n.str(), "", None});
+    result.push_back(ContextNameFingerprint(n.str(), "", None));
   return result;
 }
 
@@ -840,7 +840,7 @@ static std::vector<ContextNameFingerprint> getCompoundProvides(
     ArrayRef<std::pair<std::string, std::string>> compoundNames) {
   std::vector<ContextNameFingerprint> result;
   for (const auto &p : compoundNames)
-    result.push_back({p.first, p.second, None});
+    result.push_back(ContextNameFingerprint(p.first, p.second, None));
   return result;
 }
 

--- a/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
+++ b/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/FileSystem.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/ReferenceDependencyKeys.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Frontend/FrontendOptions.h"
 #include "llvm/ADT/MapVector.h"
@@ -214,8 +215,11 @@ public:
 private:
   /// Extensions may contain nominals and operators.
   void findNominalsFromExtensions() {
-    for (auto *ED : extensions)
-      findNominalsAndOperatorsIn(ED->getExtendedNominal(), ED);
+    for (auto *ED : extensions) {
+      const auto *const NTD = ED->getExtendedNominal();
+      if (NTD)
+        findNominalsAndOperatorsIn(NTD, ED);
+    }
   }
   /// Top-level nominals may contain nominals and operators.
   void findNominalsInTopNominals() {
@@ -260,16 +264,19 @@ private:
   /// Extensions may contain ValueDecls.
   void findValuesInExtensions() {
     for (const auto *ED : extensions) {
-      if (excludeIfPrivate(ED->getExtendedNominal()))
+      const auto *const NTD = ED->getExtendedNominal();
+      if (!NTD || excludeIfPrivate(NTD))
         continue;
       if (!includePrivateDecls &&
           (!allInheritedProtocolsArePrivate(ED) || allMembersArePrivate(ED)))
         continue;
       for (const auto *member : ED->getMembers())
         if (const auto *VD = dyn_cast<ValueDecl>(member))
-          if (VD->hasName() && (includePrivateDecls || !declIsPrivate(VD)))
-            valuesInExtensions.push_back(
-                std::make_pair(ED->getExtendedNominal(), VD));
+          if (VD->hasName() && (includePrivateDecls || !declIsPrivate(VD))) {
+            const auto *const NTD = ED->getExtendedNominal();
+            if (NTD)
+              valuesInExtensions.push_back(std::make_pair(NTD, VD));
+          }
     }
   }
 
@@ -424,46 +431,38 @@ std::string DependencyKey::computeNameForProvidedEntity<
 
 template <>
 DependencyKey
-DependencyKey::createDependedUponKey<NodeKind::topLevel, DeclBaseName>(
-    const DeclBaseName &dbn) {
-  return DependencyKey(NodeKind::topLevel, DeclAspect::interface, "",
-                       dbn.userFacingName());
+DependencyKey::createDependedUponKey<NodeKind::topLevel>(StringRef name) {
+  return DependencyKey(NodeKind::topLevel, DeclAspect::interface, "", name);
 }
 
 template <>
 DependencyKey
-DependencyKey::createDependedUponKey<NodeKind::dynamicLookup, DeclBaseName>(
-    const DeclBaseName &dbn) {
+DependencyKey::createDependedUponKey<NodeKind::dynamicLookup>(StringRef name) {
   return DependencyKey(NodeKind::dynamicLookup, DeclAspect::interface, "",
-                       dbn.userFacingName());
+                       name);
 }
 
 template <>
-DependencyKey DependencyKey::createDependedUponKey<
-    NodeKind::nominal, std::pair<const NominalTypeDecl *, DeclBaseName>>(
-    const std::pair<const NominalTypeDecl *, DeclBaseName> &p) {
-  return DependencyKey(NodeKind::nominal, DeclAspect::interface,
-                       mangleTypeAsContext(p.first), "");
+DependencyKey
+DependencyKey::createDependedUponKey<NodeKind::externalDepend>(StringRef name) {
+  return DependencyKey(NodeKind::externalDepend, DeclAspect::interface, "",
+                       name);
 }
 
 template <>
-DependencyKey DependencyKey::createDependedUponKey<
-    NodeKind::member, std::pair<const NominalTypeDecl *, DeclBaseName>>(
-    const std::pair<const NominalTypeDecl *, DeclBaseName> &p) {
-  const bool isMemberBlank = p.second.empty();
+DependencyKey
+DependencyKey::createDependedUponKey<NodeKind::nominal>(StringRef mangledName) {
+  return DependencyKey(NodeKind::nominal, DeclAspect::interface, mangledName,
+                       "");
+}
+
+DependencyKey DependencyKey::createDependedUponKey(StringRef mangledHolderName,
+                                                   StringRef memberBaseName) {
+  const bool isMemberBlank = memberBaseName.empty();
   const auto kind =
       isMemberBlank ? NodeKind::potentialMember : NodeKind::member;
-  return DependencyKey(kind, DeclAspect::interface,
-                       mangleTypeAsContext(p.first),
-                       isMemberBlank ? "" : p.second.userFacingName());
-}
-
-template <>
-DependencyKey
-DependencyKey::createDependedUponKey<NodeKind::externalDepend, std::string>(
-    const std::string &file) {
-  return DependencyKey(NodeKind::externalDepend, DeclAspect::interface, "",
-                       file);
+  return DependencyKey(kind, DeclAspect::interface, mangledHolderName,
+                       isMemberBlank ? "" : memberBaseName);
 }
 
 //==============================================================================
@@ -475,12 +474,6 @@ namespace {
 /// Reads the information provided by the frontend and builds the
 /// SourceFileDepGraph
 class SourceFileDepGraphConstructor {
-  /// The SourceFile containing the Decls.
-  SourceFile *SF;
-
-  /// Furnishes depended-upon names resulting from lookups.
-  const DependencyTracker &depTracker;
-
   /// Name of the swiftDeps file, for inclusion in the constructed graph.
   StringRef swiftDeps; // TODO rm?
 
@@ -491,18 +484,133 @@ class SourceFileDepGraphConstructor {
   /// If there was an error, cannot get accurate info.
   const bool hadCompilationError;
 
+  /// Functions as the fingerprint of the entire file
+  const std::string interfaceHash;
+
+  /// Top-level base names of decls that are depended-upon and a flag indicating
+  /// if the dependency "cascades"
+  const std::vector<std::pair<std::string, bool>> topLevelDepends;
+
+  /// A mangled nominal name and the member base name that are depended-upon,
+  /// a flag indicating if the member is private to its enclosing file, and
+  /// a flag indicating if the dependency cascades.
+  const std::vector<std::pair<std::tuple<std::string, std::string, bool>, bool>>
+      memberDepends;
+
+  /// The base name of a class member depended-upon for dynamic lookup, and a
+  /// cascades flag.
+  const std::vector<std::pair<std::string, bool>> dynamicLookupDepends;
+
+  /// The paths of swiftdeps files of other modules that are depended-upon.
+  const std::vector<std::string> externalDependencies;
+
+  /// Provided names
+  std::vector<ContextNameFingerprint> precedenceGroups;
+  std::vector<ContextNameFingerprint> memberOperatorDecls;
+  std::vector<ContextNameFingerprint> operators;
+  std::vector<ContextNameFingerprint> topNominals;
+  std::vector<ContextNameFingerprint> topValues;
+  std::vector<ContextNameFingerprint> allNominals;
+  std::vector<ContextNameFingerprint> potentialMemberHolders;
+  std::vector<ContextNameFingerprint> valuesInExtensions;
+  std::vector<ContextNameFingerprint> classMembers;
+
   /// Graph under construction
   SourceFileDepGraph g;
 
 public:
-  SourceFileDepGraphConstructor(SourceFile *SF,
+  /// Expose this layer to enable faking up a constructor for testing.
+  /// See the instance variable comments for explanation.
+  // clang-format off
+  SourceFileDepGraphConstructor(
+    StringRef swiftDeps,
+    bool includePrivateDeps,
+    bool hadCompilationError,
+    const std::string &interfaceHash,
+    ArrayRef<std::pair<std::string, bool>> topLevelDepends,
+    ArrayRef<std::pair<std::tuple<std::string, std::string, bool>, bool>> memberDepends,
+    ArrayRef<std::pair<std::string, bool>> dynamicLookupDepends,
+    ArrayRef<std::string> externalDependencies,
+
+    ArrayRef<ContextNameFingerprint> precedenceGroups,
+    ArrayRef<ContextNameFingerprint> memberOperatorDecls,
+    ArrayRef<ContextNameFingerprint> operators,
+    ArrayRef<ContextNameFingerprint> topNominals,
+    ArrayRef<ContextNameFingerprint> topValues,
+    ArrayRef<ContextNameFingerprint> allNominals,
+    ArrayRef<ContextNameFingerprint> potentialMemberHolders,
+    ArrayRef<ContextNameFingerprint> valuesInExtensions,
+    ArrayRef<ContextNameFingerprint> classMembers
+    ) :
+    swiftDeps(swiftDeps),
+    includePrivateDeps(includePrivateDeps),
+    hadCompilationError(hadCompilationError),
+
+    interfaceHash(interfaceHash),
+    topLevelDepends(topLevelDepends),
+    memberDepends(memberDepends),
+    dynamicLookupDepends(dynamicLookupDepends),
+    externalDependencies(externalDependencies),
+
+    precedenceGroups(precedenceGroups),
+    memberOperatorDecls(memberOperatorDecls),
+    operators(operators),
+    topNominals(topNominals),
+    topValues(topValues),
+    allNominals(allNominals),
+    potentialMemberHolders(potentialMemberHolders),
+    valuesInExtensions(valuesInExtensions),
+    classMembers(classMembers)
+    {}
+
+  SourceFileDepGraphConstructor static forSourceFile(SourceFile *SF,
                                 const DependencyTracker &depTracker,
                                 StringRef swiftDeps,
                                 const bool includePrivateDeps,
-                                const bool hadCompilationError)
-      : SF(SF), depTracker(depTracker), swiftDeps(swiftDeps),
-        includePrivateDeps(includePrivateDeps),
-        hadCompilationError(hadCompilationError) {}
+                                const bool hadCompilationError) {
+
+  SourceFileDeclFinder declFinder(SF, includePrivateDeps);
+    std::vector<std::pair<std::string, bool>> topLevelDepends;
+    for (const auto p: SF->getReferencedNameTracker()->getTopLevelNames())
+      topLevelDepends.push_back(std::make_pair(p.getFirst().userFacingName(), p.getSecond()));
+
+    std::vector<std::pair<std::string, bool>> dynamicLookupDepends;
+    for (const auto p: SF->getReferencedNameTracker()->getDynamicLookupNames())
+      dynamicLookupDepends.push_back(std::make_pair(p.getFirst().userFacingName(), p.getSecond()));
+
+    std::vector<std::pair<std::tuple<std::string, std::string, bool>, bool>> memberDepends;
+    for (const auto &p: SF->getReferencedNameTracker()->getUsedMembers())
+      memberDepends.push_back(
+        std::make_pair(
+          std::make_tuple(
+            mangleTypeAsContext(p.getFirst().first),
+            p.getFirst().second.userFacingName(),
+            declIsPrivate(p.getFirst().first)),
+          p.getSecond()));
+
+      return SourceFileDepGraphConstructor(
+        swiftDeps,
+        includePrivateDeps,
+        hadCompilationError,
+
+        getInterfaceHash(SF),
+        topLevelDepends,
+        memberDepends,
+        dynamicLookupDepends,
+        depTracker.getDependencies(),
+
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.precedenceGroups),
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.memberOperatorDecls),
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.operators),
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.topNominals),
+        namesForProvidersOfAGivenType<NodeKind::topLevel>(declFinder.topValues),
+        namesForProvidersOfAGivenType<NodeKind::nominal>(declFinder.allNominals),
+        namesForProvidersOfAGivenType<NodeKind::potentialMember>(declFinder.potentialMemberHolders),
+        namesForProvidersOfAGivenType<NodeKind::member>(declFinder.valuesInExtensions),
+        namesForProvidersOfAGivenType<NodeKind::dynamicLookup>(declFinder.classMembers)
+        );
+  }
+  // clang-format on
 
   /// Construct the graph and return it.
   SourceFileDepGraph construct() {
@@ -517,7 +625,7 @@ public:
   }
 
 private:
-  std::string getSourceFileFingerprint() const { return getInterfaceHash(SF); }
+  std::string getSourceFileFingerprint() const { return interfaceHash; }
 
   static std::string getInterfaceHash(SourceFile *SF) {
     llvm::SmallString<32> interfaceHash;
@@ -533,19 +641,26 @@ private:
   void addDependencyArcsToGraph();
 
   /// Given an array of Decls or pairs of them in \p declsOrPairs
-  /// create nodes if needed and add the new nodes to the graph.
+  /// create string pairs for context and name
   template <NodeKind kind, typename ContentsT>
-  void addAllProviderNodesOfAGivenType(std::vector<ContentsT> &contentsVec) {
-    for (const auto declOrPair : contentsVec) {
-      // No fingerprints for providers (Decls) yet.
-      // Someday ...
-      const Optional<std::string> fingerprint = None;
+  static std::vector<ContextNameFingerprint>
+  namesForProvidersOfAGivenType(std::vector<ContentsT> &contentsVec) {
+    std::vector<ContextNameFingerprint> result;
+    for (const auto declOrPair : contentsVec)
+      result.push_back(
+          {DependencyKey::computeContextForProvidedEntity<kind>(declOrPair),
+           DependencyKey::computeNameForProvidedEntity<kind>(declOrPair),
+           Optional<std::string>()});
+    return result;
+  }
+
+  template <NodeKind kind>
+  void addAllProviderNodesOfAGivenType(
+      ArrayRef<ContextNameFingerprint> contextNameFingerprints) {
+    for (const auto &contextNameFingerprint : contextNameFingerprints) {
       auto p = g.findExistingNodePairOrCreateAndAddIfNew(
-          kind,
-          DependencyKey::computeContextForProvidedEntity<kind>(declOrPair),
-          DependencyKey::computeNameForProvidedEntity<kind>(declOrPair),
-          fingerprint);
-      // Since we don't have fingerprints yet, must rebuild every provider when
+          kind, contextNameFingerprint);
+      // When we don't have a fingerprint yet, must rebuild every provider when
       // interfaceHash changes. So when interface (i.e. interface hash) of
       // sourceFile changes, every provides is dirty. And since we don't know
       // what happened, dirtyness might affect the interface.
@@ -557,8 +672,8 @@ private:
   /// Given a map of names and isCascades, add the resulting dependencies to the
   /// graph.
   template <NodeKind kind>
-  void addAllDependenciesFrom(const llvm::DenseMap<DeclBaseName, bool> &map) {
-    for (const auto &p : map)
+  void addAllDependenciesFrom(ArrayRef<std::pair<std::string, bool>> names) {
+    for (const auto &p : names)
       recordThatThisWholeFileDependsOn(
           DependencyKey::createDependedUponKey<kind>(p.first), p.second);
   }
@@ -566,8 +681,7 @@ private:
   /// Given a map of holder-and-member-names and isCascades, add the resulting
   /// dependencies to the graph.
   void addAllDependenciesFrom(
-      const llvm::DenseMap<std::pair<const NominalTypeDecl *, DeclBaseName>,
-                           bool> &);
+      ArrayRef<std::pair<std::tuple<std::string, std::string, bool>, bool>>);
 
   /// Given an array of external swiftDeps files, add the resulting external
   /// dependencies to the graph.
@@ -587,28 +701,27 @@ private:
 };
 } // namespace
 
-using UsedMembersMap =
-    llvm::DenseMap<std::pair<const NominalTypeDecl *, DeclBaseName>, bool>;
 void SourceFileDepGraphConstructor::addAllDependenciesFrom(
-    const UsedMembersMap &map) {
+    ArrayRef<std::pair<std::tuple<std::string, std::string, bool>, bool>>
+        members) {
 
-  UsedMembersMap filteredMap;
-  for (const auto &entry : map)
-    if (includePrivateDeps || !declIsPrivate(entry.first.first))
-      filteredMap[entry.getFirst()] = entry.getSecond();
-
-  std::unordered_set<const NominalTypeDecl *> holdersOfCascadingMembers;
-  for (auto &entry : filteredMap)
+  llvm::StringSet<> holdersOfCascadingMembers;
+  for (const auto &entry : members) {
+    if (!includePrivateDeps && std::get<2>(entry.first))
+      continue;
     if (entry.second)
-      holdersOfCascadingMembers.insert(entry.first.first);
-
-  for (auto &entry : filteredMap) {
-    // mangles twice in the name of symmetry
+      holdersOfCascadingMembers.insert(std::get<0>(entry.first));
+  }
+  for (const auto &entry : members) {
+    if (!includePrivateDeps && std::get<2>(entry.first))
+      continue;
     recordThatThisWholeFileDependsOn(
-        DependencyKey::createDependedUponKey<NodeKind::nominal>(entry.first),
-        holdersOfCascadingMembers.count(entry.first.first) != 0);
+        DependencyKey::createDependedUponKey<NodeKind::nominal>(
+            std::get<0>(entry.first)),
+        holdersOfCascadingMembers.count(std::get<0>(entry.first)) != 0);
     recordThatThisWholeFileDependsOn(
-        DependencyKey::createDependedUponKey<NodeKind::member>(entry.first),
+        DependencyKey::createDependedUponKey(std::get<0>(entry.first),
+                                             std::get<1>(entry.first)),
         entry.second);
   }
 }
@@ -620,47 +733,40 @@ void SourceFileDepGraphConstructor::addAllDependenciesFrom(
 void SourceFileDepGraphConstructor::addSourceFileNodesToGraph() {
   g.findExistingNodePairOrCreateAndAddIfNew(
       NodeKind::sourceFileProvide,
-      DependencyKey::computeContextForProvidedEntity<
-          NodeKind::sourceFileProvide>(swiftDeps),
-      DependencyKey::computeNameForProvidedEntity<NodeKind::sourceFileProvide>(
-          swiftDeps),
-      getSourceFileFingerprint());
+      {DependencyKey::computeContextForProvidedEntity<
+           NodeKind::sourceFileProvide>(swiftDeps),
+       DependencyKey::computeNameForProvidedEntity<NodeKind::sourceFileProvide>(
+           swiftDeps),
+       getSourceFileFingerprint()});
 }
 
 void SourceFileDepGraphConstructor::addProviderNodesToGraph() {
-  SourceFileDeclFinder declFinder(SF, includePrivateDeps);
   // TODO: express the multiple provides and depends streams with variadic
   // templates
 
   // Many kinds of Decls become top-level depends.
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(
-      declFinder.precedenceGroups);
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(
-      declFinder.memberOperatorDecls);
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(declFinder.operators);
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(declFinder.topNominals);
-  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(declFinder.topValues);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(precedenceGroups);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(memberOperatorDecls);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(operators);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(topNominals);
+  addAllProviderNodesOfAGivenType<NodeKind::topLevel>(topValues);
 
-  addAllProviderNodesOfAGivenType<NodeKind::nominal>(declFinder.allNominals);
+  addAllProviderNodesOfAGivenType<NodeKind::nominal>(allNominals);
 
   addAllProviderNodesOfAGivenType<NodeKind::potentialMember>(
-      declFinder.potentialMemberHolders);
-  addAllProviderNodesOfAGivenType<NodeKind::member>(
-      declFinder.valuesInExtensions);
+      potentialMemberHolders);
+  addAllProviderNodesOfAGivenType<NodeKind::member>(valuesInExtensions);
 
-  addAllProviderNodesOfAGivenType<NodeKind::dynamicLookup>(
-      declFinder.classMembers);
+  addAllProviderNodesOfAGivenType<NodeKind::dynamicLookup>(classMembers);
 }
 
 void SourceFileDepGraphConstructor::addDependencyArcsToGraph() {
   // TODO: express the multiple provides and depends streams with variadic
   // templates
-  addAllDependenciesFrom<NodeKind::topLevel>(
-      SF->getReferencedNameTracker()->getTopLevelNames());
-  addAllDependenciesFrom(SF->getReferencedNameTracker()->getUsedMembers());
-  addAllDependenciesFrom<NodeKind::dynamicLookup>(
-      SF->getReferencedNameTracker()->getDynamicLookupNames());
-  addAllDependenciesFrom(depTracker.getDependencies());
+  addAllDependenciesFrom<NodeKind::topLevel>(topLevelDepends);
+  addAllDependenciesFrom(memberDepends);
+  addAllDependenciesFrom<NodeKind::dynamicLookup>(dynamicLookupDepends);
+  addAllDependenciesFrom(externalDependencies);
 }
 
 void SourceFileDepGraphConstructor::recordThatThisWholeFileDependsOn(
@@ -676,7 +782,8 @@ void SourceFileDepGraphConstructor::recordThatThisWholeFileDependsOn(
 
 bool swift::fine_grained_dependencies::emitReferenceDependencies(
     DiagnosticEngine &diags, SourceFile *const SF,
-    const DependencyTracker &depTracker, StringRef outputPath) {
+    const DependencyTracker &depTracker, StringRef outputPath,
+    const bool alsoEmitDotFile) {
 
   // Before writing to the dependencies file path, preserve any previous file
   // that may have been there. No error handling -- this is just a nicety, it
@@ -685,8 +792,8 @@ bool swift::fine_grained_dependencies::emitReferenceDependencies(
   const bool includeIntrafileDeps =
       SF->getASTContext().LangOpts.FineGrainedDependenciesIncludeIntrafileOnes;
   const bool hadCompilationError = SF->getASTContext().hadError();
-  SourceFileDepGraphConstructor gc(SF, depTracker, outputPath,
-                                   includeIntrafileDeps, hadCompilationError);
+  auto gc = SourceFileDepGraphConstructor::forSourceFile(
+      SF, depTracker, outputPath, includeIntrafileDeps, hadCompilationError);
   SourceFileDepGraph g = gc.construct();
 
   const bool hadError =
@@ -699,10 +806,114 @@ bool swift::fine_grained_dependencies::emitReferenceDependencies(
 
   assert(g.verifyReadsWhatIsWritten(outputPath));
 
-  std::string dotFileName = outputPath.str() + ".dot";
-  withOutputFile(diags, dotFileName, [&](llvm::raw_pwrite_stream &out) {
-    DotFileEmitter<SourceFileDepGraph>(out, g, false, false).emit();
-    return false;
-  });
+  if (alsoEmitDotFile) {
+    std::string dotFileName = outputPath.str() + ".dot";
+    withOutputFile(diags, dotFileName, [&](llvm::raw_pwrite_stream &out) {
+      DotFileEmitter<SourceFileDepGraph>(out, g, false, false).emit();
+      return false;
+    });
+  }
   return hadError;
+}
+
+//==============================================================================
+// Entry point from the unit tests
+//==============================================================================
+
+static std::vector<ContextNameFingerprint>
+getBaseNameProvides(ArrayRef<std::string> simpleNames) {
+  std::vector<ContextNameFingerprint> result;
+  for (StringRef n : simpleNames)
+    result.push_back({"", n.str(), None});
+  return result;
+}
+
+static std::vector<ContextNameFingerprint>
+getMangledHolderProvides(ArrayRef<std::string> simpleNames) {
+  std::vector<ContextNameFingerprint> result;
+  for (StringRef n : simpleNames)
+    result.push_back({n.str(), "", None});
+  return result;
+}
+
+static std::vector<ContextNameFingerprint> getCompoundProvides(
+    ArrayRef<std::pair<std::string, std::string>> compoundNames) {
+  std::vector<ContextNameFingerprint> result;
+  for (const auto &p : compoundNames)
+    result.push_back({p.first, p.second, None});
+  return result;
+}
+
+// Use '_' as a prefix indicating non-cascading
+static bool cascades(const std::string &s) { return s.empty() || s[0] != '_'; }
+
+// Use '_' as a prefix for a file-private member
+static bool isPrivate(const std::string &s) {
+  return !s.empty() && s[0] == '_';
+}
+
+static std::vector<std::pair<std::string, bool>>
+getSimpleDepends(ArrayRef<std::string> simpleNames) {
+  std::vector<std::pair<std::string, bool>> result;
+  for (std::string n : simpleNames)
+    result.push_back({n, cascades((n))});
+  return result;
+}
+
+static std::vector<std::string>
+getExternalDepends(ArrayRef<std::string> simpleNames) {
+  return simpleNames;
+}
+
+static std::vector<std::pair<std::tuple<std::string, std::string, bool>, bool>>
+getCompoundDepends(
+    ArrayRef<std::string> simpleNames,
+    ArrayRef<std::pair<std::string, std::string>> compoundNames) {
+  std::vector<std::pair<std::tuple<std::string, std::string, bool>, bool>>
+      result;
+  for (std::string n : simpleNames) {
+    // (On Linux, the compiler needs more verbosity than:
+    //  result.push_back({{n, "", false}, cascades(n)});
+    result.push_back(
+        std::make_pair(std::make_tuple(n, std::string(), false), cascades(n)));
+  }
+  for (auto &p : compoundNames) {
+    // Likewise, for Linux expand the following out:
+    //    result.push_back(
+    //        {{p.first, p.second, isPrivate(p.second)}, cascades(p.first)});
+    result.push_back(
+        std::make_pair(std::make_tuple(p.first, p.second, isPrivate(p.second)),
+                       cascades(p.first)));
+  }
+  return result;
+}
+
+SourceFileDepGraph SourceFileDepGraph::simulateLoad(
+    std::string swiftDepsFilename, const bool includePrivateDeps,
+    const bool hadCompilationError, std::string interfaceHash,
+    llvm::StringMap<std::vector<std::string>> simpleNamesByRDK,
+    llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
+        compoundNamesByRDK) {
+
+  using namespace reference_dependency_keys;
+
+  // clang-format off
+  SourceFileDepGraphConstructor c(
+    swiftDepsFilename, includePrivateDeps, hadCompilationError, interfaceHash,
+    getSimpleDepends(simpleNamesByRDK[dependsTopLevel]),
+    getCompoundDepends(simpleNamesByRDK[dependsNominal], compoundNamesByRDK[dependsMember]),
+    getSimpleDepends(simpleNamesByRDK[dependsDynamicLookup]),
+    getExternalDepends(simpleNamesByRDK[dependsExternal]),
+    {}, // precedence groups
+    {}, // memberOperatorDecls
+    {}, // operators
+    getMangledHolderProvides(simpleNamesByRDK[providesNominal]), // topNominals
+    getBaseNameProvides(simpleNamesByRDK[providesTopLevel]), // topValues
+    getMangledHolderProvides(simpleNamesByRDK[providesNominal]), // allNominals
+    getMangledHolderProvides(simpleNamesByRDK[providesNominal]), // potentialMemberHolders
+    getCompoundProvides(compoundNamesByRDK[providesMember]), // valuesInExtensions
+    getBaseNameProvides(simpleNamesByRDK[providesDynamicLookup]) // classMembers
+    );
+  // clang-format on
+  return c.construct();
 }

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -272,7 +272,7 @@ namespace driver {
 
     void noteBuilding(const Job *cmd, const bool willBeBuilding,
                       const bool isTentative, const bool forRanges,
-                      StringRef reason) {
+                      StringRef reason) const {
       if (!Comp.getShowIncrementalBuildDecisions())
         return;
       if (ScheduledCommands.count(cmd))
@@ -298,6 +298,23 @@ namespace driver {
                                      llvm::outs(), cmd, [](raw_ostream &out, const Job *base) {
                                        out << llvm::sys::path::filename(base->getOutput().getBaseInput(0));
                                      });
+    }
+
+    template <typename JobsCollection>
+    void noteBuildingJobs(const JobsCollection &unsortedJobsArg,
+                          const bool forRanges, const StringRef reason) const {
+      if (!Comp.getShowIncrementalBuildDecisions() &&
+          !Comp.getShowJobLifecycle())
+        return;
+      // Sigh, must manually convert SmallPtrSet to ArrayRef-able container
+      llvm::SmallVector<const Job *, 16> unsortedJobs;
+      for (const Job *j : unsortedJobsArg)
+        unsortedJobs.push_back(j);
+      llvm::SmallVector<const Job *, 16> sortedJobs;
+      Comp.sortJobsToMatchCompilationInputs(unsortedJobs, sortedJobs);
+      for (const Job *j : sortedJobs)
+        noteBuilding(j, /*willBeBuilding=*/true, /*isTentative=*/false,
+                     forRanges, reason);
     }
 
     const Job *findUnfinishedJob(ArrayRef<const Job *> JL) {
@@ -432,7 +449,7 @@ namespace driver {
                                  diag::warn_unable_to_load_dependencies,
                                  DependenciesFile);
       Comp.disableIncrementalBuild(
-          Twine("Malformed swift dependencies file ' ") + DependenciesFile +
+          Twine("malformed swift dependencies file ' ") + DependenciesFile +
           "'");
     }
 
@@ -468,7 +485,7 @@ namespace driver {
         // other recompilations. It is possible that the current code marks
         // things that do not need to be marked. Unecessary compilation would
         // result if that were the case.
-        bool wasCascading = isMarkedInDepGraph(FinishedCmd, forRanges);
+        bool wasKnownToNeedRunning = isMarkedInDepGraph(FinishedCmd, forRanges);
 
         switch (loadDepGraphFromPath(FinishedCmd, DependenciesFile,
                                      Comp.getDiags(), forRanges)) {
@@ -484,7 +501,7 @@ namespace driver {
           break;
 
         case CoarseGrainedDependencyGraph::LoadResult::UpToDate:
-          if (!wasCascading)
+          if (!wasKnownToNeedRunning)
             break;
           LLVM_FALLTHROUGH;
         case CoarseGrainedDependencyGraph::LoadResult::AffectsDownstream:
@@ -674,14 +691,22 @@ namespace driver {
       const CommandSet &DependentsInEffect = useRangesForScheduling
                                                  ? DependentsWithRanges
                                                  : DependentsWithoutRanges;
-      for (const Job *Cmd : DependentsInEffect) {
+
+      noteBuildingJobs(DependentsInEffect, useRangesForScheduling,
+                       "because of dependencies discovered later");
+
+      // Sort dependents for more deterministic behavior
+      llvm::SmallVector<const Job *, 16> UnsortedDependents;
+      for (const Job *j : DependentsInEffect)
+        UnsortedDependents.push_back(j);
+      llvm::SmallVector<const Job *, 16> SortedDependents;
+      Comp.sortJobsToMatchCompilationInputs(UnsortedDependents,
+                                            SortedDependents);
+
+      for (const Job *Cmd : SortedDependents) {
         DeferredCommands.erase(Cmd);
-        noteBuilding(Cmd, /*willBeBuilding=*/true, useRangesForScheduling,
-                     /*isTentative=*/false,
-                     "because of dependencies discovered later");
         scheduleCommandIfNecessaryAndPossible(Cmd);
       }
-
       return TaskFinishedResponse::ContinueExecution;
     }
 
@@ -692,6 +717,7 @@ namespace driver {
 
       // Store this task's ReturnCode as our Result if we haven't stored
       // anything yet.
+
       if (Result == EXIT_SUCCESS)
         Result = ReturnCode;
 
@@ -1007,10 +1033,6 @@ namespace driver {
 
       const bool isCascading = isCascadingJobAccordingToCondition(
           Cmd, Cond, HasDependenciesFileName);
-
-      if (Comp.getEnableFineGrainedDependencies())
-        assert(getFineGrainedDepGraph(/*forRanges=*/false)
-                   .emitDotFileAndVerify(Comp.getDiags()));
       return std::make_pair(shouldSched, isCascading);
     }
 
@@ -1055,6 +1077,10 @@ namespace driver {
         const Job *const Cmd, const Job::Condition Condition,
         const bool hasDependenciesFileName, const bool forRanges) {
 
+      // When using ranges may still decide not to schedule the job.
+      const bool isTentative =
+          Comp.getEnableSourceRangeDependencies() || forRanges;
+
       switch (Condition) {
       case Job::Condition::Always:
       case Job::Condition::NewlyAdded:
@@ -1070,11 +1096,11 @@ namespace driver {
         }
         LLVM_FALLTHROUGH;
       case Job::Condition::RunWithoutCascading:
-        noteBuilding(Cmd, /*willBeBuilding=*/true, /*isTentative=*/true,
+        noteBuilding(Cmd, /*willBeBuilding=*/true, /*isTentative=*/isTentative,
                      forRanges, "(initial)");
         return true;
       case Job::Condition::CheckDependencies:
-        noteBuilding(Cmd, /*willBeBuilding=*/false, /*isTentative=*/true,
+        noteBuilding(Cmd, /*willBeBuilding=*/false, /*isTentative=*/isTentative,
                      forRanges, "file is up-to-date and output exists");
         return false;
       }
@@ -1118,11 +1144,7 @@ namespace driver {
                                  IncrementalTracer))
           CascadedJobs.insert(transitiveCmd);
       }
-      for (auto *transitiveCmd : CascadedJobs)
-        noteBuilding(transitiveCmd, /*willBeBuilding=*/true,
-                     /*isTentative=*/false, forRanges,
-                     "because of the initial set");
-
+      noteBuildingJobs(CascadedJobs, forRanges, "because of the initial set");
       return CascadedJobs;
     }
 
@@ -1138,11 +1160,8 @@ namespace driver {
         for (const Job * marked: markExternalInDepGraph(dependency, forRanges))
           ExternallyDependentJobs.push_back(marked);
       });
-      for (auto *externalCmd : ExternallyDependentJobs) {
-        noteBuilding(externalCmd, /*willBeBuilding=*/true,
-                     /*isTentative=*/false, forRanges,
-                     "because of external dependencies");
-      }
+      noteBuildingJobs(ExternallyDependentJobs, forRanges,
+                       "because of external dependencies");
       return ExternallyDependentJobs;
     }
 
@@ -1493,11 +1512,11 @@ namespace driver {
             continue;
 
           // Be conservative, in case we use ranges this time but not next.
-          bool isCascading = true;
+          bool mightBeCascading = true;
           if (Comp.getIncrementalBuildEnabled())
-            isCascading = isMarkedInDepGraph(
+            mightBeCascading = isMarkedInDepGraph(
                 Cmd, /*forRanges=*/Comp.getEnableSourceRangeDependencies());
-          UnfinishedCommands.insert({Cmd, isCascading});
+          UnfinishedCommands.insert({Cmd, mightBeCascading});
         }
       }
     }
@@ -1824,8 +1843,6 @@ int Compilation::performJobsImpl(bool &abnormalExit,
                                CompilationRecordPath + "~moduleonly");
     }
   }
-  if (getEnableFineGrainedDependencies())
-    assert(State.FineGrainedDepGraph.emitDotFileAndVerify(getDiags()));
   abnormalExit = State.hadAnyAbnormalExit();
   return State.getResult();
 }
@@ -2051,5 +2068,25 @@ void Compilation::addDependencyPathOrCreateDummy(
     // Create dummy empty file
     std::error_code EC;
     llvm::raw_fd_ostream(depPath, EC, llvm::sys::fs::F_None);
+  }
+}
+
+void Compilation::sortJobsToMatchCompilationInputs(
+    const ArrayRef<const Job *> unsortedJobs,
+    SmallVectorImpl<const Job *> &sortedJobs) const {
+  llvm::DenseMap<StringRef, const Job *> jobsByInput;
+  for (const Job *J : unsortedJobs) {
+    const CompileJobAction *CJA = cast<CompileJobAction>(&J->getSource());
+    const InputAction *IA = CJA->findSingleSwiftInput();
+    auto R =
+        jobsByInput.insert(std::make_pair(IA->getInputArg().getValue(), J));
+    assert(R.second);
+    (void)R;
+  }
+  for (const InputPair &P : getInputFiles()) {
+    auto I = jobsByInput.find(P.second->getValue());
+    if (I != jobsByInput.end()) {
+      sortedJobs.push_back(I->second);
+    }
   }
 }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -958,7 +958,8 @@ Driver::buildCompilation(const ToolChain &TC,
 
     // relies on the new dependency graph
     const bool EnableFineGrainedDependencies =
-        ArgList->hasArg(options::OPT_enable_fine_grained_dependencies);
+        ArgList->hasFlag(options::OPT_enable_fine_grained_dependencies,
+                         options::OPT_disable_fine_grained_dependencies, false);
 
     const bool VerifyFineGrainedDependencyGraphAfterEveryImport = ArgList->hasArg(
         options::

--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -428,8 +428,9 @@ void ModuleDepGraph::traceDeparture(size_t pathLengthAfterArrival) {
   currentPath.pop_back();
 }
 
-// Emitting Dot file for ModuleDepGraph
-// ===========================================
+// =============================================================================
+// MARK: Emitting Dot file for ModuleDepGraph
+// =============================================================================
 
 void ModuleDepGraph::emitDotFileForJob(DiagnosticEngine &diags,
                                        const Job *job) {

--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -42,8 +42,7 @@ using namespace swift::driver;
 // MARK: Interfacing to Compilation
 //==============================================================================
 
-using LoadResult =
-    fine_grained_dependencies::CoarseGrainedDependencyGraphImpl::LoadResult;
+using LoadResult = CoarseGrainedDependencyGraphImpl::LoadResult;
 
 LoadResult ModuleDepGraph::loadFromPath(const Job *Cmd, StringRef path,
                                         DiagnosticEngine &diags) {
@@ -66,6 +65,11 @@ LoadResult ModuleDepGraph::loadFromPath(const Job *Cmd, StringRef path,
   return r;
 }
 
+LoadResult ModuleDepGraph::loadFromString(const Job *cmd, StringRef data) {
+  auto buffer = llvm::MemoryBuffer::getMemBuffer(data);
+  return loadFromBuffer(cmd, *buffer.get());
+}
+
 LoadResult ModuleDepGraph::loadFromBuffer(const Job *job,
                                           llvm::MemoryBuffer &buffer) {
 
@@ -73,50 +77,73 @@ LoadResult ModuleDepGraph::loadFromBuffer(const Job *job,
       SourceFileDepGraph::loadFromBuffer(buffer);
   if (!sourceFileDepGraph)
     return CoarseGrainedDependencyGraphImpl::LoadResult::HadError;
+  return loadFromSourceFileDepGraph(job, sourceFileDepGraph.getValue());
+}
+
+LoadResult ModuleDepGraph::loadFromSourceFileDepGraph(
+    const Job *job, const SourceFileDepGraph &sourceFileDepGraph) {
   addIndependentNode(job);
-  return integrate(sourceFileDepGraph.getValue());
+  return integrate(sourceFileDepGraph);
 }
 
 bool ModuleDepGraph::isMarked(const Job *cmd) const {
-  return cascadingJobs.count(getSwiftDeps(cmd));
+  return swiftDepsOfJobsThatNeedRunning.count(getSwiftDeps(cmd));
 }
 
 std::vector<const Job*> ModuleDepGraph::markTransitive(
     const Job *jobToBeRecompiled, const void *ignored) {
   FrontendStatsTracer tracer(stats, "fine-grained-dependencies-markTransitive");
+  assert(jobToBeRecompiled && "Ensure there is really a job");
 
   std::unordered_set<const ModuleDepGraphNode *> dependentNodes;
   const StringRef swiftDepsToBeRecompiled = getSwiftDeps(jobToBeRecompiled);
-  // Do the traversal.
+  assert(!swiftDepsToBeRecompiled.empty() && "Must have a swift deps");
+  // Caller already knows to run this job, no need to return it.
+  recordJobNeedsRunning(swiftDepsToBeRecompiled);
+
+  // Do the traversal for every node in the job to be recompiled.
   for (auto &fileAndNode : nodeMap[swiftDepsToBeRecompiled]) {
     assert(isCurrentPathForTracingEmpty());
-    findDependentNodesAndRecordCascadingOnes(dependentNodes,
-                                             fileAndNode.second);
+    findDependentNodes(dependentNodes, fileAndNode.second);
   }
-  return computeUniqueJobsFromNodes(dependentNodes);
-}
-
-std::vector<const Job*> ModuleDepGraph::computeUniqueJobsFromNodes(
-    const std::unordered_set<const ModuleDepGraphNode *> &nodes) {
-
-  std::vector<const Job*>jobs;
-
-  std::unordered_set<std::string> swiftDepsOfNodes;
-  for (const ModuleDepGraphNode *n : nodes) {
-    if (!n->getSwiftDeps().hasValue())
-      continue;
-    const std::string &swiftDeps = n->getSwiftDeps().getValue();
-    if (swiftDepsOfNodes.insert(swiftDeps).second) {
-      assert(n->assertImplementationMustBeInAFile());
-      ensureJobIsTracked(swiftDeps);
-      jobs.push_back(getJob(swiftDeps));
+  std::vector<const Job *> newJobsToCompile;
+  // The job containing the interface "cascades", in other words
+  // whenever that job gets recompiled, anything depending on it
+  // (since we don't have interface-specific dependency info as of Dec.
+  // 2018) must be recompiled.
+  std::vector<const ModuleDepGraphNode *> dependentNodesVec{
+      dependentNodes.begin(), dependentNodes.end()};
+  for (const auto &entry :
+       computeSwiftDepsFromInterfaceNodes(dependentNodesVec)) {
+    const StringRef swiftDeps = entry.getKey();
+    if (recordJobNeedsRunning(swiftDeps)) {
+      const Job *j = getJob(swiftDeps.str());
+      newJobsToCompile.push_back(j);
     }
   }
-  return jobs;
+  return newJobsToCompile;
 }
 
-bool ModuleDepGraph::markIntransitive(const Job *node) {
-  return rememberThatJobCascades(getSwiftDeps(node));
+llvm::StringSet<> ModuleDepGraph::computeSwiftDepsFromInterfaceNodes(
+    const ArrayRef<const ModuleDepGraphNode *> nodes) {
+
+  llvm::StringSet<> swiftDepsOfNodes;
+  for (const ModuleDepGraphNode *n : nodes) {
+    //    if (!n->doesNodeProvideAnInterface())
+    //      continue;
+    if (!n->getIsProvides())
+      continue;
+    const std::string &swiftDeps = n->getSwiftDepsOfProvides();
+    if (swiftDepsOfNodes.insert(swiftDeps).second) {
+      assert(n->assertImplementationMustBeInAFile());
+      assert(ensureJobIsTracked(swiftDeps));
+    }
+  }
+  return swiftDepsOfNodes;
+}
+
+bool ModuleDepGraph::markIntransitive(const Job *job) {
+  return recordJobNeedsRunning(getSwiftDeps(job));
 }
 
 void ModuleDepGraph::addIndependentNode(const Job *job) {
@@ -150,11 +177,10 @@ void ModuleDepGraph::forEachUnmarkedJobDirectlyDependentOnExternalSwiftdeps(
   DependencyKey key =
       DependencyKey::createDependedUponKey<NodeKind::externalDepend>(
           externalSwiftDeps.str());
-  // collect answers into useSet
-  std::unordered_set<std::string> visitedSet;
   for (const ModuleDepGraphNode *useNode : usesByDef[key]) {
-    const Job *job = getJob(useNode->getSwiftDeps());
-    if (!isMarked(job))
+    const auto swiftDepsOfUse = useNode->getSwiftDepsOfProvides();
+    const Job *job = getJob(swiftDepsOfUse);
+    if (isMarked(job))
       continue;
     fn(job);
   }
@@ -167,7 +193,7 @@ void ModuleDepGraph::forEachUnmarkedJobDirectlyDependentOnExternalSwiftdeps(
 LoadResult ModuleDepGraph::integrate(const SourceFileDepGraph &g) {
   FrontendStatsTracer tracer(stats, "fine-grained-dependencies-integrate");
 
-  StringRef swiftDeps = g.getSwiftDepsFromSourceFileProvide();
+  StringRef swiftDeps = g.getSwiftDepsOfJobThatProducedThisGraph();
   // When done, disappearedNodes contains the nodes which no longer exist.
   auto disappearedNodes = nodeMap[swiftDeps];
   // When done, changeDependencyKeys contains a list of keys that changed
@@ -229,10 +255,14 @@ bool ModuleDepGraph::integrateSourceFileDepGraphNode(
   if (integrand->getKey().getKind() == NodeKind::externalDepend)
     return externalDependencies.insert(integrand->getKey().getName()).second;
 
+  // Since dependencies are modeled as arcs in both SourceFile and Module
+  // dependency graphs, no more integration need be done for a depends node. The
+  // information will be obtained front the using node's arcs.
   if (integrand->isDepends())
-    return false; // dependency will be handled by the use node
+    return false;
 
-  StringRef swiftDepsOfSourceFileGraph = g.getSwiftDepsFromSourceFileProvide();
+  StringRef swiftDepsOfSourceFileGraph =
+      g.getSwiftDepsOfJobThatProducedThisGraph();
   auto changedAndUseNode = integrateSourceFileDeclNode(
       integrand, swiftDepsOfSourceFileGraph, preexistingMatch);
   recordWhatUseDependsUpon(g, integrand, changedAndUseNode.second);
@@ -292,6 +322,10 @@ void ModuleDepGraph::recordWhatUseDependsUpon(
 
 void ModuleDepGraph::removeNode(ModuleDepGraphNode *n) {
   eraseNodeFromMap(n);
+  eraseNodeFromUsesByDef(n);
+  eraseNodeFromCurrentPathIfTracing(n);
+  eraseNodeFromDependencyPathToJobs(n);
+
   delete n;
 }
 
@@ -307,6 +341,15 @@ void ModuleDepGraph::forEachUseOf(
     return;
   for (const ModuleDepGraphNode *useNode : iter->second)
     fn(useNode);
+  // Add in implicit interface->implementation dependency
+  if (def->getKey().isInterface() && def->getSwiftDeps()) {
+    const auto &dk = def->getKey();
+    const DependencyKey key(dk.getKind(), DeclAspect::interface,
+                            dk.getContext(), dk.getName());
+    if (const auto interfaceNode =
+            nodeMap.find(def->getSwiftDeps().getValue(), dk))
+      fn(interfaceNode.getValue());
+  }
 }
 
 void ModuleDepGraph::forEachNode(
@@ -340,31 +383,22 @@ void ModuleDepGraph::forEachArc(
 // Could be faster by passing in a file, not a node, but we are trying for
 // generality.
 
-void ModuleDepGraph::findDependentNodesAndRecordCascadingOnes(
+void ModuleDepGraph::findDependentNodes(
     std::unordered_set<const ModuleDepGraphNode *> &foundDependents,
     const ModuleDepGraphNode *definition) {
 
-    size_t pathLengthAfterArrival = traceArrival(definition);
+  size_t pathLengthAfterArrival = traceArrival(definition);
 
   // Moved this out of the following loop for effieciency.
-  assert(definition->getSwiftDeps().hasValue() &&
-         "Should only call me for Decl nodes.");
+  assert(definition->getIsProvides() && "Should only call me for Decl nodes.");
 
   forEachUseOf(definition, [&](const ModuleDepGraphNode *u) {
     // Cycle recording and check.
     if (!foundDependents.insert(u).second)
       return;
-    if (u->getKey().isInterface() && u->getSwiftDeps().hasValue()) {
-      // An interface depends on something. Thus, if that something changes
-      // the interface must be recompiled. But if an interface changes, then
-      // anything using that interface must also be recompiled.
-      // So, the job containing the interface "cascades", in other words
-      // whenever that job gets recompiled, anything depending on it
-      // (since we don't have interface-specific dependency info as of Dec.
-      // 2018) must be recompiled.
-      rememberThatJobCascades(u->getSwiftDeps().getValue());
-      findDependentNodesAndRecordCascadingOnes(foundDependents, u);
-    }
+    // If this use also provides something, follow it
+    if (u->getIsProvides())
+      findDependentNodes(foundDependents, u);
   });
   traceDeparture(pathLengthAfterArrival);
 }
@@ -373,9 +407,9 @@ size_t ModuleDepGraph::traceArrival(const ModuleDepGraphNode *visitedNode) {
   if (!currentPathIfTracing.hasValue())
     return 0;
   auto &currentPath = currentPathIfTracing.getValue();
-  recordDependencyPathToJob(currentPath, getJob(visitedNode->getSwiftDeps()));
-
   currentPath.push_back(visitedNode);
+  const auto visitedSwiftDepsIfAny = visitedNode->getSwiftDeps();
+  recordDependencyPathToJob(currentPath, getJob(visitedSwiftDepsIfAny));
   return currentPath.size();
 }
 
@@ -404,7 +438,8 @@ void ModuleDepGraph::emitDotFileForJob(DiagnosticEngine &diags,
 
 void ModuleDepGraph::emitDotFile(DiagnosticEngine &diags, StringRef baseName) {
   unsigned seqNo = dotFileSequenceNumber[baseName]++;
-  std::string fullName = baseName.str() + "." + std::to_string(seqNo) + ".dot";
+  std::string fullName =
+      baseName.str() + "-post-integration." + std::to_string(seqNo) + ".dot";
   withOutputFile(diags, fullName, [&](llvm::raw_ostream &out) {
     emitDotFile(out);
     return false;
@@ -422,8 +457,8 @@ void ModuleDepGraph::emitDotFile(llvm::raw_ostream &out) {
 
 void ModuleDepGraphNode::dump() const {
   DepGraphNode::dump();
-  if (getSwiftDeps().hasValue())
-    llvm::errs() << " swiftDeps: <" << getSwiftDeps().getValue() << ">\n";
+  if (getIsProvides())
+    llvm::errs() << " swiftDeps: <" << getSwiftDepsOfProvides() << ">\n";
   else
     llvm::errs() << " no swiftDeps\n";
 }
@@ -478,9 +513,7 @@ void ModuleDepGraph::verifyNodeIsUniqueWithinSubgraph(
   assert(submapIndex < nodesSeenInNodeMap.size() &&
          "submapIndex is out of bounds.");
   auto iterInserted = nodesSeenInNodeMap[submapIndex][n->getKey()].insert(
-      std::make_pair(n->getSwiftDeps().hasValue() ? n->getSwiftDeps().getValue()
-                                                  : std::string(),
-                     n));
+      std::make_pair(n->getSwiftDepsForMapKey(), n));
   if (!iterInserted.second) {
     llvm_unreachable("duplicate driver keys");
   }
@@ -523,23 +556,75 @@ void ModuleDepGraph::verifyEachJobInGraphIsTracked() const {
       });
 }
 
-bool ModuleDepGraph::emitDotFileAndVerify(DiagnosticEngine &diags) {
-  if (!driverDotFileBasePath.empty())
-    emitDotFile(diags, driverDotFileBasePath);
-  return verify();
-}
-
-/// Dump the path that led to \p node.
-/// TODO: make output more like existing system's
+/// Dump the path(s) that led to \p node.
+/// TODO: break up
 void ModuleDepGraph::printPath(raw_ostream &out,
                                const driver::Job *jobToBeBuilt) const {
   assert(currentPathIfTracing.hasValue() &&
          "Cannot print paths of paths weren't tracked.");
-  auto const allPaths = dependencyPathsToJobs.find(jobToBeBuilt);
-  if (allPaths == dependencyPathsToJobs.cend())
-    return;
-  for (const auto *n : allPaths->second) {
-    out << n->humanReadableName() << "\n";
+
+  for (auto paths = dependencyPathsToJobs.find(jobToBeBuilt);
+       paths != dependencyPathsToJobs.end() && paths->first == jobToBeBuilt;
+       ++paths) {
+    const auto &path = paths->second;
+    bool first = true;
+    out << "\t";
+    for (const ModuleDepGraphNode *n : path) {
+      if (first)
+        first = false;
+      else
+        out << " -> ";
+
+      const StringRef providerName = getProvidingFilename(n->getSwiftDeps());
+      printOneNodeOfPath(out, n->getKey(), providerName);
+    }
+    out << "\n";
   }
-  out << "\n";
+}
+
+StringRef ModuleDepGraph::getProvidingFilename(
+    const Optional<std::string> swiftDeps) const {
+  if (!swiftDeps)
+    return "<unknown";
+  const StringRef inputName =
+      llvm::sys::path::filename(getJob(swiftDeps)->getFirstSwiftPrimaryInput());
+  // FineGrainedDependencyGraphTests work with simulated jobs with empty
+  // input names.
+  return !inputName.empty() ? inputName : StringRef(swiftDeps.getValue());
+}
+
+void ModuleDepGraph::printOneNodeOfPath(raw_ostream &out,
+                                        const DependencyKey &key,
+                                        const StringRef filename) {
+  switch (key.getKind()) {
+  case NodeKind::topLevel:
+    out << key.aspectName() << " of top-level name '" << key.humanReadableName()
+        << "' in " << filename;
+    break;
+  case NodeKind::nominal:
+    out << key.aspectName() << " of type '" << key.humanReadableName()
+        << "' in " << filename;
+    break;
+  case NodeKind::potentialMember:
+    out << key.aspectName() << " of non-private members '"
+        << key.humanReadableName() << "' in " << filename;
+    break;
+  case NodeKind::member:
+    out << key.aspectName() << " of member '" << key.humanReadableName()
+        << "' in " << filename;
+    break;
+  case NodeKind::dynamicLookup:
+    out << key.aspectName() << " of AnyObject member '"
+        << key.humanReadableName() << "' in " << filename;
+    break;
+  case NodeKind::externalDepend:
+    out << filename << " depends on " << key.aspectName() << " of module '"
+        << key.humanReadableName() << "'";
+    break;
+  case NodeKind::sourceFileProvide:
+    out << key.aspectName() << " of source file " << key.humanReadableName();
+    break;
+  default:
+    llvm_unreachable("unknown NodeKind");
+  }
 }

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -25,6 +25,11 @@
 using namespace swift;
 using namespace swift::driver;
 
+CommandOutput::CommandOutput(StringRef dummyBase, OutputFileMap &dummyOFM)
+    : Inputs({CommandInputPair(dummyBase, "")}), DerivedOutputMap(dummyOFM) {
+  setAdditionalOutputForType(file_types::TY_SwiftDeps, dummyBase);
+}
+
 StringRef CommandOutput::getOutputForInputAndType(StringRef PrimaryInputFile,
                                                   file_types::ID Type) const {
   if (Type == file_types::TY_Nothing)

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -231,6 +231,8 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_fine_grained_dependencies);
   inputArgs.AddLastArg(arguments,
+                       options::OPT_disable_fine_grained_dependencies);
+  inputArgs.AddLastArg(arguments,
                        options::OPT_fine_grained_dependency_include_intrafile);
   inputArgs.AddLastArg(arguments, options::OPT_package_description_version);
   inputArgs.AddLastArg(arguments, options::OPT_serialize_diagnostics_path);
@@ -641,6 +643,12 @@ void ToolChain::JobContext::addFrontendCommandLineInputArguments(
     if ((!isPrimary || usePrimaryFileList) && !useFileList)
       arguments.push_back(inputName);
   }
+  if (C.getEnableFineGrainedDependencies())
+    arguments.push_back("-enable-fine-grained-dependencies");
+
+  if (Args.hasArg(
+          options::OPT_emit_fine_grained_dependency_sourcefile_dot_files))
+    arguments.push_back("-emit-fine-grained-dependency-sourcefile-dot-files");
 }
 
 void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -357,9 +357,13 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.BuildSyntaxTree = true;
     Opts.VerifySyntaxTree = true;
   }
-  
-  if (Args.hasArg(OPT_enable_fine_grained_dependencies))
-    Opts.EnableFineGrainedDependencies = true;
+
+  Opts.EnableFineGrainedDependencies =
+      Args.hasFlag(options::OPT_enable_fine_grained_dependencies,
+                   options::OPT_disable_fine_grained_dependencies, false);
+
+  if (Args.hasArg(OPT_emit_fine_grained_dependency_sourcefile_dot_files))
+    Opts.EmitFineGrainedDependencySourcefileDotFiles = true;
 
   if (Args.hasArg(OPT_fine_grained_dependency_include_intrafile))
     Opts.FineGrainedDependenciesIncludeIntrafileOnes = true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -979,7 +979,9 @@ static void emitReferenceDependenciesForAllPrimaryInputsIfNeeded(
       if (Invocation.getLangOptions().EnableFineGrainedDependencies)
         (void)fine_grained_dependencies::emitReferenceDependencies(
             Instance.getASTContext().Diags, SF,
-            *Instance.getDependencyTracker(), referenceDependenciesFilePath);
+            *Instance.getDependencyTracker(), referenceDependenciesFilePath,
+            Invocation.getLangOptions()
+                .EmitFineGrainedDependencySourcefileDotFiles);
       else
         (void)emitReferenceDependencies(Instance.getASTContext().Diags, SF,
                                         *Instance.getDependencyTracker(),

--- a/test/Driver/batch_mode_dependencies_make_wrong_order.swift
+++ b/test/Driver/batch_mode_dependencies_make_wrong_order.swift
@@ -16,13 +16,13 @@
 // RUN: cd %t && %swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift -driver-show-incremental -driver-show-job-lifecycle >%t/out.txt 2>&1
 // RUN: %FileCheck %s <%t/out.txt
 //
-// Check that we saw invalidation happen in alphabetic order
-// CHECK: Queuing because of dependencies discovered later: {compile: b.o <= b.swift}
-// CHECK: Queuing because of dependencies discovered later: {compile: c.o <= c.swift}
+// Check that we saw invalidation happen in command-line argument order
 // CHECK: Queuing because of dependencies discovered later: {compile: d.o <= d.swift}
-// CHECK: Batchable: {compile: b.o <= b.swift}
-// CHECK: Batchable: {compile: c.o <= c.swift}
+// CHECK: Queuing because of dependencies discovered later: {compile: c.o <= c.swift}
+// CHECK: Queuing because of dependencies discovered later: {compile: b.o <= b.swift}
 // CHECK: Batchable: {compile: d.o <= d.swift}
+// CHECK: Batchable: {compile: c.o <= c.swift}
+// CHECK: Batchable: {compile: b.o <= b.swift}
 //
-// But check that we still issued the job in reverse-alphabetic order
+// Check that we still issued the job in reverse-alphabetic order
 // CHECK: Adding batch job to task queue: {compile: d.o c.o b.o <= d.swift c.swift b.swift}

--- a/unittests/Driver/CMakeLists.txt
+++ b/unittests/Driver/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_swift_unittest(SwiftDriverTests
   CoarseGrainedDependencyGraphTests.cpp
+  FineGrainedDependencyGraphTests.cpp
 )
 
 target_link_libraries(SwiftDriverTests
    PRIVATE
    swiftDriver
+   swiftClangImporter
+   swiftAST
 )

--- a/unittests/Driver/FineGrainedDependencyGraphTests.cpp
+++ b/unittests/Driver/FineGrainedDependencyGraphTests.cpp
@@ -1,0 +1,833 @@
+#include "swift/Basic/ReferenceDependencyKeys.h"
+#include "swift/Driver/CoarseGrainedDependencyGraph.h"
+#include "swift/Driver/FineGrainedDependencyDriverGraph.h"
+#include "swift/Driver/Job.h"
+#include "gtest/gtest.h"
+
+// This file adapts the unit tests from the older, coarse-grained, dependency
+// graph to the new fine-grained graph.
+
+// \c markTransitive and \c markExternal may include jobs in their result
+// that would be excluded in the coarse-grained graph. But since these will be
+// jobs that have already been scheduled, downstream mechanisms will filter
+// them out.
+
+using namespace swift;
+using LoadResult = CoarseGrainedDependencyGraphImpl::LoadResult;
+using namespace reference_dependency_keys;
+using namespace fine_grained_dependencies;
+using Job = driver::Job;
+
+/// Initial underscore makes non-cascading, on member means private.
+static LoadResult
+simulateLoad(ModuleDepGraph &dg, const Job *cmd,
+             llvm::StringMap<std::vector<std::string>> simpleNames,
+             llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
+                 compoundNames = {},
+             const bool includePrivateDeps = true,
+             const bool hadCompilationError = false) {
+  StringRef swiftDeps =
+      cmd->getOutput().getAdditionalOutputForType(file_types::TY_SwiftDeps);
+  assert(!swiftDeps.empty());
+  StringRef interfaceHash = swiftDeps;
+  auto sfdg = SourceFileDepGraph::simulateLoad(
+      swiftDeps, includePrivateDeps, hadCompilationError, interfaceHash,
+      simpleNames, compoundNames);
+
+  return dg.loadFromSourceFileDepGraph(cmd, sfdg);
+}
+
+LLVM_ATTRIBUTE_UNUSED
+static std::vector<const Job *>
+printForDebugging(std::vector<const Job *> jobs) {
+  llvm::errs() << "\nprintForDebugging: ";
+  for (auto *j : jobs) {
+    const auto swiftDeps =
+        j->getOutput().getAdditionalOutputForType(file_types::TY_SwiftDeps);
+    assert(!swiftDeps.empty());
+    llvm::errs() << "job" << swiftDeps << ", ";
+  }
+  llvm::errs() << "\n";
+  return jobs;
+}
+
+static OutputFileMap OFM;
+
+static Job job0(OFM, "0"), job1(OFM, "1"), job2(OFM, "2"), job3(OFM, "3"),
+    job4(OFM, "4"), job5(OFM, "5"), job6(OFM, "6"), job7(OFM, "7"),
+    job8(OFM, "8"), job9(OFM, "9"), job10(OFM, "10"), job11(OFM, "11"),
+    job12(OFM, "12");
+
+template <typename Range, typename T>
+static bool contains(const Range &range, const T &value) {
+  return std::find(std::begin(range), std::end(range), value) !=
+         std::end(range);
+}
+
+TEST(ModuleDepGraph, BasicLoad) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsTopLevel, {"a", "b"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"c", "d"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{providesTopLevel, {"e", "f"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job3, {{providesNominal, {"g", "h"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job4, {{providesDynamicLookup, {"i", "j"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job5, {{dependsDynamicLookup, {"k", "l"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job6, {},
+                         {{providesMember, {{"m", "mm"}, {"n", "nn"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job7, {},
+                         {{dependsMember, {{"o", "oo"}, {"p", "pp"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job8, {{dependsExternal, {"/foo", "/bar"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(simulateLoad(graph, &job9,
+                         {{providesNominal, {"a", "b"}},
+                          {providesTopLevel, {"b", "c"}},
+                          {dependsNominal, {"c", "d"}},
+                          {dependsTopLevel, {"d", "a"}}}),
+            LoadResult::AffectsDownstream);
+}
+
+TEST(ModuleDepGraph, IndependentNodes) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0,
+                   {{dependsTopLevel, {"a"}}, {providesTopLevel, {"a0"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsTopLevel, {"b"}}, {providesTopLevel, {"b0"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job2,
+                   {{dependsTopLevel, {"c"}}, {providesTopLevel, {"c0"}}}),
+      LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Mark 0 again -- should be no change.
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job2).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, IndependentDepKinds) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, IndependentDepKinds2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, IndependentMembers) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {}, {{providesMember, {{"a", "aa"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {}, {{dependsMember, {{"a", "bb"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {}, {{dependsMember, {{"a", ""}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job3, {}, {{dependsMember, {{"b", "aa"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job4, {}, {{dependsMember, {{"b", "bb"}}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+  EXPECT_FALSE(graph.isMarked(&job3));
+  EXPECT_FALSE(graph.isMarked(&job4));
+}
+
+TEST(ModuleDepGraph, SimpleDependent) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependentReverse) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{providesTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job1);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job0, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent3) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent4) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsNominal, {"a"}}, {dependsTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent5) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsNominal, {"a"}}, {dependsTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  auto marked = graph.markTransitive(&job0);
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent6) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0, {{providesDynamicLookup, {"a", "b", "c"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1, {{dependsDynamicLookup, {"x", "b", "z"}}}),
+      LoadResult::AffectsDownstream);
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependentMember) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0, {},
+                   {{providesMember, {{"a", "aa"}, {"b", "bb"}, {"c", "cc"}}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1, {},
+                   {{dependsMember, {{"x", "xx"}, {"b", "bb"}, {"z", "zz"}}}}),
+      LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, MultipleDependentsSame) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"q", "b", "s"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MultipleDependentsDifferent) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"q", "r", "c"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedDependents) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsNominal, {"x", "b"}}, {providesNominal, {"z"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"z"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedNoncascadingDependents) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsNominal, {"x", "b"}}, {providesNominal, {"_z"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"_z"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedNoncascadingDependents2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "_b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsTopLevel, {"x", "_b"}}, {providesNominal, {"z"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"z"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MarkTwoNodes) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsTopLevel, {"a"}}, {providesTopLevel, {"z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsTopLevel, {"z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job10,
+                   {{providesTopLevel, {"y", "z"}}, {dependsTopLevel, {"q"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job11, {{dependsTopLevel, {"y"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job12,
+                         {{dependsTopLevel, {"q"}}, {providesTopLevel, {"q"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+  EXPECT_FALSE(graph.isMarked(&job10));
+  EXPECT_FALSE(graph.isMarked(&job11));
+  EXPECT_FALSE(graph.isMarked(&job12));
+
+  {
+    auto marked = graph.markTransitive(&job10);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job11, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+  EXPECT_TRUE(graph.isMarked(&job10));
+  EXPECT_TRUE(graph.isMarked(&job11));
+  EXPECT_FALSE(graph.isMarked(&job12));
+}
+
+TEST(ModuleDepGraph, MarkOneNodeTwice) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 0.
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job2, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MarkOneNodeTwice2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 0.
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job2, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ReloadDetectsChange) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 1.
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job2, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  // Re-mark 1.
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, DependencyLoops) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{providesTopLevel, {"a", "b", "c"}},
+                          {dependsTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{providesTopLevel, {"x"}},
+                          {dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsTopLevel, {"x"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, marked.size());
+    EXPECT_TRUE(contains(marked, &job1));
+    EXPECT_TRUE(contains(marked, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MarkIntransitive) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(graph.markIntransitive(&job0));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+
+  {
+    auto marked = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, MarkIntransitiveTwice) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(graph.markIntransitive(&job0));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+
+  EXPECT_FALSE(graph.markIntransitive(&job0));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, MarkIntransitiveThenIndirect) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(graph.markIntransitive(&job1));
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleExternal) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsExternal, {"/foo", "/bar"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
+
+  EXPECT_EQ(1u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+}
+
+TEST(ModuleDepGraph, SimpleExternal2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsExternal, {"/foo", "/bar"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(1u, graph.markExternal("/bar").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+
+  EXPECT_EQ(0u, graph.markExternal("/bar").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+}
+
+TEST(ModuleDepGraph, ChainedExternal) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0,
+                   {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
+
+  EXPECT_EQ(2u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, ChainedExternalReverse) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0,
+                   {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+
+  {
+    auto marked = graph.markExternal("/bar");
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job1, marked.front());
+  }
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markExternal("/bar").size());
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  {
+    auto marked = graph.markExternal("/foo");
+    EXPECT_EQ(1u, marked.size());
+    EXPECT_EQ(&job0, marked.front());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, ChainedExternalPreMarked) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0,
+                   {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+
+  graph.markIntransitive(&job0);
+
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+}


### PR DESCRIPTION
1. Only emit dot files for fine-grained dependencies when `-emit-fine-grained-dependency-source-file-dot-files` is specified
2. Better comments, esp. for fine-grained dependencies
3. Restructuring of fine-grained dependencies to support unit testing
4. Added unit test for fine-grained dependencies
5. Bug fixes for fine-grained dependencies
6. Batch sorting refactoring.
7. Better fine-grained dependency printing
8. Added -disable-fine-grained-dependencies to frontend and driver
9. Cleanups to driver to better support fine-grained-dependencies