### PR TITLE
[5.2][AST] Handle visiting UnresolvedType in TypeMatcher

### DIFF
--- a/include/swift/AST/CanTypeVisitor.h
+++ b/include/swift/AST/CanTypeVisitor.h
@@ -31,15 +31,12 @@ class CanTypeVisitor {
 public:
   RetTy visit(CanType T, Args... args) {
     switch (T->getKind()) {
-#define UNCHECKED_TYPE(CLASS, PARENT) \
-    case TypeKind::CLASS:
 #define SUGARED_TYPE(CLASS, PARENT) \
     case TypeKind::CLASS:
 #define TYPE(CLASS, PARENT)
 #include "swift/AST/TypeNodes.def"
-      llvm_unreachable("non-canonical or unchecked type");
+      llvm_unreachable("non-canonical type");
 
-#define UNCHECKED_TYPE(CLASS, PARENT)
 #define SUGARED_TYPE(CLASS, PARENT)
 #define TYPE(CLASS, PARENT)                                  \
     case TypeKind::CLASS:                                    \
@@ -64,7 +61,12 @@ public:
 #define TYPE(CLASS, PARENT) ABSTRACT_TYPE(CLASS, PARENT)
 #define ABSTRACT_SUGARED_TYPE(CLASS, PARENT)
 #define SUGARED_TYPE(CLASS, PARENT)
-#define UNCHECKED_TYPE(CLASS, PARENT)
+  // Don't allow unchecked types by default, but allow visitors to opt-in to
+  // handling them.
+#define UNCHECKED_TYPE(CLASS, PARENT)                          \
+  RetTy visit##CLASS##Type(Can##CLASS##Type T, Args... args) { \
+     llvm_unreachable("unchecked type");                       \
+  }
 #include "swift/AST/TypeNodes.def"
 };
 

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -111,6 +111,12 @@ class TypeMatcher {
     TRIVIAL_CASE(BuiltinVectorType)
     TRIVIAL_CASE(SILTokenType)
 
+    bool visitUnresolvedType(CanUnresolvedType firstType, Type secondType,
+                             Type sugaredFirstType) {
+      // Unresolved types never match.
+      return mismatch(firstType.getPointer(), secondType, sugaredFirstType);
+    }
+
     bool visitTupleType(CanTupleType firstTuple, Type secondType,
                         Type sugaredFirstType) {
       if (auto secondTuple = secondType->getAs<TupleType>()) {
@@ -264,23 +270,6 @@ class TypeMatcher {
       return mismatch(firstInOut.getPointer(), secondType, sugaredFirstType);
     }
 
-    bool visitUnboundBoundGenericType(CanUnboundGenericType firstUBGT,
-                                      Type secondType, Type sugaredFirstType) {
-      if (auto secondUBGT = secondType->getAs<UnboundGenericType>()) {
-        if (firstUBGT->getDecl() != secondUBGT->getDecl())
-          return mismatch(firstUBGT.getPointer(), secondUBGT, sugaredFirstType);
-
-        if (firstUBGT.getParent())
-          return this->visit(firstUBGT.getParent(), secondUBGT->getParent(),
-                             sugaredFirstType->castTo<UnboundGenericType>()
-                               ->getParent());
-
-        return true;
-      }
-
-      return mismatch(firstUBGT.getPointer(), secondType, sugaredFirstType);
-    }
-
     bool visitBoundGenericType(CanBoundGenericType firstBGT,
                                Type secondType, Type sugaredFirstType) {
       auto _secondBGT = secondType->getCanonicalType();
@@ -308,8 +297,6 @@ class TypeMatcher {
 
       return mismatch(firstBGT.getPointer(), secondType, sugaredFirstType);
     }
-
-    TRIVIAL_CASE(TypeVariableType)
 
 #undef TRIVIAL_CASE
   };

--- a/test/IDE/complete_uninferred_generic.swift
+++ b/test/IDE/complete_uninferred_generic.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNINFERRED | %FileCheck %s -check-prefix=UNINFERRED
+
+struct S1<V0> {}
+protocol P1 {
+    associatedtype A1
+}
+extension P1 where A1 == S1<Int> {
+    subscript<T>(v0: T) -> Int  { fatalError() }
+    subscript<T>(v0: T) -> Undefined { fatalError() }
+}
+struct S2<T> : P1 {
+    typealias A1 = S1<T>
+}
+_ = S2()#^UNINFERRED^#
+
+// UNINFERRED: Decl[Subscript]/Super:     [{#(v0): T#}][#Int#]; name=[v0: T]
+// UNINFERRED: Decl[Subscript]/Super:     [{#(v0): T#}][#<<error type>>#]; name=[v0: T]
+// UNINFERRED: Keyword[self]/CurrNominal: .self[#S2<_>#]; name=self


### PR DESCRIPTION
This fixes code completion crashing / hitting llvm_unreachable("non-canonical or
unchecked type") when calling lookupVisibleMemberDecls with a base type that contains `UnresolvedType`. The GenericSignatureBuilder's `addSameTypeRequirementBetweenConcrete` uses a TypeMatcher based on CanTypeVisitor, which assumes it will never be given anything containing unchecked types.

This PR changes CanTypeVisitor to still disallow unchecked types by default, but to allow subclasses to opt-in to handling them. TypeMatcher now does do for UnresolvedType and reports any comparison involving it as a mismatch.

Cherry-pick of https://github.com/apple/swift/pull/28605 (reviewed by @slavapestov)
Resolves rdar://problem/56726715
