### PR TITLE
[AutoDiff] switch array and floating point derivatives to @derivative(of:)

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1680,9 +1680,6 @@ extension FloatingPoint {
   }
 
   @_transparent
-  // SWIFT_ENABLE_TENSORFLOW
-  @differentiable(wrt: self, vjp: _vjpSquareRoot
-                  where Self : Differentiable, Self == Self.TangentVector)
   public func squareRoot( ) -> Self {
     var lhs = self
     lhs.formSquareRoot( )
@@ -1690,9 +1687,6 @@ extension FloatingPoint {
   }
 
   @_transparent
-  /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(wrt: (self, lhs, rhs), vjp: _vjpAddingProduct
-                  where Self : Differentiable, Self == Self.TangentVector)
   public func addingProduct(_ lhs: Self, _ rhs: Self) -> Self {
     var addend = self
     addend.addProduct(lhs, rhs)
@@ -1741,16 +1735,18 @@ extension FloatingPoint where Self : Differentiable,
   /// original result and pullback of `addingProduct` with respect to `self`,
   /// `lhs` and `rhs`.
   @inlinable
+  @derivative(of: addingProduct)
   func _vjpAddingProduct(
     _ lhs: Self, _ rhs: Self
-  ) -> (Self, (Self) -> (Self, Self, Self)) {
+  ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
     return (addingProduct(lhs, rhs), { _ in (1, rhs, lhs) })
   }
 
   /// The vector-Jacobian product function of `squareRoot`. Returns the original
   /// result and pullback of `squareRoot` with respect to `self`.
   @inlinable // FIXME(sil-serialize-all)
-  func _vjpSquareRoot() -> (Self, (Self) -> Self) {
+  @derivative(of: squareRoot)
+  func _vjpSquareRoot() -> (value: Self, pullback: (Self) -> Self) {
     let y = squareRoot()
     return (y, { v in v / (2 * y) })
   }

--- a/test/AutoDiff/floating_point.swift.gyb
+++ b/test/AutoDiff/floating_point.swift.gyb
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swiftgyb
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var FloatingPointTests = TestSuite("FloatingPoint")
+
+%for Self in ['Float', 'Double', 'Float80']:
+% if Self == 'Float80':
+#if !os(Windows) && (arch(i386) || arch(x86_64))
+% end
+
+FloatingPointTests.test("${Self}.squareRoot") {
+  expectEqual(${Self}(0.5), gradient(at: ${Self}(1), in: { $0.squareRoot() }))
+  expectEqual(${Self}(0.25), gradient(at: ${Self}(4), in: { $0.squareRoot() }))
+}
+
+FloatingPointTests.test("${Self}.addingProduct") {
+  expectEqual(
+    (${Self}(1), ${Self}(2), ${Self}(3)),
+    gradient(
+      at: ${Self}(10), ${Self}(3), ${Self}(2),
+      in: { $0.addingProduct($1, $2) }
+    )
+  )
+}
+
+%   if Self == 'Float80':
+#endif
+%   end
+% end
+
+runAllTests()


### PR DESCRIPTION
Also I added a test for the `FloatingPoint.swift` derivatives because there isn't an existing test for them.

Once this and https://github.com/apple/swift/pull/28933 are merged, there will be no more vjp:s in the stdlib.