### PR TITLE
[5.2] Unset IFS after its use in set_build_options_for_host

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -623,10 +623,14 @@ function set_build_options_for_host() {
             esac
 
             if [[ "${DARWIN_SDK_DEPLOYMENT_TARGETS}" != "" ]]; then
-                local IFS=";"; DARWIN_SDK_DEPLOYMENT_TARGETS=($DARWIN_SDK_DEPLOYMENT_TARGETS)
+                # IFS is immediately unset after its use to avoid unwanted
+                # replacement of characters in subsequent lines.
+                local IFS=";"; DARWIN_SDK_DEPLOYMENT_TARGETS=($DARWIN_SDK_DEPLOYMENT_TARGETS); unset IFS
 
                 for target in "${DARWIN_SDK_DEPLOYMENT_TARGETS[@]}"; do
-                    local IFS="-"; triple=($target)
+                    # IFS is immediately unset after its use to avoid unwanted
+                    # replacement of characters in subsequent lines.
+                    local IFS="-"; triple=($target); unset IFS
                     sdk_target=$(toupper ${triple[0]}_${triple[1]})
                     swift_cmake_options+=(
                         "-DSWIFTLIB_DEPLOYMENT_VERSION_${sdk_target}=${triple[2]}"


### PR DESCRIPTION
If IFS remains set, it may cause compilation errors due to unanticipated
replacement of characters in some parameters.

Addresses rdar://problem/57927748 and rdar://problem/58347344

(cherry picked from commit f67ccf5c9dda486dd43e074ffab8c7d554393b3d)