### PR TITLE
CTensorFlow: enable on Windows

### DIFF
--- a/stdlib/public/CTensorFlow/CMakeLists.txt
+++ b/stdlib/public/CTensorFlow/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 include_directories(BEFORE "${TF_INCLUDE_DIR}")
 
 # Get target SDKs.
-set(TARGET_SDKS "OSX" "LINUX")
+set(TARGET_SDKS "OSX" "LINUX" "WINDOWS")
 list_intersect("${TARGET_SDKS}" "${SWIFT_SDKS}" TARGET_SDKS)
 
 set(ctensorflow_modulemap_target_list)


### PR DESCRIPTION
Unfortunately, there was a preparatory step that was missed on Windows
due to the custom handling for the injection of the TensorFlow headers.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
