### PR TITLE
AST: Weak-link declarations in extensions of weak-linked types [5.2]

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4348,21 +4348,23 @@ NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())
 
 WARNING(public_decl_needs_availability, none,
-     "public declarations should have an availability attribute with -require-explicit-availability", ())
+        "public declarations should have an availability attribute when building "
+        "with -require-explicit-availability", ())
 
 // This doesn't display as an availability diagnostic, but it's
 // implemented there and fires when these subscripts are marked
 // unavailable, so it seems appropriate to put it here.
 ERROR(availabilty_string_subscript_migration, none,
-      "subscripts returning String were obsoleted in Swift 4; explicitly construct a String from subscripted result", ())
+      "subscripts returning String were obsoleted in Swift 4; explicitly "
+      "construct a String from subscripted result", ())
 
 //------------------------------------------------------------------------------
 // MARK: @discardableResult
 //------------------------------------------------------------------------------
 
 WARNING(discardable_result_on_void_never_function, none,
-        "@discardableResult declared on a function returning %select{Never|Void}0 is unnecessary",
-        (bool))
+        "@discardableResult declared on a function returning %select{Never|Void}0 "
+        "is unnecessary", (bool))
 
 //------------------------------------------------------------------------------
 // MARK: Resilience diagnostics

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -766,6 +766,10 @@ AvailabilityContext Decl::getAvailabilityForLinkage() const {
   if (auto *accessor = dyn_cast<AccessorDecl>(this))
     return accessor->getStorage()->getAvailabilityForLinkage();
 
+  if (auto *ext = dyn_cast<ExtensionDecl>(this))
+    if (auto *nominal = ext->getExtendedNominal())
+      return nominal->getAvailabilityForLinkage();
+
   auto *dc = getDeclContext();
   if (auto *ext = dyn_cast<ExtensionDecl>(dc))
     return ext->getAvailabilityForLinkage();
@@ -786,6 +790,10 @@ bool Decl::isAlwaysWeakImported() const {
 
   if (auto *accessor = dyn_cast<AccessorDecl>(this))
     return accessor->getStorage()->isAlwaysWeakImported();
+
+  if (auto *ext = dyn_cast<ExtensionDecl>(this))
+    if (auto *nominal = ext->getExtendedNominal())
+      return nominal->isAlwaysWeakImported();
 
   auto *dc = getDeclContext();
   if (auto *ext = dyn_cast<ExtensionDecl>(dc))

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -192,6 +192,8 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);
   inputArgs.AddLastArg(arguments, options::OPT_enable_library_evolution);
+  inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability);
+  inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability_target);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);
   inputArgs.AddLastArg(arguments, options::OPT_enable_private_imports);
   inputArgs.AddLastArg(arguments, options::OPT_enable_cxx_interop);

--- a/test/IRGen/Inputs/weak_import_extension_helper.swift
+++ b/test/IRGen/Inputs/weak_import_extension_helper.swift
@@ -1,0 +1,8 @@
+@available(macOS 10.60, *)
+public struct Foo {
+  public init() {}
+}
+
+extension Foo {
+  public func extensionMethod() {}
+}

--- a/test/IRGen/weak_import_extension.swift
+++ b/test/IRGen/weak_import_extension.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -target x86_64-apple-macosx10.60 -emit-module-path %t/weak_import_extension_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_extension_helper.swift
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.50 | %FileCheck %s --check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.60 | %FileCheck %s --check-prefix=CHECK-NEW
+//
+// REQUIRES: OS=macosx
+
+import weak_import_extension_helper
+
+@available(macOS 10.60, *)
+public func callsExtensionMethod() {
+  Foo().extensionMethod()
+}
+
+// CHECK-OLD: declare extern_weak swiftcc %swift.metadata_response @"$s28weak_import_extension_helper3FooVMa"
+// CHECK-OLD: declare extern_weak swiftcc void @"$s28weak_import_extension_helper3FooVACycfC"
+// CHECK-OLD: declare extern_weak swiftcc void @"$s28weak_import_extension_helper3FooV0C6MethodyyF"
+
+// CHECK-NEW: declare swiftcc %swift.metadata_response @"$s28weak_import_extension_helper3FooVMa"
+// CHECK-NEW: declare swiftcc void @"$s28weak_import_extension_helper3FooVACycfC"
+// CHECK-NEW: declare swiftcc void @"$s28weak_import_extension_helper3FooV0C6MethodyyF"

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -1,5 +1,5 @@
-// RUN: %swift -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
-// RUN: %swift -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -warnings-as-errors %s
+// RUN: %swiftc_driver -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -Xfrontend -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
+// RUN: %swiftc_driver -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -warnings-as-errors %s
 
 public struct S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}}
   public func method() { }

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -1,14 +1,14 @@
 // RUN: %swift -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
 // RUN: %swift -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -warnings-as-errors %s
 
-public struct S { // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}}
+public struct S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}}
   public func method() { }
 }
 
-public func foo() { bar() } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public func foo() { bar() } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @usableFromInline
-func bar() { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+func bar() { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @available(macOS 10.1, *)
 public func ok() { }
@@ -17,10 +17,10 @@ public func ok() { }
 public func unavailableOk() { }
 
 @available(macOS, deprecated: 10.10)
-public func missingIntro() { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public func missingIntro() { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @available(iOS 9.0, *)
-public func missingTargetPlatform() { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public func missingTargetPlatform() { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
 func privateFunc() { }
 
@@ -35,19 +35,19 @@ struct SOk {
 precedencegroup MediumPrecedence {}
 infix operator + : MediumPrecedence
 
-public func +(lhs: S, rhs: S) -> S { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public func +(lhs: S, rhs: S) -> S { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
-public enum E { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public enum E { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
-public class C { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public class C { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
-public protocol P { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public protocol P { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
-extension S { // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+extension S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
   func ok() { }
 }
 
-open class OpenClass { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+open class OpenClass { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
 private class PrivateClass { }
 


### PR DESCRIPTION
This is a workaround to fix weak linking of frameworks that define
types with availability, but then define extensions of those types
without availability.

This can come up if the framework itself is built with a newer
deployment target than the client that uses the framework. Since the
type checker only enforces that an extension has availability if
the extension is less available than the deployment target, we were
failing to weak link the members of the extension in this case.

This is not a perfect fix; ideally such frameworks should be built
with -require-explicit-availability, and all reported warnings
fixed by adding explicit availability.

However, it allows clients to weak link when using existing
swiftinterface files that have already shipped in the mean time,
and it should not cause any problems once the frameworks are properly
annotated in the future.

Fixes <rdar://problem/58490723>.