### PR TITLE
Reflection: Implement a TypeRef -> Demangle tree adapter

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -150,6 +150,9 @@ public:
   void dump() const;
   void dump(FILE *file, unsigned Indent = 0) const;
 
+  /// Build a demangle tree from this TypeRef.
+  Demangle::NodePointer getDemangling(Demangle::Demangler &Dem) const;
+
   bool isConcrete() const;
   bool isConcreteAfterSubstitutions(const GenericArgumentMap &Subs) const;
 

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -376,6 +376,295 @@ void TypeRef::dump(FILE *file, unsigned Indent) const {
   fprintf(file, "\n");
 }
 
+class DemanglingForTypeRef
+    : public TypeRefVisitor<DemanglingForTypeRef, Demangle::NodePointer> {
+  Demangle::Demangler &Dem;
+
+public:
+  DemanglingForTypeRef(Demangle::Demangler &Dem) : Dem(Dem) {}
+
+  Demangle::NodePointer visitBuiltinTypeRef(const BuiltinTypeRef *B) {
+    return Dem.demangleType(B->getMangledName());
+  }
+
+  Demangle::NodePointer visitNominalTypeRef(const NominalTypeRef *N) {
+    if (auto parent = N->getParent())
+      assert(false && "not implemented");
+    return Dem.demangleType(N->getMangledName());
+  }
+
+  Demangle::NodePointer
+  visitBoundGenericTypeRef(const BoundGenericTypeRef *BG) {
+    Node::Kind nodeKind;
+    Node::Kind genericNodeKind;
+    if (BG->isStruct()) {
+      nodeKind = Node::Kind::Structure;
+      genericNodeKind = Node::Kind::BoundGenericStructure;
+    } else if (BG->isEnum()) {
+      nodeKind = Node::Kind::Enum;
+      genericNodeKind = Node::Kind::BoundGenericEnum;
+    } else if (BG->isClass()) {
+      nodeKind = Node::Kind::Class;
+      genericNodeKind = Node::Kind::BoundGenericClass;
+    } else {
+      nodeKind = Node::Kind::OtherNominalType;
+      genericNodeKind = Node::Kind::BoundGenericOtherNominalType;
+    }
+    auto unspecializedType = Dem.demangleType(BG->getMangledName());
+
+    auto genericArgsList = Dem.createNode(Node::Kind::TypeList);
+    for (auto param : BG->getGenericParams())
+      genericArgsList->addChild(visit(param), Dem);
+
+    auto genericNode = Dem.createNode(genericNodeKind);
+    genericNode->addChild(unspecializedType, Dem);
+    genericNode->addChild(genericArgsList, Dem);
+
+    if (auto parent = BG->getParent())
+      assert(false && "not implemented");
+
+    auto top = Dem.createNode(Node::Kind::Type);
+    top->addChild(genericNode, Dem);
+    return top;
+  }
+
+  Demangle::NodePointer visitTupleTypeRef(const TupleTypeRef *T) {
+    auto tuple = Dem.createNode(Node::Kind::Tuple);
+    if (T->isVariadic()) {
+      auto tupleElt = Dem.createNode(Node::Kind::TupleElement);
+      tupleElt->addChild(Dem.createNode(Node::Kind::VariadicMarker), Dem);
+      tuple->addChild(tupleElt, Dem);
+      return tuple;
+    }
+
+    for (auto element : T->getElements()) {
+      auto tupleElt = Dem.createNode(Node::Kind::TupleElement);
+      tupleElt->addChild(visit(element), Dem);
+      tuple->addChild(tupleElt, Dem);
+    }
+    return tuple;
+  }
+
+  Demangle::NodePointer visitFunctionTypeRef(const FunctionTypeRef *F) {
+    Node::Kind kind;
+    switch (F->getFlags().getConvention()) {
+    case FunctionMetadataConvention::Swift:
+      kind = !F->getFlags().isEscaping() ? Node::Kind::NoEscapeFunctionType
+                                         : Node::Kind::FunctionType;
+      break;
+    case FunctionMetadataConvention::Block:
+      kind = Node::Kind::ObjCBlock;
+      break;
+    case FunctionMetadataConvention::Thin:
+      kind = Node::Kind::ThinFunctionType;
+      break;
+    case FunctionMetadataConvention::CFunctionPointer:
+      kind = Node::Kind::CFunctionPointer;
+      break;
+    }
+
+    SmallVector<std::pair<NodePointer, bool>, 8> inputs;
+    for (const auto &param : F->getParameters()) {
+      auto flags = param.getFlags();
+      auto input = visit(param.getType());
+
+      auto wrapInput = [&](Node::Kind kind) {
+        auto parent = Dem.createNode(kind);
+        parent->addChild(input, Dem);
+        input = parent;
+      };
+      switch (flags.getValueOwnership()) {
+      case ValueOwnership::Default:
+        /* nothing */
+        break;
+      case ValueOwnership::InOut:
+        wrapInput(Node::Kind::InOut);
+        break;
+      case ValueOwnership::Shared:
+        wrapInput(Node::Kind::Shared);
+        break;
+      case ValueOwnership::Owned:
+        wrapInput(Node::Kind::Owned);
+        break;
+      }
+
+      inputs.push_back({input, flags.isVariadic()});
+    }
+    NodePointer totalInput = nullptr;
+    // FIXME: this is copy&paste from Demangle.cpp
+    switch (inputs.size()) {
+    case 1: {
+      auto singleParam = inputs.front();
+
+      // If the sole unlabeled parameter has a non-tuple type, encode
+      // the parameter list as a single type.
+      if (!singleParam.second) {
+        auto singleType = singleParam.first;
+        if (singleType->getKind() == Node::Kind::Type)
+          singleType = singleType->getFirstChild();
+        if (singleType->getKind() != Node::Kind::Tuple) {
+          totalInput = singleParam.first;
+          break;
+        }
+      }
+
+      // Otherwise it requires a tuple wrapper.
+      LLVM_FALLTHROUGH;
+    }
+
+    // This covers both none and multiple parameters.
+    default:
+      auto tuple = Dem.createNode(Node::Kind::Tuple);
+      for (auto &input : inputs) {
+        NodePointer eltType;
+        bool isVariadic;
+        std::tie(eltType, isVariadic) = input;
+
+        // Tuple element := variadic-marker label? type
+        auto tupleElt = Dem.createNode(Node::Kind::TupleElement);
+
+        if (isVariadic)
+          tupleElt->addChild(Dem.createNode(Node::Kind::VariadicMarker), Dem);
+
+        if (eltType->getKind() == Node::Kind::Type) {
+          tupleElt->addChild(eltType, Dem);
+        } else {
+          auto type = Dem.createNode(Node::Kind::Type);
+          type->addChild(eltType, Dem);
+          tupleElt->addChild(type, Dem);
+        }
+
+        tuple->addChild(tupleElt, Dem);
+      }
+      totalInput = tuple;
+      break;
+    }
+
+    NodePointer parameters = Dem.createNode(Node::Kind::ArgumentTuple);
+    NodePointer paramType = Dem.createNode(Node::Kind::Type);
+
+    paramType->addChild(totalInput, Dem);
+    parameters->addChild(paramType, Dem);
+
+    NodePointer resultTy = visit(F->getResult());
+    NodePointer result = Dem.createNode(Node::Kind::ReturnType);
+    result->addChild(resultTy, Dem);
+
+    auto funcNode = Dem.createNode(kind);
+    if (F->getFlags().throws())
+      funcNode->addChild(Dem.createNode(Node::Kind::ThrowsAnnotation), Dem);
+    funcNode->addChild(parameters, Dem);
+    funcNode->addChild(result, Dem);
+    return funcNode;
+  }
+
+  Demangle::NodePointer
+  visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
+    auto type_list = Dem.createNode(Node::Kind::TypeList);
+    for (auto protocol : PC->getProtocols())
+      type_list->addChild(visit(protocol), Dem);
+
+    auto proto_list = Dem.createNode(Node::Kind::ProtocolList);
+    proto_list->addChild(type_list, Dem);
+
+    auto node = proto_list;
+    if (auto superclass = PC->getSuperclass()) {
+      node = Dem.createNode(Node::Kind::ProtocolListWithClass);
+      node->addChild(proto_list, Dem);
+      node->addChild(visit(superclass), Dem);
+    } else if (PC->hasExplicitAnyObject()) {
+      node = Dem.createNode(Node::Kind::ProtocolListWithAnyObject);
+      node->addChild(proto_list, Dem);
+    }
+    auto typeNode = Dem.createNode(Node::Kind::Type);
+    typeNode->addChild(node, Dem);
+    return typeNode;
+  }
+
+  Demangle::NodePointer visitMetatypeTypeRef(const MetatypeTypeRef *M) {
+    auto node = Dem.createNode(Node::Kind::Metatype);
+    assert(!M->wasAbstract() && "not implemented");
+    node->addChild(visit(M->getInstanceType()), Dem);
+    auto typeNode = Dem.createNode(Node::Kind::Type);
+    typeNode->addChild(node, Dem);
+    return typeNode;
+  }
+
+  Demangle::NodePointer
+  visitExistentialMetatypeTypeRef(const ExistentialMetatypeTypeRef *EM) {
+    auto node = Dem.createNode(Node::Kind::Metatype);
+    node->addChild(visit(EM->getInstanceType()), Dem);
+    return node;
+  }
+
+  Demangle::NodePointer
+  visitGenericTypeParameterTypeRef(const GenericTypeParameterTypeRef *GTP) {
+    assert(false && "not tested");
+    auto node = Dem.createNode(Node::Kind::DependentGenericParamType);
+    node->addChild(Dem.createNode(Node::Kind::Index, GTP->getDepth()), Dem);
+    node->addChild(Dem.createNode(Node::Kind::Index, GTP->getIndex()), Dem);
+    return node;
+  }
+
+  Demangle::NodePointer
+  visitDependentMemberTypeRef(const DependentMemberTypeRef *DM) {
+    assert(false && "not tested");
+    assert(DM->getProtocol().empty() && "not implemented");
+    auto node = Dem.createNode(Node::Kind::DependentMemberType);
+    node->addChild(visit(DM->getBase()), Dem);
+    node->addChild(Dem.createNode(Node::Kind::Identifier, DM->getMember()),
+                   Dem);
+    return node;
+  }
+
+  Demangle::NodePointer visitForeignClassTypeRef(const ForeignClassTypeRef *F) {
+    assert(false && "not implemented");
+    return nullptr;
+  }
+
+  Demangle::NodePointer visitObjCClassTypeRef(const ObjCClassTypeRef *OC) {
+    auto module = Dem.createNode(Node::Kind::Module, MANGLING_MODULE_OBJC);
+    auto node = Dem.createNode(Node::Kind::Class);
+    node->addChild(module, Dem);
+    node->addChild(Dem.createNode(Node::Kind::Identifier, OC->getName()), Dem);
+    return node;
+  }
+
+  Demangle::NodePointer
+  visitObjCProtocolTypeRef(const ObjCProtocolTypeRef *OC) {
+    auto module = Dem.createNode(Node::Kind::Module, MANGLING_MODULE_OBJC);
+    auto node = Dem.createNode(Node::Kind::Protocol);
+    node->addChild(module, Dem);
+    node->addChild(Dem.createNode(Node::Kind::Identifier, OC->getName()), Dem);
+    auto typeNode = Dem.createNode(Node::Kind::Type);
+    typeNode->addChild(node, Dem);
+    return typeNode;
+  }
+
+#define REF_STORAGE(Name, name, ...)                                           \
+  Demangle::NodePointer visit##Name##StorageTypeRef(                           \
+      const Name##StorageTypeRef *US) {                                        \
+    auto node = Dem.createNode(Node::Kind::Name);                              \
+    node->addChild(visit(US->getType()), Dem);                                 \
+    return node;                                                               \
+  }
+#include "swift/AST/ReferenceStorage.def"
+
+  Demangle::NodePointer visitSILBoxTypeRef(const SILBoxTypeRef *SB) {
+    auto node = Dem.createNode(Node::Kind::SILBoxType);
+    node->addChild(visit(SB->getBoxedType()), Dem);
+    return node;
+  }
+
+  Demangle::NodePointer visitOpaqueTypeRef(const OpaqueTypeRef *O) {
+    return Dem.createNode(Node::Kind::OpaqueType);
+  }
+};
+
+Demangle::NodePointer TypeRef::getDemangling(Demangle::Demangler &Dem) const {
+  return DemanglingForTypeRef(Dem).visit(this);
+}
+
 bool TypeRef::isConcrete() const {
   GenericArgumentMap Subs;
   return TypeRefIsConcrete(Subs).visit(this);

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -19,6 +19,7 @@ SWIFT_REMOTE_MIRROR_LINKAGE
 unsigned long long swift_reflection_classIsSwiftMask = 2;
 }
 
+#include "swift/Demangling/Demangler.h"
 #include "swift/Reflection/ReflectionContext.h"
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Remote/CMemoryReader.h"
@@ -431,6 +432,17 @@ void swift_reflection_dumpInfoForTypeRef(SwiftReflectionContextRef ContextRef,
     fprintf(stdout, "<null type info>\n");
   } else {
     TI->dump(stdout);
+    Demangle::Demangler Dem;
+    std::string MangledName = mangleNode(TR->getDemangling(Dem));
+    fprintf(stdout, "Mangled name: %s%s\n", MANGLING_PREFIX_STR,
+            MangledName.c_str());
+#ifndef NDEBUG
+    auto *Reconstructed = reinterpret_cast<const TypeRef *>(
+        swift_reflection_typeRefForMangledTypeName(
+            ContextRef, MangledName.c_str(), MangledName.size()));
+    assert(mangleNode(TR->getDemangling(Dem)) == MangledName &&
+           "round-trip diff");
+#endif
   }
 }
 

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -10,12 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Basic/Range.h"
+#include "Private.h"
 #include "swift/ABI/TypeIdentity.h"
+#include "swift/Basic/Range.h"
+#include "swift/Reflection/TypeRef.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Portability.h"
 #include "swift/Strings.h"
-#include "Private.h"
 
 #include <vector>
 

--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -67,6 +67,7 @@ reflect(any: mc)
 // CHECK-64-NEXT:    (struct Swift.Int))
 // CHECK-64: Type info:
 // CHECK-64: (reference kind=strong refcounting=native)
+// CHECK-64: Mangled name: $s12existentials7MyClassCyS2iG
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -76,6 +77,7 @@ reflect(any: mc)
 // CHECK-32-NEXT:   (struct Swift.Int))
 // CHECK-32: Type info:
 // CHECK-32: (reference kind=strong refcounting=native)
+// CHECK-32: Mangled name: $s12existentials7MyClassCyS2iG
 
 // This value fits in the 3-word buffer in the container.
 var smallStruct = MyStruct(x: 1, y: 2, z: 3)
@@ -103,6 +105,7 @@ reflect(any: smallStruct)
 // CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
+// CHECK-64-NEXT:   Mangled name:  $s12existentials8MyStructVyS3iG
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -126,6 +129,7 @@ reflect(any: smallStruct)
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
+// CHECK-32-NEXT:   Mangled name:  $s12existentials8MyStructVyS3iG
 
 // This value will be copied into a heap buffer, with a
 // pointer to it in the existential.
@@ -192,6 +196,7 @@ reflect(any: largeStruct)
 // CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:           (field name=_value offset=0
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
+// CHECK-64-NEXT:   Mangled name: $s12existentials8MyStructVySi_S2itSi_S2itSi_S2itG
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -253,6 +258,41 @@ reflect(any: largeStruct)
 // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:           (field name=_value offset=0
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))
+// CHECK-32-NEXT:   Mangled name: $s12existentials8MyStructVySi_S2itSi_S2itSi_S2itG
+
+// Function type:
+reflect(any: {largeStruct})
+// CHECK-64: Mangled name: $s12existentials8MyStructVySi_S2itSi_S2itSi_S2itGyc
+// CHECK-32: Mangled name: $s12existentials8MyStructVySi_S2itSi_S2itSi_S2itGyc
+
+// Protocol composition:
+protocol P {}
+protocol Q {}
+protocol Composition : P, Q {}
+struct S : Composition {}
+func getComposition() -> P & Q { return S() }
+reflect(any: getComposition())
+// CHECK-64: Mangled name: $s12existentials1P_AA1Qp
+// CHECK-32: Mangled name: $s12existentials1P_AA1Qp
+
+// Metatype:
+reflect(any: Int.self)
+// CHECK-64: Mangled name: $sSim
+// CHECK-32: Mangled name: $sSim
+
+protocol WithType {
+  associatedtype T
+  func f() -> T
+}
+struct S1 : WithType {
+  typealias T = Int
+  func f() -> Int { return 0 }
+}
+func getWithType<T>(_ t: T)  where T: WithType {
+  reflect(any: T.self)
+}
+getWithType(S1())
+
 
 var he = HasError(singleError: MyError(), errorInComposition: MyError(), customError: MyCustomError(), customErrorInComposition: MyCustomError())
 reflect(any: he)
@@ -290,6 +330,7 @@ reflect(any: he)
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-64-NEXT:       (field name=wtable offset=40
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
+// CHECK-64-NEXT:   Mangled name: $s12existentials8HasErrorV
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -324,6 +365,7 @@ reflect(any: he)
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
 // CHECK-32-NEXT:       (field name=wtable offset=20
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
+// CHECK-32-NEXT:   Mangled name: $s12existentials8HasErrorV
 
 reflect(error: MyError())
 
@@ -338,6 +380,7 @@ reflect(error: MyError())
 // CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-64-NEXT:       (field name=_value offset=0
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
+// CHECK-64-NEXT:   Mangled name: $s12existentials7MyErrorV
 
 // CHECK-32: Reflecting an error existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -350,5 +393,6 @@ reflect(error: MyError())
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
+// CHECK-32-NEXT:   Mangled name: $s12existentials7MyErrorV
 
 doneReflecting()

--- a/validation-test/Reflection/existentials_objc.swift
+++ b/validation-test/Reflection/existentials_objc.swift
@@ -27,6 +27,11 @@ if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
   // CHECK: Type reference:
   // CHECK: (objective_c_class name=__NSCFNumber)
   reflect(object: NSNumber(123))
+
+  // Objective-C protocol:
+  // CHECK: Type info:
+  // CHECK: $sSo9NSCopying_Xl 
+  reflect(any: { () -> NSCopying in NSString("abc") }())
 } else {
   // The Swift 5.0 libraries don't support this test.
   class SkipTheTest {}


### PR DESCRIPTION
To allow more pervasive use of TypeRefs in LLDB, we need a way to build mangled
names from TypeRef pointers to allow round-tripping between TypeRefs and AST
types. The goal is to experiment with making lldb::CompilerType backed by
TypeRefs instead of AST types.

<rdar://problem/55412775>
