### PR TITLE
[5.2] Allow function builder attrs on vars without bodies in interfaces

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2477,8 +2477,24 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
       decl = func;
     } else if (auto storage = dyn_cast<AbstractStorageDecl>(D)) {
       decl = storage;
-      auto getter = storage->getParsedAccessor(AccessorKind::Get);
-      if (!getter || !getter->hasBody()) {
+
+      // Check whether this is a property without an explicit getter.
+      auto shouldDiagnose = [&]() -> bool {
+        auto getter = storage->getParsedAccessor(AccessorKind::Get);
+        if (!getter)
+          return true;
+
+        // Module interfaces don't print bodies for all getters, so allow getters
+        // that don't have a body if we're compiling a module interface.
+        SourceFile *parent = storage->getDeclContext()->getParentSourceFile();
+        bool isInInterface = parent && parent->Kind == SourceFileKind::Interface;
+        if (!isInInterface && !getter->hasBody())
+          return true;
+
+        return false;
+      };
+
+      if (shouldDiagnose()) {
         diagnose(attr->getLocation(),
                  diag::function_builder_attribute_on_storage_without_getter,
                  nominal->getFullName(),

--- a/test/ModuleInterface/function_builders.swift
+++ b/test/ModuleInterface/function_builders.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -typecheck -module-name FunctionBuilders -emit-module-interface-path %t/FunctionBuilders.swiftinterface %s
 // RUN: %FileCheck %s < %t/FunctionBuilders.swiftinterface
 // RUN: %target-swift-frontend -I %t -typecheck -verify %S/Inputs/function_builders_client.swift
+// RUN: %target-swift-frontend -compile-module-from-interface %t/FunctionBuilders.swiftinterface -o %t/FunctionBuilders.swiftmodule
 
 @_functionBuilder
 public struct TupleBuilder {
@@ -32,4 +33,14 @@ public struct TupleBuilder {
 // CHECK-LABEL: public func tuplify<T>(_ cond: Swift.Bool, @FunctionBuilders.TupleBuilder body: (Swift.Bool) -> T)
 public func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
   print(body(cond))
+}
+
+public struct UsesBuilderProperty {
+  // CHECK: @FunctionBuilders.TupleBuilder public var myVar: (Swift.String, Swift.String) {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: }
+  @TupleBuilder public var myVar: (String, String) {
+    "hello"
+    "goodbye"
+  }
 }


### PR DESCRIPTION
The check for whether or not we can use a function builder on a property
checked whether the attached getter had a body, which is not always true for
module interfaces. Just disable that part of the check when compiling a
module interface.

rdar://58535753