### PR TITLE
Optimize getter keypath patterns

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -263,7 +263,6 @@ static SILValue createKeypathStoredPropertyProjections(SILValue addr,
 
 static SILValue createKeypathGettablePropertyProjections(KeyPathInst *keyPath,
                                                          SILValue addr,
-                                                         SILValue valueAddr,
                                                        SILLocation loc,
                                                        BeginAccessInst *&beginAccess,
                                                        SILBuilder &builder,
@@ -304,7 +303,6 @@ static SILValue createKeypathGettablePropertyProjections(KeyPathInst *keyPath,
 /// Returns false if \p keyPath is not a keypath instruction or if there is any
 /// other reason why the optimization cannot be done.
 static SILValue createKeypathProjections(SILValue keyPath, SILValue root,
-                                         SILValue valueAddr,
                                          SILLocation loc,
                                          BeginAccessInst *&beginAccess,
                                          SILBuilder &builder) {
@@ -328,8 +326,7 @@ static SILValue createKeypathProjections(SILValue keyPath, SILValue root,
         break;
       case KeyPathPatternComponent::Kind::GettableProperty:
         addr = createKeypathGettablePropertyProjections(cast<KeyPathInst>(keyPath),
-                                                        addr, valueAddr,
-                                                        loc, beginAccess,
+                                                        addr, loc, beginAccess,
                                                         builder, comp);
         break;
       default:
@@ -374,7 +371,7 @@ bool SILCombiner::tryOptimizeKeypath(ApplyInst *AI) {
   }
 
   BeginAccessInst *beginAccess = nullptr;
-  SILValue projectedAddr = createKeypathProjections(keyPath, rootAddr, valueAddr,
+  SILValue projectedAddr = createKeypathProjections(keyPath, rootAddr,
                                                     AI->getLoc(), beginAccess,
                                                     Builder);
   if (!projectedAddr)

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -434,7 +434,7 @@ bool SILCombiner::tryOptimizeInoutKeypath(BeginApplyInst *AI) {
 
   BeginAccessInst *beginAccess = nullptr;
   SILValue projectedAddr = createKeypathProjections(
-      keyPath, rootAddr, nullptr, AI->getLoc(), beginAccess, Builder);
+      keyPath, rootAddr, AI->getLoc(), beginAccess, Builder);
   if (!projectedAddr)
     return false;
 

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -309,4 +309,45 @@ print("SimpleClass obj count: \(SimpleClass.numObjs)")
 // CHECK-OUTPUT: GenClass obj count: 0
 print("GenClass obj count: \(numGenClassObjs)")
 
+// Optimize subscript getter
+
+struct Sub {
+  public let x : Int
+  public subscript(y: Int, z: Int) -> Int { return x + y + z }
+  public subscript(y: Int) -> Int { return x + y }
+  public subscript() -> Int { return x }
+}
+
+// CHECK-LABEL: sil {{.*}}test_subscript_1
+// CHECK: bb0:
+// CHECK-NEXT: integer_literal $Builtin.Int64, 42
+// CHECK-NEXT: struct
+// CHECK-NEXT: return
+public func test_subscript_1() -> Int {
+  let v = Sub(x: 40)
+  let xKeyPath = \Sub.[1, 1]
+  return v[keyPath: xKeyPath]
+}
+
+// CHECK-LABEL: sil {{.*}}test_subscript_2
+// CHECK: bb0:
+// CHECK-NEXT: integer_literal $Builtin.Int64, 42
+// CHECK-NEXT: struct
+// CHECK-NEXT: return
+public func test_subscript_2() -> Int {
+  let v = Sub(x: 40)
+  let xKeyPath = \Sub.[2]
+  return v[keyPath: xKeyPath]
+}
+
+// CHECK-LABEL: sil {{.*}}test_subscript_3
+// CHECK: bb0:
+// CHECK-NEXT: integer_literal $Builtin.Int64, 42
+// CHECK-NEXT: struct
+// CHECK-NEXT: return
+public func test_subscript_3() -> Int {
+  let v = Sub(x: 42)
+  let xKeyPath = \Sub.[]
+  return v[keyPath: xKeyPath]
+}
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch reworks the `createKeypathProjections` function so that it can handle multiple kinds of keypath components. It also adds support for projecting getter keypaths (i.e. subscripts). 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->