### PR TITLE
[silargument] Centralize creation logic on SILBasicBlock and add a helper macro to define the external interface functions to make it easier to add new arguments and avoid writing boilerplate.

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -15,6 +15,7 @@
 
 #include "swift/Basic/Compiler.h"
 #include "swift/SIL/SILArgumentConvention.h"
+#include "swift/SIL/SILArgumentKind.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILValue.h"
 
@@ -36,30 +37,6 @@ SILFunctionConventions::getSILArgumentConvention(unsigned index) const {
     return SILArgumentConvention(param.getConvention());
   }
 }
-
-struct SILArgumentKind {
-  enum innerty : std::underlying_type<ValueKind>::type {
-#define ARGUMENT(ID, PARENT) ID = unsigned(SILNodeKind::ID),
-#define ARGUMENT_RANGE(ID, FIRST, LAST) First_##ID = FIRST, Last_##ID = LAST,
-#include "swift/SIL/SILNodes.def"
-  } value;
-
-  explicit SILArgumentKind(ValueKind kind)
-      : value(*SILArgumentKind::fromValueKind(kind)) {}
-  SILArgumentKind(innerty value) : value(value) {}
-  operator innerty() const { return value; }
-
-  static Optional<SILArgumentKind> fromValueKind(ValueKind kind) {
-    switch (kind) {
-#define ARGUMENT(ID, PARENT)                                                   \
-  case ValueKind::ID:                                                          \
-    return SILArgumentKind(ID);
-#include "swift/SIL/SILNodes.def"
-    default:
-      return None;
-    }
-  }
-};
 
 class SILArgument : public ValueBase {
   friend class SILBasicBlock;

--- a/include/swift/SIL/SILArgumentKind.h
+++ b/include/swift/SIL/SILArgumentKind.h
@@ -1,0 +1,46 @@
+//===--- SILArgumentKind.h ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILARGUMENTKIND_H
+#define SWIFT_SIL_SILARGUMENTKIND_H
+
+#include "swift/SIL/SILValue.h"
+
+namespace swift {
+
+struct SILArgumentKind {
+  enum innerty : std::underlying_type<ValueKind>::type {
+#define ARGUMENT(ID, PARENT) ID = unsigned(SILNodeKind::ID),
+#define ARGUMENT_RANGE(ID, FIRST, LAST) First_##ID = FIRST, Last_##ID = LAST,
+#include "swift/SIL/SILNodes.def"
+  } value;
+
+  explicit SILArgumentKind(ValueKind kind)
+      : value(*SILArgumentKind::fromValueKind(kind)) {}
+  SILArgumentKind(innerty value) : value(value) {}
+  operator innerty() const { return value; }
+
+  static Optional<SILArgumentKind> fromValueKind(ValueKind kind) {
+    switch (kind) {
+#define ARGUMENT(ID, PARENT)                                                   \
+  case ValueKind::ID:                                                          \
+    return SILArgumentKind(ID);
+#include "swift/SIL/SILNodes.def"
+    default:
+      return None;
+    }
+  }
+};
+
+} // namespace swift
+
+#endif


### PR DESCRIPTION
I am currently working on adding some new SIL arguments so that:

1. We can distinguish in between true Phi arguments and the result arguments of
   SwitchEnum, CheckedCastBr. This is just semantic goodness.
2. Suppress insertion of end_borrows on the results of SwitchEnum,
   CheckedCastBr.

This will just make my job easier.
