### PR TITLE
[NFC] Unblock Lazy Member Loading For Import-As-Member

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3010,7 +3010,7 @@ void ClangImporter::loadExtensions(NominalTypeDecl *nominal,
       // FIXME: If we already looked at this for this generation,
       // skip.
 
-      for (auto entry : table.lookupGlobalsAsMembers(effectiveClangContext)) {
+      for (auto entry : table.allGlobalsAsMembersInContext(effectiveClangContext)) {
         // If the entry is not visible, skip it.
         if (!isVisibleClangEntry(clangCtx, entry)) continue;
 
@@ -3763,17 +3763,6 @@ ClangImporter::Implementation::loadNamedMembers(
       return None;
   }
 
-  // Also bail out if there are any global-as-member mappings for this context;
-  // we can support some of them lazily but the full set of idioms seems
-  // prohibitively complex (also they're not stored in by-name lookup, for
-  // reasons unclear).
-  if (isa<ExtensionDecl>(D) && !checkedGlobalsAsMembers.insert(IDC).second) {
-    if (forEachLookupTable([&](SwiftLookupTable &table) -> bool {
-        return (!table.lookupGlobalsAsMembers(effectiveClangContext).empty());
-      }))
-      return None;
-  }
-
   // There are 3 cases:
   //
   //  - The decl is from a bridging header, CMO is Some(nullptr)
@@ -3809,6 +3798,27 @@ ClangImporter::Implementation::loadNamedMembers(
     if (!isVisibleClangEntry(clangCtx, member)) continue;
 
     // Skip Decls from different clang::DeclContexts
+    if (member->getDeclContext() != CDC) continue;
+
+    SmallVector<Decl*, 4> tmp;
+    insertMembersAndAlternates(member, tmp);
+    for (auto *TD : tmp) {
+      if (auto *V = dyn_cast<ValueDecl>(TD)) {
+        // Skip ValueDecls if they import under different names.
+        if (V->getBaseName() == N) {
+          Members.push_back(V);
+        }
+      }
+    }
+  }
+
+  for (auto entry : table->lookupGlobalsAsMembers(SerializedSwiftName(N),
+                                                  effectiveClangContext)) {
+    if (!entry.is<clang::NamedDecl *>()) continue;
+    auto member = entry.get<clang::NamedDecl *>();
+    if (!isVisibleClangEntry(clangCtx, member)) continue;
+
+     // Skip Decls from different clang::DeclContexts
     if (member->getDeclContext() != CDC) continue;
 
     SmallVector<Decl*, 4> tmp;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8544,7 +8544,7 @@ void ClangImporter::Implementation::loadAllMembersIntoExtension(
   startedImportingEntity();
 
   // Load the members.
-  for (auto entry : table->lookupGlobalsAsMembers(effectiveClangContext)) {
+  for (auto entry : table->allGlobalsAsMembersInContext(effectiveClangContext)) {
     auto decl = entry.get<clang::NamedDecl *>();
 
     // Only include members in the same submodule as this extension.

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -276,7 +276,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 15; // Special names
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 16; // Lazy Member Loading Index
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.
@@ -385,10 +385,19 @@ public:
   }
 
 private:
+  using TableType =
+      llvm::DenseMap<SerializedSwiftName, SmallVector<FullTableEntry, 2>>;
+  using CacheCallback = void(SmallVectorImpl<FullTableEntry> &,
+                             SwiftLookupTableReader &,
+                             SerializedSwiftName);
+
   /// A table mapping from the base name of Swift entities to all of
   /// the C entities that have that name, in all contexts.
-  llvm::DenseMap<SerializedSwiftName, SmallVector<FullTableEntry, 2>>
-      LookupTable;
+  TableType LookupTable;
+
+  /// A table mapping the base names of Swift entities to all of the C entities
+  /// that are remapped to that name by the globals-as-members utility, in all contexts.
+  TableType GlobalsAsMembers;
 
   /// The list of Objective-C categories and extensions.
   llvm::SmallVector<clang::ObjCCategoryDecl *, 4> Categories;
@@ -398,7 +407,7 @@ private:
   ///
   /// The values use the same representation as
   /// FullTableEntry::DeclsOrMacros.
-  llvm::DenseMap<StoredContext, SmallVector<uint64_t, 2>> GlobalsAsMembers;
+  llvm::DenseMap<StoredContext, SmallVector<uint64_t, 2>> GlobalsAsMembersIndex;
 
   /// The reader responsible for lazily loading the contents of this table.
   SwiftLookupTableReader *Reader;
@@ -413,7 +422,9 @@ private:
 
   /// Find or create the table entry for the given base name.
   llvm::DenseMap<SerializedSwiftName, SmallVector<FullTableEntry, 2>>::iterator
-  findOrCreate(SerializedSwiftName baseName);
+  findOrCreate(TableType &table,
+               SerializedSwiftName baseName,
+               llvm::function_ref<CacheCallback> create);
 
   /// Add the given entry to the list of entries, if it's not already
   /// present.
@@ -474,8 +485,22 @@ private:
          llvm::Optional<StoredContext> searchContext);
 
   /// Retrieve the set of global declarations that are going to be
-  /// imported as members into the given context.
-  SmallVector<SingleEntry, 4> lookupGlobalsAsMembers(StoredContext context);
+  /// imported as the given Swift name into the given context.
+  ///
+  /// \param baseName The base name to search for. All results will
+  /// have this base name.
+  ///
+  /// \param searchContext The context in which the resulting set of
+  /// entities should reside. This may be None to indicate that
+  /// all results from all contexts should be produced.
+  SmallVector<SingleEntry, 4>
+  lookupGlobalsAsMembersImpl(SerializedSwiftName baseName,
+                             llvm::Optional<StoredContext> searchContext);
+
+  /// Retrieve the set of global declarations that are going to be imported as
+  /// members in the given context.
+  SmallVector<SingleEntry, 4>
+  allGlobalsAsMembersInContext(StoredContext context);
 
 public:
   /// Lookup an unresolved context name and resolve it to a Clang
@@ -488,14 +513,16 @@ public:
   /// have this base name.
   ///
   /// \param searchContext The context in which the resulting set of
-  /// entities should reside. This may be None to indicate that
-  /// all results from all contexts should be produced.
+  /// entities should reside.
   SmallVector<SingleEntry, 4> lookup(SerializedSwiftName baseName,
                                      EffectiveClangContext searchContext);
 
   /// Retrieve the set of base names that are stored in the lookup table.
   SmallVector<SerializedSwiftName, 4> allBaseNames();
 
+  /// Retrieve the set of base names that are stored in the globals-as-members lookup table.
+  SmallVector<SerializedSwiftName, 4> allGlobalsAsMembersBaseNames();
+  
   /// Lookup Objective-C members with the given base name, regardless
   /// of context.
   SmallVector<clang::NamedDecl *, 4>
@@ -506,12 +533,27 @@ public:
 
   /// Retrieve the set of global declarations that are going to be
   /// imported as members into the given context.
+  ///
+  /// \param baseName The base name to search for. All results will
+  /// have this base name.
+  ///
+  /// \param searchContext The context in which the resulting set of
+  /// entities should reside.
   SmallVector<SingleEntry, 4>
-  lookupGlobalsAsMembers(EffectiveClangContext context);
+  lookupGlobalsAsMembers(SerializedSwiftName baseName,
+                         Optional<EffectiveClangContext> searchContext);
+
+  SmallVector<SingleEntry, 4>
+  allGlobalsAsMembersInContext(EffectiveClangContext context);
 
   /// Retrieve the set of global declarations that are going to be
   /// imported as members.
   SmallVector<SingleEntry, 4> allGlobalsAsMembers();
+
+  /// Retrieve the set of base names that are going to be imported as members in the
+  /// given context.
+  SmallVector<SerializedSwiftName, 4>
+  globalsAsMembersBaseNames(EffectiveClangContext context);
 
   /// Deserialize all entries.
   void deserializeAll();


### PR DESCRIPTION
Lazy member loading had an antagonistic relationship with the import-as-member facilities. The member tables were stored in a hash map that is keyed by serialized declaration context.  While this was good for importing the entire member set of a given extension, it's in the complete wrong order for lazy member loading, which wants the same data keyed by base name.

Given that it is annoying to redo the globals-as-member tables to support one use case or the other, coupled with the fact that optimizing for one use-case automatically pessimizes the other, just take a page from rdar://18696086 and store the same information twice in two separate formats each optimized for the task at hand.

Preliminary benchmarks indicate that this leads to a 5% reduction in Clang-Imported entities which will drastically speed up most apps that use Dispatch and CoreGraphics.

This is just a cleaned-up copy of #29051.