### PR TITLE
SILGen: Fix crash when a closure captures two values with dynamic 'Self' type [5.2]

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2288,9 +2288,7 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
           continue;
 
         // We can always capture the storage in these cases.
-        Type captureType = capturedVar->getType();
-        if (auto *metatypeType = captureType->getAs<MetatypeType>())
-          captureType = metatypeType->getInstanceType();
+        Type captureType = capturedVar->getType()->getMetatypeInstanceType();
 
         if (auto *selfType = captureType->getAs<DynamicSelfType>()) {
           captureType = selfType->getSelfType();
@@ -2302,11 +2300,22 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
           // mutable, we're going to be capturing a box or an address.
           if (captureType->getClassOrBoundGenericClass() &&
               capturedVar->isLet()) {
-            if (selfCapture)
+            // If we've already captured the same value already, just merge
+            // flags.
+            if (selfCapture && selfCapture->getDecl() == capture.getDecl()) {
               selfCapture = selfCapture->mergeFlags(capture);
-            else
+              continue;
+
+            // Otherwise, record the canonical self capture. It will appear
+            // at the end of the capture list.
+            } else if (!selfCapture) {
               selfCapture = capture;
-            continue;
+              continue;
+            }
+
+            // If we end up here, we have multiple different captured values
+            // with a dynamic 'Self' type. Handle this and any subsequent
+            // captures via the normal code path below.
           }
         }
 

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -442,6 +442,25 @@ public class FunctionConversionTest : EmptyProtocol {
   }
 }
 
+public class CaptureTwoValuesTest {
+  public required init() {}
+
+  // CHECK-LABEL: sil [ossa] @$s12dynamic_self20CaptureTwoValuesTestC08capturesdE0yyFZ : $@convention(method) (@thick CaptureTwoValuesTest.Type) -> () {
+  public static func capturesTwoValues() {
+    let a = Self()
+    let b = Self()
+
+    // CHECK: function_ref @$s12dynamic_self20CaptureTwoValuesTestC08capturesdE0yyFZyycfU_ : $@convention(thin) (@guaranteed CaptureTwoValuesTest, @guaranteed CaptureTwoValuesTest) -> ()
+    _ = {
+      _ = a
+      _ = b
+      _ = Self.self
+    }
+
+    // CHECK-LABEL: sil private [ossa] @$s12dynamic_self20CaptureTwoValuesTestC08capturesdE0yyFZyycfU_ : $@convention(thin) (@guaranteed CaptureTwoValuesTest, @guaranteed CaptureTwoValuesTest) -> () {
+  }
+}
+
 // CHECK-LABEL: sil_witness_table hidden X: P module dynamic_self {
 // CHECK: method #P.f!1: {{.*}} : @$s12dynamic_self1XCAA1PA2aDP1f{{[_0-9a-zA-Z]*}}FTW
 


### PR DESCRIPTION
We give special treatment to a capture of a value with dynamic 'Self'
type, by adding it at the end of the capture list. This ensures that
IRGen can recover the 'Self' metadata from this parameter if needed.

However, the code would crash with an assertion if there were multiple
captured values having the dynamic 'Self' type. This was slightly more
difficult to spell before SE-0068, but it was still possible if you
tried; now its completely trivial.

Fixes <https://bugs.swift.org/browse/SR-11928>, <rdar://problem/57823886>.
