### PR TITLE
[stdlib] `KeyPathIterable` fixes.

### DIFF
--- a/stdlib/public/core/KeyPathIterable.swift
+++ b/stdlib/public/core/KeyPathIterable.swift
@@ -99,7 +99,7 @@ public extension KeyPathIterable {
 
 /// Returns `true` if all of the given key paths are instances of
 /// `WritableKeyPath<Root, Value>`.
-private func areAllWritableKeyPaths<Root, Value>(
+private func areAllKeyPathsWritable<Root, Value>(
   _ keyPaths: [PartialKeyPath<Root>], toValueType valueType: Value.Type
 ) -> Bool {
   return !keyPaths.contains(
@@ -112,7 +112,7 @@ extension Array: KeyPathIterable {
   public var allKeyPaths: [PartialKeyPath<Array>] {
     let result = indices.map { \Array[$0] }
     _internalInvariant(
-      areAllWritableKeyPaths(result, toValueType: Element.self))
+      areAllKeyPathsWritable(result, toValueType: Element.self))
     return result
   }
 }
@@ -134,7 +134,7 @@ where Element: Differentiable {
   public typealias AllKeyPaths = [PartialKeyPath<Array.DifferentiableView>]
   public var allKeyPaths: [PartialKeyPath<Array.DifferentiableView>] {
     let result = [\Array.DifferentiableView.base]
-    _internalInvariant(areAllWritableKeyPaths(result, toValueType: Array.self))
+    _internalInvariant(areAllKeyPathsWritable(result, toValueType: Array.self))
     return result
   }
 }
@@ -146,7 +146,7 @@ extension Dictionary: KeyPathIterable {
     // form `WritableKeyPath<Self, Value>` key paths.
     // Force-unwrapping the result is necessary.
     let result = keys.map { \Dictionary[$0]! }
-    _internalInvariant(areAllWritableKeyPaths(result, toValueType: Value.self))
+    _internalInvariant(areAllKeyPathsWritable(result, toValueType: Value.self))
     return result
   }
 }

--- a/stdlib/public/core/KeyPathIterable.swift
+++ b/stdlib/public/core/KeyPathIterable.swift
@@ -26,9 +26,9 @@ public protocol _KeyPathIterableBase {
 }
 
 /// A type whose values provides custom key paths to properties or elements.
-public protocol KeyPathIterable : _KeyPathIterableBase {
+public protocol KeyPathIterable: _KeyPathIterableBase {
   /// A type that can represent a collection of all key paths of this type.
-  associatedtype AllKeyPaths : Collection
+  associatedtype AllKeyPaths: Collection
     where AllKeyPaths.Element == PartialKeyPath<Self>
 
   /// A collection of all custom key paths of this value.
@@ -97,30 +97,56 @@ public extension KeyPathIterable {
 // Collection conformances
 //===----------------------------------------------------------------------===//
 
-extension Array : KeyPathIterable {
+/// Returns `true` if all of the given key paths are instances of
+/// `WritableKeyPath<Root, Value>`.
+private func areAllWritableKeyPaths<Root, Value>(
+  _ keyPaths: [PartialKeyPath<Root>], toValueType valueType: Value.Type
+) -> Bool {
+  return !keyPaths.contains(
+    where: { kp in !(kp is WritableKeyPath<Root, Value>) }
+  )
+}
+
+extension Array: KeyPathIterable {
   public typealias AllKeyPaths = [PartialKeyPath<Array>]
   public var allKeyPaths: [PartialKeyPath<Array>] {
-    return indices.map { \Array[$0] }
+    let result = indices.map { \Array[$0] }
+    _internalInvariant(
+      areAllWritableKeyPaths(result, toValueType: Element.self))
+    return result
   }
 }
 
-// TODO(TF-938): Remove 'Element : Differentiable' constraint.
-extension Array.DifferentiableView : KeyPathIterable where Element : Differentiable {
+// TODO(TF-938): Remove this conformance after removing
+// `Element: Differentiable` requirement.
+//
+// Currently necessary to avoid error:
+//
+//   error: conditional conformance of type 'Array<Element>.DifferentiableView'
+//   to protocol 'KeyPathIterable' does not imply conformance to inherited
+//   protocol '_KeyPathIterableBase'.
+extension Array.DifferentiableView: _KeyPathIterableBase
+where Element: Differentiable {}
+
+// TODO(TF-938): Remove `Element: Differentiable` requirement.
+extension Array.DifferentiableView: KeyPathIterable
+where Element: Differentiable {
   public typealias AllKeyPaths = [PartialKeyPath<Array.DifferentiableView>]
   public var allKeyPaths: [PartialKeyPath<Array.DifferentiableView>] {
-    return [\Array.DifferentiableView.base]
+    let result = [\Array.DifferentiableView.base]
+    _internalInvariant(areAllWritableKeyPaths(result, toValueType: Array.self))
+    return result
   }
 }
 
-// TODO(TF-938): Remove this.
-// This is neccessary now because otherwise the compiler complains:
-//   error: conditional conformance of type 'Array<Element>.DifferentiableView' to protocol
-//   'KeyPathIterable' does not imply conformance to inherited protocol '_KeyPathIterableBase'
-extension Array.DifferentiableView : _KeyPathIterableBase where Element : Differentiable {}
-
-extension Dictionary : KeyPathIterable {
+extension Dictionary: KeyPathIterable {
   public typealias AllKeyPaths = [PartialKeyPath<Dictionary>]
   public var allKeyPaths: [PartialKeyPath<Dictionary>] {
-    return values.indices.map { \Dictionary[$0].value }
+    // Note: `Dictionary.subscript(_: Key)` returns `Value?` and can be used to
+    // form `WritableKeyPath<Self, Value>` key paths.
+    // Force-unwrapping the result is necessary.
+    let result = keys.map { \Dictionary[$0]! }
+    _internalInvariant(areAllWritableKeyPaths(result, toValueType: Value.self))
+    return result
   }
 }

--- a/stdlib/public/core/KeyPathIterable.swift
+++ b/stdlib/public/core/KeyPathIterable.swift
@@ -99,8 +99,8 @@ public extension KeyPathIterable {
 
 /// Returns `true` if all of the given key paths are instances of
 /// `WritableKeyPath<Root, Value>`.
-private func areAllKeyPathsWritable<Root, Value>(
-  _ keyPaths: [PartialKeyPath<Root>], toValueType valueType: Value.Type
+private func areWritable<Root, Value>(
+  _ keyPaths: [PartialKeyPath<Root>], valueType: Value.Type
 ) -> Bool {
   return !keyPaths.contains(
     where: { kp in !(kp is WritableKeyPath<Root, Value>) }
@@ -111,8 +111,7 @@ extension Array: KeyPathIterable {
   public typealias AllKeyPaths = [PartialKeyPath<Array>]
   public var allKeyPaths: [PartialKeyPath<Array>] {
     let result = indices.map { \Array[$0] }
-    _internalInvariant(
-      areAllKeyPathsWritable(result, toValueType: Element.self))
+    _internalInvariant(areWritable(result, valueType: Element.self))
     return result
   }
 }
@@ -134,7 +133,7 @@ where Element: Differentiable {
   public typealias AllKeyPaths = [PartialKeyPath<Array.DifferentiableView>]
   public var allKeyPaths: [PartialKeyPath<Array.DifferentiableView>] {
     let result = [\Array.DifferentiableView.base]
-    _internalInvariant(areAllKeyPathsWritable(result, toValueType: Array.self))
+    _internalInvariant(areWritable(result, valueType: Array.self))
     return result
   }
 }
@@ -146,7 +145,7 @@ extension Dictionary: KeyPathIterable {
     // form `WritableKeyPath<Self, Value>` key paths.
     // Force-unwrapping the result is necessary.
     let result = keys.map { \Dictionary[$0]! }
-    _internalInvariant(areAllKeyPathsWritable(result, toValueType: Value.self))
+    _internalInvariant(areWritable(result, valueType: Value.self))
     return result
   }
 }

--- a/test/AutoDiff/downstream/compiler_crashers_fixed/tf123-differentiable-function-opaque-reabstraction.swift
+++ b/test/AutoDiff/downstream/compiler_crashers_fixed/tf123-differentiable-function-opaque-reabstraction.swift
@@ -1,0 +1,24 @@
+// RUN: not --crash %target-swift-frontend-emit-silgen %s
+// REQUIRES: asserts
+
+// TF-123: SILGen crashes when reabstracting `@differentiable` functions to
+// opaque abstraction patterns.
+// The culprit is `createAutoDiffThunk` in lib/SILGen/SILGenPoly.cpp.
+
+// Reproducer: cast `@differentiable` function-typed value to `Any`.
+let function: @differentiable (Float) -> Float
+_ = function as Any
+
+// SIL verification failed: JVP type does not match expected JVP type
+//   $@callee_guaranteed (@in_guaranteed Float) -> @out (Float, @callee_guaranteed (@in_guaranteed Float) -> @out Float)
+//   $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float)
+
+// Reproducer: create key path to `@differentiable` function-typed value.
+struct TF_123: KeyPathIterable {
+  let function: @differentiable (Float) -> Float
+}
+_ = \TF_123.function
+
+// SIL verification failed: JVP type does not match expected JVP type
+//   $@callee_guaranteed (@in_guaranteed Float) -> @out (Float, @callee_guaranteed (@in_guaranteed Float) -> @out Float)
+//   $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @owned @callee_guaranteed (@in_guaranteed Float) -> @out Float)

--- a/test/stdlib/KeyPathIterable.swift
+++ b/test/stdlib/KeyPathIterable.swift
@@ -1,0 +1,184 @@
+// SWIFT_ENABLE_TENSORFLOW
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -swift-version 5 -g %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+//
+// `KeyPathIterable` tests.
+
+import StdlibUnittest
+
+var KeyPathIterableTests = TestSuite("KeyPathIterable")
+
+struct Simple : KeyPathIterable, Equatable {
+  var w, b: Float
+}
+
+struct Mixed : KeyPathIterable, Equatable {
+  // Mutable.
+  var string: String
+  var float: Float
+  // Immutable.
+  let int: Int
+}
+
+struct Nested : KeyPathIterable, Equatable {
+  // Immutable.
+  let simple: Simple
+  // Mutable.
+  var mixed: Mixed
+}
+
+struct ComplexNested : KeyPathIterable, Equatable {
+  var float: Float
+  let simple: Simple
+  let array: [Simple]
+  var dictionary: [String : Simple]
+}
+
+KeyPathIterableTests.test("Simple") {
+  var x = Simple(w: 1, b: 2)
+  expectEqual([\Simple.w, \Simple.b], x.allKeyPaths)
+  expectEqual([\Simple.w, \Simple.b], x.allKeyPaths(to: Float.self))
+  expectEqual([\Simple.w, \Simple.b], x.allWritableKeyPaths(to: Float.self))
+  expectEqual([\Simple.w, \Simple.b], x.recursivelyAllKeyPaths)
+  expectEqual([\Simple.w, \Simple.b], x.recursivelyAllKeyPaths(to: Float.self))
+  expectEqual([\Simple.w, \Simple.b], x.recursivelyAllWritableKeyPaths(to: Float.self))
+  expectEqual([], x.allKeyPaths(to: Int.self))
+  expectEqual([], x.recursivelyAllKeyPaths(to: Double.self))
+
+  // Mutate recursively all `Float` properties.
+  for kp in x.allWritableKeyPaths(to: Float.self) {
+    x[keyPath: kp] += x[keyPath: kp]
+  }
+  // Check that recursively all `Float` properties have been mutated.
+  expectEqual(Simple(w: 2, b: 4), x)
+}
+
+KeyPathIterableTests.test("Mixed") {
+  var x = Mixed(string: "hello", float: .pi, int: 0)
+  expectEqual([\Mixed.string, \Mixed.float, \Mixed.int], x.allKeyPaths)
+  expectEqual([\Mixed.string, \Mixed.float, \Mixed.int], x.recursivelyAllKeyPaths)
+
+  expectEqual([\Mixed.string], x.allKeyPaths(to: String.self))
+  expectEqual([\Mixed.string], x.allWritableKeyPaths(to: String.self))
+  expectEqual([\Mixed.string], x.recursivelyAllKeyPaths(to: String.self))
+  expectEqual([\Mixed.string], x.recursivelyAllWritableKeyPaths(to: String.self))
+
+  expectEqual([\Mixed.float], x.allKeyPaths(to: Float.self))
+  expectEqual([\Mixed.float], x.allWritableKeyPaths(to: Float.self))
+  expectEqual([\Mixed.float], x.recursivelyAllKeyPaths(to: Float.self))
+  expectEqual([\Mixed.float], x.recursivelyAllWritableKeyPaths(to: Float.self))
+
+  expectEqual([\Mixed.int], x.allKeyPaths(to: Int.self))
+  expectEqual([], x.allWritableKeyPaths(to: Int.self))
+  expectEqual([\Mixed.int], x.recursivelyAllKeyPaths(to: Int.self))
+  expectEqual([], x.recursivelyAllWritableKeyPaths(to: Int.self))
+
+  // Mutate recursively all `String` properties.
+  for kp in x.allWritableKeyPaths(to: String.self) {
+    x[keyPath: kp] = x[keyPath: kp] + " world"
+  }
+  // Check that recursively all `String` properties have been mutated.
+  expectEqual(Mixed(string: "hello world", float: .pi, int: 0), x)
+}
+
+KeyPathIterableTests.test("SimpleNested") {
+  var x = Nested(simple: Simple(w: 1, b: 2),
+                 mixed: Mixed(string: "foo", float: 3, int: 0))
+
+  expectEqual([\Nested.simple, \Nested.mixed], x.allKeyPaths)
+  expectEqual([\Nested.simple, \Nested.simple.w, \Nested.simple.b,
+               \Nested.mixed, \Nested.mixed.string,
+               \Nested.mixed.float, \Nested.mixed.int],
+              x.recursivelyAllKeyPaths)
+
+  expectEqual([], x.allKeyPaths(to: Float.self))
+  expectEqual([], x.allKeyPaths(to: Int.self))
+  expectEqual([], x.allKeyPaths(to: String.self))
+
+  expectEqual([], x.allWritableKeyPaths(to: Float.self))
+  expectEqual([], x.allWritableKeyPaths(to: Int.self))
+  expectEqual([], x.allWritableKeyPaths(to: String.self))
+
+  expectEqual([\Nested.simple.w, \Nested.simple.b, \Nested.mixed.float],
+              x.recursivelyAllKeyPaths(to: Float.self))
+  expectEqual([\Nested.mixed.int], x.recursivelyAllKeyPaths(to: Int.self))
+  expectEqual([\Nested.mixed.string], x.recursivelyAllKeyPaths(to: String.self))
+
+  expectEqual([\Nested.mixed.float], x.recursivelyAllWritableKeyPaths(to: Float.self))
+  expectEqual([], x.recursivelyAllWritableKeyPaths(to: Int.self))
+  expectEqual([\Nested.mixed.string], x.recursivelyAllWritableKeyPaths(to: String.self))
+
+  expectEqual([], x.recursivelyAllKeyPaths(to: Double.self))
+
+  // Mutate recursively all `Float` properties.
+  for kp in x.recursivelyAllWritableKeyPaths(to: Float.self) {
+    x[keyPath: kp] *= 100
+  }
+  // Check that recursively all `Float` properties have been mutated.
+  let expected = Nested(simple: Simple(w: 1, b: 2),
+                        mixed: Mixed(string: "foo", float: 300, int: 0))
+  expectEqual(expected, x)
+}
+
+KeyPathIterableTests.test("ComplexNested") {
+  var x = ComplexNested(float: 1, simple: Simple(w: 3, b: 4),
+                        array: [Simple(w: 5, b: 6), Simple(w: 7, b: 8)],
+                        dictionary: ["foo" : Simple(w: 1, b: 2),
+                                     "bar" : Simple(w: 3, b: 4)])
+  expectEqual([\ComplexNested.float, \ComplexNested.simple,
+               \ComplexNested.array, \ComplexNested.dictionary],
+              x.allKeyPaths)
+  expectEqual([\ComplexNested.float,
+               \ComplexNested.simple,
+               \ComplexNested.simple.w,
+               \ComplexNested.simple.b,
+               \ComplexNested.array,
+               \ComplexNested.array[0],
+               \ComplexNested.array[0].w,
+               \ComplexNested.array[0].b,
+               \ComplexNested.array[1],
+               \ComplexNested.array[1].w,
+               \ComplexNested.array[1].b,
+               \ComplexNested.dictionary,
+               \ComplexNested.dictionary["bar"]!,
+               \ComplexNested.dictionary["bar"]!.w,
+               \ComplexNested.dictionary["bar"]!.b,
+               \ComplexNested.dictionary["foo"]!,
+               \ComplexNested.dictionary["foo"]!.w,
+               \ComplexNested.dictionary["foo"]!.b],
+              x.recursivelyAllKeyPaths)
+  expectEqual([\ComplexNested.float,
+               \ComplexNested.simple.w,
+               \ComplexNested.simple.b,
+               \ComplexNested.array[0].w,
+               \ComplexNested.array[0].b,
+               \ComplexNested.array[1].w,
+               \ComplexNested.array[1].b,
+               \ComplexNested.dictionary["bar"]!.w,
+               \ComplexNested.dictionary["bar"]!.b,
+               \ComplexNested.dictionary["foo"]!.w,
+               \ComplexNested.dictionary["foo"]!.b],
+              x.recursivelyAllKeyPaths(to: Float.self))
+  expectEqual([\ComplexNested.float,
+               \ComplexNested.dictionary["bar"]!.w,
+               \ComplexNested.dictionary["bar"]!.b,
+               \ComplexNested.dictionary["foo"]!.w,
+               \ComplexNested.dictionary["foo"]!.b],
+              x.recursivelyAllWritableKeyPaths(to: Float.self))
+
+  // Mutate recursively all `Float` properties.
+  for kp in x.recursivelyAllWritableKeyPaths(to: Float.self) {
+    x[keyPath: kp] += 1
+  }
+  // Check that recursively all `Float` properties have been mutated.
+  let expected = ComplexNested(float: 2, simple: Simple(w: 3, b: 4),
+                               array: [Simple(w: 5, b: 6), Simple(w: 7, b: 8)],
+                               dictionary: ["foo" : Simple(w: 2, b: 3),
+                                            "bar" : Simple(w: 4, b: 5)])
+  expectEqual(expected, x)
+}
+
+runAllTests()


### PR DESCRIPTION
- Change `Dictionary.allKeyPaths` to return `WritableKeyPath` instances.
  - Previously, `\Dictionary[_: Index].value` was used. Those key paths are not
    writable.
- Assert that `{Array,Array.DifferentiableView,Dictionary}.allKeyPaths` return
  `WritableKeyPath` instances.
- Re-add `test/stdlib/KeyPathIterable.swift`.
  - This test existed at [`test/TensorFlowRuntime/key_path_iterable.swift`](https://github.com/apple/swift/blob/tensorflow-0.2/test/TensorFlowRuntime/key_path_iterable.swift)
    but was deleted.
- Add negative test for TF-123: `@differentiable` function opaque reabstraction.
- Minor gardening included.

---

Examples:

```swift
// Context:
//
// `Dictionary` has two subscripting interfaces:
//
// 1. Subscripting with a key, yielding an optional value:
//   v = d[k]!
// 2. Subscripting with an index, yielding a key-value pair:
//   (k, v) = d[i]
//
// Only (1) can be used to form a `WritableKeyPath`. (2) cannot.

print(\Dictionary<String, Int>["key"]!) // key
// Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Int>, Swift.Int>

let dummyIndex: Dictionary<String, Int>.Index = [:].startIndex
print(\Dictionary<String, Int>[dummyIndex].value) // index
// Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Int>, Swift.Int>
```
```swift
// Test:
var dict = ["a": 1, "b": 2, "c": 3]
for kp in dict.allWritableKeyPaths(to: Int.self) {
  dict[keyPath: kp] += 1
}
print(dict)
// Before: ["a": 1, "b": 2, "c": 3]
// After: ["a": 2, "b": 3, "c": 4]

```