### PR TITLE
[Diagnostics] Port diagnostics for array/dictionary literals

### DIFF
--- a/docs/TypeChecker.rst
+++ b/docs/TypeChecker.rst
@@ -992,4 +992,3 @@ The things in the queue yet to be ported are:
   - ``diagnoseParameterErrors``
   - ``diagnoseSimpleErrors``
 
-- Diagnostics related to array/dictionary literals: ``visit{Array, Dictionary}Expr``.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -670,6 +670,12 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
       break;
     }
 
+    case ConstraintLocator::TupleElement: {
+      if (auto *array = dyn_cast<ArrayExpr>(getRawAnchor()))
+        diagnostic = getDiagnosticFor(CTP_ArrayElement);
+      break;
+    }
+
     default:
       return false;
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -671,10 +671,11 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
     }
 
     case ConstraintLocator::TupleElement: {
-      if (auto *array = dyn_cast<ArrayExpr>(getRawAnchor()))
-        diagnostic = getDiagnosticFor(CTP_ArrayElement);
+      auto *anchor = getRawAnchor();
 
-      if (auto *dict = dyn_cast<DictionaryExpr>(getRawAnchor())) {
+      if (isa<ArrayExpr>(anchor)) {
+        diagnostic = getDiagnosticFor(CTP_ArrayElement);
+      } else if (isa<DictionaryExpr>(anchor)) {
         auto eltLoc = last.castTo<LocatorPathElt::TupleElement>();
         diagnostic = getDiagnosticFor(
             eltLoc.getIndex() == 0 ? CTP_DictionaryKey : CTP_DictionaryValue);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -673,6 +673,12 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
     case ConstraintLocator::TupleElement: {
       if (auto *array = dyn_cast<ArrayExpr>(getRawAnchor()))
         diagnostic = getDiagnosticFor(CTP_ArrayElement);
+
+      if (auto *dict = dyn_cast<DictionaryExpr>(getRawAnchor())) {
+        auto eltLoc = last.castTo<LocatorPathElt::TupleElement>();
+        diagnostic = getDiagnosticFor(
+            eltLoc.getIndex() == 0 ? CTP_DictionaryKey : CTP_DictionaryValue);
+      }
       break;
     }
 

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -835,3 +835,14 @@ func sr_11491(_ value: [String]) {
   arr.insert(value)
   // expected-error@-1 {{cannot convert value of type '[String]' to expected argument type 'String'}}
 }
+
+func test_dictionary_with_generic_mismatch_in_key_or_value() {
+  struct S<T> : Hashable {}
+  // expected-note@-1 2 {{arguments to generic parameter 'T' ('Int' and 'Bool') are expected to be equal}}
+
+  let _: [Int: S<Bool>] = [0: S<Bool>(), 1: S<Int>()]
+  // expected-error@-1 {{cannot convert value of type 'S<Int>' to expected dictionary value type 'S<Bool>'}}
+
+  let _: [S<Bool>: Int] = [S<Int>(): 42]
+  // expected-error@-1 {{cannot convert value of type 'S<Int>' to expected dictionary key type 'S<Bool>'}}
+}


### PR DESCRIPTION
`CollectionElementContextualMismatch` covers almost all of the related diagnostics
already with a single exception - generic argument mismatches which has been "fixed"
already just didn't have a diagnostic support.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
