### PR TITLE
[AutoDiff] add cross-file registration flag to .swiftinterface

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -238,6 +238,15 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     return;
   ArgStringList RenderedArgs;
   for (auto A : Args) {
+    // SWIFT_ENABLE_TENSORFLOW: Copy
+    // `-Xllvm -enable-experimental-cross-file-derivative-registration` into the
+    // .swiftinterface file.
+    if (A->getOption().matches(options::OPT_Xllvm) &&
+        StringRef(A->getValue()) ==
+            "-enable-experimental-cross-file-derivative-registration") {
+      A->render(Args, RenderedArgs);
+      continue;
+    }
     if (A->getOption().hasFlag(options::ModuleInterfaceOption))
       A->render(Args, RenderedArgs);
   }

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -7,11 +7,6 @@
 # RUN: %{python} %s %target-os %target-cpu %platform-sdk-overlay-dir %t \
 # RUN:   %target-swift-frontend -build-module-from-parseable-interface \
 # RUN:     -Fsystem %sdk/System/Library/PrivateFrameworks/ \
-# SWIFT_ENABLE_TENSORFLOW
-# NOTE(TF-1097): Remove flag when retroactive derivative registration is enabled
-# by default.
-# RUN:     -Xllvm -enable-experimental-cross-file-derivative-registration \
-# SWIFT_ENABLE_TENSORFLOW END
 # RUN:     | sort > %t/failures.txt
 # RUN: grep '# %target-os:' %s > %t/filter.txt || true
 # RUN: test ! -e %t/failures.txt || \


### PR DESCRIPTION
Fixes TF-1101 and https://github.com/tensorflow/swift/issues/359.