### PR TITLE
[Constraint solver] Use a constraint system to apply all function builders

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -216,6 +216,15 @@ public:
      return lhs.TheFunction != rhs.TheFunction;
    }
 
+  friend llvm::hash_code hash_value(AnyFunctionRef fn) {
+    using llvm::hash_value;
+    return hash_value(fn.TheFunction.getOpaqueValue());
+  }
+
+  friend SourceLoc extractNearestSourceLoc(AnyFunctionRef fn) {
+    return fn.getLoc();
+  }
+
 private:
   ArrayRef<AnyFunctionType::Yield>
   getYieldResultsImpl(SmallVectorImpl<AnyFunctionType::Yield> &buffer,
@@ -242,6 +251,8 @@ private:
 #if SWIFT_COMPILER_IS_MSVC
 #pragma warning(pop)
 #endif
+
+void simple_display(llvm::raw_ostream &out, AnyFunctionRef fn);
 
 } // namespace swift
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4808,6 +4808,13 @@ NOTE(previous_function_builder_here, none,
      "previous function builder specified here", ())
 ERROR(function_builder_arguments, none,
       "function builder attributes cannot have arguments", ())
+WARNING(function_builder_disabled_by_return, none,
+        "application of function builder %0 disabled by explicit 'return' "
+        "statement", (Type))
+NOTE(function_builder_remove_attr, none,
+     "remove the attribute to explicitly disable the function builder", ())
+NOTE(function_builder_remove_returns, none,
+     "remove 'return' statements to apply the function builder", ())
 
 //------------------------------------------------------------------------------
 // MARK: differentiable programming diagnostics

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -16,6 +16,7 @@
 #ifndef SWIFT_TYPE_CHECK_REQUESTS_H
 #define SWIFT_TYPE_CHECK_REQUESTS_H
 
+#include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/ASTTypeIDs.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Type.h"
@@ -1760,7 +1761,7 @@ enum class FunctionBuilderClosurePreCheck : uint8_t {
 
 class PreCheckFunctionBuilderRequest
     : public SimpleRequest<PreCheckFunctionBuilderRequest,
-                           FunctionBuilderClosurePreCheck(ClosureExpr *),
+                           FunctionBuilderClosurePreCheck(AnyFunctionRef),
                            CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1770,7 +1771,7 @@ private:
 
   // Evaluation.
   llvm::Expected<FunctionBuilderClosurePreCheck>
-  evaluate(Evaluator &evaluator, ClosureExpr *closure) const;
+  evaluate(Evaluator &evaluator, AnyFunctionRef fn) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -196,7 +196,7 @@ SWIFT_REQUEST(TypeChecker, HasUserDefinedDesignatedInitRequest,
 SWIFT_REQUEST(TypeChecker, HasMemberwiseInitRequest,
               bool(StructDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, PreCheckFunctionBuilderRequest,
-              FunctionBuilderClosurePreCheck(ClosureExpr *),
+              FunctionBuilderClosurePreCheck(AnyFunctionRef),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
               bool(NominalTypeDecl *, ImplicitMemberAction), Uncached,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7907,3 +7907,10 @@ void ParseAbstractFunctionBodyRequest::cacheResult(BraceStmt *value) const {
   }
 
 }
+
+void swift::simple_display(llvm::raw_ostream &out, AnyFunctionRef fn) {
+  if (auto func = fn.getAbstractFunctionDecl())
+    simple_display(out, func);
+  else
+    out << "closure";
+}

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7261,7 +7261,7 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
        singleExpr->getStartLoc(), singleExpr, /*implicit=*/true);
     auto braceStmt = BraceStmt::create(
         ctx, returnStmt->getStartLoc(), ASTNode(returnStmt),
-        returnStmt->getEndLoc(), /*implicit=*/true);
+        returnStmt->getEndLoc(), /*implicit=*/false);
     result = braceStmt;
   }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7239,15 +7239,30 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
   if (auto expr = target.getAsExpr()) {
     result = expr->walk(walker);
   } else {
-    // FIXME: Implement this!
-    llvm_unreachable("Not yet implemented");
-
-#if false
     auto fn = *target.getAsFunction();
-    auto transform = rewriter.getAppliedBuilderTransform(fn);
-    assert(transform && "Not applying builder transform?");
-    result = walker.applyFunctionBuilderBodyTransform(fn, transform);
-#endif
+
+    // Dig out the function builder transformation we applied.
+    auto transformed = solution.functionBuilderTransformed.find(fn);
+    assert(transformed != solution.functionBuilderTransformed.end());
+
+    auto singleExpr = transformed->second.singleExpr;
+    singleExpr = singleExpr->walk(walker);
+    if (!singleExpr)
+      return result;
+
+    singleExpr = rewriter.coerceToType(singleExpr,
+                                       transformed->second.bodyResultType,
+                                       getConstraintLocator(singleExpr));
+    if (!singleExpr)
+      return result;
+
+    ASTContext &ctx = getASTContext();
+    auto returnStmt = new (ctx) ReturnStmt(
+       singleExpr->getStartLoc(), singleExpr, /*implicit=*/true);
+    auto braceStmt = BraceStmt::create(
+        ctx, returnStmt->getStartLoc(), ASTNode(returnStmt),
+        returnStmt->getEndLoc(), /*implicit=*/true);
+    result = braceStmt;
   }
 
   if (result.isNull())

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -969,7 +969,8 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
   if (Binding.hasDefaultedLiteralProtocol()) {
     type = cs.openUnboundGenericType(type, dstLocator);
     type = type->reconstituteSugar(/*recursive=*/false);
-  } else if (srcLocator->isLastElement<LocatorPathElt::ApplyArgToParam>() &&
+  } else if (srcLocator &&
+             srcLocator->isLastElement<LocatorPathElt::ApplyArgToParam>() &&
              !type->hasTypeVariable() && cs.isCollectionType(type)) {
     // If the type binding comes from the argument conversion, let's
     // instead of binding collection types directly, try to bind

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2455,6 +2455,10 @@ void ConstraintSystem::diagnoseFailureFor(SolutionApplicationTarget target) {
     // then it must be well-formed... but is ambiguous.  Handle this by diagnostic
     // various cases that come up.
     diagnosis.diagnoseAmbiguity(expr);
+  } else {
+    // Emit a poor fallback message.
+    getASTContext().Diags.diagnose(
+         target.getAsFunction()->getLoc(), diag::failed_to_produce_diagnostic);
   }
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1145,9 +1145,11 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
               = paramInfo.getFunctionBuilderType(paramIdx)) {
         Expr *arg = getArgumentExpr(locator.getAnchor(), argIdx);
         if (auto closure = dyn_cast_or_null<ClosureExpr>(arg)) {
-          auto result =
-              cs.applyFunctionBuilder(closure, functionBuilderType,
-                                      calleeLocator, loc);
+          auto closureType = cs.getType(closure);
+          auto result = cs.matchFunctionBuilder(
+              closure, functionBuilderType,
+              closureType->castTo<FunctionType>()->getResult(),
+              calleeLocator, loc);
           if (result.isFailure())
             return result;
         }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -668,6 +668,10 @@ struct AppliedBuilderTransform {
 
   /// The single expression to which the closure was transformed.
   Expr *singleExpr;
+
+  /// The result type of the body, to which the returned expression will be
+  /// converted.
+  Type bodyResultType;
 };
 
 /// Describes the fixed score of a solution to the constraint system.
@@ -3479,6 +3483,7 @@ public:
   /// Apply the given function builder to the closure expression.
   TypeMatchResult matchFunctionBuilder(
       AnyFunctionRef fn, Type builderType, Type bodyResultType,
+      ConstraintKind bodyResultConstraintKind,
       ConstraintLocator *calleeLocator, ConstraintLocatorBuilder locator);
 
 private:
@@ -3991,6 +3996,13 @@ public:
                       bool performingDiagnostics) {
     return applySolutionImpl(solution, expr, convertType, discardedExpr,
                              performingDiagnostics).get<Expr *>();
+  }
+
+  /// Apply a given solution to the body of the given function.
+  BraceStmt *applySolutionToBody(Solution &solution, AnyFunctionRef fn) {
+    return cast_or_null<BraceStmt>(
+        applySolutionImpl(solution, fn, Type(), false, false)
+      .dyn_cast<Stmt *>());
   }
 
   /// Reorder the disjunctive clauses for a given expression to

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3477,9 +3477,9 @@ public:
   void simplifyDisjunctionChoice(Constraint *choice);
 
   /// Apply the given function builder to the closure expression.
-  TypeMatchResult applyFunctionBuilder(ClosureExpr *closure, Type builderType,
-                                       ConstraintLocator *calleeLocator,
-                                       ConstraintLocatorBuilder locator);
+  TypeMatchResult matchFunctionBuilder(
+      AnyFunctionRef fn, Type builderType, Type bodyResultType,
+      ConstraintLocator *calleeLocator, ConstraintLocatorBuilder locator);
 
 private:
   /// The kind of bindings that are permitted.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -700,9 +700,16 @@ public:
                                                  SourceLoc EndTypeCheckLoc);
   static bool typeCheckAbstractFunctionBody(AbstractFunctionDecl *AFD);
 
-  static BraceStmt *applyFunctionBuilderBodyTransform(FuncDecl *FD,
-                                                      BraceStmt *body,
-                                                      Type builderType);
+  /// Try to apply the function builder transform of the given builder type
+  /// to the body of the function.
+  ///
+  /// \returns \c None if the builder transformation cannot be applied at all,
+  /// e.g., because of a \c return statement. Otherwise, returns either the
+  /// fully type-checked body of the function (on success) or a \c nullptr
+  /// value if an error occurred while type checking the transformed body.
+  static Optional<BraceStmt *> applyFunctionBuilderBodyTransform(
+      FuncDecl *func, Type builderType);
+
   static bool typeCheckClosureBody(ClosureExpr *closure);
 
   static bool typeCheckTapBody(TapExpr *expr, DeclContext *DC);

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -234,3 +234,16 @@ tuplify(true) { x in
   #warning("oops")  // expected-warning{{oops}}
   3.14159
 }
+
+struct MyTuplifiedStruct {
+  var condition: Bool
+
+  @TupleBuilder var computed: some Any { // expected-note{{remove the attribute to explicitly disable the function builder}}{{3-17=}}
+    if condition {
+      return 17 // expected-warning{{application of function builder 'TupleBuilder' disabled by explicit 'return' statement}}
+      // expected-note@-1{{remove 'return' statements to apply the function builder}}{{7-14=}}{{12-19=}}
+    } else {
+           return 42
+    }
+  }
+}

--- a/test/IDE/complete_function_builder.swift
+++ b/test/IDE/complete_function_builder.swift
@@ -51,14 +51,14 @@ let globalStringVal: String = ""
 func testAcceptColorTagged(paramIntVal: Int, paramStringVal: String) {
 
   let taggedValue = paramIntVal.tag(Color.red)
-  
+
   acceptColorTagged { color in
     #^IN_CLOSURE_TOP^#
 // IN_CLOSURE_TOP_CONTEXT: Begin completions
-// IN_CLOSURE_TOP-DAG: Decl[LocalVar]/Local:               taggedValue[#Tagged<Color, Int>#]; name=taggedValue
+// IN_CLOSURE_TOP-DAG: Decl[LocalVar]/Local{{.*}}:               taggedValue[#Tagged<Color, Int>#]; name=taggedValue
 // IN_CLOSURE_TOP-DAG: Decl[GlobalVar]/CurrModule:         globalIntVal[#Int#]; name=globalIntVal
 // IN_CLOSURE_TOP-DAG: Decl[GlobalVar]/CurrModule:         globalStringVal[#String#]; name=globalStringVal
-// IN_CLOSURE_TOP-DAG: Decl[LocalVar]/Local:               color; name=color
+// IN_CLOSURE_TOP-DAG: Decl[LocalVar]/Local:               color{{.*}}; name=color
 // IN_CLOSURE_TOP-DAG: Decl[LocalVar]/Local:               paramIntVal[#Int#]; name=paramIntVal
 // IN_CLOSURE_TOP-DAG: Decl[LocalVar]/Local:               paramStringVal[#String#]; name=paramStringVal
 // IN_CLOSURE_TOP: End completions

--- a/test/Profiler/coverage_function_builder.swift
+++ b/test/Profiler/coverage_function_builder.swift
@@ -13,7 +13,7 @@ struct Summer {
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test0SiyF"
 @Summer
 func test0() -> Int {
-  // CHECK: [[@LINE-1]]:21 -> [[@LINE+3]]:2 : 0
+  // CHECK: [[@LINE-1]]:21 -> [[@LINE+2]]:5 : 0
   18
   12
 }
@@ -21,7 +21,7 @@ func test0() -> Int {
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test1SiyF"
 @Summer
 func test1() -> Int {
-  // CHECK: [[@LINE-1]]:21 -> [[@LINE+7]]:2 : 0
+  // CHECK: [[@LINE-1]]:21 -> [[@LINE+6]]:4 : 0
   18
   12
   if 7 < 23 {


### PR DESCRIPTION
When type checking the body of a function declaration that has a function
builder on it (e.g., `@ViewBuilder var body: some View { ... }`), create a
constraint system that is responsible for constraint generation and
application, sending function declarations through the same code paths
used by closures.