### PR TITLE
[5.2][SourceKit] Disable module system headers validation in all SourceKit requests

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -293,6 +293,11 @@ bool swift::ide::CompletionInstance::performOperation(
   // source text. That breaks an invariant of syntax tree building.
   Invocation.getLangOptions().BuildSyntaxTree = false;
 
+  // This validation may call stat(2) many times. Disable it to prevent
+  // performance regression.
+  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
+      true;
+
   // FIXME: ASTScopeLookup doesn't support code completion yet.
   Invocation.disableASTScopeLookup();
 

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -293,11 +293,6 @@ bool swift::ide::CompletionInstance::performOperation(
   // source text. That breaks an invariant of syntax tree building.
   Invocation.getLangOptions().BuildSyntaxTree = false;
 
-  // This validation may call stat(2) many times. Disable it to prevent
-  // performance regression.
-  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
-      true;
-
   // FIXME: ASTScopeLookup doesn't support code completion yet.
   Invocation.disableASTScopeLookup();
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -539,6 +539,11 @@ bool SwiftASTManager::initCompilerInvocation(
   // We don't care about LLVMArgs
   FrontendOpts.LLVMArgs.clear();
 
+  // This validation may call stat(2) many times. Disable it to prevent
+  // performance issues.
+  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
+      true;
+
   // SwiftSourceInfo files provide source location information for decls coming
   // from loaded modules. For most IDE use cases it either has an undesirable
   // impact on performance with no benefit (code completion), results in stale

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3302,6 +3302,8 @@ int main(int argc, char *argv[]) {
     options::DebugForbidTypecheckPrefix;
   InitInvok.getTypeCheckerOptions().DebugConstraintSolver =
       options::DebugConstraintSolver;
+  InitInvok.getSearchPathOptions().DisableModulesValidateSystemDependencies =
+      true;
 
   for (auto ConfigName : options::BuildConfigs)
     InitInvok.getLangOptions().addCustomConditionalCompilationFlag(ConfigName);


### PR DESCRIPTION
Cherry-pick of #29180 and #29196 into `swift-5.2-branch` originally reviewed by @nathawes 

This validation may call many stat(2). Since we don't expect system files are edited. Disable it for SourceKit requests. Even if they are edited, manual builds can validates and updates them if necessary.

rdar://problem/58550697