### PR TITLE
tests: adjust the SourceKit tests for line endings (NFCI)

### DIFF
--- a/test/SourceKit/CodeComplete/complete_constructor.swift
+++ b/test/SourceKit/CodeComplete/complete_constructor.swift
@@ -7,4 +7,4 @@ class Foo {
 Foo(
 
 // RUN: %sourcekitd-test -req=complete -pos=7:5 %s -- %s > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/CodeComplete/complete_member.swift
+++ b/test/SourceKit/CodeComplete/complete_member.swift
@@ -40,7 +40,7 @@ func testOverrideUSR() {
 }
 
 // RUN: %sourcekitd-test -req=complete -pos=15:5 %s -- %s > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 //
 // RUN: %sourcekitd-test -req=complete -pos=19:5 %s -- %s | %FileCheck %s -check-prefix=CHECK-OPTIONAL
 // RUN: %sourcekitd-test -req=complete.open -pos=19:5 %s -- %s | %FileCheck %s -check-prefix=CHECK-OPTIONAL-OPEN

--- a/test/SourceKit/CodeComplete/complete_override.swift
+++ b/test/SourceKit/CodeComplete/complete_override.swift
@@ -6,5 +6,5 @@ class Derived : Base {
 }
 
 // RUN: %sourcekitd-test -req=complete -pos=5:1 %s -- %s > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 

--- a/test/SourceKit/CodeComplete/complete_unresolvedmember.swift
+++ b/test/SourceKit/CodeComplete/complete_unresolvedmember.swift
@@ -12,5 +12,5 @@ func test() -> Foo {
 }
 
 // RUN: %sourcekitd-test -req=complete -pos=11:11 %s -- %s > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 

--- a/test/SourceKit/ConformingMethods/basic.swift
+++ b/test/SourceKit/ConformingMethods/basic.swift
@@ -27,4 +27,4 @@ func testing(obj: C) {
 }
 
 // RUN: %sourcekitd-test -req=conformingmethods -pos=26:14 %s -req-opts=expectedtypes='$s8MyModule7Target2PD;$s8MyModule7Target1PD' -- -module-name MyModule %s > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/ConformingMethods/generics.swift
+++ b/test/SourceKit/ConformingMethods/generics.swift
@@ -18,6 +18,6 @@ func test<X>(value: S<X>) {
 }
 
 // RUN: %sourcekitd-test -req=conformingmethods -pos=12:10 %s -req-opts=expectedtypes='$s8MyModule5ProtoPD' -- -module-name MyModule %s > %t.response.1
-// RUN: diff -u %s.response.1 %t.response.1
+// RUN: diff --strip-trailing-cr -u %s.response.1 %t.response.1
 // RUN: %sourcekitd-test -req=conformingmethods -pos=17:8 %s -req-opts=expectedtypes='$s8MyModule5ProtoPD' -- -module-name MyModule %s > %t.response.2
-// RUN: diff -u %s.response.2 %t.response.2
+// RUN: diff --strip-trailing-cr -u %s.response.2 %t.response.2

--- a/test/SourceKit/CursorInfo/rdar_18677108-2.swift
+++ b/test/SourceKit/CursorInfo/rdar_18677108-2.swift
@@ -2,7 +2,7 @@
 // RUN:                               --  %S/Inputs/rdar_18677108-2-b.swift \
 // RUN:                                   %S/Inputs/rdar_18677108-2-a.swift \
 // RUN:               == -req=print-diags %S/Inputs/rdar_18677108-2-a.swift | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 
 

--- a/test/SourceKit/DocSupport/doc_source_file.swift
+++ b/test/SourceKit/DocSupport/doc_source_file.swift
@@ -1,5 +1,5 @@
 // RUN: %sourcekitd-test -req=doc-info %S/Inputs/main.swift > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 // RUN: not %sourcekitd-test -req=doc-info %S/Inputs/main.swift -- %S/Inputs/cake.swift 2> %t.error
 // RUN: %FileCheck %s -check-prefix=MULTI_FILE < %t.error

--- a/test/SourceKit/DocSupport/doc_swift_module.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift
@@ -1,4 +1,4 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library  -enable-objc-interop -emit-module-doc-path %t.mod/cake.swiftdoc
 // RUN: %sourcekitd-test -req=doc-info -module cake -- -I %t.mod > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/DocSupport/doc_swift_module1.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module1.swift
@@ -1,4 +1,4 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %swift -emit-module -o %t.mod/cake1.swiftmodule %S/Inputs/cake1.swift -parse-as-library
 // RUN: %sourcekitd-test -req=doc-info -module cake1 -- -I %t.mod > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/DocumentStructure/access_parse.swift
+++ b/test/SourceKit/DocumentStructure/access_parse.swift
@@ -1,3 +1,3 @@
 // RUN: %swift -typecheck %S/Inputs/access.swift
 // RUN: %sourcekitd-test -req=structure %S/Inputs/access.swift -- -module-name Access %S/Inputs/access.swift > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/DocumentStructure/mark_edit.swift
+++ b/test/SourceKit/DocumentStructure/mark_edit.swift
@@ -1,2 +1,2 @@
 // RUN: %sourcekitd-test -req=structure -pos=1:1 -length=0 -replace=" " %S/Inputs/mark.swift > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/DocumentStructure/structure.swift
+++ b/test/SourceKit/DocumentStructure/structure.swift
@@ -1,14 +1,14 @@
 // RUN: %sourcekitd-test -req=structure %S/Inputs/main.swift -- -module-name StructureTest %S/Inputs/main.swift | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 // RUN: %sourcekitd-test -req=structure %S/Inputs/invalid.swift | %sed_clean > %t.invalid.response
-// RUN: diff -u %s.invalid.response %t.invalid.response
+// RUN: diff --strip-trailing-cr -u %s.invalid.response %t.invalid.response
 
 // RUN: %sourcekitd-test -req=structure %S/../Inputs/placeholders.swift | %sed_clean > %t.placeholders.response
-// RUN: diff -u %s.placeholders.response %t.placeholders.response
+// RUN: diff --strip-trailing-cr -u %s.placeholders.response %t.placeholders.response
 
 // RUN: %sourcekitd-test -req=structure %S/Inputs/main.swift -name -foobar | %sed_clean > %t.foobar.response
-// RUN: diff -u %s.foobar.response %t.foobar.response
+// RUN: diff --strip-trailing-cr -u %s.foobar.response %t.foobar.response
 
 // RUN: %sourcekitd-test -req=structure -text-input %S/Inputs/main.swift | %sed_clean > %t.empty.response
-// RUN: diff -u %s.empty.response %t.empty.response
+// RUN: diff --strip-trailing-cr -u %s.empty.response %t.empty.response

--- a/test/SourceKit/DocumentStructure/structure_object_literals.swift
+++ b/test/SourceKit/DocumentStructure/structure_object_literals.swift
@@ -1,5 +1,5 @@
 // RUN: %sourcekitd-test -req=structure %s -- -module-name StructureTest %s | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 let color: S = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
 let image: I? = #imageLiteral(resourceName: "hello.png")

--- a/test/SourceKit/DocumentStructure/structure_object_literals.swift.response
+++ b/test/SourceKit/DocumentStructure/structure_object_literals.swift.response
@@ -1,66 +1,66 @@
 {
   key.offset: 0,
-  key.length: 267,
+  key.length: 287,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
       key.kind: source.lang.swift.decl.var.global,
       key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "color",
-      key.offset: 144,
+      key.offset: 164,
       key.length: 65,
       key.typename: "S",
-      key.nameoffset: 148,
+      key.nameoffset: 168,
       key.namelength: 5
     },
     {
       key.kind: source.lang.swift.expr.object_literal,
       key.name: "colorLiteral",
-      key.offset: 159,
+      key.offset: 179,
       key.length: 50,
-      key.nameoffset: 160,
+      key.nameoffset: 180,
       key.namelength: 12,
-      key.bodyoffset: 172,
+      key.bodyoffset: 192,
       key.bodylength: 36,
       key.substructure: [
         {
           key.kind: source.lang.swift.expr.argument,
           key.name: "red",
-          key.offset: 173,
+          key.offset: 193,
           key.length: 6,
-          key.nameoffset: 173,
+          key.nameoffset: 193,
           key.namelength: 3,
-          key.bodyoffset: 178,
+          key.bodyoffset: 198,
           key.bodylength: 1
         },
         {
           key.kind: source.lang.swift.expr.argument,
           key.name: "green",
-          key.offset: 181,
+          key.offset: 201,
           key.length: 8,
-          key.nameoffset: 181,
+          key.nameoffset: 201,
           key.namelength: 5,
-          key.bodyoffset: 188,
+          key.bodyoffset: 208,
           key.bodylength: 1
         },
         {
           key.kind: source.lang.swift.expr.argument,
           key.name: "blue",
-          key.offset: 191,
+          key.offset: 211,
           key.length: 7,
-          key.nameoffset: 191,
+          key.nameoffset: 211,
           key.namelength: 4,
-          key.bodyoffset: 197,
+          key.bodyoffset: 217,
           key.bodylength: 1
         },
         {
           key.kind: source.lang.swift.expr.argument,
           key.name: "alpha",
-          key.offset: 200,
+          key.offset: 220,
           key.length: 8,
-          key.nameoffset: 200,
+          key.nameoffset: 220,
           key.namelength: 5,
-          key.bodyoffset: 207,
+          key.bodyoffset: 227,
           key.bodylength: 1
         }
       ]
@@ -69,30 +69,30 @@
       key.kind: source.lang.swift.decl.var.global,
       key.accessibility: source.lang.swift.accessibility.internal,
       key.name: "image",
-      key.offset: 210,
+      key.offset: 230,
       key.length: 56,
       key.typename: "I?",
-      key.nameoffset: 214,
+      key.nameoffset: 234,
       key.namelength: 5
     },
     {
       key.kind: source.lang.swift.expr.object_literal,
       key.name: "imageLiteral",
-      key.offset: 226,
+      key.offset: 246,
       key.length: 40,
-      key.nameoffset: 227,
+      key.nameoffset: 247,
       key.namelength: 12,
-      key.bodyoffset: 239,
+      key.bodyoffset: 259,
       key.bodylength: 26,
       key.substructure: [
         {
           key.kind: source.lang.swift.expr.argument,
           key.name: "resourceName",
-          key.offset: 240,
+          key.offset: 260,
           key.length: 25,
-          key.nameoffset: 240,
+          key.nameoffset: 260,
           key.namelength: 12,
-          key.bodyoffset: 254,
+          key.bodyoffset: 274,
           key.bodylength: 11
         }
       ]

--- a/test/SourceKit/ExtractComment/extract_comments.swift
+++ b/test/SourceKit/ExtractComment/extract_comments.swift
@@ -1,28 +1,28 @@
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/DocComment1.swift > %t.DocComment1.response
-// RUN: diff -u %s.DocComment1.response %t.DocComment1.response
+// RUN: diff --strip-trailing-cr -u %s.DocComment1.response %t.DocComment1.response
 
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/DocComment2.swift > %t.DocComment2.response
-// RUN: diff -u %s.DocComment2.response %t.DocComment2.response
+// RUN: diff --strip-trailing-cr -u %s.DocComment2.response %t.DocComment2.response
 
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/DocComment3.swift > %t.DocComment3.response
-// RUN: diff -u %s.DocComment3.response %t.DocComment3.response
+// RUN: diff --strip-trailing-cr -u %s.DocComment3.response %t.DocComment3.response
 
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/DocCommentEmptyLine1.swift > %t.DocCommentEmptyLine1.response
-// RUN: diff -u %s.DocCommentEmptyLine1.response %t.DocCommentEmptyLine1.response
+// RUN: diff --strip-trailing-cr -u %s.DocCommentEmptyLine1.response %t.DocCommentEmptyLine1.response
 
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/DocCommentEmptyLine2.swift > %t.DocCommentEmptyLine2.response
-// RUN: diff -u %s.DocCommentEmptyLine2.response %t.DocCommentEmptyLine2.response
+// RUN: diff --strip-trailing-cr -u %s.DocCommentEmptyLine2.response %t.DocCommentEmptyLine2.response
 
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/DocCommentEmptyLine3.swift > %t.DocCommentEmptyLine3.response
-// RUN: diff -u %s.DocCommentEmptyLine3.response %t.DocCommentEmptyLine3.response
+// RUN: diff --strip-trailing-cr -u %s.DocCommentEmptyLine3.response %t.DocCommentEmptyLine3.response
 
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/Comment1.swift > %t.Comment1.response
-// RUN: diff -u %s.Comment1.response %t.Comment1.response
+// RUN: diff --strip-trailing-cr -u %s.Comment1.response %t.Comment1.response
 
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/CommentIndent1.swift > %t.CommentIndent1.response
-// RUN: diff -u %s.CommentIndent1.response %t.CommentIndent1.response
+// RUN: diff --strip-trailing-cr -u %s.CommentIndent1.response %t.CommentIndent1.response
 
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/CommentIndent2.swift > %t.CommentIndent2.response
-// RUN: diff -u %s.CommentIndent2.response %t.CommentIndent2.response
+// RUN: diff --strip-trailing-cr -u %s.CommentIndent2.response %t.CommentIndent2.response
 
 // RUN: %sourcekitd-test -req=extract-comment -pass-as-sourcetext %S/Inputs/NotComment1.swift

--- a/test/SourceKit/Indexing/index_big_array.swift
+++ b/test/SourceKit/Indexing/index_big_array.swift
@@ -1,2 +1,2 @@
 // RUN: %sourcekitd-test -req=index %S/../Inputs/big_array.swift -- %S/../Inputs/big_array.swift | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/Indexing/index_enum_case.swift
+++ b/test/SourceKit/Indexing/index_enum_case.swift
@@ -1,5 +1,5 @@
 // RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 public enum E {
 

--- a/test/SourceKit/Indexing/index_forbid_typecheck.swift
+++ b/test/SourceKit/Indexing/index_forbid_typecheck.swift
@@ -1,2 +1,2 @@
 // RUN: %sourcekitd-test -req=index %S/../Inputs/forbid_typecheck_primary.swift -- -Xfrontend -debug-forbid-typecheck-prefix -Xfrontend NOTYPECHECK %S/../Inputs/forbid_typecheck_2.swift %S/../Inputs/forbid_typecheck_primary.swift -module-name forbid_typecheck | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/Indexing/index_func_import.swift
+++ b/test/SourceKit/Indexing/index_func_import.swift
@@ -2,7 +2,7 @@
 // RUN: %swift -emit-module -o %t/test_module.swiftmodule %S/Inputs/test_module.swift
 
 // RUN: %sourcekitd-test -req=index %s -- %s -I %t | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 import func test_module.globalFunc
 

--- a/test/SourceKit/Indexing/index_implicit_vis.swift
+++ b/test/SourceKit/Indexing/index_implicit_vis.swift
@@ -1,4 +1,4 @@
 // RUN: %sourcekitd-test -req=index %S/Inputs/implicit-vis/a.swift -- %S/Inputs/implicit-vis/a.swift %S/Inputs/implicit-vis/b.swift -o implicit_vis.o | %sed_clean > %t.a.response
 // RUN: %sourcekitd-test -req=index %S/Inputs/implicit-vis/b.swift -- %S/Inputs/implicit-vis/a.swift %S/Inputs/implicit-vis/b.swift -o implicit_vis.o | %sed_clean > %t.b.response
-// RUN: diff -u %S/Inputs/implicit-vis/a.index.response %t.a.response
-// RUN: diff -u %S/Inputs/implicit-vis/b.index.response %t.b.response
+// RUN: diff --strip-trailing-cr -u %S/Inputs/implicit-vis/a.index.response %t.a.response
+// RUN: diff --strip-trailing-cr -u %S/Inputs/implicit-vis/b.index.response %t.b.response

--- a/test/SourceKit/Indexing/index_operators.swift
+++ b/test/SourceKit/Indexing/index_operators.swift
@@ -1,5 +1,5 @@
 // RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 class ClassA {
     init(){}

--- a/test/SourceKit/Indexing/index_with_swift_module.swift
+++ b/test/SourceKit/Indexing/index_with_swift_module.swift
@@ -4,7 +4,7 @@
 // RUN: %sourcekitd-test -req=index %s -- %s -I %t | %FileCheck %s
 
 // RUN: %sourcekitd-test -req=index %t/test_module.swiftmodule | %sed_clean > %t.response
-// RUN: diff -u %S/Inputs/test_module.index.response %t.response
+// RUN: diff --strip-trailing-cr -u %S/Inputs/test_module.index.response %t.response
 
 import test_module
 

--- a/test/SourceKit/Indexing/rdar_21602898.swift
+++ b/test/SourceKit/Indexing/rdar_21602898.swift
@@ -1,5 +1,5 @@
 // RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 protocol P {}
 class C {

--- a/test/SourceKit/Indexing/sr_3815.swift
+++ b/test/SourceKit/Indexing/sr_3815.swift
@@ -1,5 +1,5 @@
 // RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 protocol P {
   typealias Index = Int

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift
@@ -8,7 +8,7 @@ func f(s : inout [Int]) {
 // RUN: %empty-directory(%t.mod/mcp)
 // RUN: %swift -emit-module -o %t.mod/swift_mod.swiftmodule %S/Inputs/swift_mod.swift -parse-as-library
 // RUN: %sourcekitd-test -req=interface-gen -module swift_mod -- -I %t.mod > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 // RUN: %sourcekitd-test -req=module-groups -module swift_mod -- -I %t.mod | %FileCheck -check-prefix=GROUP-EMPTY %s
 // GROUP-EMPTY: <GROUPS>
@@ -32,4 +32,4 @@ func f(s : inout [Int]) {
 // RUN: %empty-directory(%t.mod)
 // RUN: %swift -emit-module -o /dev/null -emit-module-interface-path %t.mod/swift_mod.swiftinterface -O %S/Inputs/swift_mod.swift -parse-as-library
 // RUN: %sourcekitd-test -req=interface-gen -module swift_mod -- -I %t.mod -module-cache-path %t.mod/mcp > %t.response
-// RUN: diff -u %s.from_swiftinterface.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.from_swiftinterface.response %t.response

--- a/test/SourceKit/InterfaceGen/gen_swiftonly_systemmodule.swift
+++ b/test/SourceKit/InterfaceGen/gen_swiftonly_systemmodule.swift
@@ -9,7 +9,7 @@
 // RUN:     %s
 
 // RUN: %sourcekitd-test -req=interface-gen -module SomeModule -- -sdk %t/SDK -Fsystem %t/SDK/Frameworks -target %target-triple > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 public struct SomeValue {
   internal var internalValue: Int { return 1 }

--- a/test/SourceKit/MarkupXML/basic.swift
+++ b/test/SourceKit/MarkupXML/basic.swift
@@ -1,2 +1,2 @@
 // RUN: %sourcekitd-test -req=markup-xml -pass-as-sourcetext %S/Input/DocComment1.md > %t.DocComment1.response
-// RUN: diff -u %s.DocComment1.response %t.DocComment1.response
+// RUN: diff --strip-trailing-cr -u %s.DocComment1.response %t.DocComment1.response

--- a/test/SourceKit/Sema/enum-toraw/enum-toraw.swift
+++ b/test/SourceKit/Sema/enum-toraw/enum-toraw.swift
@@ -1,3 +1,3 @@
 // RUN: %sourcekitd-test -req=sema %S/Inputs/t2.swift -- %S/Inputs/t1.swift %S/Inputs/t2.swift | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 

--- a/test/SourceKit/Sema/placeholders.swift
+++ b/test/SourceKit/Sema/placeholders.swift
@@ -1,2 +1,2 @@
 // RUN: %sourcekitd-test -req=sema %S/../Inputs/placeholders.swift -- %S/../Inputs/placeholders.swift | %sed_clean > %t.placeholders.response
-// RUN: diff -u %s.placeholders.response %t.placeholders.response
+// RUN: diff --strip-trailing-cr -u %s.placeholders.response %t.placeholders.response

--- a/test/SourceKit/Sema/sema_big_array.swift
+++ b/test/SourceKit/Sema/sema_big_array.swift
@@ -1,2 +1,2 @@
 // RUN: %sourcekitd-test -req=sema %S/../Inputs/big_array.swift -- %S/../Inputs/big_array.swift > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/Sema/sema_config.swift
+++ b/test/SourceKit/Sema/sema_config.swift
@@ -7,6 +7,6 @@ x = 2
 #endif
 
 // RUN: %sourcekitd-test -req=sema %s -- %s > %t.false.response
-// RUN: diff -u %s.false.response %t.false.response
+// RUN: diff --strip-trailing-cr -u %s.false.response %t.false.response
 // RUN: %sourcekitd-test -req=sema %s -- %s -D FOO > %t.true.response
-// RUN: diff -u %s.true.response %t.true.response
+// RUN: diff --strip-trailing-cr -u %s.true.response %t.true.response

--- a/test/SourceKit/Sema/sema_edits.swift
+++ b/test/SourceKit/Sema/sema_edits.swift
@@ -6,4 +6,4 @@ print("hello")
 // RUN: %sourcekitd-test -req=open %s -- %s == -req=edit -pos=3:5 -replace="}" -length=0 %s == \
 // RUN:    -req=edit -pos=3:1 -replace="}" -length=5 %s == \
 // RUN:    -req=print-annotations %s > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/Sema/sema_forbid_typecheck.swift
+++ b/test/SourceKit/Sema/sema_forbid_typecheck.swift
@@ -1,4 +1,4 @@
 // RUN: %sourcekitd-test -req=sema  %S/../Inputs/forbid_typecheck_primary.swift -- \
 // RUN:     -Xfrontend -debug-forbid-typecheck-prefix -Xfrontend NOTYPECHECK -module-name forbid \
 // RUN:     %S/../Inputs/forbid_typecheck_2.swift %S/../Inputs/forbid_typecheck_primary.swift > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/Sema/sema_lazy_var.swift
+++ b/test/SourceKit/Sema/sema_lazy_var.swift
@@ -7,4 +7,4 @@ class C1 {
 }
 
 // RUN: %sourcekitd-test -req=sema %s -- %s > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/Sema/sema_playground.swift
+++ b/test/SourceKit/Sema/sema_playground.swift
@@ -4,4 +4,4 @@ var x = 0
 x
 
 // RUN: %sourcekitd-test -req=sema %s -- %s -Xfrontend -playground | %sed_clean > %t1.response
-// RUN: diff -u %s.response %t1.response
+// RUN: diff --strip-trailing-cr -u %s.response %t1.response

--- a/test/SourceKit/Sema/sema_symlink.swift
+++ b/test/SourceKit/Sema/sema_symlink.swift
@@ -2,6 +2,6 @@
 // RUN: echo "let foo: Int = goo" > %t.dir/real.swift
 // RUN: %{python} %S/../../Inputs/symlink.py %t.dir/real.swift %t.dir/linked.swift
 // RUN: %sourcekitd-test -req=sema %t.dir/linked.swift -- %t.dir/real.swift | %sed_clean > %t.link.response
-// RUN: diff -u %s.response %t.link.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.link.response
 // RUN: %sourcekitd-test -req=sema %t.dir/real.swift -- %t.dir/linked.swift | %sed_clean > %t.real.response
-// RUN: diff -u %s.response %t.real.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.real.response

--- a/test/SourceKit/SyntaxMapData/diags.swift
+++ b/test/SourceKit/SyntaxMapData/diags.swift
@@ -1,3 +1,3 @@
 // RUN: %sourcekitd-test -req=sema %S/Inputs/parse_error.swift -- %S/Inputs/parse_error.swift == \
 // RUN:       -req=edit -pos=3:1 -length=0 -replace="   " %S/Inputs/parse_error.swift == -req=print-diags %S/Inputs/parse_error.swift | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift
@@ -1,4 +1,4 @@
 // RUN: %sourcekitd-test -req=syntax-map -pos=2:1 -length=2 -replace=" " %S/Inputs/syntaxmap-edit-del.swift | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 // RUN: %sourcekitd-test -req=syntax-map -pos=4:1 -length=2 -replace="" %S/Inputs/syntaxmap-edit-del.swift | %sed_clean > %t.response2
-// RUN: diff -u %s.response2 %t.response2
+// RUN: diff --strip-trailing-cr -u %s.response2 %t.response2

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit.swift
@@ -1,2 +1,2 @@
 // RUN: %sourcekitd-test -req=syntax-map -pos=4:10 -replace="Bar" %S/Inputs/syntaxmap-edit.swift > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift
@@ -1,5 +1,5 @@
 // RUN: %sourcekitd-test -req=syntax-map %s | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 let image = #imageLiteral(resourceName: "cloud.png")
 let color = #colorLiteral(red: 1, blue: 0, green: 1, alpha: 1)

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 279,
+  key.length: 299,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -11,51 +11,51 @@
     {
       key.kind: source.lang.swift.syntaxtype.comment,
       key.offset: 71,
-      key.length: 40
+      key.length: 60
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 112,
+      key.offset: 132,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 116,
+      key.offset: 136,
       key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.objectliteral,
-      key.offset: 124,
+      key.offset: 144,
       key.length: 40
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 165,
+      key.offset: 185,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 169,
+      key.offset: 189,
       key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.objectliteral,
-      key.offset: 177,
+      key.offset: 197,
       key.length: 50
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 228,
+      key.offset: 248,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 232,
+      key.offset: 252,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.objectliteral,
-      key.offset: 239,
+      key.offset: 259,
       key.length: 38
     }
   ]

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift
@@ -1,5 +1,5 @@
 // RUN: %sourcekitd-test -req=syntax-map %s | %sed_clean > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response
 
 let fn = #function
 let f = #file

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 342,
+  key.length: 362,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -11,147 +11,137 @@
     {
       key.kind: source.lang.swift.syntaxtype.comment,
       key.offset: 71,
-      key.length: 40
+      key.length: 60
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 112,
+      key.offset: 132,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 116,
+      key.offset: 136,
       key.length: 2
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 121,
+      key.offset: 141,
       key.length: 9
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 131,
+      key.offset: 151,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 135,
+      key.offset: 155,
       key.length: 1
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 139,
-      key.length: 5
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 145,
-      key.length: 3
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 149,
-      key.length: 1
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 153,
-      key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
       key.offset: 159,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 165,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 163,
+      key.offset: 169,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 167,
-      key.length: 7
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 176,
-      key.length: 2
+      key.offset: 173,
+      key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
       key.offset: 179,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 183,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 187,
+      key.length: 7
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 196,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 199,
       key.length: 10
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 190,
+      key.offset: 210,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.number,
-      key.offset: 194,
+      key.offset: 214,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
-      key.offset: 206,
+      key.offset: 226,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 210,
+      key.offset: 230,
       key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.pounddirective.keyword,
-      key.offset: 216,
+      key.offset: 236,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.string,
-      key.offset: 223,
+      key.offset: 243,
       key.length: 7
     },
     {
       key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
-      key.offset: 232,
+      key.offset: 252,
       key.length: 7
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 240,
+      key.offset: 260,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.pounddirective.keyword,
-      key.offset: 245,
+      key.offset: 265,
       key.length: 8
     },
     {
       key.kind: source.lang.swift.syntaxtype.string,
-      key.offset: 254,
+      key.offset: 274,
       key.length: 9
     },
     {
       key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
-      key.offset: 265,
+      key.offset: 285,
       key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.pounddirective.keyword,
-      key.offset: 271,
+      key.offset: 291,
       key.length: 15
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 287,
-      key.length: 4
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.string,
-      key.offset: 293,
-      key.length: 12
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
@@ -159,18 +149,28 @@
       key.length: 4
     },
     {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 313,
+      key.length: 12
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 327,
+      key.length: 4
+    },
+    {
       key.kind: source.lang.swift.syntaxtype.number,
-      key.offset: 312,
+      key.offset: 332,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.pounddirective.keyword,
-      key.offset: 317,
+      key.offset: 337,
       key.length: 15
     },
     {
       key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
-      key.offset: 335,
+      key.offset: 355,
       key.length: 6
     }
   ]

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift
@@ -1,3 +1,3 @@
 // XFAIL: broken_std_regex
 // RUN: %sourcekitd-test -req=syntax-map %S/Inputs/syntaxmap.swift > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/TypeContextInfo/typecontext_basic.swift
+++ b/test/SourceKit/TypeContextInfo/typecontext_basic.swift
@@ -26,4 +26,4 @@ func test(obj: C) {
 }
 
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=25:22 %s -- %s > %t.response
-// RUN: diff -u %s.response %t.response
+// RUN: diff --strip-trailing-cr -u %s.response %t.response

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift
@@ -20,15 +20,15 @@ struct S<T> {
 }
 
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=7:12 %s -- %s > %t.response.1
-// RUN: diff -u %s.response.1 %t.response.1
+// RUN: diff --strip-trailing-cr -u %s.response.1 %t.response.1
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=8:12 %s -- %s > %t.response.2
-// RUN: diff -u %s.response.2 %t.response.2
+// RUN: diff --strip-trailing-cr -u %s.response.2 %t.response.2
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=9:17 %s -- %s > %t.response.3
-// RUN: diff -u %s.response.3 %t.response.3
+// RUN: diff --strip-trailing-cr -u %s.response.3 %t.response.3
 
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=14:18 %s -- %s > %t.response.4
-// RUN: diff -u %s.response.4 %t.response.4
+// RUN: diff --strip-trailing-cr -u %s.response.4 %t.response.4
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=15:18 %s -- %s > %t.response.5
-// RUN: diff -u %s.response.5 %t.response.5
+// RUN: diff --strip-trailing-cr -u %s.response.5 %t.response.5
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=16:18 %s -- %s > %t.response.6
-// RUN: diff -u %s.response.6 %t.response.6
+// RUN: diff --strip-trailing-cr -u %s.response.6 %t.response.6


### PR DESCRIPTION
This adjusts the tests for the difference between line endings on
different platforms.  Windows uses CRLF while most Unicies use LF.  This
was exposed during the update to the new LLVM snapshot.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
