### PR TITLE
[5.2][CodeCompletion] Stop printing underscored keyword in override completion

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4276,6 +4276,7 @@ public:
       PrintOptions Options;
       if (auto transformType = CurrDeclContext->getDeclaredTypeInContext())
         Options.setBaseType(transformType);
+      Options.SkipUnderscoredKeywords = true;
       Options.PrintImplicitAttrs = false;
       Options.ExclusiveAttrList.push_back(TAK_escaping);
       Options.ExclusiveAttrList.push_back(TAK_autoclosure);

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -66,6 +66,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INFIX_STRING_1 | %FileCheck %s -check-prefix=INFIX_STRING
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INFIX_EXT_STRING_1 | %FileCheck %s -check-prefix=INFIX_EXT_STRING
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONFORM_SEQUENCE | %FileCheck %s -check-prefix=CONFORM_SEQUENCE
+
 // NO_STDLIB_PRIVATE: Begin completions
 // NO_STDLIB_PRIVATE: End completions
 
@@ -286,3 +288,14 @@ func testInfixOperator4(_ x: String) {
 // INFIX_EXT_STRING-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  && {#Bool#}[#Bool#]
 // INFIX_EXT_STRING-NOT: ==
 // INFIX_EXT_STRING: End completions
+
+class TestSequence : Sequence {
+#^CONFORM_SEQUENCE^#
+// CONFORM_SEQUENCE: Begin completions
+// CONFORM_SEQUENCE-DAG: Decl[AssociatedType]/Super: typealias Element = {#(Type)#};
+// CONFORM_SEQUENCE-DAG: Decl[AssociatedType]/Super: typealias Iterator = {#(Type)#};
+// CONFORM_SEQUENCE-DAG: Decl[InstanceMethod]/Super: func makeIterator() -> some IteratorProtocol {|};
+// CONFORM_SEQUENCE-DAG: Decl[InstanceVar]/Super:    var underestimatedCount: Int;
+// CONFORM_SEQUENCE-DAG: Decl[InstanceMethod]/Super: func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<Element>) throws -> R) rethrows -> R? {|};
+// CONFORM_SEQUENCE: End completions
+}


### PR DESCRIPTION
Cherry-pick of #29127 into `swift-5.2-branch` originally reviewed by @nathawes

rdar://problem/56963545
