### PR TITLE
Sema: Fix crash when synthesizing RawRepresentable conformance with non-Equatable raw type [5.2]

### DIFF
--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -71,7 +71,7 @@ bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
         // The presence of a raw type is an explicit declaration that
         // the compiler should derive a RawRepresentable conformance.
       case KnownProtocolKind::RawRepresentable:
-        return enumDecl->hasRawType();
+        return canDeriveRawRepresentable(DC, Nominal);
 
         // Enums without associated values can implicitly derive Equatable
         // conformance.

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -109,6 +109,12 @@ public:
   /// \returns the derived member, which will also be added to the type.
   Type deriveCaseIterable(AssociatedTypeDecl *assocType);
 
+  /// Determine if a RawRepresentable requirement can be derived for a type.
+  ///
+  /// This is implemented for non-empty enums without associated values,
+  /// that declare a raw type in the inheritance clause.
+  static bool canDeriveRawRepresentable(DeclContext *DC, NominalTypeDecl *type);
+
   /// Derive a RawRepresentable requirement for an enum, if it has a valid
   /// raw type and raw values for all of its cases.
   ///

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4038,8 +4038,6 @@ static void diagnoseConformanceFailure(Type T,
   // conformance to RawRepresentable was inferred.
   if (auto enumDecl = T->getEnumOrBoundGenericEnum()) {
     if (Proto->isSpecificProtocol(KnownProtocolKind::RawRepresentable) &&
-        DerivedConformance::derivesProtocolConformance(DC, enumDecl,
-                                                       Proto) &&
         enumDecl->hasRawType() &&
         !enumDecl->getRawType()->is<ErrorType>()) {
 


### PR DESCRIPTION
The error recovery logic around derived conformances is a little bit
tricky. Make sure we don't crash if a type explicitly provides a
RawValue type witness that is not equatable, but omits the witnesses
for init(rawValue:) and the rawValue property.

Fixes https://bugs.swift.org/browse/SR-6897, <rdar://problem/58127114>.