### PR TITLE
[CodeCompletion] Use GenericSignature methods to get 'associatedtype' requirements

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3039,10 +3039,10 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
   Printer << " -> ";
 
   TypeLoc elementTy = decl->getElementTypeLoc();
-  Printer.printDeclResultTypePre(decl, elementTy);
-  Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
   if (!elementTy.getTypeRepr())
     elementTy = TypeLoc::withoutLoc(decl->getElementInterfaceType());
+  Printer.printDeclResultTypePre(decl, elementTy);
+  Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
 
   // HACK: When printing result types for subscripts with opaque result types,
   //       always print them using the `some` keyword instead of printing

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4201,28 +4201,21 @@ public:
       // If resolved print it.
       return nullptr;
 
-    // Collect requirements on the associatedtype.
-    ProtocolDecl *protoD =
-        ResultT->castTo<DependentMemberType>()->getAssocType()->getProtocol();
+    auto genericSig = VD->getDeclContext()->getGenericSignatureOfContext();
 
+    if (genericSig->isConcreteType(ResultT))
+      // If it has same type requrement, we will emit the concrete type.
+      return nullptr;
+
+    // Collect requirements on the associatedtype.
     SmallVector<Type, 2> opaqueTypes;
     bool hasExplicitAnyObject = false;
-    for (auto req : protoD->getRequirementSignature()) {
-      if (!req.getFirstType()->isEqual(ResultT))
-        continue;
-
-      switch (req.getKind()) {
-      case RequirementKind::Conformance:
-      case RequirementKind::Superclass:
-        opaqueTypes.push_back(req.getSecondType());
-        break;
-      case RequirementKind::Layout:
-        hasExplicitAnyObject |= req.getLayoutConstraint()->isClass();
-        break;
-      case RequirementKind::SameType:
-        return nullptr;
-      }
-    }
+    if (auto superTy = genericSig->getSuperclassBound(ResultT))
+      opaqueTypes.push_back(superTy);
+    for (auto proto : genericSig->getConformsTo(ResultT))
+      opaqueTypes.push_back(proto->getDeclaredInterfaceType());
+    if (auto layout = genericSig->getLayoutConstraint(ResultT))
+      hasExplicitAnyObject = layout->isClass();
 
     if (!hasExplicitAnyObject) {
       if (opaqueTypes.empty())

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4170,14 +4170,23 @@ public:
       return nullptr;
 
     Type ResultT;
-    if (auto *FD = dyn_cast<FuncDecl>(VD))
+    if (auto *FD = dyn_cast<FuncDecl>(VD)) {
+      if (FD->getGenericParams()) {
+        // Generic function cannot have opaque result type.
+        return nullptr;
+      }
       ResultT = FD->getResultInterfaceType();
-    else if (auto *SD = dyn_cast<SubscriptDecl>(VD))
+    } else if (auto *SD = dyn_cast<SubscriptDecl>(VD)) {
+      if (SD->getGenericParams()) {
+        // Generic subscript cannot have opaque result type.
+        return nullptr;
+      }
       ResultT = SD->getElementInterfaceType();
-    else if (auto *VarD = dyn_cast<VarDecl>(VD))
+    } else if (auto *VarD = dyn_cast<VarDecl>(VD)) {
       ResultT = VarD->getInterfaceType();
-    else
+    } else {
       return nullptr;
+    }
 
     if (!ResultT->is<DependentMemberType>() ||
         !ResultT->castTo<DependentMemberType>()->getAssocType())

--- a/test/IDE/complete_crossmodule.swift
+++ b/test/IDE/complete_crossmodule.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/Test.swift -I %t -code-completion-token=OPAQUE_RESULT | %FileCheck --check-prefix=OPAQUE_RESULT %s
+
+// BEGIN MyModule.swift
+
+public protocol HasAssocWithConstraint {
+  associatedtype AssocWithContraint: HasAssocWithConstraint
+  var value: AssocWithContraint { get }
+}
+
+// BEGIN Test.swift
+import MyModule
+
+struct MyValue: HasAssocWithConstraint {
+  var #^OPAQUE_RESULT^#
+// OPAQUE_RESULT: Begin completions
+// OPAQUE_RESULT-DAG: Decl[InstanceVar]/Super: value: some HasAssocWithConstraint;
+// OPAQUE_RESULT: End completions
+}

--- a/test/IDE/complete_opaque_result.swift
+++ b/test/IDE/complete_opaque_result.swift
@@ -110,8 +110,8 @@ protocol HasAssocWithConstraintOnProto where Self.AssocWithConstraintOnProto : M
   associatedtype AssocWithConstraintOnProto
   func returnAssocWithConstraintOnProto() -> AssocWithConstraintOnProto
 }
-protocol HasAssocWithSameTypeConstraint where Self.AssocWithSameTypeConstraint == MyClass {
-  associatedtype AssocWithSameTypeConstraint
+protocol HasAssocWithSameTypeConstraint where Self.AssocWithSameTypeConstraint == ConcreteMyProtocol {
+  associatedtype AssocWithSameTypeConstraint : MyProtocol
   func returnAssocWithSameTypeConstraint() -> AssocWithSameTypeConstraint
 }
 protocol HasAssocWithConformanceConstraintGeneric {

--- a/test/IDE/complete_opaque_result.swift
+++ b/test/IDE/complete_opaque_result.swift
@@ -102,6 +102,18 @@ protocol HasAssocWithConstraintAndDefault {
   associatedtype AssocWithConstraintAndDefault: MyProtocol = ConcreteMyProtocol
   func returnAssocWithConstraintAndDefault() -> AssocWithConstraintAndDefault
 }
+protocol HasAssocWithAnyObjectConstraint {
+  associatedtype AssocWithAnyObjectConstraint: AnyObject & MyProtocol 
+  func returnAssocWithAnyObjectConstraint() -> AssocWithAnyObjectConstraint
+}
+protocol HasAssocWithConstraintOnProto where Self.AssocWithConstraintOnProto : MyProtocol {
+  associatedtype AssocWithConstraintOnProto
+  func returnAssocWithConstraintOnProto() -> AssocWithConstraintOnProto
+}
+protocol HasAssocWithSameTypeConstraint where Self.AssocWithSameTypeConstraint == MyClass {
+  associatedtype AssocWithSameTypeConstraint
+  func returnAssocWithSameTypeConstraint() -> AssocWithSameTypeConstraint
+}
 
 class TestClass :
     HasAssocPlain,
@@ -109,7 +121,10 @@ class TestClass :
     HasAssocWithSuperClassConstraint,
     HasAssocWithCompositionConstraint,
     HasAssocWithDefault,
-    HasAssocWithConstraintAndDefault {
+    HasAssocWithConstraintAndDefault,
+    HasAssocWithAnyObjectConstraint,
+    HasAssocWithConstraintOnProto,
+    HasAssocWithSameTypeConstraint {
   #^OVERRIDE_TestClass^#
 // OVERRIDE: Begin completions
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocPlain() -> AssocPlain {|};
@@ -118,6 +133,9 @@ class TestClass :
 // OVERRIDE-DAG: Decl[Subscript]/Super:              subscript<T>(idx: T) -> some MyClass & MyProtocol where T : Comparable {|};
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithDefault() -> MyEnum {|};
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConstraintAndDefault() -> ConcreteMyProtocol {|};
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithAnyObjectConstraint() -> some MyProtocol & AnyObject {|}
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConstraintOnProto() -> some MyProtocol {|}
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithSameTypeConstraint() -> AssocWithSameTypeConstraint {|}
 // OVERRIDE: End completions
 }
 
@@ -127,7 +145,10 @@ struct TestStruct :
     HasAssocWithSuperClassConstraint,
     HasAssocWithCompositionConstraint,
     HasAssocWithDefault,
-    HasAssocWithConstraintAndDefault {
+    HasAssocWithConstraintAndDefault,
+    HasAssocWithAnyObjectConstraint,
+    HasAssocWithConstraintOnProto,
+    HasAssocWithSameTypeConstraint {
   #^OVERRIDE_TestStruct^#
 }
 

--- a/test/IDE/complete_opaque_result.swift
+++ b/test/IDE/complete_opaque_result.swift
@@ -92,7 +92,7 @@ protocol HasAssocWithSuperClassConstraint {
 }
 protocol HasAssocWithCompositionConstraint {
   associatedtype AssocWithCompositionConstraint: MyClass & MyProtocol
-  subscript<T>(idx: T) -> AssocWithCompositionConstraint where T: Comparable { get }
+  subscript(idx: Int) -> AssocWithCompositionConstraint { get }
 }
 protocol HasAssocWithDefault {
   associatedtype AssocWithDefault = MyEnum
@@ -114,6 +114,10 @@ protocol HasAssocWithSameTypeConstraint where Self.AssocWithSameTypeConstraint =
   associatedtype AssocWithSameTypeConstraint
   func returnAssocWithSameTypeConstraint() -> AssocWithSameTypeConstraint
 }
+protocol HasAssocWithConformanceConstraintGeneric {
+  associatedtype AssocWithConformanceConstraintGeneric: MyProtocol
+  func returnAssocWithConformanceConstraintGeneric<T>(arg: T) -> AssocWithConformanceConstraintGeneric
+}
 
 class TestClass :
     HasAssocPlain,
@@ -124,18 +128,20 @@ class TestClass :
     HasAssocWithConstraintAndDefault,
     HasAssocWithAnyObjectConstraint,
     HasAssocWithConstraintOnProto,
-    HasAssocWithSameTypeConstraint {
+    HasAssocWithSameTypeConstraint,
+    HasAssocWithConformanceConstraintGeneric {
   #^OVERRIDE_TestClass^#
 // OVERRIDE: Begin completions
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocPlain() -> AssocPlain {|};
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConformanceConstraint(fn: (Int) -> Int) -> some MyProtocol {|};
 // OVERRIDE-DAG: Decl[InstanceVar]/Super:            var valAssocWithSuperClassConstraint: some MyClass;
-// OVERRIDE-DAG: Decl[Subscript]/Super:              subscript<T>(idx: T) -> some MyClass & MyProtocol where T : Comparable {|};
+// OVERRIDE-DAG: Decl[Subscript]/Super:              subscript(idx: Int) -> some MyClass & MyProtocol {|};
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithDefault() -> MyEnum {|};
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConstraintAndDefault() -> ConcreteMyProtocol {|};
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithAnyObjectConstraint() -> some MyProtocol & AnyObject {|}
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConstraintOnProto() -> some MyProtocol {|}
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithSameTypeConstraint() -> AssocWithSameTypeConstraint {|}
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConformanceConstraintGeneric<T>(arg: T) -> AssocWithConformanceConstraintGeneric {|}
 // OVERRIDE: End completions
 }
 
@@ -148,7 +154,8 @@ struct TestStruct :
     HasAssocWithConstraintAndDefault,
     HasAssocWithAnyObjectConstraint,
     HasAssocWithConstraintOnProto,
-    HasAssocWithSameTypeConstraint {
+    HasAssocWithSameTypeConstraint,
+    HasAssocWithConformanceConstraintGeneric {
   #^OVERRIDE_TestStruct^#
 }
 


### PR DESCRIPTION
instead of `AssociatedTypeDecl::getInherited()` when checking if the return type should be suggested as "opaque result type" in override completion.

`AssociatedTypeDecl::getInherited()` is not serialized. So if the protocol is declared in a module, it was never suggested as `some` result.

rdar://problem/57245073

Also, stop suggesting opaque result type for generic requirements:
[SE-244](https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md#associated-type-inference) explicitly states that the following example cannot infer the `associatedtype`. So we can't use `some` here.
```swift
protocol P {
  associatedtype A: P
  func foo<T: P>(x: T) -> A
}

struct Foo: P {
  func foo<T: P>(x: T) -> some P {
    return x
  }
}
```