### PR TITLE
[AutoDiff] Gardening.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1722,7 +1722,7 @@ class DifferentiableAttr final
   // SWIFT_ENABLE_TENSORFLOW END
   /// Whether this function is linear (optional).
   bool Linear;
-  /// The number of parsed parameters specified in 'wrt:'.
+  /// The number of parsed differentiability parameters specified in 'wrt:'.
   unsigned NumParsedParameters = 0;
   /// The JVP function.
   Optional<DeclNameRefWithLoc> JVP;
@@ -1737,7 +1737,7 @@ class DifferentiableAttr final
   // SWIFT_ENABLE_TENSORFLOW
   // NOTE: Parameter indices requestification is done on `tensorflow` branch but
   // has not yet been upstreamed to `master` branch.
-  /// The differentiation parameters' indices, resolved by the type checker.
+  /// The differentiability parameter indices, resolved by the type checker.
   /// The bit stores whether the parameter indices have been computed.
   llvm::PointerIntPair<IndexSubset *, 1, bool> ParameterIndicesAndBit;
   // SWIFT_ENABLE_TENSORFLOW END
@@ -1801,7 +1801,7 @@ public:
   void setParameterIndices(IndexSubset *paramIndices);
   // SWIFT_ENABLE_TENSORFLOW END
 
-  /// The parsed differentiation parameters, i.e. the list of parameters
+  /// The parsed differentiability parameters, i.e. the list of parameters
   /// specified in 'wrt:'.
   ArrayRef<ParsedAutoDiffParameter> getParsedParameters() const {
     return {getTrailingObjects<ParsedAutoDiffParameter>(), NumParsedParameters};
@@ -1852,15 +1852,15 @@ public:
 ///
 /// The `@derivative(of:)` attribute also has an optional `wrt:` clause
 /// specifying the parameters that are differentiated "with respect to", i.e.
-/// the differentiation parameters. The differentiation parameters must conform
-/// to the `Differentiable` protocol.
+/// the differentiability parameters. The differentiability parameters must
+/// conform to the `Differentiable` protocol.
 ///
-/// If the `wrt:` clause is unspecified, the differentiation parameters are
+/// If the `wrt:` clause is unspecified, the differentiability parameters are
 /// inferred to be all parameters that conform to `Differentiable`.
 ///
 /// `@derivative(of:)` attribute type-checking verifies that the type of the
 /// derivative function declaration is consistent with the type of the
-/// referenced original declaration and the differentiation parameters.
+/// referenced original declaration and the differentiability parameters.
 ///
 /// Examples:
 ///   @derivative(of: sin(_:))
@@ -1879,9 +1879,9 @@ class DerivativeAttr final
   DeclNameRefWithLoc OriginalFunctionName;
   /// The original function declaration, resolved by the type checker.
   AbstractFunctionDecl *OriginalFunction = nullptr;
-  /// The number of parsed parameters specified in 'wrt:'.
+  /// The number of parsed differentiability parameters specified in 'wrt:'.
   unsigned NumParsedParameters = 0;
-  /// The differentiation parameters' indices, resolved by the type checker.
+  /// The differentiability parameter indices, resolved by the type checker.
   IndexSubset *ParameterIndices = nullptr;
   /// The derivative function kind (JVP or VJP), resolved by the type checker.
   Optional<AutoDiffDerivativeFunctionKind> Kind = None;
@@ -1924,7 +1924,7 @@ public:
   }
   void setDerivativeKind(AutoDiffDerivativeFunctionKind kind) { Kind = kind; }
 
-  /// The parsed differentiation parameters, i.e. the list of parameters
+  /// The parsed differentiability parameters, i.e. the list of parameters
   /// specified in 'wrt:'.
   ArrayRef<ParsedAutoDiffParameter> getParsedParameters() const {
     return {getTrailingObjects<ParsedAutoDiffParameter>(), NumParsedParameters};
@@ -1958,7 +1958,7 @@ using DifferentiatingAttr = DerivativeAttr;
 /// computed property declaration.
 ///
 /// The `@transpose(of:)` attribute also has a `wrt:` clause specifying the
-/// parameters that are transposed "with respect to", i.e. the transposed
+/// parameters that are transposed "with respect to", i.e. the linearity
 /// parameters.
 ///
 /// Examples:
@@ -1978,9 +1978,9 @@ class TransposeAttr final
   DeclNameRefWithLoc OriginalFunctionName;
   /// The original function declaration, resolved by the type checker.
   AbstractFunctionDecl *OriginalFunction = nullptr;
-  /// The number of parsed parameters specified in 'wrt:'.
+  /// The number of parsed linearity parameters specified in 'wrt:'.
   unsigned NumParsedParameters = 0;
-  /// The transposed parameters' indices, resolved by the type checker.
+  /// The linearity parameter indices, resolved by the type checker.
   IndexSubset *ParameterIndices = nullptr;
 
   explicit TransposeAttr(bool implicit, SourceLoc atLoc, SourceRange baseRange,
@@ -2013,7 +2013,7 @@ public:
     OriginalFunction = decl;
   }
 
-  /// The parsed transposed parameters, i.e. the list of parameters specified in
+  /// The parsed linearity parameters, i.e. the list of parameters specified in
   /// 'wrt:'.
   ArrayRef<ParsedAutoDiffParameter> getParsedParameters() const {
     return {getTrailingObjects<ParsedAutoDiffParameter>(), NumParsedParameters};

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3035,18 +3035,19 @@ NOTE(derivative_attr_duplicate_note,none,
      "other attribute declared here", ())
 
 // @transpose
-ERROR(transpose_params_clause_param_not_differentiable,none,
-      "can only transpose with respect to parameters that conform to "
-      "'Differentiable' and where '%0 == %0.TangentVector'", (StringRef))
+ERROR(transpose_attr_invalid_linearity_parameter_or_result,none,
+      "cannot transpose with respect to original %select{result|parameter}1 "
+      "'%0' that does not conform to 'Differentiable' and satisfy "
+      "'%0 == %0.TangentVector'", (StringRef, /*isParameter*/ bool))
 ERROR(transpose_attr_overload_not_found,none,
       "could not find function %0 with expected type %1", (DeclName, Type))
 ERROR(transpose_attr_cannot_use_named_wrt_params,none,
       "cannot use named 'wrt' parameters in '@transpose(of:)' attribute, found "
       "%0", (Identifier))
-ERROR(transpose_func_wrt_self_must_be_static,none,
+ERROR(transpose_attr_wrt_self_must_be_static,none,
      "the transpose of an instance method must be a 'static' method in the "
      "same type when 'self' is a linearity parameter", ())
-NOTE(transpose_func_wrt_self_self_type_mismatch_note,none,
+NOTE(transpose_attr_wrt_self_self_type_mismatch_note,none,
      "the transpose is declared in %0 but the original function is declared in "
      "%1", (Type, Type))
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3235,12 +3235,12 @@ public:
       GenericSignature whereClauseGenericSignature = GenericSignature(),
       bool makeSelfParamFirst = false);
 
-  /// Given the type of an autodiff derivative function, returns the
+  /// Given that `this` is an autodiff derivative function type, returns the
   /// corresponding original function type.
-  AnyFunctionType *getAutoDiffOriginalFunctionType();
+  AnyFunctionType *getDerivativeOriginalFunctionType();
 
-  /// Given the type of a transpose function, returns the corresponding original
-  /// function type.
+  /// Given that `this` is an autodiff transpose function type, returns the
+  /// corresponding original function type.
   AnyFunctionType *
   getTransposeOriginalFunctionType(IndexSubset *wrtParamIndices, bool wrtSelf);
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1002,12 +1002,13 @@ public:
       Optional<DeclNameRefWithLoc> &vjpSpec,
       TrailingWhereClause *&whereClause);
 
-  /// Parse a differentiation parameters clause, i.e. the 'wrt:' clause in
-  /// `@differentiable` and `@derivative` attributes.
+  /// Parse a differentiability parameters clause, i.e. the 'wrt:' clause in
+  /// `@differentiable`, `@derivative`, and `@transpose` attributes.
+  ///
   /// If `allowNamedParameters` is false, allow only index parameters and
-  /// 'self'.
-  bool parseDifferentiationParametersClause(
-      SmallVectorImpl<ParsedAutoDiffParameter> &params, StringRef attrName,
+  /// 'self'. Used for `@transpose` attributes.
+  bool parseDifferentiabilityParametersClause(
+      SmallVectorImpl<ParsedAutoDiffParameter> &parameters, StringRef attrName,
       bool allowNamedParameters = true);
 
   /// Parse the @derivative attribute.

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -372,9 +372,9 @@ static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
   Printer.printNewline();
 }
 
-/// The kind of a differentiation parameter in a `wrt:` differentiation
-/// parameters clause: differentiability or linearity. Used for printing
-/// `@differentiable`, `@derivative`, and `@transpose` attributes.
+/// The kind of a parameter in a `wrt:` differentiation parameters clause:
+/// either a differentiability parameter or a linearity parameter. Used for
+/// printing `@differentiable`, `@derivative`, and `@transpose` attributes.
 enum class DifferentiationParameterKind {
   /// A differentiability parameter, printed by name.
   /// Used for `@differentiable` and `@derivative` attribute.

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -272,10 +272,10 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
   };
 
   // Calculate differentiation parameter infos.
-  SmallVector<SILParameterInfo, 4> wrtParams;
+  SmallVector<SILParameterInfo, 4> diffParams;
   for (auto valueAndIndex : enumerate(getParameters()))
     if (isWrtIndex(valueAndIndex.index()))
-      wrtParams.push_back(valueAndIndex.value());
+      diffParams.push_back(valueAndIndex.value());
 
   // Get the canonical derivative function generic signature.
   if (!derivativeFnGenSig)
@@ -338,7 +338,7 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
   switch (kind) {
   case AutoDiffDerivativeFunctionKind::JVP: {
     SmallVector<SILParameterInfo, 8> differentialParams;
-    for (auto &param : wrtParams) {
+    for (auto &param : diffParams) {
       auto paramTan =
           param.getInterfaceType()->getAutoDiffAssociatedTangentSpace(
               lookupConformance);
@@ -372,7 +372,7 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
         getTangentParameterInfoForOriginalResult(resultTan->getCanonicalType(),
                                                  origRes.getConvention()));
     SmallVector<SILResultInfo, 8> pullbackResults;
-    for (auto &param : wrtParams) {
+    for (auto &param : diffParams) {
       auto paramTan =
           param.getInterfaceType()->getAutoDiffAssociatedTangentSpace(
               lookupConformance);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -640,8 +640,8 @@ static bool overridesDifferentiableAttribute(ValueDecl *derivedDecl,
     diagnosed = true;
     // Omit printing wrt clause if attribute differentiation parameters match
     // inferred differentiation parameters.
-    auto *inferredParameters = TypeChecker::inferDifferentiationParameters(
-        derivedAFD, nullptr);
+    auto *inferredParameters =
+        TypeChecker::inferDifferentiabilityParameters(derivedAFD, nullptr);
     bool omitWrtClause = !baseParameters ||
         baseParameters->getNumIndices() == inferredParameters->getNumIndices();
     // Get `@differentiable` attribute description.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2304,7 +2304,7 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     auto *original = cast<AbstractFunctionDecl>(match.Witness);
     auto *whereClauseGenEnv =
         reqAttr->getDerivativeGenericEnvironment(original);
-    auto *inferredParameters = TypeChecker::inferDifferentiationParameters(
+    auto *inferredParameters = TypeChecker::inferDifferentiabilityParameters(
         original, whereClauseGenEnv);
     bool omitWrtClause = reqAttr->getParameterIndices()->getNumIndices() ==
                          inferredParameters->getNumIndices();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1662,18 +1662,19 @@ public:
   static DeclTypeCheckingSemantics
   getDeclTypeCheckingSemantics(ValueDecl *decl);
 
-  /// Creates an `IndexSubset` for the given function type, representing
-  /// all inferred differentiation parameters. Used by `@differentiable` and
-  /// `@derivative` attribute type-checking.
+  /// Infers the differentiability parameter indices for the given
+  /// original or derivative `AbstractFunctionDecl`.
   ///
-  /// The differentiation parameters are inferred to be:
+  /// The differentiability parameters are inferred to be:
   /// - All parameters of the function type that conform to `Differentiable`.
   /// - If the function type's result is a function type (i.e. it is a curried
   ///   method type), then also all parameters of the function result type that
   ///   conform to `Differentiable`.
+  ///
+  /// Used by `@differentiable` and `@derivative` attribute type-checking.
   static IndexSubset *
-  inferDifferentiationParameters(AbstractFunctionDecl *AFD,
-                                 GenericEnvironment *derivativeGenEnv);
+  inferDifferentiabilityParameters(AbstractFunctionDecl *AFD,
+                                   GenericEnvironment *derivativeGenEnv);
 
 public:
   /// Require that the library intrinsics for working with Optional<T>


### PR DESCRIPTION
- Clean up AutoDiff attribute parsing, printing, type-checking.
- Rename "wrt parameters" to "differentiability/linearity parameters".
- Improve `@transpose` attribute diagnostics.
  - Generalize diagnostic for `@transpose` attribute invalid original result.
- Uncomment tests in test/AutoDiff/transpose_attr_type_checking.swift.

NFC except `@transpose` attribute diagnostic message changes.

Todo: upstream changes to master.