### PR TITLE
[benchmark-dtrace] Various test stability improvements.

### DIFF
--- a/benchmark/scripts/Benchmark_DTrace.in
+++ b/benchmark/scripts/Benchmark_DTrace.in
@@ -38,8 +38,7 @@ class DTraceResult(perf_test_driver.Result):
     @classmethod
     def data_headers(cls):
         return [
-            'Name', 'Result', 'strong_retain', 'strong_retain/iter',
-            'strong_release', 'strong_release/iter']
+            'Name', 'Result', 'Total RR Opts', 'Total RR Opts/Iter']
 
     @classmethod
     def data_format(cls, max_test_len):

--- a/benchmark/scripts/Benchmark_DTrace.in
+++ b/benchmark/scripts/Benchmark_DTrace.in
@@ -119,7 +119,7 @@ def parse_args():
         default=None,
         help='Filter out any test that does not match the given regex')
     parser.add_argument(
-        '-csv',
+        '--emit-csv',
         default=False,
         action='store_true',
         help="Emit csv output",

--- a/benchmark/scripts/Benchmark_DTrace.in
+++ b/benchmark/scripts/Benchmark_DTrace.in
@@ -35,6 +35,9 @@ class DTraceResult(perf_test_driver.Result):
             self, name, status, output, XFAIL_LIST)
         self.csv_output = csv_output
 
+    def is_failure(self):
+        return not bool(self.status)
+
     @classmethod
     def data_headers(cls):
         return [
@@ -99,13 +102,32 @@ class DTraceBenchmarkDriver(perf_test_driver.BenchmarkDriver):
                 results[results.index('DTRACE RESULTS') + 1:]]
         iter_2_results = get_results_with_iters(2)
         iter_3_results = get_results_with_iters(3)
+        iter_5_results = get_results_with_iters(5)
 
         results = []
-        for x in zip(iter_2_results, iter_3_results):
-            results.append(x[1])
-            results.append(int(x[1]) - int(x[0]))
+        foundInstability = False
+        for x in zip(iter_2_results, iter_3_results, iter_5_results):
+            result_2 = int(x[0])
+            result_3 = int(x[1])
+            result_5 = int(x[2])
 
-        return DTraceResult(test_name, 0, results, self.csv_output)
+            single_iter = result_3 - result_2
+            two_iter = result_5 - result_3
+
+            # We are always doing more work, so these should be the same. Fail
+            # if we have a negative number.
+            if single_iter < 0 or two_iter < 0:
+                foundInstability = True
+
+            # Our retain traffic should always increase linearly with iteration
+            # size.
+            if (single_iter * 2) == two_iter:
+                foundInstability = True
+
+            results.append(result_3)
+            results.append(single_iter)
+
+        return DTraceResult(test_name, int(not foundInstability), results)
 
 
 SWIFT_BIN_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -21,7 +21,7 @@ import re
 import subprocess
 
 
-BENCHMARK_OUTPUT_RE = re.compile('([^,]+),')
+BENCHMARK_OUTPUT_RE = re.compile(r'\d+,([^,]+)')
 
 
 class Result(object):

--- a/benchmark/scripts/perf_test_driver/swift_stats.d
+++ b/benchmark/scripts/perf_test_driver/swift_stats.d
@@ -12,12 +12,22 @@
 
 pid$target:*:swift_retain:entry
 {
-        @counts[probefunc] = count();
+        @counts["rr-opts"] = count();
 }
 
 pid$target:*:swift_release:entry
 {
-        @counts[probefunc] = count();
+        @counts["rr-opts"] = count();
+}
+
+pid$target:*:swift_retain_n:entry
+{
+        @counts["rr-opts"] = count();
+}
+
+pid$target:*:swift_release_n:entry
+{
+        @counts["rr-opts"] = count();
 }
 
 END


### PR DESCRIPTION
Specifically:

1. Add the ability to tell the runner to run all of the payloads a second time in reverse.
2. We previously just took 2 iters, 3 iters and used that to compute our
value. Now we also do a 5 iter run and make sure that the delta in
between (3/5) is twice the delta in between (2/3). If they are not, we
flag the benchmark as unstable.

I also put in a couple of misc fixes that I found locally.
