### PR TITLE
Use #file string for force-unwrap and force-try

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4865,34 +4865,30 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
                    finalArgs, calleeTypeInfo, ApplyOptions::None, ctx);
 }
 
-static StringRef
-getMagicFunctionString(SILGenFunction &SGF) {
-  assert(SGF.MagicFunctionName
+StringRef SILGenFunction::getMagicFunctionString() {
+  assert(MagicFunctionName
          && "asking for #function but we don't have a function name?!");
-  if (SGF.MagicFunctionString.empty()) {
-    llvm::raw_string_ostream os(SGF.MagicFunctionString);
-    SGF.MagicFunctionName.print(os);
+  if (MagicFunctionString.empty()) {
+    llvm::raw_string_ostream os(MagicFunctionString);
+    MagicFunctionName.print(os);
   }
-  return SGF.MagicFunctionString;
+  return MagicFunctionString;
 }
 
-static StringRef
-getMagicFilePathString(SILGenFunction &SGF, SourceLoc loc) {
-  if (!loc.isValid())
-    return "";
-
-  return SGF.getASTContext().SourceMgr.getDisplayNameForLoc(loc);
+StringRef SILGenFunction::getMagicFilePathString(SourceLoc loc) {
+  assert(loc.isValid());
+  return getSourceManager().getDisplayNameForLoc(loc);
 }
 
-static std::string
-getConciseMagicFileString(SILGenFunction &SGF, SourceLoc loc) {
-  if (!loc.isValid())
-    return "";
+std::string SILGenFunction::getMagicFileString(SourceLoc loc) {
+  auto path = getMagicFilePathString(loc);
 
-  auto path = getMagicFilePathString(SGF, loc);
+  if (!getASTContext().LangOpts.EnableConcisePoundFile)
+    return path;
+
   auto value = llvm::sys::path::filename(path).str();
   value += " (";
-  value += SGF.getModule().getSwiftModule()->getNameStr();
+  value += getModule().getSwiftModule()->getNameStr();
   value += ")";
   return value;
 }
@@ -5152,9 +5148,7 @@ RValue SILGenFunction::emitLiteral(LiteralExpr *literal, SGFContext C) {
     auto magicLiteral = cast<MagicIdentifierLiteralExpr>(literal);
     switch (magicLiteral->getKind()) {
     case MagicIdentifierLiteralExpr::File: {
-      std::string value = getASTContext().LangOpts.EnableConcisePoundFile
-                        ? getConciseMagicFileString(*this, loc)
-                        : getMagicFilePathString(*this, loc).str();
+      std::string value = loc.isValid() ? getMagicFileString(loc) : "";
       builtinLiteralArgs = emitStringLiteral(*this, literal, value, C,
                                              magicLiteral->getStringEncoding());
       builtinInit = magicLiteral->getBuiltinInitializer();
@@ -5163,7 +5157,7 @@ RValue SILGenFunction::emitLiteral(LiteralExpr *literal, SGFContext C) {
     }
 
     case MagicIdentifierLiteralExpr::FilePath: {
-      StringRef value = getMagicFilePathString(*this, loc);
+      StringRef value = loc.isValid() ? getMagicFilePathString(loc) : "";
       builtinLiteralArgs = emitStringLiteral(*this, literal, value, C,
                                              magicLiteral->getStringEncoding());
       builtinInit = magicLiteral->getBuiltinInitializer();
@@ -5172,9 +5166,7 @@ RValue SILGenFunction::emitLiteral(LiteralExpr *literal, SGFContext C) {
     }
 
     case MagicIdentifierLiteralExpr::Function: {
-      StringRef value = "";
-      if (loc.isValid())
-        value = getMagicFunctionString(*this);
+      StringRef value = loc.isValid() ? getMagicFunctionString() : "";
       builtinLiteralArgs = emitStringLiteral(*this, literal, value, C,
                                              magicLiteral->getStringEncoding());
       builtinInit = magicLiteral->getBuiltinInitializer();

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -140,11 +140,11 @@ auto SILGenFunction::emitSourceLocationArgs(SourceLoc sourceLoc,
 -> SourceLocArgs {
   auto &ctx = getASTContext();
   
-  StringRef filename = "";
+  std::string filename = "";
   unsigned line = 0;
   unsigned column = 0;
   if (sourceLoc.isValid()) {
-    filename = ctx.SourceMgr.getDisplayNameForLoc(sourceLoc);
+    filename = getMagicFileString(sourceLoc);
     std::tie(line, column) = ctx.SourceMgr.getLineAndColumn(sourceLoc);
   }
   
@@ -160,7 +160,7 @@ auto SILGenFunction::emitSourceLocationArgs(SourceLoc sourceLoc,
   auto i1Ty = SILType::getBuiltinIntegerType(1, ctx);
   
   SourceLocArgs result;
-  SILValue literal = B.createStringLiteral(emitLoc, filename,
+  SILValue literal = B.createStringLiteral(emitLoc, StringRef(filename),
                                            StringLiteralInst::Encoding::UTF8);
   result.filenameStartPointer = ManagedValue::forUnmanaged(literal);
   // File length

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -557,6 +557,9 @@ public:
   Optional<SILAccessEnforcement> getUnknownEnforcement(VarDecl *var = nullptr);
 
   SourceManager &getSourceManager() { return SGM.M.getASTContext().SourceMgr; }
+  std::string getMagicFileString(SourceLoc loc);
+  StringRef getMagicFilePathString(SourceLoc loc);
+  StringRef getMagicFunctionString();
 
   /// Push a new debug scope and set its parent pointer.
   void enterDebugScope(SILLocation Loc) {

--- a/test/SILGen/magic_identifier_file.swift
+++ b/test/SILGen/magic_identifier_file.swift
@@ -17,3 +17,17 @@ func indirectUse() {
 // ABSOLUTE: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_file.swift"
 // CONCISE: string_literal utf8 "magic_identifier_file.swift (Foo)"
 }
+
+func forceUnwrap(_ x: ()?) {
+// BOTH-LABEL: sil {{.*}} @$s3Foo11forceUnwrapyyytSgF
+  _ = x!
+// ABSOLUTE: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_file.swift"
+// CONCISE: string_literal utf8 "magic_identifier_file.swift (Foo)"
+}
+
+func forceTry(_ fn: () throws -> ()) {
+// BOTH-LABEL: sil {{.*}} @$s3Foo8forceTryyyyyKXEF
+  try! fn()
+// ABSOLUTE: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_file.swift"
+// CONCISE: string_literal utf8 "magic_identifier_file.swift (Foo)"
+}


### PR DESCRIPTION
This ensures that `-enable-experimental-concise-pound-file` affects more of the file names that might be automatically embedded in a binary. With this change (and with the sense of the flag flipped so that even the standard library is built with it), there are no full paths to .swift files embedded in libSwiftPM.dylib.

Fixes rdar://problem/58485813.