### PR TITLE
tests: fix accidental `not env` usage

### DIFF
--- a/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash.test-sh
@@ -1,4 +1,4 @@
-RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/mock-sdk/ -o %t/output -debug-crash-compiler 2>&1 | %FileCheck %s
+RUN: env SWIFT_EXEC=%swiftc_driver_plain not --crash %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/mock-sdk/ -o %t/output -debug-crash-compiler 2>&1 | %FileCheck %s
 
 CHECK: Program arguments:
 CHECK-SAME: -debug-crash-immediately


### PR DESCRIPTION
Manually expand out the few places where we had a `not ...` substitution
where the substituted value was invoking `env` to alter the environment.
This pattern is not portable and causes problems when using the
integrated shell, such as on Windows.  This was identified during the
LLVM update.

This additionally corrects the use of `not` to indicate that it is
expecting a crashing failure.  This was resulting in the Windows tests
failing as `not` was not expecting a crashing failure.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
