### PR TITLE
IRGen: Work around RemoteMirror bug generating reflection info for empty builtin types.

### DIFF
--- a/validation-test/Reflection/reflect_empty_struct_compat.swift
+++ b/validation-test/Reflection/reflect_empty_struct_compat.swift
@@ -1,7 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct -target x86_64-apple-macosx10.99.0
-// RUN: %target-codesign %t/reflect_empty_struct
 
+// RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct -target x86_64-apple-macosx10.15.0
+// RUN: %target-codesign %t/reflect_empty_struct
+// RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail
+
+// RUN: %target-build-swift -lswiftSwiftReflectionTest -I %S/Inputs/EmptyStruct/ %s -o %t/reflect_empty_struct -target x86_64-apple-macosx10.14.0
+// RUN: %target-codesign %t/reflect_empty_struct
 // RUN: %target-run %target-swift-reflection-test %t/reflect_empty_struct | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --dump-input fail
 
 // REQUIRES: objc_interop
@@ -32,13 +36,13 @@ reflect(object: obj)
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=80 alignment=8 stride=80 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64:   (field name=a offset=16
-// CHECK-64:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-64:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64:   (field name=b offset=16
 // CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))
 // CHECK-64:   (field name=c offset=48
-// CHECK-64:     (builtin size=0 alignment=4 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-64:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-64:   (field name=d offset=48
 // CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
@@ -52,13 +56,13 @@ reflect(object: obj)
 // CHECK-32: Type info:
 // CHECK-32: (class_instance size=40 alignment=4 stride=40 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32:   (field name=a offset=8
-// CHECK-32:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-32:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-32:   (field name=b offset=8
 // CHECK-32:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32:       (field name=metadata offset=12
 // CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))
 // CHECK-32:   (field name=c offset=24
-// CHECK-32:     (builtin size=0 alignment=4 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-32:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
 // CHECK-32:   (field name=d offset=24
 // CHECK-32:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096 bitwise_takable=1
 // CHECK-32:       (field name=metadata offset=12


### PR DESCRIPTION
The RemoteMirror library in shipping versions of macOS/iOS/tvOS/watchOS crashes if the compiler
emits a BuiltinTypeDescriptor with size zero. Although this is fixed in top-of-tree RemoteMirror,
we want binaries built with the new compiler to still be inspectable when run on older OSes.
Generate the metadata as an empty struct with no fields when deploying back to these older
platforms, which should be functionally equivalent for most purposes.
Fixes rdar://problem/57924984.