### PR TITLE
Improve data locality for statements checker

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -137,7 +137,9 @@ enum class AllocationArena {
   /// lifetime of a particular instance of the constraint solver.
   ///
   /// Any type involving a type variable is allocated in this arena.
-  ConstraintSolver
+  ConstraintSolver,
+
+  Declarations
 };
 
 /// Lists the set of "known" Foundation entities that are used in the

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -28,6 +28,7 @@
 #ifndef SWIFT_AST_AST_SCOPE_H
 #define SWIFT_AST_AST_SCOPE_H
 
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/NameLookup.h" // for DeclVisibilityKind
 #include "swift/AST/SimpleRequest.h"
@@ -180,7 +181,8 @@ public:
   // Only allow allocation of scopes using the allocator of a particular source
   // file.
   void *operator new(size_t bytes, const ASTContext &ctx,
-                     unsigned alignment = alignof(ASTScopeImpl));
+                     unsigned alignment = alignof(ASTScopeImpl),
+                     AllocationArena arena = AllocationArena::Permanent);
   void *operator new(size_t Bytes, void *Mem) {
     ASTScopeAssert(Mem, "Allocation failed");
     return Mem;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_DECL_H
 #define SWIFT_DECL_H
 
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/CaptureInfo.h"
@@ -954,7 +955,7 @@ void *allocateMemoryForDecl(AllocatorTy &allocator, size_t baseSize,
   if (includeSpaceForClangNode)
     size += alignof(DeclTy);
 
-  void *mem = allocator.Allocate(size, alignof(DeclTy));
+  void *mem = allocator.Allocate(size, alignof(DeclTy), AllocationArena::Declarations);
   if (includeSpaceForClangNode)
     mem = reinterpret_cast<char *>(mem) + alignof(DeclTy);
   return mem;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -150,6 +150,7 @@ struct ASTContext::Implementation {
   ~Implementation();
 
   llvm::BumpPtrAllocator Allocator; // used in later initializations
+  llvm::BumpPtrAllocator DeclarationsAllocator; // used in later initializations
 
   /// The set of cleanups to be called when the ASTContext is destroyed.
   std::vector<std::function<void(void)>> Cleanups;
@@ -458,6 +459,9 @@ struct ASTContext::Implementation {
     case AllocationArena::ConstraintSolver:
       assert(CurrentConstraintSolverArena && "No constraint solver active?");
       return *CurrentConstraintSolverArena;
+
+    default: 
+      llvm_unreachable("bad AllocationArena");
     }
     llvm_unreachable("bad AllocationArena");
   }
@@ -603,6 +607,9 @@ llvm::BumpPtrAllocator &ASTContext::getAllocator(AllocationArena arena) const {
   case AllocationArena::ConstraintSolver:
     assert(getImpl().CurrentConstraintSolverArena != nullptr);
     return getImpl().CurrentConstraintSolverArena->Allocator;
+
+  case AllocationArena::Declarations:
+    return getImpl().DeclarationsAllocator;
   }
   llvm_unreachable("bad AllocationArena");
 }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1755,8 +1755,9 @@ void *Portion::operator new(size_t bytes, const ASTContext &ctx,
   return ctx.Allocate(bytes, alignment);
 }
 void *ASTScope::operator new(size_t bytes, const ASTContext &ctx,
-                             unsigned alignment) {
-  return ctx.Allocate(bytes, alignment);
+                             unsigned alignment,
+                             AllocationArena arena) {
+  return ctx.Allocate(bytes, alignment, arena);
 }
 void *ScopeCreator::operator new(size_t bytes, const ASTContext &ctx,
                                  unsigned alignment) {

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1746,8 +1746,9 @@ void ScopeCreator::forEachClosureIn(
 
 #pragma mark new operators
 void *ASTScopeImpl::operator new(size_t bytes, const ASTContext &ctx,
-                                 unsigned alignment) {
-  return ctx.Allocate(bytes, alignment);
+                                 unsigned alignment,
+                                 AllocationArena arena) {
+  return ctx.Allocate(bytes, alignment, arena);
 }
 
 void *Portion::operator new(size_t bytes, const ASTContext &ctx,
@@ -1755,9 +1756,8 @@ void *Portion::operator new(size_t bytes, const ASTContext &ctx,
   return ctx.Allocate(bytes, alignment);
 }
 void *ASTScope::operator new(size_t bytes, const ASTContext &ctx,
-                             unsigned alignment,
-                             AllocationArena arena) {
-  return ctx.Allocate(bytes, alignment, arena);
+                             unsigned alignment) {
+  return ctx.Allocate(bytes, alignment);
 }
 void *ScopeCreator::operator new(size_t bytes, const ASTContext &ctx,
                                  unsigned alignment) {

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -36,7 +36,7 @@ using namespace swift;
 // Only allow allocation of Stmts using the allocator in ASTContext.
 void *Stmt::operator new(size_t Bytes, ASTContext &C,
                          unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
+  return C.Allocate(Bytes, Alignment, AllocationArena::Declarations);
 }
 
 StringRef Stmt::getKindName(StmtKind K) {

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -172,7 +172,8 @@ BraceStmt *BraceStmt::create(ASTContext &ctx, SourceLoc lbloc,
   //  }
 
   void *Buffer = ctx.Allocate(totalSizeToAlloc<ASTNode>(elts.size()),
-                              alignof(BraceStmt));
+                              alignof(BraceStmt),
+                              AllocationArena::Declarations);
   return ::new(Buffer) BraceStmt(lbloc, elts, rbloc, implicit);
 }
 
@@ -191,7 +192,8 @@ YieldStmt *YieldStmt::create(const ASTContext &ctx, SourceLoc yieldLoc,
                              SourceLoc lpLoc, ArrayRef<Expr*> yields,
                              SourceLoc rpLoc, Optional<bool> implicit) {
   void *buffer = ctx.Allocate(totalSizeToAlloc<Expr*>(yields.size()),
-                              alignof(YieldStmt));
+                              alignof(YieldStmt),
+                              AllocationArena::Declarations);
   return ::new(buffer) YieldStmt(yieldLoc, lpLoc, yields, rpLoc, implicit);
 }
 
@@ -273,7 +275,8 @@ DoCatchStmt *DoCatchStmt::create(ASTContext &ctx, LabeledStmtInfo labelInfo,
                                  ArrayRef<CatchStmt*> catches,
                                  Optional<bool> implicit) {
   void *mem = ctx.Allocate(totalSizeToAlloc<CatchStmt*>(catches.size()),
-                           alignof(DoCatchStmt));
+                           alignof(DoCatchStmt),
+                           AllocationArena::Declarations);
   return ::new (mem) DoCatchStmt(labelInfo, doLoc, body, catches, implicit);
 }
 
@@ -308,7 +311,7 @@ PoundAvailableInfo *PoundAvailableInfo::create(ASTContext &ctx,
                                        ArrayRef<AvailabilitySpec *> queries,
                                                      SourceLoc RParenLoc) {
   unsigned size = totalSizeToAlloc<AvailabilitySpec *>(queries.size());
-  void *Buffer = ctx.Allocate(size, alignof(PoundAvailableInfo));
+  void *Buffer = ctx.Allocate(size, alignof(PoundAvailableInfo), AllocationArena::Declarations);
   return ::new (Buffer) PoundAvailableInfo(PoundLoc, queries, RParenLoc);
 }
 
@@ -449,7 +452,8 @@ CaseStmt *CaseStmt::create(ASTContext &ctx, SourceLoc caseLoc,
   void *mem =
       ctx.Allocate(totalSizeToAlloc<FallthroughStmt *, CaseLabelItem>(
                        fallthroughStmt.isNonNull(), caseLabelItems.size()),
-                   alignof(CaseStmt));
+                   alignof(CaseStmt),
+                   AllocationArena::Declarations);
   return ::new (mem) CaseStmt(caseLoc, caseLabelItems, unknownAttrLoc, colonLoc,
                               body, caseVarDecls, implicit, fallthroughStmt);
 }
@@ -468,7 +472,8 @@ SwitchStmt *SwitchStmt::create(LabeledStmtInfo LabelInfo, SourceLoc SwitchLoc,
 #endif
 
   void *p = C.Allocate(totalSizeToAlloc<ASTNode>(Cases.size()),
-                       alignof(SwitchStmt));
+                       alignof(SwitchStmt),
+                       AllocationArena::Declarations);
   SwitchStmt *theSwitch = ::new (p) SwitchStmt(LabelInfo, SwitchLoc,
                                                SubjectExpr, LBraceLoc,
                                                Cases.size(), RBraceLoc);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1581,7 +1581,7 @@ ParserStatus Parser::parseStmtCondition(StmtCondition &Condition,
     break;
   }; 
   
-  Condition = Context.AllocateCopy(result);
+  Condition = Context.AllocateCopy(result, AllocationArena::Declarations);
   return Status;
 }
 
@@ -1617,7 +1617,7 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
       if (Condition.empty()) {
         SmallVector<StmtConditionElement, 1> ConditionElems;
         ConditionElems.emplace_back(new (Context) ErrorExpr(IfLoc));
-        Condition = Context.AllocateCopy(ConditionElems);
+        Condition = Context.AllocateCopy(ConditionElems, AllocationArena::Declarations);
       }
       auto EndLoc = Condition.back().getEndLoc();
       return makeParserResult(
@@ -1634,7 +1634,7 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
         .highlight(SourceRange(IfLoc, LBraceLoc));
       SmallVector<StmtConditionElement, 1> ConditionElems;
       ConditionElems.emplace_back(new (Context) ErrorExpr(LBraceLoc));
-      Condition = Context.AllocateCopy(ConditionElems);
+      Condition = Context.AllocateCopy(ConditionElems, AllocationArena::Declarations);
     } else {
       Status |= parseStmtCondition(Condition, diag::expected_condition_if,
                                    StmtKind::If);
@@ -1716,7 +1716,7 @@ ParserResult<Stmt> Parser::parseStmtGuard() {
     if (Condition.empty()) {
       SmallVector<StmtConditionElement, 1> ConditionElems;
       ConditionElems.emplace_back(new (Context) ErrorExpr(GuardLoc));
-      Condition = Context.AllocateCopy(ConditionElems);
+      Condition = Context.AllocateCopy(ConditionElems, AllocationArena::Declarations);
     }
     auto EndLoc = Condition.back().getEndLoc();
     return makeParserResult(
@@ -1732,7 +1732,7 @@ ParserResult<Stmt> Parser::parseStmtGuard() {
       .highlight(SourceRange(GuardLoc, LBraceLoc));
     SmallVector<StmtConditionElement, 1> ConditionElems;
     ConditionElems.emplace_back(new (Context) ErrorExpr(LBraceLoc));
-    Condition = Context.AllocateCopy(ConditionElems);
+    Condition = Context.AllocateCopy(ConditionElems, AllocationArena::Declarations);
   } else {
     Status |= parseStmtCondition(Condition, diag::expected_condition_guard,
                                  StmtKind::Guard);
@@ -1793,7 +1793,7 @@ ParserResult<Stmt> Parser::parseStmtWhile(LabeledStmtInfo LabelInfo) {
     if (Condition.empty()) {
       SmallVector<StmtConditionElement, 1> ConditionElems;
       ConditionElems.emplace_back(new (Context) ErrorExpr(WhileLoc));
-      Condition = Context.AllocateCopy(ConditionElems);
+      Condition = Context.AllocateCopy(ConditionElems, AllocationArena::Declarations);
     }
     auto EndLoc = Condition.back().getEndLoc();
     return makeParserResult(
@@ -1809,7 +1809,7 @@ ParserResult<Stmt> Parser::parseStmtWhile(LabeledStmtInfo LabelInfo) {
       .highlight(SourceRange(WhileLoc, LBraceLoc));
     SmallVector<StmtConditionElement, 1> ConditionElems;
     ConditionElems.emplace_back(new (Context) ErrorExpr(LBraceLoc));
-    Condition = Context.AllocateCopy(ConditionElems);
+    Condition = Context.AllocateCopy(ConditionElems, AllocationArena::Declarations);
   } else {
     Status |= parseStmtCondition(Condition, diag::expected_condition_while,
                                  StmtKind::While);
@@ -2293,7 +2293,7 @@ parseStmtCase(Parser &P, SourceLoc &CaseLoc,
     // body var decls.
     SmallVector<VarDecl *, 4> tmp;
     LabelItems.front().getPattern()->collectVariables(tmp);
-    auto Result = P.Context.AllocateUninitialized<VarDecl *>(tmp.size());
+    auto Result = P.Context.AllocateUninitialized<VarDecl *>(tmp.size(), AllocationArena::Declarations);
     for (unsigned i : indices(tmp)) {
       auto *vOld = tmp[i];
       auto *vNew = new (P.Context) VarDecl(


### PR DESCRIPTION
From benchmark on my typical iOS app incremental workload, this change speeds up compiler by 5% +/- 1% (as measured applying this PR to 5.0.1 release)

Bottleneck in my workload is `TypeChecker`. Speedup is achieved by allocating objects representing AST friendlier wrt `TypeChecker` access patterns. 

Purpose of this PR is to better understand:
1\. Are changes towards micro architectural friendliness in specific scenario and CPU desired and could be accepted in future? 

Scenario i wish to improve is working on iOS app on my laptop. I'm daily iterating on iOS app and most of the time it's not optimized, incremental, single file mode compiler invocation. I have specific intel processor at my hands and very specific workload. Do you think specific optimizations worth it?

2\. What's the easiest way to benchmark compiler performance when working on this PR.

I don't think my measurements are good enough because of specific workload/thermals/inability to capture performance counters on macOS. Is it right, that installing Linux and running CI test suite is the way to go?