### PR TITLE
stdlib: add a shortcut for Array.append(contentsOf:) in case the argument is an Array, too.

### DIFF
--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -54,3 +54,20 @@ public func testString(_ a: inout [String], s: String) {
 public func dontPropagateContiguousArray(_ a: inout ContiguousArray<UInt8>) {
   a += [4]
 }
+
+// Check if the specialized Array.append<A>(contentsOf:) is reasonably optimized for Array<Int>.
+
+// CHECK-LABEL: sil shared {{.*}}@$sSa6append10contentsOfyqd__n_t7ElementQyd__RszSTRd__lFSi_SaySiGTg5
+
+// There should only be a single call to _createNewBuffer or reserveCapacityForAppend/reserveCapacityImpl.
+
+// CHECK-NOT: apply
+// CHECK: [[F:%[0-9]+]] = function_ref @{{.*(_createNewBuffer|reserveCapacity).*}}
+// CHECK-NEXT: apply [[F]]
+// CHECK-NOT: apply
+
+// The number of basic blocks should not exceed 20 (ideally there are no more than 16 blocks in this function).
+// CHECK-NOT: bb20:
+
+// CHECK: } // end sil function '$sSa6append10contentsOfyqd__n_t7ElementQyd__RszSTRd__lFSi_SaySiGTg5
+


### PR DESCRIPTION
This additional check lets the optimizer eliminate most of the append-code in specializations where the appended sequence is also an Array.
For example, when "adding" arrays, e.g. arr += other_arr
