### PR TITLE
[Diagnostics] Diagnose general ambiguity failures in diagnoseAmbiguityWithFixes

### DIFF
--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -616,8 +616,11 @@ func rdar50679161() {
 
 func rdar_50467583_and_50909555() {
   // rdar://problem/50467583
-  let _: Set = [Int][]
-  // expected-error@-1 {{instance member 'subscript' cannot be used on type '[Int]'}}
+  let _: Set = [Int][] // expected-error {{no exact matches in call to subscript}}
+  // expected-note@-1 {{found candidate with type '(Int) -> Int'}}
+  // expected-note@-2 {{found candidate with type '(Range<Int>) -> ArraySlice<Int>'}}
+  // expected-note@-3 {{found candidate with type '((UnboundedRange_) -> ()) -> ArraySlice<Int>'}}
+  // expected-note@-4 {{found candidate with type '(Range<Array<Int>.Index>) -> Slice<[Int]>' (aka '(Range<Int>) -> Slice<Array<Int>>')}}
 
   // rdar://problem/50909555
   struct S {

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -218,7 +218,6 @@ func rdar46459603() {
 
   _ = arr.values == [e]
   // expected-error@-1 {{binary operator '==' cannot be applied to operands of type 'Dictionary<String, E>.Values' and '[E]'}}
-  // expected-note@-2  {{expected an argument list of type '(Self, Self)'}}
   _ = [arr.values] == [[e]]
   // expected-error@-1 {{value of protocol type 'Any' cannot conform to 'Equatable'; only struct/enum/class types can conform to protocols}}
   // expected-note@-2 {{requirement from conditional conformance of '[Any]' to 'Equatable'}}

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -127,12 +127,11 @@ func test20886179(_ handlers: [(Int) -> Void], buttonIndex: Int) {
 
 // The problem here is that the call has a contextual result type incompatible
 // with *all* overload set candidates.  This is not an ambiguity.
-func overloaded_identity(_ a : Int) -> Int {}
-func overloaded_identity(_ b : Float) -> Float {}
+func overloaded_identity(_ a : Int) -> Int {} // expected-note {{found this candidate}}
+func overloaded_identity(_ b : Float) -> Float {} // expected-note {{found this candidate}}
 
 func test_contextual_result_1() {
-  return overloaded_identity()  // expected-error {{cannot invoke 'overloaded_identity' with no arguments}}
-  // expected-note @-1 {{overloads for 'overloaded_identity' exist with these partially matching parameter lists: (Float), (Int)}}
+  return overloaded_identity()  // expected-error {{no exact matches in call to global function 'overloaded_identity'}}
 }
 
 func test_contextual_result_2() {

--- a/test/Parse/super.swift
+++ b/test/Parse/super.swift
@@ -4,8 +4,8 @@ class B {
   var foo: Int
   func bar() {}
 
-  init() {}
-  init(x: Int) {}
+  init() {} // expected-note {{found this candidate}}
+  init(x: Int) {} // expected-note {{found this candidate}}
 
   subscript(x: Int) -> Int {
     get {}
@@ -38,7 +38,8 @@ class D : B {
     super.foo.bar    // expected-error {{value of type 'Int' has no member 'bar'}}
     super.bar        // expected-error {{expression resolves to an unused function}}
     super.bar()
-    super.init // expected-error{{'super.init' cannot be called outside of an initializer}}
+    // FIXME: should also say "'super.init' cannot be referenced outside of an initializer"
+    super.init // expected-error{{no exact matches in call to initializer}}
     super.init() // expected-error{{'super.init' cannot be called outside of an initializer}}
     super.init(0) // expected-error{{'super.init' cannot be called outside of an initializer}} // expected-error {{missing argument label 'x:' in call}}
     super[0]        // expected-error {{expression resolves to an unused subscript}}

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -265,7 +265,7 @@ protocol P2 {}
 protocol P3 {}
 func compositionType() {
   _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{14-14=).self}}
-  _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}} expected-note {{overloads}}
+  _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
   _ = (P1 & (P2, P3)).self // expected-error {{non-protocol, non-class type '(P2, P3)' cannot be used within a protocol-constrained type}}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -349,12 +349,14 @@ func testUnresolvedMemberSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
 struct SubscriptTest1 {
   subscript(keyword:String) -> Bool { return true }
-  // expected-note@-1 3 {{found this candidate}} expected-note@-1 {{found candidate with type 'Bool'}}
+  // expected-note@-1 5 {{found this candidate}} expected-note@-1 {{found candidate with type 'Bool'}}
   subscript(keyword:String) -> String? {return nil }
-  // expected-note@-1 3 {{found this candidate}} expected-note@-1 {{found candidate with type 'String?'}}
+  // expected-note@-1 5 {{found this candidate}} expected-note@-1 {{found candidate with type 'String?'}}
 
   subscript(arg: SubClass) -> Bool { return true } // expected-note {{declared here}}
+  // expected-note@-1 2 {{found this candidate}}
   subscript(arg: Protocol) -> Bool { return true } // expected-note 2 {{declared here}}
+  // expected-note@-1 2 {{found this candidate}}
 
   subscript(arg: (foo: Bool, bar: (Int, baz: SubClass)), arg2: String) -> Bool { return true }
   // expected-note@-1 3 {{declared here}}
@@ -379,11 +381,9 @@ func testSubscript1(_ s1 : SubscriptTest1) {
   _ = s1.subscript(ClassConformingToRefinedProtocol())
   // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{54-55=]}}
   _ = s1.subscript(true)
-  // expected-error@-1 {{cannot invoke 'subscript' with an argument list of type '(Bool)'}}
-  // expected-note@-2 {{overloads for 'subscript' exist with these partially matching parameter lists: (Protocol), (String), (SubClass)}}
+  // expected-error@-1 {{no exact matches in call to subscript}}
   _ = s1.subscript(SuperClass())
-  // expected-error@-1 {{cannot invoke 'subscript' with an argument list of type '(SuperClass)'}}
-  // expected-note@-2 {{overloads for 'subscript' exist with these partially matching parameter lists: (Protocol), (String), (SubClass)}}
+  // expected-error@-1 {{no exact matches in call to subscript}}
   _ = s1.subscript("hello")
   // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
   _ = s1.subscript("hello"


### PR DESCRIPTION
For now, we only emit the general error message `no exact matches in call to x` with a note pointing to each candidate. If we don't have the candidate's source location, we emit a note at the call site with the candidate's type.