### PR TITLE
stdlib: annotate Array's remove functions with semantic attributes.

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1258,6 +1258,7 @@ extension Array: RangeReplaceableCollection {
   }
 
   @inlinable
+  @_semantics("array.mutate_unknown")
   public mutating func _customRemoveLast() -> Element? {
     _makeMutableAndUnique()
     let newCount = _getCount() - 1
@@ -1285,6 +1286,7 @@ extension Array: RangeReplaceableCollection {
   /// - Complexity: O(*n*), where *n* is the length of the array.
   @inlinable
   @discardableResult
+  @_semantics("array.mutate_unknown")
   public mutating func remove(at index: Int) -> Element {
     _makeMutableAndUnique()
     let currentCount = _getCount()

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -890,6 +890,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   }
 
   @inlinable
+  @_semantics("array.mutate_unknown")
   public mutating func _customRemoveLast() -> Element? {
     _makeMutableAndUnique()
     let newCount = _getCount() - 1
@@ -917,6 +918,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   /// - Complexity: O(*n*), where *n* is the length of the array.
   @inlinable
   @discardableResult
+  @_semantics("array.mutate_unknown")
   public mutating func remove(at index: Int) -> Element {
     _makeMutableAndUnique()
     let currentCount = _getCount()


### PR DESCRIPTION
All mutating Array functions must be annotated with semantics, because otherwise some high level optimizations get confused.
The semantic attributes prevent inlining those functions in high-level-sil.
This is need so that the optimizer sees that the Array is taken as inout and can reason that it's modified.
This restriction is not needed anymore when we’ll have COW representation in SIL.

Fixes a crash in the stdlib/Arrays.swift.gyb test in optimized mode.
rdar://problem/58478089
