### PR TITLE
[stdlib] Add withContiguousStorageIfAvailable to SubString.UTF8View

### DIFF
--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -389,6 +389,13 @@ extension Substring.UTF8View: BidirectionalCollection {
     return _slice.distance(from: start, to: end)
   }
 
+  @_alwaysEmitIntoClient
+  public func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    return try _slice.withContiguousStorageIfAvailable(body)
+  }
+
   @inlinable
   public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
     _slice._failEarlyRangeCheck(index, bounds: bounds)

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -12,6 +12,19 @@ func checkMatch<S: Collection, T: Collection>(_ x: S, _ y: T, _ i: S.Index)
   expectEqual(x[i], y[i])
 }
 
+func checkMatchContiguousStorage<S: Collection, T: Collection>(_ x: S, _ y: T)
+  where S.Element == T.Element, S.Element: Equatable
+{
+  let xElement = x.withContiguousStorageIfAvailable { $0.first }
+  let yElement = y.withContiguousStorageIfAvailable { $0.first }
+  expectEqual(xElement, yElement)
+}
+
+func checkHasContiguousStorage<S: Collection>(_ x: S) {
+  let hasStorage = x.withContiguousStorageIfAvailable { _ in true } ?? false
+  expectTrue(hasStorage)
+}
+
 SubstringTests.test("Equality") {
   let s = "abcdefg"
   let s1 = s[s.index(s.startIndex, offsetBy: 2) ..<
@@ -228,6 +241,13 @@ SubstringTests.test("UTF8View") {
     expectEqual("", String(t.dropLast(100))!)
     expectEqual("", String(u.dropFirst(100))!)
     expectEqual("", String(u.dropLast(100))!)
+
+    checkHasContiguousStorage(s.utf8)
+    checkHasContiguousStorage(t)
+    checkHasContiguousStorage(u)
+    checkMatchContiguousStorage(Array(s.utf8), s.utf8)
+    checkMatchContiguousStorage(Array(t), t)
+    checkMatchContiguousStorage(Array(u), u)
   }
 }
 


### PR DESCRIPTION
Due to an oversight it seems that we never added a
withContigousStorageIfAvailable implementation to SubString.UTF8View,
which meant that if you sliced a String you lost the ability to get fast
access to the backing storage. There's no good reason for this
functionality to be missing, so this patch adds it in by delegating to
the Slice implementation.

Resolves [SR-11999](https://bugs.swift.org/browse/SR-11999).