### PR TITLE
[AutoDiff] Enable derivative registration for imported C functions.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1078,9 +1078,6 @@ void IRGenerator::emitGlobalTopLevel(llvm::StringSet<> *linkerDirectives) {
   // Emit differentiability witnesses.
   for (auto &dw :
            PrimaryIGM->getSILModule().getDifferentiabilityWitnessList()) {
-    if (dw.isDeclaration())
-      continue;
-
     // Emit into same IRGenModule as the original function.
     // NOTE(TF-894): Investigate whether `getGenModule(dw.getVJP())` is
     // significant/desirable; `getGenModule` seems relevant for multi-threaded
@@ -4487,7 +4484,7 @@ IRGenModule::getAddrOfWitnessTablePattern(const NormalProtocolConformance *conf,
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-/// Look up the address of a witness table.
+/// Look up the address of a differentiability witness.
 llvm::Constant *IRGenModule::getAddrOfDifferentiabilityWitness(
     const SILDifferentiabilityWitness *witness, ConstantInit definition) {
   auto entity = LinkEntity::forDifferentiabilityWitness(witness);

--- a/lib/IRGen/GenDiffWitness.cpp
+++ b/lib/IRGen/GenDiffWitness.cpp
@@ -34,9 +34,8 @@ void IRGenModule::emitSILDifferentiabilityWitness(
   if (dw->isDeclaration())
     return;
 
-  // Don't emit public_external witnesses.
-  if (hasPublicVisibility(dw->getLinkage()) &&
-      isAvailableExternally(dw->getLinkage()))
+  // Don't emit `public_external` witnesses.
+  if (dw->getLinkage() == SILLinkage::PublicExternal)
     return;
 
   ConstantInitBuilder builder(*this);

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -427,7 +427,7 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
   // have `@convention(thin)`. IRGen does not support `@convention(c)` functions
   // with multiple results.
   auto extInfo = getExtInfo();
-  if (getLanguage() == SILFunctionLanguage::C)
+  if (getRepresentation() == SILFunctionTypeRepresentation::CFunctionPointer)
     extInfo = extInfo.withRepresentation(SILFunctionTypeRepresentation::Thin);
   return SILFunctionType::get(canGenSig, extInfo, getCoroutineKind(),
                               getCalleeConvention(), newParameters, getYields(),

--- a/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/LinearMapInfo.cpp
@@ -472,7 +472,6 @@ bool LinearMapInfo::shouldDifferentiateApplySite(FullApplySite applySite) {
 
   // TODO: Pattern match to make sure there is at least one `store` to the
   // array's active buffer.
-  // if (isArrayLiteralIntrinsic(ai) && hasActiveResults)
   if (isArrayLiteralIntrinsic(applySite) && hasActiveResults)
     return true;
 

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -56,6 +56,15 @@ public:
   const TBDGenOptions &Opts;
   Decl* TopLevelDecl = nullptr;
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// A set of original function and derivative configuration pairs for which
+  /// derivative symbols have been emitted.
+  ///
+  /// Used to deduplicate derivative symbol emission for `@differentiable` and
+  /// `@derivative` attributes.
+  llvm::DenseSet<std::pair<AbstractFunctionDecl *, AutoDiffConfig>>
+      AddedDerivatives;
+
 private:
   void addSymbolInternal(StringRef name, llvm::MachO::SymbolKind kind,
                          bool isLinkerDirective = false);

--- a/test/AutoDiff/derivative_registration_foreign/Inputs/Foreign.c
+++ b/test/AutoDiff/derivative_registration_foreign/Inputs/Foreign.c
@@ -1,0 +1,1 @@
+float cFunction(float x) { return x; }

--- a/test/AutoDiff/derivative_registration_foreign/Inputs/Foreign.h
+++ b/test/AutoDiff/derivative_registration_foreign/Inputs/Foreign.h
@@ -1,0 +1,1 @@
+float cFunction(float);

--- a/test/AutoDiff/derivative_registration_foreign/Inputs/module.modulemap
+++ b/test/AutoDiff/derivative_registration_foreign/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module CForeign {
+  header "Foreign.h"
+  export *
+}

--- a/test/AutoDiff/derivative_registration_foreign/main.swift
+++ b/test/AutoDiff/derivative_registration_foreign/main.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: %clang -shared %S/Inputs/Foreign.c -fmodules -o %t/libCForeign.dylib
+// RUN: %target-swift-emit-silgen -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s | %FileCheck %s --check-prefix=CHECK-SILGEN --check-prefix=CHECK
+// RUN: %target-swift-emit-sil -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s | %FileCheck %s --check-prefix=CHECK-SIL --check-prefix=CHECK
+// RUN: %target-build-swift -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s -L %t -lCForeign
+
+import CForeign
+
+// TF-1087: Test derivative registration for foreign declaration (Clang-imported).
+// Original SILDeclRef must have `isForeign` bit set correctly.
+
+// CHECK-SILGEN-LABEL: // differentiability witness for cFunction
+// CHECK-SILGEN: sil_differentiability_witness [serialized] [parameters 0] [results 0] @cFunction : $@convention(c) (Float) -> Float {
+// CHECK-SILGEN:   vjp: @AD__cFunction__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-SILGEN: }
+
+// CHECK-SIL-LABEL: // differentiability witness for cFunction
+// CHECK-SIL: sil_differentiability_witness [serialized] [parameters 0] [results 0] @cFunction : $@convention(c) (Float) -> Float {
+// CHECK-SIL:   jvp: @AD__cFunction__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-SIL:   vjp: @AD__cFunction__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-SIL: }
+
+// Check that original SIL function is correct.
+
+// CHECK-SILGEN-LABEL: sil [serializable] [clang cFunction] @cFunction : $@convention(c) (Float) -> Float
+
+@inlinable
+@derivative(of: cFunction)
+func vjpCFunction(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  (cFunction(x), { $0 })
+}
+
+@_silgen_name("test_derivative")
+@differentiable
+func testDerivative(_ x: Float) -> Float {
+  cFunction(x)
+}
+
+// CHECK-SILGEN-LABEL: sil hidden [ossa] @test_derivative : $@convention(thin) (Float) -> Float {
+// CHECK-SILGEN: {{%.*}} = function_ref @cFunction : $@convention(c) (Float) -> Float

--- a/test/AutoDiff/derivative_registration_foreign/main.swift
+++ b/test/AutoDiff/derivative_registration_foreign/main.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %clang -shared %S/Inputs/Foreign.c -fmodules -o %t/libCForeign.dylib
+// RUN: %clang -shared %S/Inputs/Foreign.c -fmodules -o %t/%target-library-name(CForeign)
 // RUN: %target-swift-emit-silgen -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s | %FileCheck %s --check-prefix=CHECK-SILGEN --check-prefix=CHECK
 // RUN: %target-swift-emit-sil -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s | %FileCheck %s --check-prefix=CHECK-SIL --check-prefix=CHECK
 // RUN: %target-build-swift -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s -L %t -lCForeign


### PR DESCRIPTION
- Edit `SILFunctionType::getAutoDiffDerivativeFunctionType`.
  - Return `@convention(thin)` derivative function types given `@convention(c)`
    original function types.
  - Necessary because derivative function types have multiple results, which is
    unsupported for `@convention(c)` functions.
- Revert derivative symbol TBDGen to visit `@differentiable` and `@derivative`
  attributes instead of visiting derivative configurations.
  - Necessary for `@derivative` attributes with cross-file original functions.
    `TBDGenVisitor` does not visit functions in other files, so the derivative
     configurations of the cross-file original function would not be visited.
  - Adapted from https://github.com/apple/swift/pull/28790.
- SILGen: strip external from differentiability witness linkages.
  - Clang-imported functions have `public_external` linkage, but their
    differentiability witnesses should have `public` linkage.
- Set `SILDeclRef` `isForeign` correctly for original functions that require
  a foreign entry point (including imported functions).
  - Done in SILGen, TBDGen, derivative lookup, IRGen.

Resolves TF-1087: `@derivative` attribute SILGen crash for foreign functions.

---

Imported function derivative registration example:

```c
// Foreign.h
float cFunction(float);
```
```
// module.modulemap
module CForeign {
  header "Foreign.h"
  export *
}
```
```swift
import CForeign

// Register derivative for imported C function.
@inlinable
@derivative(of: cFunction)
func vjpCFunction(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
  (cFunction(x), { $0 })
}

print(gradient(at: 10, in: cFunction)) // 1.0
```

---

`@derivative` attribute SILGen crash example (TF-1087):

```swift
import Darwin

@derivative(of: tan)
@inlinable
func vjpTan(_ x: Double) -> (value: Double, pullback: (Double) -> Double) {
  fatalError()
}
```

Before:
```console
$ swift -Xllvm -enable-experimental-cross-file-derivative-registration tan.swift
SIL verification failed: external declaration of internal SILFunction not allowed: F->isAvailableExternally()
In function:
// @nonobjc tan(_:)
sil shared [serializable] [readnone] @$sSo3tanyS2dFTO : $@convention(thin) (Double) -> Double

Stack dump:
0.	Program arguments: /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2019-12-22-a.xctoolchain/usr/bin/swift -frontend -interpret tan.swift -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -color-diagnostics -Xllvm -enable-experimental-cross-file-derivative-registration -module-name tan
1.	Swift version 5.2-dev (Swift a34e25915a)
2.	While verifying SIL function "@$sSo3tanyS2dFTO".
 for 'tan(_:)' (in module 'Darwin')
0  swift                    0x00000001047f6a05 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
1  swift                    0x00000001047f5c15 llvm::sys::RunSignalHandlers() + 85
2  swift                    0x00000001047f6ff6 SignalHandler(int) + 278
3  libsystem_platform.dylib 0x00007fff728e4b5d _sigtramp + 29
4  libsystem_platform.dylib 0x000000010dec3b76 _sigtramp + 2606624822
5  libsystem_c.dylib        0x00007fff7279e6a6 abort + 127
6  swift                    0x00000001013b5968 (anonymous namespace)::SILVerifier::_require(bool, llvm::Twine const&, std::__1::function<void ()> const&) + 616
7  swift                    0x00000001013af4d8 swift::SILFunction::verify(bool) const + 440
```

After: no crash.

TF-1087 fix will be tested by `test/stdlib/tgmath.swift.gyb` in https://github.com/apple/swift/pull/28933.