### PR TITLE
SourceKit: annotate helper function as public

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/FileSystemProvider.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/FileSystemProvider.h
@@ -15,6 +15,7 @@
 
 #include "clang/Basic/InMemoryOutputFileSystem.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "sourcekitd.h"
 
 namespace SourceKit {
 
@@ -25,7 +26,7 @@ namespace SourceKit {
 ///
 /// \param FS may be null, which makes subsequent requests start writing
 /// temporary output files to the real filesystem again.
-void setGlobalInMemoryOutputFileSystem(
+void SOURCEKITD_PUBLIC setGlobalInMemoryOutputFileSystem(
     llvm::IntrusiveRefCntPtr<clang::InMemoryOutputFileSystem> FS);
 
 } // namespace SourceKit

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -129,7 +129,7 @@ static SourceKit::Context &getGlobalContext() {
 }
 
 namespace SourceKit {
-void setGlobalInMemoryOutputFileSystem(IntrusiveRefCntPtr<clang::InMemoryOutputFileSystem> FS) {
+void SOURCEKITD_PUBLIC setGlobalInMemoryOutputFileSystem(IntrusiveRefCntPtr<clang::InMemoryOutputFileSystem> FS) {
   getGlobalContext().getSwiftLangSupport().setInMemoryOutputFileSystem(std::move(FS));
 }
 } // namespace SourceKit


### PR DESCRIPTION
This function is used by the testing tools which requires it to be
explicitly marked public to enable building on Windows which by default
will make this function unavailable to users otherwise.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
