### PR TITLE
TensorFlow: normalise path before using (NFCI)

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -35,10 +35,14 @@ set(SOURCES "")
 
 # Copy TensorFlow high-level API sources, if they exist.
 if (TENSORFLOW_SWIFT_APIS)
+  message(STATUS "Using TensorFlow high-level APIs library.")
+
   file(GLOB_RECURSE TENSORFLOW_SWIFT_API_SOURCES
     "${TENSORFLOW_SWIFT_APIS}/Sources/*.swift")
-  message(STATUS "Using TensorFlow high-level APIs library.")
-  list(APPEND SOURCES "${TENSORFLOW_SWIFT_API_SOURCES}")
+  foreach(_TENSORFLOW_SWIFT_APIS_SOURCE ${TENSORFLOW_SWIFT_API_SOURCES})
+    file(TO_CMAKE_PATH ${_TENSORFLOW_SWIFT_APIS_SOURCE} _TENSORFLOW_SWIFT_APIS_SOURCE)
+    list(APPEND SOURCES ${_TENSORFLOW_SWIFT_APIS_SOURCE})
+  endforeach()
 endif()
 
 # When Python exists, PythonConversion.swift imports it, so it must be


### PR DESCRIPTION
This normalises the path before using it in the
`add_target_swift_library`.  This is important for platforms where the
path separator is not the Unix path separator (i.e. `/`), such as
Windows.  CMake will not normalise the path when globbing which can
result in unusable paths being passed to the function:

  ```
  Syntax error in cmake code when parsing string

  S:\3\s/tensorflow-swift-apis/Sources/TensorFlow/Operators/Comparison.swift

  Invalid character escape '\3'.
  ```

This should enable the glob to function properly in such environments.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
