### PR TITLE
Revert "[Diagnostics] Removing FailureDiagnosis::visitCoerceExpr from CSDiag"

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -244,6 +244,7 @@ private:
   bool visitObjectLiteralExpr(ObjectLiteralExpr *E);
 
   bool visitApplyExpr(ApplyExpr *AE);
+  bool visitCoerceExpr(CoerceExpr *CE);
   bool visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *E);
 };
 } // end anonymous namespace
@@ -1715,6 +1716,17 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   // Did the user intend on invoking a different overload?
   calleeInfo.suggestPotentialOverloads(fnExpr->getLoc());
   return true;
+}
+
+bool FailureDiagnosis::visitCoerceExpr(CoerceExpr *CE) {
+  // Coerce the input to whatever type is specified by the CoerceExpr.
+  auto expr = typeCheckChildIndependently(CE->getSubExpr(),
+                                          CS.getType(CE->getCastTypeLoc()),
+                                          CTP_CoerceOperand);
+  if (!expr)
+    return true;
+
+  return false;
 }
 
 bool FailureDiagnosis::

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1905,12 +1905,6 @@ bool ContextualFailure::diagnoseAsError() {
     diagnostic = diag::cannot_convert_condition_value;
     break;
   }
-      
-  case ConstraintLocator::InstanceType: {
-    if (diagnoseCoercionToUnrelatedType())
-      return true;
-    break;
-  }
 
   case ConstraintLocator::TernaryBranch: {
     auto *ifExpr = cast<IfExpr>(getRawAnchor());
@@ -2241,12 +2235,11 @@ bool ContextualFailure::diagnoseCoercionToUnrelatedType() const {
   auto *anchor = getAnchor();
   
   if (auto *coerceExpr = dyn_cast<CoerceExpr>(anchor)) {
-    auto fromType = getType(coerceExpr->getSubExpr());
+    auto fromType = getFromType();
     auto toType = getType(coerceExpr->getCastTypeLoc());
-    
     auto diagnostic =
         getDiagnosticFor(CTP_CoerceOperand,
-                         /*forProtocol=*/toType->isExistentialType());
+                         /*forProtocol=*/toType->isAnyExistentialType());
     
     auto diag =
         emitDiagnostic(anchor->getLoc(), *diagnostic, fromType, toType);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2200,18 +2200,8 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
           }
         } else { // There are no elements in the path
           auto *anchor = locator.getAnchor();
-          if (!(anchor &&
-               (isa<AssignExpr>(anchor) || isa<CoerceExpr>(anchor))))
+          if (!(anchor && isa<AssignExpr>(anchor)))
             return getTypeMatchFailure(locator);
-        }
-        
-        auto *anchor = locator.getAnchor();
-        if (isa<CoerceExpr>(anchor)) {
-          auto *fix = ContextualMismatch::create(
-              *this, type1, type2, getConstraintLocator(locator));
-          if (recordFix(fix))
-            return getTypeMatchFailure(locator);
-          break;
         }
 
         auto *fix = MissingConformance::forContextual(
@@ -2840,16 +2830,10 @@ bool ConstraintSystem::repairFailures(
         conversionsOrFixes.push_back(coerceToCheckCastFix);
         return true;
       }
-
+      
       // If it has a deep equality restriction, defer the diagnostic to
       // GenericMismatch.
-      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality) &&
-          !hasConversionOrRestriction(
-              ConversionRestrictionKind::OptionalToOptional)) {
-        return false;
-      }
-
-      if (hasConversionOrRestriction(ConversionRestrictionKind::Existential))
+      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality))
         return false;
       
       auto *fix = ContextualMismatch::create(*this, lhs, rhs,
@@ -3508,13 +3492,6 @@ bool ConstraintSystem::repairFailures(
         break;
       }
     }
-    // Handle function result coerce expression wrong type conversion.
-    if (isa<CoerceExpr>(anchor)) {
-      auto *fix =
-          ContextualMismatch::create(*this, lhs, rhs, loc);
-      conversionsOrFixes.push_back(fix);
-      break;
-    }
     LLVM_FALLTHROUGH;
   }
 
@@ -4082,20 +4059,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         subKind = ConstraintKind::Bind;
       }
 
-      auto result =
-          matchTypes(instanceType1, instanceType2, subKind, subflags,
-                     locator.withPathElement(ConstraintLocator::InstanceType));
-      if (shouldAttemptFixes() && result.isFailure()) {
-        auto *anchor = locator.getAnchor();
-        if (anchor && isa<CoerceExpr>(anchor)) {
-          auto *fix =
-              ContextualMismatch::create(*this, instanceType1, instanceType2,
-                                         getConstraintLocator(locator));
-          conversionsOrFixes.push_back(fix);
-          break;
-        }
-      }
-      return result;
+      return matchTypes(
+          instanceType1, instanceType2, subKind, subflags,
+          locator.withPathElement(ConstraintLocator::InstanceType));
     }
 
     case TypeKind::Function: {

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -550,8 +550,8 @@ func testProtocolQualified(_ obj: CopyableNSObject, cell: CopyableSomeCell,
   _ = cell as NSCopying
   _ = cell as SomeCell
   
-  _ = plainObj as CopyableNSObject // expected-error {{value of type 'NSObject' does not conform to 'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') in coercion}} 
-  _ = plainCell as CopyableSomeCell // expected-error {{value of type 'SomeCell' does not conform to 'CopyableSomeCell' (aka 'SomeCell & NSCopying') in coercion}}
+  _ = plainObj as CopyableNSObject // expected-error {{'NSObject' is not convertible to 'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol'); did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
+  _ = plainCell as CopyableSomeCell // expected-error {{'SomeCell' is not convertible to 'CopyableSomeCell' (aka 'SomeCell & NSCopying'); did you mean to use 'as!' to force downcast?}}
 }
 
 extension Printing {

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -53,7 +53,7 @@ func otherExistential<T : EqualComparable>(_ t1: T) {
   otherEqComp2 = t1 // expected-error{{value of type 'T' does not conform to 'OtherEqualComparable' in assignment}}
   _ = otherEqComp2
 
-  _ = t1 as EqualComparable & OtherEqualComparable // expected-error{{value of type 'T' does not conform to 'EqualComparable & OtherEqualComparable' in coercion}} expected-error{{protocol 'OtherEqualComparable' can only be used as a generic constraint}} expected-error{{protocol 'EqualComparable' can only be used as a generic constraint}}
+  _ = t1 as EqualComparable & OtherEqualComparable // expected-error{{'T' is not convertible to 'EqualComparable & OtherEqualComparable'; did you mean to use 'as!' to force downcast?}} {{10-12=as!}} expected-error{{protocol 'OtherEqualComparable' can only be used as a generic constraint}} expected-error{{protocol 'EqualComparable' can only be used as a generic constraint}}
 }
 
 protocol Runcible {

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -118,7 +118,7 @@ struct Circle {
 func testCircular(_ circle: Circle) {
   // FIXME: It would be nice if this failure were suppressed because the protocols
   // have circular definitions.
-  _ = circle as CircleStart // expected-error{{value of type 'Circle' does not conform to 'CircleStart' in coercion}}
+  _ = circle as CircleStart // expected-error{{'Circle' is not convertible to 'CircleStart'; did you mean to use 'as!' to force downcast?}} {{14-16=as!}}
 }
 
 // <rdar://problem/14750346>
@@ -482,7 +482,7 @@ func f<T : C1>(_ x : T) {
 
 class C2 {}
 func g<T : C2>(_ x : T) {
-  x as P2 // expected-error{{value of type 'T' does not conform to 'P2' in coercion}}
+  x as P2 // expected-error{{'T' is not convertible to 'P2'; did you mean to use 'as!' to force downcast?}} {{5-7=as!}}
 }
 
 class C3 : P1 {} // expected-error{{type 'C3' does not conform to protocol 'P1'}}


### PR DESCRIPTION
Reverts apple/swift#29064

@hamishknight Reports this this might be causing problems with source compatibility suite.