### PR TITLE
[Runtime] Error bridged to NSError should return its description rather than NSError description

### DIFF
--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -24,19 +24,20 @@
 #include "swift/Runtime/Config.h"
 
 #if SWIFT_OBJC_INTEROP
+#include "ErrorObject.h"
+#include "Private.h"
+#include "SwiftObject.h"
+#include "swift/Basic/Lazy.h"
+#include "swift/Demangling/ManglingMacros.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/ObjCBridge.h"
-#include "swift/Basic/Lazy.h"
-#include "swift/Demangling/ManglingMacros.h"
-#include "ErrorObject.h"
-#include "Private.h"
+#include <Foundation/Foundation.h>
 #include <dlfcn.h>
 #include <objc/NSObject.h>
-#include <objc/runtime.h>
 #include <objc/message.h>
 #include <objc/objc.h>
-#include <Foundation/Foundation.h>
+#include <objc/runtime.h>
 
 using namespace swift;
 using namespace swift::hashable_support;
@@ -97,6 +98,12 @@ using namespace swift::hashable_support;
          && "Error box used as NSError before initialization");
   // Don't need to .retain.autorelease since it's immutable.
   return cf_const_cast<id>(domain);
+}
+
+- (id /* NSString */)description {
+  auto error = (const SwiftError *)self;
+  return getDescription(const_cast<OpaqueValue *>(error->getValue()),
+                        error->type);
 }
 
 - (NSInteger)code {

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -836,4 +836,22 @@ ErrorBridgingTests.test("SR-9207 crash in failed cast to NSError") {
   }
 }
 
+// SR-7652
+
+enum SwiftError: Error, CustomStringConvertible {
+  case something
+  var description: String { return "Something" }
+}
+
+ErrorBridgingTests.test("Swift Error bridged to NSError description") {
+  func checkDescription() {
+    let bridgedError = SwiftError.something as NSError
+    expectEqual("Something", bridgedError.description)
+  }
+
+  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+    checkDescription()
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
An `Error` bridged to `NSError` currently prints the `NSError` description, where as it should print the `Error` description. For example:

```swift
enum DecodingError: Error, CustomStringConvertible {
  case keyNotFound

  var description: String {
    switch self {
      case .keyNotFound: 
        return "Key not found"
    }
  }
}

// Prints: Error Domain=test.DecodingError Code=0 "(null)"
// instead of: "Key not found"
print((DecodingError.keyNotFound as NSError).description)
```

Resolves SR-7652