### PR TITLE
[PropertyWrappers] Fix a bug with class property wrapper access control

### DIFF
--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -36,6 +36,12 @@ enum class PropertyWrapperInitKind {
   Default
 };
 
+static bool isDeclNotAsAccessibleAsParent(ValueDecl *decl,
+                                          NominalTypeDecl *parent) {
+  return decl->getFormalAccess() <
+         std::min(parent->getFormalAccess(), AccessLevel::Public);
+}
+
 /// Find the named property in a property wrapper to which access will
 /// be delegated.
 static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
@@ -79,7 +85,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
 
   // The property must be as accessible as the nominal type.
   VarDecl *var = vars.front();
-  if (var->getFormalAccess() < nominal->getFormalAccess()) {
+  if (isDeclNotAsAccessibleAsParent(var, nominal)) {
     var->diagnose(diag::property_wrapper_type_requirement_not_accessible,
                   var->getFormalAccess(), var->getDescriptiveKind(),
                   var->getFullName(), nominal->getDeclaredType(),
@@ -157,8 +163,7 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
     }
 
     // Check accessibility.
-    if (init->getFormalAccess() <
-        std::min(nominal->getFormalAccess(), AccessLevel::Public)) {
+    if (isDeclNotAsAccessibleAsParent(init, nominal)) {
       nonviable.push_back(
           std::make_tuple(init, NonViableReason::Inaccessible, Type()));
       continue;
@@ -274,7 +279,7 @@ static SubscriptDecl *findEnclosingSelfSubscript(ASTContext &ctx,
 
   auto subscript = subscripts.front();
   // the subscript must be as accessible as the nominal type.
-  if (subscript->getFormalAccess() < nominal->getFormalAccess()) {
+  if (isDeclNotAsAccessibleAsParent(subscript, nominal)) {
     subscript->diagnose(diag::property_wrapper_type_requirement_not_accessible,
                         subscript->getFormalAccess(),
                         subscript->getDescriptiveKind(),

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -157,7 +157,8 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
     }
 
     // Check accessibility.
-    if (init->getFormalAccess() < nominal->getFormalAccess()) {
+    if (init->getFormalAccess() <
+        std::min(nominal->getFormalAccess(), AccessLevel::Public)) {
       nonviable.push_back(
           std::make_tuple(init, NonViableReason::Inaccessible, Type()));
       continue;

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1870,3 +1870,13 @@ struct Rdar57411331 {
 
   var other: Int
 }
+
+// SR-11994
+@propertyWrapper
+open class OpenPropertyWrapperWithPublicInit {
+  public init(wrappedValue: String) { // Okay
+    self.wrappedValue = wrappedValue
+  }
+  
+  open var wrappedValue: String = "Hello, world"
+}


### PR DESCRIPTION
The following code currently triggers an error saying that the access level of the initializer is less than the type:

```swift
@propertyWrapper
open class OpenPropertyWrapperWithPublicInit {
  // error: public initializer 'init(wrappedValue:)' cannot have 
  //        more restrictive access than its enclosing property 
  //        wrapper type 'OpenPropertyWrapperWithPublicInit' (which is open)  
  public init(wrappedValue: String) {
    self.wrappedValue = wrappedValue
  }
  
  open var wrappedValue: String = "Hello, world"
}
```

If you change it from `public` to `open`, then you get an error because initializers cannot be marked `open`. So, you're stuck in a loop.

When looking for suitable wrapper inits, make sure we bound the check to `AccessLevel::Public`.

Resolves SR-11994.