### PR TITLE
[validation-test] Adding validation test for generic function match

### DIFF
--- a/validation-test/Sema/generic_function_signature.swift
+++ b/validation-test/Sema/generic_function_signature.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -typecheck %s
+enum E<T> {}
+
+protocol P {
+  associatedtype T 
+  var closure: () -> E<T> { get }
+}
+
+struct Concrete<Value>: P {
+  let closure: () -> E<Value>
+}


### PR DESCRIPTION
Follow up to #29064 
Adding a validation test from a source compatibility test that crashed.

cc @xedin 