### PR TITLE
[ConstraintSystem] Fix `getArgumentExpr` to check number of tuple ele…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3384,8 +3384,12 @@ Expr *constraints::getArgumentExpr(Expr *expr, unsigned index) {
     return PE->getSubExpr();
   }
 
-  assert(isa<TupleExpr>(argExpr));
-  return cast<TupleExpr>(argExpr)->getElement(index);
+  if (auto *tuple = dyn_cast<TupleExpr>(argExpr)) {
+    return (tuple->getNumElements() > index) ? tuple->getElement(index)
+                                             : nullptr;
+  }
+
+  return nullptr;
 }
 
 bool constraints::isAutoClosureArgument(Expr *argExpr) {

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -160,9 +160,9 @@ struct Text : P {
   init(_: T) {}
 }
 
-struct Label<L> : P where L : P { // expected-note {{'L' declared as parameter to type 'Label'}}
+struct Label<L> : P where L : P { // expected-note 2 {{'L' declared as parameter to type 'Label'}}
   typealias T = L
-  init(@Builder _: () -> L) {}
+  init(@Builder _: () -> L) {} // expected-note {{'init(_:)' declared here}}
 }
 
 func test_51167632() -> some P {
@@ -170,6 +170,15 @@ func test_51167632() -> some P {
     Text("hello")
     Label  // expected-error {{generic parameter 'L' could not be inferred}}
     // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}} {{10-10=<<#L: P#>>}}
+  })
+}
+
+func test_56221372() -> some P {
+  AnyP(G {
+    Text("hello")
+    Label() // expected-error {{generic parameter 'L' could not be inferred}}
+    // expected-error@-1 {{missing argument for parameter #1 in call}}
+    // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}} {{10-10=<<#L: P#>>}}
   })
 }
 


### PR DESCRIPTION
…ments before access

Fix `getArgumentExpr` to not assume that constraint system
always asks for index that exists in an argument tuple,
because sometimes arguments could be synthesized (such
arguments do not have corresponding expression).

Resolves: rdar://problem/56221372

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
