### PR TITLE
tests: fix accidental `not env` usage

### DIFF
--- a/test/ModuleInterface/swift_build_sdk_interfaces/early-exits.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/early-exits.test-sh
@@ -1,8 +1,8 @@
-RUN: not %swift_build_sdk_interfaces 2>&1 | %FileCheck -check-prefix NO-OUTPUT %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt 2>&1 | %FileCheck -check-prefix NO-OUTPUT %s
 NO-OUTPUT: argument -o is required
 
-RUN: not env -u SDKROOT %swift_build_sdk_interfaces -o %t 2>&1 | %FileCheck -check-prefix NO-SDK %s
+RUN: env -u SDKROOT SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -o %t 2>&1 | %FileCheck -check-prefix NO-SDK %s
 NO-SDK: SDKROOT must be set
 
-RUN: not %swift_build_sdk_interfaces -o %t -sdk %S/nonexistent 2>&1 | %FileCheck -check-prefix BAD-SDK %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -o %t -sdk %S/nonexistent 2>&1 | %FileCheck -check-prefix BAD-SDK %s
 BAD-SDK: invalid SDK: {{.+[/\\]nonexistent$}}

--- a/test/ModuleInterface/swift_build_sdk_interfaces/ignore-non-stdlib-failures.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/ignore-non-stdlib-failures.test-sh
@@ -1,4 +1,4 @@
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output | %FileCheck %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -v -o %t/output | %FileCheck %s
 
 CHECK-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 CHECK-DAG: # (PASS) {{.+}}{{\\|/}}Good.swiftinterface
@@ -8,11 +8,11 @@ RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -ign
 CHECK-IGNORING-FAILURES-DAG: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 CHECK-IGNORING-FAILURES-DAG: # (UPASS) {{.+}}{{\\|/}}Good.swiftinterface
 
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output | %FileCheck -check-prefix CHECK-BROKEN-STDLIB %s
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output -ignore-non-stdlib-failures | %FileCheck -check-prefix CHECK-BROKEN-STDLIB %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output | %FileCheck -check-prefix CHECK-BROKEN-STDLIB %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output -ignore-non-stdlib-failures | %FileCheck -check-prefix CHECK-BROKEN-STDLIB %s
 
 CHECK-BROKEN-STDLIB: # (FAIL) {{.+}}{{\\|/}}Swift.swiftinterface
 CHECK-BROKEN-STDLIB-NOT: {{^}}#
 
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output -skip-stdlib | %FileCheck %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output -skip-stdlib | %FileCheck %s
 RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output -skip-stdlib -ignore-non-stdlib-failures | %FileCheck -check-prefix=CHECK-IGNORING-FAILURES %s

--- a/test/ModuleInterface/swift_build_sdk_interfaces/xfail-logs.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/xfail-logs.test-sh
@@ -1,5 +1,5 @@
 RUN: %empty-directory(%t)
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t/logs | %FileCheck %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t/logs | %FileCheck %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/Bad-Bad-err.txt
 
 CHECK: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
@@ -8,7 +8,7 @@ PRINTS-ERROR: unresolved identifier 'garbage'
 
 RUN: %empty-directory(%t)
 RUN: echo '["Good"]' > %t/xfails-good.json
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t/logs -xfails %t/xfails-good.json | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t/logs -xfails %t/xfails-good.json | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/Bad-Bad-err.txt
 
 CHECK-XFAIL-GOOD-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
@@ -30,7 +30,7 @@ RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/Bad-Bad-err.txt
 CHECK-XFAIL-BAD: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 
 RUN: %empty-directory(%t)
-RUN: not %swift_build_sdk_interfaces -sdk %t -o %t/output -log-path %t/logs %S/Inputs/xfail-logs-framework/ | %FileCheck -check-prefix=CHECK-FRAMEWORK %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %t -o %t/output -log-path %t/logs %S/Inputs/xfail-logs-framework/ | %FileCheck -check-prefix=CHECK-FRAMEWORK %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/BadFMWK-x86_64-apple-macos-err.txt
 
 CHECK-FRAMEWORK: # (FAIL) {{.+}}{{\\|/}}BadFMWK.swiftmodule{{\\|/}}x86_64-apple-macos.swiftinterface

--- a/test/ModuleInterface/swift_build_sdk_interfaces/xfails.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/xfails.test-sh
@@ -1,7 +1,7 @@
 RUN: %empty-directory(%t)
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output 2> %t/stderr.txt | %FileCheck %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -o %t/output 2> %t/stderr.txt | %FileCheck %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output 2> %t/stderr.txt | %FileCheck -check-prefix CHECK-VERBOSE %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -v -o %t/output 2> %t/stderr.txt | %FileCheck -check-prefix CHECK-VERBOSE %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
 
 CHECK: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
@@ -13,9 +13,9 @@ HIDES-ERROR-NOT: unresolved identifier 'garbage'
 
 RUN: %empty-directory(%t)
 RUN: echo '["Good"]' > %t/xfails-good.json
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output -xfails %t/xfails-good.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -o %t/output -xfails %t/xfails-good.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-good.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-good.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
 
 CHECK-XFAIL-GOOD-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface


### PR DESCRIPTION
Manually expand out the few places where we had a `not ...` substitution
where the substituted value was invoking `env` to alter the environment.
This pattern is not portable and causes problems when using the
integrated shell, such as on Windows.  This was identified during the
LLVM update.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
