### PR TITLE
SILGen: Emit vtable thunks to re-abstract generic requirements [5.2]

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -52,11 +52,10 @@ enum class CombineSubstitutionMaps {
 /// any entity that can reference type parameters, e.g., types (via
 /// Type::subst()) and conformances (via ProtocolConformanceRef::subst()).
 ///
-/// SubstitutionMaps are constructed by calling the getSubstitutionMap() method
-/// on a GenericSignature or (equivalently) by calling one of the static
-/// \c SubstitutionMap::get() methods. However, most substitution maps are
+/// SubstitutionMaps are constructed by calling the an overload of the static
+/// method \c SubstitutionMap::get(). However, most substitution maps are
 /// computed using higher-level entry points such as
-/// TypeBase::getMemberSubstitutionMap().
+/// TypeBase::getContextSubstitutionMap().
 ///
 /// Substitution maps are ASTContext-allocated and are uniqued on construction,
 /// so they can be used as fields in AST nodes.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4400,10 +4400,12 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
                                         const ValueDecl *derived) {
   auto baseGenericCtx = base->getAsGenericContext();
   auto derivedGenericCtx = derived->getAsGenericContext();
-  auto &ctx = base->getASTContext();
 
   if (!baseGenericCtx || !derivedGenericCtx)
     return nullptr;
+
+  if (base == derived)
+    return derivedGenericCtx->getGenericSignature();
 
   auto baseClass = base->getDeclContext()->getSelfClassDecl();
   if (!baseClass)
@@ -4460,7 +4462,7 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
     }
 
     return CanGenericTypeParamType::get(
-        gp->getDepth() - baseDepth + derivedDepth, gp->getIndex(), ctx);
+        gp->getDepth() - baseDepth + derivedDepth, gp->getIndex(), *this);
   };
 
   auto lookupConformanceFn =
@@ -4480,7 +4482,7 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
   }
 
   auto genericSig = evaluateOrDefault(
-      ctx.evaluator,
+      evaluator,
       AbstractGenericSignatureRequest{
         derivedClass->getGenericSignature().getPointer(),
         std::move(addedGenericParams),

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3602,10 +3602,10 @@ SILGenFunction::emitVTableThunk(SILDeclRef base,
         SGM.Types.getConstantInfo(getTypeExpansionContext(), derived).SILFnType;
   }
 
-  SubstitutionMap subs;
-  if (auto *genericEnv = fd->getGenericEnvironment()) {
-    F.setGenericEnvironment(genericEnv);
-    subs = getForwardingSubstitutionMap();
+  auto subs = getForwardingSubstitutionMap();
+  if (auto genericSig = derivedFTy->getSubstGenericSignature()) {
+    subs = SubstitutionMap::get(derivedFTy->getSubstGenericSignature(), subs);
+
     derivedFTy =
         derivedFTy->substGenericArgs(SGM.M, subs, getTypeExpansionContext());
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -165,12 +165,16 @@ SILGenModule::emitVTableMethod(ClassDecl *theClass,
   if (auto existingThunk = M.lookUpFunction(name))
     return SILVTable::Entry(base, existingThunk, implKind);
 
+  GenericEnvironment *genericEnv = nullptr;
+  if (auto genericSig = overrideInfo.FormalType.getOptGenericSignature())
+    genericEnv = genericSig->getGenericEnvironment();
+
   // Emit the thunk.
   SILLocation loc(derivedDecl);
   SILGenFunctionBuilder builder(*this);
   auto thunk = builder.createFunction(
       SILLinkage::Private, name, overrideInfo.SILFnType,
-      cast<AbstractFunctionDecl>(derivedDecl)->getGenericEnvironment(), loc,
+      genericEnv, loc,
       IsBare, IsNotTransparent, IsNotSerialized, IsNotDynamic,
       ProfileCounter(), IsThunk);
   thunk->setDebugScope(new (M) SILDebugScope(loc, thunk));

--- a/test/SILGen/vtable_generic_signature.swift
+++ b/test/SILGen/vtable_generic_signature.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+protocol P {}
+protocol Q : P {}
+
+class ConcreteBase {
+  func f<U : Q>(_: U) {}
+}
+
+class ConcreteDerivedFromConcreteBase : ConcreteBase {
+  override func f<U : P>(_: U) {}
+}
+
+class GenericDerivedFromConcreteBase<T> : ConcreteBase {
+  override func f<U : P>(_: U) {}
+}
+
+class GenericBase<T> {
+  func f<U : Q>(_: U) {}
+}
+
+class ConcreteDerivedFromGenericBase : GenericBase<Int> {
+  override func f<U : P>(_: U) {}
+}
+
+class GenericDerivedFromGenericBase<T> : GenericBase<(T) -> Int> {
+  override func f<U : P>(_: U) {}
+}
+
+// All the vtable thunks should traffic in <U where U : Q>, because that's
+// what the base method declares.
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s24vtable_generic_signature019ConcreteDerivedFromD4BaseC1fyyxAA1PRzlFAA0dG0CADyyxAA1QRzlFTV : $@convention(method) <U where U : Q> (@in_guaranteed U, @guaranteed ConcreteDerivedFromConcreteBase) -> ()
+// CHECK-LABEL: sil private [thunk] [ossa] @$s24vtable_generic_signature30GenericDerivedFromConcreteBaseC1fyyqd__AA1PRd__lFAA0gH0CADyyxAA1QRzlFTV : $@convention(method) <T><U where U : Q> (@in_guaranteed U, @guaranteed GenericDerivedFromConcreteBase<T>) -> ()
+// CHECK-LABEL: sil private [thunk] [ossa] @$s24vtable_generic_signature30ConcreteDerivedFromGenericBaseC1fyyxAA1PRzlFAA0gH0CADyyqd__AA1QRd__lFTV : $@convention(method) <U where U : Q> (@in_guaranteed U, @guaranteed ConcreteDerivedFromGenericBase) -> ()
+// CHECK-LABEL: sil private [thunk] [ossa] @$s24vtable_generic_signature018GenericDerivedFromD4BaseC1fyyqd__AA1PRd__lFAA0dG0CADyyqd__AA1QRd__lFTV : $@convention(method) <T><U where U : Q> (@in_guaranteed U, @guaranteed GenericDerivedFromGenericBase<T>) -> ()
+
+// CHECK-LABEL: sil_vtable ConcreteBase {
+// CHECK-NEXT:   #ConcreteBase.f!1: <U where U : Q> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature12ConcreteBaseC1fyyxAA1QRzlF
+// CHECK-NEXT:   #ConcreteBase.init!allocator.1: (ConcreteBase.Type) -> () -> ConcreteBase : @$s24vtable_generic_signature12ConcreteBaseCACycfC
+// CHECK-NEXT:   #ConcreteBase.deinit!deallocator.1: @$s24vtable_generic_signature12ConcreteBaseCfD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable ConcreteDerivedFromConcreteBase {
+// CHECK-NEXT:   #ConcreteBase.f!1: <U where U : Q> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature019ConcreteDerivedFromD4BaseC1fyyxAA1PRzlFAA0dG0CADyyxAA1QRzlFTV [override]
+// CHECK-NEXT:   #ConcreteBase.init!allocator.1: (ConcreteBase.Type) -> () -> ConcreteBase : @$s24vtable_generic_signature019ConcreteDerivedFromD4BaseCACycfC [override]
+// CHECK-NEXT:   #ConcreteDerivedFromConcreteBase.f!1: <U where U : P> (ConcreteDerivedFromConcreteBase) -> (U) -> () : @$s24vtable_generic_signature019ConcreteDerivedFromD4BaseC1fyyxAA1PRzlF
+// CHECK-NEXT:   #ConcreteDerivedFromConcreteBase.deinit!deallocator.1: @$s24vtable_generic_signature019ConcreteDerivedFromD4BaseCfD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable GenericDerivedFromConcreteBase {
+// CHECK-NEXT:   #ConcreteBase.f!1: <U where U : Q> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature30GenericDerivedFromConcreteBaseC1fyyqd__AA1PRd__lFAA0gH0CADyyxAA1QRzlFTV [override]
+// CHECK-NEXT:   #ConcreteBase.init!allocator.1: (ConcreteBase.Type) -> () -> ConcreteBase : @$s24vtable_generic_signature30GenericDerivedFromConcreteBaseCACyxGycfC [override]
+// CHECK-NEXT:   #GenericDerivedFromConcreteBase.f!1: <T><U where U : P> (GenericDerivedFromConcreteBase<T>) -> (U) -> () : @$s24vtable_generic_signature30GenericDerivedFromConcreteBaseC1fyyqd__AA1PRd__lF
+// CHECK-NEXT:   #GenericDerivedFromConcreteBase.deinit!deallocator.1: @$s24vtable_generic_signature30GenericDerivedFromConcreteBaseCfD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable GenericBase {
+// CHECK-NEXT:   #GenericBase.f!1: <T><U where U : Q> (GenericBase<T>) -> (U) -> () : @$s24vtable_generic_signature11GenericBaseC1fyyqd__AA1QRd__lF
+// CHECK-NEXT:   #GenericBase.init!allocator.1: <T> (GenericBase<T>.Type) -> () -> GenericBase<T> : @$s24vtable_generic_signature11GenericBaseCACyxGycfC
+// CHECK-NEXT:   #GenericBase.deinit!deallocator.1: @$s24vtable_generic_signature11GenericBaseCfD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable ConcreteDerivedFromGenericBase {
+// CHECK-NEXT:   #GenericBase.f!1: <T><U where U : Q> (GenericBase<T>) -> (U) -> () : @$s24vtable_generic_signature30ConcreteDerivedFromGenericBaseC1fyyxAA1PRzlFAA0gH0CADyyqd__AA1QRd__lFTV [override]
+// CHECK-NEXT:   #GenericBase.init!allocator.1: <T> (GenericBase<T>.Type) -> () -> GenericBase<T> : @$s24vtable_generic_signature30ConcreteDerivedFromGenericBaseCACycfC [override]
+// CHECK-NEXT:   #ConcreteDerivedFromGenericBase.f!1: <U where U : P> (ConcreteDerivedFromGenericBase) -> (U) -> () : @$s24vtable_generic_signature30ConcreteDerivedFromGenericBaseC1fyyxAA1PRzlF
+// CHECK-NEXT:   #ConcreteDerivedFromGenericBase.deinit!deallocator.1: @$s24vtable_generic_signature30ConcreteDerivedFromGenericBaseCfD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable GenericDerivedFromGenericBase {
+// CHECK-NEXT:   #GenericBase.f!1: <T><U where U : Q> (GenericBase<T>) -> (U) -> () : @$s24vtable_generic_signature018GenericDerivedFromD4BaseC1fyyqd__AA1PRd__lFAA0dG0CADyyqd__AA1QRd__lFTV [override]
+// CHECK-NEXT:   #GenericBase.init!allocator.1: <T> (GenericBase<T>.Type) -> () -> GenericBase<T> : @$s24vtable_generic_signature018GenericDerivedFromD4BaseCACyxGycfC [override]
+// CHECK-NEXT:   #GenericDerivedFromGenericBase.f!1: <T><U where U : P> (GenericDerivedFromGenericBase<T>) -> (U) -> () : @$s24vtable_generic_signature018GenericDerivedFromD4BaseC1fyyqd__AA1PRd__lF
+// CHECK-NEXT:   #GenericDerivedFromGenericBase.deinit!deallocator.1: @$s24vtable_generic_signature018GenericDerivedFromD4BaseCfD
+// CHECK-NEXT: }

--- a/test/SILGen/vtable_thunks_reabstraction_modify.swift
+++ b/test/SILGen/vtable_thunks_reabstraction_modify.swift
@@ -15,21 +15,21 @@ public class DerivedClass<Result> : BaseClass<Int, Result> {
   }
 }
 
-// CHECK-LABEL: sil private [thunk] [ossa] @$s34vtable_thunks_reabstraction_modify12DerivedClassC8callbackyxSicvMAA04BaseF0CADyq_xcvMTV : $@yield_once @convention(method) <Result> (@guaranteed DerivedClass<Result>) -> @yields @inout @callee_guaranteed (@in_guaranteed Int) -> @out Result {
+// CHECK-LABEL: sil private [thunk] [ossa] @$s34vtable_thunks_reabstraction_modify12DerivedClassC8callbackyxSicvMAA04BaseF0CADyq_xcvMTV : $@yield_once @convention(method) <τ_0_0> (@guaranteed DerivedClass<τ_0_0>) -> @yields @inout @callee_guaranteed (@in_guaranteed Int) -> @out τ_0_0 {
 // CHECK: [[DERIVED:%.*]] = function_ref @$s34vtable_thunks_reabstraction_modify12DerivedClassC8callbackyxSicvM : $@yield_once @convention(method) <τ_0_0> (@guaranteed DerivedClass<τ_0_0>) -> @yields @inout @callee_guaranteed (Int) -> @out τ_0_0
-// CHECK: ([[RESULT_BUF:%.*]], [[TOKEN:%.*]]) = begin_apply [[DERIVED]]<Result>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed DerivedClass<τ_0_0>) -> @yields @inout @callee_guaranteed (Int) -> @out τ_0_0
-// CHECK: [[OUTER_RESULT_BUF:%.*]] = alloc_stack $@callee_guaranteed (@in_guaranteed Int) -> @out Result
-// CHECK: [[RESULT:%.*]] = load [take] [[RESULT_BUF]] : $*@callee_guaranteed (Int) -> @out Result
+// CHECK: ([[RESULT_BUF:%.*]], [[TOKEN:%.*]]) = begin_apply [[DERIVED]]<τ_0_0>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed DerivedClass<τ_0_0>) -> @yields @inout @callee_guaranteed (Int) -> @out τ_0_0
+// CHECK: [[OUTER_RESULT_BUF:%.*]] = alloc_stack $@callee_guaranteed (@in_guaranteed Int) -> @out τ_0_0
+// CHECK: [[RESULT:%.*]] = load [take] [[RESULT_BUF]] : $*@callee_guaranteed (Int) -> @out τ_0_0
 // CHECK: [[THUNK_FN:%.*]] = function_ref @$sSixIegyr_SixIegnr_lTR : $@convention(thin) <τ_0_0> (@in_guaranteed Int, @guaranteed @callee_guaranteed (Int) -> @out τ_0_0) -> @out τ_0_0
-// CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<Result>([[RESULT]]) : $@convention(thin) <τ_0_0> (@in_guaranteed Int, @guaranteed @callee_guaranteed (Int) -> @out τ_0_0) -> @out τ_0_0
-// CHECK: store [[THUNK]] to [init] [[OUTER_RESULT_BUF]] : $*@callee_guaranteed (@in_guaranteed Int) -> @out Result
-// CHECK: yield [[OUTER_RESULT_BUF]] : $*@callee_guaranteed (@in_guaranteed Int) -> @out Result, resume bb1, unwind bb2
+// CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<τ_0_0>([[RESULT]]) : $@convention(thin) <τ_0_0> (@in_guaranteed Int, @guaranteed @callee_guaranteed (Int) -> @out τ_0_0) -> @out τ_0_0
+// CHECK: store [[THUNK]] to [init] [[OUTER_RESULT_BUF]] : $*@callee_guaranteed (@in_guaranteed Int) -> @out τ_0_0
+// CHECK: yield [[OUTER_RESULT_BUF]] : $*@callee_guaranteed (@in_guaranteed Int) -> @out τ_0_0, resume bb1, unwind bb2
 
 // CHECK: bb1:
-// CHECK: [[MODIFIED:%.*]] = load [take] [[OUTER_RESULT_BUF]] : $*@callee_guaranteed (@in_guaranteed Int) -> @out Result
+// CHECK: [[MODIFIED:%.*]] = load [take] [[OUTER_RESULT_BUF]] : $*@callee_guaranteed (@in_guaranteed Int) -> @out τ_0_0
 // CHECK: [[THUNK_FN:%.*]] = function_ref @$sSixIegnr_SixIegyr_lTR : $@convention(thin) <τ_0_0> (Int, @guaranteed @callee_guaranteed (@in_guaranteed Int) -> @out τ_0_0) -> @out τ_0_0
-// CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<Result>([[MODIFIED]]) : $@convention(thin) <τ_0_0> (Int, @guaranteed @callee_guaranteed (@in_guaranteed Int) -> @out τ_0_0) -> @out τ_0_0
-// CHECK: store [[THUNK]] to [init] [[RESULT_BUF]] : $*@callee_guaranteed (Int) -> @out Result
-// CHECK: dealloc_stack [[OUTER_RESULT_BUF]] : $*@callee_guaranteed (@in_guaranteed Int) -> @out Result
+// CHECK: [[THUNK:%.*]] = partial_apply [callee_guaranteed] [[THUNK_FN]]<τ_0_0>([[MODIFIED]]) : $@convention(thin) <τ_0_0> (Int, @guaranteed @callee_guaranteed (@in_guaranteed Int) -> @out τ_0_0) -> @out τ_0_0
+// CHECK: store [[THUNK]] to [init] [[RESULT_BUF]] : $*@callee_guaranteed (Int) -> @out τ_0_0
+// CHECK: dealloc_stack [[OUTER_RESULT_BUF]] : $*@callee_guaranteed (@in_guaranteed Int) -> @out τ_0_0
 // CHECK: end_apply [[TOKEN]]
 // CHECK: return


### PR DESCRIPTION
We recently added some checking to ensure that a method override's
generic signature does not have any generic requirements not
satisfied by the base method.

Loosening requirements in the other direction was allowed, because
it means the derived method can be called on potentially more types
than the base method.

However, if the generic signatures don't match, a thunk must be
emitted. While we correctly determined whether a thunk should be
emitted, the thunk had the wrong generic signature, and therefore
the wrong calling convention, which would cause crashes at runtime.

Fixes rdar://problem/57429775.