### PR TITLE
stdlib: remove unnecessarily complex library detection

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -72,16 +72,16 @@ endif()
 # SWIFT_ENABLE_TENSORFLOW
 if(SWIFT_BUILD_STDLIB)
   add_subdirectory(Python)
-endif()
 
-# SWIFT_ENABLE_TENSORFLOW
-# Note: Python should be built before TensorFlow because Python is a
-# dependency for `numpy.ndarray` bridging to `ShapedArray`/`Tensor`.
-if(SWIFT_BUILD_STDLIB AND SWIFT_ENABLE_TENSORFLOW)
-  # TODO: Add TensorFlow support for iOS/Raspberry Pi.
-  add_subdirectory(CTensorFlow)
-  add_subdirectory(TensorFlow)
+  # Note: Python should be built before TensorFlow because Python is a
+  # dependency for `numpy.ndarray` bridging to `ShapedArray`/`Tensor`.
+  if(SWIFT_ENABLE_TENSORFLOW)
+    # TODO: Add TensorFlow support for iOS/Raspberry Pi.
+    add_subdirectory(CTensorFlow)
+    add_subdirectory(TensorFlow)
+  endif()
 endif()
+# SWIFT_ENABLE_TENSORFLOW END
 
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
   add_subdirectory(Reflection)

--- a/stdlib/public/Python/CMakeLists.txt
+++ b/stdlib/public/Python/CMakeLists.txt
@@ -14,8 +14,6 @@
 #
 #===----------------------------------------------------------------------===#
 
-set(SWIFT_PYTHON_EXISTS TRUE PARENT_SCOPE)
-
 set(SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES)
 if(SWIFT_BUILD_DYNAMIC_SDK_OVERLAY)
   list(APPEND SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES SHARED)

--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -45,13 +45,6 @@ if (TENSORFLOW_SWIFT_APIS)
   endforeach()
 endif()
 
-# When Python exists, PythonConversion.swift imports it, so it must be
-# available at link time.
-set(TENSORFLOW_DEPENDS_PYTHON)
-if (SWIFT_PYTHON_EXISTS)
-  list(APPEND TENSORFLOW_DEPENDS_PYTHON SWIFT_MODULE_DEPENDS Python)
-endif()
-
 add_swift_target_library(swiftTensorFlow ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   "${SOURCES}"
 
@@ -67,7 +60,7 @@ add_swift_target_library(swiftTensorFlow ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_
   SWIFT_MODULE_DEPENDS_CYGWIN Glibc
   SWIFT_MODULE_DEPENDS_HAIKU Glibc
   SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
-  ${TENSORFLOW_DEPENDS_PYTHON}
+  SWIFT_MODULE_DEPENDS Python
   SWIFT_COMPILE_FLAGS "${swift_stdlib_compile_flags}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib


### PR DESCRIPTION
The python module will always be available when TensorFlow is being
built, remove the ad-hoc detection for it.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
