### PR TITLE
[Diagnostics] Removing FailureDiagnosis::visitCoerceExpr from CSDiag

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -247,7 +247,6 @@ private:
 
   bool visitSubscriptExpr(SubscriptExpr *SE);
   bool visitApplyExpr(ApplyExpr *AE);
-  bool visitCoerceExpr(CoerceExpr *CE);
   bool visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *E);
 };
 } // end anonymous namespace
@@ -1878,6 +1877,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   return true;
 }
 
+<<<<<<< HEAD
 bool FailureDiagnosis::visitCoerceExpr(CoerceExpr *CE) {
   // Coerce the input to whatever type is specified by the CoerceExpr.
   auto expr = typeCheckChildIndependently(CE->getSubExpr(),

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1877,18 +1877,6 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   return true;
 }
 
-<<<<<<< HEAD
-bool FailureDiagnosis::visitCoerceExpr(CoerceExpr *CE) {
-  // Coerce the input to whatever type is specified by the CoerceExpr.
-  auto expr = typeCheckChildIndependently(CE->getSubExpr(),
-                                          CS.getType(CE->getCastTypeLoc()),
-                                          CTP_CoerceOperand);
-  if (!expr)
-    return true;
-
-  return false;
-}
-
 bool FailureDiagnosis::
 visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *E) {
   // Don't walk the children for this node, it leads to multiple diagnostics

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1905,6 +1905,12 @@ bool ContextualFailure::diagnoseAsError() {
     diagnostic = diag::cannot_convert_condition_value;
     break;
   }
+      
+  case ConstraintLocator::InstanceType: {
+    if (diagnoseCoercionToUnrelatedType())
+      return true;
+    break;
+  }
 
   case ConstraintLocator::TernaryBranch: {
     auto *ifExpr = cast<IfExpr>(getRawAnchor());
@@ -2235,11 +2241,12 @@ bool ContextualFailure::diagnoseCoercionToUnrelatedType() const {
   auto *anchor = getAnchor();
   
   if (auto *coerceExpr = dyn_cast<CoerceExpr>(anchor)) {
-    auto fromType = getFromType();
+    auto fromType = getType(coerceExpr->getSubExpr());
     auto toType = getType(coerceExpr->getCastTypeLoc());
+    
     auto diagnostic =
         getDiagnosticFor(CTP_CoerceOperand,
-                         /*forProtocol=*/toType->isAnyExistentialType());
+                         /*forProtocol=*/toType->isExistentialType());
     
     auto diag =
         emitDiagnostic(anchor->getLoc(), *diagnostic, fromType, toType);
@@ -4769,6 +4776,13 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
 
     case ConstraintLocator::SequenceElementType: {
       diagnostic = diag::cannot_convert_sequence_element_protocol;
+      break;
+    }
+
+    case ConstraintLocator::InstanceType: {
+      // If the missing conformance involves a coercion of metatypes
+      if (diagnoseCoercionToUnrelatedType())
+        return true;
       break;
     }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4779,13 +4779,6 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
       break;
     }
 
-    case ConstraintLocator::InstanceType: {
-      // If the missing conformance involves a coercion of metatypes
-      if (diagnoseCoercionToUnrelatedType())
-        return true;
-      break;
-    }
-
     default:
       break;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2842,8 +2842,8 @@ bool ConstraintSystem::repairFailures(
       
       // If it has a deep equality restriction, defer the diagnostic to
       // GenericMismatch.
-      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality)) {
-        if (!lhs->getOptionalObjectType() && !rhs->getOptionalObjectType())
+      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality) &&
+          !lhs->getOptionalObjectType() && !rhs->getOptionalObjectType()) {
           return false;
       }
       
@@ -3502,6 +3502,13 @@ bool ConstraintSystem::repairFailures(
             IgnoreContextualType::create(*this, lhs, rhs, locator));
         break;
       }
+    }
+    // Handle function result coerce expression wrong type conversion.
+    if (isa<CoerceExpr>(anchor)) {
+      auto *fix =
+          ContextualMismatch::create(*this, lhs, rhs, loc);
+      conversionsOrFixes.push_back(fix);
+      break;
     }
     LLVM_FALLTHROUGH;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2842,8 +2842,10 @@ bool ConstraintSystem::repairFailures(
       
       // If it has a deep equality restriction, defer the diagnostic to
       // GenericMismatch.
-      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality))
-        return false;
+      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality)) {
+        if (!lhs->getOptionalObjectType() && !rhs->getOptionalObjectType())
+          return false;
+      }
       
       auto *fix = ContextualMismatch::create(*this, lhs, rhs,
                                              getConstraintLocator(locator));

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -550,8 +550,8 @@ func testProtocolQualified(_ obj: CopyableNSObject, cell: CopyableSomeCell,
   _ = cell as NSCopying
   _ = cell as SomeCell
   
-  _ = plainObj as CopyableNSObject // expected-error {{'NSObject' is not convertible to 'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol'); did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
-  _ = plainCell as CopyableSomeCell // expected-error {{'SomeCell' is not convertible to 'CopyableSomeCell' (aka 'SomeCell & NSCopying'); did you mean to use 'as!' to force downcast?}}
+  _ = plainObj as CopyableNSObject // expected-error {{value of type 'NSObject' does not conform to 'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') in coercion}} 
+  _ = plainCell as CopyableSomeCell // expected-error {{value of type 'SomeCell' does not conform to 'CopyableSomeCell' (aka 'SomeCell & NSCopying') in coercion}}
 }
 
 extension Printing {

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -53,7 +53,7 @@ func otherExistential<T : EqualComparable>(_ t1: T) {
   otherEqComp2 = t1 // expected-error{{value of type 'T' does not conform to 'OtherEqualComparable' in assignment}}
   _ = otherEqComp2
 
-  _ = t1 as EqualComparable & OtherEqualComparable // expected-error{{'T' is not convertible to 'EqualComparable & OtherEqualComparable'; did you mean to use 'as!' to force downcast?}} {{10-12=as!}} expected-error{{protocol 'OtherEqualComparable' can only be used as a generic constraint}} expected-error{{protocol 'EqualComparable' can only be used as a generic constraint}}
+  _ = t1 as EqualComparable & OtherEqualComparable // expected-error{{value of type 'T' does not conform to 'EqualComparable & OtherEqualComparable' in coercion}} expected-error{{protocol 'OtherEqualComparable' can only be used as a generic constraint}} expected-error{{protocol 'EqualComparable' can only be used as a generic constraint}}
 }
 
 protocol Runcible {

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -118,7 +118,7 @@ struct Circle {
 func testCircular(_ circle: Circle) {
   // FIXME: It would be nice if this failure were suppressed because the protocols
   // have circular definitions.
-  _ = circle as CircleStart // expected-error{{'Circle' is not convertible to 'CircleStart'; did you mean to use 'as!' to force downcast?}} {{14-16=as!}}
+  _ = circle as CircleStart // expected-error{{value of type 'Circle' does not conform to 'CircleStart' in coercion}}
 }
 
 // <rdar://problem/14750346>
@@ -482,7 +482,7 @@ func f<T : C1>(_ x : T) {
 
 class C2 {}
 func g<T : C2>(_ x : T) {
-  x as P2 // expected-error{{'T' is not convertible to 'P2'; did you mean to use 'as!' to force downcast?}} {{5-7=as!}}
+  x as P2 // expected-error{{value of type 'T' does not conform to 'P2' in coercion}}
 }
 
 class C3 : P1 {} // expected-error{{type 'C3' does not conform to protocol 'P1'}}


### PR DESCRIPTION
Follow up #29011, fixing the remaining failures diagnostics and removing `FailureDiagnosis::visitCoerceExpr` from `CSDiag`.

cc @xedin @hborla 