### PR TITLE
fix tensorflow toolchain compilation on mac

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -43,7 +43,7 @@ using namespace swift;
 // SWIFT_ENABLE_TENSORFLOW
 static llvm::cl::opt<bool> EnableExperimentalCrossFileDerivativeRegistration(
     "enable-experimental-cross-file-derivative-registration",
-    llvm::cl::init(false));
+    llvm::cl::init(false), llvm::cl::ZeroOrMore);
 
 namespace {
   /// This emits a diagnostic with a fixit to remove the attribute.


### PR DESCRIPTION
https://github.com/apple/swift/pull/29137 didn't completely fix toolchain compilation -- it still fails with this while compiling swiftpm:
```
error: manifest parse error(s):
swift (LLVM option parsing): for the --enable-experimental-cross-file-derivative-registration option: may only occur zero or one times!
```

I wasn't able to easily figure out why there are multiple occurrences of the flag, but we can make the problem go away by allowing multiple occurrences.

I have confirmed that the toolchain builds successfully on my mac after this patch.