### PR TITLE
Remove DelayedDeclLists from PersistentParserState

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -607,14 +607,13 @@ public:
   void performSema();
 
   /// Parses the input file but does no type-checking or module imports.
-  /// Note that this only supports parsing an invocation with a single file.
   void performParseOnly(bool EvaluateConditionals = false,
                         bool CanDelayBodies = true);
 
   /// Parses and performs name binding on all input files.
   ///
-  /// Like a parse-only invocation, a single file is required. Unlike a
-  /// parse-only invocation, module imports will be processed.
+  /// This is similar to a parse-only invocation, but module imports will also
+  /// be processed.
   void performParseAndResolveImportsOnly();
 
   /// Performs mandatory, diagnostic, and optimization passes over the SIL.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -609,7 +609,7 @@ public:
   /// Parses the input file but does no type-checking or module imports.
   /// Note that this only supports parsing an invocation with a single file.
   void performParseOnly(bool EvaluateConditionals = false,
-                        bool ParseDelayedBodyOnEnd = false);
+                        bool CanDelayBodies = true);
 
   /// Parses and performs name binding on all input files.
   ///

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -78,8 +78,6 @@ private:
 
   std::unique_ptr<CodeCompletionDelayedDeclState> CodeCompletionDelayedDeclStat;
 
-  std::vector<IterableDeclContext *> DelayedDeclLists;
-
   /// The local context for all top-level code.
   TopLevelContext TopLevelCode;
 
@@ -111,10 +109,6 @@ public:
     assert(hasCodeCompletionDelayedDeclState());
     return std::move(CodeCompletionDelayedDeclStat);
   }
-
-  void delayDeclList(IterableDeclContext *D);
-
-  void parseAllDelayedDeclLists();
 
   TopLevelContext &getTopLevelContext() {
     return TopLevelCode;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1071,7 +1071,7 @@ SourceFile *CompilerInstance::createSourceFileForMainModule(
 }
 
 void CompilerInstance::performParseOnly(bool EvaluateConditionals,
-                                        bool ParseDelayedBodyOnEnd) {
+                                        bool CanDelayBodies) {
   const InputFileKind Kind = Invocation.getInputKind();
   ModuleDecl *const MainModule = getMainModule();
   Context->LoadedModules[MainModule->getName()] = MainModule;
@@ -1093,12 +1093,8 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals,
   }
 
   PersistentState = llvm::make_unique<PersistentParserState>();
-
-  SWIFT_DEFER {
-    if (ParseDelayedBodyOnEnd)
-      PersistentState->parseAllDelayedDeclLists();
-  };
   PersistentState->PerformConditionEvaluation = EvaluateConditionals;
+
   // Parse all the library files.
   for (auto BufferID : InputSourceCodeBufferIDs) {
     if (BufferID == MainBufferID)
@@ -1111,7 +1107,7 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals,
         BufferID);
 
     parseIntoSourceFileFull(*NextInput, BufferID, PersistentState.get(),
-                            /*DelayBodyParsing=*/!IsPrimary);
+                            /*DelayBodyParsing=*/!IsPrimary && CanDelayBodies);
   }
 
   // Now parse the main file.

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1262,11 +1262,12 @@ static bool performCompile(CompilerInstance &Instance,
     return compileLLVMIR(Invocation, Instance, Stats);
 
   if (FrontendOptions::shouldActionOnlyParse(Action)) {
-    bool ParseDelayedDeclListsOnEnd =
-      Action == FrontendOptions::ActionType::DumpParse;
+    // Disable delayed parsing of type and function bodies when we've been
+    // asked to dump the resulting AST.
+    bool CanDelayBodies = Action != FrontendOptions::ActionType::DumpParse;
     Instance.performParseOnly(/*EvaluateConditionals*/
                     Action == FrontendOptions::ActionType::EmitImportedModules,
-                              ParseDelayedDeclListsOnEnd);
+                              CanDelayBodies);
   } else if (Action == FrontendOptions::ActionType::ResolveImports) {
     Instance.performParseAndResolveImportsOnly();
   } else {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1263,8 +1263,7 @@ static bool performCompile(CompilerInstance &Instance,
 
   if (FrontendOptions::shouldActionOnlyParse(Action)) {
     bool ParseDelayedDeclListsOnEnd =
-      Action == FrontendOptions::ActionType::DumpParse ||
-      Invocation.getDiagnosticOptions().VerifyMode != DiagnosticOptions::NoVerify;
+      Action == FrontendOptions::ActionType::DumpParse;
     Instance.performParseOnly(/*EvaluateConditionals*/
                     Action == FrontendOptions::ActionType::EmitImportedModules,
                               ParseDelayedDeclListsOnEnd);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4441,8 +4441,6 @@ bool Parser::delayParsingDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
     RBLoc = Tok.getLoc();
     error = true;
   }
-
-  State->delayDeclList(IDC);
   return error;
 }
 

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -50,12 +50,3 @@ void PersistentParserState::restoreCodeCompletionDelayedDeclState(
       ScopeInfo.saveCurrentScope(), other.StartOffset, other.EndOffset,
       other.PrevOffset));
 }
-
-void PersistentParserState::delayDeclList(IterableDeclContext *D) {
-  DelayedDeclLists.push_back(D);
-}
-
-void PersistentParserState::parseAllDelayedDeclLists() {
-  for (auto IDC : DelayedDeclLists)
-    IDC->loadAllMembers();
-}


### PR DESCRIPTION
`DelayedDeclLists` is currently only used by `-verify` and `-dump-parse` to fully parse the bodies of types which we've previously skipped.

For `-verify`, avoid doing this as ideally we shouldn't emit any additional parsing diagnostics that an equivalent invocation without `-verify` would. For `-dump-parse`, tell the parser not to delay any bodies.

In addition, this PR enables the delayed body parsing for `-parse` of a non-primary main file, which better matches the behavior of `parseAndTypeCheckMainFileUpTo`.