### PR TITLE
[test][android] Mark inherits-superclass-initializers-client as executable.

### DIFF
--- a/test/ModuleInterface/inherits-superclass-initializers-client.swift
+++ b/test/ModuleInterface/inherits-superclass-initializers-client.swift
@@ -1,6 +1,8 @@
 // Compile the imported module to a .swiftinterface and ensure the convenience
 // init delegates through the subclasses correctly.
 
+// REQUIRES: executable_test
+
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/inherits-superclass-initializers.swift -emit-module-path %t/Module.swiftmodule -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution
 // RUN: rm %t/Module.swiftmodule


### PR DESCRIPTION
The test uses %target-run, which requires executing code. Android CI
cannot execute code because no device is attached. Marking the test as
executable skip it in the Android CI machines.

This is a NFC for almost every other platform except Android.

/cc @harlanhaskins