### PR TITLE
Basic: out-of-line equality operator (NFCI)

### DIFF
--- a/include/swift/Basic/Located.h
+++ b/include/swift/Basic/Located.h
@@ -30,9 +30,8 @@ namespace swift {
 /// the ClangImporter needs to keep track of where imports were originally written.
 /// Located makes it easy to do so while making the code more readable, compared to
 /// using `std::pair`.
-template<typename T>
+template <typename T>
 struct Located {
-
   /// The main item whose source location is being tracked.
   T Item;
 
@@ -45,12 +44,12 @@ struct Located {
 
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &os) const;
-
-  template<typename U>
-  friend bool operator ==(const Located<U> &lhs, const Located<U> &rhs) {
-    return lhs.Item == rhs.Item && lhs.Loc == rhs.Loc;
-  }
 };
+
+template <typename T>
+bool operator ==(const Located<T> &lhs, const Located<T> &rhs) {
+  return lhs.Item == rhs.Item && lhs.Loc == rhs.Loc;
+}
 
 } // end namespace swift
 


### PR DESCRIPTION
MSVC did not like the original code and would fail to build as:

  ```
  swift\include\swift/Basic/Located.h(50): error C2995: 'bool swift::operator ==(const swift::Located<T> &,const swift::Located<T> &)': function template has already been defined
  swift\include\swift/Basic/Located.h(50): note: see declaration of 'swift::operator =='
  llvm\include\llvm/Support/TrailingObjects.h(76): note: see reference to class template instantiation 'swift::Located<swift::Identifier>' being compiled
  llvm\include\llvm/Support/TrailingObjects.h(233): note: see reference to class template instantiation 'llvm::trailing_objects_internal::AlignmentCalcHelper<swift::Located<swift::Identifier>>' being compiled
  swift\include\swift/AST/Decl.h(1512): note: see reference to class template instantiation 'llvm::TrailingObjects<swift::ImportDecl,swift::Located<swift::Identifier>>' being compiled
  ```

The original code is odd.  There appears to be some unnecessary
complexity.

First, the member function is marked as a friend of a
`struct` type which does not change the member's visibility, thus all
the members are `public`, and the function need not be friended.

Second, the function is templated over the same parameter type, which
means that the original template parameter could be used and the
standard member equality operator could be used rather than the
free-standing form.

It is unclear why the member equality operator is insufficient, and the
extraneous template instatiations here seem wasteful.  Out-of-line the
free-standing form and not mark it as a friend to restore the build.
Switching to a member form can be a follow up change.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
