### PR TITLE
[Parser]: Labeled block without do diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -933,6 +933,8 @@ ERROR(statement_same_line_without_semi,none,
       "consecutive statements on a line must be separated by ';'", ())
 ERROR(invalid_label_on_stmt,none,
       "labels are only valid on loops, if, and switch statements", ())
+ERROR(labeled_block_needs_do,none,
+      "labeled block needs 'do'", ())
 
 ERROR(snake_case_deprecated,none,
       "%0 has been replaced with %1 in Swift 3",

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1603,7 +1603,8 @@ public:
   ParserResult<Stmt> parseStmtGuard();
   ParserResult<Stmt> parseStmtWhile(LabeledStmtInfo LabelInfo);
   ParserResult<Stmt> parseStmtRepeat(LabeledStmtInfo LabelInfo);
-  ParserResult<Stmt> parseStmtDo(LabeledStmtInfo LabelInfo);
+  ParserResult<Stmt> parseStmtDo(LabeledStmtInfo LabelInfo,
+                                 bool shouldSkipDoTokenConsume = false);
   ParserResult<CatchStmt> parseStmtCatch();
   ParserResult<Stmt> parseStmtForEach(LabeledStmtInfo LabelInfo);
   ParserResult<Stmt> parseStmtSwitch(LabeledStmtInfo LabelInfo);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -647,7 +647,7 @@ ParserResult<Stmt> Parser::parseStmt() {
     if (tryLoc.isValid()) diagnose(tryLoc, diag::try_on_stmt, Tok.getText());
     SourceLoc colonLoc = Tok.getLoc();
     diagnose(colonLoc, diag::labeled_block_needs_do)
-      .fixItInsert(colonLoc, "do");
+      .fixItInsert(colonLoc, "do ");
     return parseStmtDo(LabelInfo, /*shouldSkipDoTokenConsume*/ true);
   }
 }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -349,6 +349,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
         diagnose(EndOfPreviousLoc, diag::labeled_block_needs_do)
           .fixItInsert(EndOfPreviousLoc, "do");
         skipUntilDeclStmtRBrace(tok::r_brace);
+        continue;
       } else {
         diagnose(EndOfPreviousLoc, diag::statement_same_line_without_semi)
           .fixItInsert(EndOfPreviousLoc, ";");

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -345,9 +345,15 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
         PreviousHadSemi || Tok.isAtStartOfLine();
     if (!IsAtStartOfLineOrPreviousHadSemi) {
       SourceLoc EndOfPreviousLoc = getEndOfPreviousLoc();
-      diagnose(EndOfPreviousLoc, diag::statement_same_line_without_semi)
-        .fixItInsert(EndOfPreviousLoc, ";");
-      // FIXME: Add semicolon to the AST?
+      if (Tok.getKind() == tok::colon && peekToken().getKind() == tok::l_brace) {
+        diagnose(EndOfPreviousLoc, diag::labeled_block_needs_do)
+          .fixItInsert(EndOfPreviousLoc, "do");
+        skipUntilDeclStmtRBrace(tok::r_brace);
+      } else {
+        diagnose(EndOfPreviousLoc, diag::statement_same_line_without_semi)
+          .fixItInsert(EndOfPreviousLoc, ";");
+        // FIXME: Add semicolon to the AST?
+      }
     }
 
     ParserPosition BeginParserPosition;

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -252,6 +252,12 @@ func DoWhileStmt2() {
   }
 }
 
+func LabeledDoStmt() {
+  LABEL: { // expected-error {{labeled block needs 'do'}} {{8-8=do}}
+  // expected-error@-1 {{use of unresolved identifier 'LABEL'}}
+  }
+} // expected-error {{expected expression}}
+
 //===--- Repeat-while statement.
 
 func RepeatWhileStmt1() {

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -254,7 +254,6 @@ func DoWhileStmt2() {
 
 func LabeledDoStmt() {
   LABEL: { // expected-error {{labeled block needs 'do'}} {{8-8=do}}
-  // expected-error@-1 {{use of unresolved identifier 'LABEL'}}
   }
 }
 

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -253,7 +253,7 @@ func DoWhileStmt2() {
 }
 
 func LabeledDoStmt() {
-  LABEL: { // expected-error {{labeled block needs 'do'}} {{10-10=do}}
+  LABEL: { // expected-error {{labeled block needs 'do'}} {{10-10=do }}
   }
 }
 

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -253,7 +253,7 @@ func DoWhileStmt2() {
 }
 
 func LabeledDoStmt() {
-  LABEL: { // expected-error {{labeled block needs 'do'}} {{8-8=do}}
+  LABEL: { // expected-error {{labeled block needs 'do'}} {{10-10=do}}
   }
 }
 

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -256,7 +256,7 @@ func LabeledDoStmt() {
   LABEL: { // expected-error {{labeled block needs 'do'}} {{8-8=do}}
   // expected-error@-1 {{use of unresolved identifier 'LABEL'}}
   }
-} // expected-error {{expected expression}}
+}
 
 //===--- Repeat-while statement.
 


### PR DESCRIPTION
Improve diagnostics for labeled block without 'do'

More information in ticket https://bugs.swift.org/browse/SR-3867
