### PR TITLE
[parse-sil] Refactor huge per op code parsing switch into its own method.

### DIFF
--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -454,6 +454,10 @@ namespace {
     bool parseScopeRef(SILDebugScope *&DS);
     bool parseSILDebugLocation(SILLocation &L, SILBuilder &B,
                                bool parsedComma = false);
+    bool parseSpecificSILInstruction(SILBuilder &B, SILInstructionKind Opcode,
+                                     SourceLoc OpcodeLoc, StringRef OpcodeName,
+                                     SILInstruction *&ResultVal);
+
     bool parseSILInstruction(SILBuilder &B);
     bool parseCallInstruction(SILLocation InstLoc,
                               SILInstructionKind Opcode, SILBuilder &B,
@@ -2357,67 +2361,11 @@ SILParser::parseKeyPathPatternComponent(KeyPathPatternComponent &component,
   }
 }
 
-/// sil-instruction-result ::= sil-value-name '='
-/// sil-instruction-result ::= '(' sil-value-name? ')'
-/// sil-instruction-result ::= '(' sil-value-name (',' sil-value-name)* ')'
-/// sil-instruction-source-info ::= (',' sil-scope-ref)? (',' sil-loc)?
-/// sil-instruction-def ::=
-///   (sil-instruction-result '=')? sil-instruction sil-instruction-source-info
-bool SILParser::parseSILInstruction(SILBuilder &B) {
-  // We require SIL instructions to be at the start of a line to assist
-  // recovery.
-  if (!P.Tok.isAtStartOfLine()) {
-    P.diagnose(P.Tok, diag::expected_sil_instr_start_of_line);
-    return true;
-  }
-
-  SmallVector<Located<StringRef>, 4> resultNames;
-  SourceLoc resultClauseBegin;
-
-  // If the instruction has a name '%foo =', parse it.
-  if (P.Tok.is(tok::sil_local_name)) {
-    resultClauseBegin = P.Tok.getLoc();
-    resultNames.push_back({P.Tok.getText(), P.Tok.getLoc()});
-    P.consumeToken(tok::sil_local_name);
-
-  // If the instruction has a '(%foo, %bar) = ', parse it.
-  } else if (P.consumeIf(tok::l_paren)) {
-    resultClauseBegin = P.PreviousLoc;
-
-    if (!P.consumeIf(tok::r_paren)) {
-      while (true) {
-        if (!P.Tok.is(tok::sil_local_name)) {
-          P.diagnose(P.Tok, diag::expected_sil_value_name);
-          return true;
-        }
-
-        resultNames.push_back({P.Tok.getText(), P.Tok.getLoc()});
-        P.consumeToken(tok::sil_local_name);
-
-        if (P.consumeIf(tok::comma))
-          continue;
-        if (P.consumeIf(tok::r_paren))
-          break;
-
-        P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, ",");
-        return true;
-      }
-    }
-  }
-
-  if (resultClauseBegin.isValid()) {
-    if (P.parseToken(tok::equal, diag::expected_equal_in_sil_instr))
-      return true;
-  }
-
-  SILInstructionKind Opcode;
-  SourceLoc OpcodeLoc;
-  StringRef OpcodeName;
-  
-  // Parse the opcode name.
-  if (parseSILOpcode(Opcode, OpcodeLoc, OpcodeName))
-    return true;
-
+bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
+                                            SILInstructionKind Opcode,
+                                            SourceLoc OpcodeLoc,
+                                            StringRef OpcodeName,
+                                            SILInstruction *&ResultVal) {
   SmallVector<SILValue, 4> OpList;
   SILValue Val;
   SILType Ty;
@@ -2457,26 +2405,25 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   CanType SourceType, TargetType;
   SILValue SourceAddr, DestAddr;
   auto parseSourceAndDestAddress = [&] {
-    return parseFormalTypeAndValue(SourceType, SourceAddr)
-           || parseVerbatim("to")
-           || parseFormalTypeAndValue(TargetType, DestAddr);
+    return parseFormalTypeAndValue(SourceType, SourceAddr) ||
+           parseVerbatim("to") || parseFormalTypeAndValue(TargetType, DestAddr);
   };
 
   Identifier SuccessBBName, FailureBBName;
   SourceLoc SuccessBBLoc, FailureBBLoc;
   auto parseConditionalBranchDestinations = [&] {
-    return P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",")
-           || parseSILIdentifier(SuccessBBName, SuccessBBLoc,
-                                 diag::expected_sil_block_name)
-           || P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",")
-           || parseSILIdentifier(FailureBBName, FailureBBLoc,
-                                 diag::expected_sil_block_name)
-           || parseSILDebugLocation(InstLoc, B);
+    return P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+           parseSILIdentifier(SuccessBBName, SuccessBBLoc,
+                              diag::expected_sil_block_name) ||
+           P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+           parseSILIdentifier(FailureBBName, FailureBBLoc,
+                              diag::expected_sil_block_name) ||
+           parseSILDebugLocation(InstLoc, B);
   };
 
   // Validate the opcode name, and do opcode-specific parsing logic based on the
   // opcode we find.
-  SILInstruction *ResultVal;
+
   switch (Opcode) {
   case SILInstructionKind::AllocBoxInst: {
     bool hasDynamicLifetime = false;
@@ -2484,7 +2431,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       return true;
 
     SILType Ty;
-    if (parseSILType(Ty)) return true;
+    if (parseSILType(Ty))
+      return true;
     SILDebugVariable VarInfo;
     if (parseSILDebugVar(VarInfo))
       return true;
@@ -2504,7 +2452,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   case SILInstructionKind::AbortApplyInst:
   case SILInstructionKind::EndApplyInst: {
     UnresolvedValueName argName;
-    if (parseValueName(argName)) return true;
+    if (parseValueName(argName))
+      return true;
 
     if (parseSILDebugLocation(InstLoc, B))
       return true;
@@ -2524,7 +2473,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     if (parseSILType(Ty) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
       return true;
-    
+
     bool Negative = false;
     if (P.Tok.isAnyOperator() && P.Tok.getText() == "-") {
       Negative = true;
@@ -2534,7 +2483,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "integer");
       return true;
     }
-    
+
     auto intTy = Ty.getAs<AnyBuiltinIntegerType>();
     if (!intTy) {
       P.diagnose(P.Tok, diag::sil_integer_literal_not_integer_type);
@@ -2561,13 +2510,13 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     if (parseSILType(Ty) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
       return true;
-   
+
     // The value is expressed as bits.
     if (P.Tok.getKind() != tok::integer_literal) {
       P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "integer");
       return true;
     }
-    
+
     auto floatTy = Ty.getAs<BuiltinFloatType>();
     if (!floatTy) {
       P.diagnose(P.Tok, diag::sil_float_literal_not_float_type);
@@ -2575,15 +2524,15 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     }
 
     StringRef text = prepareIntegerLiteralForParsing(P.Tok.getText());
-    
+
     APInt bits(floatTy->getBitWidth(), 0);
     bool error = text.getAsInteger(0, bits);
     assert(!error && "float_literal token did not parse as APInt?!");
     (void)error;
-    
+
     if (bits.getBitWidth() != floatTy->getBitWidth())
       bits = bits.zextOrTrunc(floatTy->getBitWidth());
-    
+
     APFloat value(floatTy->getAPFloatSemantics(), bits);
     if (parseSILDebugLocation(InstLoc, B))
       return true;
@@ -2654,8 +2603,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       break;
     }
 
-    StringRef string = P.L->getEncodedStringSegment(segments.front(),
-                                                    stringBuffer);
+    StringRef string =
+        P.L->getEncodedStringSegment(segments.front(), stringBuffer);
     ResultVal = B.createStringLiteral(InstLoc, string, encoding);
     break;
   }
@@ -2689,9 +2638,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
 
   case SILInstructionKind::AllocValueBufferInst: {
     SILType Ty;
-    if (parseSILType(Ty) ||
-        parseVerbatim("in") ||
-        parseTypedValueRef(Val, B) ||
+    if (parseSILType(Ty) || parseVerbatim("in") || parseTypedValueRef(Val, B) ||
         parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createAllocValueBuffer(InstLoc, Ty, Val);
@@ -2699,9 +2646,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   }
   case SILInstructionKind::ProjectValueBufferInst: {
     SILType Ty;
-    if (parseSILType(Ty) ||
-        parseVerbatim("in") ||
-        parseTypedValueRef(Val, B) ||
+    if (parseSILType(Ty) || parseVerbatim("in") || parseTypedValueRef(Val, B) ||
         parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createProjectValueBuffer(InstLoc, Ty, Val);
@@ -2709,9 +2654,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   }
   case SILInstructionKind::DeallocValueBufferInst: {
     SILType Ty;
-    if (parseSILType(Ty) ||
-        parseVerbatim("in") ||
-        parseTypedValueRef(Val, B) ||
+    if (parseSILType(Ty) || parseVerbatim("in") || parseTypedValueRef(Val, B) ||
         parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createDeallocValueBuffer(InstLoc, Ty, Val);
@@ -2722,12 +2665,12 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     if (parseTypedValueRef(Val, B) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
       return true;
-    
+
     if (!P.Tok.is(tok::integer_literal)) {
       P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "integer");
       return true;
     }
-    
+
     unsigned Index;
     bool error = parseIntegerLiteral(P.Tok.getText(), 0, Index);
     assert(!error && "project_box index did not parse as integer?!");
@@ -2736,34 +2679,30 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     P.consumeToken(tok::integer_literal);
     if (parseSILDebugLocation(InstLoc, B))
       return true;
-    
+
     ResultVal = B.createProjectBox(InstLoc, Val, Index);
     break;
   }
-      
+
   case SILInstructionKind::ProjectExistentialBoxInst: {
     SILType Ty;
-    if (parseSILType(Ty) ||
-        parseVerbatim("in") ||
-        parseTypedValueRef(Val, B) ||
+    if (parseSILType(Ty) || parseVerbatim("in") || parseTypedValueRef(Val, B) ||
         parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createProjectExistentialBox(InstLoc, Ty, Val);
     break;
   }
-      
+
   case SILInstructionKind::FunctionRefInst: {
     SILFunction *Fn;
-    if (parseSILFunctionRef(InstLoc, Fn) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseSILFunctionRef(InstLoc, Fn) || parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createFunctionRef(InstLoc, Fn);
     break;
   }
   case SILInstructionKind::DynamicFunctionRefInst: {
     SILFunction *Fn;
-    if (parseSILFunctionRef(InstLoc, Fn) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseSILFunctionRef(InstLoc, Fn) || parseSILDebugLocation(InstLoc, B))
       return true;
     // Set a forward reference's dynamic property for the first time.
     if (!Fn->isDynamicallyReplaceable()) {
@@ -2778,40 +2717,38 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   }
   case SILInstructionKind::PreviousDynamicFunctionRefInst: {
     SILFunction *Fn;
-    if (parseSILFunctionRef(InstLoc, Fn) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseSILFunctionRef(InstLoc, Fn) || parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createPreviousDynamicFunctionRef(InstLoc, Fn);
     break;
   }
   case SILInstructionKind::BuiltinInst: {
     if (P.Tok.getKind() != tok::string_literal) {
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr,"builtin name");
+      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "builtin name");
       return true;
     }
     StringRef Str = P.Tok.getText();
-    Identifier Id = P.Context.getIdentifier(Str.substr(1, Str.size()-2));
+    Identifier Id = P.Context.getIdentifier(Str.substr(1, Str.size() - 2));
     P.consumeToken(tok::string_literal);
-    
+
     // Find the builtin in the Builtin module
-    SmallVector<ValueDecl*, 2> foundBuiltins;
-    P.Context.TheBuiltinModule->lookupMember(foundBuiltins,
-                                             P.Context.TheBuiltinModule, Id,
-                                             Identifier());
+    SmallVector<ValueDecl *, 2> foundBuiltins;
+    P.Context.TheBuiltinModule->lookupMember(
+        foundBuiltins, P.Context.TheBuiltinModule, Id, Identifier());
     if (foundBuiltins.empty()) {
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr,"builtin name");
+      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "builtin name");
       return true;
     }
     assert(foundBuiltins.size() == 1 && "ambiguous builtin name?!");
 
     auto *builtinFunc = cast<FuncDecl>(foundBuiltins[0]);
     GenericEnvironment *genericEnv = builtinFunc->getGenericEnvironment();
-    
+
     SmallVector<ParsedSubstitution, 4> parsedSubs;
     SubstitutionMap subMap;
     if (parseSubstitutions(parsedSubs))
       return true;
-    
+
     if (!parsedSubs.empty()) {
       if (!genericEnv) {
         P.diagnose(P.Tok, diag::sil_substitutions_on_non_polymorphic_type);
@@ -2821,7 +2758,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       if (!subMap)
         return true;
     }
-    
+
     if (P.Tok.getKind() != tok::l_paren) {
       P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "(");
       return true;
@@ -2844,76 +2781,78 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, ")' or ',");
       return true;
     }
-    
+
     if (P.Tok.getKind() != tok::colon) {
       P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, ":");
       return true;
     }
     P.consumeToken(tok::colon);
-    
+
     SILType ResultTy;
     if (parseSILType(ResultTy))
       return true;
-    
+
     if (parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createBuiltin(InstLoc, Id, ResultTy, subMap, Args);
     break;
   }
   case SILInstructionKind::OpenExistentialAddrInst:
-    if (parseOpenExistAddrKind() || parseTypedValueRef(Val, B)
-        || parseVerbatim("to") || parseSILType(Ty)
-        || parseSILDebugLocation(InstLoc, B))
+    if (parseOpenExistAddrKind() || parseTypedValueRef(Val, B) ||
+        parseVerbatim("to") || parseSILType(Ty) ||
+        parseSILDebugLocation(InstLoc, B))
       return true;
 
     ResultVal = B.createOpenExistentialAddr(InstLoc, Val, Ty, AccessKind);
     break;
 
   case SILInstructionKind::OpenExistentialBoxInst:
-    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty)
-        || parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty) ||
+        parseSILDebugLocation(InstLoc, B))
       return true;
 
     ResultVal = B.createOpenExistentialBox(InstLoc, Val, Ty);
     break;
 
   case SILInstructionKind::OpenExistentialBoxValueInst:
-    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty)
-        || parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty) ||
+        parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createOpenExistentialBoxValue(InstLoc, Val, Ty);
     break;
 
   case SILInstructionKind::OpenExistentialMetatypeInst:
-    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty)
-        || parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty) ||
+        parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createOpenExistentialMetatype(InstLoc, Val, Ty);
     break;
 
   case SILInstructionKind::OpenExistentialRefInst:
-    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty)
-        || parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty) ||
+        parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createOpenExistentialRef(InstLoc, Val, Ty);
     break;
 
   case SILInstructionKind::OpenExistentialValueInst:
-    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty)
-        || parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseVerbatim("to") || parseSILType(Ty) ||
+        parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createOpenExistentialValue(InstLoc, Val, Ty);
     break;
 
-#define UNARY_INSTRUCTION(ID) \
-  case SILInstructionKind::ID##Inst:                   \
-    if (parseTypedValueRef(Val, B)) return true; \
-    if (parseSILDebugLocation(InstLoc, B)) return true; \
-    ResultVal = B.create##ID(InstLoc, Val);   \
+#define UNARY_INSTRUCTION(ID)                                                  \
+  case SILInstructionKind::ID##Inst:                                           \
+    if (parseTypedValueRef(Val, B))                                            \
+      return true;                                                             \
+    if (parseSILDebugLocation(InstLoc, B))                                     \
+      return true;                                                             \
+    ResultVal = B.create##ID(InstLoc, Val);                                    \
     break;
 
 #define REFCOUNTING_INSTRUCTION(ID)                                            \
-  case SILInstructionKind::ID##Inst: {                                                  \
+  case SILInstructionKind::ID##Inst: {                                         \
     Atomicity atomicity = Atomicity::Atomic;                                   \
     StringRef Optional;                                                        \
     if (parseSILOptional(Optional, *this)) {                                   \
@@ -2968,8 +2907,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     bool IsObjcVerifcationType = false;
     if (parseSILOptional(IsObjcVerifcationType, *this, "objc"))
       return true;
-    if (parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createIsEscapingClosure(
         InstLoc, Val,
@@ -2978,98 +2916,98 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     break;
   }
 
- case SILInstructionKind::DebugValueInst:
- case SILInstructionKind::DebugValueAddrInst: {
-   SILDebugVariable VarInfo;
-   if (parseTypedValueRef(Val, B) ||
-       parseSILDebugVar(VarInfo) ||
-       parseSILDebugLocation(InstLoc, B))
-     return true;
-   if (Opcode == SILInstructionKind::DebugValueInst)
-     ResultVal = B.createDebugValue(InstLoc, Val, VarInfo);
-   else
-     ResultVal = B.createDebugValueAddr(InstLoc, Val, VarInfo);
-   break;
- }
+  case SILInstructionKind::DebugValueInst:
+  case SILInstructionKind::DebugValueAddrInst: {
+    SILDebugVariable VarInfo;
+    if (parseTypedValueRef(Val, B) || parseSILDebugVar(VarInfo) ||
+        parseSILDebugLocation(InstLoc, B))
+      return true;
+    if (Opcode == SILInstructionKind::DebugValueInst)
+      ResultVal = B.createDebugValue(InstLoc, Val, VarInfo);
+    else
+      ResultVal = B.createDebugValueAddr(InstLoc, Val, VarInfo);
+    break;
+  }
 
- // unchecked_ownership_conversion <reg> : <type>, <ownership> to <ownership>
- case SILInstructionKind::UncheckedOwnershipConversionInst: {
-   ValueOwnershipKind LHSKind = ValueOwnershipKind::None;
-   ValueOwnershipKind RHSKind = ValueOwnershipKind::None;
-   SourceLoc Loc;
+    // unchecked_ownership_conversion <reg> : <type>, <ownership> to <ownership>
+  case SILInstructionKind::UncheckedOwnershipConversionInst: {
+    ValueOwnershipKind LHSKind = ValueOwnershipKind::None;
+    ValueOwnershipKind RHSKind = ValueOwnershipKind::None;
+    SourceLoc Loc;
 
-   if (parseTypedValueRef(Val, Loc, B) ||
-       P.parseToken(tok::comma, diag::expected_sil_colon,
-                    "unchecked_ownership_conversion value ownership kind "
-                    "conversion specification") ||
-       parseSILOwnership(LHSKind) || parseVerbatim("to") ||
-       parseSILOwnership(RHSKind) || parseSILDebugLocation(InstLoc, B)) {
-     return true;
-   }
+    if (parseTypedValueRef(Val, Loc, B) ||
+        P.parseToken(tok::comma, diag::expected_sil_colon,
+                     "unchecked_ownership_conversion value ownership kind "
+                     "conversion specification") ||
+        parseSILOwnership(LHSKind) || parseVerbatim("to") ||
+        parseSILOwnership(RHSKind) || parseSILDebugLocation(InstLoc, B)) {
+      return true;
+    }
 
-   if (Val.getOwnershipKind() != LHSKind) {
-     return true;
-   }
+    if (Val.getOwnershipKind() != LHSKind) {
+      return true;
+    }
 
-   ResultVal = B.createUncheckedOwnershipConversion(InstLoc, Val, RHSKind);
-   break;
- }
+    ResultVal = B.createUncheckedOwnershipConversion(InstLoc, Val, RHSKind);
+    break;
+  }
 
- case SILInstructionKind::LoadInst: {
-   LoadOwnershipQualifier Qualifier;
-   SourceLoc AddrLoc;
+  case SILInstructionKind::LoadInst: {
+    LoadOwnershipQualifier Qualifier;
+    SourceLoc AddrLoc;
 
-   if (parseLoadOwnershipQualifier(Qualifier, *this) ||
-       parseTypedValueRef(Val, AddrLoc, B) || parseSILDebugLocation(InstLoc, B))
-     return true;
+    if (parseLoadOwnershipQualifier(Qualifier, *this) ||
+        parseTypedValueRef(Val, AddrLoc, B) ||
+        parseSILDebugLocation(InstLoc, B))
+      return true;
 
-   ResultVal = B.createLoad(InstLoc, Val, Qualifier);
-   break;
- }
+    ResultVal = B.createLoad(InstLoc, Val, Qualifier);
+    break;
+  }
 
- case SILInstructionKind::LoadBorrowInst: {
-   SourceLoc AddrLoc;
+  case SILInstructionKind::LoadBorrowInst: {
+    SourceLoc AddrLoc;
 
-   if (parseTypedValueRef(Val, AddrLoc, B) || parseSILDebugLocation(InstLoc, B))
-     return true;
+    if (parseTypedValueRef(Val, AddrLoc, B) ||
+        parseSILDebugLocation(InstLoc, B))
+      return true;
 
-   ResultVal = B.createLoadBorrow(InstLoc, Val);
-   break;
- }
+    ResultVal = B.createLoadBorrow(InstLoc, Val);
+    break;
+  }
 
- case SILInstructionKind::BeginBorrowInst: {
-   SourceLoc AddrLoc;
+  case SILInstructionKind::BeginBorrowInst: {
+    SourceLoc AddrLoc;
 
-   if (parseTypedValueRef(Val, AddrLoc, B) || parseSILDebugLocation(InstLoc, B))
-     return true;
+    if (parseTypedValueRef(Val, AddrLoc, B) ||
+        parseSILDebugLocation(InstLoc, B))
+      return true;
 
-   ResultVal = B.createBeginBorrow(InstLoc, Val);
-   break;
- }
+    ResultVal = B.createBeginBorrow(InstLoc, Val);
+    break;
+  }
 
-#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  case SILInstructionKind::Load##Name##Inst: { \
-    bool isTake = false; \
-    SourceLoc addrLoc; \
-    if (parseSILOptional(isTake, *this, "take") || \
-        parseTypedValueRef(Val, addrLoc, B) || \
-        parseSILDebugLocation(InstLoc, B)) \
-      return true; \
-    if (!Val->getType().is<Name##StorageType>()) { \
-      P.diagnose(addrLoc, diag::sil_operand_not_ref_storage_address, \
-                 "source", OpcodeName, ReferenceOwnership::Name); \
-    } \
-    ResultVal = B.createLoad##Name(InstLoc, Val, IsTake_t(isTake)); \
-    break; \
+#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)             \
+  case SILInstructionKind::Load##Name##Inst: {                                 \
+    bool isTake = false;                                                       \
+    SourceLoc addrLoc;                                                         \
+    if (parseSILOptional(isTake, *this, "take") ||                             \
+        parseTypedValueRef(Val, addrLoc, B) ||                                 \
+        parseSILDebugLocation(InstLoc, B))                                     \
+      return true;                                                             \
+    if (!Val->getType().is<Name##StorageType>()) {                             \
+      P.diagnose(addrLoc, diag::sil_operand_not_ref_storage_address, "source", \
+                 OpcodeName, ReferenceOwnership::Name);                        \
+    }                                                                          \
+    ResultVal = B.createLoad##Name(InstLoc, Val, IsTake_t(isTake));            \
+    break;                                                                     \
   }
 #include "swift/AST/ReferenceStorage.def"
 
   case SILInstructionKind::CopyBlockWithoutEscapingInst: {
     SILValue Closure;
-    if (parseTypedValueRef(Val, B) ||
-        parseVerbatim("withoutEscaping") ||
-        parseTypedValueRef(Closure, B) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseVerbatim("withoutEscaping") ||
+        parseTypedValueRef(Closure, B) || parseSILDebugLocation(InstLoc, B))
       return true;
 
     ResultVal = B.createCopyBlockWithoutEscaping(InstLoc, Val, Closure);
@@ -3078,10 +3016,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
 
   case SILInstructionKind::MarkDependenceInst: {
     SILValue Base;
-    if (parseTypedValueRef(Val, B) ||
-        parseVerbatim("on") ||
-        parseTypedValueRef(Base, B) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseVerbatim("on") ||
+        parseTypedValueRef(Base, B) || parseSILDebugLocation(InstLoc, B))
       return true;
 
     ResultVal = B.createMarkDependence(InstLoc, Val, Base);
@@ -3091,8 +3027,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   case SILInstructionKind::KeyPathInst: {
     SmallVector<KeyPathPatternComponent, 4> components;
     SILType Ty;
-    if (parseSILType(Ty)
-        || P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
+    if (parseSILType(Ty) ||
+        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
       return true;
 
     GenericParamList *generics = nullptr;
@@ -3107,7 +3043,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
 
       if (P.parseToken(tok::l_paren, diag::expected_tok_in_sil_instr, "("))
         return true;
-      
+
       while (true) {
         Identifier componentKind;
         SourceLoc componentLoc;
@@ -3115,47 +3051,47 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
                                diag::sil_keypath_expected_component_kind))
           return true;
 
-        
         if (componentKind.str() == "root") {
-          if (P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$")
-              || parseASTType(rootType, patternEnv))
+          if (P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr,
+                           "$") ||
+              parseASTType(rootType, patternEnv))
             return true;
         } else if (componentKind.str() == "objc") {
           auto tok = P.Tok;
           if (P.parseToken(tok::string_literal, diag::expected_tok_in_sil_instr,
                            "string literal"))
             return true;
-          
+
           auto objcStringValue = tok.getText().drop_front().drop_back();
-          objcString = StringRef(
-            P.Context.AllocateCopy<char>(objcStringValue.begin(),
-                                         objcStringValue.end()),
-            objcStringValue.size());
+          objcString =
+              StringRef(P.Context.AllocateCopy<char>(objcStringValue.begin(),
+                                                     objcStringValue.end()),
+                        objcStringValue.size());
         } else {
           KeyPathPatternComponent component;
           if (parseKeyPathPatternComponent(component, operandTypes,
-                                           componentLoc, componentKind,
-                                           InstLoc, patternEnv))
+                                           componentLoc, componentKind, InstLoc,
+                                           patternEnv))
             return true;
           components.push_back(component);
         }
-        
+
         if (!P.consumeIf(tok::semi))
           break;
       }
-      
+
       if (P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")") ||
           parseSILDebugLocation(InstLoc, B))
         return true;
     }
-    
+
     if (rootType.isNull())
       P.diagnose(InstLoc.getSourceLoc(), diag::sil_keypath_no_root);
-    
+
     SmallVector<ParsedSubstitution, 4> parsedSubs;
     if (parseSubstitutions(parsedSubs, ContextGenericEnv))
       return true;
-    
+
     SubstitutionMap subMap;
     if (!parsedSubs.empty()) {
       if (!patternEnv) {
@@ -3168,26 +3104,26 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       if (!subMap)
         return true;
     }
-    
+
     SmallVector<SILValue, 4> operands;
-    
+
     if (P.consumeIf(tok::l_paren)) {
       while (true) {
         SILValue v;
-        
-        if (operands.size() >= operandTypes.size()
-            || !operandTypes[operands.size()]) {
+
+        if (operands.size() >= operandTypes.size() ||
+            !operandTypes[operands.size()]) {
           P.diagnose(P.Tok, diag::sil_keypath_no_use_of_operand_in_pattern,
                      operands.size());
           return true;
         }
-        
+
         auto ty = operandTypes[operands.size()].subst(SILMod, subMap);
-        
+
         if (parseValueRef(v, ty, RegularLocation(P.Tok.getLoc()), B))
           return true;
         operands.push_back(v);
-        
+
         if (P.consumeIf(tok::comma))
           continue;
         if (P.consumeIf(tok::r_paren))
@@ -3195,7 +3131,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
         return true;
       }
     }
-    
+
     if (parseSILDebugLocation(InstLoc, B))
       return true;
 
@@ -3208,15 +3144,14 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       leafType = components.back().getComponentType();
     else
       leafType = rootType;
-    auto pattern = KeyPathPattern::get(B.getModule(), canSig,
-                     rootType, leafType,
-                     components, objcString);
+    auto pattern = KeyPathPattern::get(B.getModule(), canSig, rootType,
+                                       leafType, components, objcString);
 
     ResultVal = B.createKeyPath(InstLoc, pattern, subMap, operands, Ty);
     break;
   }
 
-  // Conversion instructions.
+    // Conversion instructions.
   case SILInstructionKind::UncheckedRefCastInst:
   case SILInstructionKind::UncheckedAddrCastInst:
   case SILInstructionKind::UncheckedTrivialBitCastInst:
@@ -3227,8 +3162,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   case SILInstructionKind::BridgeObjectToWordInst:
   case SILInstructionKind::RefToRawPointerInst:
   case SILInstructionKind::RawPointerToRefInst:
-#define LOADABLE_REF_STORAGE(Name, ...) \
-  case SILInstructionKind::RefTo##Name##Inst: \
+#define LOADABLE_REF_STORAGE(Name, ...)                                        \
+  case SILInstructionKind::RefTo##Name##Inst:                                  \
   case SILInstructionKind::Name##ToRefInst:
 #include "swift/AST/ReferenceStorage.def"
   case SILInstructionKind::ThinFunctionToPointerInst:
@@ -3254,9 +3189,9 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
           return true;
       }
     }
-    if (parseTypedValueRef(Val, B)
-        || parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
-                              "to"))
+    if (parseTypedValueRef(Val, B) ||
+        parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
+                           "to"))
       return true;
 
     if (ToToken.str() != "to") {
@@ -3276,7 +3211,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       return true;
 
     switch (Opcode) {
-    default: llvm_unreachable("Out of sync with parent switch");
+    default:
+      llvm_unreachable("Out of sync with parent switch");
     case SILInstructionKind::UncheckedRefCastInst:
       ResultVal = B.createUncheckedRefCast(InstLoc, Val, Ty);
       break;
@@ -3315,13 +3251,13 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     case SILInstructionKind::RawPointerToRefInst:
       ResultVal = B.createRawPointerToRef(InstLoc, Val, Ty);
       break;
-#define LOADABLE_REF_STORAGE(Name, ...) \
-    case SILInstructionKind::RefTo##Name##Inst: \
-      ResultVal = B.createRefTo##Name(InstLoc, Val, Ty); \
-      break; \
-    case SILInstructionKind::Name##ToRefInst: \
-      ResultVal = B.create##Name##ToRef(InstLoc, Val, Ty); \
-      break;
+#define LOADABLE_REF_STORAGE(Name, ...)                                        \
+  case SILInstructionKind::RefTo##Name##Inst:                                  \
+    ResultVal = B.createRefTo##Name(InstLoc, Val, Ty);                         \
+    break;                                                                     \
+  case SILInstructionKind::Name##ToRefInst:                                    \
+    ResultVal = B.create##Name##ToRef(InstLoc, Val, Ty);                       \
+    break;
 #include "swift/AST/ReferenceStorage.def"
     case SILInstructionKind::ThinFunctionToPointerInst:
       ResultVal = B.createThinFunctionToPointer(InstLoc, Val, Ty);
@@ -3353,13 +3289,12 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SourceLoc ToLoc;
     StringRef attr;
     if (parseTypedValueRef(Val, B) ||
-        parseSILIdentifier(ToToken, ToLoc,
-                           diag::expected_tok_in_sil_instr, "to"))
+        parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
+                           "to"))
       return true;
     if (parseSILOptional(attr, *this) && attr.empty())
       return true;
-    if (parseSILType(Ty) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseSILType(Ty) || parseSILDebugLocation(InstLoc, B))
       return true;
 
     bool isStrict = attr.equals("strict");
@@ -3370,16 +3305,15 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       return true;
     }
 
-    ResultVal = B.createPointerToAddress(InstLoc, Val, Ty,
-                                         isStrict, isInvariant);
+    ResultVal =
+        B.createPointerToAddress(InstLoc, Val, Ty, isStrict, isInvariant);
     break;
   }
   case SILInstructionKind::RefToBridgeObjectInst: {
     SILValue BitsVal;
     if (parseTypedValueRef(Val, B) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseTypedValueRef(BitsVal, B) ||
-        parseSILDebugLocation(InstLoc, B))
+        parseTypedValueRef(BitsVal, B) || parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createRefToBridgeObject(InstLoc, Val, BitsVal);
     break;
@@ -3409,8 +3343,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     }
     auto consumptionKind = kind.getValue();
 
-    if (parseSourceAndDestAddress() || parseConditionalBranchDestinations()
-        || parseSILDebugLocation(InstLoc, B))
+    if (parseSourceAndDestAddress() || parseConditionalBranchDestinations() ||
+        parseSILDebugLocation(InstLoc, B))
       return true;
 
     ResultVal = B.createCheckedCastAddrBranch(
@@ -3436,36 +3370,29 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     break;
 
   case SILInstructionKind::UnconditionalCheckedCastValueInst: {
-    if (parseASTType(SourceType)
-        || parseVerbatim("in")
-        || parseTypedValueRef(Val, B)
-        || parseVerbatim("to")
-        || parseASTType(TargetType)
-        || parseSILDebugLocation(InstLoc, B))
+    if (parseASTType(SourceType) || parseVerbatim("in") ||
+        parseTypedValueRef(Val, B) || parseVerbatim("to") ||
+        parseASTType(TargetType) || parseSILDebugLocation(InstLoc, B))
       return true;
 
     auto opaque = Lowering::AbstractionPattern::getOpaque();
-    ResultVal =
-      B.createUnconditionalCheckedCastValue(InstLoc,
-                                            Val, SourceType,
-                                            F->getLoweredType(opaque, TargetType),
-                                            TargetType);
+    ResultVal = B.createUnconditionalCheckedCastValue(
+        InstLoc, Val, SourceType, F->getLoweredType(opaque, TargetType),
+        TargetType);
     break;
   }
 
   case SILInstructionKind::UnconditionalCheckedCastInst: {
-    if (parseTypedValueRef(Val, B) || parseVerbatim("to")
-        || parseASTType(TargetType))
+    if (parseTypedValueRef(Val, B) || parseVerbatim("to") ||
+        parseASTType(TargetType))
       return true;
 
     if (parseSILDebugLocation(InstLoc, B))
       return true;
 
     auto opaque = Lowering::AbstractionPattern::getOpaque();
-    ResultVal =
-      B.createUnconditionalCheckedCast(InstLoc, Val,
-                                       F->getLoweredType(opaque, TargetType),
-                                       TargetType);
+    ResultVal = B.createUnconditionalCheckedCast(
+        InstLoc, Val, F->getLoweredType(opaque, TargetType), TargetType);
     break;
   }
 
@@ -3475,33 +3402,27 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
         parseSILOptional(isExact, *this, "exact"))
       return true;
 
-    if (parseTypedValueRef(Val, B) || parseVerbatim("to")
-        || parseASTType(TargetType)
-        || parseConditionalBranchDestinations())
+    if (parseTypedValueRef(Val, B) || parseVerbatim("to") ||
+        parseASTType(TargetType) || parseConditionalBranchDestinations())
       return true;
 
     auto opaque = Lowering::AbstractionPattern::getOpaque();
     ResultVal = B.createCheckedCastBranch(
-        InstLoc, isExact, Val,
-        F->getLoweredType(opaque, TargetType), TargetType,
-        getBBForReference(SuccessBBName, SuccessBBLoc),
+        InstLoc, isExact, Val, F->getLoweredType(opaque, TargetType),
+        TargetType, getBBForReference(SuccessBBName, SuccessBBLoc),
         getBBForReference(FailureBBName, FailureBBLoc));
     break;
   }
   case SILInstructionKind::CheckedCastValueBranchInst: {
-    if (parseASTType(SourceType)
-        || parseVerbatim("in")
-        || parseTypedValueRef(Val, B)
-        || parseVerbatim("to")
-        || parseASTType(TargetType)
-        || parseConditionalBranchDestinations())
+    if (parseASTType(SourceType) || parseVerbatim("in") ||
+        parseTypedValueRef(Val, B) || parseVerbatim("to") ||
+        parseASTType(TargetType) || parseConditionalBranchDestinations())
       return true;
 
     auto opaque = Lowering::AbstractionPattern::getOpaque();
     ResultVal = B.createCheckedCastValueBranch(
-        InstLoc, Val, SourceType,
-        F->getLoweredType(opaque, TargetType), TargetType,
-        getBBForReference(SuccessBBName, SuccessBBLoc),
+        InstLoc, Val, SourceType, F->getLoweredType(opaque, TargetType),
+        TargetType, getBBForReference(SuccessBBName, SuccessBBLoc),
         getBBForReference(FailureBBName, FailureBBLoc));
     break;
   }
@@ -3509,15 +3430,15 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   case SILInstructionKind::MarkUninitializedInst: {
     if (P.parseToken(tok::l_square, diag::expected_tok_in_sil_instr, "["))
       return true;
-    
+
     Identifier KindId;
     SourceLoc KindLoc = P.Tok.getLoc();
     if (P.consumeIf(tok::kw_var))
       KindId = P.Context.getIdentifier("var");
-    else if (P.parseIdentifier(KindId, KindLoc,
-                               diag::expected_tok_in_sil_instr, "kind"))
+    else if (P.parseIdentifier(KindId, KindLoc, diag::expected_tok_in_sil_instr,
+                               "kind"))
       return true;
-    
+
     if (P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]"))
       return true;
 
@@ -3543,17 +3464,17 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       return true;
     }
 
-    if (parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createMarkUninitialized(InstLoc, Val, Kind);
     break;
   }
-  
+
   case SILInstructionKind::MarkFunctionEscapeInst: {
     SmallVector<SILValue, 4> OpList;
     do {
-      if (parseTypedValueRef(Val, B)) return true;
+      if (parseTypedValueRef(Val, B))
+        return true;
       OpList.push_back(Val);
     } while (!peekSILDebugLocation(P) && P.consumeIf(tok::comma));
 
@@ -3602,15 +3523,15 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SILType ValType = AddrVal->getType().getObjectType();
 
     if (IsStore) {
-      ResultVal = B.createStore(InstLoc,
-                                getLocalValue(From, ValType, InstLoc, B),
-                                AddrVal, StoreQualifier);
+      ResultVal =
+          B.createStore(InstLoc, getLocalValue(From, ValType, InstLoc, B),
+                        AddrVal, StoreQualifier);
     } else {
       assert(IsAssign);
 
-      ResultVal = B.createAssign(InstLoc,
-                                getLocalValue(From, ValType, InstLoc, B),
-                                AddrVal, AssignQualifier);
+      ResultVal =
+          B.createAssign(InstLoc, getLocalValue(From, ValType, InstLoc, B),
+                         AddrVal, AssignQualifier);
     }
 
     break;
@@ -3620,16 +3541,13 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SILValue Src, DestAddr, InitFn, SetFn;
     SourceLoc DestLoc;
     AssignOwnershipQualifier AssignQualifier;
-    if (parseTypedValueRef(Src,  B) ||
-        parseVerbatim("to") ||
+    if (parseTypedValueRef(Src, B) || parseVerbatim("to") ||
         parseAssignOwnershipQualifier(AssignQualifier, *this) ||
         parseTypedValueRef(DestAddr, DestLoc, B) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseVerbatim("init") ||
-        parseTypedValueRef(InitFn, B) ||
+        parseVerbatim("init") || parseTypedValueRef(InitFn, B) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseVerbatim("set") ||
-        parseTypedValueRef(SetFn, B) ||
+        parseVerbatim("set") || parseTypedValueRef(SetFn, B) ||
         parseSILDebugLocation(InstLoc, B))
       return true;
 
@@ -3640,7 +3558,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     }
 
     ResultVal = B.createAssignByWrapper(InstLoc, Src, DestAddr, InitFn, SetFn,
-                                         AssignQualifier);
+                                        AssignQualifier);
     break;
   }
 
@@ -3654,10 +3572,11 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     ParsedEnum<bool> noNestedConflict;
     ParsedEnum<bool> fromBuiltin;
 
-    bool isBeginAccess = (Opcode == SILInstructionKind::BeginAccessInst ||
-                          Opcode == SILInstructionKind::BeginUnpairedAccessInst);
-    bool wantsEnforcement = (isBeginAccess ||
-                             Opcode == SILInstructionKind::EndUnpairedAccessInst);
+    bool isBeginAccess =
+        (Opcode == SILInstructionKind::BeginAccessInst ||
+         Opcode == SILInstructionKind::BeginUnpairedAccessInst);
+    bool wantsEnforcement =
+        (isBeginAccess || Opcode == SILInstructionKind::EndUnpairedAccessInst);
 
     while (P.consumeIf(tok::l_square)) {
       Identifier ident;
@@ -3754,15 +3673,13 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       return true;
 
     if (!addrVal->getType().isAddress()) {
-      P.diagnose(addrLoc, diag::sil_operand_not_address, "operand",
-                 OpcodeName);
+      P.diagnose(addrLoc, diag::sil_operand_not_address, "operand", OpcodeName);
       return true;
     }
 
     if (Opcode == SILInstructionKind::BeginAccessInst) {
-      ResultVal =
-          B.createBeginAccess(InstLoc, addrVal, *kind, *enforcement,
-                              *noNestedConflict, *fromBuiltin);
+      ResultVal = B.createBeginAccess(InstLoc, addrVal, *kind, *enforcement,
+                                      *noNestedConflict, *fromBuiltin);
     } else if (Opcode == SILInstructionKind::EndAccessInst) {
       ResultVal = B.createEndAccess(InstLoc, addrVal, *aborting);
     } else if (Opcode == SILInstructionKind::BeginUnpairedAccessInst) {
@@ -3776,14 +3693,14 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     break;
   }
 
-#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
+#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)             \
   case SILInstructionKind::Store##Name##Inst:
 #include "swift/AST/ReferenceStorage.def"
   case SILInstructionKind::StoreBorrowInst: {
     UnresolvedValueName from;
     bool isRefStorage = false;
-#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-    isRefStorage |= Opcode == SILInstructionKind::Store##Name##Inst;
+#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)             \
+  isRefStorage |= Opcode == SILInstructionKind::Store##Name##Inst;
 #include "swift/AST/ReferenceStorage.def"
 
     SourceLoc toLoc, addrLoc;
@@ -3791,8 +3708,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SILValue addrVal;
     bool isInit = false;
     if (parseValueName(from) ||
-        parseSILIdentifier(toToken, toLoc,
-                           diag::expected_tok_in_sil_instr, "to") ||
+        parseSILIdentifier(toToken, toLoc, diag::expected_tok_in_sil_instr,
+                           "to") ||
         (isRefStorage && parseSILOptional(isInit, *this, "initialization")) ||
         parseTypedValueRef(addrVal, addrLoc, B) ||
         parseSILDebugLocation(InstLoc, B))
@@ -3804,8 +3721,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     }
 
     if (!addrVal->getType().isAddress()) {
-      P.diagnose(addrLoc, diag::sil_operand_not_address,
-                 "destination", OpcodeName);
+      P.diagnose(addrLoc, diag::sil_operand_not_address, "destination",
+                 OpcodeName);
       return true;
     }
 
@@ -3816,20 +3733,20 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       break;
     }
 
-#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-    if (Opcode == SILInstructionKind::Store##Name##Inst) { \
-      auto refType = addrVal->getType().getAs<Name##StorageType>(); \
-      if (!refType) { \
-        P.diagnose(addrLoc, diag::sil_operand_not_ref_storage_address, \
-                   "destination", OpcodeName, ReferenceOwnership::Name); \
-        return true; \
-      } \
-      auto valueTy =SILType::getPrimitiveObjectType(refType.getReferentType());\
-      ResultVal = B.createStore##Name(InstLoc, \
-                                      getLocalValue(from, valueTy, InstLoc, B),\
-                                      addrVal, IsInitialization_t(isInit)); \
-      break; \
-    }
+#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)             \
+  if (Opcode == SILInstructionKind::Store##Name##Inst) {                       \
+    auto refType = addrVal->getType().getAs<Name##StorageType>();              \
+    if (!refType) {                                                            \
+      P.diagnose(addrLoc, diag::sil_operand_not_ref_storage_address,           \
+                 "destination", OpcodeName, ReferenceOwnership::Name);         \
+      return true;                                                             \
+    }                                                                          \
+    auto valueTy = SILType::getPrimitiveObjectType(refType.getReferentType()); \
+    ResultVal =                                                                \
+        B.createStore##Name(InstLoc, getLocalValue(from, valueTy, InstLoc, B), \
+                            addrVal, IsInitialization_t(isInit));              \
+    break;                                                                     \
+  }
 #include "swift/AST/ReferenceStorage.def"
 
     break;
@@ -3848,8 +3765,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
 
     if (Opcode == SILInstructionKind::AllocStackInst) {
       SILDebugVariable VarInfo;
-      if (parseSILDebugVar(VarInfo) ||
-          parseSILDebugLocation(InstLoc, B))
+      if (parseSILDebugVar(VarInfo) || parseSILDebugLocation(InstLoc, B))
         return true;
       ResultVal = B.createAllocStack(InstLoc, Ty, VarInfo, hasDynamicLifetime);
     } else {
@@ -3876,8 +3792,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
         OnStack = true;
       } else if (Optional == "tail_elems") {
         SILType ElemTy;
-        if (parseSILType(ElemTy) ||
-            !P.Tok.isAnyOperator() ||
+        if (parseSILType(ElemTy) || !P.Tok.isAnyOperator() ||
             P.Tok.getText() != "*")
           return true;
         P.consumeToken();
@@ -3915,8 +3830,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       if (OnStack)
         return true;
 
-      ResultVal = B.createAllocRefDynamic(InstLoc, Metadata, ObjectType,
-                                          IsObjC, ElementTypes, ElementCounts);
+      ResultVal = B.createAllocRefDynamic(InstLoc, Metadata, ObjectType, IsObjC,
+                                          ElementTypes, ElementCounts);
     } else {
       ResultVal = B.createAllocRef(InstLoc, ObjectType, IsObjC, OnStack,
                                    ElementTypes, ElementCounts);
@@ -3925,8 +3840,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   }
 
   case SILInstructionKind::DeallocStackInst:
-    if (parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createDeallocStack(InstLoc, Val);
     break;
@@ -3935,8 +3849,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     if (parseSILOptional(OnStack, *this, "stack"))
       return true;
 
-    if (parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
+    if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createDeallocRef(InstLoc, Val, OnStack);
     break;
@@ -3945,71 +3858,110 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SILValue Metatype, Instance;
     if (parseTypedValueRef(Instance, B) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseTypedValueRef(Metatype, B) ||
-        parseSILDebugLocation(InstLoc, B))
+        parseTypedValueRef(Metatype, B) || parseSILDebugLocation(InstLoc, B))
       return true;
 
     ResultVal = B.createDeallocPartialRef(InstLoc, Instance, Metatype);
     break;
   }
-  case SILInstructionKind::DeallocBoxInst:
-    if (parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    ResultVal = B.createDeallocBox(InstLoc, Val);
-    break;
-  case SILInstructionKind::ValueMetatypeInst:
-  case SILInstructionKind::ExistentialMetatypeInst: {
-    SILType Ty;
-    if (parseSILType(Ty) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    switch (Opcode) {
-    default: llvm_unreachable("Out of sync with parent switch");
-    case SILInstructionKind::ValueMetatypeInst:
-      ResultVal = B.createValueMetatype(InstLoc, Ty, Val);
-      break;
-    case SILInstructionKind::ExistentialMetatypeInst:
-      ResultVal = B.createExistentialMetatype(InstLoc, Ty, Val);
-      break;
     case SILInstructionKind::DeallocBoxInst:
+      if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
       ResultVal = B.createDeallocBox(InstLoc, Val);
       break;
-    }
-    break;
-  }
-  case SILInstructionKind::DeallocExistentialBoxInst: {
-    CanType ConcreteTy;
-    if (parseTypedValueRef(Val, B)
-        || P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",")
-        || P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$")
-        || parseASTType(ConcreteTy)
-        || parseSILDebugLocation(InstLoc, B))
-      return true;
-    
-    ResultVal = B.createDeallocExistentialBox(InstLoc, ConcreteTy, Val);
-    break;
-  }
-  case SILInstructionKind::TupleInst: {
-    // Tuple instructions have two different syntaxes, one for simple tuple
-    // types, one for complicated ones.
-    if (P.Tok.isNot(tok::sil_dollar)) {
-      // If there is no type, parse the simple form.
-      if (P.parseToken(tok::l_paren, diag::expected_tok_in_sil_instr, "("))
+    case SILInstructionKind::ValueMetatypeInst:
+    case SILInstructionKind::ExistentialMetatypeInst: {
+      SILType Ty;
+      if (parseSILType(Ty) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
         return true;
-      
-      // TODO: Check for a type here.  This is how tuples with "interesting"
-      // types are described.
-      
-      // This form is used with tuples that have elements with no names or
-      // default values.
+      switch (Opcode) {
+      default:
+        llvm_unreachable("Out of sync with parent switch");
+      case SILInstructionKind::ValueMetatypeInst:
+        ResultVal = B.createValueMetatype(InstLoc, Ty, Val);
+        break;
+      case SILInstructionKind::ExistentialMetatypeInst:
+        ResultVal = B.createExistentialMetatype(InstLoc, Ty, Val);
+        break;
+      case SILInstructionKind::DeallocBoxInst:
+        ResultVal = B.createDeallocBox(InstLoc, Val);
+        break;
+      }
+      break;
+    }
+    case SILInstructionKind::DeallocExistentialBoxInst: {
+      CanType ConcreteTy;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
+          parseASTType(ConcreteTy) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      ResultVal = B.createDeallocExistentialBox(InstLoc, ConcreteTy, Val);
+      break;
+    }
+    case SILInstructionKind::TupleInst: {
+      // Tuple instructions have two different syntaxes, one for simple tuple
+      // types, one for complicated ones.
+      if (P.Tok.isNot(tok::sil_dollar)) {
+        // If there is no type, parse the simple form.
+        if (P.parseToken(tok::l_paren, diag::expected_tok_in_sil_instr, "("))
+          return true;
+
+        // TODO: Check for a type here.  This is how tuples with "interesting"
+        // types are described.
+
+        // This form is used with tuples that have elements with no names or
+        // default values.
+        SmallVector<TupleTypeElt, 4> TypeElts;
+        if (P.Tok.isNot(tok::r_paren)) {
+          do {
+            if (parseTypedValueRef(Val, B))
+              return true;
+            OpList.push_back(Val);
+            TypeElts.push_back(Val->getType().getASTType());
+          } while (P.consumeIf(tok::comma));
+        }
+        HadError |=
+            P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")");
+
+        auto Ty = TupleType::get(TypeElts, P.Context);
+        auto Ty2 = SILType::getPrimitiveObjectType(Ty->getCanonicalType());
+        if (parseSILDebugLocation(InstLoc, B))
+          return true;
+        ResultVal = B.createTuple(InstLoc, Ty2, OpList);
+        break;
+      }
+
+      // Otherwise, parse the fully general form.
+      SILType Ty;
+      if (parseSILType(Ty) ||
+          P.parseToken(tok::l_paren, diag::expected_tok_in_sil_instr, "("))
+        return true;
+
+      TupleType *TT = Ty.getAs<TupleType>();
+      if (TT == nullptr) {
+        P.diagnose(OpcodeLoc, diag::expected_tuple_type_in_tuple);
+        return true;
+      }
+
       SmallVector<TupleTypeElt, 4> TypeElts;
       if (P.Tok.isNot(tok::r_paren)) {
         do {
-          if (parseTypedValueRef(Val, B)) return true;
+          if (TypeElts.size() > TT->getNumElements()) {
+            P.diagnose(P.Tok, diag::sil_tuple_inst_wrong_value_count,
+                       TT->getNumElements());
+            return true;
+          }
+          Type EltTy = TT->getElement(TypeElts.size()).getType();
+          if (parseValueRef(
+                  Val,
+                  SILType::getPrimitiveObjectType(EltTy->getCanonicalType()),
+                  RegularLocation(P.Tok.getLoc()), B))
+            return true;
           OpList.push_back(Val);
           TypeElts.push_back(Val->getType().getASTType());
         } while (P.consumeIf(tok::comma));
@@ -4017,1060 +3969,1059 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       HadError |= P.parseToken(tok::r_paren,
                                diag::expected_tok_in_sil_instr,")");
 
-      auto Ty = TupleType::get(TypeElts, P.Context);
-      auto Ty2 = SILType::getPrimitiveObjectType(Ty->getCanonicalType());
+      if (TypeElts.size() != TT->getNumElements()) {
+        P.diagnose(OpcodeLoc, diag::sil_tuple_inst_wrong_value_count,
+                   TT->getNumElements());
+        return true;
+      }
+
       if (parseSILDebugLocation(InstLoc, B))
         return true;
-      ResultVal = B.createTuple(InstLoc, Ty2, OpList);
+      ResultVal = B.createTuple(InstLoc, Ty, OpList);
       break;
     }
-    
-    // Otherwise, parse the fully general form.
-    SILType Ty;
-    if (parseSILType(Ty) ||
-        P.parseToken(tok::l_paren, diag::expected_tok_in_sil_instr, "("))
-      return true;
-    
-    TupleType *TT = Ty.getAs<TupleType>();
-    if (TT == nullptr) {
-      P.diagnose(OpcodeLoc, diag::expected_tuple_type_in_tuple);
-      return true;
-    }
-    
-    SmallVector<TupleTypeElt, 4> TypeElts;
-    if (P.Tok.isNot(tok::r_paren)) {
-      do {
-        if (TypeElts.size() > TT->getNumElements()) {
-          P.diagnose(P.Tok, diag::sil_tuple_inst_wrong_value_count,
-                     TT->getNumElements());
-          return true;
-        }
-        Type EltTy = TT->getElement(TypeElts.size()).getType();
-        if (parseValueRef(Val,
-                 SILType::getPrimitiveObjectType(EltTy->getCanonicalType()),
-                          RegularLocation(P.Tok.getLoc()), B))
-          return true;
-        OpList.push_back(Val);
-        TypeElts.push_back(Val->getType().getASTType());
-      } while (P.consumeIf(tok::comma));
-    }
-    HadError |= P.parseToken(tok::r_paren,
-                             diag::expected_tok_in_sil_instr,")");
-
-    if (TypeElts.size() != TT->getNumElements()) {
-      P.diagnose(OpcodeLoc, diag::sil_tuple_inst_wrong_value_count,
-                 TT->getNumElements());
-      return true;
-    }
-
-    if (parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createTuple(InstLoc, Ty, OpList);
-    break;
-  }
-  case SILInstructionKind::EnumInst: {
-    SILType Ty;
-    SILDeclRef Elt;
-    SILValue Operand;
-    if (parseSILType(Ty) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILDeclRef(Elt))
-      return true;
-    
-    if (P.Tok.is(tok::comma) && !peekSILDebugLocation(P)) {
-      P.consumeToken(tok::comma);
-      if (parseTypedValueRef(Operand, B))
+    case SILInstructionKind::EnumInst: {
+      SILType Ty;
+      SILDeclRef Elt;
+      SILValue Operand;
+      if (parseSILType(Ty) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILDeclRef(Elt))
         return true;
-    }
-    
-    if (parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createEnum(InstLoc, Operand,
-                              cast<EnumElementDecl>(Elt.getDecl()), Ty);
-    break;
-  }
-  case SILInstructionKind::InitEnumDataAddrInst:
-  case SILInstructionKind::UncheckedEnumDataInst:
-  case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
-    SILValue Operand;
-    SILDeclRef EltRef;
-    if (parseTypedValueRef(Operand, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILDeclRef(EltRef) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    
-    EnumElementDecl *Elt = cast<EnumElementDecl>(EltRef.getDecl());
-    auto ResultTy = Operand->getType().getEnumElementType(
-        Elt, SILMod, B.getTypeExpansionContext());
 
-    switch (Opcode) {
-    case swift::SILInstructionKind::InitEnumDataAddrInst:
-      ResultVal = B.createInitEnumDataAddr(InstLoc, Operand, Elt, ResultTy);
-      break;
-    case swift::SILInstructionKind::UncheckedTakeEnumDataAddrInst:
-      ResultVal = B.createUncheckedTakeEnumDataAddr(InstLoc, Operand, Elt,
-                                                    ResultTy);
-      break;
-    case swift::SILInstructionKind::UncheckedEnumDataInst:
-      ResultVal = B.createUncheckedEnumData(InstLoc, Operand, Elt, ResultTy);
-      break;
-    default:
-      llvm_unreachable("switch out of sync");
-    }
-    break;
-  }
-  case SILInstructionKind::InjectEnumAddrInst: {
-    SILValue Operand;
-    SILDeclRef EltRef;
-    if (parseTypedValueRef(Operand, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILDeclRef(EltRef) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    
-    EnumElementDecl *Elt = cast<EnumElementDecl>(EltRef.getDecl());
-    ResultVal = B.createInjectEnumAddr(InstLoc, Operand, Elt);
-    break;
-  }
-  case SILInstructionKind::TupleElementAddrInst:
-  case SILInstructionKind::TupleExtractInst: {
-    SourceLoc NameLoc;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
-      return true;
+      if (P.Tok.is(tok::comma) && !peekSILDebugLocation(P)) {
+        P.consumeToken(tok::comma);
+        if (parseTypedValueRef(Operand, B))
+          return true;
+      }
 
-    unsigned Field = 0;
-    TupleType *TT = Val->getType().getAs<TupleType>();
-    if (P.Tok.isNot(tok::integer_literal) ||
-        parseIntegerLiteral(P.Tok.getText(), 10, Field) ||
-        Field >= TT->getNumElements()) {
-      P.diagnose(P.Tok, diag::sil_tuple_inst_wrong_field);
-      return true;
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createEnum(InstLoc, Operand,
+                               cast<EnumElementDecl>(Elt.getDecl()), Ty);
+      break;
     }
-    P.consumeToken(tok::integer_literal);
-    if (parseSILDebugLocation(InstLoc, B))
-      return true;
-    auto ResultTy = TT->getElement(Field).getType()->getCanonicalType();
-    if (Opcode == SILInstructionKind::TupleElementAddrInst)
-      ResultVal = B.createTupleElementAddr(InstLoc, Val, Field,
-                                  SILType::getPrimitiveAddressType(ResultTy));
-    else
-      ResultVal = B.createTupleExtract(InstLoc, Val, Field,
-                          SILType::getPrimitiveObjectType(ResultTy));
-    break;
-  }
-  case SILInstructionKind::ReturnInst: {
-    if (parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createReturn(InstLoc, Val);
-    break;
-  }
-  case SILInstructionKind::ThrowInst: {
-    if (parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createThrow(InstLoc, Val);
-    break;
-  }
-  case SILInstructionKind::UnwindInst: {
-    if (parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createUnwind(InstLoc);
-    break;
-  }
-  case SILInstructionKind::YieldInst: {
-    SmallVector<SILValue, 6> values;
+    case SILInstructionKind::InitEnumDataAddrInst:
+    case SILInstructionKind::UncheckedEnumDataInst:
+    case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
+      SILValue Operand;
+      SILDeclRef EltRef;
+      if (parseTypedValueRef(Operand, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILDeclRef(EltRef) || parseSILDebugLocation(InstLoc, B))
+        return true;
 
-    // Parse a parenthesized (unless length-1), comma-separated list
-    // of yielded values.
-    if (P.consumeIf(tok::l_paren)) {
-      if (!P.Tok.is(tok::r_paren)) {
+      EnumElementDecl *Elt = cast<EnumElementDecl>(EltRef.getDecl());
+      auto ResultTy = Operand->getType().getEnumElementType(
+          Elt, SILMod, B.getTypeExpansionContext());
+
+      switch (Opcode) {
+      case swift::SILInstructionKind::InitEnumDataAddrInst:
+        ResultVal = B.createInitEnumDataAddr(InstLoc, Operand, Elt, ResultTy);
+        break;
+      case swift::SILInstructionKind::UncheckedTakeEnumDataAddrInst:
+        ResultVal =
+            B.createUncheckedTakeEnumDataAddr(InstLoc, Operand, Elt, ResultTy);
+        break;
+      case swift::SILInstructionKind::UncheckedEnumDataInst:
+        ResultVal = B.createUncheckedEnumData(InstLoc, Operand, Elt, ResultTy);
+        break;
+      default:
+        llvm_unreachable("switch out of sync");
+      }
+      break;
+    }
+    case SILInstructionKind::InjectEnumAddrInst: {
+      SILValue Operand;
+      SILDeclRef EltRef;
+      if (parseTypedValueRef(Operand, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILDeclRef(EltRef) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      EnumElementDecl *Elt = cast<EnumElementDecl>(EltRef.getDecl());
+      ResultVal = B.createInjectEnumAddr(InstLoc, Operand, Elt);
+      break;
+    }
+    case SILInstructionKind::TupleElementAddrInst:
+    case SILInstructionKind::TupleExtractInst: {
+      SourceLoc NameLoc;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
+        return true;
+
+      unsigned Field = 0;
+      TupleType *TT = Val->getType().getAs<TupleType>();
+      if (P.Tok.isNot(tok::integer_literal) ||
+          parseIntegerLiteral(P.Tok.getText(), 10, Field) ||
+          Field >= TT->getNumElements()) {
+        P.diagnose(P.Tok, diag::sil_tuple_inst_wrong_field);
+        return true;
+      }
+      P.consumeToken(tok::integer_literal);
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+      auto ResultTy = TT->getElement(Field).getType()->getCanonicalType();
+      if (Opcode == SILInstructionKind::TupleElementAddrInst)
+        ResultVal = B.createTupleElementAddr(
+            InstLoc, Val, Field, SILType::getPrimitiveAddressType(ResultTy));
+      else
+        ResultVal = B.createTupleExtract(
+            InstLoc, Val, Field, SILType::getPrimitiveObjectType(ResultTy));
+      break;
+    }
+    case SILInstructionKind::ReturnInst: {
+      if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createReturn(InstLoc, Val);
+      break;
+    }
+    case SILInstructionKind::ThrowInst: {
+      if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createThrow(InstLoc, Val);
+      break;
+    }
+    case SILInstructionKind::UnwindInst: {
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createUnwind(InstLoc);
+      break;
+    }
+    case SILInstructionKind::YieldInst: {
+      SmallVector<SILValue, 6> values;
+
+      // Parse a parenthesized (unless length-1), comma-separated list
+      // of yielded values.
+      if (P.consumeIf(tok::l_paren)) {
+        if (!P.Tok.is(tok::r_paren)) {
+          do {
+            if (parseTypedValueRef(Val, B))
+              return true;
+            values.push_back(Val);
+          } while (P.consumeIf(tok::comma));
+        }
+
+        if (P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")"))
+          return true;
+
+      } else {
+        if (parseTypedValueRef(Val, B))
+          return true;
+        values.push_back(Val);
+      }
+
+      Identifier resumeName, unwindName;
+      SourceLoc resumeLoc, unwindLoc;
+      if (P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseVerbatim("resume") ||
+          parseSILIdentifier(resumeName, resumeLoc,
+                             diag::expected_sil_block_name) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseVerbatim("unwind") ||
+          parseSILIdentifier(unwindName, unwindLoc,
+                             diag::expected_sil_block_name) ||
+          parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      auto resumeBB = getBBForReference(resumeName, resumeLoc);
+      auto unwindBB = getBBForReference(unwindName, unwindLoc);
+      ResultVal = B.createYield(InstLoc, values, resumeBB, unwindBB);
+      break;
+    }
+    case SILInstructionKind::BranchInst: {
+      Identifier BBName;
+      SourceLoc NameLoc;
+      if (parseSILIdentifier(BBName, NameLoc, diag::expected_sil_block_name))
+        return true;
+
+      SmallVector<SILValue, 6> Args;
+      if (parseSILBBArgsAtBranch(Args, B))
+        return true;
+
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      // Note, the basic block here could be a reference to an undefined
+      // basic block, which will be parsed later on.
+      ResultVal =
+          B.createBranch(InstLoc, getBBForReference(BBName, NameLoc), Args);
+      break;
+    }
+    case SILInstructionKind::CondBranchInst: {
+      UnresolvedValueName Cond;
+      Identifier BBName, BBName2;
+      SourceLoc NameLoc, NameLoc2;
+      SmallVector<SILValue, 6> Args, Args2;
+      if (parseValueName(Cond) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILIdentifier(BBName, NameLoc, diag::expected_sil_block_name) ||
+          parseSILBBArgsAtBranch(Args, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILIdentifier(BBName2, NameLoc2,
+                             diag::expected_sil_block_name) ||
+          parseSILBBArgsAtBranch(Args2, B) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      auto I1Ty = SILType::getBuiltinIntegerType(1, SILMod.getASTContext());
+      SILValue CondVal = getLocalValue(Cond, I1Ty, InstLoc, B);
+      ResultVal = B.createCondBranch(
+          InstLoc, CondVal, getBBForReference(BBName, NameLoc), Args,
+          getBBForReference(BBName2, NameLoc2), Args2);
+      break;
+    }
+    case SILInstructionKind::UnreachableInst:
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createUnreachable(InstLoc);
+      break;
+
+    case SILInstructionKind::ClassMethodInst:
+    case SILInstructionKind::SuperMethodInst:
+    case SILInstructionKind::ObjCMethodInst:
+    case SILInstructionKind::ObjCSuperMethodInst: {
+      SILDeclRef Member;
+      SILType MethodTy;
+      SourceLoc TyLoc;
+      SmallVector<ValueDecl *, 4> values;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
+        return true;
+
+      if (parseSILDeclRef(Member, true))
+        return true;
+
+      if (P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILType(MethodTy, TyLoc) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      switch (Opcode) {
+      default:
+        llvm_unreachable("Out of sync with parent switch");
+      case SILInstructionKind::ClassMethodInst:
+        ResultVal = B.createClassMethod(InstLoc, Val, Member, MethodTy);
+        break;
+      case SILInstructionKind::SuperMethodInst:
+        ResultVal = B.createSuperMethod(InstLoc, Val, Member, MethodTy);
+        break;
+      case SILInstructionKind::ObjCMethodInst:
+        ResultVal = B.createObjCMethod(InstLoc, Val, Member, MethodTy);
+        break;
+      case SILInstructionKind::ObjCSuperMethodInst:
+        ResultVal = B.createObjCSuperMethod(InstLoc, Val, Member, MethodTy);
+        break;
+      }
+      break;
+    }
+    case SILInstructionKind::WitnessMethodInst: {
+      CanType LookupTy;
+      SILDeclRef Member;
+      SILType MethodTy;
+      SourceLoc TyLoc;
+      if (P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
+          parseASTType(LookupTy) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
+        return true;
+      if (parseSILDeclRef(Member, true))
+        return true;
+      // Optional operand.
+      SILValue Operand;
+      if (P.Tok.is(tok::comma)) {
+        P.consumeToken(tok::comma);
+        if (parseTypedValueRef(Operand, B))
+          return true;
+      }
+      if (P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
+          parseSILType(MethodTy, TyLoc) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      // If LookupTy is a non-archetype, look up its conformance.
+      ProtocolDecl *proto =
+          dyn_cast<ProtocolDecl>(Member.getDecl()->getDeclContext());
+      if (!proto) {
+        P.diagnose(TyLoc, diag::sil_witness_method_not_protocol);
+        return true;
+      }
+      auto conformance =
+          P.SF.getParentModule()->lookupConformance(LookupTy, proto);
+      if (conformance.isInvalid()) {
+        P.diagnose(TyLoc, diag::sil_witness_method_type_does_not_conform);
+        return true;
+      }
+
+      ResultVal = B.createWitnessMethod(InstLoc, LookupTy, conformance, Member,
+                                        MethodTy);
+      break;
+    }
+    case SILInstructionKind::CopyAddrInst: {
+      bool IsTake = false, IsInit = false;
+      UnresolvedValueName SrcLName;
+      SILValue DestLVal;
+      SourceLoc ToLoc, DestLoc;
+      Identifier ToToken;
+      if (parseSILOptional(IsTake, *this, "take") || parseValueName(SrcLName) ||
+          parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
+                             "to") ||
+          parseSILOptional(IsInit, *this, "initialization") ||
+          parseTypedValueRef(DestLVal, DestLoc, B) ||
+          parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      if (ToToken.str() != "to") {
+        P.diagnose(ToLoc, diag::expected_tok_in_sil_instr, "to");
+        return true;
+      }
+
+      if (!DestLVal->getType().isAddress()) {
+        P.diagnose(DestLoc, diag::sil_invalid_instr_operands);
+        return true;
+      }
+
+      SILValue SrcLVal =
+          getLocalValue(SrcLName, DestLVal->getType(), InstLoc, B);
+      ResultVal = B.createCopyAddr(InstLoc, SrcLVal, DestLVal, IsTake_t(IsTake),
+                                   IsInitialization_t(IsInit));
+      break;
+    }
+    case SILInstructionKind::BindMemoryInst: {
+      SILValue IndexVal;
+      Identifier ToToken;
+      SourceLoc ToLoc;
+      SILType EltTy;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseTypedValueRef(IndexVal, B) ||
+          parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
+                             "to") ||
+          parseSILType(EltTy) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      if (ToToken.str() != "to") {
+        P.diagnose(ToLoc, diag::expected_tok_in_sil_instr, "to");
+        return true;
+      }
+      ResultVal = B.createBindMemory(InstLoc, Val, IndexVal, EltTy);
+      break;
+    }
+    case SILInstructionKind::ObjectInst:
+    case SILInstructionKind::StructInst: {
+      SILType Ty;
+      if (parseSILType(Ty) ||
+          P.parseToken(tok::l_paren, diag::expected_tok_in_sil_instr, "("))
+        return true;
+
+      // Parse a list of SILValue.
+      bool OpsAreTailElems = false;
+      unsigned NumBaseElems = 0;
+      if (P.Tok.isNot(tok::r_paren)) {
         do {
+          if (Opcode == SILInstructionKind::ObjectInst) {
+            if (parseSILOptional(OpsAreTailElems, *this, "tail_elems"))
+              return true;
+          }
           if (parseTypedValueRef(Val, B))
             return true;
-          values.push_back(Val);
+          OpList.push_back(Val);
+          if (!OpsAreTailElems)
+            NumBaseElems = OpList.size();
         } while (P.consumeIf(tok::comma));
       }
-
-      if (P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")"))
+      if (P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")") ||
+          parseSILDebugLocation(InstLoc, B))
         return true;
 
-    } else {
+      if (Opcode == SILInstructionKind::StructInst) {
+        ResultVal = B.createStruct(InstLoc, Ty, OpList);
+      } else {
+        ResultVal = B.createObject(InstLoc, Ty, OpList, NumBaseElems);
+      }
+      break;
+    }
+    case SILInstructionKind::StructElementAddrInst:
+    case SILInstructionKind::StructExtractInst: {
+      ValueDecl *FieldV;
+      SourceLoc NameLoc = P.Tok.getLoc();
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILDottedPath(FieldV) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      if (!FieldV || !isa<VarDecl>(FieldV)) {
+        P.diagnose(NameLoc, diag::sil_struct_inst_wrong_field);
+        return true;
+      }
+      VarDecl *Field = cast<VarDecl>(FieldV);
+
+      // FIXME: substitution means this type should be explicit to improve
+      // performance.
+      auto ResultTy = Val->getType().getFieldType(Field, SILMod,
+                                                  B.getTypeExpansionContext());
+      if (Opcode == SILInstructionKind::StructElementAddrInst)
+        ResultVal = B.createStructElementAddr(InstLoc, Val, Field,
+                                              ResultTy.getAddressType());
+      else
+        ResultVal = B.createStructExtract(InstLoc, Val, Field,
+                                          ResultTy.getObjectType());
+      break;
+    }
+    case SILInstructionKind::RefElementAddrInst: {
+      ValueDecl *FieldV;
+      SourceLoc NameLoc;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILDottedPath(FieldV) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      if (!FieldV || !isa<VarDecl>(FieldV)) {
+        P.diagnose(NameLoc, diag::sil_ref_inst_wrong_field);
+        return true;
+      }
+      VarDecl *Field = cast<VarDecl>(FieldV);
+      auto ResultTy = Val->getType().getFieldType(Field, SILMod,
+                                                  B.getTypeExpansionContext());
+      ResultVal = B.createRefElementAddr(InstLoc, Val, Field, ResultTy);
+      break;
+    }
+    case SILInstructionKind::RefTailAddrInst: {
+      SourceLoc NameLoc;
+      SILType ResultObjTy;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILType(ResultObjTy) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      SILType ResultTy = ResultObjTy.getAddressType();
+      ResultVal = B.createRefTailAddr(InstLoc, Val, ResultTy);
+      break;
+    }
+    case SILInstructionKind::IndexAddrInst: {
+      SILValue IndexVal;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseTypedValueRef(IndexVal, B) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createIndexAddr(InstLoc, Val, IndexVal);
+      break;
+    }
+    case SILInstructionKind::TailAddrInst: {
+      SILValue IndexVal;
+      SILType ResultObjTy;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseTypedValueRef(IndexVal, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILType(ResultObjTy) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      SILType ResultTy = ResultObjTy.getAddressType();
+      ResultVal = B.createTailAddr(InstLoc, Val, IndexVal, ResultTy);
+      break;
+    }
+    case SILInstructionKind::IndexRawPointerInst: {
+      SILValue IndexVal;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseTypedValueRef(IndexVal, B) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createIndexRawPointer(InstLoc, Val, IndexVal);
+      break;
+    }
+    case SILInstructionKind::ObjCProtocolInst: {
+      Identifier ProtocolName;
+      SILType Ty;
+      if (P.parseToken(tok::pound, diag::expected_sil_constant) ||
+          parseSILIdentifier(ProtocolName, diag::expected_sil_constant) ||
+          P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
+          parseSILType(Ty) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      // Find the decl for the protocol name.
+      ValueDecl *VD;
+      SmallVector<ValueDecl *, 4> CurModuleResults;
+      // Perform a module level lookup on the first component of the
+      // fully-qualified name.
+      P.SF.getParentModule()->lookupValue(
+          ProtocolName, NLKind::UnqualifiedLookup, CurModuleResults);
+      assert(CurModuleResults.size() == 1);
+      VD = CurModuleResults[0];
+      ResultVal = B.createObjCProtocol(InstLoc, cast<ProtocolDecl>(VD), Ty);
+      break;
+    }
+    case SILInstructionKind::AllocGlobalInst: {
+      Identifier GlobalName;
+      SourceLoc IdLoc;
+      if (P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
+          parseSILIdentifier(GlobalName, IdLoc,
+                             diag::expected_sil_value_name) ||
+          parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      // Go through list of global variables in the SILModule.
+      SILGlobalVariable *global = SILMod.lookUpGlobalVariable(GlobalName.str());
+      if (!global) {
+        P.diagnose(IdLoc, diag::sil_global_variable_not_found, GlobalName);
+        return true;
+      }
+
+      ResultVal = B.createAllocGlobal(InstLoc, global);
+      break;
+    }
+    case SILInstructionKind::GlobalAddrInst:
+    case SILInstructionKind::GlobalValueInst: {
+      Identifier GlobalName;
+      SourceLoc IdLoc;
+      SILType Ty;
+      if (P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
+          parseSILIdentifier(GlobalName, IdLoc,
+                             diag::expected_sil_value_name) ||
+          P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
+          parseSILType(Ty) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      // Go through list of global variables in the SILModule.
+      SILGlobalVariable *global = SILMod.lookUpGlobalVariable(GlobalName.str());
+      if (!global) {
+        P.diagnose(IdLoc, diag::sil_global_variable_not_found, GlobalName);
+        return true;
+      }
+
+      SILType expectedType = (Opcode == SILInstructionKind::GlobalAddrInst
+                                  ? global->getLoweredType().getAddressType()
+                                  : global->getLoweredType());
+      if (expectedType != Ty) {
+        P.diagnose(IdLoc, diag::sil_value_use_type_mismatch, GlobalName.str(),
+                   global->getLoweredType().getASTType(), Ty.getASTType());
+        return true;
+      }
+
+      if (Opcode == SILInstructionKind::GlobalAddrInst) {
+        ResultVal = B.createGlobalAddr(InstLoc, global);
+      } else {
+        ResultVal = B.createGlobalValue(InstLoc, global);
+      }
+      break;
+    }
+    case SILInstructionKind::SelectEnumInst:
+    case SILInstructionKind::SelectEnumAddrInst: {
       if (parseTypedValueRef(Val, B))
         return true;
-      values.push_back(Val);
-    }
 
-    Identifier resumeName, unwindName;
-    SourceLoc resumeLoc, unwindLoc;
-    if (P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseVerbatim("resume") ||
-        parseSILIdentifier(resumeName, resumeLoc,
-                           diag::expected_sil_block_name) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseVerbatim("unwind") ||
-        parseSILIdentifier(unwindName, unwindLoc,
-                           diag::expected_sil_block_name) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    auto resumeBB = getBBForReference(resumeName, resumeLoc);
-    auto unwindBB = getBBForReference(unwindName, unwindLoc);
-    ResultVal = B.createYield(InstLoc, values, resumeBB, unwindBB);
-    break;
-  }
-  case SILInstructionKind::BranchInst: {
-    Identifier BBName;
-    SourceLoc NameLoc;
-    if (parseSILIdentifier(BBName, NameLoc, diag::expected_sil_block_name))
-      return true;
-
-    SmallVector<SILValue, 6> Args;
-    if (parseSILBBArgsAtBranch(Args, B))
-      return true;
-
-    if (parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    // Note, the basic block here could be a reference to an undefined
-    // basic block, which will be parsed later on.
-    ResultVal = B.createBranch(InstLoc, getBBForReference(BBName, NameLoc),
-                               Args);
-    break;
-  }
-  case SILInstructionKind::CondBranchInst: {
-    UnresolvedValueName Cond;
-    Identifier BBName, BBName2;
-    SourceLoc NameLoc, NameLoc2;
-    SmallVector<SILValue, 6> Args, Args2;
-    if (parseValueName(Cond) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILIdentifier(BBName, NameLoc, diag::expected_sil_block_name) ||
-        parseSILBBArgsAtBranch(Args, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILIdentifier(BBName2, NameLoc2,
-                           diag::expected_sil_block_name) ||
-        parseSILBBArgsAtBranch(Args2, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    auto I1Ty =
-      SILType::getBuiltinIntegerType(1, SILMod.getASTContext());
-    SILValue CondVal = getLocalValue(Cond, I1Ty, InstLoc, B);
-    ResultVal = B.createCondBranch(InstLoc, CondVal,
-                                   getBBForReference(BBName, NameLoc),
-                                   Args,
-                                   getBBForReference(BBName2, NameLoc2),
-                                   Args2);
-    break;
-  }
-  case SILInstructionKind::UnreachableInst:
-    if (parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createUnreachable(InstLoc);
-    break;
-    
-  case SILInstructionKind::ClassMethodInst:
-  case SILInstructionKind::SuperMethodInst:
-  case SILInstructionKind::ObjCMethodInst:
-  case SILInstructionKind::ObjCSuperMethodInst: {
-    SILDeclRef Member;
-    SILType MethodTy;
-    SourceLoc TyLoc;
-    SmallVector<ValueDecl *, 4> values;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
-      return true;
-
-    if (parseSILDeclRef(Member, true))
-      return true;
-
-    if (P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILType(MethodTy, TyLoc) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    switch (Opcode) {
-    default: llvm_unreachable("Out of sync with parent switch");
-    case SILInstructionKind::ClassMethodInst:
-      ResultVal = B.createClassMethod(InstLoc, Val, Member, MethodTy);
-      break;
-    case SILInstructionKind::SuperMethodInst:
-      ResultVal = B.createSuperMethod(InstLoc, Val, Member, MethodTy);
-      break;
-    case SILInstructionKind::ObjCMethodInst:
-      ResultVal = B.createObjCMethod(InstLoc, Val, Member, MethodTy);
-      break;
-    case SILInstructionKind::ObjCSuperMethodInst:
-      ResultVal = B.createObjCSuperMethod(InstLoc, Val, Member, MethodTy);
-      break;
-    }
-    break;
-  }
-  case SILInstructionKind::WitnessMethodInst: {
-    CanType LookupTy;
-    SILDeclRef Member;
-    SILType MethodTy;
-    SourceLoc TyLoc;
-    if (P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
-        parseASTType(LookupTy) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
-      return true;
-    if (parseSILDeclRef(Member, true))
-      return true;
-    // Optional operand.
-    SILValue Operand;
-    if (P.Tok.is(tok::comma)) {
-      P.consumeToken(tok::comma);
-      if (parseTypedValueRef(Operand, B))
-        return true;
-    }
-    if (P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-        parseSILType(MethodTy, TyLoc) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    // If LookupTy is a non-archetype, look up its conformance.
-    ProtocolDecl *proto
-      = dyn_cast<ProtocolDecl>(Member.getDecl()->getDeclContext());
-    if (!proto) {
-      P.diagnose(TyLoc, diag::sil_witness_method_not_protocol);
-      return true;
-    }
-    auto conformance = P.SF.getParentModule()->lookupConformance(LookupTy, proto);
-    if (conformance.isInvalid()) {
-      P.diagnose(TyLoc, diag::sil_witness_method_type_does_not_conform);
-      return true;
-    }
-
-    ResultVal =
-        B.createWitnessMethod(InstLoc, LookupTy, conformance, Member, MethodTy);
-    break;
-  }
-  case SILInstructionKind::CopyAddrInst: {
-    bool IsTake = false, IsInit = false;
-    UnresolvedValueName SrcLName;
-    SILValue DestLVal;
-    SourceLoc ToLoc, DestLoc;
-    Identifier ToToken;
-    if (parseSILOptional(IsTake, *this, "take") || parseValueName(SrcLName) ||
-        parseSILIdentifier(ToToken, ToLoc,
-                           diag::expected_tok_in_sil_instr, "to") ||
-        parseSILOptional(IsInit, *this, "initialization") ||
-        parseTypedValueRef(DestLVal, DestLoc, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    if (ToToken.str() != "to") {
-      P.diagnose(ToLoc, diag::expected_tok_in_sil_instr, "to");
-      return true;
-    }
-
-    if (!DestLVal->getType().isAddress()) {
-      P.diagnose(DestLoc, diag::sil_invalid_instr_operands);
-      return true;
-    }
-
-    SILValue SrcLVal = getLocalValue(SrcLName, DestLVal->getType(), InstLoc, B);
-    ResultVal = B.createCopyAddr(InstLoc, SrcLVal, DestLVal,
-                                 IsTake_t(IsTake),
-                                 IsInitialization_t(IsInit));
-    break;
-  }
-  case SILInstructionKind::BindMemoryInst: {
-    SILValue IndexVal;
-    Identifier ToToken;
-    SourceLoc ToLoc;
-    SILType EltTy;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseTypedValueRef(IndexVal, B) ||
-        parseSILIdentifier(ToToken, ToLoc,
-                           diag::expected_tok_in_sil_instr, "to") ||
-        parseSILType(EltTy) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    if (ToToken.str() != "to") {
-      P.diagnose(ToLoc, diag::expected_tok_in_sil_instr, "to");
-      return true;
-    }
-    ResultVal = B.createBindMemory(InstLoc, Val, IndexVal, EltTy);
-    break;
-  }
-  case SILInstructionKind::ObjectInst:
-  case SILInstructionKind::StructInst: {
-    SILType Ty;
-    if (parseSILType(Ty) ||
-        P.parseToken(tok::l_paren, diag::expected_tok_in_sil_instr, "("))
-      return true;
-
-    // Parse a list of SILValue.
-    bool OpsAreTailElems = false;
-    unsigned NumBaseElems = 0;
-    if (P.Tok.isNot(tok::r_paren)) {
-      do {
-        if (Opcode == SILInstructionKind::ObjectInst) {
-          if (parseSILOptional(OpsAreTailElems, *this, "tail_elems"))
+      SmallVector<std::pair<EnumElementDecl *, UnresolvedValueName>, 4>
+          CaseValueNames;
+      Optional<UnresolvedValueName> DefaultValueName;
+      while (P.consumeIf(tok::comma)) {
+        Identifier BBName;
+        SourceLoc BBLoc;
+        // Parse 'default' sil-value.
+        UnresolvedValueName tmp;
+        if (P.consumeIf(tok::kw_default)) {
+          if (parseValueName(tmp))
             return true;
-        }
-        if (parseTypedValueRef(Val, B)) return true;
-        OpList.push_back(Val);
-        if (!OpsAreTailElems)
-          NumBaseElems = OpList.size();
-      } while (P.consumeIf(tok::comma));
-    }
-    if (P.parseToken(tok::r_paren,
-                     diag::expected_tok_in_sil_instr,")") ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    if (Opcode == SILInstructionKind::StructInst) {
-      ResultVal = B.createStruct(InstLoc, Ty, OpList);
-    } else {
-      ResultVal = B.createObject(InstLoc, Ty, OpList, NumBaseElems);
-    }
-    break;
-  }
-  case SILInstructionKind::StructElementAddrInst:
-  case SILInstructionKind::StructExtractInst: {
-    ValueDecl *FieldV;
-    SourceLoc NameLoc = P.Tok.getLoc();
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILDottedPath(FieldV) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    if (!FieldV || !isa<VarDecl>(FieldV)) {
-      P.diagnose(NameLoc, diag::sil_struct_inst_wrong_field);
-      return true;
-    }
-    VarDecl *Field = cast<VarDecl>(FieldV);
-
-    // FIXME: substitution means this type should be explicit to improve
-    // performance.
-    auto ResultTy =
-        Val->getType().getFieldType(Field, SILMod, B.getTypeExpansionContext());
-    if (Opcode == SILInstructionKind::StructElementAddrInst)
-      ResultVal = B.createStructElementAddr(InstLoc, Val, Field,
-                                            ResultTy.getAddressType());
-    else
-      ResultVal = B.createStructExtract(InstLoc, Val, Field,
-                                        ResultTy.getObjectType());
-    break;
-  }
-  case SILInstructionKind::RefElementAddrInst: {
-    ValueDecl *FieldV;
-    SourceLoc NameLoc;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILDottedPath(FieldV) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    if (!FieldV || !isa<VarDecl>(FieldV)) {
-      P.diagnose(NameLoc, diag::sil_ref_inst_wrong_field);
-      return true;
-    }
-    VarDecl *Field = cast<VarDecl>(FieldV);
-    auto ResultTy =
-        Val->getType().getFieldType(Field, SILMod, B.getTypeExpansionContext());
-    ResultVal = B.createRefElementAddr(InstLoc, Val, Field, ResultTy);
-    break;
-  }
-  case SILInstructionKind::RefTailAddrInst: {
-    SourceLoc NameLoc;
-    SILType ResultObjTy;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILType(ResultObjTy) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    SILType ResultTy = ResultObjTy.getAddressType();
-    ResultVal = B.createRefTailAddr(InstLoc, Val, ResultTy);
-    break;
-  }
-  case SILInstructionKind::IndexAddrInst: {
-    SILValue IndexVal;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseTypedValueRef(IndexVal, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createIndexAddr(InstLoc, Val, IndexVal);
-    break;
-  }
-  case SILInstructionKind::TailAddrInst: {
-    SILValue IndexVal;
-    SILType ResultObjTy;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseTypedValueRef(IndexVal, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILType(ResultObjTy) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    SILType ResultTy = ResultObjTy.getAddressType();
-    ResultVal = B.createTailAddr(InstLoc, Val, IndexVal, ResultTy);
-    break;
-  }
-  case SILInstructionKind::IndexRawPointerInst: {
-    SILValue IndexVal;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseTypedValueRef(IndexVal, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createIndexRawPointer(InstLoc, Val, IndexVal);
-    break;
-  }
-  case SILInstructionKind::ObjCProtocolInst: {
-    Identifier ProtocolName;
-    SILType Ty;
-    if (P.parseToken(tok::pound, diag::expected_sil_constant) ||
-        parseSILIdentifier(ProtocolName, diag::expected_sil_constant) ||
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-        parseSILType(Ty) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    // Find the decl for the protocol name.
-    ValueDecl *VD;
-    SmallVector<ValueDecl*, 4> CurModuleResults;
-    // Perform a module level lookup on the first component of the
-    // fully-qualified name.
-    P.SF.getParentModule()->lookupValue(ProtocolName,
-                                        NLKind::UnqualifiedLookup,
-                                        CurModuleResults);
-    assert(CurModuleResults.size() == 1);
-    VD = CurModuleResults[0];
-    ResultVal = B.createObjCProtocol(InstLoc, cast<ProtocolDecl>(VD), Ty);
-    break;
-  }
-  case SILInstructionKind::AllocGlobalInst: {
-    Identifier GlobalName;
-    SourceLoc IdLoc;
-    if (P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
-        parseSILIdentifier(GlobalName, IdLoc, diag::expected_sil_value_name) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    // Go through list of global variables in the SILModule.
-    SILGlobalVariable *global = SILMod.lookUpGlobalVariable(GlobalName.str());
-    if (!global) {
-      P.diagnose(IdLoc, diag::sil_global_variable_not_found, GlobalName);
-      return true;
-    }
-
-    ResultVal = B.createAllocGlobal(InstLoc, global);
-    break;
-  }
-  case SILInstructionKind::GlobalAddrInst:
-  case SILInstructionKind::GlobalValueInst: {
-    Identifier GlobalName;
-    SourceLoc IdLoc;
-    SILType Ty;
-    if (P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
-        parseSILIdentifier(GlobalName, IdLoc, diag::expected_sil_value_name) ||
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-        parseSILType(Ty) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    // Go through list of global variables in the SILModule.
-    SILGlobalVariable *global = SILMod.lookUpGlobalVariable(GlobalName.str());
-    if (!global) {
-      P.diagnose(IdLoc, diag::sil_global_variable_not_found, GlobalName);
-      return true;
-    }
-
-    SILType expectedType = (Opcode == SILInstructionKind::GlobalAddrInst ?
-                            global->getLoweredType().getAddressType() :
-                            global->getLoweredType());
-    if (expectedType != Ty) {
-      P.diagnose(IdLoc, diag::sil_value_use_type_mismatch, GlobalName.str(),
-                 global->getLoweredType().getASTType(),
-                 Ty.getASTType());
-      return true;
-    }
-
-    if (Opcode == SILInstructionKind::GlobalAddrInst) {
-      ResultVal = B.createGlobalAddr(InstLoc, global);
-    } else {
-      ResultVal = B.createGlobalValue(InstLoc, global);
-    }
-    break;
-  }
-  case SILInstructionKind::SelectEnumInst:
-  case SILInstructionKind::SelectEnumAddrInst: {
-    if (parseTypedValueRef(Val, B))
-      return true;
-
-    SmallVector<std::pair<EnumElementDecl*, UnresolvedValueName>, 4>
-      CaseValueNames;
-    Optional<UnresolvedValueName> DefaultValueName;
-    while (P.consumeIf(tok::comma)) {
-      Identifier BBName;
-      SourceLoc BBLoc;
-      // Parse 'default' sil-value.
-     UnresolvedValueName tmp;
-      if (P.consumeIf(tok::kw_default)) {
-        if (parseValueName(tmp))
-          return true;
-        DefaultValueName = tmp;
-        break;
-      }
-
-      // Parse 'case' sil-decl-ref ':' sil-value.
-      if (P.consumeIf(tok::kw_case)) {
-        SILDeclRef ElemRef;
-        if (parseSILDeclRef(ElemRef))
-          return true;
-        assert(ElemRef.hasDecl() && isa<EnumElementDecl>(ElemRef.getDecl()));
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":");
-        parseValueName(tmp);
-        CaseValueNames.push_back(std::make_pair(
-                                     cast<EnumElementDecl>(ElemRef.getDecl()),
-                                     tmp));
-        continue;
-      }
-
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "case or default");
-      return true;
-    }
-    
-    // Parse the type of the result operands.
-    SILType ResultType;
-    if (P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
-        || parseSILType(ResultType) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    
-    // Resolve the results.
-    SmallVector<std::pair<EnumElementDecl*, SILValue>, 4> CaseValues;
-    SILValue DefaultValue;
-    if (DefaultValueName)
-      DefaultValue = getLocalValue(*DefaultValueName, ResultType, InstLoc, B);
-    for (auto &caseName : CaseValueNames)
-      CaseValues.push_back(std::make_pair(
-          caseName.first,
-          getLocalValue(caseName.second, ResultType, InstLoc, B)));
-
-    if (Opcode == SILInstructionKind::SelectEnumInst)
-      ResultVal = B.createSelectEnum(InstLoc, Val, ResultType,
-                                     DefaultValue, CaseValues);
-    else
-      ResultVal = B.createSelectEnumAddr(InstLoc, Val, ResultType,
-                                         DefaultValue, CaseValues);
-    break;
-  }
-      
-  case SILInstructionKind::SwitchEnumInst:
-  case SILInstructionKind::SwitchEnumAddrInst: {
-    if (parseTypedValueRef(Val, B))
-      return true;
-
-    SmallVector<std::pair<EnumElementDecl*, SILBasicBlock*>, 4> CaseBBs;
-    SILBasicBlock *DefaultBB = nullptr;
-    while (!peekSILDebugLocation(P) && P.consumeIf(tok::comma)) {
-      Identifier BBName;
-      SourceLoc BBLoc;
-      // Parse 'default' sil-identifier.
-      if (P.consumeIf(tok::kw_default)) {
-        parseSILIdentifier(BBName, BBLoc, diag::expected_sil_block_name);
-        DefaultBB = getBBForReference(BBName, BBLoc);
-        break;
-      }
-
-      // Parse 'case' sil-decl-ref ':' sil-identifier.
-      if (P.consumeIf(tok::kw_case)) {
-        SILDeclRef ElemRef;
-        if (parseSILDeclRef(ElemRef))
-          return true;
-        assert(ElemRef.hasDecl() && isa<EnumElementDecl>(ElemRef.getDecl()));
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":");
-        parseSILIdentifier(BBName, BBLoc, diag::expected_sil_block_name);
-        CaseBBs.push_back( {cast<EnumElementDecl>(ElemRef.getDecl()),
-                            getBBForReference(BBName, BBLoc)} );
-        continue;
-      }
-
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "case or default");
-      return true;
-    }
-    if (parseSILDebugLocation(InstLoc, B))
-      return true;
-    if (Opcode == SILInstructionKind::SwitchEnumInst)
-      ResultVal = B.createSwitchEnum(InstLoc, Val, DefaultBB, CaseBBs);
-    else
-      ResultVal = B.createSwitchEnumAddr(InstLoc, Val, DefaultBB, CaseBBs);
-    break;
-  }
-  case SILInstructionKind::SwitchValueInst: {
-    if (parseTypedValueRef(Val, B))
-      return true;
-
-    SmallVector<std::pair<SILValue, SILBasicBlock *>, 4> CaseBBs;
-    SILBasicBlock *DefaultBB = nullptr;
-    while (!peekSILDebugLocation(P) && P.consumeIf(tok::comma)) {
-      Identifier BBName;
-      SourceLoc BBLoc;
-      SILValue CaseVal;
-      
-      // Parse 'default' sil-identifier.
-      if (P.consumeIf(tok::kw_default)) {
-        parseSILIdentifier(BBName, BBLoc, diag::expected_sil_block_name);
-        DefaultBB = getBBForReference(BBName, BBLoc);
-        break;
-      }
-
-      // Parse 'case' value-ref ':' sil-identifier.
-      if (P.consumeIf(tok::kw_case)) {
-        if (parseValueRef(CaseVal, Val->getType(),
-                          RegularLocation(P.Tok.getLoc()), B)) {
-          // TODO: Issue a proper error message here
-          P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "reference to a value");
-          return true;
+          DefaultValueName = tmp;
+          break;
         }
 
-        auto intTy = Val->getType().getAs<BuiltinIntegerType>();
-        auto functionTy = Val->getType().getAs<SILFunctionType>();
-        if (!intTy && !functionTy) {
-          P.diagnose(P.Tok, diag::sil_integer_literal_not_integer_type);
-          return true;
+        // Parse 'case' sil-decl-ref ':' sil-value.
+        if (P.consumeIf(tok::kw_case)) {
+          SILDeclRef ElemRef;
+          if (parseSILDeclRef(ElemRef))
+            return true;
+          assert(ElemRef.hasDecl() && isa<EnumElementDecl>(ElemRef.getDecl()));
+          P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":");
+          parseValueName(tmp);
+          CaseValueNames.push_back(
+              std::make_pair(cast<EnumElementDecl>(ElemRef.getDecl()), tmp));
+          continue;
         }
 
-        if (intTy) {
-          // If it is a switch on an integer type, check that all case values
-          // are integer literals or undef.
-          if (!isa<SILUndef>(CaseVal)) {
-            auto *IL = dyn_cast<IntegerLiteralInst>(CaseVal);
-            if (!IL) {
-              P.diagnose(P.Tok, diag::sil_integer_literal_not_integer_type);
-              return true;
-            }
-            APInt CaseValue = IL->getValue();
+        P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "case or default");
+        return true;
+      }
 
-            if (CaseValue.getBitWidth() != intTy->getGreatestWidth())
-              CaseVal = B.createIntegerLiteral(
-                  IL->getLoc(), Val->getType(),
-                  CaseValue.zextOrTrunc(intTy->getGreatestWidth()));
+      // Parse the type of the result operands.
+      SILType ResultType;
+      if (P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
+          parseSILType(ResultType) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      // Resolve the results.
+      SmallVector<std::pair<EnumElementDecl *, SILValue>, 4> CaseValues;
+      SILValue DefaultValue;
+      if (DefaultValueName)
+        DefaultValue = getLocalValue(*DefaultValueName, ResultType, InstLoc, B);
+      for (auto &caseName : CaseValueNames)
+        CaseValues.push_back(std::make_pair(
+            caseName.first,
+            getLocalValue(caseName.second, ResultType, InstLoc, B)));
+
+      if (Opcode == SILInstructionKind::SelectEnumInst)
+        ResultVal = B.createSelectEnum(InstLoc, Val, ResultType, DefaultValue,
+                                       CaseValues);
+      else
+        ResultVal = B.createSelectEnumAddr(InstLoc, Val, ResultType,
+                                           DefaultValue, CaseValues);
+      break;
+    }
+
+    case SILInstructionKind::SwitchEnumInst:
+    case SILInstructionKind::SwitchEnumAddrInst: {
+      if (parseTypedValueRef(Val, B))
+        return true;
+
+      SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 4> CaseBBs;
+      SILBasicBlock *DefaultBB = nullptr;
+      while (!peekSILDebugLocation(P) && P.consumeIf(tok::comma)) {
+        Identifier BBName;
+        SourceLoc BBLoc;
+        // Parse 'default' sil-identifier.
+        if (P.consumeIf(tok::kw_default)) {
+          parseSILIdentifier(BBName, BBLoc, diag::expected_sil_block_name);
+          DefaultBB = getBBForReference(BBName, BBLoc);
+          break;
+        }
+
+        // Parse 'case' sil-decl-ref ':' sil-identifier.
+        if (P.consumeIf(tok::kw_case)) {
+          SILDeclRef ElemRef;
+          if (parseSILDeclRef(ElemRef))
+            return true;
+          assert(ElemRef.hasDecl() && isa<EnumElementDecl>(ElemRef.getDecl()));
+          P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":");
+          parseSILIdentifier(BBName, BBLoc, diag::expected_sil_block_name);
+          CaseBBs.push_back({cast<EnumElementDecl>(ElemRef.getDecl()),
+                             getBBForReference(BBName, BBLoc)});
+          continue;
+        }
+
+        P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "case or default");
+        return true;
+      }
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+      if (Opcode == SILInstructionKind::SwitchEnumInst)
+        ResultVal = B.createSwitchEnum(InstLoc, Val, DefaultBB, CaseBBs);
+      else
+        ResultVal = B.createSwitchEnumAddr(InstLoc, Val, DefaultBB, CaseBBs);
+      break;
+    }
+    case SILInstructionKind::SwitchValueInst: {
+      if (parseTypedValueRef(Val, B))
+        return true;
+
+      SmallVector<std::pair<SILValue, SILBasicBlock *>, 4> CaseBBs;
+      SILBasicBlock *DefaultBB = nullptr;
+      while (!peekSILDebugLocation(P) && P.consumeIf(tok::comma)) {
+        Identifier BBName;
+        SourceLoc BBLoc;
+        SILValue CaseVal;
+
+        // Parse 'default' sil-identifier.
+        if (P.consumeIf(tok::kw_default)) {
+          parseSILIdentifier(BBName, BBLoc, diag::expected_sil_block_name);
+          DefaultBB = getBBForReference(BBName, BBLoc);
+          break;
+        }
+
+        // Parse 'case' value-ref ':' sil-identifier.
+        if (P.consumeIf(tok::kw_case)) {
+          if (parseValueRef(CaseVal, Val->getType(),
+                            RegularLocation(P.Tok.getLoc()), B)) {
+            // TODO: Issue a proper error message here
+            P.diagnose(P.Tok, diag::expected_tok_in_sil_instr,
+                       "reference to a value");
+            return true;
           }
-        }
 
-        if (functionTy) {
-          // If it is a switch on a function type, check that all case values
-          // are function references or undef.
-          if (!isa<SILUndef>(CaseVal)) {
-            auto *FR = dyn_cast<FunctionRefInst>(CaseVal);
-            if (!FR) {
-              if (auto *CF = dyn_cast<ConvertFunctionInst>(CaseVal)) {
-                FR = dyn_cast<FunctionRefInst>(CF->getOperand());
+          auto intTy = Val->getType().getAs<BuiltinIntegerType>();
+          auto functionTy = Val->getType().getAs<SILFunctionType>();
+          if (!intTy && !functionTy) {
+            P.diagnose(P.Tok, diag::sil_integer_literal_not_integer_type);
+            return true;
+          }
+
+          if (intTy) {
+            // If it is a switch on an integer type, check that all case values
+            // are integer literals or undef.
+            if (!isa<SILUndef>(CaseVal)) {
+              auto *IL = dyn_cast<IntegerLiteralInst>(CaseVal);
+              if (!IL) {
+                P.diagnose(P.Tok, diag::sil_integer_literal_not_integer_type);
+                return true;
+              }
+              APInt CaseValue = IL->getValue();
+
+              if (CaseValue.getBitWidth() != intTy->getGreatestWidth())
+                CaseVal = B.createIntegerLiteral(
+                    IL->getLoc(), Val->getType(),
+                    CaseValue.zextOrTrunc(intTy->getGreatestWidth()));
+            }
+          }
+
+          if (functionTy) {
+            // If it is a switch on a function type, check that all case values
+            // are function references or undef.
+            if (!isa<SILUndef>(CaseVal)) {
+              auto *FR = dyn_cast<FunctionRefInst>(CaseVal);
+              if (!FR) {
+                if (auto *CF = dyn_cast<ConvertFunctionInst>(CaseVal)) {
+                  FR = dyn_cast<FunctionRefInst>(CF->getOperand());
+                }
+              }
+              if (!FR) {
+                P.diagnose(P.Tok, diag::sil_integer_literal_not_integer_type);
+                return true;
               }
             }
-            if (!FR) {
-              P.diagnose(P.Tok, diag::sil_integer_literal_not_integer_type);
-              return true;
-            }
           }
+
+          P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":");
+          parseSILIdentifier(BBName, BBLoc, diag::expected_sil_block_name);
+          CaseBBs.push_back({CaseVal, getBBForReference(BBName, BBLoc)});
+          continue;
         }
 
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":");
-        parseSILIdentifier(BBName, BBLoc, diag::expected_sil_block_name);
-        CaseBBs.push_back({CaseVal, getBBForReference(BBName, BBLoc)});
-        continue;
+        P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "case or default");
+        return true;
+      }
+      if (parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createSwitchValue(InstLoc, Val, DefaultBB, CaseBBs);
+      break;
+    }
+    case SILInstructionKind::SelectValueInst: {
+      if (parseTypedValueRef(Val, B))
+        return true;
+
+      SmallVector<std::pair<UnresolvedValueName, UnresolvedValueName>, 4>
+          CaseValueAndResultNames;
+      Optional<UnresolvedValueName> DefaultResultName;
+      while (P.consumeIf(tok::comma)) {
+        Identifier BBName;
+        SourceLoc BBLoc;
+        // Parse 'default' sil-value.
+        UnresolvedValueName tmp;
+        if (P.consumeIf(tok::kw_default)) {
+          if (parseValueName(tmp))
+            return true;
+          DefaultResultName = tmp;
+          break;
+        }
+
+        // Parse 'case' sil-decl-ref ':' sil-value.
+        if (P.consumeIf(tok::kw_case)) {
+          UnresolvedValueName casevalue;
+          parseValueName(casevalue);
+          P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":");
+          parseValueName(tmp);
+          CaseValueAndResultNames.push_back(std::make_pair(casevalue, tmp));
+          continue;
+        }
+
+        P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "case or default");
+        return true;
       }
 
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "case or default");
-      return true;
-    }
-    if (parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createSwitchValue(InstLoc, Val, DefaultBB, CaseBBs);
-    break;
-  }
-  case SILInstructionKind::SelectValueInst: {
-    if (parseTypedValueRef(Val, B))
-      return true;
+      if (!DefaultResultName) {
+        P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "default");
+        return true;
+      }
 
-    SmallVector<std::pair<UnresolvedValueName, UnresolvedValueName>, 4>
-      CaseValueAndResultNames;
-    Optional<UnresolvedValueName> DefaultResultName;
-    while (P.consumeIf(tok::comma)) {
-      Identifier BBName;
-      SourceLoc BBLoc;
-      // Parse 'default' sil-value.
-      UnresolvedValueName tmp;
-      if (P.consumeIf(tok::kw_default)) {
-        if (parseValueName(tmp))
+      // Parse the type of the result operands.
+      SILType ResultType;
+      if (P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
+          parseSILType(ResultType) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      // Resolve the results.
+      SmallVector<std::pair<SILValue, SILValue>, 4> CaseValues;
+      SILValue DefaultValue;
+      if (DefaultResultName)
+        DefaultValue =
+            getLocalValue(*DefaultResultName, ResultType, InstLoc, B);
+      SILType ValType = Val->getType();
+      for (auto &caseName : CaseValueAndResultNames)
+        CaseValues.push_back(std::make_pair(
+            getLocalValue(caseName.first, ValType, InstLoc, B),
+            getLocalValue(caseName.second, ResultType, InstLoc, B)));
+
+      ResultVal = B.createSelectValue(InstLoc, Val, ResultType, DefaultValue,
+                                      CaseValues);
+      break;
+    }
+    case SILInstructionKind::DeinitExistentialAddrInst: {
+      if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createDeinitExistentialAddr(InstLoc, Val);
+      break;
+    }
+    case SILInstructionKind::DeinitExistentialValueInst: {
+      if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
+        return true;
+      ResultVal = B.createDeinitExistentialValue(InstLoc, Val);
+      break;
+    }
+    case SILInstructionKind::InitExistentialAddrInst: {
+      CanType Ty;
+      SourceLoc TyLoc;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
+          parseASTType(Ty, TyLoc) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      // Lower the type at the abstraction level of the existential.
+      auto archetype = OpenedArchetypeType::get(Val->getType().getASTType())
+                           ->getCanonicalType();
+
+      auto &F = B.getFunction();
+      SILType LoweredTy =
+          F.getLoweredType(Lowering::AbstractionPattern(archetype), Ty)
+              .getAddressType();
+
+      // Collect conformances for the type.
+      ArrayRef<ProtocolConformanceRef> conformances =
+          collectExistentialConformances(P, Ty, TyLoc,
+                                         Val->getType().getASTType());
+
+      ResultVal = B.createInitExistentialAddr(InstLoc, Val, Ty, LoweredTy,
+                                              conformances);
+      break;
+    }
+    case SILInstructionKind::InitExistentialValueInst: {
+      CanType FormalConcreteTy;
+      SILType ExistentialTy;
+      SourceLoc TyLoc;
+
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
+          parseASTType(FormalConcreteTy, TyLoc) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILType(ExistentialTy) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      ArrayRef<ProtocolConformanceRef> conformances =
+          collectExistentialConformances(P, FormalConcreteTy, TyLoc,
+                                         ExistentialTy.getASTType());
+
+      ResultVal = B.createInitExistentialValue(
+          InstLoc, ExistentialTy, FormalConcreteTy, Val, conformances);
+      break;
+    }
+    case SILInstructionKind::AllocExistentialBoxInst: {
+      SILType ExistentialTy;
+      CanType ConcreteFormalTy;
+      SourceLoc TyLoc;
+
+      if (parseSILType(ExistentialTy) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
+          parseASTType(ConcreteFormalTy, TyLoc) ||
+          parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      // Collect conformances for the type.
+      ArrayRef<ProtocolConformanceRef> conformances =
+          collectExistentialConformances(P, ConcreteFormalTy, TyLoc,
+                                         ExistentialTy.getASTType());
+
+      ResultVal = B.createAllocExistentialBox(InstLoc, ExistentialTy,
+                                              ConcreteFormalTy, conformances);
+
+      break;
+    }
+    case SILInstructionKind::InitExistentialRefInst: {
+      CanType FormalConcreteTy;
+      SILType ExistentialTy;
+      SourceLoc TyLoc;
+
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
+          P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
+          parseASTType(FormalConcreteTy, TyLoc) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILType(ExistentialTy) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      ArrayRef<ProtocolConformanceRef> conformances =
+          collectExistentialConformances(P, FormalConcreteTy, TyLoc,
+                                         ExistentialTy.getASTType());
+
+      // FIXME: Conformances in InitExistentialRefInst is currently not included
+      // in SIL.rst.
+      ResultVal = B.createInitExistentialRef(
+          InstLoc, ExistentialTy, FormalConcreteTy, Val, conformances);
+      break;
+    }
+    case SILInstructionKind::InitExistentialMetatypeInst: {
+      SourceLoc TyLoc;
+      SILType ExistentialTy;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILType(ExistentialTy, TyLoc) ||
+          parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      auto baseExType = ExistentialTy.getASTType();
+      auto formalConcreteType = Val->getType().getASTType();
+      while (auto instExType = dyn_cast<ExistentialMetatypeType>(baseExType)) {
+        baseExType = instExType.getInstanceType();
+        formalConcreteType =
+            cast<MetatypeType>(formalConcreteType).getInstanceType();
+      }
+
+      ArrayRef<ProtocolConformanceRef> conformances =
+          collectExistentialConformances(P, formalConcreteType, TyLoc,
+                                         baseExType);
+
+      ResultVal = B.createInitExistentialMetatype(InstLoc, Val, ExistentialTy,
+                                                  conformances);
+      break;
+    }
+    case SILInstructionKind::DynamicMethodBranchInst: {
+      SILDeclRef Member;
+      Identifier BBName, BBName2;
+      SourceLoc NameLoc, NameLoc2;
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILDeclRef(Member) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILIdentifier(BBName, NameLoc, diag::expected_sil_block_name) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILIdentifier(BBName2, NameLoc2,
+                             diag::expected_sil_block_name) ||
+          parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      ResultVal = B.createDynamicMethodBranch(
+          InstLoc, Val, Member, getBBForReference(BBName, NameLoc),
+          getBBForReference(BBName2, NameLoc2));
+      break;
+    }
+    case SILInstructionKind::ProjectBlockStorageInst: {
+      if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      ResultVal = B.createProjectBlockStorage(InstLoc, Val);
+      break;
+    }
+    case SILInstructionKind::InitBlockStorageHeaderInst: {
+      Identifier invoke, type;
+      SourceLoc invokeLoc, typeLoc;
+
+      UnresolvedValueName invokeName;
+      SILType invokeTy;
+      GenericEnvironment *invokeGenericEnv;
+
+      SILType blockType;
+      SmallVector<ParsedSubstitution, 4> parsedSubs;
+
+      if (parseTypedValueRef(Val, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILIdentifier(invoke, invokeLoc, diag::expected_tok_in_sil_instr,
+                             "invoke") ||
+          parseValueName(invokeName) || parseSubstitutions(parsedSubs) ||
+          P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
+          parseSILType(invokeTy, invokeGenericEnv) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+          parseSILIdentifier(type, typeLoc, diag::expected_tok_in_sil_instr,
+                             "type") ||
+          parseSILType(blockType) || parseSILDebugLocation(InstLoc, B))
+        return true;
+
+      if (invoke.str() != "invoke") {
+        P.diagnose(invokeLoc, diag::expected_tok_in_sil_instr, "invoke");
+        return true;
+      }
+      if (type.str() != "type") {
+        P.diagnose(invokeLoc, diag::expected_tok_in_sil_instr, "type");
+        return true;
+      }
+
+      auto invokeVal = getLocalValue(invokeName, invokeTy, InstLoc, B);
+
+      SubstitutionMap subMap;
+      if (!parsedSubs.empty()) {
+        if (!invokeGenericEnv) {
+          P.diagnose(typeLoc, diag::sil_substitutions_on_non_polymorphic_type);
           return true;
-        DefaultResultName = tmp;
-        break;
+        }
+
+        subMap = getApplySubstitutionsFromParsed(*this, invokeGenericEnv,
+                                                 parsedSubs);
+        if (!subMap)
+          return true;
       }
 
-      // Parse 'case' sil-decl-ref ':' sil-value.
-      if (P.consumeIf(tok::kw_case)) {
-        UnresolvedValueName casevalue;
-        parseValueName(casevalue);
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":");
-        parseValueName(tmp);
-        CaseValueAndResultNames.push_back(std::make_pair(
-                                          casevalue,
-                                          tmp));
-        continue;
-      }
-
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "case or default");
-      return true;
+      ResultVal = B.createInitBlockStorageHeader(InstLoc, Val, invokeVal,
+                                                 blockType, subMap);
+      break;
+    }
     }
 
-    if (!DefaultResultName) {
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "default");
-      return true;
-    }
+    return false;
+}
 
-    // Parse the type of the result operands.
-    SILType ResultType;
-    if (P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-        parseSILType(ResultType) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    // Resolve the results.
-    SmallVector<std::pair<SILValue, SILValue>, 4> CaseValues;
-    SILValue DefaultValue;
-    if (DefaultResultName)
-      DefaultValue = getLocalValue(*DefaultResultName, ResultType, InstLoc, B);
-    SILType ValType = Val->getType();
-    for (auto &caseName : CaseValueAndResultNames)
-      CaseValues.push_back(std::make_pair(
-          getLocalValue(caseName.first, ValType, InstLoc, B),
-          getLocalValue(caseName.second, ResultType, InstLoc, B)));
-
-    ResultVal = B.createSelectValue(InstLoc, Val, ResultType,
-                                    DefaultValue, CaseValues);
-    break;
+/// sil-instruction-result ::= sil-value-name '='
+/// sil-instruction-result ::= '(' sil-value-name? ')'
+/// sil-instruction-result ::= '(' sil-value-name (',' sil-value-name)* ')'
+/// sil-instruction-source-info ::= (',' sil-scope-ref)? (',' sil-loc)?
+/// sil-instruction-def ::=
+///   (sil-instruction-result '=')? sil-instruction sil-instruction-source-info
+bool SILParser::parseSILInstruction(SILBuilder &B) {
+  // We require SIL instructions to be at the start of a line to assist
+  // recovery.
+  if (!P.Tok.isAtStartOfLine()) {
+    P.diagnose(P.Tok, diag::expected_sil_instr_start_of_line);
+    return true;
   }
-  case SILInstructionKind::DeinitExistentialAddrInst: {
-    if (parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createDeinitExistentialAddr(InstLoc, Val);
-    break;
-  }
-  case SILInstructionKind::DeinitExistentialValueInst: {
-    if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
-      return true;
-    ResultVal = B.createDeinitExistentialValue(InstLoc, Val);
-    break;
-  }
-  case SILInstructionKind::InitExistentialAddrInst: {
-    CanType Ty;
-    SourceLoc TyLoc;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
-        parseASTType(Ty, TyLoc) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    
-    // Lower the type at the abstraction level of the existential.
-    auto archetype
-      = OpenedArchetypeType::get(Val->getType().getASTType())
-        ->getCanonicalType();
-    
-    auto &F = B.getFunction();
-    SILType LoweredTy = F.getLoweredType(
-        Lowering::AbstractionPattern(archetype), Ty)
-      .getAddressType();
-    
-    // Collect conformances for the type.
-    ArrayRef<ProtocolConformanceRef> conformances
-      = collectExistentialConformances(P, Ty, TyLoc,
-                                       Val->getType().getASTType());
-    
-    ResultVal = B.createInitExistentialAddr(InstLoc, Val, Ty, LoweredTy,
-                                        conformances);
-    break;
-  }
-  case SILInstructionKind::InitExistentialValueInst: {
-    CanType FormalConcreteTy;
-    SILType ExistentialTy;
-    SourceLoc TyLoc;
 
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
-        parseASTType(FormalConcreteTy, TyLoc) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILType(ExistentialTy) || parseSILDebugLocation(InstLoc, B))
-      return true;
+  SmallVector<Located<StringRef>, 4> resultNames;
+  SourceLoc resultClauseBegin;
 
-    ArrayRef<ProtocolConformanceRef> conformances =
-        collectExistentialConformances(P, FormalConcreteTy, TyLoc,
-                                       ExistentialTy.getASTType());
+  // If the instruction has a name '%foo =', parse it.
+  if (P.Tok.is(tok::sil_local_name)) {
+    resultClauseBegin = P.Tok.getLoc();
+    resultNames.push_back({P.Tok.getText(), P.Tok.getLoc()});
+    P.consumeToken(tok::sil_local_name);
 
-    ResultVal = B.createInitExistentialValue(
-        InstLoc, ExistentialTy, FormalConcreteTy, Val, conformances);
-    break;
-  }
-  case SILInstructionKind::AllocExistentialBoxInst: {
-    SILType ExistentialTy;
-    CanType ConcreteFormalTy;
-    SourceLoc TyLoc;
-    
-    if (parseSILType(ExistentialTy) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
-        parseASTType(ConcreteFormalTy, TyLoc) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    
-    // Collect conformances for the type.
-    ArrayRef<ProtocolConformanceRef> conformances
-      = collectExistentialConformances(P, ConcreteFormalTy, TyLoc,
-                                       ExistentialTy.getASTType());
-    
-    ResultVal = B.createAllocExistentialBox(InstLoc, ExistentialTy,
-                                            ConcreteFormalTy, conformances);
-    
-    break;
-  }
-  case SILInstructionKind::InitExistentialRefInst: {
-    CanType FormalConcreteTy;
-    SILType ExistentialTy;
-    SourceLoc TyLoc;
+    // If the instruction has a '(%foo, %bar) = ', parse it.
+  } else if (P.consumeIf(tok::l_paren)) {
+    resultClauseBegin = P.PreviousLoc;
 
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-        P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
-        parseASTType(FormalConcreteTy, TyLoc) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILType(ExistentialTy) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    
-    ArrayRef<ProtocolConformanceRef> conformances
-      = collectExistentialConformances(P, FormalConcreteTy, TyLoc,
-                            ExistentialTy.getASTType());
+    if (!P.consumeIf(tok::r_paren)) {
+      while (true) {
+        if (!P.Tok.is(tok::sil_local_name)) {
+          P.diagnose(P.Tok, diag::expected_sil_value_name);
+          return true;
+        }
 
-    // FIXME: Conformances in InitExistentialRefInst is currently not included
-    // in SIL.rst.
-    ResultVal = B.createInitExistentialRef(InstLoc, ExistentialTy,
-                                           FormalConcreteTy, Val,
-                                           conformances);
-    break;
-  }
-  case SILInstructionKind::InitExistentialMetatypeInst: {
-    SourceLoc TyLoc;
-    SILType ExistentialTy;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILType(ExistentialTy, TyLoc) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
+        resultNames.push_back({P.Tok.getText(), P.Tok.getLoc()});
+        P.consumeToken(tok::sil_local_name);
 
-    auto baseExType = ExistentialTy.getASTType();
-    auto formalConcreteType = Val->getType().getASTType();
-    while (auto instExType = dyn_cast<ExistentialMetatypeType>(baseExType)) {
-      baseExType = instExType.getInstanceType();
-      formalConcreteType =
-        cast<MetatypeType>(formalConcreteType).getInstanceType();
-    }
+        if (P.consumeIf(tok::comma))
+          continue;
+        if (P.consumeIf(tok::r_paren))
+          break;
 
-    ArrayRef<ProtocolConformanceRef> conformances
-      = collectExistentialConformances(P, formalConcreteType, TyLoc,
-                                       baseExType);
-    
-    ResultVal = B.createInitExistentialMetatype(InstLoc, Val, ExistentialTy,
-                                                conformances);
-    break;
-  }
-  case SILInstructionKind::DynamicMethodBranchInst: {
-    SILDeclRef Member;
-    Identifier BBName, BBName2;
-    SourceLoc NameLoc, NameLoc2;
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILDeclRef(Member) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILIdentifier(BBName, NameLoc, diag::expected_sil_block_name) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILIdentifier(BBName2, NameLoc2,
-                           diag::expected_sil_block_name) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    ResultVal = B.createDynamicMethodBranch(InstLoc, Val, Member,
-                                            getBBForReference(BBName, NameLoc),
-                                            getBBForReference(BBName2,
-                                                              NameLoc2));
-    break;
-  }
-  case SILInstructionKind::ProjectBlockStorageInst: {
-    if (parseTypedValueRef(Val, B) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    
-    ResultVal = B.createProjectBlockStorage(InstLoc, Val);
-    break;
-  }
-  case SILInstructionKind::InitBlockStorageHeaderInst: {
-    Identifier invoke, type;
-    SourceLoc invokeLoc, typeLoc;
-    
-    UnresolvedValueName invokeName;
-    SILType invokeTy;
-    GenericEnvironment *invokeGenericEnv;
-    
-    SILType blockType;
-    SmallVector<ParsedSubstitution, 4> parsedSubs;
-
-    
-    if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILIdentifier(invoke, invokeLoc,
-                           diag::expected_tok_in_sil_instr, "invoke") ||
-        parseValueName(invokeName) ||
-        parseSubstitutions(parsedSubs) ||
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-        parseSILType(invokeTy, invokeGenericEnv) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILIdentifier(type, typeLoc,
-                           diag::expected_tok_in_sil_instr, "type") ||
-        parseSILType(blockType) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-    
-    if (invoke.str() != "invoke") {
-      P.diagnose(invokeLoc, diag::expected_tok_in_sil_instr, "invoke");
-      return true;
-    }
-    if (type.str() != "type") {
-      P.diagnose(invokeLoc, diag::expected_tok_in_sil_instr, "type");
-      return true;
-    }
-    
-    auto invokeVal = getLocalValue(invokeName, invokeTy, InstLoc, B);
-
-    SubstitutionMap subMap;
-    if (!parsedSubs.empty()) {
-      if (!invokeGenericEnv) {
-        P.diagnose(typeLoc, diag::sil_substitutions_on_non_polymorphic_type);
+        P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, ",");
         return true;
       }
-
-      subMap = getApplySubstitutionsFromParsed(*this, invokeGenericEnv,
-                                               parsedSubs);
-      if (!subMap)
-        return true;
     }
-    
-    ResultVal = B.createInitBlockStorageHeader(InstLoc, Val, invokeVal,
-                                               blockType, subMap);
-    break;
   }
+
+  if (resultClauseBegin.isValid()) {
+    if (P.parseToken(tok::equal, diag::expected_equal_in_sil_instr))
+      return true;
   }
+
+  SILInstructionKind Opcode;
+  SourceLoc OpcodeLoc;
+  StringRef OpcodeName;
+
+  // Parse the opcode name.
+  if (parseSILOpcode(Opcode, OpcodeLoc, OpcodeName))
+    return true;
+
+  // Perform opcode specific parsing.
+  SILInstruction *ResultVal;
+  if (parseSpecificSILInstruction(B, Opcode, OpcodeLoc, OpcodeName, ResultVal))
+    return true;
 
   // Match the results clause if we had one.
   if (resultClauseBegin.isValid()) {


### PR DESCRIPTION
Done using Xcode's refactoring engine! Should be NFC.

I am going to turn this method into a visitor on the op code.

NOTE: Xcode's refactoring engine messd with the whitespace, so I also ran this
through git-clang-format.

----

Just done while I was bored last night. We have talked about doing this a long time since it is impossible to separate the rest of the functionality from the method from the huge switch.