### PR TITLE
Allow function builder attrs on vars without bodies in interfaces

### DIFF
--- a/test/ModuleInterface/function_builders.swift
+++ b/test/ModuleInterface/function_builders.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -typecheck -module-name FunctionBuilders -emit-module-interface-path %t/FunctionBuilders.swiftinterface %s
 // RUN: %FileCheck %s < %t/FunctionBuilders.swiftinterface
 // RUN: %target-swift-frontend -I %t -typecheck -verify %S/Inputs/function_builders_client.swift
+// RUN: %target-swift-frontend -compile-module-from-interface %t/FunctionBuilders.swiftinterface -o %t/FunctionBuilders.swiftmodule
 
 @_functionBuilder
 public struct TupleBuilder {
@@ -32,4 +33,14 @@ public struct TupleBuilder {
 // CHECK-LABEL: public func tuplify<T>(_ cond: Swift.Bool, @FunctionBuilders.TupleBuilder body: (Swift.Bool) -> T)
 public func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
   print(body(cond))
+}
+
+public struct UsesBuilderProperty {
+  // CHECK: @FunctionBuilders.TupleBuilder public var myVar: (Swift.String, Swift.String) {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: }
+  @TupleBuilder public var myVar: (String, String) {
+    "hello"
+    "goodbye"
+  }
 }


### PR DESCRIPTION
The check for whether or not we can use a function builder on a property
checked whether the attached getter had a body, which is not always true for
module interfaces. Just disable that part of the check when compiling a
module interface.

rdar://58535753