### PR TITLE
[AutoDiff] make libraries in tests static

### DIFF
--- a/test/AutoDiff/downstream/cross_module_derivative_attr_e2e.swift
+++ b/test/AutoDiff/downstream/cross_module_derivative_attr_e2e.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -I%t -parse-as-library -emit-module -module-name module1 -emit-module-path %t/module1.swiftmodule -emit-library -o %t/%target-library-name(module1) %S/Inputs/cross_module_derivative_attr_e2e/module1/module1.swift %S/Inputs/cross_module_derivative_attr_e2e/module1/module1_other_file.swift -Xllvm -enable-experimental-cross-file-derivative-registration -Xfrontend -validate-tbd-against-ir=none
-// RUN: %target-build-swift -I%t -L%t %S/Inputs/cross_module_derivative_attr_e2e/main/main.swift -o %t/a.out -lm -lmodule1 -Xllvm -enable-experimental-cross-file-derivative-registration -Xfrontend -validate-tbd-against-ir=none %target-rpath(%t)
+// RUN: %target-build-swift -working-directory %t -I%t -parse-as-library -emit-module -module-name module1 -emit-module-path %t/module1.swiftmodule -emit-library -static %S/Inputs/cross_module_derivative_attr_e2e/module1/module1.swift %S/Inputs/cross_module_derivative_attr_e2e/module1/module1_other_file.swift -Xllvm -enable-experimental-cross-file-derivative-registration -Xfrontend -validate-tbd-against-ir=none
+// RUN: %target-build-swift -I%t -L%t %S/Inputs/cross_module_derivative_attr_e2e/main/main.swift -o %t/a.out -lm -lmodule1 -Xllvm -enable-experimental-cross-file-derivative-registration -Xfrontend -validate-tbd-against-ir=none
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 

--- a/test/AutoDiff/downstream/derivative_registration_foreign/main.swift
+++ b/test/AutoDiff/downstream/derivative_registration_foreign/main.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %clang -shared %S/Inputs/Foreign.c -fmodules -o %t/%target-library-name(CForeign)
+// RUN: %clang -c %S/Inputs/Foreign.c -fmodules -o %t/CForeign.o
 // RUN: %target-swift-emit-silgen -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s | %FileCheck %s --check-prefix=CHECK-SILGEN --check-prefix=CHECK
 // RUN: %target-swift-emit-sil -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s | %FileCheck %s --check-prefix=CHECK-SIL --check-prefix=CHECK
-// RUN: %target-build-swift -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s -L %t -lCForeign
+// RUN: %target-build-swift -Xllvm -enable-experimental-cross-file-derivative-registration -I %S/Inputs -I %t %s %t/CForeign.o
 
 import CForeign
 

--- a/test/AutoDiff/downstream/e2e_cross_module.swift
+++ b/test/AutoDiff/downstream/e2e_cross_module.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -parse-as-library -emit-module -module-name e2e_cross_module_external_module -emit-module-path %t/e2e_cross_module_external_module.swiftmodule -emit-library -o %t/%target-library-name(e2e_cross_module_external_module) %S/Inputs/e2e_cross_module_external_module.swift
-// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lm -le2e_cross_module_external_module  %target-rpath(%t)
+// RUN: %target-build-swift -working-directory %t -parse-as-library -emit-module -module-name e2e_cross_module_external_module -emit-module-path %t/e2e_cross_module_external_module.swiftmodule -emit-library -static %S/Inputs/e2e_cross_module_external_module.swift
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lm -le2e_cross_module_external_module
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 

--- a/test/AutoDiff/downstream/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/downstream/loadable_by_address_cross_module.swift
@@ -9,7 +9,7 @@
 // Compile the module.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -parse-as-library -emit-module -module-name external -emit-module-path %t/external.swiftmodule -emit-library -o %t/%target-library-name(external) %S/Inputs/loadable_by_address_cross_module.swift
+// RUN: %target-build-swift -working-directory %t -parse-as-library -emit-module -module-name external -emit-module-path %t/external.swiftmodule -emit-library -static %S/Inputs/loadable_by_address_cross_module.swift
 
 // Next, check that differentiability_witness_functions in the client get
 // correctly modified by LBA.
@@ -26,7 +26,7 @@
 
 // Finally, execute the test.
 
-// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lm -lexternal %target-rpath(%t)
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lm -lexternal
 // RUN: %target-run %t/a.out
 
 // REQUIRES: executable_test


### PR DESCRIPTION
The internal Google testing infrastructure does not support tests that make shared libraries, so I changed all our AutoDiff tests to use static libraries instead.