### PR TITLE
Revert "[build-script] Do not specify LLDB_FRAMEWORK_INSTALL_PATH (#2…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2069,6 +2069,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
                     -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+                    -DLLDB_FRAMEWORK_INSTALL_DIR="$(get_host_install_prefix ${host})../System/Library/PrivateFrameworks"
                     -DLLVM_DIR:PATH=${llvm_build_dir}/lib/cmake/llvm
                     -DClang_DIR:PATH=${llvm_build_dir}/lib/cmake/clang
                     -DSwift_DIR:PATH=${swift_build_dir}/lib/cmake/swift


### PR DESCRIPTION
…8418)" (#28675)

This reverts commit 486e2e76ba91761bf20d68362c95134136abafb1 to fix an issue causing the lldb driver to crash (see: https://forums.swift.org/t/lldb-broken-in-swift-5-2-development-snapshots/32597).

This bug was fixed on master, but the fix was not merged into the 5.2 branch.