### PR TITLE
TBDGen: teach the compiler to take a json file indicating previous install names

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -260,6 +260,28 @@ WARNING(tbd_only_supported_in_whole_module,none,
         "TBD generation is only supported when the whole module can be seen",
         ())
 
+WARNING(linker_directives_choice_confusion,none,
+        "only one of -emit-ldadd-cfile-path and -module-installname-map-file can be specified;"
+        "the c file won't be generated",
+        ())
+
+ERROR(previous_installname_map_missing,none,
+      "cannot open previous install name map from %0",
+      (StringRef))
+
+ERROR(previous_installname_map_corrupted,none,
+      "previous install name map from %0 is malformed",
+      (StringRef))
+
+REMARK(default_previous_install_name, none,
+      "default previous install name for %0 is %1", (StringRef, StringRef))
+
+REMARK(platform_previous_install_name, none,
+       "previous install name for %0 in %1 is %2", (StringRef, StringRef, StringRef))
+
+ERROR(unknown_platform_name, none,
+      "unkown platform name %0", (StringRef))
+
 ERROR(symbol_in_tbd_not_in_ir,none,
       "symbol '%0' (%1) is in TBD file, but not in generated IR",
       (StringRef, StringRef))

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -658,4 +658,8 @@ def type_info_dump_filter_EQ : Joined<["-"], "type-info-dump-filter=">,
 def emit_ldadd_cfile_path
   : Separate<["-"], "emit-ldadd-cfile-path">, MetaVarName<"<path>">,
     HelpText<"Generate .c file defining symbols to add back">;
+
+def previous_module_installname_map_file
+  : Separate<["-"], "previous-module-installname-map-file">, MetaVarName<"<path>">,
+    HelpText<"Path to a Json file indicating module name to installname map for @_originallyDefinedIn">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -49,6 +49,10 @@ struct TBDGenOptions {
   /// The dylib compatibility-version to use in the generated TBD file. Defaults
   /// to empty string if not provided.
   std::string CompatibilityVersion;
+
+  /// The path to a Json file indicating the module name to install-name map
+  /// used by @_originallyDefinedIn
+  std::string ModuleInstallNameMapPath;
 };
 
 void enumeratePublicSymbols(FileUnit *module, llvm::StringSet<> &symbols,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1018,6 +1018,9 @@ static bool ParseTBDGenArgs(TBDGenOptions &Opts, ArgList &Args,
   if (const Arg *A = Args.getLastArg(OPT_tbd_current_version)) {
     Opts.CurrentVersion = A->getValue();
   }
+  if (const Arg *A = Args.getLastArg(OPT_previous_module_installname_map_file)) {
+    Opts.ModuleInstallNameMapPath = A->getValue();
+  }
   return false;
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1068,6 +1068,11 @@ static bool writeLdAddCFileIfNeeded(CompilerInvocation &Invocation,
                                  diag::tbd_only_supported_in_whole_module);
     return true;
   }
+  if (!Invocation.getTBDGenOptions().ModuleInstallNameMapPath.empty()) {
+    Instance.getDiags().diagnose(SourceLoc(),
+                                 diag::linker_directives_choice_confusion);
+    return true;
+  }
   auto tbdOpts = Invocation.getTBDGenOptions();
   tbdOpts.LinkerDirectivesOnly = true;
   llvm::StringSet<> ldSymbols;

--- a/lib/TBDGen/ldPlatformKinds.def
+++ b/lib/TBDGen/ldPlatformKinds.def
@@ -1,0 +1,30 @@
+//===--- ldPlatformKinds.def - Compiler declaration metaprogramming --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines platform IDs used to emit linker directives $ld$previous
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LD_PLATFORM
+#  define LD_PLATFORM(Name, Id)
+#endif
+
+LD_PLATFORM(macOS, 1)
+LD_PLATFORM(iOS, 2)
+LD_PLATFORM(tvOS, 3)
+LD_PLATFORM(watchOS, 4)
+LD_PLATFORM(macCatalyst, 6)
+LD_PLATFORM(iOS_sim, 7)
+LD_PLATFORM(tvOS_sim, 8)
+LD_PLATFORM(watchOS_sim, 9)
+
+#undef LD_PLATFORM

--- a/test/TBD/Inputs/install-name-map.json
+++ b/test/TBD/Inputs/install-name-map.json
@@ -1,0 +1,16 @@
+[
+  {
+    "module": "Foo",
+    "platforms": ["macOS"],
+    "install_name": "/System/MacOS"
+  },
+  {
+    "module": "Foo",
+    "install_name": "/System/default"
+  },
+  {
+    "module": "Foo",
+    "platforms": ["iOS", "tvOS", "watchOS"],
+    "install_name": "/System/Others"
+  },
+]

--- a/test/TBD/previous-install-name-map.swift
+++ b/test/TBD/previous-install-name-map.swift
@@ -1,0 +1,13 @@
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map.json >& %t/remark.txt
+// RUN: %FileCheck %s < %t/remark.txt
+
+// CHECK: remark: default previous install name for Foo is /System/default
+// CHECK: remark: previous install name for Foo in macOS is /System/MacOS
+// CHECK: remark: previous install name for Foo in iOS is /System/Others
+// CHECK: remark: previous install name for Foo in tvOS is /System/Others
+// CHECK: remark: previous install name for Foo in watchOS is /System/Others


### PR DESCRIPTION
Using the new linker directives $ld$previous requires the compiler to know the previous
install names for the symbols marked as removed. This patch teaches the compiler
to take a path to a Json file specifying the map between module names and previous
install names. Also, these install names can be platform-specific.

Progress towards: rdar://58281536