### PR TITLE
[master-rebranch] Change a check to be CHECK-DAG to avoid issues around these two attributes being printed in the wrong order.

### DIFF
--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -145,5 +145,5 @@ func makeGenericMetatypes() {
 // CHECK-NOT: call void @llvm.lifetime.end
 // CHECK:   ret %swift.metadata_response
 
-// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
-// CHECK: attributes [[NOUNWIND_OPT]] = { noinline nounwind "frame-pointer"="none" "target-cpu"
+// CHECK-DAG: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
+// CHECK-DAG: attributes [[NOUNWIND_OPT]] = { noinline nounwind "frame-pointer"="none" "target-cpu"


### PR DESCRIPTION
This makes this test pass after we rebranch and before.
