### PR TITLE
[AutoDiff] Require `[parameters ...]` for `{differentiable,linear}_fu…

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5606,7 +5606,7 @@ differentiable_function
 ::
 
   sil-instruction ::= 'differentiable_function'
-                      sil-differentiable-function-parameter-indices?
+                      sil-differentiable-function-parameter-indices
                       sil-value ':' sil-type
                       sil-differentiable-function-derivative-functions-clause?
                       
@@ -5641,7 +5641,7 @@ linear_function
 ::
 
   sil-instruction ::= 'linear_function'
-                      sil-linear-function-parameter-indices?
+                      sil-linear-function-parameter-indices
                       sil-value ':' sil-type
                       sil-linear-function-transpose-function-clause?
 

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5624,8 +5624,7 @@ function. There are two derivative functions: a Jacobian-vector products (JVP)
 function and a vector-Jacobian products (VJP) function.
 
 ``[parameters ...]`` specifies parameter indices that the original function is
-differentiable with respect to. When not specified, it defaults to all
-parameters.
+differentiable with respect to.
 
 A ``with_derivative`` clause specifies the differentiation functions associated
 with the original function. When a ``with_derivative`` clause is not specified,
@@ -5656,7 +5655,7 @@ Bundles a function with its transpose function into a
 ``@differentiable(linear)`` function.
 
 ``[parameters ...]`` specifies parameter indices that the original function is
-linear with respect to. When not specified, it defaults to all parameters.
+linear with respect to.
 
 A ``with_transpose`` clause specifies the transpose function associated
 with the original function. When a ``with_transpose`` clause is not specified,

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2072,6 +2072,31 @@ static bool parseAssignOwnershipQualifier(AssignOwnershipQualifier &Result,
 }
 
 // SWIFT_ENABLE_TENSORFLOW
+// Parse an index set, prefaced with the given label. Returns true on error.
+static bool parseIndexSet(Parser &P, StringRef label,
+                          SmallVectorImpl<unsigned> &indices,
+                          const Diagnostic &parseIndexDiag) {
+  SourceLoc loc;
+  // Parse `[<label> <integer_literal>...]`.
+  if (P.parseToken(tok::l_square, diag::sil_autodiff_expected_lsquare,
+                   "index list") ||
+      P.parseSpecificIdentifier(
+          label, diag::sil_autodiff_expected_index_list_label, label))
+    return true;
+  while (P.Tok.is(tok::integer_literal)) {
+    unsigned index;
+    if (P.parseUnsignedInteger(index, loc, parseIndexDiag))
+      return true;
+    indices.push_back(index);
+  }
+  if (P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
+                   "index list"))
+    return true;
+  return false;
+};
+// SWIFT_ENABLE_TENSORFLOW END
+
+// SWIFT_ENABLE_TENSORFLOW
 /// sil-differentiability-witness-config-and-function ::=
 ///   '[' 'parameters' index-subset ']'
 ///   '[' 'results' index-subset ']'
@@ -2083,34 +2108,13 @@ static bool parseAssignOwnershipQualifier(AssignOwnershipQualifier &Result,
 static Optional<std::pair<AutoDiffConfig, SILFunction *>>
 parseSILDifferentiabilityWitnessConfigAndFunction(Parser &P, SILParser &SP,
                                                   SILLocation L) {
-  SourceLoc lastLoc;
-  // Parse an index set, prefaced with the given label.
-  auto parseIndexSet = [&](StringRef label, SmallVectorImpl<unsigned> &indices,
-                           const Diagnostic &parseIndexDiag) -> bool {
-    // Parse `[<label> <integer_literal>...]`.
-    if (P.parseToken(tok::l_square, diag::sil_autodiff_expected_lsquare,
-                     "index list") ||
-        P.parseSpecificIdentifier(
-            label, diag::sil_autodiff_expected_index_list_label, label))
-      return true;
-    while (P.Tok.is(tok::integer_literal)) {
-      unsigned index;
-      if (P.parseUnsignedInteger(index, lastLoc, parseIndexDiag))
-        return true;
-      indices.push_back(index);
-    }
-    if (P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
-                     "index list"))
-      return true;
-    return false;
-  };
   // Parse parameter and result indices.
   SmallVector<unsigned, 8> parameterIndices;
   SmallVector<unsigned, 8> resultIndices;
-  if (parseIndexSet("parameters", parameterIndices,
+  if (parseIndexSet(P, "parameters", parameterIndices,
                     diag::sil_autodiff_expected_parameter_index))
     return {};
-  if (parseIndexSet("results", resultIndices,
+  if (parseIndexSet(P, "results", resultIndices,
                     diag::sil_autodiff_expected_result_index))
     return {};
   // Parse witness generic parameter clause.
@@ -2938,27 +2942,12 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     //
     // e.g. differentiable_function [parameters 0 1 2] %0 : $T with_derivative
     //      {%1 : $T, %2 : $T}
-    //        ^ jvp    ^ vjp
-    SourceLoc lastLoc;
+    //       ^~ jvp   ^~ vjp
+    // Parse `[parameters <integer_literal>...]`.
     SmallVector<unsigned, 8> parameterIndices;
-    // Parse optional `[parameters <integer_literal>...]`
-    if (P.Tok.is(tok::l_square) &&
-        P.peekToken().is(tok::identifier) &&
-        P.peekToken().getText() == "parameters") {
-      P.consumeToken(tok::l_square);
-      P.consumeToken(tok::identifier);
-      // Parse indices.
-      while (P.Tok.is(tok::integer_literal)) {
-        unsigned index;
-        if (P.parseUnsignedInteger(index, lastLoc,
-              diag::sil_autodiff_expected_parameter_index))
-          return true;
-        parameterIndices.push_back(index);
-      }
-      if (P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
-                       "parameter index list"))
-        return true;
-    }
+    if (parseIndexSet(P, "parameters", parameterIndices,
+                      diag::sil_autodiff_expected_parameter_index))
+      return true;
     // Parse the original function value.
     SILValue original;
     SourceLoc originalOperandLoc;
@@ -3001,26 +2990,11 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   case SILInstructionKind::LinearFunctionInst: {
     // e.g. linear_function [parameters 0 1 2] %0 : $T
     // e.g. linear_function [parameters 0 1 2] %0 : $T with_transpose %1 : $T
-    SourceLoc lastLoc;
+    // Parse `[parameters <integer_literal>...]`.
     SmallVector<unsigned, 8> parameterIndices;
-    // Parse optional `[parameters <integer_literal>...]`
-    if (P.Tok.is(tok::l_square) &&
-        P.peekToken().is(tok::identifier) &&
-        P.peekToken().getText() == "parameters") {
-      P.consumeToken(tok::l_square);
-      P.consumeToken(tok::identifier);
-      // Parse indices.
-      while (P.Tok.is(tok::integer_literal)) {
-        unsigned index;
-        if (P.parseUnsignedInteger(index, lastLoc,
-              diag::sil_autodiff_expected_parameter_index))
-          return true;
-        parameterIndices.push_back(index);
-      }
-      if (P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
-                       "parameter index list"))
-        return true;
-    }
+    if (parseIndexSet(P, "parameters", parameterIndices,
+                      diag::sil_autodiff_expected_parameter_index))
+      return true;
     // Parse the original function value.
     SILValue original;
     SourceLoc originalOperandLoc;
@@ -3117,9 +3091,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SourceLoc keyStartLoc = P.Tok.getLoc();
     auto configAndFn = parseSILDifferentiabilityWitnessConfigAndFunction(
         P, *this, InstLoc);
-    if (!configAndFn) {
+    if (!configAndFn)
       return true;
-    }
     auto config = configAndFn->first;
     auto originalFn = configAndFn->second;
     auto *witness = SILMod.lookUpDifferentiabilityWitness(

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2072,10 +2072,11 @@ static bool parseAssignOwnershipQualifier(AssignOwnershipQualifier &Result,
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-// Parse an index set, prefaced with the given label. Returns true on error.
-static bool parseIndexSet(Parser &P, StringRef label,
-                          SmallVectorImpl<unsigned> &indices,
-                          const Diagnostic &parseIndexDiag) {
+// Parse a list of integer indices, prefaced with the given string label.
+// Returns true on error.
+static bool parseIndexList(Parser &P, StringRef label,
+                           SmallVectorImpl<unsigned> &indices,
+                           const Diagnostic &parseIndexDiag) {
   SourceLoc loc;
   // Parse `[<label> <integer_literal>...]`.
   if (P.parseToken(tok::l_square, diag::sil_autodiff_expected_lsquare,
@@ -2111,11 +2112,11 @@ parseSILDifferentiabilityWitnessConfigAndFunction(Parser &P, SILParser &SP,
   // Parse parameter and result indices.
   SmallVector<unsigned, 8> parameterIndices;
   SmallVector<unsigned, 8> resultIndices;
-  if (parseIndexSet(P, "parameters", parameterIndices,
-                    diag::sil_autodiff_expected_parameter_index))
+  if (parseIndexList(P, "parameters", parameterIndices,
+                     diag::sil_autodiff_expected_parameter_index))
     return {};
-  if (parseIndexSet(P, "results", resultIndices,
-                    diag::sil_autodiff_expected_result_index))
+  if (parseIndexList(P, "results", resultIndices,
+                     diag::sil_autodiff_expected_result_index))
     return {};
   // Parse witness generic parameter clause.
   GenericSignature witnessGenSig = GenericSignature();
@@ -2945,8 +2946,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     //       ^~ jvp   ^~ vjp
     // Parse `[parameters <integer_literal>...]`.
     SmallVector<unsigned, 8> parameterIndices;
-    if (parseIndexSet(P, "parameters", parameterIndices,
-                      diag::sil_autodiff_expected_parameter_index))
+    if (parseIndexList(P, "parameters", parameterIndices,
+                       diag::sil_autodiff_expected_parameter_index))
       return true;
     // Parse the original function value.
     SILValue original;
@@ -2992,8 +2993,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     // e.g. linear_function [parameters 0 1 2] %0 : $T with_transpose %1 : $T
     // Parse `[parameters <integer_literal>...]`.
     SmallVector<unsigned, 8> parameterIndices;
-    if (parseIndexSet(P, "parameters", parameterIndices,
-                      diag::sil_autodiff_expected_parameter_index))
+    if (parseIndexList(P, "parameters", parameterIndices,
+                       diag::sil_autodiff_expected_parameter_index))
       return true;
     // Parse the original function value.
     SILValue original;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1212,12 +1212,10 @@ public:
 
   // SWIFT_ENABLE_TENSORFLOW
   void visitDifferentiableFunctionInst(DifferentiableFunctionInst *dfi) {
-    if (!dfi->getParameterIndices()->isEmpty()) {
-      *this << "[parameters";
-      for (auto i : dfi->getParameterIndices()->getIndices())
-        *this << ' ' << i;
-      *this << "] ";
-    }
+    *this << "[parameters";
+    for (auto i : dfi->getParameterIndices()->getIndices())
+      *this << ' ' << i;
+    *this << "] ";
     *this << getIDAndType(dfi->getOriginalFunction());
     if (dfi->hasDerivativeFunctions()) {
       *this << " with_derivative ";
@@ -1227,12 +1225,10 @@ public:
   }
 
   void visitLinearFunctionInst(LinearFunctionInst *lfi) {
-    if (!lfi->getParameterIndices()->isEmpty()) {
-      *this << "[parameters";
-      for (auto i : lfi->getParameterIndices()->getIndices())
-        *this << ' ' << i;
-      *this << "] ";
-    }
+    *this << "[parameters";
+    for (auto i : lfi->getParameterIndices()->getIndices())
+      *this << ' ' << i;
+    *this << "] ";
     *this << getIDAndType(lfi->getOriginalFunction());
     if (lfi->hasTransposeFunction()) {
       *this << " with_transpose ";


### PR DESCRIPTION
…nction`.

Make the `[parameters ...]` argument always required in the textual
representation for `{differentiable,linear}_function` instructions, instead of
defaulting to all parameter indices when unspecified..

This makes the textual representation consistent with other `[parameters ...]`
arguments in SIL:
- `differentiability_witness_function`
- `differentiability_witness`