### PR TITLE
[Diagnostics] Handle CoerceExpr conversion failure in contextual mismatch

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1888,16 +1888,6 @@ bool FailureDiagnosis::visitCoerceExpr(CoerceExpr *CE) {
   if (!expr)
     return true;
 
-  auto ref = expr->getReferencedDecl();
-  if (auto *decl = ref.getDecl()) {
-    // Without explicit coercion we might end up
-    // type-checking sub-expression as unavaible
-    // declaration, let's try to diagnose that here.
-    if (AvailableAttr::isUnavailable(decl))
-      return diagnoseExplicitUnavailability(
-          decl, expr->getSourceRange(), CS.DC, dyn_cast<ApplyExpr>(expr));
-  }
-
   return false;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1853,6 +1853,22 @@ bool ContextualFailure::diagnoseAsError() {
                      getFromType(), getToType());
       return true;
     }
+    
+    if (auto *coerceExpr = dyn_cast<CoerceExpr>(anchor)) {
+      auto fromType = getFromType();
+      auto toType = getType(coerceExpr->getCastTypeLoc());
+      auto diagnostic =
+          getDiagnosticFor(CTP_CoerceOperand,
+                           /*forProtocol=*/toType->isAnyExistentialType());
+      
+      auto diag =
+          emitDiagnostic(anchor->getLoc(), *diagnostic, fromType, toType);
+      diag.highlight(anchor->getSourceRange());
+
+      (void)tryFixIts(diag);
+      
+      return true;
+    }
 
     return false;
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1854,7 +1854,7 @@ bool ContextualFailure::diagnoseAsError() {
       return true;
     }
     
-    if (diagnoseConversionInCoercion())
+    if (diagnoseCoercionToUnrelatedType())
       return true;
 
     return false;
@@ -2223,7 +2223,7 @@ bool ContextualFailure::diagnoseMissingFunctionCall() const {
   return true;
 }
 
-bool ContextualFailure::diagnoseConversionInCoercion() const {
+bool ContextualFailure::diagnoseCoercionToUnrelatedType() const {
   auto *anchor = getAnchor();
   
   if (auto *coerceExpr = dyn_cast<CoerceExpr>(anchor)) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1854,21 +1854,8 @@ bool ContextualFailure::diagnoseAsError() {
       return true;
     }
     
-    if (auto *coerceExpr = dyn_cast<CoerceExpr>(anchor)) {
-      auto fromType = getFromType();
-      auto toType = getType(coerceExpr->getCastTypeLoc());
-      auto diagnostic =
-          getDiagnosticFor(CTP_CoerceOperand,
-                           /*forProtocol=*/toType->isAnyExistentialType());
-      
-      auto diag =
-          emitDiagnostic(anchor->getLoc(), *diagnostic, fromType, toType);
-      diag.highlight(anchor->getSourceRange());
-
-      (void)tryFixIts(diag);
-      
+    if (diagnoseConversionInCoercion())
       return true;
-    }
 
     return false;
   }
@@ -2236,6 +2223,28 @@ bool ContextualFailure::diagnoseMissingFunctionCall() const {
   return true;
 }
 
+bool ContextualFailure::diagnoseConversionInCoercion() const {
+  auto *anchor = getAnchor();
+  
+  if (auto *coerceExpr = dyn_cast<CoerceExpr>(anchor)) {
+    auto fromType = getFromType();
+    auto toType = getType(coerceExpr->getCastTypeLoc());
+    auto diagnostic =
+        getDiagnosticFor(CTP_CoerceOperand,
+                         /*forProtocol=*/toType->isAnyExistentialType());
+    
+    auto diag =
+        emitDiagnostic(anchor->getLoc(), *diagnostic, fromType, toType);
+    diag.highlight(anchor->getSourceRange());
+
+    (void)tryFixIts(diag);
+    
+    return true;
+  }
+
+  return false;
+}
+
 bool ContextualFailure::diagnoseConversionToBool() const {
   auto toType = getToType();
   if (!toType->isBool())
@@ -2581,6 +2590,10 @@ bool ContextualFailure::trySequenceSubsequenceFixIts(
   if (getFromType()->isEqual(Substring)) {
     if (getToType()->isEqual(String)) {
       auto *anchor = getAnchor()->getSemanticsProvidingExpr();
+      if (auto *CE = dyn_cast<CoerceExpr>(anchor)) {
+        anchor = CE->getSubExpr();
+      }
+      
       auto range = anchor->getSourceRange();
       diagnostic.fixItInsert(range.Start, "String(");
       diagnostic.fixItInsertAfter(range.End, ")");

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -554,6 +554,9 @@ public:
 
   /// If we're trying to convert something to `nil`.
   bool diagnoseConversionToNil() const;
+  
+  /// Diagnose failed conversion in a `CoerceExpr`.
+  bool diagnoseConversionInCoercion() const;
 
   // If we're trying to convert something of type "() -> T" to T,
   // then we probably meant to call the value.

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -556,7 +556,7 @@ public:
   bool diagnoseConversionToNil() const;
   
   /// Diagnose failed conversion in a `CoerceExpr`.
-  bool diagnoseConversionInCoercion() const;
+  bool diagnoseCoercionToUnrelatedType() const;
 
   // If we're trying to convert something of type "() -> T" to T,
   // then we probably meant to call the value.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2823,6 +2823,16 @@ bool ConstraintSystem::repairFailures(
         conversionsOrFixes.push_back(coerceToCheckCastFix);
         return true;
       }
+      
+      // If it has a deep equality restriction defer the diagnostic to a
+      // GenericMismatch fix.
+      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality)) {
+        return false;
+      }
+      
+      auto *fix = ContextualMismatch::create(*this, lhs, rhs,
+                                             getConstraintLocator(locator));
+      conversionsOrFixes.push_back(fix);
     }
 
     // This could be:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2824,11 +2824,10 @@ bool ConstraintSystem::repairFailures(
         return true;
       }
       
-      // If it has a deep equality restriction defer the diagnostic to a
-      // GenericMismatch fix.
-      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality)) {
+      // If it has a deep equality restriction, defer the diagnostic to
+      // GenericMismatch.
+      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality))
         return false;
-      }
       
       auto *fix = ContextualMismatch::create(*this, lhs, rhs,
                                              getConstraintLocator(locator));

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -619,9 +619,11 @@ class WrongInheritanceClause6(Int {}
 class WrongInheritanceClause7<T>(Int where T:AnyObject {}
 
 // <rdar://problem/18502220> [swift-crashes 078] parser crash on invalid cast in sequence expr
-Base=1 as Base=1  // expected-error {{cannot convert value of type 'Int' to type 'Base' in coercion}}
-
-
+Base=1 as Base=1 // expected-error{{cannot convert value of type 'Int' to type 'Base' in coercion}}
+// expected-error@-1 {{cannot assign to immutable expression of type 'Base.Type'}}
+// expected-error@-2 {{left side of mutating operator has immutable type 'Base'}}
+// expected-error@-3 {{cannot assign value of type '()' to type 'Base.Type'}}
+// expected-error@-4 {{cannot assign value of type 'Int' to type 'Base'}}
 
 // <rdar://problem/18634543> Parser hangs at swift::Parser::parseType
 public enum TestA {

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -621,7 +621,7 @@ class WrongInheritanceClause7<T>(Int where T:AnyObject {}
 // <rdar://problem/18502220> [swift-crashes 078] parser crash on invalid cast in sequence expr
 Base=1 as Base=1 // expected-error{{cannot convert value of type 'Int' to type 'Base' in coercion}}
 // expected-error@-1 {{cannot assign to immutable expression of type 'Base.Type'}}
-// expected-error@-2 {{left side of mutating operator has immutable type 'Base'}}
+// expected-error@-2 {{cannot assign to immutable expression of type 'Base'}}
 // expected-error@-3 {{cannot assign value of type '()' to type 'Base.Type'}}
 // expected-error@-4 {{cannot assign value of type 'Int' to type 'Base'}}
 

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -105,8 +105,7 @@ func basicSubtyping(
   let _: Derived = baseAndP2 // expected-error {{cannot convert value of type 'Base<Int> & P2' to specified type 'Derived'}}
   let _: Derived & P2 = baseAndP2 // expected-error {{value of type 'Base<Int> & P2' does not conform to specified type 'Derived & P2'}}
 
-  // TODO(diagnostics): Diagnostic regression, better message is `value of type 'Unrelated' does not conform to 'Derived & P2' in coercion`
-  let _ = Unrelated() as Derived & P2 // expected-error {{cannot convert value of type 'Unrelated' to type 'Derived' in coercion}}
+  let _ = Unrelated() as Derived & P2 // expected-error {{value of type 'Unrelated' does not conform to 'Derived & P2' in coercion}}
   let _ = Unrelated() as? Derived & P2 // expected-warning {{always fails}}
   let _ = baseAndP2 as Unrelated // expected-error {{cannot convert value of type 'Base<Int> & P2' to type 'Unrelated' in coercion}}
   let _ = baseAndP2 as? Unrelated // expected-warning {{always fails}}


### PR DESCRIPTION
While working in #27895, more specifically in https://github.com/apple/swift/pull/27895/commits/82529a6e7db2c46b86d8ede9bb520cfc112f8a6c I note that the cannot convert diagnostic for expr `Double(1) as Double as String` is being emitted via fix but still going re-typechecking passing through `CSDiag`. Note that actually when tried to put a `if (Options.contains(ConstraintSystemFlags::SubExpressionDiagnostics))` in `applySolutionFixes`.
So this PR is to handle coercion conversion error early on `repairFailures` and avoid this. 
This also handles the TODO diagnostic in `test/type/subclass_composition.swift`.

cc @xedin @hborla :))


