### PR TITLE
[CodeCompletion] Disable module system headers validation

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -324,6 +324,11 @@ bool swift::ide::CompletionInstance::performOperation(
   // source text. That breaks an invariant of syntax tree building.
   Invocation.getLangOptions().BuildSyntaxTree = false;
 
+  // This validation may call stat(2) many times. Disable it to prevent
+  // performance regression.
+  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
+      true;
+
   // FIXME: ASTScopeLookup doesn't support code completion yet.
   Invocation.disableASTScopeLookup();
 


### PR DESCRIPTION
This validation may call many `stat(2)`. Since we don't expect system files are edited. Disable it for code completion. Even if they are edited, they are validated/updated when the user manually build the project.

rdar://problem/58550697
