### PR TITLE
Eliminate context descriptor cache

### DIFF
--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -253,19 +253,6 @@ public:
   const ContextDescriptor *
   _searchConformancesByMangledTypeName(Demangle::NodePointer node);
 
-  /// Iterate over protocol conformance sections starting from the given index.
-  /// The index is updated to the current number of protocol sections. Passing
-  /// the same index to the next call will iterate over any sections that were
-  /// added after the previous call.
-  ///
-  /// Takes a function to call for each section found. The two parameters are
-  /// the start and end of the section.
-  void
-  _forEachProtocolConformanceSectionAfter(
-    size_t *start, 
-    const std::function<void(const ProtocolConformanceRecord *,
-                             const ProtocolConformanceRecord *)> &f);
-
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type,
                                                       Demangle::Demangler &Dem);
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -642,22 +642,6 @@ swift::_searchConformancesByMangledTypeName(Demangle::NodePointer node) {
   return nullptr;
 }
 
-void
-swift::_forEachProtocolConformanceSectionAfter(
-  size_t *start, 
-  const std::function<void(const ProtocolConformanceRecord *,
-                           const ProtocolConformanceRecord *)> &f) {
-  auto snapshot = Conformances.get().SectionsToScan.snapshot();
-  if (snapshot.Count > *start) {
-    auto *begin = snapshot.begin() + *start;
-    auto *end = snapshot.end();
-    for (auto *section = begin; section != end; section++) {
-      f(section->Begin, section->End);
-    }
-    *start = snapshot.Count;
-  }
-}
-
 bool swift::_checkGenericRequirements(
                       llvm::ArrayRef<GenericRequirementDescriptor> requirements,
                       SmallVectorImpl<const void *> &extraArguments,


### PR DESCRIPTION
Joe's recent changes to how we look up metadata should have reduced the need for this. Reverts #26579 