### PR TITLE
Accelerate fix interpolate between neighbours tests

### DIFF
--- a/stdlib/public/Darwin/Accelerate/vDSP_FFT.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_FFT.swift
@@ -329,7 +329,8 @@ struct vDSP_FFTFunctions {
     }
 }
 
-@available(swift, deprecated: 5.2, message: "Use the `withUnsafeMutableBufferPointer` method on the real and imaginary arrays to create `DSPSplitComplex` for a defined scope.")
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension DSPSplitComplex {
     
     /// Creates a new `DSPSplitComplex` structure from a real array not in even-odd split configuration.
@@ -352,7 +353,7 @@ extension DSPSplitComplex {
     }
 }
 
-@available(swift, deprecated: 5.2, message: "Use the `withUnsafeMutableBufferPointer` method on the real and imaginary arrays to create `DSPDoubleSplitComplex` for a defined scope.")
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension DSPDoubleSplitComplex {
     
     /// Creates a new `DSPDoubleSplitComplex` structure from a real array not in even-odd split configuration.

--- a/stdlib/public/Darwin/Accelerate/vDSP_FFT.swift
+++ b/stdlib/public/Darwin/Accelerate/vDSP_FFT.swift
@@ -329,8 +329,7 @@ struct vDSP_FFTFunctions {
     }
 }
 
-
-@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@available(swift, deprecated: 5.2, message: "Use the `withUnsafeMutableBufferPointer` method on the real and imaginary arrays to create `DSPSplitComplex` for a defined scope.")
 extension DSPSplitComplex {
     
     /// Creates a new `DSPSplitComplex` structure from a real array not in even-odd split configuration.
@@ -353,7 +352,7 @@ extension DSPSplitComplex {
     }
 }
 
-@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@available(swift, deprecated: 5.2, message: "Use the `withUnsafeMutableBufferPointer` method on the real and imaginary arrays to create `DSPDoubleSplitComplex` for a defined scope.")
 extension DSPDoubleSplitComplex {
     
     /// Creates a new `DSPDoubleSplitComplex` structure from a real array not in even-odd split configuration.

--- a/test/stdlib/Accelerate.swift
+++ b/test/stdlib/Accelerate.swift
@@ -209,7 +209,7 @@ if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
             var controlVector = [Float](repeating: 0, count: 1024)
             
             vDSP_vgen([0],
-                      [Float(shortSignal.count)],
+                      [Float(shortSignal.count) - 2],
                       &controlVector, 1,
                       vDSP_Length(n))
             
@@ -276,7 +276,7 @@ if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
             var controlVector = [Double](repeating: 0, count: 1024)
             
             vDSP_vgenD([0],
-                       [Double(shortSignal.count)],
+                       [Double(shortSignal.count) - 2],
                        &controlVector, 1,
                        vDSP_Length(n))
             

--- a/test/stdlib/Accelerate.swift
+++ b/test/stdlib/Accelerate.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_Quadrature.swift
+++ b/test/stdlib/Accelerate_Quadrature.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPBiquad.swift
+++ b/test/stdlib/Accelerate_vDSPBiquad.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPClippingLimitThreshold.swift
+++ b/test/stdlib/Accelerate_vDSPClippingLimitThreshold.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPComplexOperations.swift
+++ b/test/stdlib/Accelerate_vDSPComplexOperations.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPConversion.swift
+++ b/test/stdlib/Accelerate_vDSPConversion.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPConvolution.swift
+++ b/test/stdlib/Accelerate_vDSPConvolution.swift
@@ -2,7 +2,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPElementwiseArithmetic.swift
+++ b/test/stdlib/Accelerate_vDSPElementwiseArithmetic.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPFillClearGenerate.swift
+++ b/test/stdlib/Accelerate_vDSPFillClearGenerate.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPFourierTransform.swift
+++ b/test/stdlib/Accelerate_vDSPFourierTransform.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPGeometry.swift
+++ b/test/stdlib/Accelerate_vDSPGeometry.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPIntegration.swift
+++ b/test/stdlib/Accelerate_vDSPIntegration.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPReduction.swift
+++ b/test/stdlib/Accelerate_vDSPReduction.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vDSPSingleVectorOps.swift
+++ b/test/stdlib/Accelerate_vDSPSingleVectorOps.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vForce.swift
+++ b/test/stdlib/Accelerate_vForce.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50301438
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 

--- a/test/stdlib/Accelerate_vImage.swift
+++ b/test/stdlib/Accelerate_vImage.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar50244151
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos
 


### PR DESCRIPTION
The single- and double-precision InterpolateBetweenNeighbours tests created illegal indices in the control vector that lead to undefined behaviour and occasional test failures. This PR fixes that.

cc: @stephentyrone  
