### PR TITLE
[AutoDiff upstream] Add `@differentiable` declaration attribute type-checking.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -64,6 +64,7 @@ namespace swift {
   class DeclContext;
   class DefaultArgumentInitializer;
   class DerivativeAttr;
+  class DifferentiableAttr;
   class ExtensionDecl;
   class ForeignRepresentationInfo;
   class FuncDecl;
@@ -286,6 +287,11 @@ public:
 
   /// Cached mapping from types to their associated tangent spaces.
   llvm::DenseMap<Type, Optional<TangentSpace>> AutoDiffTangentSpaces;
+
+  /// Cache of `@differentiable` attributes keyed by parameter indices. Used to
+  /// diagnose duplicate `@differentiable` attributes for the same key.
+  llvm::DenseMap<std::pair<Decl *, IndexSubset *>, DifferentiableAttr *>
+      DifferentiableAttrs;
 
   /// Cache of `@derivative` attributes keyed by parameter indices and
   /// derivative function kind. Used to diagnose duplicate `@derivative`

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1647,6 +1647,7 @@ class DifferentiableAttr final
       private llvm::TrailingObjects<DifferentiableAttr,
                                     ParsedAutoDiffParameter> {
   friend TrailingObjects;
+  friend class DifferentiableAttributeTypeCheckRequest;
 
   /// The declaration on which the `@differentiable` attribute is declared.
   /// May not be a valid declaration for `@differentiable` attributes.
@@ -1667,7 +1668,8 @@ class DifferentiableAttr final
   /// specified.
   FuncDecl *VJPFunction = nullptr;
   /// The differentiability parameter indices, resolved by the type checker.
-  IndexSubset *ParameterIndices = nullptr;
+  /// The bit stores whether the parameter indices have been computed.
+  llvm::PointerIntPair<IndexSubset *, 1, bool> ParameterIndicesAndBit;
   /// The trailing where clause (optional).
   TrailingWhereClause *WhereClause = nullptr;
   /// The generic signature for autodiff associated functions. Resolved by the
@@ -1723,12 +1725,14 @@ public:
   /// registered VJP.
   Optional<DeclNameRefWithLoc> getVJP() const { return VJP; }
 
-  IndexSubset *getParameterIndices() const {
-    return ParameterIndices;
-  }
-  void setParameterIndices(IndexSubset *parameterIndices) {
-    ParameterIndices = parameterIndices;
-  }
+private:
+  /// Returns true if the given `@differentiable` attribute has been
+  /// type-checked.
+  bool hasBeenTypeChecked() const;
+
+public:
+  IndexSubset *getParameterIndices() const;
+  void setParameterIndices(IndexSubset *parameterIndices);
 
   /// The parsed differentiability parameters, i.e. the list of parameters
   /// specified in 'wrt:'.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1669,6 +1669,10 @@ class DifferentiableAttr final
   FuncDecl *VJPFunction = nullptr;
   /// The differentiability parameter indices, resolved by the type checker.
   /// The bit stores whether the parameter indices have been computed.
+  ///
+  /// Note: it is necessary to use a bit instead of `nullptr` parameter indices
+  /// to represent "parameter indices not yet type-checked" because invalid
+  /// attributes have `nullptr` parameter indices but have been type-checked.
   llvm::PointerIntPair<IndexSubset *, 1, bool> ParameterIndicesAndBit;
   /// The trailing where clause (optional).
   TrailingWhereClause *WhereClause = nullptr;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5736,6 +5736,20 @@ public:
 private:
   ParameterList *Params;
 
+  /// The generation at which we last loaded derivative function configurations.
+  unsigned DerivativeFunctionConfigGeneration = 0;
+  /// Prepare to traverse the list of derivative function configurations.
+  void prepareDerivativeFunctionConfigurations();
+
+  /// A uniqued list of derivative function configurations.
+  /// - `@differentiable` and `@derivative` attribute type-checking is
+  ///   responsible for populating derivative function configurations specified
+  ///   in the current module.
+  /// - Module loading is responsible for populating derivative function
+  ///   configurations from imported modules.
+  struct DerivativeFunctionConfigurationList;
+  DerivativeFunctionConfigurationList *DerivativeFunctionConfigs = nullptr;
+
 protected:
   // If a function has a body at all, we have either a parsed body AST node or
   // we have saved the end location of the unparsed body.
@@ -6059,6 +6073,12 @@ public:
   /// Tests if this is a function returning a DynamicSelfType, or a
   /// constructor.
   bool hasDynamicSelfResult() const;
+
+  /// Get all derivative function configurations.
+  ArrayRef<AutoDiffConfig> getDerivativeFunctionConfigurations();
+
+  /// Add the given derivative function configuration.
+  void addDerivativeFunctionConfiguration(AutoDiffConfig config);
 
   using DeclContext::operator new;
   using Decl::getASTContext;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2904,6 +2904,62 @@ ERROR(implements_attr_protocol_not_conformed_to,none,
       "containing type %0 does not conform to protocol %1",
       (DeclName, DeclName))
 
+// @differentiable
+ERROR(differentiable_attr_void_result,none,
+      "cannot differentiate void function %0", (DeclName))
+ERROR(differentiable_attr_no_vjp_or_jvp_when_linear,none,
+      "cannot specify 'vjp:' or 'jvp:' for linear functions; use '@transpose' "
+      "attribute for transpose registration instead", ())
+ERROR(differentiable_attr_overload_not_found,none,
+      "%0 does not have expected type %1", (DeclNameRef, Type))
+// TODO(TF-482): Change duplicate `@differentiable` attribute diagnostic to also
+// mention "same generic requirements".
+ERROR(differentiable_attr_duplicate,none,
+      "duplicate '@differentiable' attribute with same parameters", ())
+NOTE(differentiable_attr_duplicate_note,none,
+     "other attribute declared here", ())
+ERROR(differentiable_attr_function_not_same_type_context,none,
+      "%0 is not defined in the current type context", (DeclNameRef))
+ERROR(differentiable_attr_derivative_not_function,none,
+      "registered derivative %0 must be a 'func' declaration", (DeclNameRef))
+ERROR(differentiable_attr_class_derivative_not_final,none,
+      "class member derivative must be final", ())
+ERROR(differentiable_attr_invalid_access,none,
+      "derivative function %0 is required to either be public or "
+      "'@usableFromInline' because the original function %1 is public or "
+      "'@usableFromInline'", (DeclNameRef, DeclName))
+ERROR(differentiable_attr_result_not_differentiable,none,
+      "can only differentiate functions with results that conform to "
+      "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
+ERROR(differentiable_attr_protocol_req_where_clause,none,
+      "'@differentiable' attribute on protocol requirement cannot specify "
+      "'where' clause", ())
+ERROR(differentiable_attr_protocol_req_assoc_func,none,
+      "'@differentiable' attribute on protocol requirement cannot specify "
+      "'jvp:' or 'vjp:'", ())
+ERROR(differentiable_attr_stored_property_variable_unsupported,none,
+      "'@differentiable' attribute on stored property cannot specify "
+      "'jvp:' or 'vjp:'", ())
+ERROR(differentiable_attr_class_member_no_dynamic_self,none,
+      "'@differentiable' attribute cannot be declared on class methods "
+      "returning 'Self'", ())
+// TODO(TF-654): Remove when differentiation supports class initializers.
+ERROR(differentiable_attr_class_init_not_yet_supported,none,
+      "'@differentiable' attribute does not yet support class initializers",
+      ())
+ERROR(differentiable_attr_empty_where_clause,none,
+      "empty 'where' clause in '@differentiable' attribute", ())
+ERROR(differentiable_attr_where_clause_for_nongeneric_original,none,
+      "'where' clause is valid only when original function is generic %0",
+      (DeclName))
+ERROR(differentiable_attr_layout_req_unsupported,none,
+      "'@differentiable' attribute does not yet support layout requirements",
+      ())
+ERROR(overriding_decl_missing_differentiable_attr,none,
+      "overriding declaration is missing attribute '%0'", (StringRef))
+NOTE(protocol_witness_missing_differentiable_attr,none,
+     "candidate is missing attribute '%0'", (StringRef))
+
 // @derivative
 ERROR(derivative_attr_expected_result_tuple,none,
       "'@derivative(of:)' attribute requires function to return a two-element "

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -375,7 +375,9 @@ struct WhereClauseOwner {
 
   /// The source of the where clause, which can be a generic parameter list
   /// or a declaration that can have a where clause.
-  llvm::PointerUnion<GenericParamList *, TrailingWhereClause *, SpecializeAttr *> source;
+  llvm::PointerUnion<GenericParamList *, TrailingWhereClause *,
+                     SpecializeAttr *, DifferentiableAttr *>
+      source;
 
   WhereClauseOwner(GenericContext *genCtx);
   WhereClauseOwner(AssociatedTypeDecl *atd);
@@ -384,6 +386,9 @@ struct WhereClauseOwner {
       : dc(dc), source(genericParams) {}
 
   WhereClauseOwner(DeclContext *dc, SpecializeAttr *attr)
+      : dc(dc), source(attr) {}
+
+  WhereClauseOwner(DeclContext *dc, DifferentiableAttr *attr)
       : dc(dc), source(attr) {}
 
   SourceLoc getLoc() const;
@@ -2018,6 +2023,35 @@ public:
   SourceLoc getNearestLoc() const {
     return std::get<0>(getStorage()).getPattern()->getLoc();
   }
+};
+
+/// Type-checks a `@differentiable` attribute and returns the resolved parameter
+/// indices on success. On failure, emits diagnostics and returns `nullptr`.
+///
+/// Currently, this request resolves other `@differentiable` attribute
+/// components but mutates them in place:
+/// - `JVPFunction`
+/// - `VJPFunction`
+/// - `DerivativeGenericSignature`
+class DifferentiableAttributeTypeCheckRequest
+    : public SimpleRequest<DifferentiableAttributeTypeCheckRequest,
+                           IndexSubset *(DifferentiableAttr *),
+                           CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<IndexSubset *> evaluate(Evaluator &evaluator,
+                                         DifferentiableAttr *attr) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<IndexSubset *> getCachedResult() const;
+  void cacheResult(IndexSubset *value) const;
 };
 
 // Allow AnyValue to compare two Type values, even though Type doesn't

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -43,6 +43,9 @@ SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,
 SWIFT_REQUEST(TypeChecker, DefaultTypeRequest,
               Type(KnownProtocolKind, const DeclContext *), SeparatelyCached,
               NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DifferentiableAttributeTypeCheckRequest,
+              IndexSubset *(DifferentiableAttr *),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DynamicallyReplacedDeclRequest,
               ValueDecl *(ValueDecl *),
               Cached, NoLocationInfo)

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/IndexSubset.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Defer.h"
@@ -1503,6 +1504,30 @@ void DifferentiableAttr::setOriginalDeclaration(Decl *originalDeclaration) {
   assert(!OriginalDeclaration &&
          "Original declaration cannot have already been set");
   OriginalDeclaration = originalDeclaration;
+}
+
+bool DifferentiableAttr::hasBeenTypeChecked() const {
+  return ParameterIndicesAndBit.getInt();
+}
+
+IndexSubset *DifferentiableAttr::getParameterIndices() const {
+  assert(getOriginalDeclaration() &&
+         "Original declaration must have been resolved");
+  auto &ctx = getOriginalDeclaration()->getASTContext();
+  return evaluateOrDefault(ctx.evaluator,
+                           DifferentiableAttributeTypeCheckRequest{
+                               const_cast<DifferentiableAttr *>(this)},
+                           nullptr);
+}
+
+void DifferentiableAttr::setParameterIndices(IndexSubset *paramIndices) {
+  assert(getOriginalDeclaration() &&
+         "Original declaration must have been resolved");
+  auto &ctx = getOriginalDeclaration()->getASTContext();
+  ctx.evaluator.cacheOutput(
+      DifferentiableAttributeTypeCheckRequest{
+          const_cast<DifferentiableAttr *>(this)},
+      std::move(paramIndices));
 }
 
 void DifferentiableAttr::setJVPFunction(FuncDecl *decl) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6982,6 +6982,45 @@ StringRef AbstractFunctionDecl::getInlinableBodyText(
   return extractInlinableText(getASTContext().SourceMgr, body, scratch);
 }
 
+/// A uniqued list of derivative function configurations.
+struct AbstractFunctionDecl::DerivativeFunctionConfigurationList
+    : public llvm::SetVector<AutoDiffConfig> {
+  // Necessary for `ASTContext` allocation.
+  void *operator new(
+      size_t bytes, ASTContext &ctx,
+      unsigned alignment = alignof(DerivativeFunctionConfigurationList)) {
+    return ctx.Allocate(bytes, alignment);
+  }
+};
+
+void AbstractFunctionDecl::prepareDerivativeFunctionConfigurations() {
+  if (DerivativeFunctionConfigs)
+    return;
+  auto &ctx = getASTContext();
+  DerivativeFunctionConfigs = new (ctx) DerivativeFunctionConfigurationList();
+  // Register an `ASTContext` cleanup calling the list destructor.
+  ctx.addCleanup([this]() {
+    this->DerivativeFunctionConfigs->~DerivativeFunctionConfigurationList();
+  });
+}
+
+ArrayRef<AutoDiffConfig>
+AbstractFunctionDecl::getDerivativeFunctionConfigurations() {
+  prepareDerivativeFunctionConfigurations();
+  auto &ctx = getASTContext();
+  if (ctx.getCurrentGeneration() > DerivativeFunctionConfigGeneration) {
+    // TODO(TF-1100): Upstream derivative function configuration serialization
+    // logic.
+  }
+  return DerivativeFunctionConfigs->getArrayRef();
+}
+
+void AbstractFunctionDecl::addDerivativeFunctionConfiguration(
+    AutoDiffConfig config) {
+  prepareDerivativeFunctionConfigurations();
+  DerivativeFunctionConfigs->insert(config);
+}
+
 FuncDecl *FuncDecl::createImpl(ASTContext &Context,
                                SourceLoc StaticLoc,
                                StaticSpellingKind StaticSpelling,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -115,10 +115,6 @@ public:
   IGNORED_ATTR(ProjectedValueProperty)
   IGNORED_ATTR(ReferenceOwnership)
   IGNORED_ATTR(OriginallyDefinedIn)
-
-  // TODO(TF-828): Upstream `@differentiable` attribute type-checking from
-  // tensorflow branch.
-  IGNORED_ATTR(Differentiable)
   // TODO(TF-830): Upstream `@transpose` attribute type-checking from tensorflow
   // branch.
   IGNORED_ATTR(Transpose)
@@ -254,6 +250,8 @@ public:
   void visitImplementationOnlyAttr(ImplementationOnlyAttr *attr);
   void visitNonEphemeralAttr(NonEphemeralAttr *attr);
   void checkOriginalDefinedInAttrs(Decl *D, ArrayRef<OriginallyDefinedInAttr*> Attrs);
+
+  void visitDifferentiableAttr(DifferentiableAttr *attr);
   void visitDerivativeAttr(DerivativeAttr *attr);
 };
 } // end anonymous namespace
@@ -3399,6 +3397,504 @@ getDerivativeOriginalFunctionType(AnyFunctionType *derivativeFnTy) {
                              : nullptr);
   }
   return originalType;
+}
+
+// Finds a derivative function declaration using the given function specifier,
+// original function declaration, expected type, and "is valid" predicate. If no
+// valid derivative function is found, emits diagnostics and returns false.
+static FuncDecl *findAutoDiffDerivativeFunction(
+    DeclNameRefWithLoc specifier, AbstractFunctionDecl *original,
+    Type expectedTy, std::function<bool(AbstractFunctionDecl *)> isValid) {
+  auto &ctx = original->getASTContext();
+  auto &diags = ctx.Diags;
+  auto noneValidDiagnostic = [&]() {
+    diags.diagnose(specifier.Loc, diag::differentiable_attr_overload_not_found,
+                   specifier.Name, expectedTy);
+  };
+  auto ambiguousDiagnostic = [&]() {
+    diags.diagnose(specifier.Loc, diag::attr_ambiguous_reference_to_decl,
+                   specifier.Name, "differentiable");
+  };
+  auto notFunctionDiagnostic = [&]() {
+    diags.diagnose(specifier.Loc,
+                   diag::differentiable_attr_derivative_not_function,
+                   specifier.Name);
+  };
+  std::function<void()> invalidTypeContextDiagnostic = [&]() {
+    diags.diagnose(specifier.Loc,
+                   diag::differentiable_attr_function_not_same_type_context,
+                   specifier.Name);
+  };
+
+  // Returns true if the original function and derivative function candidate are
+  // defined in compatible type contexts. If the original function and the
+  // derivative function have different parents, or if they both have no type
+  // context and are in different modules, return false.
+  std::function<bool(AbstractFunctionDecl *)> hasValidTypeContext =
+      [&](AbstractFunctionDecl *func) {
+        // Check if both functions are top-level.
+        if (!original->getInnermostTypeContext() &&
+            !func->getInnermostTypeContext() &&
+            original->getParentModule() == func->getParentModule())
+          return true;
+        // Check if both functions are defined in the same type context.
+        if (auto typeCtx1 = original->getInnermostTypeContext())
+          if (auto typeCtx2 = func->getInnermostTypeContext())
+            return typeCtx1->getSelfNominalTypeDecl() ==
+                   typeCtx2->getSelfNominalTypeDecl();
+        return original->getParent() == func->getParent();
+      };
+
+  auto isABIPublic = [&](AbstractFunctionDecl *func) {
+    return func->getFormalAccess() >= AccessLevel::Public ||
+           func->getAttrs().hasAttribute<InlinableAttr>() ||
+           func->getAttrs().hasAttribute<UsableFromInlineAttr>();
+  };
+
+  // If the original function is exported (i.e. it is public or
+  // `@usableFromInline`), then the derivative functions must also be exported.
+  // Returns true on error.
+  auto checkAccessControl = [&](AbstractFunctionDecl *func) {
+    if (!isABIPublic(original))
+      return false;
+    if (isABIPublic(func))
+      return false;
+    diags.diagnose(specifier.Loc, diag::differentiable_attr_invalid_access,
+                   specifier.Name, original->getFullName());
+    return true;
+  };
+
+  auto originalTypeCtx = original->getInnermostTypeContext();
+  if (!originalTypeCtx)
+    originalTypeCtx = original->getParent();
+  assert(originalTypeCtx);
+
+  // Set lookup options.
+  auto lookupOptions =
+      defaultMemberLookupOptions | NameLookupFlags::IgnoreAccessControl;
+
+  auto *candidate = findAbstractFunctionDecl(
+      specifier.Name, specifier.Loc.getBaseNameLoc(), /*baseType*/ Type(),
+      originalTypeCtx, isValid, noneValidDiagnostic, ambiguousDiagnostic,
+      notFunctionDiagnostic, lookupOptions, hasValidTypeContext,
+      invalidTypeContextDiagnostic);
+  if (!candidate)
+    return nullptr;
+  // Reject non-`func` registered derivatives. JVPs and VJPs must be `func`
+  // declarations.
+  if (isa<AccessorDecl>(candidate)) {
+    diags.diagnose(specifier.Loc,
+                   diag::differentiable_attr_derivative_not_function,
+                   specifier.Name);
+    return nullptr;
+  }
+  if (checkAccessControl(candidate))
+    return nullptr;
+  // Derivatives of class members must be final.
+  if (original->getDeclContext()->getSelfClassDecl() && !candidate->isFinal()) {
+    diags.diagnose(specifier.Loc,
+                   diag::differentiable_attr_class_derivative_not_final);
+    return nullptr;
+  }
+  assert(isa<FuncDecl>(candidate));
+  auto *funcDecl = cast<FuncDecl>(candidate);
+  return funcDecl;
+}
+
+llvm::Expected<IndexSubset *> DifferentiableAttributeTypeCheckRequest::evaluate(
+    Evaluator &evaluator, DifferentiableAttr *attr) const {
+  // Skip type-checking for implicit `@differentiable` attributes. We currently
+  // assume that all implicit `@differentiable` attributes are valid.
+  //
+  // Motivation: some implicit attributes do not have a `where` clause, and this
+  // function assumes that the `where` clauses exist. Propagating `where`
+  // clauses and requirements consistently is a larger problem, to be revisited.
+  if (attr->isImplicit())
+    return nullptr;
+
+  auto *D = attr->getOriginalDeclaration();
+  auto &ctx = D->getASTContext();
+  auto &diags = ctx.Diags;
+  // `@differentiable` attribute requires experimental differentiable
+  // programming to be enabled.
+  if (!ctx.LangOpts.EnableExperimentalDifferentiableProgramming) {
+    diags
+        .diagnose(attr->getLocation(),
+                  diag::experimental_differentiable_programming_disabled)
+        .highlight(attr->getRangeWithAt());
+    return nullptr;
+  }
+  // The `Differentiable` protocol must be available.
+  if (!ctx.getProtocol(KnownProtocolKind::Differentiable)) {
+    diags
+        .diagnose(attr->getLocation(), diag::attr_used_without_required_module,
+                  attr, ctx.Id_Differentiation)
+        .highlight(attr->getRangeWithAt());
+    return nullptr;
+  }
+
+  // Derivative registration is disabled for `@differentiable(linear)`
+  // attributes. Instead, use `@transpose` attribute to register transpose
+  // functions.
+  if (attr->isLinear() && (attr->getVJP() || attr->getJVP())) {
+    diagnoseAndRemoveAttr(diags, D, attr,
+                          diag::differentiable_attr_no_vjp_or_jvp_when_linear);
+    attr->setInvalid();
+    return nullptr;
+  }
+
+  auto *original = dyn_cast<AbstractFunctionDecl>(D);
+  if (auto *asd = dyn_cast<AbstractStorageDecl>(D)) {
+    // Derivative registration is unsupported for stored properties.
+    if (asd->getImplInfo().isSimpleStored() &&
+        (attr->getJVP() || attr->getVJP())) {
+      diagnoseAndRemoveAttr(
+          diags, D, attr,
+          diag::differentiable_attr_stored_property_variable_unsupported);
+      attr->setInvalid();
+      return nullptr;
+    }
+    // If `@differentiable` attribute is declared directly on a
+    // `AbstractStorageDecl` (a stored/computed property or subscript),
+    // forward the attribute to the storage's getter.
+    // TODO(TF-129): Forward `@differentiable` attributes to setters after
+    // differentiation supports inout parameters.
+    // TODO(TF-1080): Forward `@differentiable` attributes to `read` and
+    // `modify` accessors after differentiation supports `inout` parameters.
+    if (!asd->getDeclContext()->isModuleScopeContext()) {
+      original = asd->getSynthesizedAccessor(AccessorKind::Get);
+    } else {
+      original = nullptr;
+    }
+  }
+  // Non-`get` accessors are not yet supported: `set`, `read`, and `modify`.
+  // TODO(TF-129): Enable `set` when differentiation supports inout parameters.
+  // TODO(TF-1080): Enable `read` and `modify` when differentiation supports
+  // coroutines.
+  if (auto *accessor = dyn_cast_or_null<AccessorDecl>(original))
+    if (!accessor->isGetter())
+      original = nullptr;
+
+  // Diagnose if original `AbstractFunctionDecl *` could not be resolved.
+  if (!original) {
+    diagnoseAndRemoveAttr(diags, D, attr, diag::invalid_decl_attribute, attr);
+    attr->setInvalid();
+    return nullptr;
+  }
+  // If the original function has an error interface type, return.
+  if (original->getInterfaceType()->hasError())
+    return nullptr;
+
+  auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
+  bool isMethod = original->hasImplicitSelfDecl();
+
+  // If the original function returns the empty tuple type, there is no output
+  // to differentiate from.
+  auto originalResultTy = originalFnTy->getResult();
+  if (isMethod)
+    originalResultTy = originalResultTy->castTo<AnyFunctionType>()->getResult();
+  if (originalResultTy->isEqual(ctx.TheEmptyTupleType)) {
+    diags
+        .diagnose(attr->getLocation(), diag::differentiable_attr_void_result,
+                  original->getFullName())
+        .highlight(original->getSourceRange());
+    attr->setInvalid();
+    return nullptr;
+  }
+
+  bool isOriginalProtocolRequirement =
+      isa<ProtocolDecl>(original->getDeclContext()) &&
+      original->isProtocolRequirement();
+
+  bool isOriginalClassMember = original->getDeclContext() &&
+                               original->getDeclContext()->getSelfClassDecl();
+
+  // Diagnose if original function is an invalid class member.
+  if (isOriginalClassMember) {
+    // Class methods returning dynamic `Self` are not supported.
+    // (For class methods, dynamic `Self` is supported only as the single
+    // result - tuple-returning JVPs/VJPs would not type-check.)
+    if (auto *originalFn = dyn_cast<FuncDecl>(original)) {
+      if (originalFn->hasDynamicSelfResult()) {
+        diags.diagnose(attr->getLocation(),
+                       diag::differentiable_attr_class_member_no_dynamic_self);
+        attr->setInvalid();
+        return nullptr;
+      }
+    }
+
+    // TODO(TF-654): Class initializers are not yet supported.
+    // Extra JVP/VJP type calculation logic is necessary because classes have
+    // both allocators and initializers.
+    if (auto *initDecl = dyn_cast<ConstructorDecl>(original)) {
+      diags.diagnose(attr->getLocation(),
+                     diag::differentiable_attr_class_init_not_yet_supported);
+      attr->setInvalid();
+      return nullptr;
+    }
+  }
+
+  // Compute the derivative generic signature for the `@differentiable`
+  // attribute:
+  // - If the `@differentiable` attribute has a `where` clause, use it to
+  //   compute the derivative generic signature.
+  // - Otherwise, use the original function's generic signature by default.
+  auto derivativeGenSig = original->getGenericSignature();
+
+  // Handle the `where` clause, if it exists.
+  // - Resolve attribute where clause requirements and store in the attribute
+  //   for serialization.
+  // - Compute generic signature for autodiff derivative functions based on
+  //   the original function's generate signature and the attribute's where
+  //   clause requirements.
+  GenericEnvironment *derivativeGenEnv = nullptr;
+  if (auto *whereClause = attr->getWhereClause()) {
+    // `@differentiable` attributes on protocol requirements do not support
+    // `where` clauses.
+    if (isOriginalProtocolRequirement) {
+      diags.diagnose(attr->getLocation(),
+                     diag::differentiable_attr_protocol_req_where_clause);
+      attr->setInvalid();
+      return nullptr;
+    }
+    if (whereClause->getRequirements().empty()) {
+      // `where` clause must not be empty.
+      diags.diagnose(attr->getLocation(),
+                     diag::differentiable_attr_empty_where_clause);
+      attr->setInvalid();
+      return nullptr;
+    }
+
+    auto originalGenSig = original->getGenericSignature();
+    if (!originalGenSig) {
+      // `where` clauses are valid only when the original function is generic.
+      diags
+          .diagnose(
+              attr->getLocation(),
+              diag::differentiable_attr_where_clause_for_nongeneric_original,
+              original->getFullName())
+          .highlight(whereClause->getSourceRange());
+      attr->setInvalid();
+      return nullptr;
+    }
+
+    // Build a new generic signature for autodiff derivative functions.
+    GenericSignatureBuilder builder(ctx);
+    // Add the original function's generic signature.
+    builder.addGenericSignature(originalGenSig);
+
+    using FloatingRequirementSource =
+        GenericSignatureBuilder::FloatingRequirementSource;
+
+    bool errorOccurred = false;
+    WhereClauseOwner(original, attr)
+        .visitRequirements(
+            TypeResolutionStage::Structural,
+            [&](const Requirement &req, RequirementRepr *reqRepr) {
+              switch (req.getKind()) {
+              case RequirementKind::SameType:
+              case RequirementKind::Superclass:
+              case RequirementKind::Conformance:
+                break;
+
+              // Layout requirements are not supported.
+              case RequirementKind::Layout:
+                diags
+                    .diagnose(attr->getLocation(),
+                              diag::differentiable_attr_layout_req_unsupported)
+                    .highlight(reqRepr->getSourceRange());
+                errorOccurred = true;
+                return false;
+              }
+
+              // Add requirement to generic signature builder.
+              builder.addRequirement(
+                  req, reqRepr, FloatingRequirementSource::forExplicit(reqRepr),
+                  nullptr, original->getModuleContext());
+              return false;
+            });
+
+    if (errorOccurred) {
+      attr->setInvalid();
+      return nullptr;
+    }
+
+    // Compute generic signature and environment for derivative functions.
+    derivativeGenSig = std::move(builder).computeGenericSignature(
+        attr->getLocation(), /*allowConcreteGenericParams=*/true);
+    derivativeGenEnv = derivativeGenSig->getGenericEnvironment();
+  }
+
+  // Set the resolved derivative generic signature in the attribute.
+  // Do not set the derivative generic signature if the original function's
+  // generic signature is equal to `derivativeGenSig` and all generic parameters
+  // are concrete. In that case, the original function and derivative functions
+  // are all lowered as SIL functions with no generic signature (specialized
+  // with concrete types from same-type requirements), so the derivative generic
+  // signature should not be set.
+  auto skipDerivativeGenericSignature = [&] {
+    CanGenericSignature origCanGenSig;
+    if (auto origGenSig = original->getGenericSignature())
+      origCanGenSig = origGenSig->getCanonicalSignature();
+    CanGenericSignature derivativeCanGenSig;
+    if (derivativeGenSig)
+      derivativeCanGenSig = derivativeGenSig->getCanonicalSignature();
+    if (!derivativeGenSig)
+      return false;
+    return origCanGenSig == derivativeCanGenSig &&
+           derivativeCanGenSig->areAllParamsConcrete();
+  };
+  if (skipDerivativeGenericSignature())
+    derivativeGenSig = GenericSignature();
+  attr->setDerivativeGenericSignature(derivativeGenSig);
+
+  // Validate the differentiability parameters.
+
+  // Get the parsed differentiability parameter indices, which have not yet been
+  // resolved. Parsed differentiability parameter indices are defined only for
+  // parsed attributes.
+  auto parsedDiffParams = attr->getParsedParameters();
+
+  // Compute the derivative function type.
+  auto derivativeFnTy = originalFnTy;
+  if (derivativeGenEnv)
+    derivativeFnTy = derivativeGenEnv->mapTypeIntoContext(derivativeFnTy)
+                         ->castTo<AnyFunctionType>();
+
+  auto *resolvedDiffParamIndices = computeDifferentiabilityParameters(
+      parsedDiffParams, original, derivativeGenEnv, attr->getAttrName(),
+      attr->getLocation());
+  if (!resolvedDiffParamIndices) {
+    attr->setInvalid();
+    return nullptr;
+  }
+
+  // Check if differentiability parameter indices are valid.
+  if (checkDifferentiabilityParameters(original, resolvedDiffParamIndices,
+                                       derivativeFnTy, derivativeGenEnv,
+                                       original->getModuleContext(),
+                                       parsedDiffParams, attr->getLocation())) {
+    attr->setInvalid();
+    return nullptr;
+  }
+
+  if (derivativeGenEnv)
+    originalResultTy = derivativeGenEnv->mapTypeIntoContext(originalResultTy);
+  else
+    originalResultTy = original->mapTypeIntoContext(originalResultTy);
+  // Check that original function's result type conforms to `Differentiable`.
+  if (!conformsToDifferentiable(originalResultTy, original)) {
+    diags.diagnose(attr->getLocation(),
+                   diag::differentiable_attr_result_not_differentiable,
+                   originalResultTy);
+    attr->setInvalid();
+    return nullptr;
+  }
+
+  // `@differentiable` attributes on protocol requirements do not support
+  // JVP/VJP.
+  if (isOriginalProtocolRequirement && (attr->getJVP() || attr->getVJP())) {
+    diags.diagnose(attr->getLocation(),
+                   diag::differentiable_attr_protocol_req_assoc_func);
+    attr->setInvalid();
+    return nullptr;
+  }
+
+  auto lookupConformance =
+      LookUpConformanceInModule(D->getDeclContext()->getParentModule());
+
+  // Resolve the JVP function, if it exists.
+  if (attr->getJVP()) {
+    auto *expectedJVPFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
+        resolvedDiffParamIndices, /*resultIndex*/ 0,
+        AutoDiffDerivativeFunctionKind::JVP, lookupConformance,
+        derivativeGenSig, /*makeSelfParamFirst*/ true);
+
+    auto isValidJVP = [&](AbstractFunctionDecl *jvpCandidate) -> bool {
+      return checkFunctionSignature(
+          cast<AnyFunctionType>(expectedJVPFnTy->getCanonicalType()),
+          jvpCandidate->getInterfaceType()->getCanonicalType());
+    };
+
+    auto *jvp = findAutoDiffDerivativeFunction(
+        attr->getJVP().getValue(), original, expectedJVPFnTy, isValidJVP);
+    if (!jvp) {
+      attr->setInvalid();
+      return nullptr;
+    }
+    // Set the JVP function in the attribute.
+    attr->setJVPFunction(jvp);
+  }
+
+  // Resolve the VJP function, if it exists.
+  if (attr->getVJP()) {
+    auto *expectedVJPFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
+        resolvedDiffParamIndices, /*resultIndex*/ 0,
+        AutoDiffDerivativeFunctionKind::VJP, lookupConformance,
+        derivativeGenSig, /*makeSelfParamFirst*/ true);
+
+    auto isValidVJP = [&](AbstractFunctionDecl *vjpCandidate) -> bool {
+      return checkFunctionSignature(
+          cast<AnyFunctionType>(expectedVJPFnTy->getCanonicalType()),
+          vjpCandidate->getInterfaceType()->getCanonicalType());
+    };
+
+    auto *vjp = findAutoDiffDerivativeFunction(
+        attr->getVJP().getValue(), original, expectedVJPFnTy, isValidVJP);
+    if (!vjp) {
+      attr->setInvalid();
+      return nullptr;
+    }
+    // Set the VJP function in the attribute.
+    attr->setVJPFunction(vjp);
+  }
+
+  if (auto *asd = dyn_cast<AbstractStorageDecl>(D)) {
+    // Remove `@differentiable` attribute from storage declaration to prevent
+    // duplicate attribute registration during SILGen.
+    D->getAttrs().removeAttribute(attr);
+    // Transfer `@differentiable` attribute from storage declaration to
+    // getter accessor.
+    auto *getterDecl = asd->getAccessor(AccessorKind::Get);
+    auto *newAttr = DifferentiableAttr::create(
+        getterDecl, /*implicit*/ true, attr->AtLoc, attr->getRange(),
+        attr->isLinear(), resolvedDiffParamIndices, attr->getJVP(),
+        attr->getVJP(), attr->getDerivativeGenericSignature());
+    newAttr->setJVPFunction(attr->getJVPFunction());
+    newAttr->setVJPFunction(attr->getVJPFunction());
+    auto insertion = ctx.DifferentiableAttrs.try_emplace(
+        {getterDecl, resolvedDiffParamIndices}, newAttr);
+    // Reject duplicate `@differentiable` attributes.
+    if (!insertion.second) {
+      diagnoseAndRemoveAttr(diags, D, attr,
+                            diag::differentiable_attr_duplicate);
+      diags.diagnose(insertion.first->getSecond()->getLocation(),
+                     diag::differentiable_attr_duplicate_note);
+      return nullptr;
+    }
+    getterDecl->getAttrs().add(newAttr);
+    return resolvedDiffParamIndices;
+  }
+  auto insertion =
+      ctx.DifferentiableAttrs.try_emplace({D, resolvedDiffParamIndices}, attr);
+  // Reject duplicate `@differentiable` attributes.
+  if (!insertion.second && insertion.first->getSecond() != attr) {
+    diagnoseAndRemoveAttr(diags, D, attr, diag::differentiable_attr_duplicate);
+    diags.diagnose(insertion.first->getSecond()->getLocation(),
+                   diag::differentiable_attr_duplicate_note);
+    return nullptr;
+  }
+  // Register derivative function configuration.
+  auto *resultIndices = IndexSubset::get(ctx, 1, {0});
+  original->addDerivativeFunctionConfiguration(
+      {resolvedDiffParamIndices, resultIndices, derivativeGenSig});
+  return resolvedDiffParamIndices;
+}
+
+void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
+  // Call `getParameterIndices` to trigger
+  // `DifferentiableAttributeTypeCheckRequest`.
+  (void)attr->getParameterIndices();
 }
 
 /// Typechecks the given derivative attribute `attr` on decl `D`.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -303,6 +303,132 @@ static ValueDecl *getStandinForAccessor(AbstractStorageDecl *witness,
   return witness;
 }
 
+/// Given a witness, a requirement, and an existing `RequirementMatch` result,
+/// check if the requirement's `@differentiable` attributes are met by the
+/// witness.
+/// - If requirement's `@differentiable` attributes are met, or if `result` is
+///   not viable, returns `result`.
+/// - Otherwise, returns a `DifferentiableConflict` `RequirementMatch`.
+// Note: the `result` argument is only necessary for using
+// `RequirementMatch::WitnessSubstitutions`.
+static RequirementMatch
+matchWitnessDifferentiableAttr(DeclContext *dc, ValueDecl *req,
+                               ValueDecl *witness, RequirementMatch result) {
+  if (!result.isViable())
+    return result;
+
+  // Get the requirement and witness attributes.
+  const auto &reqAttrs = req->getAttrs();
+  const auto &witnessAttrs = witness->getAttrs();
+
+  // For all `@differentiable` attributes of the protocol requirement, check
+  // that the witness has a derivative configuration with exactly the same
+  // parameter indices, or one with "superset" parameter indices. If there
+  // exists a witness derivative configuration with "superset" parameter
+  // indices, create an implicit `@differentiable` attribute for the witness
+  // with the exact parameter indices from the requirement `@differentiable`
+  // attribute.
+  ASTContext &ctx = witness->getASTContext();
+  auto *witnessAFD = dyn_cast<AbstractFunctionDecl>(witness);
+  if (auto *witnessASD = dyn_cast<AbstractStorageDecl>(witness))
+    witnessAFD = witnessASD->getAccessor(AccessorKind::Get);
+  // NOTE: Validate `@differentiable` attributes by calling
+  // `getParameterIndices`. This is important for type-checking
+  // `@differentiable` attributes in non-primary files to skip invalid
+  // attributes and to resolve derivative configurations, used below.
+  for (auto *witnessDiffAttr :
+       witnessAttrs.getAttributes<DifferentiableAttr>()) {
+    (void)witnessDiffAttr->getParameterIndices();
+  }
+  for (auto *reqDiffAttr : reqAttrs.getAttributes<DifferentiableAttr>()) {
+    (void)reqDiffAttr->getParameterIndices();
+  }
+  for (auto *reqDiffAttr : reqAttrs.getAttributes<DifferentiableAttr>()) {
+    bool foundExactConfig = false;
+    Optional<AutoDiffConfig> supersetConfig = None;
+    for (auto witnessConfig :
+         witnessAFD->getDerivativeFunctionConfigurations()) {
+      // All the witness's derivative generic requirements must be satisfied
+      // by the requirement's derivative generic requirements OR by the
+      // conditional conformance requirements.
+      if (witnessConfig.derivativeGenericSignature) {
+        bool genericRequirementsSatisfied = true;
+        auto reqDiffGenSig = reqDiffAttr->getDerivativeGenericSignature();
+        auto conformanceGenSig = dc->getGenericSignatureOfContext();
+        for (const auto &req :
+             witnessConfig.derivativeGenericSignature->getRequirements()) {
+          auto substReq = req.subst(result.WitnessSubstitutions);
+          bool reqDiffGenSigSatisfies =
+              reqDiffGenSig && substReq &&
+              reqDiffGenSig->isRequirementSatisfied(*substReq);
+          bool conformanceGenSigSatisfies =
+              conformanceGenSig &&
+              conformanceGenSig->isRequirementSatisfied(req);
+          if (!reqDiffGenSigSatisfies && !conformanceGenSigSatisfies) {
+            genericRequirementsSatisfied = false;
+            break;
+          }
+        }
+        if (!genericRequirementsSatisfied)
+          continue;
+      }
+
+      if (witnessConfig.parameterIndices ==
+          reqDiffAttr->getParameterIndices()) {
+        foundExactConfig = true;
+        break;
+      }
+      if (witnessConfig.parameterIndices->isSupersetOf(
+              reqDiffAttr->getParameterIndices()))
+        supersetConfig = witnessConfig;
+    }
+    if (!foundExactConfig) {
+      bool success = false;
+      if (supersetConfig) {
+        // If the witness has a "superset" derivative configuration, create an
+        // implicit `@differentiable` attribute with the exact requirement
+        // `@differentiable` attribute parameter indices.
+        auto *newAttr = DifferentiableAttr::create(
+            witnessAFD, /*implicit*/ true, reqDiffAttr->AtLoc,
+            reqDiffAttr->getRange(), reqDiffAttr->isLinear(),
+            reqDiffAttr->getParameterIndices(), /*jvp*/ None,
+            /*vjp*/ None, supersetConfig->derivativeGenericSignature);
+        auto insertion = ctx.DifferentiableAttrs.try_emplace(
+            {witnessAFD, newAttr->getParameterIndices()}, newAttr);
+        // Valid `@differentiable` attributes are uniqued by original function
+        // and parameter indices. Reject duplicate attributes.
+        if (!insertion.second) {
+          newAttr->setInvalid();
+        } else {
+          witness->getAttrs().add(newAttr);
+          success = true;
+        }
+      }
+      if (!success) {
+        LLVM_DEBUG({
+          llvm::dbgs() << "Protocol requirement match failure: missing "
+                          "`@differentiable` attribute for witness ";
+          witnessAFD->dumpRef(llvm::dbgs());
+          llvm::dbgs() << " from requirement ";
+          req->dumpRef(llvm::dbgs());
+          llvm::dbgs() << '\n';
+        });
+        // FIXME(TF-1014): `@differentiable` attribute diagnostic does not
+        // appear if associated type inference is involved.
+        if (auto *vdWitness = dyn_cast<VarDecl>(witness)) {
+          return RequirementMatch(
+              getStandinForAccessor(vdWitness, AccessorKind::Get),
+              MatchKind::DifferentiableConflict, reqDiffAttr);
+        } else {
+          return RequirementMatch(witness, MatchKind::DifferentiableConflict,
+                                  reqDiffAttr);
+        }
+      }
+    }
+  }
+  return result;
+}
+
 RequirementMatch
 swift::matchWitness(
              DeclContext *dc, ValueDecl *req, ValueDecl *witness,
@@ -531,112 +657,9 @@ swift::matchWitness(
 
   // Now finalize the match.
   auto result = finalize(anyRenaming, optionalAdjustments);
-  if (result.isViable()) {
-    // For all `@differentiable` attributes of the protocol requirement, check
-    // that the witness has a derivative configuration with exactly the same
-    // parameter indices, or one with "superset" parameter indices. If there
-    // exists a witness derivative configuration with "superset" parameter
-    // indices, create an implicit `@differentiable` attribute for the witness
-    // with the exact parameter indices from the requirement `@differentiable`
-    // attribute.
-    ASTContext &ctx = witness->getASTContext();
-    auto *witnessAFD = dyn_cast<AbstractFunctionDecl>(witness);
-    if (auto *witnessASD = dyn_cast<AbstractStorageDecl>(witness))
-      witnessAFD = witnessASD->getAccessor(AccessorKind::Get);
-    // NOTE: Validate `@differentiable` attributes by calling
-    // `getParameterIndices`. This is important for type-checking
-    // `@differentiable` attributes in non-primary files to skip invalid
-    // attributes and to resolve derivative configurations, used below.
-    for (auto *witnessDiffAttr :
-         witnessAttrs.getAttributes<DifferentiableAttr>()) {
-      (void)witnessDiffAttr->getParameterIndices();
-    }
-    for (auto *reqDiffAttr : reqAttrs.getAttributes<DifferentiableAttr>()) {
-      (void)reqDiffAttr->getParameterIndices();
-    }
-    for (auto *reqDiffAttr : reqAttrs.getAttributes<DifferentiableAttr>()) {
-      bool foundExactConfig = false;
-      Optional<AutoDiffConfig> supersetConfig = None;
-      for (auto witnessConfig :
-           witnessAFD->getDerivativeFunctionConfigurations()) {
-        // All the witness's derivative generic requirements must be satisfied
-        // by the requirement's derivative generic requirements OR by the
-        // conditional conformance requirements.
-        if (witnessConfig.derivativeGenericSignature) {
-          bool genericRequirementsSatisfied = true;
-          auto reqDiffGenSig = reqDiffAttr->getDerivativeGenericSignature();
-          auto conformanceGenSig = dc->getGenericSignatureOfContext();
-          for (const auto &req :
-               witnessConfig.derivativeGenericSignature->getRequirements()) {
-            auto substReq = req.subst(result.WitnessSubstitutions);
-            bool reqDiffGenSigSatisfies =
-                reqDiffGenSig && substReq &&
-                reqDiffGenSig->isRequirementSatisfied(*substReq);
-            bool conformanceGenSigSatisfies =
-                conformanceGenSig &&
-                conformanceGenSig->isRequirementSatisfied(req);
-            if (!reqDiffGenSigSatisfies && !conformanceGenSigSatisfies) {
-              genericRequirementsSatisfied = false;
-              break;
-            }
-          }
-          if (!genericRequirementsSatisfied)
-            continue;
-        }
-
-        if (witnessConfig.parameterIndices ==
-            reqDiffAttr->getParameterIndices()) {
-          foundExactConfig = true;
-          break;
-        }
-        if (witnessConfig.parameterIndices->isSupersetOf(
-                reqDiffAttr->getParameterIndices()))
-          supersetConfig = witnessConfig;
-      }
-      if (!foundExactConfig) {
-        bool success = false;
-        if (supersetConfig) {
-          // If the witness has a "superset" derivative configuration, create an
-          // implicit `@differentiable` attribute with the exact requirement
-          // `@differentiable` attribute parameter indices.
-          auto *newAttr = DifferentiableAttr::create(
-              witnessAFD, /*implicit*/ true, reqDiffAttr->AtLoc,
-              reqDiffAttr->getRange(), reqDiffAttr->isLinear(),
-              reqDiffAttr->getParameterIndices(), /*jvp*/ None,
-              /*vjp*/ None, supersetConfig->derivativeGenericSignature);
-          auto insertion = ctx.DifferentiableAttrs.try_emplace(
-              {witnessAFD, newAttr->getParameterIndices()}, newAttr);
-          // Valid `@differentiable` attributes are uniqued by original function
-          // and parameter indices. Reject duplicate attributes.
-          if (!insertion.second) {
-            newAttr->setInvalid();
-          } else {
-            witness->getAttrs().add(newAttr);
-            success = true;
-          }
-        }
-        if (!success) {
-          LLVM_DEBUG({
-            llvm::dbgs() << "Protocol requirement match failure: missing "
-                            "`@differentiable` attribute for witness ";
-            witnessAFD->dumpRef(llvm::dbgs());
-            llvm::dbgs() << " from requirement ";
-            req->dumpRef(llvm::dbgs());
-            llvm::dbgs() << '\n';
-          });
-          // FIXME(TF-1014): `@differentiable` attribute diagonstic does not
-          // appear if associated type inference is involved.
-          if (auto *vdWitness = dyn_cast<VarDecl>(witness))
-            return RequirementMatch(
-                getStandinForAccessor(vdWitness, AccessorKind::Get),
-                MatchKind::DifferentiableConflict, reqDiffAttr);
-          else
-            return RequirementMatch(witness, MatchKind::DifferentiableConflict,
-                                    reqDiffAttr);
-        }
-      }
-    }
-  }
+  // Check if the requirement's `@differentiable` attributes are satisfied by
+  // the witness.
+  result = matchWitnessDifferentiableAttr(dc, req, witness, result);
   return result;
 }
 
@@ -2299,6 +2322,8 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     // Emit a note showing the missing requirement `@differentiable` attribute.
     auto *reqAttr = cast<DifferentiableAttr>(match.UnmetAttribute);
     assert(reqAttr);
+    if (!reqAttr->getParameterIndices())
+      break;
     // Omit printing wrt clause if attribute differentiation parameters match
     // inferred differentiation parameters.
     auto *original = cast<AbstractFunctionDecl>(match.Witness);

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -1,0 +1,1173 @@
+// RUN: %target-swift-frontend-typecheck -enable-experimental-differentiable-programming -verify %s
+// REQUIRES: differentiable_programming
+
+import _Differentiation
+
+// Dummy `Differentiable`-conforming type.
+struct DummyTangentVector: Differentiable & AdditiveArithmetic {
+  static var zero: Self { Self() }
+  static func + (_: Self, _: Self) -> Self { Self() }
+  static func - (_: Self, _: Self) -> Self { Self() }
+  typealias TangentVector = Self
+}
+
+@differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+let globalConst: Float = 1
+
+@differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+var globalVar: Float = 1
+
+func testLocalVariables() {
+  // expected-error @+1 {{'_' has no parameters to differentiate with respect to}}
+  @differentiable
+  var getter: Float {
+    return 1
+  }
+
+  // expected-error @+1 {{'_' has no parameters to differentiate with respect to}}
+  @differentiable
+  var getterSetter: Float {
+    get { return 1 }
+    set {}
+  }
+}
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(vjp: dfoo) // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+protocol P {}
+
+@differentiable() // ok!
+func no_jvp_or_vjp(_ x: Float) -> Float {
+  return x * x
+}
+
+// Test duplicate `@differentiable` attributes.
+
+@differentiable // expected-error {{duplicate '@differentiable' attribute with same parameters}}
+@differentiable // expected-note {{other attribute declared here}}
+func dupe_attributes(arg: Float) -> Float { return arg }
+
+@differentiable(wrt: arg1)
+@differentiable(wrt: arg2) // expected-error {{duplicate '@differentiable' attribute with same parameters}}
+@differentiable(wrt: arg2) // expected-note {{other attribute declared here}}
+func dupe_attributes(arg1: Float, arg2: Float) -> Float { return arg1 }
+
+struct ComputedPropertyDupeAttributes<T: Differentiable>: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  var value: T
+
+  @differentiable // expected-note {{other attribute declared here}}
+  var computed1: T {
+    @differentiable // expected-error {{duplicate '@differentiable' attribute with same parameters}}
+    get { value }
+    set { value = newValue }
+  }
+
+  // TODO(TF-482): Remove diagnostics when `@differentiable` attributes are
+  // also uniqued based on generic requirements.
+  @differentiable(where T == Float) // expected-error {{duplicate '@differentiable' attribute with same parameters}}
+  @differentiable(where T == Double) // expected-note {{other attribute declared here}}
+  var computed2: T {
+    get { value }
+    set { value = newValue }
+  }
+}
+
+// Test TF-568.
+protocol WrtOnlySelfProtocol: Differentiable {
+  @differentiable
+  var computedProperty: Float { get }
+
+  @differentiable
+  func method() -> Float
+}
+
+class Class: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  func move(along _: TangentVector) {}
+}
+@differentiable(wrt: x)
+func invalidDiffWrtClass(_ x: Class) -> Class {
+  return x
+}
+
+protocol Proto {}
+// expected-error @+1 {{can only differentiate with respect to parameters that conform to 'Differentiable', but 'Proto' does not conform to 'Differentiable'}}
+@differentiable(wrt: x)
+func invalidDiffWrtExistential(_ x: Proto) -> Proto {
+  return x
+}
+
+// expected-error @+1 {{can only differentiate with respect to parameters that conform to 'Differentiable', but '@differentiable (Float) -> Float' does not conform to 'Differentiable'}}
+@differentiable(wrt: fn)
+func invalidDiffWrtFunction(_ fn: @differentiable(Float) -> Float) -> Float {
+  return fn(.pi)
+}
+
+// expected-error @+1 {{'invalidDiffNoParams()' has no parameters to differentiate with respect to}}
+@differentiable
+func invalidDiffNoParams() -> Float {
+  return 1
+}
+
+// expected-error @+1 {{cannot differentiate void function 'invalidDiffVoidResult(x:)'}}
+@differentiable
+func invalidDiffVoidResult(x: Float) {}
+
+// Test static methods.
+struct StaticMethod {
+  // expected-error @+1 {{'invalidDiffNoParams()' has no parameters to differentiate with respect to}}
+  @differentiable
+  static func invalidDiffNoParams() -> Float {
+    return 1
+  }
+
+  // expected-error @+1 {{cannot differentiate void function 'invalidDiffVoidResult(x:)'}}
+  @differentiable
+  static func invalidDiffVoidResult(x: Float) {}
+}
+
+// Test instance methods.
+struct InstanceMethod {
+  // expected-error @+1 {{'invalidDiffNoParams()' has no parameters to differentiate with respect to}}
+  @differentiable
+  func invalidDiffNoParams() -> Float {
+    return 1
+  }
+
+  // expected-error @+1 {{cannot differentiate void function 'invalidDiffVoidResult(x:)'}}
+  @differentiable
+  func invalidDiffVoidResult(x: Float) {}
+}
+
+// Test instance methods for a `Differentiable` type.
+struct DifferentiableInstanceMethod: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  @differentiable // ok
+  func noParams() -> Float {
+    return 1
+  }
+}
+
+// Test subscript methods.
+struct SubscriptMethod {
+  @differentiable // ok
+  subscript(implicitGetter x: Float) -> Float {
+    return x
+  }
+
+  @differentiable // ok
+  subscript(implicitGetterSetter x: Float) -> Float {
+    get { return x }
+    set {}
+  }
+
+  subscript(explicit x: Float) -> Float {
+    @differentiable // ok
+    get { return x }
+    @differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+    set {}
+  }
+
+  subscript(x: Float, y: Float) -> Float {
+    @differentiable // ok
+    get { return x + y }
+    @differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+    set {}
+  }
+}
+
+// JVP
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(jvp: jvpSimpleJVP)
+func jvpSimple(x: Float) -> Float {
+  return x
+}
+
+func jvpSimpleJVP(x: Float) -> (Float, ((Float) -> Float)) {
+  return (x, { v in v })
+}
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(wrt: y, jvp: jvpWrtSubsetJVP)
+func jvpWrtSubset1(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(wrt: (y), jvp: jvpWrtSubsetJVP)
+func jvpWrtSubset2(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+func jvpWrtSubsetJVP(x: Float, y: Float) -> (Float, (Float) -> Float) {
+  return (x + y, { v in v })
+}
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(jvp: jvp2ParamsJVP)
+func jvp2Params(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+func jvp2ParamsJVP(x: Float, y: Float) -> (Float, (Float, Float) -> Float) {
+  return (x + y, { (a, b) in a + b })
+}
+
+// expected-error @+1 {{unknown parameter name 'y'}}
+@differentiable(wrt: (y))
+func jvpUnknownParam(x: Float) -> Float {
+  return x
+}
+
+// expected-error @+1 {{parameters must be specified in original order}}
+@differentiable(wrt: (y, x))
+func jvpParamOrderNotIncreasing(x: Float, y: Float) -> Float {
+  return x * y
+}
+
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{'jvpWrongTypeJVP' does not have expected type '(Float) -> (Float, (Float.TangentVector) -> Float.TangentVector)' (aka '(Float) -> (Float, (Float) -> Float)'}}
+@differentiable(jvp: jvpWrongTypeJVP)
+func jvpWrongType(x: Float) -> Float {
+  return x
+}
+
+func jvpWrongTypeJVP(x: Float) -> (Float, (Float) -> Int) {
+  return (x, { v in Int(v) })
+}
+
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
+@differentiable(jvp: jvpSimpleJVP)
+func jvpNonDiffParam(x: Int) -> Float {
+  return Float(x)
+}
+
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'Int' does not conform to 'Differentiable'}}
+@differentiable(jvp: jvpSimpleJVP)
+func jvpNonDiffResult(x: Float) -> Int {
+  return Int(x)
+}
+
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but '(Float, Int)' does not conform to 'Differentiable'}}
+@differentiable(jvp: jvpSimpleJVP)
+func jvpNonDiffResult2(x: Float) -> (Float, Int) {
+  return (x, Int(x))
+}
+
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{ambiguous reference to 'jvpAmbiguousVJP' in '@differentiable' attribute}}
+@differentiable(jvp: jvpAmbiguousVJP)
+func jvpAmbiguous(x: Float) -> Float {
+  return x
+}
+func jvpAmbiguousVJP(_ x: Float) -> (Float, (Float) -> Float) {
+  return (x, { $0 })
+}
+func jvpAmbiguousVJP(x: Float) -> (Float, (Float) -> Float) {
+  return (x, { $0 })
+}
+
+class DifferentiableClassMethod {
+  // Direct differentiation case.
+  @differentiable
+  func foo(_ x: Float) -> Float {
+    return x
+  }
+}
+
+struct JVPStruct {
+  @differentiable
+  let p: Float
+
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{'funcJVP' does not have expected type '(JVPStruct) -> () -> (Double, (JVPStruct.TangentVector) -> Double.TangentVector)' (aka '(JVPStruct) -> () -> (Double, (JVPStruct) -> Double)'}}
+  @differentiable(wrt: (self), jvp: funcJVP)
+  func funcWrongType() -> Double {
+    fatalError("unimplemented")
+  }
+}
+
+extension JVPStruct {
+  func funcJVP() -> (Float, (JVPStruct) -> Float) {
+    fatalError("unimplemented")
+  }
+}
+
+extension JVPStruct: AdditiveArithmetic {
+  static var zero: JVPStruct { fatalError("unimplemented") }
+  static func + (lhs: JVPStruct, rhs: JVPStruct) -> JVPStruct {
+    fatalError("unimplemented")
+  }
+  static func - (lhs: JVPStruct, rhs: JVPStruct) -> JVPStruct {
+    fatalError("unimplemented")
+  }
+  typealias Scalar = Float
+  static func * (lhs: Float, rhs: JVPStruct) -> JVPStruct {
+    fatalError("unimplemented")
+  }
+}
+
+extension JVPStruct: Differentiable {
+  typealias TangentVector = JVPStruct
+}
+
+extension JVPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(wrt: x, jvp: wrtAllNonSelfJVP)
+  func wrtAllNonSelf(x: Float) -> Float {
+    return x + p
+  }
+
+  func wrtAllNonSelfJVP(x: Float) -> (Float, (Float) -> Float) {
+    return (x + p, { v in v })
+  }
+}
+
+extension JVPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(wrt: (self, x), jvp: wrtAllJVP)
+  func wrtAll(x: Float) -> Float {
+    return x + p
+  }
+
+  func wrtAllJVP(x: Float) -> (Float, (JVPStruct, Float) -> Float) {
+    return (x + p, { (a, b) in a.p + b })
+  }
+}
+
+extension JVPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(jvp: computedPropJVP)
+  var computedPropOk1: Float {
+    return 0
+  }
+
+  var computedPropOk2: Float {
+    // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+    @differentiable(jvp: computedPropJVP)
+    get {
+      return 0
+    }
+  }
+
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{'computedPropJVP' does not have expected type '(JVPStruct) -> () -> (Double, (JVPStruct.TangentVector) -> Double.TangentVector)' (aka '(JVPStruct) -> () -> (Double, (JVPStruct) -> Double)'}}
+  @differentiable(jvp: computedPropJVP)
+  var computedPropWrongType: Double {
+    return 0
+  }
+
+  var computedPropWrongAccessor: Float {
+    get {
+      return 0
+    }
+    // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable(jvp: computedPropJVP)
+    set {
+      fatalError("unimplemented")
+    }
+  }
+
+  func computedPropJVP() -> (Float, (JVPStruct) -> Float) {
+    fatalError("unimplemented")
+  }
+}
+
+// VJP
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(vjp: vjpSimpleVJP)
+func vjpSimple(x: Float) -> Float {
+  return x
+}
+
+func vjpSimpleVJP(x: Float) -> (Float, ((Float) -> Float)) {
+  return (x, { v in v })
+}
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(wrt: (y), vjp: vjpWrtSubsetVJP)
+func vjpWrtSubset(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+func vjpWrtSubsetVJP(x: Float, y: Float) -> (Float, (Float) -> Float) {
+  return (x + y, { v in v })
+}
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(vjp: vjp2ParamsVJP)
+func vjp2Params(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+func vjp2ParamsVJP(x: Float, y: Float) -> (Float, (Float) -> (Float, Float)) {
+  return (x + y, { v in (v, v) })
+}
+
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{'vjpWrongTypeVJP' does not have expected type '(Float) -> (Float, (Float.TangentVector) -> Float.TangentVector)' (aka '(Float) -> (Float, (Float) -> Float)'}}
+@differentiable(vjp: vjpWrongTypeVJP)
+func vjpWrongType(x: Float) -> Float {
+  return x
+}
+
+func vjpWrongTypeVJP(x: Float) -> (Float, (Float) -> Int) {
+  return (x, { v in Int(v) })
+}
+
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
+@differentiable(vjp: vjpSimpleVJP)
+func vjpNonDiffParam(x: Int) -> Float {
+  return Float(x)
+}
+
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'Int' does not conform to 'Differentiable'}}
+@differentiable(vjp: vjpSimpleVJP)
+func vjpNonDiffResult(x: Float) -> Int {
+  return Int(x)
+}
+
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but '(Float, Int)' does not conform to 'Differentiable'}}
+@differentiable(vjp: vjpSimpleVJP)
+func vjpNonDiffResult2(x: Float) -> (Float, Int) {
+  return (x, Int(x))
+}
+
+struct VJPStruct {
+  let p: Float
+
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{'funcVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
+  @differentiable(vjp: funcVJP)
+  func funcWrongType() -> Double {
+    fatalError("unimplemented")
+  }
+}
+
+extension VJPStruct {
+  func funcVJP() -> (Float, (Float) -> VJPStruct) {
+    fatalError("unimplemented")
+  }
+}
+
+extension VJPStruct: AdditiveArithmetic {
+  static var zero: VJPStruct { fatalError("unimplemented") }
+  static func + (lhs: VJPStruct, rhs: VJPStruct) -> VJPStruct {
+    fatalError("unimplemented")
+  }
+  static func - (lhs: VJPStruct, rhs: VJPStruct) -> VJPStruct {
+    fatalError("unimplemented")
+  }
+  typealias Scalar = Float
+  static func * (lhs: Float, rhs: VJPStruct) -> VJPStruct {
+    fatalError("unimplemented")
+  }
+}
+
+extension VJPStruct: Differentiable {
+  typealias TangentVector = VJPStruct
+}
+
+extension VJPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(wrt: x, vjp: wrtAllNonSelfVJP)
+  func wrtAllNonSelf(x: Float) -> Float {
+    return x + p
+  }
+
+  func wrtAllNonSelfVJP(x: Float) -> (Float, (Float) -> Float) {
+    return (x + p, { v in v })
+  }
+}
+
+extension VJPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(wrt: (self, x), vjp: wrtAllVJP)
+  func wrtAll(x: Float) -> Float {
+    return x + p
+  }
+
+  func wrtAllVJP(x: Float) -> (Float, (Float) -> (VJPStruct, Float)) {
+    fatalError("unimplemented")
+  }
+}
+
+extension VJPStruct {
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(vjp: computedPropVJP)
+  var computedPropOk1: Float {
+    return 0
+  }
+
+  var computedPropOk2: Float {
+    // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+    @differentiable(vjp: computedPropVJP)
+    get {
+      return 0
+    }
+  }
+
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{'computedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
+  @differentiable(vjp: computedPropVJP)
+  var computedPropWrongType: Double {
+    return 0
+  }
+
+  var computedPropWrongAccessor: Float {
+    get {
+      return 0
+    }
+    // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable(vjp: computedPropVJP)
+    set {
+      fatalError("unimplemented")
+    }
+  }
+
+  func computedPropVJP() -> (Float, (Float) -> VJPStruct) {
+    fatalError("unimplemented")
+  }
+}
+
+// expected-error @+2 {{empty 'where' clause in '@differentiable' attribute}}
+// expected-error @+1 {{expected type}}
+@differentiable(where)
+func emptyWhereClause<T>(x: T) -> T {
+  return x
+}
+
+// expected-error @+1 {{'where' clause is valid only when original function is generic 'nongenericWhereClause(x:)'}}
+@differentiable(where T: Differentiable)
+func nongenericWhereClause(x: Float) -> Float {
+  return x
+}
+
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(jvp: jvpWhere1, vjp: vjpWhere1 where T: Differentiable)
+func where1<T>(x: T) -> T {
+  return x
+}
+func jvpWhere1<T: Differentiable>(x: T) -> (T, (T.TangentVector) -> T.TangentVector) {
+  return (x, { v in v })
+}
+func vjpWhere1<T: Differentiable>(x: T) -> (T, (T.TangentVector) -> T.TangentVector) {
+  return (x, { v in v })
+}
+
+// Test derivative functions with result tuple type labels.
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(jvp: jvpResultLabels, vjp: vjpResultLabels)
+func derivativeResultLabels(_ x: Float) -> Float {
+  return x
+}
+func jvpResultLabels(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+  return (x, { $0 })
+}
+func vjpResultLabels(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  return (x, { $0 })
+}
+struct ResultLabelTest {
+  // expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(jvp: jvpResultLabels, vjp: vjpResultLabels)
+  static func derivativeResultLabels(_ x: Float) -> Float {
+    return x
+  }
+  static func jvpResultLabels(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+    return (x, { $0 })
+  }
+  static func vjpResultLabels(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (x, { $0 })
+  }
+
+  // expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(jvp: jvpResultLabels, vjp: vjpResultLabels)
+  func derivativeResultLabels(_ x: Float) -> Float {
+    return x
+  }
+  func jvpResultLabels(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+    return (x, { $0 })
+  }
+  func vjpResultLabels(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (x, { $0 })
+  }
+}
+
+struct Tensor<Scalar>: AdditiveArithmetic {
+  static var zero: Self { Self() }
+  static func + (_: Self, _: Self) -> Self { Self() }
+  static func - (_: Self, _: Self) -> Self { Self() }
+}
+extension Tensor: Differentiable where Scalar: Differentiable {
+  typealias TangentVector = Self
+}
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(jvp: jvpWhere2, vjp: vjpWhere2 where Scalar: Differentiable)
+func where2<Scalar: Numeric>(x: Tensor<Scalar>) -> Tensor<Scalar> {
+  return x
+}
+func jvpWhere2<Scalar: Numeric & Differentiable>(x: Tensor<Scalar>) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
+  return (x, { v in v })
+}
+func vjpWhere2<Scalar: Numeric & Differentiable>(x: Tensor<Scalar>) -> (Tensor<Scalar>, (Tensor<Scalar>) -> Tensor<Scalar>) {
+  return (x, { v in v })
+}
+
+struct A<T> {
+  struct B<U, V> {
+    @differentiable(wrt: x where T: Differentiable, V: Differentiable, V.TangentVector == V)
+    func whereInGenericContext<T>(x: T) -> T {
+      return x
+    }
+  }
+}
+
+extension FloatingPoint {
+  @differentiable(wrt: (self) where Self: Differentiable)
+  func whereClauseExtension() -> Self {
+    return self
+  }
+}
+// expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+// expected-error @+1 {{'vjpNonvariadic' does not have expected type '(Float, Int32...) -> (Float, (Float.TangentVector) -> Float.TangentVector)' (aka '(Float, Int32...) -> (Float, (Float) -> Float)')}}
+@differentiable(wrt: x, vjp: vjpNonvariadic)
+func variadic(_ x: Float, indices: Int32...) -> Float {
+  return x
+}
+func vjpNonvariadic(_ x: Float, indices: [Int32]) -> (Float, (Float) -> Float) {
+  return (x, { $0 })
+}
+
+// expected-error @+3 {{type 'Scalar' constrained to non-protocol, non-class type 'Float'}}
+// expected-error @+2 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
+// expected-note @+1 {{use 'Scalar == Float' to require 'Scalar' to be 'Float'}}
+@differentiable(where Scalar: Float)
+func invalidRequirementConformance<Scalar>(x: Scalar) -> Scalar {
+  return x
+}
+
+@differentiable(where T: AnyObject)
+func invalidAnyObjectRequirement<T: Differentiable>(x: T) -> T {
+  return x
+}
+
+// expected-error @+1 {{'@differentiable' attribute does not yet support layout requirements}}
+@differentiable(where Scalar: _Trivial)
+func invalidRequirementLayout<Scalar>(x: Scalar) -> Scalar {
+  return x
+}
+
+// expected-error @+1 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
+@differentiable
+func missingConformance<T>(_ x: T) -> T {
+  return x
+}
+
+protocol ProtocolRequirements: Differentiable {
+  // expected-note @+2 {{protocol requires initializer 'init(x:y:)' with type '(x: Float, y: Float)'}}
+  @differentiable
+  init(x: Float, y: Float)
+
+  // expected-note @+2 {{protocol requires initializer 'init(x:y:)' with type '(x: Float, y: Int)'}}
+  @differentiable(wrt: x)
+  init(x: Float, y: Int)
+
+  // expected-note @+2 {{protocol requires function 'amb(x:y:)' with type '(Float, Float) -> Float';}}
+  @differentiable
+  func amb(x: Float, y: Float) -> Float
+
+  // expected-note @+2 {{protocol requires function 'amb(x:y:)' with type '(Float, Int) -> Float';}}
+  @differentiable(wrt: x)
+  func amb(x: Float, y: Int) -> Float
+
+  // expected-note @+3 {{protocol requires function 'f1'}}
+  // expected-note @+2 {{overridden declaration is here}}
+  @differentiable(wrt: (self, x))
+  func f1(_ x: Float) -> Float
+
+  // expected-note @+2 {{protocol requires function 'f2'}}
+  @differentiable(wrt: (self, x, y))
+  func f2(_ x: Float, _ y: Float) -> Float
+}
+
+protocol ProtocolRequirementsRefined: ProtocolRequirements {
+  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable'}}
+  func f1(_ x: Float) -> Float
+}
+
+// expected-error @+1 {{does not conform to protocol 'ProtocolRequirements'}}
+struct DiffAttrConformanceErrors: ProtocolRequirements {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  var x: Float
+  var y: Float
+
+  // FIXME(TF-284): Fix unexpected diagnostic.
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Float)'}}
+  init(x: Float, y: Float) {
+    self.x = x
+    self.y = y
+  }
+
+  // FIXME(TF-284): Fix unexpected diagnostic.
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Int)'}}
+  init(x: Float, y: Int) {
+    self.x = x
+    self.y = Float(y)
+  }
+
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+1 {{candidate has non-matching type '(Float, Float) -> Float'}}
+  func amb(x: Float, y: Float) -> Float {
+    return x
+  }
+
+  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: x)'}}
+  // expected-note @+1 {{candidate has non-matching type '(Float, Int) -> Float'}}
+  func amb(x: Float, y: Int) -> Float {
+    return x
+  }
+
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  func f1(_ x: Float) -> Float {
+    return x
+  }
+
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  @differentiable(wrt: (self, x))
+  func f2(_ x: Float, _ y: Float) -> Float {
+    return x + y
+  }
+}
+
+protocol ProtocolRequirementsWithDefault_NoConformingTypes {
+  @differentiable
+  func f1(_ x: Float) -> Float
+}
+extension ProtocolRequirementsWithDefault_NoConformingTypes {
+  // TODO(TF-650): It would be nice to diagnose protocol default implementation
+  // with missing `@differentiable` attribute.
+  func f1(_ x: Float) -> Float { x }
+}
+
+protocol ProtocolRequirementsWithDefault {
+  // expected-note @+2 {{protocol requires function 'f1'}}
+  @differentiable
+  func f1(_ x: Float) -> Float
+}
+extension ProtocolRequirementsWithDefault {
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  func f1(_ x: Float) -> Float { x }
+}
+// expected-error @+1 {{type 'DiffAttrConformanceErrors2' does not conform to protocol 'ProtocolRequirementsWithDefault'}}
+struct DiffAttrConformanceErrors2: ProtocolRequirementsWithDefault {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  func f1(_ x: Float) -> Float { x }
+}
+
+protocol NotRefiningDiffable {
+  @differentiable(wrt: x)
+  // expected-note @+1 {{protocol requires function 'a' with type '(Float) -> Float'; do you want to add a stub?}}
+  func a(_ x: Float) -> Float
+}
+
+// expected-error @+1 {{type 'CertainlyNotDiffableWrtSelf' does not conform to protocol 'NotRefiningDiffable'}}
+struct CertainlyNotDiffableWrtSelf: NotRefiningDiffable {
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  func a(_ x: Float) -> Float { return x * 5.0 }
+}
+
+
+protocol TF285: Differentiable {
+  @differentiable(wrt: (x, y))
+  @differentiable(wrt: x)
+  // expected-note @+1 {{protocol requires function 'foo(x:y:)' with type '(Float, Float) -> Float'; do you want to add a stub?}}
+  func foo(x: Float, y: Float) -> Float
+}
+
+// expected-error @+1 {{type 'TF285MissingOneDiffAttr' does not conform to protocol 'TF285'}}
+struct TF285MissingOneDiffAttr: TF285 {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  // Requirement is missing an attribute.
+  @differentiable(wrt: x)
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x, y))}}
+  func foo(x: Float, y: Float) -> Float {
+    return x
+  }
+}
+
+// TF-521: Test invalid `@differentiable` attribute due to invalid
+// `Differentiable` conformance (`TangentVector` does not conform to
+// `AdditiveArithmetic`).
+struct TF_521<T: FloatingPoint> {
+  var real: T
+  var imaginary: T
+
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'TF_521<T>' does not conform to 'Differentiable'}}
+  @differentiable(vjp: _vjpInit where T: Differentiable, T == T.TangentVector)
+  init(real: T = 0, imaginary: T = 0) {
+    self.real = real
+    self.imaginary = imaginary
+  }
+}
+// expected-error @+1 {{type 'TF_521<T>' does not conform to protocol 'Differentiable'}}
+extension TF_521: Differentiable where T: Differentiable {
+  // expected-note @+1 {{possibly intended match 'TF_521<T>.TangentVector' does not conform to 'AdditiveArithmetic'}}
+  typealias TangentVector = TF_521
+  typealias AllDifferentiableVariables = TF_521
+}
+extension TF_521 where T: Differentiable, T == T.TangentVector {
+  static func _vjpInit(real: T, imaginary: T) -> (TF_521, (TF_521) -> (T, T)) {
+    return (TF_521(real: real, imaginary: imaginary), { ($0.real, $0.imaginary) })
+  }
+}
+let _: @differentiable (Float, Float) -> TF_521<Float> = { r, i in
+  TF_521(real: r, imaginary: i)
+}
+
+// TF-296: Infer `@differentiable` wrt parameters to be to all parameters that conform to `Differentiable`.
+
+@differentiable
+func infer1(_ a: Float, _ b: Int) -> Float {
+  return a + Float(b)
+}
+
+@differentiable
+func infer2(_ fn: @differentiable(Float) -> Float, x: Float) -> Float {
+  return fn(x)
+}
+
+struct DiffableStruct: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  var a: Float
+
+  @differentiable
+  func fn(_ b: Float, _ c: Int) -> Float {
+    return a + b + Float(c)
+  }
+}
+
+struct NonDiffableStruct {
+  var a: Float
+
+  @differentiable
+  func fn(_ b: Float) -> Float {
+    return a + b
+  }
+}
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(linear, wrt: x, vjp: const3) // expected-error {{cannot specify 'vjp:' or 'jvp:' for linear functions; use '@transpose' attribute for transpose registration instead}}
+func slope1(_ x: Float) -> Float {
+  return 3 * x
+}
+
+// expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(linear, wrt: x, jvp: const3) // expected-error {{cannot specify 'vjp:' or 'jvp:' for linear functions; use '@transpose' attribute for transpose registration instead}}
+func slope2(_ x: Float) -> Float {
+  return 3 * x
+}
+
+// expected-warning @+1 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+@differentiable(linear, jvp: const3, vjp: const3) // expected-error {{cannot specify 'vjp:' or 'jvp:' for linear functions; use '@transpose' attribute for transpose registration instead}}
+func slope3(_ x: Float) -> Float {
+  return 3 * x
+}
+
+// Check that `@differentiable` attribute rejects stored properties.
+struct StoredProperty: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{'@differentiable' attribute on stored property cannot specify 'jvp:' or 'vjp:'}}
+  @differentiable(vjp: vjpStored)
+  var stored: Float
+
+  func vjpStored() -> (Float, (Float) -> TangentVector) {
+    (stored, { _ in .zero })
+  }
+}
+
+// Check that `@differentiable` attribute rejects non-`func` derivatives.
+struct Struct: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{registered derivative 'computedPropertyVJP' must be a 'func' declaration}}
+  @differentiable(vjp: computedPropertyVJP)
+  func testComputedProperty() -> Float { 1 }
+  var computedPropertyVJP: (Float, (Float) -> TangentVector) {
+    (1, { _ in .zero })
+  }
+
+  // expected-error @+1 {{expected a vjp function name}}
+  @differentiable(vjp: init)
+  func testInitializer() -> Struct { self }
+  init(_ x: Struct) {}
+
+  // expected-error @+1 {{expected a vjp function name}}
+  @differentiable(vjp: subscript)
+  func testSubscript() -> Float { 1 }
+  subscript() -> (Float, (Float) -> TangentVector) {
+    (1, { _ in .zero })
+  }
+}
+
+// Index based 'wrt:'
+
+struct NumberWrtStruct: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  var a, b: Float
+
+  @differentiable(wrt: 0) // ok
+  @differentiable(wrt: 1) // ok
+  func foo1(_ x: Float, _ y: Float) -> Float {
+    return a*x + b*y
+  }
+
+  @differentiable(wrt: -1) // expected-error {{expected a parameter, which can be a function parameter name, parameter index, or 'self'}}
+  @differentiable(wrt: (1, x)) // expected-error {{parameters must be specified in original order}}
+  func foo2(_ x: Float, _ y: Float) -> Float {
+    return a*x + b*y
+  }
+
+  @differentiable(wrt: (x, 1)) // ok
+  @differentiable(wrt: (0)) // ok
+  static func staticFoo1(_ x: Float, _ y: Float) -> Float {
+    return x + y
+  }
+
+  @differentiable(wrt: (1, 1)) // expected-error {{parameters must be specified in original order}}
+  @differentiable(wrt: (2)) // expected-error {{parameter index is larger than total number of parameters}}
+  static func staticFoo2(_ x: Float, _ y: Float) -> Float {
+    return x + y
+  }
+}
+
+@differentiable(wrt: y) // ok
+func two1(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+@differentiable(wrt: (x, y)) // ok
+func two2(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+@differentiable(wrt: (0, y)) // ok
+func two3(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+@differentiable(wrt: (x, 1)) // ok
+func two4(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+@differentiable(wrt: (0, 1)) // ok
+func two5(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+@differentiable(wrt: 2) // expected-error {{parameter index is larger than total number of parameters}}
+func two6(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+@differentiable(wrt: (1, 0)) // expected-error {{parameters must be specified in original order}}
+func two7(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+@differentiable(wrt: (1, x)) // expected-error {{parameters must be specified in original order}}
+func two8(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+@differentiable(wrt: (y, 0)) // expected-error {{parameters must be specified in original order}}
+func two9(x: Float, y: Float) -> Float {
+  return x + y
+}
+
+// Inout 'wrt:' arguments.
+
+@differentiable(wrt: y) // expected-error {{cannot differentiate void function 'inout1(x:y:)'}}
+func inout1(x: Float, y: inout Float) -> Void {
+  let _ = x + y
+}
+
+@differentiable(wrt: y) // expected-error {{cannot differentiate with respect to 'inout' parameter ('inout Float')}}
+func inout2(x: Float, y: inout Float) -> Float {
+  let _ = x + y
+}
+
+// Test refining protocol requirements with `@differentiable` attribute.
+
+public protocol Distribution {
+  associatedtype Value
+  func logProbability(of value: Value) -> Float
+}
+
+public protocol DifferentiableDistribution: Differentiable, Distribution {
+  // expected-note @+2 {{overridden declaration is here}}
+  @differentiable(wrt: self)
+  func logProbability(of value: Value) -> Float
+}
+
+// Adding a more general `@differentiable` attribute.
+public protocol DoubleDifferentiableDistribution: DifferentiableDistribution
+  where Value: Differentiable {
+  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable(wrt: self)'}}
+  func logProbability(of value: Value) -> Float
+}
+
+// Test protocol requirement `@differentiable` attribute unsupported features.
+
+protocol ProtocolRequirementUnsupported: Differentiable {
+  associatedtype Scalar
+
+  // expected-error @+1 {{'@differentiable' attribute on protocol requirement cannot specify 'where' clause}}
+  @differentiable(where Scalar: Differentiable)
+  func unsupportedWhereClause(value: Scalar) -> Float
+
+  // expected-warning @+2 2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{'@differentiable' attribute on protocol requirement cannot specify 'jvp:' or 'vjp:'}}
+  @differentiable(wrt: x, jvp: dfoo, vjp: dfoo)
+  func unsupportedDerivatives(_ x: Float) -> Float
+}
+extension ProtocolRequirementUnsupported {
+  func dfoo(_ x: Float) -> (Float, (Float) -> Float) {
+    (x, { $0 })
+  }
+}
+
+// Classes.
+
+class Super: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  func move(along _: TangentVector) {}
+
+  var base: Float
+
+  // NOTE(TF-654): Class initializers are not yet supported.
+  // expected-error @+1 {{'@differentiable' attribute does not yet support class initializers}}
+  @differentiable
+  init(base: Float) {
+    self.base = base
+  }
+
+  // NOTE(TF-1040): `@differentiable` attribute on class methods currently
+  // does two orthogonal things:
+  // - Requests derivative generation for the class method.
+  // - Adds JVP/VJP vtable entries for the class method.
+  // There's currently no way using `@differentiable` to do only one of the
+  // above.
+  @differentiable
+  func testClassMethod(_ x: Float) -> Float { x }
+
+  @differentiable
+  final func testFinalMethod(_ x: Float) -> Float { x }
+
+  @differentiable
+  static func testStaticMethod(_ x: Float) -> Float { x }
+
+  @differentiable(wrt: (self, x))
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(wrt: x, vjp: vjp)
+  // expected-note @+1 2 {{overridden declaration is here}}
+  func testMissingAttributes(_ x: Float) -> Float { x }
+
+  // expected-warning @+1 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  @differentiable(wrt: x, vjp: vjp)
+  func testSuperclassDerivatives(_ x: Float) -> Float { x }
+
+  final func vjp(_ x: Float) -> (Float, (Float) -> Float) {
+    fatalError()
+  }
+
+  // Test duplicate attributes with different derivative generic signatures.
+  // expected-error @+1 {{duplicate '@differentiable' attribute with same parameters}}
+  @differentiable(wrt: x where T: Differentiable)
+  // expected-note @+1 {{other attribute declared here}}
+  @differentiable(wrt: x)
+  func instanceMethod<T>(_ x: Float, y: T) -> Float { x }
+
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{'@differentiable' attribute cannot be declared on class methods returning 'Self'}}
+  @differentiable(vjp: vjpDynamicSelfResult)
+  func dynamicSelfResult() -> Self { self }
+
+  // TODO(TF-632): Fix "'TangentVector' is not a member type of 'Self'" diagnostic.
+  // The underlying error should appear instead:
+  // "covariant 'Self' can only appear at the top level of method result type".
+  // expected-error @+1 2 {{'TangentVector' is not a member type of 'Self'}}
+  func vjpDynamicSelfResult() -> (Self, (Self.TangentVector) -> Self.TangentVector) {
+    return (self, { $0 })
+  }
+}
+
+class Sub: Super {
+  // expected-error @+2 {{overriding declaration is missing attribute '@differentiable(wrt: x)'}}
+  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable'}}
+  override func testMissingAttributes(_ x: Float) -> Float { x }
+
+  // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}
+  // expected-error @+1 {{'vjp' is not defined in the current type context}}
+  @differentiable(wrt: x, vjp: vjp)
+  override func testSuperclassDerivatives(_ x: Float) -> Float { x }
+}
+
+// Test unsupported accessors: `set`, `_read`, `_modify`.
+
+struct UnsupportedAccessors: Differentiable {
+  typealias TangentVector = DummyTangentVector
+  mutating func move(along _: TangentVector) {}
+
+  var stored: Float
+  var computed: Float {
+    // `set` has an `inout` parameter: `(inout Self) -> (Float) -> ()`.
+    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable
+    set { stored = newValue }
+
+    // `_read` is a coroutine: `(Self) -> () -> ()`.
+    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable
+    _read { yield stored }
+
+    // `_modify` is a coroutine: `(inout Self) -> () -> ()`.
+    // expected-error @+1 {{'@differentiable' attribute cannot be applied to this declaration}}
+    @differentiable
+    _modify { yield &stored }
+  }
+}


### PR DESCRIPTION
The `@differentiable` attribute marks a function as differentiable.

Example:
```swift
@differentiable(wrt: x, jvp: derivativeFoo where T: Differentiable)
func id<T>(_ x: T) -> T { x }
```

The `@differentiable` attribute has an optional `wrt:` clause specifying the
parameters that are differentiated "with respect to", i.e. the differentiability
parameters. The differentiability parameters must conform to the
`Differentiable` protocol.

If the `wrt:` clause is unspecified, the differentiability parameters are
currently inferred to be all parameters that conform to `Differentiable`.

The `@differentiable` attribute also has optional `jvp:` and `vjp:` labels
for registering derivative functions. These labels are deprecated in favor of
the `@derivative` attribute and will be removed soon.

The `@differentiable` attribute also has an optional `where` clause, specifying
extra differentiability requirements for generic functions.

The `@differentiable` attribute is gated by the
`-enable-experimental-differentiable-programming` flag.

---

Type-checking rules (summary):
- `@differentiable` attribute must be declared on a function-like "original"
  declaration: `func`, `init`, `subscript`, `var` (computed properties only).
- Parsed differentiability parameters must be valid (if they exist).
- Parsed `where` clause must be valid (if it exists).
- Differentiability parameters must all conform to `Differentiable`.
- Original result must all conform to `Differentiable`.
- If JVP/VJP functions are specified, they must match the expected type.
  - `@differentiable(jvp:vjp:)` for derivative registration is deprecated in
    favor of `@derivative` attribute, and will be removed soon.
- Duplicate `@differentiable` attributes with the same differentiability
  parameters are invalid.
- For protocol requirements and class members with `@differentiable` attribute,
  conforming types and subclasses must have the same `@differentiable` attribute
  (or one with a superset of differentiability parameter indices) on
  implementing/overriding declarations.

These rules are consistent with the [differentiable programming manifesto](https://github.com/apple/swift/blob/master/docs/DifferentiableProgramming.md#the-differentiable-declaration-attribute-1).
The main proposed rules are implemented.

Code changes:
- Add `DifferentiableAttributeTypeCheckRequest`.
  - Currently, the request returns differentiability parameter indices,
    while also resolving `JVPFunction`, `VJPFunction`, and
    `DerivativeGenericSignature` and mutating them in-place in
    `DifferentiableAttr`. This works fine for now.
- Add "is type-checked" bit to `DifferentiableAttr`.
  - Alternatively, I tried changing `CacheKind::SeparatelyCached` to
    `CacheKind::Cached`, but it did not seem to work: `@differentiable`
    attributes in non-primary-files were left unchecked.

Upstream disorganized tests as-is from `tensorflow` branch.

Resolves TF-828: upstream `@differentiable` attribute type-checking.