### PR TITLE
[5.2][CodeCompletion] Use getBodySourceRange() instead of getSourceRange()

### DIFF
--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1089,8 +1089,8 @@ static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
       // FIXME: when we can parse and typecheck the function body partially for
       // code completion, AFD->getBody() check can be removed.
       if (Loc.isValid() &&
-          AFD->getSourceRange().isValid() &&
-          SM.rangeContainsTokenLoc(AFD->getSourceRange(), Loc) &&
+          AFD->getBodySourceRange().isValid() &&
+          SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc) &&
           AFD->getBody()) {
         namelookup::FindLocalVal(SM, Loc, Consumer).visit(AFD->getBody());
       }

--- a/test/SourceKit/CodeComplete/complete_sequence_localvar.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_localvar.swift
@@ -1,0 +1,26 @@
+func test() {
+  var localVar = 1
+
+  var afterVar = 1
+}
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=3:1 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=3:1 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=3:1 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=3:1 %s -- %s == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=3:1 %s -- %s | %FileCheck %s
+
+// CHECK-NOT: key.name: "localVar"
+// CHECK-NOT: key.name: "afterVar"
+// CHECK: key.name: "localVar"
+// CHECK-NOT: key.name: "afterVar"
+// CHECK: key.name: "localVar"
+// CHECK-NOT: key.name: "afterVar"
+// CHECK: key.name: "localVar"
+// CHECK-NOT: key.name: "afterVar"
+// CHECK: key.name: "localVar"
+// CHECK-NOT: key.name: "afterVar"
+// CHECK: key.name: "localVar"
+// CHECK-NOT: key.name: "localVar"
+// CHECK-NOT: key.name: "afterVar"


### PR DESCRIPTION
Cherry-pick of #28944 into `swift-5.2-branch` originally reviewed by @nathawes 

rdar://problem/58175106
