### PR TITLE
[AutoDiff] %target-swift-frontend -> %target-build-swift

### DIFF
--- a/test/AutoDiff/downstream/cross_module_derivative_attr_e2e.swift
+++ b/test/AutoDiff/downstream/cross_module_derivative_attr_e2e.swift
@@ -1,5 +1,8 @@
 // RUN: %empty-directory(%t)
-￼// RUN: %target-swift-frontend -I%t -c -parse-as-library -emit-module -module-name module1 -emit-module-path %t/module1.swiftmodule -o %t/module1.o %S/Inputs/cross_module_derivative_attr_e2e/module1/module1.swift %S/Inputs/cross_module_derivative_attr_e2e/module1/module1_other_file.swift -Xllvm -enable-experimental-cross-file-derivative-registration -validate-tbd-against-ir=none
-￼// RUN: %target-build-swift -I%t %S/Inputs/cross_module_derivative_attr_e2e/main/main.swift %t/module1.o -o %t/a.out -lm -Xllvm -enable-experimental-cross-file-derivative-registration -Xfrontend -validate-tbd-against-ir=none
-￼// RUN: %target-run %t/a.out
-￼// REQUIRES: executable_test
+// RUN: %target-build-swift -I%t -parse-as-library -emit-module -module-name module1 -emit-module-path %t/module1.swiftmodule -emit-library -o %t/%target-library-name(module1) %S/Inputs/cross_module_derivative_attr_e2e/module1/module1.swift %S/Inputs/cross_module_derivative_attr_e2e/module1/module1_other_file.swift -Xllvm -enable-experimental-cross-file-derivative-registration -Xfrontend -validate-tbd-against-ir=none
+// RUN: %target-build-swift -I%t -L%t %S/Inputs/cross_module_derivative_attr_e2e/main/main.swift -o %t/a.out -lm -lmodule1 -Xllvm -enable-experimental-cross-file-derivative-registration -Xfrontend -validate-tbd-against-ir=none %target-rpath(%t)
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+
+// TODO(TF-1104): Fix.
+// XFAIL: swift_test_mode_optimize

--- a/test/AutoDiff/downstream/e2e_cross_module.swift
+++ b/test/AutoDiff/downstream/e2e_cross_module.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -c -parse-as-library -emit-module -module-name e2e_cross_module_external_module -emit-module-path %t/e2e_cross_module_external_module.swiftmodule -o %t/e2e_cross_module_external_module.o %S/Inputs/e2e_cross_module_external_module.swift
-// RUN: %target-build-swift -I%t %s %t/e2e_cross_module_external_module.o -o %t/a.out -lm
+// RUN: %target-build-swift -parse-as-library -emit-module -module-name e2e_cross_module_external_module -emit-module-path %t/e2e_cross_module_external_module.swiftmodule -emit-library -o %t/%target-library-name(e2e_cross_module_external_module) %S/Inputs/e2e_cross_module_external_module.swift
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lm -le2e_cross_module_external_module  %target-rpath(%t)
 // RUN: %target-run %t/a.out
+// REQUIRES: executable_test
 
 import e2e_cross_module_external_module
 import StdlibUnittest

--- a/test/AutoDiff/downstream/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/downstream/loadable_by_address_cross_module.swift
@@ -9,7 +9,7 @@
 // Compile the module.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -c -parse-as-library -emit-module -module-name external -emit-module-path %t/external.swiftmodule -o %t/external.o %S/Inputs/loadable_by_address_cross_module.swift
+// RUN: %target-build-swift -parse-as-library -emit-module -module-name external -emit-module-path %t/external.swiftmodule -emit-library -o %t/%target-library-name(external) %S/Inputs/loadable_by_address_cross_module.swift
 
 // Next, check that differentiability_witness_functions in the client get
 // correctly modified by LBA.
@@ -26,7 +26,7 @@
 
 // Finally, execute the test.
 
-// RUN: %target-build-swift -I%t %s %t/external.o -o %t/a.out -lm
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lm -lexternal %target-rpath(%t)
 // RUN: %target-run %t/a.out
 
 // REQUIRES: executable_test


### PR DESCRIPTION
`%target-build-swift` is closer than `%target-swift-frontend` to the normal way you build swift modules, so this change makes the tests a bit more realistic and more likely to catch problems that happen in practice.

For example, `test/AutoDiff/downstream/cross_module_derivative_attr_e2e.swift` now fails in optimize mode. So I made that XFAIL and filed TF-1104.