### PR TITLE
Change swift-cmark repo when checking out swift-5.1-branch

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -228,7 +228,7 @@
             "repos": {
                 "llvm-project": "swift/swift-5.1-branch",
                 "swift": "swift-5.1-branch",
-                "cmark": "master",
+                "cmark": "swift-5.1-branch",
                 "llbuild": "swift-5.1-branch",
                 "swiftpm": "swift-5.1-branch",
                 "swift-syntax": "swift-5.1-branch",


### PR DESCRIPTION
<!-- What's in this pull request? -->
A recent change to `swift-cmark` 
https://github.com/apple/swift-cmark/pull/15
has revealed an error in the `update-checkout-config.json` file.

When running `update-checkout --clone --scheme swift-5.1-branch` the file incorrectly checks out the `master-branch` for `swift-cmark` when it should be checking out the `swift-5.1-branch`

This is causing `swift-5.1-branch` builds to fail with this error:-
```
CMake Error at cmake/modules/SwiftSharedCMakeConfig.cmake:189 (include):
  include could not find load file:

    /home/worksonarm_test/jenkins_slave/workspace/swift-5.1-dev/build/buildbot_linux/cmark-linux-aarch64/src/CMarkExports.cmake
```

@shahmishal this is what is causing the build fails on https://ci-external.swift.org/view/swift-5.1-branch/job/oss-swift-5.1-RA-linux-ubuntu-16.04-aarch64/
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
