### PR TITLE
[DNM] test: adjust Migrator tests (NFCI)

### DIFF
--- a/test/Migrator/double_fixit_ok.swift
+++ b/test/Migrator/double_fixit_ok.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: not %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/double_fixit_ok.result -swift-version 4
-// RUN: diff -u %s.expected %t/double_fixit_ok.result
+// RUN: diff --strip-trailing-cr -u %s.expected %t/double_fixit_ok.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
 
 @available(swift, obsoleted: 4, renamed: "Thing.constant___renamed")

--- a/test/Migrator/double_fixit_ok.swift.expected
+++ b/test/Migrator/double_fixit_ok.swift.expected
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: not %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/double_fixit_ok.result -swift-version 4
-// RUN: diff -u %s.expected %t/double_fixit_ok.result
+// RUN: diff --strip-trailing-cr -u %s.expected %t/double_fixit_ok.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
 
 @available(swift, obsoleted: 4, renamed: "Thing.constant___renamed")

--- a/test/Migrator/insert_replace_fixit.swift
+++ b/test/Migrator/insert_replace_fixit.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift -swift-version 4
-// RUN: diff -u %s.expected %t/result.swift
+// RUN: diff --strip-trailing-cr -u %s.expected %t/result.swift
 
 import TestMyTime
 

--- a/test/Migrator/insert_replace_fixit.swift.expected
+++ b/test/Migrator/insert_replace_fixit.swift.expected
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift -swift-version 4
-// RUN: diff -u %s.expected %t/result.swift
+// RUN: diff --strip-trailing-cr -u %s.expected %t/result.swift
 
 import TestMyTime
 

--- a/test/Migrator/no_extraneous_argument_labels.swift
+++ b/test/Migrator/no_extraneous_argument_labels.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 4
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 4 -o /dev/null
-// RUN: diff -u %s.expected %t/no_extraneous_argument_labels.result
+// RUN: diff --strip-trailing-cr -u %s.expected %t/no_extraneous_argument_labels.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
 
 func foo(_ oc: [String]) {

--- a/test/Migrator/no_extraneous_argument_labels.swift.expected
+++ b/test/Migrator/no_extraneous_argument_labels.swift.expected
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 4
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 4 -o /dev/null
-// RUN: diff -u %s.expected %t/no_extraneous_argument_labels.result
+// RUN: diff --strip-trailing-cr -u %s.expected %t/no_extraneous_argument_labels.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
 
 func foo(_ oc: [String]) {

--- a/test/Migrator/no_var_to_let.swift
+++ b/test/Migrator/no_var_to_let.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 4
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/no_var_to_let.swift.result -swift-version 4 -o /dev/null
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/no_var_to_let.swift.result -swift-version 4 -o /dev/null
-// RUN: diff -u %s %t/no_var_to_let.swift.result
+// RUN: diff --strip-trailing-cr -u %s %t/no_var_to_let.swift.result
 // RUN: %target-swift-frontend -typecheck %s -swift-version 5
 
 // Note that the diff run line indicates that there should be no change.

--- a/test/Migrator/null_migration.swift
+++ b/test/Migrator/null_migration.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/migrated_null_migration.swift -emit-remap-file-path %t/null_migration.remap -o /dev/null
-// RUN: diff -u %s %t/migrated_null_migration.swift
+// RUN: diff --strip-trailing-cr -u %s %t/migrated_null_migration.swift
 
 // This file tests that, if all migration passes are no-op,
 // there are no changes to the file.

--- a/test/Migrator/optional_try_migration.swift
+++ b/test/Migrator/optional_try_migration.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -swift-version 4 -primary-file %s -emit-migrated-file-path %t/optional_try_migration.result.swift
-// RUN: diff -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
+// RUN: diff --strip-trailing-cr -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
 
 func fetchOptInt() throws -> Int? {
     return 3

--- a/test/Migrator/optional_try_migration.swift.expected
+++ b/test/Migrator/optional_try_migration.swift.expected
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -swift-version 4 -primary-file %s -emit-migrated-file-path %t/optional_try_migration.result.swift
-// RUN: diff -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
+// RUN: diff --strip-trailing-cr -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
 
 func fetchOptInt() throws -> Int? {
     return 3

--- a/test/Migrator/post_fixit_pass.swift
+++ b/test/Migrator/post_fixit_pass.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 4
-// RUN: diff -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
+// RUN: diff --strip-trailing-cr -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
 
 #if swift(>=4.2)
   public struct SomeAttribute: RawRepresentable {

--- a/test/Migrator/post_fixit_pass.swift.expected
+++ b/test/Migrator/post_fixit_pass.swift.expected
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 4
-// RUN: diff -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
+// RUN: diff --strip-trailing-cr -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
 
 #if swift(>=4.2)
   public struct SomeAttribute: RawRepresentable {


### PR DESCRIPTION
This adjusts the test diffing to ignore the whitespace changes across
different platforms.  `raw_fd_ostream` will write out `OF_Text` files
with the platform's line endings, which may differ from the source
file's.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
