### PR TITLE
test: adjust DebugInfo tests for new LLVM update

### DIFF
--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -7,7 +7,7 @@
 
 // CHECK-DAG: ![[FOOMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Foo", includePath: "{{.*}}test{{.*}}DebugInfo{{.*}}"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE:[0-9]+]], entity: ![[FOOMODULE]]
-// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "{{.*}}test{{/|\\5C}}DebugInfo{{/|\\5C}}Imports.swift",
+// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "{{.*}}test{{/|\\\\}}DebugInfo{{/|\\\\}}Imports.swift",
 // CHECK-DAG: ![[SWIFTFILE:[0-9]+]] = !DIFile(filename: "{{.*}}Swift.swiftmodule{{(/.+[.]swiftmodule)?}}"
 // CHECK-DAG: ![[SWIFTMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Swift"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE]], entity: ![[SWIFTMODULE]]

--- a/test/DebugInfo/ImportsStdlib.swift
+++ b/test/DebugInfo/ImportsStdlib.swift
@@ -11,7 +11,7 @@
 
 // CHECK-DAG: ![[MODULE:[0-9]+]] = !DIModule({{.*}}, name: "NotTheStdlib", includePath: "{{.*}}test{{.*}}DebugInfo{{.*}}"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE:[0-9]+]], entity: ![[MODULE]]
-// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "{{.*}}test{{/|\\5C}}DebugInfo{{/|\\5C}}ImportsStdlib.swift"
+// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "{{.*}}test{{/|\\\\}}DebugInfo{{/|\\\\}}ImportsStdlib.swift"
 
 // NEGATIVE-NOT: !DIFile(filename: "{{.*}}Swift.swiftmodule"
 // NEGATIVE-NOT: !DIModule({{.*}}, name: "Swift"

--- a/test/DebugInfo/debug_prefix_map.swift
+++ b/test/DebugInfo/debug_prefix_map.swift
@@ -9,4 +9,4 @@ func square(_ n: Int) -> Int {
 }
 
 // CHECK: !DIFile(filename: "/var/empty/debug_prefix_map.swift"
-// CHECK: !DIModule(scope: null, name: "Globals", {{.*}}includePath: "/var/empty{{(/|\\5C)}}Globals.swiftmodule"
+// CHECK: !DIModule(scope: null, name: "Globals", {{.*}}includePath: "/var/empty{{(/|\\\\)}}Globals.swiftmodule"

--- a/test/DebugInfo/macro.swift
+++ b/test/DebugInfo/macro.swift
@@ -6,7 +6,7 @@
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "macro_enum",
 // CHECK-SAME:             file: ![[MACRO_H:[0-9]+]]
-// CHECK: ![[MACRO_H]] = !DIFile(filename: "{{.*}}{{(/|\\5C)}}Inputs{{(/|\\5C)}}Macro.h",
+// CHECK: ![[MACRO_H]] = !DIFile(filename: "{{.*}}{{(/|\\\\)}}Inputs{{(/|\\\\)}}Macro.h",
 
 import Macro
 


### PR DESCRIPTION
The filename on Windows now uses `\\` rather than `\\5C` for the path
separator.  Adjust the tests accordingly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
