### PR TITLE
[build] Remove function contains_product from build-script-impl

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1066,18 +1066,6 @@ if [[ ! "${SKIP_BUILD_XCTEST}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" xctest)
 fi
 
-# Checks if a given product is enabled (i.e. part of $PRODUCTS array)
-function contains_product() {
-  local current_product
-  for current_product in "${PRODUCTS[@]}"; do
-    if [[ "$current_product" == "$1" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
-
 # get_host_specific_variable(host, name)
 #
 # Get the value of a host-specific variable expected to have been passed by the
@@ -1797,7 +1785,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
                 fi
 
-                if contains_product "lldb" ; then
+                if [[ ! "${SKIP_BUILD_LLDB}" ]] ; then
                     lldb_build_dir=$(build_directory ${host} lldb)
                     cmake_options=(
                         "${cmake_options[@]}"


### PR DESCRIPTION
The only use of this function is to see if LLDB is going to be built. That is controlled with another already-in-use variable `SKIP_LLDB_BUILD`. This function is there for unneeded.

cc @compnerd @shahmishal 