### PR TITLE
[Gardening] Sprinkle Const Qualification Around the Frontend

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -303,6 +303,16 @@ public:
     return OptMode == OptimizationMode::ForSize;
   }
 
+  std::string getDebugFlags(StringRef PrivateDiscriminator) const {
+    std::string Flags = DebugFlags;
+    if (!PrivateDiscriminator.empty()) {
+      if (!Flags.empty())
+        Flags += " ";
+      Flags += ("-private-discriminator " + PrivateDiscriminator).str();
+    }
+    return Flags;
+  }
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -272,7 +272,7 @@ public:
   /// Appends to \p os an arbitrary string representing all options which
   /// influence the llvm compilation but are not reflected in the llvm module
   /// itself.
-  void writeLLVMCodeGenOptionsTo(llvm::raw_ostream &os) {
+  void writeLLVMCodeGenOptionsTo(llvm::raw_ostream &os) const {
     // We put a letter between each value simply to keep them from running into
     // one another. There might be a vague correspondence between meaning and
     // letter, but don't sweat it.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -380,7 +380,7 @@ public:
 
   SerializationOptions
   computeSerializationOptions(const SupplementaryOutputPaths &outs,
-                              bool moduleIsPublic);
+                              bool moduleIsPublic) const;
 };
 
 /// A class which manages the state and execution of the compiler.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -484,11 +484,6 @@ public:
   }
   DependencyTracker *getDependencyTracker() { return DepTracker.get(); }
 
-  /// Set the SIL module for this compilation instance.
-  ///
-  /// The CompilerInstance takes ownership of the given SILModule object.
-  void setSILModule(std::unique_ptr<SILModule> M);
-
   SILModule *getSILModule() {
     return TheSILModule.get();
   }

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -328,7 +328,7 @@ public:
   /// in generating a cached PCH file for the bridging header.
   std::string getPCHHash() const;
 
-  SourceFile::ImplicitModuleImportKind getImplicitModuleImportKind() {
+  SourceFile::ImplicitModuleImportKind getImplicitModuleImportKind() const {
     if (getInputKind() == InputFileKind::SIL) {
       return SourceFile::ImplicitModuleImportKind::None;
     }
@@ -404,7 +404,7 @@ class CompilerInstance {
   /// Null if no tracker.
   std::unique_ptr<DependencyTracker> DepTracker;
 
-  ModuleDecl *MainModule = nullptr;
+  mutable ModuleDecl *MainModule = nullptr;
   SerializedModuleLoader *SML = nullptr;
   MemoryBufferSerializedModuleLoader *MemoryBufferLoader = nullptr;
 
@@ -453,14 +453,16 @@ public:
   void operator=(CompilerInstance &&) = delete;
 
   SourceManager &getSourceMgr() { return SourceMgr; }
+  const SourceManager &getSourceMgr() const { return SourceMgr; }
 
   DiagnosticEngine &getDiags() { return Diagnostics; }
+  const DiagnosticEngine &getDiags() const { return Diagnostics; }
 
   llvm::vfs::FileSystem &getFileSystem() { return *SourceMgr.getFileSystem(); }
 
-  ASTContext &getASTContext() {
-    return *Context;
-  }
+  ASTContext &getASTContext() { return *Context; }
+  const ASTContext &getASTContext() const { return *Context; }
+
   bool hasASTContext() const { return Context != nullptr; }
 
   SILOptions &getSILOptions() { return Invocation.getSILOptions(); }
@@ -483,6 +485,7 @@ public:
     DepTracker = llvm::make_unique<DependencyTracker>(TrackSystemDeps);
   }
   DependencyTracker *getDependencyTracker() { return DepTracker.get(); }
+  const DependencyTracker *getDependencyTracker() const { return DepTracker.get(); }
 
   SILModule *getSILModule() {
     return TheSILModule.get();
@@ -494,7 +497,7 @@ public:
     return static_cast<bool>(TheSILModule);
   }
 
-  ModuleDecl *getMainModule();
+  ModuleDecl *getMainModule() const;
 
   MemoryBufferSerializedModuleLoader *
   getMemoryBufferSerializedModuleLoader() const {
@@ -515,7 +518,7 @@ public:
 
   /// Gets the set of SourceFiles which are the primary inputs for this
   /// CompilerInstance.
-  ArrayRef<SourceFile *> getPrimarySourceFiles() {
+  ArrayRef<SourceFile *> getPrimarySourceFiles() const {
     return PrimarySourceFiles;
   }
 
@@ -525,7 +528,7 @@ public:
   ///
   /// FIXME: This should be removed eventually, once there are no longer any
   /// codepaths that rely on a single primary file.
-  SourceFile *getPrimarySourceFile() {
+  SourceFile *getPrimarySourceFile() const {
     if (PrimarySourceFiles.empty()) {
       return nullptr;
     } else {

--- a/include/swift/IRGen/IRGenPublic.h
+++ b/include/swift/IRGen/IRGenPublic.h
@@ -31,6 +31,7 @@ class IRGenModule;
 std::pair<IRGenerator *, IRGenModule *>
 createIRGenModule(SILModule *SILMod, StringRef OutputFilename,
                   StringRef MainInputFilenameForDebugInfo,
+                  StringRef PrivateDiscriminator,
                   llvm::LLVMContext &LLVMContext);
 
 /// Delete the IRGenModule and IRGenerator obtained by the above call.

--- a/include/swift/Immediate/Immediate.h
+++ b/include/swift/Immediate/Immediate.h
@@ -37,7 +37,7 @@ namespace swift {
   ///
   /// \return the result returned from main(), if execution succeeded
   int RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
-                     IRGenOptions &IRGenOpts, const SILOptions &SILOpts);
+                     const IRGenOptions &IRGenOpts, const SILOptions &SILOpts);
 
   void runREPL(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
                bool ParseStdlib);

--- a/include/swift/Immediate/Immediate.h
+++ b/include/swift/Immediate/Immediate.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_IMMEDIATE_IMMEDIATE_H
 #define SWIFT_IMMEDIATE_IMMEDIATE_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,6 +26,7 @@ namespace swift {
   class CompilerInstance;
   class IRGenOptions;
   class SILOptions;
+  class SILModule;
 
   // Using LLVM containers to store command-line arguments turns out
   // to be a lose, because LLVM's execution engine demands this vector
@@ -37,7 +39,8 @@ namespace swift {
   ///
   /// \return the result returned from main(), if execution succeeded
   int RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
-                     const IRGenOptions &IRGenOpts, const SILOptions &SILOpts);
+                     const IRGenOptions &IRGenOpts, const SILOptions &SILOpts,
+                     std::unique_ptr<SILModule> &&SM);
 
   void runREPL(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
                bool ParseStdlib);

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -254,7 +254,7 @@ private:
   bool wholeModule;
 
   /// The options passed into this SILModule.
-  SILOptions &Options;
+  const SILOptions &Options;
 
   /// Set if the SILModule was serialized already. It is used
   /// to ensure that the module is serialized only once.
@@ -270,7 +270,7 @@ private:
   // Intentionally marked private so that we need to use 'constructSIL()'
   // to construct a SILModule.
   SILModule(ModuleDecl *M, Lowering::TypeConverter &TC,
-            SILOptions &Options, const DeclContext *associatedDC,
+            const SILOptions &Options, const DeclContext *associatedDC,
             bool wholeModule);
 
   SILModule(const SILModule&) = delete;
@@ -351,13 +351,13 @@ public:
   /// source file.
   static std::unique_ptr<SILModule>
   constructSIL(ModuleDecl *M, Lowering::TypeConverter &TC,
-               SILOptions &Options, FileUnit *sf = nullptr);
+               const SILOptions &Options, FileUnit *sf = nullptr);
 
   /// Create and return an empty SIL module that we can
   /// later parse SIL bodies directly into, without converting from an AST.
   static std::unique_ptr<SILModule>
   createEmptyModule(ModuleDecl *M, Lowering::TypeConverter &TC,
-                    SILOptions &Options,
+                    const SILOptions &Options,
                     bool WholeModule = false);
 
   /// Get the Swift module associated with this SIL module.
@@ -390,7 +390,7 @@ public:
   /// Returns true if it is the optimized OnoneSupport module.
   bool isOptimizedOnoneSupportModule() const;
 
-  SILOptions &getOptions() const { return Options; }
+  const SILOptions &getOptions() const { return Options; }
 
   using iterator = FunctionListType::iterator;
   using const_iterator = FunctionListType::const_iterator;

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -263,7 +263,7 @@ namespace swift {
   /// Get the CPU, subtarget feature options, and triple to use when emitting code.
   std::tuple<llvm::TargetOptions, std::string, std::vector<std::string>,
              std::string>
-  getIRTargetOptions(ASTContext &Ctx);
+  getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx);
 
   /// Turn the given Swift module into either LLVM IR or native code
   /// and return the generated LLVM IR module.

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -234,12 +234,12 @@ namespace swift {
   /// SIL of all files in the module is present in the SILModule.
   std::unique_ptr<SILModule>
   performSILGeneration(ModuleDecl *M, Lowering::TypeConverter &TC,
-                       SILOptions &options);
+                       const SILOptions &options);
 
   /// Turn a source file into SIL IR.
   std::unique_ptr<SILModule>
   performSILGeneration(FileUnit &SF, Lowering::TypeConverter &TC,
-                       SILOptions &options);
+                       const SILOptions &options);
 
   using ModuleOrSourceFile = PointerUnion<ModuleDecl *, SourceFile *>;
 
@@ -269,7 +269,7 @@ namespace swift {
   /// and return the generated LLVM IR module.
   /// If you set an outModuleHash, then you need to call performLLVM.
   std::unique_ptr<llvm::Module>
-  performIRGeneration(IRGenOptions &Opts, ModuleDecl *M,
+  performIRGeneration(const IRGenOptions &Opts, ModuleDecl *M,
                       std::unique_ptr<SILModule> SILMod,
                       StringRef ModuleName, const PrimarySpecificPaths &PSPs,
                       llvm::LLVMContext &LLVMContext,
@@ -281,7 +281,7 @@ namespace swift {
   /// and return the generated LLVM IR module.
   /// If you set an outModuleHash, then you need to call performLLVM.
   std::unique_ptr<llvm::Module>
-  performIRGeneration(IRGenOptions &Opts, SourceFile &SF,
+  performIRGeneration(const IRGenOptions &Opts, SourceFile &SF,
                       std::unique_ptr<SILModule> SILMod,
                       StringRef ModuleName, const PrimarySpecificPaths &PSPs,
                       StringRef PrivateDiscriminator,
@@ -292,7 +292,7 @@ namespace swift {
   /// Given an already created LLVM module, construct a pass pipeline and run
   /// the Swift LLVM Pipeline upon it. This does not cause the module to be
   /// printed, only to be optimized.
-  void performLLVMOptimizations(IRGenOptions &Opts, llvm::Module *Module,
+  void performLLVMOptimizations(const IRGenOptions &Opts, llvm::Module *Module,
                                 llvm::TargetMachine *TargetMachine);
 
   /// Wrap a serialized module inside a swift AST section in an object file.
@@ -300,7 +300,7 @@ namespace swift {
                                    StringRef OutputPath);
 
   /// Turn the given LLVM module into native code and return true on error.
-  bool performLLVM(IRGenOptions &Opts, ASTContext &Ctx, llvm::Module *Module,
+  bool performLLVM(const IRGenOptions &Opts, ASTContext &Ctx, llvm::Module *Module,
                    StringRef OutputFilename,
                    UnifiedStatsReporter *Stats=nullptr);
 
@@ -315,7 +315,7 @@ namespace swift {
   /// \param TargetMachine target of code gen, required.
   /// \param effectiveLanguageVersion version of the language, effectively.
   /// \param OutputFilename Filename for output.
-  bool performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
+  bool performLLVM(const IRGenOptions &Opts, DiagnosticEngine *Diags,
                    llvm::sys::Mutex *DiagMutex,
                    llvm::GlobalVariable *HashGlobal,
                    llvm::Module *Module,
@@ -325,13 +325,13 @@ namespace swift {
                    UnifiedStatsReporter *Stats=nullptr);
 
   /// Dump YAML describing all fixed-size types imported from the given module.
-  bool performDumpTypeInfo(IRGenOptions &Opts,
+  bool performDumpTypeInfo(const IRGenOptions &Opts,
                            SILModule &SILMod,
                            llvm::LLVMContext &LLVMContext);
 
   /// Creates a TargetMachine from the IRGen opts and AST Context.
   std::unique_ptr<llvm::TargetMachine>
-  createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx);
+  createTargetMachine(const IRGenOptions &Opts, ASTContext &Ctx);
 
   /// A convenience wrapper for Parser functionality.
   class ParserUnit {

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -284,6 +284,7 @@ namespace swift {
   performIRGeneration(IRGenOptions &Opts, SourceFile &SF,
                       std::unique_ptr<SILModule> SILMod,
                       StringRef ModuleName, const PrimarySpecificPaths &PSPs,
+                      StringRef PrivateDiscriminator,
                       llvm::LLVMContext &LLVMContext,
                       llvm::GlobalVariable **outModuleHash = nullptr,
                       llvm::StringSet<> *LinkerDirectives = nullptr);

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -263,7 +263,7 @@ namespace swift {
   /// Get the CPU, subtarget feature options, and triple to use when emitting code.
   std::tuple<llvm::TargetOptions, std::string, std::vector<std::string>,
              std::string>
-  getIRTargetOptions(IRGenOptions &Opts, ASTContext &Ctx);
+  getIRTargetOptions(ASTContext &Ctx);
 
   /// Turn the given Swift module into either LLVM IR or native code
   /// and return the generated LLVM IR module.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -111,8 +111,9 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   }
 }
 
-static void setIRGenOutputOptsFromFrontendOptions(IRGenOptions &IRGenOpts,
-                                                  const FrontendOptions &FrontendOpts) {
+static void
+setIRGenOutputOptsFromFrontendOptions(IRGenOptions &IRGenOpts,
+                                      const FrontendOptions &FrontendOpts) {
   // Set the OutputKind for the given Action.
   IRGenOpts.OutputKind = [](FrontendOptions::ActionType Action) {
     switch (Action) {
@@ -140,8 +141,12 @@ static void setIRGenOutputOptsFromFrontendOptions(IRGenOptions &IRGenOpts,
   }
 }
 
-static void setBridgingHeaderFromFrontendOptions(ClangImporterOptions &ImporterOpts,
-                                                 const FrontendOptions &FrontendOpts) {
+static void
+setBridgingHeaderFromFrontendOptions(ClangImporterOptions &ImporterOpts,
+                                     const FrontendOptions &FrontendOpts) {
+  if (FrontendOpts.RequestedAction != FrontendOptions::ActionType::EmitPCH)
+    return;
+
   // If there aren't any inputs, there's nothing to do.
   if (!FrontendOpts.InputsAndOutputs.hasInputs())
     return;
@@ -1352,7 +1357,6 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.AutolinkRuntimeCompatibilityDynamicReplacementLibraryVersion =
         getRuntimeCompatVersion();
   }
-
   return false;
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -142,7 +142,7 @@ CompilerInvocation::getModuleInterfaceOutputPathForWholeModule() const {
 }
 
 SerializationOptions CompilerInvocation::computeSerializationOptions(
-    const SupplementaryOutputPaths &outs, bool moduleIsPublic) {
+    const SupplementaryOutputPaths &outs, bool moduleIsPublic) const {
   const FrontendOptions &opts = getFrontendOptions();
 
   SerializationOptions serializationOpts;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -185,10 +185,6 @@ void CompilerInstance::createSILModule() {
       Invocation.getFrontendOptions().InputsAndOutputs.isWholeModule());
 }
 
-void CompilerInstance::setSILModule(std::unique_ptr<SILModule> M) {
-  TheSILModule = std::move(M);
-}
-
 void CompilerInstance::recordPrimaryInputBuffer(unsigned BufID) {
   PrimaryBufferIDs.insert(BufID);
 }
@@ -618,7 +614,7 @@ std::unique_ptr<SILModule> CompilerInstance::takeSILModule() {
   return std::move(TheSILModule);
 }
 
-ModuleDecl *CompilerInstance::getMainModule() {
+ModuleDecl *CompilerInstance::getMainModule() const {
   if (!MainModule) {
     Identifier ID = Context->getIdentifier(Invocation.getModuleName());
     MainModule = ModuleDecl::create(ID, *Context);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -510,7 +510,7 @@ static bool writeSIL(SILModule &SM, ModuleDecl *M, bool EmitVerboseSIL,
 
 static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
                      CompilerInstance &Instance,
-                     CompilerInvocation &Invocation) {
+                     const CompilerInvocation &Invocation) {
   const FrontendOptions &opts = Invocation.getFrontendOptions();
   return writeSIL(SM, Instance.getMainModule(), opts.EmitVerboseSIL,
                   PSPs.OutputFilename, opts.EmitSortedSIL);
@@ -723,7 +723,7 @@ createOptRecordFile(StringRef Filename, DiagnosticEngine &DE) {
   return File;
 }
 
-static bool precompileBridgingHeader(CompilerInvocation &Invocation,
+static bool precompileBridgingHeader(const CompilerInvocation &Invocation,
                                      CompilerInstance &Instance) {
   auto clangImporter = static_cast<ClangImporter *>(
       Instance.getASTContext().getClangModuleLoader());
@@ -742,7 +742,7 @@ static bool precompileBridgingHeader(CompilerInvocation &Invocation,
           .InputsAndOutputs.getSingleOutputFilename());
 }
 
-static bool precompileClangModule(CompilerInvocation &Invocation,
+static bool precompileClangModule(const CompilerInvocation &Invocation,
                                   CompilerInstance &Instance) {
   auto clangImporter = static_cast<ClangImporter *>(
       Instance.getASTContext().getClangModuleLoader());
@@ -754,7 +754,7 @@ static bool precompileClangModule(CompilerInvocation &Invocation,
           .InputsAndOutputs.getSingleOutputFilename());
 }
 
-static bool dumpPrecompiledClangModule(CompilerInvocation &Invocation,
+static bool dumpPrecompiledClangModule(const CompilerInvocation &Invocation,
                                        CompilerInstance &Instance) {
   auto clangImporter = static_cast<ClangImporter *>(
       Instance.getASTContext().getClangModuleLoader());
@@ -765,7 +765,7 @@ static bool dumpPrecompiledClangModule(CompilerInvocation &Invocation,
           .InputsAndOutputs.getSingleOutputFilename());
 }
 
-static bool buildModuleFromInterface(CompilerInvocation &Invocation,
+static bool buildModuleFromInterface(const CompilerInvocation &Invocation,
                                      CompilerInstance &Instance) {
   const FrontendOptions &FEOpts = Invocation.getFrontendOptions();
   assert(FEOpts.InputsAndOutputs.hasSingleInput());
@@ -781,7 +781,7 @@ static bool buildModuleFromInterface(CompilerInvocation &Invocation,
       FEOpts.TrackSystemDeps, FEOpts.RemarkOnRebuildFromModuleInterface);
 }
 
-static bool compileLLVMIR(CompilerInvocation &Invocation,
+static bool compileLLVMIR(const CompilerInvocation &Invocation,
                           CompilerInstance &Instance,
                           UnifiedStatsReporter *Stats) {
   auto &LLVMContext = getGlobalLLVMContext();
@@ -824,7 +824,7 @@ static bool compileLLVMIR(CompilerInvocation &Invocation,
                      Stats);
 }
 
-static void verifyGenericSignaturesIfNeeded(CompilerInvocation &Invocation,
+static void verifyGenericSignaturesIfNeeded(const CompilerInvocation &Invocation,
                                             ASTContext &Context) {
   auto verifyGenericSignaturesInModule =
       Invocation.getFrontendOptions().VerifyGenericSignaturesInModule;
@@ -834,7 +834,7 @@ static void verifyGenericSignaturesIfNeeded(CompilerInvocation &Invocation,
     GenericSignatureBuilder::verifyGenericSignaturesInModule(module);
 }
 
-static void dumpAndPrintScopeMap(CompilerInvocation &Invocation,
+static void dumpAndPrintScopeMap(const CompilerInvocation &Invocation,
                                  CompilerInstance &Instance, SourceFile *SF) {
   // Not const because may require reexpansion
   ASTScope &scope = SF->getScope();
@@ -853,7 +853,7 @@ static void dumpAndPrintScopeMap(CompilerInvocation &Invocation,
   }
 }
 
-static SourceFile *getPrimaryOrMainSourceFile(CompilerInvocation &Invocation,
+static SourceFile *getPrimaryOrMainSourceFile(const CompilerInvocation &Invocation,
                                               CompilerInstance &Instance) {
   SourceFile *SF = Instance.getPrimarySourceFile();
   if (!SF) {
@@ -865,7 +865,7 @@ static SourceFile *getPrimaryOrMainSourceFile(CompilerInvocation &Invocation,
 
 /// Dumps the AST of all available primary source files. If corresponding output
 /// files were specified, use them; otherwise, dump the AST to stdout.
-static void dumpAST(CompilerInvocation &Invocation,
+static void dumpAST(const CompilerInvocation &Invocation,
                     CompilerInstance &Instance) {
   auto primaryFiles = Instance.getPrimarySourceFiles();
   if (!primaryFiles.empty()) {
@@ -887,10 +887,10 @@ static void dumpAST(CompilerInvocation &Invocation,
 /// CompilerInstance::performSema()), so dump or print the main source file and
 /// return.
 
-static Optional<bool> dumpASTIfNeeded(CompilerInvocation &Invocation,
+static Optional<bool> dumpASTIfNeeded(const CompilerInvocation &Invocation,
                                       CompilerInstance &Instance) {
-  FrontendOptions &opts = Invocation.getFrontendOptions();
-  FrontendOptions::ActionType Action = opts.RequestedAction;
+  const FrontendOptions &opts = Invocation.getFrontendOptions();
+  const FrontendOptions::ActionType Action = opts.RequestedAction;
   ASTContext &Context = Instance.getASTContext();
   switch (Action) {
   default:
@@ -935,7 +935,7 @@ static Optional<bool> dumpASTIfNeeded(CompilerInvocation &Invocation,
 }
 
 static void emitReferenceDependenciesForAllPrimaryInputsIfNeeded(
-    CompilerInvocation &Invocation, CompilerInstance &Instance) {
+    const CompilerInvocation &Invocation, CompilerInstance &Instance) {
   if (Invocation.getFrontendOptions()
           .InputsAndOutputs.hasReferenceDependenciesPath() &&
       Instance.getPrimarySourceFiles().empty()) {
@@ -962,7 +962,7 @@ static void emitReferenceDependenciesForAllPrimaryInputsIfNeeded(
   }
 }
 static void
-emitSwiftRangesForAllPrimaryInputsIfNeeded(CompilerInvocation &Invocation,
+emitSwiftRangesForAllPrimaryInputsIfNeeded(const CompilerInvocation &Invocation,
                                            CompilerInstance &Instance) {
   if (Invocation.getFrontendOptions().InputsAndOutputs.hasSwiftRangesPath() &&
       Instance.getPrimarySourceFiles().empty()) {
@@ -980,7 +980,7 @@ emitSwiftRangesForAllPrimaryInputsIfNeeded(CompilerInvocation &Invocation,
   }
 }
 static void
-emitCompiledSourceForAllPrimaryInputsIfNeeded(CompilerInvocation &Invocation,
+emitCompiledSourceForAllPrimaryInputsIfNeeded(const CompilerInvocation &Invocation,
                                               CompilerInstance &Instance) {
   if (Invocation.getFrontendOptions()
           .InputsAndOutputs.hasCompiledSourcePath() &&
@@ -999,7 +999,7 @@ emitCompiledSourceForAllPrimaryInputsIfNeeded(CompilerInvocation &Invocation,
   }
 }
 
-static bool writeTBDIfNeeded(CompilerInvocation &Invocation,
+static bool writeTBDIfNeeded(const CompilerInvocation &Invocation,
                              CompilerInstance &Instance) {
   const auto &frontendOpts = Invocation.getFrontendOptions();
   const auto &tbdOpts = Invocation.getTBDGenOptions();
@@ -1027,7 +1027,7 @@ static std::string changeToLdAdd(StringRef ldHide) {
   return OS.str().str();
 }
 
-static bool writeLdAddCFileIfNeeded(CompilerInvocation &Invocation,
+static bool writeLdAddCFileIfNeeded(const CompilerInvocation &Invocation,
                                     CompilerInstance &Instance) {
   auto frontendOpts = Invocation.getFrontendOptions();
   if (!frontendOpts.InputsAndOutputs.isWholeModule())
@@ -1076,14 +1076,14 @@ static bool writeLdAddCFileIfNeeded(CompilerInvocation &Invocation,
 }
 
 static bool performCompileStepsPostSILGen(
-    CompilerInstance &Instance, CompilerInvocation &Invocation,
+    CompilerInstance &Instance, const CompilerInvocation &Invocation,
     std::unique_ptr<SILModule> SM, bool astGuaranteedToCorrespondToSIL,
     ModuleOrSourceFile MSF, const PrimarySpecificPaths &PSPs,
     bool moduleIsPublic, int &ReturnValue, FrontendObserver *observer,
     UnifiedStatsReporter *Stats);
 
 static bool
-performCompileStepsPostSema(CompilerInvocation &Invocation,
+performCompileStepsPostSema(const CompilerInvocation &Invocation,
                             CompilerInstance &Instance,
                             bool moduleIsPublic, int &ReturnValue,
                             FrontendObserver *observer,
@@ -1098,8 +1098,8 @@ performCompileStepsPostSema(CompilerInvocation &Invocation,
                                          ReturnValue, observer, Stats);
   }
 
-  SILOptions &SILOpts = Invocation.getSILOptions();
-  FrontendOptions &opts = Invocation.getFrontendOptions();
+  const SILOptions &SILOpts = Invocation.getSILOptions();
+  const FrontendOptions &opts = Invocation.getFrontendOptions();
   auto fileIsSIB = [](const FileUnit *File) -> bool {
     auto SASTF = dyn_cast<SerializedASTFile>(File);
     return SASTF && SASTF->isSIB();
@@ -1158,7 +1158,7 @@ performCompileStepsPostSema(CompilerInvocation &Invocation,
 
 /// Emits index data for all primary inputs, or the main module.
 static bool
-emitIndexData(CompilerInvocation &Invocation, CompilerInstance &Instance) {
+emitIndexData(const CompilerInvocation &Invocation, CompilerInstance &Instance) {
   bool hadEmitIndexDataError = false;
   if (Instance.getPrimarySourceFiles().empty())
     return emitIndexDataIfNeeded(nullptr, Invocation, Instance);
@@ -1175,7 +1175,7 @@ emitIndexData(CompilerInvocation &Invocation, CompilerInstance &Instance) {
 /// `-typecheck`, but skipped for any mode that runs SIL diagnostics if there's
 /// an error found there (to get those diagnostics back to the user faster).
 static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
-    CompilerInstance &Instance, CompilerInvocation &Invocation,
+    CompilerInstance &Instance, const CompilerInvocation &Invocation,
     bool moduleIsPublic) {
   const FrontendOptions &opts = Invocation.getFrontendOptions();
 
@@ -1212,7 +1212,7 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
 ///                 mode is NoVerify and there were no errors.
 /// \returns true on error
 static bool performCompile(CompilerInstance &Instance,
-                           CompilerInvocation &Invocation,
+                           const CompilerInvocation &Invocation,
                            ArrayRef<const char *> Args,
                            int &ReturnValue,
                            FrontendObserver *observer,
@@ -1358,7 +1358,8 @@ static bool serializeSIB(SILModule *SM, const PrimarySpecificPaths &PSPs,
   return Context.hadError();
 }
 
-static void generateIR(IRGenOptions &IRGenOpts, std::unique_ptr<SILModule> SM,
+static void generateIR(const IRGenOptions &IRGenOpts,
+                       std::unique_ptr<SILModule> SM,
                        const PrimarySpecificPaths &PSPs,
                        StringRef OutputFilename, ModuleOrSourceFile MSF,
                        std::unique_ptr<llvm::Module> &IRModule,
@@ -1380,7 +1381,7 @@ static void generateIR(IRGenOptions &IRGenOpts, std::unique_ptr<SILModule> SM,
                                        &HashGlobal, &LinkerDirectives);
 }
 
-static bool processCommandLineAndRunImmediately(CompilerInvocation &Invocation,
+static bool processCommandLineAndRunImmediately(const CompilerInvocation &Invocation,
                                                 CompilerInstance &Instance,
                                                 std::unique_ptr<SILModule> SM,
                                                 ModuleOrSourceFile MSF,
@@ -1404,7 +1405,7 @@ static bool processCommandLineAndRunImmediately(CompilerInvocation &Invocation,
   return Instance.getASTContext().hadError();
 }
 
-static bool validateTBDIfNeeded(CompilerInvocation &Invocation,
+static bool validateTBDIfNeeded(const CompilerInvocation &Invocation,
                                 ModuleOrSourceFile MSF,
                                 bool astGuaranteedToCorrespondToSIL,
                                 llvm::Module &IRModule) {
@@ -1443,7 +1444,7 @@ static bool validateTBDIfNeeded(CompilerInvocation &Invocation,
                            Invocation.getTBDGenOptions(), allSymbols);
 }
 
-static bool generateCode(CompilerInvocation &Invocation,
+static bool generateCode(const CompilerInvocation &Invocation,
                          CompilerInstance &Instance, StringRef OutputFilename,
                          llvm::Module *IRModule,
                          llvm::GlobalVariable *HashGlobal,
@@ -1473,7 +1474,7 @@ static bool generateCode(CompilerInvocation &Invocation,
                      EffectiveLanguageVersion, OutputFilename, Stats);
 }
 
-static void collectLinkerDirectives(CompilerInvocation &Invocation,
+static void collectLinkerDirectives(const CompilerInvocation &Invocation,
                                     ModuleOrSourceFile MSF,
                                     llvm::StringSet<> &Symbols) {
   auto tbdOpts = Invocation.getTBDGenOptions();
@@ -1485,7 +1486,7 @@ static void collectLinkerDirectives(CompilerInvocation &Invocation,
 }
 
 static bool performCompileStepsPostSILGen(
-    CompilerInstance &Instance, CompilerInvocation &Invocation,
+    CompilerInstance &Instance, const CompilerInvocation &Invocation,
     std::unique_ptr<SILModule> SM, bool astGuaranteedToCorrespondToSIL,
     ModuleOrSourceFile MSF, const PrimarySpecificPaths &PSPs,
     bool moduleIsPublic, int &ReturnValue, FrontendObserver *observer,
@@ -1494,8 +1495,8 @@ static bool performCompileStepsPostSILGen(
   FrontendOptions opts = Invocation.getFrontendOptions();
   FrontendOptions::ActionType Action = opts.RequestedAction;
   ASTContext &Context = Instance.getASTContext();
-  SILOptions &SILOpts = Invocation.getSILOptions();
-  IRGenOptions &IRGenOpts = Invocation.getIRGenOptions();
+  const SILOptions &SILOpts = Invocation.getSILOptions();
+  const IRGenOptions &IRGenOpts = Invocation.getIRGenOptions();
 
   Optional<BufferIndirectlyCausingDiagnosticRAII> ricd;
   if (auto *SF = MSF.dyn_cast<SourceFile *>())
@@ -1604,8 +1605,6 @@ static bool performCompileStepsPostSILGen(
   if (Action == FrontendOptions::ActionType::DumpTypeInfo)
     return performDumpTypeInfo(IRGenOpts, *SM, getGlobalLLVMContext());
 
-  // TODO: remove once the frontend understands what action it should perform
-  IRGenOpts.OutputKind = getOutputKind(Action);
   if (Action == FrontendOptions::ActionType::Immediate)
     return processCommandLineAndRunImmediately(
         Invocation, Instance, std::move(SM), MSF, observer, ReturnValue);
@@ -1895,7 +1894,7 @@ createJSONFixItDiagnosticConsumerIfNeeded(
 }
 
 /// Print information about the selected target in JSON.
-static void printTargetInfo(CompilerInvocation &invocation,
+static void printTargetInfo(const CompilerInvocation &invocation,
                             llvm::raw_ostream &out) {
   out << "{\n";
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -482,8 +482,7 @@ getFileOutputStream(StringRef OutputFilename, ASTContext &Ctx) {
 }
 
 /// Writes the Syntax tree to the given file
-static bool emitSyntax(SourceFile *SF, LangOptions &LangOpts,
-                       SourceManager &SM, StringRef OutputFilename) {
+static bool emitSyntax(SourceFile *SF, StringRef OutputFilename) {
   auto bufferID = SF->getBufferID();
   assert(bufferID && "frontend should have a buffer ID "
          "for the main source file");
@@ -920,7 +919,6 @@ static Optional<bool> dumpASTIfNeeded(CompilerInvocation &Invocation,
 
   case FrontendOptions::ActionType::EmitSyntax:
     emitSyntax(getPrimaryOrMainSourceFile(Invocation, Instance),
-               Invocation.getLangOptions(), Instance.getSourceMgr(),
                opts.InputsAndOutputs.getSingleOutputFilename());
     break;
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1383,7 +1383,7 @@ static void generateIR(const IRGenOptions &IRGenOpts,
 
 static bool processCommandLineAndRunImmediately(const CompilerInvocation &Invocation,
                                                 CompilerInstance &Instance,
-                                                std::unique_ptr<SILModule> SM,
+                                                std::unique_ptr<SILModule> &&SM,
                                                 ModuleOrSourceFile MSF,
                                                 FrontendObserver *observer,
                                                 int &ReturnValue) {
@@ -1392,8 +1392,6 @@ static bool processCommandLineAndRunImmediately(const CompilerInvocation &Invoca
   const IRGenOptions &IRGenOpts = Invocation.getIRGenOptions();
   const ProcessCmdLine &CmdLine =
       ProcessCmdLine(opts.ImmediateArgv.begin(), opts.ImmediateArgv.end());
-  Instance.setSILModule(std::move(SM));
-
 
   PrettyStackTraceStringAction trace(
       "running user code",

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -152,7 +152,7 @@ static void addSanitizerCoveragePass(const PassManagerBuilder &Builder,
 
 std::tuple<llvm::TargetOptions, std::string, std::vector<std::string>,
            std::string>
-swift::getIRTargetOptions(ASTContext &Ctx) {
+swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx) {
   // Things that maybe we should collect from the command line:
   //   - relocation model
   //   - code model
@@ -657,7 +657,7 @@ swift::createTargetMachine(const IRGenOptions &Opts, ASTContext &Ctx) {
   std::string EffectiveClangTriple;
   std::vector<std::string> targetFeaturesArray;
   std::tie(TargetOpts, CPU, targetFeaturesArray, EffectiveClangTriple)
-    = getIRTargetOptions(Ctx);
+    = getIRTargetOptions(Opts, Ctx);
   const llvm::Triple &EffectiveTriple = llvm::Triple(EffectiveClangTriple);
   std::string targetFeatures;
   if (!targetFeaturesArray.empty()) {

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -179,7 +179,8 @@ void setModuleFlags(IRGenModule &IGM) {
                         IRGenModule::swiftVersion);
 }
 
-void swift::performLLVMOptimizations(IRGenOptions &Opts, llvm::Module *Module,
+void swift::performLLVMOptimizations(const IRGenOptions &Opts,
+                                     llvm::Module *Module,
                                      llvm::TargetMachine *TargetMachine) {
   // Set up a pipeline.
   PassManagerBuilderWrapper PMBuilder(Opts);
@@ -345,7 +346,7 @@ public:
 
 /// Computes the MD5 hash of the llvm \p Module including the compiler version
 /// and options which influence the compilation.
-static void getHashOfModule(MD5::MD5Result &Result, IRGenOptions &Opts,
+static void getHashOfModule(MD5::MD5Result &Result, const IRGenOptions &Opts,
                             llvm::Module *Module,
                             llvm::TargetMachine *TargetMachine,
                             version::Version const& effectiveLanguageVersion) {
@@ -457,7 +458,7 @@ diagnoseSync(DiagnosticEngine *Diags, llvm::sys::Mutex *DiagMutex,
 
 /// Run the LLVM passes. In multi-threaded compilation this will be done for
 /// multiple LLVM modules in parallel.
-bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
+bool swift::performLLVM(const IRGenOptions &Opts, DiagnosticEngine *Diags,
                         llvm::sys::Mutex *DiagMutex,
                         llvm::GlobalVariable *HashGlobal,
                         llvm::Module *Module,
@@ -645,7 +646,7 @@ bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
 }
 
 std::unique_ptr<llvm::TargetMachine>
-swift::createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
+swift::createTargetMachine(const IRGenOptions &Opts, ASTContext &Ctx) {
   CodeGenOpt::Level OptLevel = Opts.shouldOptimize()
                                    ? CodeGenOpt::Default // -Os
                                    : CodeGenOpt::None;
@@ -697,7 +698,7 @@ swift::createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
   return std::unique_ptr<llvm::TargetMachine>(TargetMachine);
 }
 
-IRGenerator::IRGenerator(IRGenOptions &options, SILModule &module)
+IRGenerator::IRGenerator(const IRGenOptions &options, SILModule &module)
   : Opts(options), SIL(module), QueueIndex(0) {
 }
 
@@ -857,7 +858,7 @@ static void runIRGenPreparePasses(SILModule &Module,
 /// Generates LLVM IR, runs the LLVM passes and produces the output file.
 /// All this is done in a single thread.
 static std::unique_ptr<llvm::Module>
-performIRGeneration(IRGenOptions &Opts, ModuleDecl *M,
+performIRGeneration(const IRGenOptions &Opts, ModuleDecl *M,
                     std::unique_ptr<SILModule> SILMod, StringRef ModuleName,
                     const PrimarySpecificPaths &PSPs,
                     StringRef PrivateDiscriminator,
@@ -1073,7 +1074,7 @@ struct LLVMCodeGenThreads {
 /// Generates LLVM IR, runs the LLVM passes and produces the output files.
 /// All this is done in multiple threads.
 static void performParallelIRGeneration(
-    IRGenOptions &Opts, swift::ModuleDecl *M, std::unique_ptr<SILModule> SILMod,
+    const IRGenOptions &Opts, swift::ModuleDecl *M, std::unique_ptr<SILModule> SILMod,
     StringRef ModuleName, int numThreads,
     ArrayRef<std::string> outputFilenames,
     llvm::StringSet<> *linkerDirectives) {
@@ -1267,7 +1268,7 @@ static void performParallelIRGeneration(
 }
 
 std::unique_ptr<llvm::Module> swift::performIRGeneration(
-    IRGenOptions &Opts, swift::ModuleDecl *M, std::unique_ptr<SILModule> SILMod,
+    const IRGenOptions &Opts, swift::ModuleDecl *M, std::unique_ptr<SILModule> SILMod,
     StringRef ModuleName, const PrimarySpecificPaths &PSPs,
     llvm::LLVMContext &LLVMContext,
     ArrayRef<std::string> parallelOutputFilenames,
@@ -1289,7 +1290,7 @@ std::unique_ptr<llvm::Module> swift::performIRGeneration(
 }
 
 std::unique_ptr<llvm::Module> swift::
-performIRGeneration(IRGenOptions &Opts, SourceFile &SF,
+performIRGeneration(const IRGenOptions &Opts, SourceFile &SF,
                     std::unique_ptr<SILModule> SILMod,
                     StringRef ModuleName, const PrimarySpecificPaths &PSPs,
                     StringRef PrivateDiscriminator,
@@ -1353,7 +1354,7 @@ swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
                 OutputPath);
 }
 
-bool swift::performLLVM(IRGenOptions &Opts, ASTContext &Ctx,
+bool swift::performLLVM(const IRGenOptions &Opts, ASTContext &Ctx,
                         llvm::Module *Module, StringRef OutputFilename,
                         UnifiedStatsReporter *Stats) {
   // Build TargetMachine.

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -152,7 +152,7 @@ static void addSanitizerCoveragePass(const PassManagerBuilder &Builder,
 
 std::tuple<llvm::TargetOptions, std::string, std::vector<std::string>,
            std::string>
-swift::getIRTargetOptions(IRGenOptions &Opts, ASTContext &Ctx) {
+swift::getIRTargetOptions(ASTContext &Ctx) {
   // Things that maybe we should collect from the command line:
   //   - relocation model
   //   - code model
@@ -656,7 +656,7 @@ swift::createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
   std::string EffectiveClangTriple;
   std::vector<std::string> targetFeaturesArray;
   std::tie(TargetOpts, CPU, targetFeaturesArray, EffectiveClangTriple)
-    = getIRTargetOptions(Opts, Ctx);
+    = getIRTargetOptions(Ctx);
   const llvm::Triple &EffectiveTriple = llvm::Triple(EffectiveClangTriple);
   std::string targetFeatures;
   if (!targetFeaturesArray.empty()) {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -143,7 +143,8 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
 public:
   IRGenDebugInfoImpl(const IRGenOptions &Opts, ClangImporter &CI,
                      IRGenModule &IGM, llvm::Module &M,
-                     StringRef MainOutputFilenameForDebugInfo);
+                     StringRef MainOutputFilenameForDebugInfo,
+                     StringRef PrivateDiscriminator);
   void finalize();
 
   void setCurrentLoc(IRBuilder &Builder, const SILDebugScope *DS,
@@ -1664,7 +1665,8 @@ private:
 IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
                                        ClangImporter &CI, IRGenModule &IGM,
                                        llvm::Module &M,
-                                       StringRef MainOutputFilenameForDebugInfo)
+                                       StringRef MainOutputFilenameForDebugInfo,
+                                       StringRef PD)
     : Opts(Opts), CI(CI), SM(IGM.Context.SourceMgr), M(M), DBuilder(M),
       IGM(IGM), DebugPrefixMap(Opts.DebugPrefixMap) {
   assert(Opts.DebugInfoLevel > IRGenDebugInfoLevel::None &&
@@ -1678,7 +1680,6 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
   unsigned Lang = llvm::dwarf::DW_LANG_Swift;
   std::string Producer = version::getSwiftFullVersion(
       IGM.Context.LangOpts.EffectiveLanguageVersion);
-  StringRef Flags = Opts.DebugFlags;
   unsigned Major, Minor;
   std::tie(Major, Minor) = version::getSwiftNumericVersion();
   unsigned MajorRuntimeVersion = Major;
@@ -1693,7 +1694,8 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
 
   TheCU = DBuilder.createCompileUnit(
       Lang, MainFile,
-      Producer, Opts.shouldOptimize(), Flags, MajorRuntimeVersion, SplitName,
+      Producer, Opts.shouldOptimize(), Opts.getDebugFlags(PD),
+      MajorRuntimeVersion, SplitName,
       Opts.DebugInfoLevel > IRGenDebugInfoLevel::LineTables
           ? llvm::DICompileUnit::FullDebug
           : llvm::DICompileUnit::LineTablesOnly);
@@ -2355,9 +2357,11 @@ SILLocation::DebugLoc IRGenDebugInfoImpl::decodeSourceLoc(SourceLoc SL) {
 
 std::unique_ptr<IRGenDebugInfo> IRGenDebugInfo::createIRGenDebugInfo(
     const IRGenOptions &Opts, ClangImporter &CI, IRGenModule &IGM,
-    llvm::Module &M, StringRef MainOutputFilenameForDebugInfo) {
+    llvm::Module &M, StringRef MainOutputFilenameForDebugInfo,
+    StringRef PrivateDiscriminator) {
   return llvm::make_unique<IRGenDebugInfoImpl>(Opts, CI, IGM, M,
-                                               MainOutputFilenameForDebugInfo);
+                                               MainOutputFilenameForDebugInfo,
+                                               PrivateDiscriminator);
 }
 
 

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -49,7 +49,8 @@ public:
   static std::unique_ptr<IRGenDebugInfo>
   createIRGenDebugInfo(const IRGenOptions &Opts, ClangImporter &CI,
                        IRGenModule &IGM, llvm::Module &M,
-                       StringRef MainOutputFilenameForDebugInfo);
+                       StringRef MainOutputFilenameForDebugInfo,
+                       StringRef PrivateDiscriminator);
   virtual ~IRGenDebugInfo();
 
   /// Finalize the llvm::DIBuilder owned by this object.

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -87,7 +87,7 @@ static llvm::PointerType *createStructPointerType(IRGenModule &IGM,
 
 static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
                                                  llvm::LLVMContext &LLVMContext,
-                                                      IRGenOptions &Opts,
+                                                      const IRGenOptions &Opts,
                                                       StringRef ModuleName,
                                                       StringRef PD) {
   auto Loader = Context.getClangModuleLoader();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1225,14 +1225,15 @@ public:
   IRGenModule(IRGenerator &irgen, std::unique_ptr<llvm::TargetMachine> &&target,
               SourceFile *SF, llvm::LLVMContext &LLVMContext,
               StringRef ModuleName, StringRef OutputFilename,
-              StringRef MainInputFilenameForDebugInfo);
+              StringRef MainInputFilenameForDebugInfo,
+              StringRef PrivateDiscriminator);
 
   /// The constructor used when we just need an IRGenModule for type lowering.
   IRGenModule(IRGenerator &irgen, std::unique_ptr<llvm::TargetMachine> &&target,
               llvm::LLVMContext &LLVMContext)
     : IRGenModule(irgen, std::move(target), /*SF=*/nullptr, LLVMContext,
                   "<fake module name>", "<fake output filename>",
-                  "<fake main input filename>") {}
+                  "<fake main input filename>", "") {}
 
   ~IRGenModule();
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -194,7 +194,7 @@ enum RequireMetadata_t : bool {
 /// IRGenModules - one for each LLVM module (= one for each input/output file).
 class IRGenerator {
 public:
-  IRGenOptions &Opts;
+  const IRGenOptions &Opts;
 
   SILModule &SIL;
 
@@ -298,7 +298,7 @@ private:
   
   friend class CurrentIGMPtr;  
 public:
-  explicit IRGenerator(IRGenOptions &opts, SILModule &module);
+  explicit IRGenerator(const IRGenOptions &opts, SILModule &module);
 
   /// Attempt to create an llvm::TargetMachine for the current target.
   std::unique_ptr<llvm::TargetMachine> createTargetMachine();

--- a/lib/IRGen/TypeLayoutDumper.cpp
+++ b/lib/IRGen/TypeLayoutDumper.cpp
@@ -152,7 +152,7 @@ void TypeLayoutDumper::write(ArrayRef<ModuleDecl *> AllModules,
   }
 }
 
-bool swift::performDumpTypeInfo(IRGenOptions &Opts,
+bool swift::performDumpTypeInfo(const IRGenOptions &Opts,
                                 SILModule &SILMod,
                                 llvm::LLVMContext &LLVMContext) {
   auto &Ctx = SILMod.getASTContext();

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -304,7 +304,7 @@ int swift::RunImmediately(CompilerInstance &CI,
   std::string Triple;
   std::vector<std::string> Features;
   std::tie(TargetOpt, CPU, Features, Triple)
-    = getIRTargetOptions(swiftModule->getASTContext());
+    = getIRTargetOptions(IRGenOpts, swiftModule->getASTContext());
   builder.setRelocationModel(llvm::Reloc::PIC_);
   builder.setTargetOptions(TargetOpt);
   builder.setMCPU(CPU);

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -301,7 +301,7 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   std::string Triple;
   std::vector<std::string> Features;
   std::tie(TargetOpt, CPU, Features, Triple)
-    = getIRTargetOptions(IRGenOpts, swiftModule->getASTContext());
+    = getIRTargetOptions(swiftModule->getASTContext());
   builder.setRelocationModel(llvm::Reloc::PIC_);
   builder.setTargetOptions(TargetOpt);
   builder.setMCPU(CPU);

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -220,7 +220,7 @@ bool swift::immediate::linkLLVMModules(llvm::Module *Module,
 }
 
 bool swift::immediate::autolinkImportedModules(ModuleDecl *M,
-                                               IRGenOptions &IRGenOpts) {
+                                               const IRGenOptions &IRGenOpts) {
   // Perform autolinking.
   SmallVector<LinkLibrary, 4> AllLinkLibraries(IRGenOpts.LinkLibraries);
   auto addLinkLibrary = [&](LinkLibrary linkLib) {
@@ -234,8 +234,10 @@ bool swift::immediate::autolinkImportedModules(ModuleDecl *M,
   return false;
 }
 
-int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
-                          IRGenOptions &IRGenOpts, const SILOptions &SILOpts) {
+int swift::RunImmediately(CompilerInstance &CI,
+                          const ProcessCmdLine &CmdLine,
+                          const IRGenOptions &IRGenOpts,
+                          const SILOptions &SILOpts) {
   ASTContext &Context = CI.getASTContext();
   
   // IRGen the main module.

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -237,7 +237,8 @@ bool swift::immediate::autolinkImportedModules(ModuleDecl *M,
 int swift::RunImmediately(CompilerInstance &CI,
                           const ProcessCmdLine &CmdLine,
                           const IRGenOptions &IRGenOpts,
-                          const SILOptions &SILOpts) {
+                          const SILOptions &SILOpts,
+                          std::unique_ptr<SILModule> &&SM) {
   ASTContext &Context = CI.getASTContext();
   
   // IRGen the main module.
@@ -246,7 +247,7 @@ int swift::RunImmediately(CompilerInstance &CI,
   // FIXME: We shouldn't need to use the global context here, but
   // something is persisting across calls to performIRGeneration.
   auto ModuleOwner = performIRGeneration(
-      IRGenOpts, swiftModule, CI.takeSILModule(), swiftModule->getName().str(),
+      IRGenOpts, swiftModule, std::move(SM), swiftModule->getName().str(),
       PSPs, getGlobalLLVMContext(), ArrayRef<std::string>());
   auto *Module = ModuleOwner.get();
 

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -44,7 +44,7 @@ bool tryLoadLibraries(ArrayRef<LinkLibrary> LinkLibraries,
                       DiagnosticEngine &Diags);
 bool linkLLVMModules(llvm::Module *Module,
                      std::unique_ptr<llvm::Module> SubModule);
-bool autolinkImportedModules(ModuleDecl *M, IRGenOptions &IRGenOpts);
+bool autolinkImportedModules(ModuleDecl *M, const IRGenOptions &IRGenOpts);
 
 } // end namespace immediate
 } // end namespace swift

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -984,7 +984,7 @@ public:
     std::string Triple;
     std::vector<std::string> Features;
     std::tie(TargetOpt, CPU, Features, Triple)
-      = getIRTargetOptions(IRGenOpts, CI.getASTContext());
+      = getIRTargetOptions(CI.getASTContext());
     
     builder.setRelocationModel(llvm::Reloc::PIC_);
     builder.setTargetOptions(TargetOpt);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -984,7 +984,7 @@ public:
     std::string Triple;
     std::vector<std::string> Features;
     std::tie(TargetOpt, CPU, Features, Triple)
-      = getIRTargetOptions(CI.getASTContext());
+      = getIRTargetOptions(IRGenOpts, CI.getASTContext());
     
     builder.setRelocationModel(llvm::Reloc::PIC_);
     builder.setTargetOptions(TargetOpt);

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -59,7 +59,7 @@ namespace {
 
 /// A "minimal" class for querying IRGen.
 struct IRGenContext {
-  IRGenOptions IROpts;
+  const IRGenOptions IROpts;
   SILOptions SILOpts;
   Lowering::TypeConverter TC;
   std::unique_ptr<SILModule> SILMod;

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -90,7 +90,7 @@ class SILModule::SerializationCallback final
 };
 
 SILModule::SILModule(ModuleDecl *SwiftModule, TypeConverter &TC,
-                     SILOptions &Options, const DeclContext *associatedDC,
+                     const SILOptions &Options, const DeclContext *associatedDC,
                      bool wholeModule)
     : TheSwiftModule(SwiftModule),
       AssociatedDeclContext(associatedDC),
@@ -120,7 +120,7 @@ SILModule::~SILModule() {
 }
 
 std::unique_ptr<SILModule>
-SILModule::createEmptyModule(ModuleDecl *M, TypeConverter &TC, SILOptions &Options,
+SILModule::createEmptyModule(ModuleDecl *M, TypeConverter &TC, const SILOptions &Options,
                              bool WholeModule) {
   return std::unique_ptr<SILModule>(
       new SILModule(M, TC, Options, M, WholeModule));

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1691,7 +1691,7 @@ void SILGenModule::emitSourceFile(SourceFile *sf) {
 
 std::unique_ptr<SILModule>
 SILModule::constructSIL(ModuleDecl *mod, TypeConverter &tc,
-                        SILOptions &options, FileUnit *SF) {
+                        const SILOptions &options, FileUnit *SF) {
   FrontendStatsTracer tracer(mod->getASTContext().Stats, "SILGen");
   const DeclContext *DC;
   if (SF) {
@@ -1751,12 +1751,12 @@ SILModule::constructSIL(ModuleDecl *mod, TypeConverter &tc,
 
 std::unique_ptr<SILModule>
 swift::performSILGeneration(ModuleDecl *mod, Lowering::TypeConverter &tc,
-                            SILOptions &options) {
+                            const SILOptions &options) {
   return SILModule::constructSIL(mod, tc, options, nullptr);
 }
 
 std::unique_ptr<SILModule>
 swift::performSILGeneration(FileUnit &sf, Lowering::TypeConverter &tc,
-                            SILOptions &options) {
+                            const SILOptions &options) {
   return SILModule::constructSIL(sf.getParentModule(), tc, options, &sf);
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -49,15 +49,15 @@ using namespace Lowering;
 
 SILGenModule::SILGenModule(SILModule &M, ModuleDecl *SM)
     : M(M), Types(M.Types), SwiftModule(SM), TopLevelSGF(nullptr) {
-  SILOptions &Opts = M.getOptions();
+  const SILOptions &Opts = M.getOptions();
   if (!Opts.UseProfile.empty()) {
     auto ReaderOrErr = llvm::IndexedInstrProfReader::create(Opts.UseProfile);
     if (auto E = ReaderOrErr.takeError()) {
       diagnose(SourceLoc(), diag::profile_read_error, Opts.UseProfile,
                llvm::toString(std::move(E)));
-      Opts.UseProfile.erase();
+    } else {
+      M.setPGOReader(std::move(ReaderOrErr.get()));
     }
-    M.setPGOReader(std::move(ReaderOrErr.get()));
   }
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -492,7 +492,7 @@ public:
   SILFunction &getFunction() { return F; }
   SILModule &getModule() { return F.getModule(); }
   SILGenBuilder &getBuilder() { return B; }
-  SILOptions &getOptions() { return getModule().getOptions(); }
+  const SILOptions &getOptions() { return getModule().getOptions(); }
 
   // Returns the type expansion context for types in this function.
   TypeExpansionContext getTypeExpansionContext() {

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -450,7 +450,7 @@ int main(int argc, char **argv) {
       auto T = irgen::createIRGenModule(
           SILMod, Invocation.getOutputFilenameForAtMostOnePrimary(),
           Invocation.getMainInputFilenameForDebugInfoForAtMostOnePrimary(),
-          getGlobalLLVMContext());
+          "", getGlobalLLVMContext());
       runCommandLineSelectedPasses(SILMod, T.second);
       irgen::deleteIRGenModule(T);
     }


### PR DESCRIPTION
Const-qualify a bunch of frontend-related data structures like the compiler instance, compiler invocation, and frontend options wherever as much as possible. This entailed pushing state callers would previously mutate down as parameters.

Goes a long way towards rdar://57122646