### PR TITLE
stdlib: remove unnecessary checks

### DIFF
--- a/stdlib/public/CTensorFlow/CMakeLists.txt
+++ b/stdlib/public/CTensorFlow/CMakeLists.txt
@@ -14,10 +14,6 @@
 #
 #===----------------------------------------------------------------------===#
 
-if(NOT SWIFT_ENABLE_TENSORFLOW)
-  return()
-endif()
-
 include("../../../cmake/modules/SwiftList.cmake")
 
 find_package(TensorFlow REQUIRED)

--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -14,10 +14,6 @@
 #
 #===----------------------------------------------------------------------===#
 
-if(NOT SWIFT_ENABLE_TENSORFLOW)
-  return()
-endif()
-
 find_package(TensorFlow REQUIRED)
 message(STATUS "Building TensorFlow.")
 


### PR DESCRIPTION
The subdirectory is never entered unless the condition holds, remove the
unnecessary check and return path for the TensorFlow modules.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
