### PR TITLE
[AutoDiff upstream] Add `TangentSpace`.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -284,6 +284,9 @@ public:
   /// across invocations of both the parser and the type-checker.
   unsigned NextAutoClosureDiscriminator = 0;
 
+  /// Cached mapping from types to their associated tangent spaces.
+  llvm::DenseMap<Type, Optional<TangentSpace>> AutoDiffTangentSpaces;
+
   /// Cache of `@derivative` attributes keyed by parameter indices and
   /// derivative function kind. Used to diagnose duplicate `@derivative`
   /// attributes for the same key.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1161,6 +1161,11 @@ public:
   /// object type.
   TypeTraitResult canBeClass();
 
+  /// Return the tangent space of the given type, if it exists. Otherwise,
+  /// return `None`.
+  Optional<TangentSpace>
+  getAutoDiffTangentSpace(LookupConformanceFn lookupConformance);
+
 private:
   // Make vanilla new/delete illegal for Types.
   void *operator new(size_t Bytes) throw() = delete;

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -66,3 +66,21 @@ void autodiff::getSubsetParameterTypes(IndexSubset *subset,
         results.push_back(curryLevel->getParams()[paramIndex].getOldType());
   }
 }
+
+Type TangentSpace::getType() const {
+  switch (kind) {
+  case Kind::TangentVector:
+    return value.tangentVectorType;
+  case Kind::Tuple:
+    return value.tupleType;
+  }
+}
+
+CanType TangentSpace::getCanonicalType() const {
+  return getType()->getCanonicalType();
+}
+
+NominalTypeDecl *TangentSpace::getNominal() const {
+  assert(isTangentVector());
+  return getTangentVector()->getNominalOrBoundGenericNominal();
+}


### PR DESCRIPTION
`TangentSpace` represents the tangent space of a type.

- For `Differentiable`-conforming types:
  - The tangent space is the `TangentVector` associated type.
- For tuple types:
  - The tangent space is a tuple of the elements' tangent space types, for the
    elements that have a tangent space.
- For function types whose innermost result type has a tangent space:
  - The tangent space is the same function type, replacing the innermost
    result type with its tangent space type.
- Other types have no tangent space.

`TangentSpace` is used to:
- Compute the derivative function type of a given original function type.
- Compute the type of tangent/adjoint values during automatic differentiation.

---

Progress towards TF-828: upstream `@differentiable` attribute type-checking.
`@differentiable` attribute type-checking mega-patch: https://github.com/apple/swift/pull/29091

---

Tests exist on `tensorflow` branch and will be upstreamed later.
Currently, not enough code has been upstreamed for meaningful testing.