### PR TITLE
Revert "[silgen] When SILGenLValue accesses ref_elt_addr, emit unsafe…

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -739,16 +739,13 @@ namespace {
         SGF.B.createRefElementAddr(loc, base.getUnmanagedValue(),
                                    Field, SubstFieldType);
 
-      // Avoid emitting non-trivial access markers for non-accesses and
-      // immutable values.
-      auto enforcement = SGF.getDynamicEnforcement(Field);
-      if (enforcement && !IsNonAccessing && !Field->isLet()) {
-        result = enterAccessScope(SGF, loc, result, getTypeData(),
-                                  getAccessKind(), *enforcement);
-      } else {
-        result =
-            enterAccessScope(SGF, loc, result, getTypeData(), getAccessKind(),
-                             SILAccessEnforcement::Unsafe);
+      // Avoid emitting access markers completely for non-accesses or immutable
+      // declarations. Access marker verification is aware of these cases.
+      if (!IsNonAccessing && !Field->isLet()) {
+        if (auto enforcement = SGF.getDynamicEnforcement(Field)) {
+          result = enterAccessScope(SGF, loc, result, getTypeData(),
+                                    getAccessKind(), *enforcement);
+        }
       }
 
       return ManagedValue::forLValue(result);

--- a/test/SILGen/access_marker_gen.swift
+++ b/test/SILGen/access_marker_gen.swift
@@ -124,9 +124,9 @@ func testClassLetProperty(c: C) -> Int {
 // CHECK-LABEL: sil hidden [ossa] @$s17access_marker_gen20testClassLetProperty1cSiAA1CC_tF : $@convention(thin) (@guaranteed C) -> Int {
 // CHECK: bb0(%0 : @guaranteed $C):
 // CHECK:   [[ADR:%.*]] = ref_element_addr %{{.*}} : $C, #C.z
-// CHECK:   [[ADR_ACCESS:%.*]] = begin_access [read] [unsafe] [[ADR]]
-// CHECK:   %{{.*}} = load [trivial] [[ADR_ACCESS]] : $*Int
-// CHECK:   end_access [[ADR_ACCESS]]
+// CHECK-NOT: begin_access
+// CHECK:   %{{.*}} = load [trivial] [[ADR]] : $*Int
+// CHECK-NOT: end_access
 // CHECK-NOT:   destroy_value %0 : $C
 // CHECK:   return %{{.*}} : $Int
 // CHECK-LABEL: } // end sil function '$s17access_marker_gen20testClassLetProperty1cSiAA1CC_tF'

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -451,14 +451,11 @@ class LetFieldClass {
   // CHECK-LABEL: sil hidden [ossa] @$s15guaranteed_self13LetFieldClassC10letkMethod{{[_0-9a-zA-Z]*}}F : $@convention(method) (@guaranteed LetFieldClass) -> () {
   // CHECK: bb0([[CLS:%.*]] : @guaranteed $LetFieldClass):
   // CHECK: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
-  // CHECK-NEXT: [[KRAKEN_ADDR_ACCESS:%.*]] = begin_access [read] [unsafe] [[KRAKEN_ADDR]]
-  // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR_ACCESS]]
-  // CHECK-NEXT: end_access [[KRAKEN_ADDR_ACCESS]]
+  // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR]]
   // CHECK-NEXT: [[KRAKEN_METH:%.*]] = class_method [[KRAKEN]]
   // CHECK-NEXT: apply [[KRAKEN_METH]]([[KRAKEN]])
   // CHECK: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
-  // CHECK-NEXT: [[KRAKEN_ADDR_ACCESS:%.*]] = begin_access [read] [unsafe] [[KRAKEN_ADDR]]
-  // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR_ACCESS]]
+  // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR]]
   // CHECK:      [[REBORROWED_KRAKEN:%.*]] = begin_borrow [[KRAKEN]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @$s15guaranteed_self11destroyShipyyAA6KrakenCF : $@convention(thin) (@guaranteed Kraken) -> ()
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[REBORROWED_KRAKEN]])
@@ -467,9 +464,7 @@ class LetFieldClass {
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
-  // CHECK-NEXT: [[KRAKEN_ADDR_ACCESS:%.*]] = begin_access [read] [unsafe] [[KRAKEN_ADDR]]
-  // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR_ACCESS]]
-  // CHECK-NEXT: end_access [[KRAKEN_ADDR_ACCESS]]
+  // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR]]
   // CHECK-NEXT: store [[KRAKEN]] to [init] [[PB]]
   // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*Kraken
   // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [copy] [[READ]]

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -616,9 +616,7 @@ func genericProps(_ x: GenericClass<String>) {
   // CHECK:   apply {{.*}}<String>([[ARG]]) : $@convention(method) <τ_0_0> (@guaranteed GenericClass<τ_0_0>) -> Int
   let _ = x.y
   // CHECK:   [[Z:%.*]] = ref_element_addr [[ARG]] : $GenericClass<String>, #GenericClass.z
-  // CHECK:   [[Z_ACCESS:%.*]] = begin_access [read] [unsafe] [[Z]]
-  // CHECK:   [[LOADED_Z:%.*]] = load [copy] [[Z_ACCESS]] : $*String
-  // CHECK:   end_access [[Z_ACCESS]]
+  // CHECK:   [[LOADED_Z:%.*]] = load [copy] [[Z]] : $*String
   // CHECK:   destroy_value [[LOADED_Z]]
   // CHECK-NOT:   destroy_value [[ARG]]
   let _ = x.z
@@ -628,8 +626,7 @@ func genericProps(_ x: GenericClass<String>) {
 func genericPropsInGenericContext<U>(_ x: GenericClass<U>) {
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $GenericClass<U>):
   // CHECK:   [[Z:%.*]] = ref_element_addr [[ARG]] : $GenericClass<U>, #GenericClass.z
-  // CHECK:   [[Z_ACCESS:%.*]] = begin_access [read] [unsafe] [[Z]]
-  // CHECK:   copy_addr [[Z_ACCESS]] {{.*}} : $*U
+  // CHECK:   copy_addr [[Z]] {{.*}} : $*U
   let _ = x.z
 }
 
@@ -645,9 +642,7 @@ class ClassWithLetProperty {
 // CHECK:       bb0([[ARG:%.*]] : @guaranteed $ClassWithLetProperty):
 // CHECK-NEXT:    debug_value
 // CHECK-NEXT:    [[PTR:%[0-9]+]] = ref_element_addr [[ARG]] : $ClassWithLetProperty, #ClassWithLetProperty.p
-// CHECK-NEXT:    [[PTR_ACCESS:%.*]] = begin_access [read] [unsafe] [[PTR]]
-// CHECK-NEXT:    [[VAL:%[0-9]+]] = load [trivial] [[PTR_ACCESS]] : $*Int
-// CHECK-NEXT:    end_access [[PTR_ACCESS]]
+// CHECK-NEXT:    [[VAL:%[0-9]+]] = load [trivial] [[PTR]] : $*Int
 // CHECK-NEXT:   return [[VAL]] : $Int
 
 
@@ -675,8 +670,7 @@ class r19254812Derived: r19254812Base{
 // Initialization of the pi field: no copy_values/releases.
 // CHECK:  [[SELF:%[0-9]+]] = load_borrow [[PB_BOX]] : $*r19254812Derived
 // CHECK-NEXT:  [[PIPTR:%[0-9]+]] = ref_element_addr [[SELF]] : $r19254812Derived, #r19254812Derived.pi
-// CHECK-NEXT:  [[PIPTR_ACCESS:%.*]] = begin_access [modify] [unsafe] [[PIPTR]]
-// CHECK-NEXT:  assign {{.*}} to [[PIPTR_ACCESS]] : $*Double
+// CHECK-NEXT:  assign {{.*}} to [[PIPTR]] : $*Double
 
 // CHECK-NOT: destroy_value
 // CHECK-NOT: copy_value
@@ -684,8 +678,7 @@ class r19254812Derived: r19254812Base{
 // Load of the pi field: no copy_values/releases.
 // CHECK:  [[SELF:%[0-9]+]] = load_borrow [[PB_BOX]] : $*r19254812Derived
 // CHECK-NEXT:  [[PIPTR:%[0-9]+]] = ref_element_addr [[SELF]] : $r19254812Derived, #r19254812Derived.pi
-// CHECK-NEXT:  [[PIPTR_ACCESS:%.*]] = begin_access [read] [unsafe] [[PIPTR]]
-// CHECK-NEXT:  {{.*}} = load [trivial] [[PIPTR_ACCESS]] : $*Double
+// CHECK-NEXT:  {{.*}} = load [trivial] [[PIPTR]] : $*Double
 // CHECK: return
 }
 

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -27,12 +27,10 @@ class Box<T> {
 // CHECK:   [[CALL:%.*]] = apply [[INIT_F]]<(Int, () -> ())>(%{{.*}}, %{{.*}}) : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0>
 // CHECK:   [[BORROW_CALL:%.*]] = begin_borrow [[CALL]] : $Box<(Int, () -> ())> 
 // CHECK:   [[REF:%.*]] = ref_element_addr [[BORROW_CALL]] : $Box<(Int, () -> ())>, #Box.value
-// CHECK:   [[REF_ACCESS:%.*]] = begin_access [read] [unsafe] [[REF]]
-// CHECK:   [[TUPLEC:%.*]] = load [copy] [[REF_ACCESS]] : $*(Int, @callee_guaranteed () -> @out ())
+// CHECK:   [[TUPLEC:%.*]] = load [copy] [[REF]] : $*(Int, @callee_guaranteed () -> @out ())
 // CHECK:   ([[TUPLEC_0:%.*]], [[TUPLEC_1:%.*]]) = destructure_tuple [[TUPLEC]]
 // CHECK:   [[THUNK2:%.*]] = function_ref @$sytIegr_Ieg_TR : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out ()) -> ()
 // CHECK:   [[PA2:%.*]] = partial_apply [callee_guaranteed] [[THUNK2]]([[TUPLEC_1]]) : $@convention(thin) (@guaranteed @callee_guaranteed () -> @out ()) -> ()
-// CHECK:   end_access [[REF_ACCESS]]
 // CHECK:   destroy_value [[PA2]] : $@callee_guaranteed () -> ()    
 // CHECK:   end_borrow [[BORROW_CALL]] : $Box<(Int, () -> ())>
 // CHECK-LABEL: } // end sil function '$s4main7testBoxyyF'

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -78,17 +78,13 @@ class Good: Foo {
   // CHECK:         store %0 to [init] [[PB_SELF_BOX]]
   // CHECK:         [[SELF_OBJ:%.*]] = load_borrow [[PB_SELF_BOX]]
   // CHECK:         [[X_ADDR:%.*]] = ref_element_addr [[SELF_OBJ]] : $Good, #Good.x
-  // CHECK:         [[X_ADDR_ACCESS:%.*]] = begin_access [modify] [unsafe] [[X_ADDR]]
-  // CHECK:         assign {{.*}} to [[X_ADDR_ACCESS]] : $*Int
-  // CHECK:         end_access [[X_ADDR_ACCESS]]
+  // CHECK:         assign {{.*}} to [[X_ADDR]] : $*Int
   // CHECK:         [[SELF_OBJ:%.*]] = load [take] [[PB_SELF_BOX]] : $*Good
   // CHECK:         [[SUPER_OBJ:%.*]] = upcast [[SELF_OBJ]] : $Good to $Foo
   // CHECK:         [[BORROWED_SUPER:%.*]] = begin_borrow [[SUPER_OBJ]]
   // CHECK:         [[DOWNCAST_BORROWED_SUPER:%.*]] = unchecked_ref_cast [[BORROWED_SUPER]] : $Foo to $Good
   // CHECK:         [[X_ADDR:%.*]] = ref_element_addr [[DOWNCAST_BORROWED_SUPER]] : $Good, #Good.x
-  // CHECK:         [[X_ADDR_ACCESS:%.*]] = begin_access [read] [unsafe] [[X_ADDR]]
-  // CHECK:         [[X:%.*]] = load [trivial] [[X_ADDR_ACCESS]] : $*Int
-  // CHECK:         end_access [[X_ADDR_ACCESS]]
+  // CHECK:         [[X:%.*]] = load [trivial] [[X_ADDR]] : $*Int
   // CHECK:         end_borrow [[BORROWED_SUPER]]
   // CHECK:         [[SUPER_INIT:%.*]] = function_ref @$s22super_init_refcounting3FooCyACSicfc : $@convention(method) (Int, @owned Foo) -> @owned Foo
   // CHECK:         apply [[SUPER_INIT]]([[X]], [[SUPER_OBJ]])

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -138,10 +138,9 @@ class TestUnownedMember {
 // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
 // CHECK:   [[FIELDPTR:%.*]] = ref_element_addr [[BORROWED_SELF]] : $TestUnownedMember, #TestUnownedMember.member
-// CHECK:   [[FIELDPTR_ACCESS:%.*]] = begin_access [modify] [unsafe] [[FIELDPTR]]
 // CHECK:   [[INVAL:%.*]] = ref_to_unowned [[ARG1_COPY]] : $C to $@sil_unowned C
 // CHECK:   [[INVAL_COPY:%.*]] = copy_value [[INVAL]] : $@sil_unowned C
-// CHECK:   assign [[INVAL_COPY]] to [[FIELDPTR_ACCESS]] : $*@sil_unowned C
+// CHECK:   assign [[INVAL_COPY]] to [[FIELDPTR]] : $*@sil_unowned C
 // CHECK:   destroy_value [[ARG1_COPY]] : $C
 // CHECK:   end_borrow [[BORROWED_ARG1]]
 // CHECK:   end_borrow [[BORROWED_SELF]]

--- a/test/SILOptimizer/definite_init_failable_initializers_objc.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_objc.swift
@@ -42,9 +42,7 @@ class Cat : FakeNSObject {
     // CHECK-NEXT: [[SELF_BOX:%.*]] = alloc_stack $Cat
     // CHECK:      store [[ARG2]] to [[SELF_BOX]] : $*Cat
     // CHECK:      [[FIELD_ADDR:%.*]] = ref_element_addr [[ARG2]] : $Cat, #Cat.x
-    // CHECK-NEXT: [[FIELD_ADDR_ACCESS:%.*]] = begin_access [modify] [unsafe] [[FIELD_ADDR]]
-    // CHECK-NEXT: store {{%.*}} to [[FIELD_ADDR_ACCESS]] : $*LifetimeTracked
-    // CHECK-NEXT: end_access [[FIELD_ADDR_ACCESS]]
+    // CHECK-NEXT: store {{%.*}} to [[FIELD_ADDR]] : $*LifetimeTracked
     // CHECK-NEXT: strong_release [[ARG2]]
     // CHECK-NEXT: [[COND:%.*]] = struct_extract %1 : $Bool, #Bool._value
     // CHECK-NEXT: cond_br [[COND]], bb1, bb2


### PR DESCRIPTION
… access for immutable or non accessing uses instead of not emitting any begin_access."

This reverts commit a3b68e6df55c5c6df2b0880bba94be53594a9f51.

Speculative revert because I believe it is the cause of the failures on
the swift-master-source-compat-suite-enable-verify-exclusivity bot.

rdar://58529726