### PR TITLE
SIL: use `size_t` for the indexing type

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2051,7 +2051,7 @@ struct OperandToInoutArgument {
       : paramInfos(paramInfos), arguments(arguments) {
     assert(paramInfos.size() == arguments.size());
   }
-  Optional<SILValue> operator()(unsigned long i) const {
+  Optional<SILValue> operator()(size_t i) const {
     if (paramInfos[i].isIndirectMutating())
       return arguments[i];
     return None;
@@ -2059,7 +2059,7 @@ struct OperandToInoutArgument {
 };
 
 using InoutArgumentRange =
-    OptionalTransformRange<IntRange<unsigned long>, OperandToInoutArgument>;
+    OptionalTransformRange<IntRange<size_t>, OperandToInoutArgument>;
 // SWIFT_ENABLE_TENSORFLOW END
 
 /// The partial specialization of ApplyInstBase for full applications.


### PR DESCRIPTION
LLP64 targets use `unsigned long long` for 64-bit types rather than
`unsigned long`.  Iteration will use `size_t` to index, which is
`unsigned long long` rather than `unsigned long`.  The type mismatch
would manifest as a type-conversion failure.

This enables this code to be built with `cl`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
