### PR TITLE
[stdlib] Re-add withContiguousStorageIfAvailable to SubString.UTF8View

### DIFF
--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -389,6 +389,13 @@ extension Substring.UTF8View: BidirectionalCollection {
     return _slice.distance(from: start, to: end)
   }
 
+  @_alwaysEmitIntoClient
+  public func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    return try _slice.withContiguousStorageIfAvailable(body)
+  }
+
   @inlinable
   public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
     _slice._failEarlyRangeCheck(index, bounds: bounds)


### PR DESCRIPTION
This is a second pass at the original patch, which broke an OS test. Originally added in #29094 and reverted in #29128. /cc @milseman

Due to an oversight it seems that we never added a
withContigousStorageIfAvailable implementation to SubString.UTF8View,
which meant that if you sliced a String you lost the ability to get fast
access to the backing storage. There's no good reason for this
functionality to be missing, so this patch adds it in by delegating to
the Slice implementation.

Resolves SR-11999. rdar://problem/58663804
