### PR TITLE
[SourceKit] Disable module system headers validation

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -324,11 +324,6 @@ bool swift::ide::CompletionInstance::performOperation(
   // source text. That breaks an invariant of syntax tree building.
   Invocation.getLangOptions().BuildSyntaxTree = false;
 
-  // This validation may call stat(2) many times. Disable it to prevent
-  // performance regression.
-  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
-      true;
-
   // FIXME: ASTScopeLookup doesn't support code completion yet.
   Invocation.disableASTScopeLookup();
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -539,6 +539,11 @@ bool SwiftASTManager::initCompilerInvocation(
   // We don't care about LLVMArgs
   FrontendOpts.LLVMArgs.clear();
 
+  // This validation may call stat(2) many times. Disable it to prevent
+  // performance issues.
+  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
+      true;
+
   // SwiftSourceInfo files provide source location information for decls coming
   // from loaded modules. For most IDE use cases it either has an undesirable
   // impact on performance with no benefit (code completion), results in stale

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3436,6 +3436,8 @@ int main(int argc, char *argv[]) {
     options::DebugForbidTypecheckPrefix;
   InitInvok.getTypeCheckerOptions().DebugConstraintSolver =
       options::DebugConstraintSolver;
+  InitInvok.getSearchPathOptions().DisableModulesValidateSystemDependencies =
+      true;
 
   for (auto ConfigName : options::BuildConfigs)
     InitInvok.getLangOptions().addCustomConditionalCompilationFlag(ConfigName);


### PR DESCRIPTION
in all SourceKit requests.
This validation may call many stat(2). Since we don't expect system files
are edited. Disable it for SourceKit requests. Even if they are edited,
manual builds can validates and updates them.

(Expand #29180 to all SourceKit requests)
rdar://problem/58550697
