### PR TITLE
IRGen: handle ASAN better with importing on ELF

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -50,6 +50,7 @@
 #include "llvm/Support/MD5.h"
 
 #include "ConformanceDescription.h"
+#include "GenDecl.h"
 #include "GenEnum.h"
 #include "GenIntegerLiteral.h"
 #include "GenType.h"
@@ -1190,6 +1191,7 @@ void IRGenModule::emitAutolinkInfo() {
     var->setSection(".swift1_autolink_entries");
     var->setAlignment(getPointerAlignment().getValue());
 
+    disableAddressSanitizer(*this, var);
     addUsedGlobal(var);
   }
 

--- a/test/IRGen/ELF-remove-autolink-section.swift
+++ b/test/IRGen/ELF-remove-autolink-section.swift
@@ -13,5 +13,15 @@
 print("Hi from Swift!")
 
 // ELF: module asm ".section .swift1_autolink_entries,\220x80000000\22"
+
+// Find the metadata entry for the blacklisting of the metadata symbol
+// Ensure that it is in the ASAN metadata
+
+// ELF-DAG: !llvm.asan.globals = !{
+// ELF-SAME: [[MD:![0-9]+]]
+// ELF-SAME: }
+
+// ELF-DAG: [[MD]] = !{[37 x i8]* @_swift1_autolink_entries, null, null, i1 false, i1 true}
+
 // SECTION: .swift1_autolink_entries
 // NOSECTION-NOT: .swift1_autolink_entries


### PR DESCRIPTION
ELF's lack of linker directives is worked around by a custom section
(`.swift1_autolink_entries`).  This is metadata that is not intended to
be emitted into the linked binary.  A previous change introduced the use
of a module (global) assembly gadget to discard the section.  However,
this interacts poorly with ASAN which would instrument the section,
resulting in a strong reference.  This reference would persist to a
discarded symbol.  lld would object to this.  Blacklist the symbol to
ensure that ASAN + autolinking can co-exist.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
