### PR TITLE
IRGen: Don't use the demangler to realize imported Objective-C class metadata for now [5.2]

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2008,10 +2008,7 @@ static bool shouldAccessByMangledName(IRGenModule &IGM, CanType type) {
   if (auto nom = dyn_cast<NominalType>(type)) {
     if (!isa<ProtocolDecl>(nom->getDecl())
         && (!nom->getDecl()->isGenericContext()
-            || nom->getDecl()->getGenericSignature()->areAllParamsConcrete())
-        && (!nom->getClassOrBoundGenericClass()
-            || !nom->getClassOrBoundGenericClass()->hasClangNode()
-            || nom->getClassOrBoundGenericClass()->isForeign())) {
+            || nom->getDecl()->getGenericSignature()->areAllParamsConcrete())) {
       return false;
     }
   }

--- a/test/IRGen/access_type_metadata_by_mangled_name_objc.swift
+++ b/test/IRGen/access_type_metadata_by_mangled_name_objc.swift
@@ -12,7 +12,8 @@ public func test() {
   var x: Any.Type
 
   // Access ObjC classes by mangled name.
-  // CHECK: @"$sSo8NSObjectCMD"
+  // FIXME: Disabled for now.
+  // CHECK: @"$sSo8NSObjectCMa"
   x = NSObject.self
 
   // Use the metadata accessor for CF classes that already has to exist.

--- a/test/IRGen/objc_types_as_member.sil
+++ b/test/IRGen/objc_types_as_member.sil
@@ -9,8 +9,10 @@ import gizmo
 sil @use_metatype : $@convention(thin) <T> (@thin T.Type) -> ()
 
 // CHECK-LABEL: define swiftcc void @test(%TSo014OuterTypeInnerB0C* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
-// CHECK:   [[TMP:%.*]] = call {{.*}}@"$sSo9OuterTypeCMD"
-// CHECK:   call swiftcc void @use_metatype(%swift.type* [[TMP]])
+// FIXME:   Metadata realization via demangling is disabled for now
+// CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$sSo9OuterTypeCMa"
+// CHECK:   [[METADATA:%.*]] = extractvalue %swift.metadata_response %1, 0
+// CHECK:   call swiftcc void @use_metatype(%swift.type* [[METADATA]])
 // CHECK:   ret void
 
 sil @test : $@convention(witness_method: NSRuncing) (@guaranteed OuterType.InnerType) -> () {


### PR DESCRIPTION
Recently we started using the runtime demangler to realize imported
Objective-C class metadata, to save on code size since no metadata
accessor function needs to be emitted in this case.

This introduced a regression where OBJC_CLASSREF symbols were no
longer being emitted in some cases, which breaks autolinking.
The fix for this was tracked by rdar://56136123, but unfortunately
had to be reverted because it caused other problems.

Until the original fix can be re-applied, let's put in a temporary
workaround where we avoid going through the runtime demangler for
imported Objective-C classes. This regresses code size but unblocks
everyone involved, until the fix for the demangling code path
(824752547129f0cfdbbfd358a164031a9024972d) can be re-applied.

Fixes <rdar://56621277>.