### PR TITLE
Avoid heap allocation for small AnyRequests & AnyValues

### DIFF
--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -330,7 +330,11 @@ private:
     auto iter = dependencies.find_as(request);
     if (iter != dependencies.end())
       return iter->first;
-    auto insertResult = dependencies.insert({AnyRequest(request), {}});
+
+    // Note it's important to use std::make_pair here to ensure the AnyRequest
+    // is moved into the DenseMap.
+    auto insertResult = dependencies.insert(
+        std::make_pair(AnyRequest(request), std::vector<AnyRequest>()));
     assert(insertResult.second && "just checked if the key was already there");
     return insertResult.first->first;
   }

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -183,7 +183,10 @@ class SimpleRequest;
 template<typename Derived, CacheKind Caching, typename Output,
          typename ...Inputs>
 class SimpleRequest<Derived, Output(Inputs...), Caching> {
-  std::tuple<Inputs...> storage;
+  using Storage = std::tuple<Inputs...>;
+  static_assert(alignof(Storage) <= alignof(void *),
+                "AnyRequest doesn't handle aligns greater than a word");
+  Storage storage;
 
   Derived &asDerived() {
     return *static_cast<Derived *>(this);
@@ -202,7 +205,7 @@ class SimpleRequest<Derived, Output(Inputs...), Caching> {
 
 protected:
   /// Retrieve the storage value directly.
-  const std::tuple<Inputs...> &getStorage() const { return storage; }
+  const Storage &getStorage() const { return storage; }
 
 public:
   static const bool isEverCached = (Caching != CacheKind::Uncached);

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -212,9 +212,11 @@ public:
   static const bool hasExternalCache = (Caching == CacheKind::SeparatelyCached);
 
   using OutputType = Output;
-  
-  explicit SimpleRequest(const Inputs& ...inputs)
-    : storage(inputs...) { }
+
+  explicit SimpleRequest(const Inputs &... inputs) : storage(inputs...) {
+    static_assert(alignof(OutputType) <= alignof(void *),
+                  "AnyValue doesn't handle aligns greater than a word");
+  }
 
   /// Request evaluation function that will be registered with the evaluator.
   static llvm::Expected<OutputType>

--- a/include/swift/AST/SmallHolder.h
+++ b/include/swift/AST/SmallHolder.h
@@ -1,0 +1,339 @@
+//===--- SmallHolder.h - Type erasing wrapper -------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the SmallHolder class, which holds a type erased value,
+//  optimized for the case where the value is small.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_SMALLHOLDER_H
+#define SWIFT_AST_SMALLHOLDER_H
+
+#include "swift/Basic/TypeID.h"
+#include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/Support/MemAlloc.h"
+#include <type_traits>
+
+namespace swift {
+
+using llvm::hash_code;
+using llvm::hash_value;
+
+class AnyHolder final {
+  uint64_t typeID;
+  const void *rawStorage;
+
+public:
+  template <typename Holder>
+  AnyHolder(const Holder &holder)
+      : typeID(holder.getVTable()->typeID), rawStorage(holder.getRawStorage()) {
+  }
+
+  /// Retrieve the underlying value, casted to its known concrete type.
+  template <typename Value> const Value &get() const {
+    assert(TypeID<Value>::value == typeID && "Wrong type provided");
+    return *static_cast<const Value *>(rawStorage);
+  }
+
+  template <typename Value> Value &getMutable() const {
+    assert(TypeID<Value>::value == typeID && "Wrong type provided");
+    return *const_cast<Value *>(static_cast<const Value *>(rawStorage));
+  }
+};
+
+/// Holds a type erased value, optimized for the case where the value is small.
+///
+/// The \c Size and \c Align templates determine the layout of SmallHolder's
+/// inline  The \c VTable template is used to provide a set of
+/// function pointers which operate on the concrete underlying value.
+template <std::size_t Size, std::size_t Align, typename VTable>
+class SmallHolder {
+  friend llvm::DenseMapInfo<SmallHolder>;
+  friend class AnyHolder;
+
+  using SmallStorage = std::aligned_storage_t<Size, Align>;
+
+  template <typename Value> static constexpr bool is_small() {
+    return sizeof(Value) <= sizeof(SmallStorage);
+  }
+
+  class HeapStorage final {
+    unsigned refCount = 1;
+    HeapStorage() {}
+
+  public:
+    template <typename Value, typename T>
+    static HeapStorage *create(T &&value) {
+      auto size = llvm::alignTo(sizeof(HeapStorage), Align) + sizeof(Value);
+      auto *memory = reinterpret_cast<HeapStorage *>(llvm::safe_malloc(size));
+      new (memory) HeapStorage();
+      new (memory->getRawStorage()) Value(std::forward<T>(value));
+      return memory;
+    }
+
+    void *getRawStorage() {
+      auto endPtr = this + 1;
+      return reinterpret_cast<void *>(llvm::alignAddr(endPtr, Align));
+    }
+
+    HeapStorage *retain() {
+      refCount += 1;
+      return this;
+    }
+    void release(SmallHolder &holder) {
+      refCount -= 1;
+      if (refCount == 0) {
+        holder.getVTable()->deleter(holder);
+        this->~HeapStorage();
+        std::free(this);
+      }
+    }
+  };
+
+  union {
+    HeapStorage *heap;
+    SmallStorage stack;
+  };
+
+  enum StorageKind : uint8_t {
+    Empty,
+    Tombstone,
+    Heap,
+    Stack,
+  };
+
+  llvm::PointerIntPair<const VTable *, 2, StorageKind> vtableAndKind;
+
+  explicit SmallHolder(StorageKind storageKind) {
+    heap = nullptr;
+    setStorageKind(storageKind);
+    assert(!hasStorage());
+  }
+
+public:
+  template <typename T, typename Value = std::decay_t<T>,
+            typename = typename std::enable_if<
+                !std::is_same<Value, SmallHolder>::value>::type>
+  explicit SmallHolder(T &&value) {
+    if (is_small<Value>()) {
+      setStorageKind(StorageKind::Stack);
+      new (&stack) Value(std::forward<T>(value));
+    } else {
+      setStorageKind(StorageKind::Heap);
+      heap = HeapStorage::template create<Value>(std::forward<T>(value));
+    }
+    vtableAndKind.setPointer(VTable::template get<Value>());
+  }
+
+  SmallHolder(const SmallHolder &other) : vtableAndKind(other.vtableAndKind) {
+    switch (getStorageKind()) {
+    case StorageKind::Empty:
+    case StorageKind::Tombstone:
+      break;
+    case StorageKind::Heap:
+      heap = other.heap->retain();
+      break;
+    case StorageKind::Stack:
+      other.getVTable()->copy(other, &stack);
+      break;
+    }
+  }
+  SmallHolder(SmallHolder &&other) : vtableAndKind(other.vtableAndKind) {
+    switch (getStorageKind()) {
+    case StorageKind::Empty:
+    case StorageKind::Tombstone:
+      break;
+    case StorageKind::Heap:
+      heap = other.heap;
+      break;
+    case StorageKind::Stack:
+      stack = other.stack;
+      break;
+    }
+
+    // Now that we've taken other's storage, overwrite it with an empty holder.
+    new (&other) SmallHolder(StorageKind::Empty);
+  }
+
+  SmallHolder &operator=(SmallHolder &&other) {
+    if (&other != this) {
+      this->~SmallHolder();
+      new (this) SmallHolder(std::move(other));
+    }
+    return *this;
+  }
+  SmallHolder &operator=(SmallHolder const &other) {
+    if (&other != this) {
+      this->~SmallHolder();
+      new (this) SmallHolder(other);
+    }
+    return *this;
+  }
+
+  ~SmallHolder() {
+    switch (getStorageKind()) {
+    case StorageKind::Empty:
+    case StorageKind::Tombstone:
+      break;
+    case StorageKind::Heap:
+      assert(heap && "Didn't allocate?");
+      heap->release(*this);
+      break;
+    case StorageKind::Stack:
+      getVTable()->deleter(*this);
+      break;
+    }
+  }
+
+private:
+  StorageKind getStorageKind() const { return vtableAndKind.getInt(); }
+  void setStorageKind(StorageKind kind) { vtableAndKind.setInt(kind); }
+
+  bool hasStorage() const {
+    switch (getStorageKind()) {
+    case StorageKind::Empty:
+    case StorageKind::Tombstone:
+      return false;
+    case StorageKind::Stack:
+    case StorageKind::Heap:
+      return true;
+    }
+    llvm_unreachable("Unhandled case in switch");
+  }
+
+  bool isOnHeap() const {
+    switch (getStorageKind()) {
+    case StorageKind::Empty:
+    case StorageKind::Tombstone:
+      llvm_unreachable("Shouldn't be querying an empty holder");
+    case StorageKind::Stack:
+      return false;
+    case StorageKind::Heap:
+      return true;
+    }
+    llvm_unreachable("Unhandled case in switch");
+  }
+
+  void *getRawStorage() {
+    return isOnHeap() ? heap->getRawStorage() : &stack;
+  }
+
+  const void *getRawStorage() const {
+    return isOnHeap() ? heap->getRawStorage() : &stack;
+  }
+
+public:
+  /// Retrieve the underlying value, casted to its known concrete type.
+  template <typename Value> Value *get() {
+    assert(TypeID<Value>::value == getTypeID() && "Wrong type provided");
+    return static_cast<Value *>(getRawStorage());
+  }
+
+  /// Retrieve the underlying value, casted to its known concrete type.
+  template <typename Value> const Value *get() const {
+    assert(TypeID<Value>::value == getTypeID() && "Wrong type provided");
+    return static_cast<const Value *>(getRawStorage());
+  }
+
+  /// Try casting to a specific (known) type, returning \c nullptr on
+  /// failure.
+  template <typename Value> const Value *getAs() const {
+    if (TypeID<Value>::value != getTypeID())
+      return nullptr;
+
+    return static_cast<const Value *>(getRawStorage());
+  }
+
+  /// Retrieve the vtable, which can be used to perform operations on the
+  /// concrete underlying value.
+  const VTable *getVTable() const {
+    assert(hasStorage() && "Shouldn't be querying an empty holder");
+    return vtableAndKind.getPointer();
+  }
+
+  /// Retrieve the TypeID of the underlying value.
+  uint64_t getTypeID() const { return getVTable()->typeID; }
+
+  /// Compare two instances for equality.
+  friend bool operator==(const SmallHolder &lhs, const SmallHolder &rhs) {
+    if (lhs.getStorageKind() != rhs.getStorageKind())
+      return false;
+
+    if (!lhs.hasStorage())
+      return true;
+
+    if (lhs.getTypeID() != rhs.getTypeID())
+      return false;
+
+    return lhs.getVTable()->isEqual(lhs, rhs);
+  }
+
+  friend bool operator!=(const SmallHolder &lhs, const SmallHolder &rhs) {
+    return !(lhs == rhs);
+  }
+
+  static SmallHolder getEmptyKey() {
+    return SmallHolder(StorageKind::Empty);
+  }
+
+  static SmallHolder getTombstoneKey() {
+    return SmallHolder(StorageKind::Tombstone);
+  }
+};
+
+template <std::size_t Size, std::size_t Align, typename VTable>
+hash_code hash_value(const SmallHolder<Size, Align, VTable> &holder) {
+  return llvm::DenseMapInfo<SmallHolder<Size, Align, VTable>>::getHashValue(
+      holder);
+}
+
+} // end namespace swift
+
+namespace llvm {
+template <std::size_t Size, std::size_t Align, typename VTable>
+struct DenseMapInfo<swift::SmallHolder<Size, Align, VTable>> {
+  using SmallHolder = swift::SmallHolder<Size, Align, VTable>;
+  using StorageKind = typename SmallHolder::StorageKind;
+
+  static inline SmallHolder getEmptyKey() { return SmallHolder::getEmptyKey(); }
+  static inline SmallHolder getTombstoneKey() {
+    return SmallHolder::getTombstoneKey();
+  }
+  static unsigned getHashValue(const SmallHolder &holder) {
+    if (!holder.hasStorage())
+      return 1;
+
+    auto valueHash = holder.getVTable()->getHash(holder);
+    return hash_combine(holder.getTypeID(), valueHash);
+  }
+  template <typename Value> static unsigned getHashValue(const Value &value) {
+    return hash_combine(swift::TypeID<Value>::value, hash_value(value));
+  }
+  static bool isEqual(const SmallHolder &lhs, const SmallHolder &rhs) {
+    return lhs == rhs;
+  }
+
+  template <typename Value>
+  static bool isEqual(const Value &value, const SmallHolder &holder) {
+    // Never equal if the holder isn't storing anything.
+    if (!holder.hasStorage())
+      return false;
+
+    auto *rhs = holder.template getAs<Value>();
+    return rhs && value == *rhs;
+  }
+};
+
+} // end namespace llvm
+
+#endif // SWIFT_AST_SMALLHOLDER_H

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2024,21 +2024,17 @@ public:
 
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
-template<>
-inline bool AnyValue::Holder<Type>::equals(const HolderBase &other) const {
-  assert(typeID == other.typeID && "Caller should match type IDs");
-  return value.getPointer() ==
-      static_cast<const Holder<Type> &>(other).value.getPointer();
+template <>
+inline bool AnyValueVTable::Impl<Type>::isEqual(AnyHolder lhs, AnyHolder rhs) {
+  return lhs.get<Type>().getPointer() == rhs.get<Type>().getPointer();
 }
 
 // Allow AnyValue to compare two GenericSignature values.
 template <>
-inline bool
-AnyValue::Holder<GenericSignature>::equals(const HolderBase &other) const {
-  assert(typeID == other.typeID && "Caller should match type IDs");
-  return value.getPointer() ==
-         static_cast<const Holder<GenericSignature> &>(other)
-             .value.getPointer();
+inline bool AnyValueVTable::Impl<GenericSignature>::isEqual(AnyHolder lhs,
+                                                            AnyHolder rhs) {
+  return lhs.get<GenericSignature>().getPointer() ==
+         rhs.get<GenericSignature>().getPointer();
 }
 
 void simple_display(llvm::raw_ostream &out, Type value);

--- a/include/swift/Basic/AnyValue.h
+++ b/include/swift/Basic/AnyValue.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_BASIC_ANYVALUE_H
 #define SWIFT_BASIC_ANYVALUE_H
 
+#include "swift/AST/SmallHolder.h"
 #include "swift/Basic/SimpleDisplay.h"
 #include "swift/Basic/TypeID.h"
 #include "llvm/ADT/PointerUnion.h"  // to define hash_value
@@ -33,6 +34,42 @@ namespace llvm {
 
 namespace swift {
 
+struct AnyValueVTable {
+  template<typename Value>
+  struct Impl {
+    static void copy(AnyHolder input, void *output) {
+      new (output) Value(input.get<Value>());
+    }
+    static void deleter(AnyHolder holder) {
+      holder.getMutable<Value>().~Value();
+    }
+    static bool isEqual(AnyHolder lhs, AnyHolder rhs) {
+      return lhs.get<Value>() == rhs.get<Value>();
+    }
+    static void display(AnyHolder holder, llvm::raw_ostream &out) {
+      simple_display(out, holder.get<Value>());
+    }
+  };
+
+  const uint64_t typeID;
+  const std::function<void(AnyHolder, void *)> copy;
+  const std::function<void(AnyHolder)> deleter;
+  const std::function<bool(AnyHolder, AnyHolder)> isEqual;
+  const std::function<void(AnyHolder, llvm::raw_ostream &)> display;
+
+  template <typename Value>
+  static const AnyValueVTable *get() {
+    static const AnyValueVTable vtable = {
+        TypeID<Value>::value,
+        &Impl<Value>::copy,
+        &Impl<Value>::deleter,
+        &Impl<Value>::isEqual,
+        &Impl<Value>::display,
+    };
+    return &vtable;
+  }
+};
+
 /// Stores a value of any type that satisfies a small set of requirements.
 ///
 /// Requirements on the values stored within an AnyValue:
@@ -43,94 +80,31 @@ namespace swift {
 ///   - Display support (free function):
 ///       void simple_display(llvm::raw_ostream &, const T &);
 class AnyValue {
-  /// Abstract base class used to hold on to a value.
-  class HolderBase {
-  public:
-    /// Type ID number.
-    const uint64_t typeID;
-
-    HolderBase() = delete;
-    HolderBase(const HolderBase &) = delete;
-    HolderBase(HolderBase &&) = delete;
-    HolderBase &operator=(const HolderBase &) = delete;
-    HolderBase &operator=(HolderBase &&) = delete;
-
-    /// Initialize base with type ID.
-    HolderBase(uint64_t typeID) : typeID(typeID) { }
-
-    virtual ~HolderBase();
-
-    /// Determine whether this value is equivalent to another.
-    ///
-    /// The caller guarantees that the type IDs are the same.
-    virtual bool equals(const HolderBase &other) const = 0;
-
-    /// Display.
-    virtual void display(llvm::raw_ostream &out) const = 0;
-  };
-
-  /// Holds a value that can be used as a request input/output.
-  template<typename T>
-  class Holder final : public HolderBase {
-  public:
-    const T value;
-
-    Holder(T &&value)
-      : HolderBase(TypeID<T>::value),
-        value(std::move(value)) { }
-
-    Holder(const T &value) : HolderBase(TypeID<T>::value), value(value) { }
-
-    virtual ~Holder() { }
-
-    /// Determine whether this value is equivalent to another.
-    ///
-    /// The caller guarantees that the type IDs are the same.
-    virtual bool equals(const HolderBase &other) const override {
-      assert(typeID == other.typeID && "Caller should match type IDs");
-      return value == static_cast<const Holder<T> &>(other).value;
-    }
-
-    /// Display.
-    virtual void display(llvm::raw_ostream &out) const override {
-      simple_display(out, value);
-    }
-  };
-
   /// The data stored in this value.
-  std::shared_ptr<HolderBase> stored;
+  using Storage = SmallHolder<8, alignof(void *), AnyValueVTable>;
+  Storage stored;
 
 public:
   /// Construct a new instance with the given value.
-  template<typename T>
-  AnyValue(T&& value) {
-    using ValueType = typename std::remove_reference<T>::type;
-    stored.reset(new Holder<ValueType>(std::forward<T>(value)));
-  }
+  template <typename T>
+  AnyValue(T &&value) : stored(Storage(std::forward<T>(value))) {}
 
   /// Cast to a specific (known) type.
   template<typename T>
   const T &castTo() const {
-    assert(stored->typeID == TypeID<T>::value);
-    return static_cast<const Holder<T> *>(stored.get())->value;
+    return *stored.get<T>();
   }
 
   /// Try casting to a specific (known) type, returning \c nullptr on
   /// failure.
   template<typename T>
   const T *getAs() const {
-    if (stored->typeID != TypeID<T>::value)
-      return nullptr;
-
-    return &static_cast<const Holder<T> *>(stored.get())->value;
+    return stored.getAs<T>();
   }
 
   /// Compare two instances for equality.
   friend bool operator==(const AnyValue &lhs, const AnyValue &rhs) {
-    if (lhs.stored->typeID != rhs.stored->typeID)
-      return false;
-
-    return lhs.stored->equals(*rhs.stored);
+    return lhs.stored == rhs.stored;
   }
 
   friend bool operator!=(const AnyValue &lhs, const AnyValue &rhs) {
@@ -138,7 +112,7 @@ public:
   }
 
   friend void simple_display(llvm::raw_ostream &out, const AnyValue &value) {
-    value.stored->display(out);
+    value.stored.getVTable()->display(value.stored, out);
   }
 
   /// Return the result of calling simple_display as a string.

--- a/include/swift/Basic/AnyValue.h
+++ b/include/swift/Basic/AnyValue.h
@@ -144,8 +144,9 @@ namespace llvm {
   void simple_display(raw_ostream &out, const Optional<T> &opt) {
     if (opt) {
       simple_display(out, *opt);
+    } else {
+      out << "None";
     }
-    out << "None";
   }
 } // end namespace llvm
 

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -24,8 +24,6 @@
 
 using namespace swift;
 
-AnyRequest::HolderBase::~HolderBase() { }
-
 std::string AnyRequest::getAsString() const {
   std::string result;
   {

--- a/lib/Basic/AnyValue.cpp
+++ b/lib/Basic/AnyValue.cpp
@@ -17,8 +17,6 @@
 #include "swift/Basic/AnyValue.h"
 using namespace swift;
 
-AnyValue::HolderBase::~HolderBase() { }
-
 std::string AnyValue::getAsString() const {
   std::string result;
   {


### PR DESCRIPTION
This PR introduces `SmallHolder`, which can store small type erased values in an inline buffer. This is then used in `AnyRequest` and `AnyValue`. 