### PR TITLE
[CodeCompletion] Allow type variable in MakeAbstractConformanceForGenericType

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3422,7 +3422,8 @@ operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {
   assert((conformingReplacementType->is<ErrorType>()
           || conformingReplacementType->is<SubstitutableType>()
-          || conformingReplacementType->is<DependentMemberType>())
+          || conformingReplacementType->is<DependentMemberType>()
+          || conformingReplacementType->is<TypeVariableType>())
          && "replacement requires looking up a concrete conformance");
   return ProtocolConformanceRef(conformedProtocol);
 }

--- a/validation-test/IDE/crashers_2_fixed/rdar56834798.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar56834798.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=B -source-filename=%s
+
+protocol Proto {}
+
+struct S<T: Proto> {
+  typealias Value = T
+
+  func test(arg: Int) -> Value {
+    return #^A^#
+  }
+}
+
+class C: Proto {
+  init() {}
+}
+extension Proto {
+  typealias Nested = C
+}
+func receiver<T: Proto>(arg: T) {}
+func test() {
+  receiver(arg: .#^B^#)
+}


### PR DESCRIPTION
When `TypeChecker::typesSatisfyConstraint()` is called with `openArchetypes` true, archetypes are substituted with type variables. If they have conformances, they used to hit assertion in `MakeAbstractConformanceForGenericType::operator()` because it doesn't accept `TypeVariableType`.

Adjust the assetion to accept `TypeVariableType`.

Resolves #54106
rdar://problem/56834798
