### PR TITLE
SR-4079: Make Enum CaseStmt introduce new type refinement context

### DIFF
--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -82,8 +82,11 @@ public:
     /// statement.
     GuardStmtElseBranch,
 
-    // The context was introduced for the body of a while statement.
-    WhileStmtBody
+    /// The context was introduced for the body of a while statement.
+    WhileStmtBody,
+
+    /// The context was introduced for the body of a switch case statement
+    CaseStmtBody
   };
 
 private:
@@ -98,6 +101,7 @@ private:
       PoundAvailableInfo *PAI;
       GuardStmt *GS;
       WhileStmt *WS;
+      CaseStmt *CS;
     };
 
   public:
@@ -113,6 +117,7 @@ private:
                                     : Reason::GuardStmtElseBranch),
           GS(GS) {}
     IntroNode(WhileStmt *WS) : IntroReason(Reason::WhileStmtBody), WS(WS) {}
+    IntroNode(CaseStmt *CS) : IntroReason(Reason::CaseStmtBody), CS(CS) {}
 
     Reason getReason() const { return IntroReason; }
 
@@ -146,6 +151,11 @@ private:
     WhileStmt *getAsWhileStmt() const {
       assert(IntroReason == Reason::WhileStmtBody);
       return WS;
+    }
+
+    CaseStmt *getAsCaseStmt() const {
+      assert(IntroReason == Reason::CaseStmtBody);
+      return CS;
     }
   };
 
@@ -209,6 +219,12 @@ public:
   /// Create a refinement context for the body of a WhileStmt.
   static TypeRefinementContext *
   createForWhileStmtBody(ASTContext &Ctx, WhileStmt *WS,
+                         TypeRefinementContext *Parent,
+                         const AvailabilityContext &Info);
+
+  /// Create a refinement context for the body of a CaseStmt.
+  static TypeRefinementContext *
+  createForCaseStmtBody(ASTContext &Ctx, CaseStmt *CS,
                          TypeRefinementContext *Parent,
                          const AvailabilityContext &Info);
 

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -131,6 +131,16 @@ TypeRefinementContext::createForWhileStmtBody(ASTContext &Ctx, WhileStmt *S,
       Ctx, S, Parent, S->getBody()->getSourceRange(), Info);
 }
 
+TypeRefinementContext *
+TypeRefinementContext::createForCaseStmtBody(ASTContext &Ctx, CaseStmt *S,
+                                             TypeRefinementContext *Parent,
+                                             const AvailabilityContext &Info) {
+  assert(S);
+  assert(Parent);
+  return new (Ctx) TypeRefinementContext(
+      Ctx, S, Parent, S->getBody()->getSourceRange(), Info);
+}
+
 // Only allow allocation of TypeRefinementContext using the allocator in
 // ASTContext.
 void *TypeRefinementContext::operator new(size_t Bytes, ASTContext &C,
@@ -187,6 +197,9 @@ SourceLoc TypeRefinementContext::getIntroductionLoc() const {
 
   case Reason::WhileStmtBody:
     return Node.getAsWhileStmt()->getStartLoc();
+
+  case Reason::CaseStmtBody:
+    return Node.getAsCaseStmt()->getStartLoc();
 
   case Reason::Root:
     return SourceLoc();
@@ -283,6 +296,9 @@ TypeRefinementContext::getAvailabilityConditionVersionSourceRange(
     return ::getAvailabilityConditionVersionSourceRange(
       Node.getAsWhileStmt()->getCond(), Platform, Version);
 
+  case Reason::CaseStmtBody:
+    return SourceRange();
+
   case Reason::Root:
     return SourceRange();
   }
@@ -350,6 +366,9 @@ StringRef TypeRefinementContext::getReasonName(Reason R) {
 
   case Reason::WhileStmtBody:
     return "while_body";
+
+  case Reason::CaseStmtBody:
+    return "case_body";
   }
 
   llvm_unreachable("Unhandled Reason in switch.");

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1268,6 +1268,12 @@ public:
         checkFallthroughPatternBindingsAndTypes(caseBlock, previousBlock);
       }
 
+      // Build type refinement context after type checking case labels
+      if (!Ctx.LangOpts.DisableAvailabilityChecking) {
+        auto *SF = DC->getParentSourceFile();
+        TypeChecker::buildTypeRefinementContextForCaseStmt(SF, caseBlock);
+      }
+
       // Type-check the body statements.
       PreviousFallthrough = nullptr;
       Stmt *body = caseBlock->getBody();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1432,6 +1432,11 @@ public:
   static void buildTypeRefinementContextHierarchy(SourceFile &SF,
                                                   unsigned StartElem);
 
+  /// Build TypeRefinementContext for CaseStmt and append it to the root
+  /// context for the source file. This cannot be done before type checking
+  /// case statement.
+  static void buildTypeRefinementContextForCaseStmt(SourceFile *SF, CaseStmt *S);
+
   /// Build the hierarchy of TypeRefinementContexts for the entire
   /// source file, if it has not already been built. Returns the root
   /// TypeRefinementContext for the source file.

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -27,7 +27,7 @@ class SomeClass {
       func innerClassMethod() { }
     }
   }
-  
+
   func someUnrefinedMethod() { }
 
   @available(OSX 10.52, *)
@@ -190,5 +190,30 @@ func functionWithWhile() {
         let x = (nil as Int?) {
     @available(OSX 10.54, *)
     func funcInWhileBody() { }
+  }
+}
+
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=SomeEnum
+// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=availableOn1052
+// CHECK-NEXT: {{^}}    (decl versions=[10.53,+Inf) decl=availableOn1053
+// CHECK-NEXT: {{^}}    (case_body versions=[10.52,+Inf)
+// CHECK-NEXT: {{^}}    (case_body versions=[10.53,+Inf)
+@available(OSX 10.51, *)
+enum SomeEnum {
+  case unrestricted
+  @available(OSX 10.52, *)
+  case availableOn1052
+  @available(OSX 10.53, *)
+  case availableOn1053
+
+  var availableVersion: Int? {
+    switch self {
+    case .unrestricted:
+      return nil
+    case .availableOn1052:
+      return 1052
+    case .availableOn1053:
+      return 1053
+    }
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
TypeRefinementContext which restrict access to declarations based on availability attributes wasn't introduced for a switch case body with partially available enum element. So this pull request attempts to fix this. The main challenge was to get an original declaration of enum element used in switch, because type refinement context building happens before type resolution of case labels. My solution is to postpone building refinement context for CaseStmt until case labels fully type checked.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-4079.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->