### PR TITLE
Revert "Merge pull request #28665 from CodaFi/the-phantom-menace"

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -535,11 +535,7 @@ DECL_ATTR(derivative, Derivative,
   ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove,
   97)
 
-DECL_ATTR(_implicitly_synthesizes_nested_requirement, ImplicitlySynthesizesNestedRequirement,
-  OnProtocol |
-  UserInaccessible |
-  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
-  98)
+// NOTE: 98 is unused
 
 DECL_ATTR(transpose, Transpose,
   OnFunc | LongAttribute | AllowMultipleAttributes |

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -685,23 +685,6 @@ public:
   }
 };
 
-/// Defines the @_implicitly_synthesizes_nested_requirement attribute.
-class ImplicitlySynthesizesNestedRequirementAttr : public DeclAttribute {
-public:
-  ImplicitlySynthesizesNestedRequirementAttr(StringRef Value, SourceLoc AtLoc,
-                                             SourceRange Range)
-    : DeclAttribute(DAK_ImplicitlySynthesizesNestedRequirement,
-                    AtLoc, Range, /*Implicit*/false),
-      Value(Value) {}
-
-  /// The name of the phantom requirement.
-  const StringRef Value;
-
-  static bool classof(const DeclAttribute *DA) {
-    return DA->getKind() == DAK_ImplicitlySynthesizesNestedRequirement;
-  }
-};
-
 /// Determine the result of comparing an availability attribute to a specific
 /// platform or language version.
 enum class AvailableVersionComparison {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -476,14 +476,10 @@ protected:
     IsDebuggerAlias : 1
   );
 
-  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1+1,
+  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1,
     /// Whether we have already added implicitly-defined initializers
     /// to this declaration.
     AddedImplicitInitializers : 1,
-
-    /// Whether we have already added the phantom CodingKeys
-    /// nested requirement to this declaration.
-    AddedPhantomCodingKeys : 1,
 
     /// Whether there is are lazily-loaded conformances for this nominal type.
     HasLazyConformances : 1,
@@ -3340,7 +3336,6 @@ protected:
     IterableDeclContext(IterableDeclContextKind::NominalTypeDecl)
   {
     Bits.NominalTypeDecl.AddedImplicitInitializers = false;
-    Bits.NominalTypeDecl.AddedPhantomCodingKeys = false;
     ExtensionGeneration = 0;
     Bits.NominalTypeDecl.HasLazyConformances = false;
     Bits.NominalTypeDecl.IsComputingSemanticMembers = false;
@@ -3379,18 +3374,6 @@ public:
   /// Note that we have attempted to add implicit initializers.
   void setAddedImplicitInitializers() {
     Bits.NominalTypeDecl.AddedImplicitInitializers = true;
-  }
-
-  /// Determine whether we have already attempted to add the
-  /// phantom CodingKeys type to this declaration.
-  bool addedPhantomCodingKeys() const {
-    return Bits.NominalTypeDecl.AddedPhantomCodingKeys;
-  }
-
-  /// Note that we have attempted to add the phantom CodingKeys type
-  /// to this declaration.
-  void setAddedPhantomCodingKeys() {
-    Bits.NominalTypeDecl.AddedPhantomCodingKeys = true;
   }
 
   /// getDeclaredType - Retrieve the type declared by this entity, without

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -296,8 +296,7 @@ struct PrintOptions {
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {DAK_Transparent, DAK_Effects,
                                               DAK_FixedLayout,
-                                              DAK_ShowInInterface,
-                                              DAK_ImplicitlySynthesizesNestedRequirement};
+                                              DAK_ShowInInterface};
 
   /// List of attribute kinds that should be printed exclusively.
   /// Empty means allow all.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1682,6 +1682,8 @@ public:
 enum class ImplicitMemberAction : uint8_t {
   ResolveImplicitInit,
   ResolveCodingKeys,
+  ResolveEncodable,
+  ResolveDecodable,
 };
 
 class ResolveImplicitMemberRequest

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -958,11 +958,6 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
-  case DAK_ImplicitlySynthesizesNestedRequirement:
-    Printer.printAttrName("@_implicitly_synthesizes_nested_requirement");
-    Printer << "(\"" << cast<ImplicitlySynthesizesNestedRequirementAttr>(this)->Value << "\")";
-    break;
-
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 
@@ -1024,8 +1019,6 @@ StringRef DeclAttribute::getAttrName() const {
     return "_swift_native_objc_runtime_base";
   case DAK_Semantics:
     return "_semantics";
-  case DAK_ImplicitlySynthesizesNestedRequirement:
-    return "_implicitly_synthesizes_nested_requirement";
   case DAK_Available:
     return "availability";
   case DAK_ObjC:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4047,6 +4047,19 @@ void NominalTypeDecl::synthesizeSemanticMembersIfNeeded(DeclName member) {
     if (baseName.getIdentifier() == getASTContext().Id_CodingKeys) {
       action.emplace(ImplicitMemberAction::ResolveCodingKeys);
     }
+  } else {
+    auto argumentNames = member.getArgumentNames();
+    if (!member.isCompoundName() || argumentNames.size() == 1) {
+      if (baseName == DeclBaseName::createConstructor() &&
+          (member.isSimpleName() || argumentNames.front() == Context.Id_from)) {
+        action.emplace(ImplicitMemberAction::ResolveDecodable);
+      } else if (!baseName.isSpecial() &&
+                 baseName.getIdentifier() == Context.Id_encode &&
+                 (member.isSimpleName() ||
+                  argumentNames.front() == Context.Id_to)) {
+        action.emplace(ImplicitMemberAction::ResolveEncodable);
+      }
+    }
   }
 
   if (auto actionToTake = action) {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1074,6 +1074,12 @@ void swift::simple_display(llvm::raw_ostream &out,
   case ImplicitMemberAction::ResolveCodingKeys:
     out << "resolve CodingKeys";
     break;
+  case ImplicitMemberAction::ResolveEncodable:
+    out << "resolve Encodable.encode(to:)";
+    break;
+  case ImplicitMemberAction::ResolveDecodable:
+    out << "resolve Decodable.init(from:)";
+    break;
   }
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1867,43 +1867,6 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     }
     break;
   }
-
-  case DAK_ImplicitlySynthesizesNestedRequirement: {
-    if (!consumeIf(tok::l_paren)) {
-      diagnose(Loc, diag::attr_expected_lparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
-      return false;
-    }
-
-    if (Tok.isNot(tok::string_literal)) {
-      diagnose(Loc, diag::attr_expected_string_literal, AttrName);
-      return false;
-    }
-
-    auto Value = getStringLiteralIfNotInterpolated(
-        Loc, ("'" + AttrName + "'").str());
-
-    consumeToken(tok::string_literal);
-
-    if (Value.hasValue())
-      AttrRange = SourceRange(Loc, Tok.getRange().getStart());
-    else
-      DiscardAttribute = true;
-
-    if (!consumeIf(tok::r_paren)) {
-      diagnose(Loc, diag::attr_expected_rparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
-      return false;
-    }
-
-    if (!DiscardAttribute) {
-      Attributes.add(new (Context)
-                     ImplicitlySynthesizesNestedRequirementAttr(Value.getValue(), AtLoc,
-                                                   AttrRange));
-    }
-    break;
-  }
-
   case DAK_Available: {
     if (!consumeIf(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -195,9 +195,6 @@ public:
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveDecodable(ValueDecl *requirement);
 
-  /// Derive the CodingKeys requirement for a value type.
-  TypeDecl *derivePhantomCodingKeysRequirement();
-
   /// Declare a read-only property.
   std::pair<VarDecl *, PatternBindingDecl *>
   declareDerivedProperty(Identifier name, Type propertyInterfaceType,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -96,7 +96,6 @@ public:
   IGNORED_ATTR(HasMissingDesignatedInitializers)
   IGNORED_ATTR(InheritsConvenienceInitializers)
   IGNORED_ATTR(Inline)
-  IGNORED_ATTR(ImplicitlySynthesizesNestedRequirement)
   IGNORED_ATTR(ObjCBridged)
   IGNORED_ATTR(ObjCNonLazyRealization)
   IGNORED_ATTR(ObjCRuntimeName)

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1298,7 +1298,6 @@ namespace  {
     UNINTERESTING_ATTR(IBInspectable)
     UNINTERESTING_ATTR(IBOutlet)
     UNINTERESTING_ATTR(IBSegueAction)
-    UNINTERESTING_ATTR(ImplicitlySynthesizesNestedRequirement)
     UNINTERESTING_ATTR(Indirect)
     UNINTERESTING_ATTR(InheritsConvenienceInitializers)
     UNINTERESTING_ATTR(Inline)

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1208,17 +1208,6 @@ public:
   static Type deriveTypeWitness(DeclContext *DC, NominalTypeDecl *nominal,
                                 AssociatedTypeDecl *assocType);
 
-  /// Derive an implicit type witness for a given "phantom" nested type
-  /// requirement that is known to the compiler but unstated as a
-  /// formal type requirement.
-  ///
-  /// This exists to support Codable and only Codable. Do not expand its
-  /// usage outside of that domain.
-  static TypeDecl *derivePhantomWitness(DeclContext *DC,
-                                        NominalTypeDecl *nominal,
-                                        ProtocolDecl *proto,
-                                        const StringRef Name);
-
   /// \name Name lookup
   ///
   /// Routines that perform name lookup.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4233,13 +4233,6 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         break;
       }
 
-      case decls_block::ImplicitlySynthesizesNestedRequirement_DECL_ATTR: {
-        serialization::decls_block::ImplicitlySynthesizesNestedRequirementDeclAttrLayout
-            ::readRecord(scratch);
-        Attr = new (ctx) ImplicitlySynthesizesNestedRequirementAttr(blobData, {}, {});
-        break;
-      }
-
 #define SIMPLE_DECL_ATTR(NAME, CLASS, ...) \
       case decls_block::CLASS##_DECL_ATTR: { \
         bool isImplicit; \

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 532; // @_hasMissingDesignatedInitializers
+const uint16_t SWIFTMODULE_VERSION_MINOR = 533; // removed @_implicitly_synthesizes_nested_requirement
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1821,10 +1821,6 @@ namespace decls_block {
     TypeIDField // type referenced by this custom attribute
   >;
 
-  using ImplicitlySynthesizesNestedRequirementDeclAttrLayout = BCRecordLayout<
-    ImplicitlySynthesizesNestedRequirement_DECL_ATTR,
-    BCBlob      // member name
-  >;
 }
 
 /// Returns the encoding kind for the given decl.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2385,14 +2385,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           origDeclID, indices);
       return;
     }
-
-    case DAK_ImplicitlySynthesizesNestedRequirement: {
-      auto *theAttr = cast<ImplicitlySynthesizesNestedRequirementAttr>(DA);
-      auto abbrCode = S.DeclTypeAbbrCodes[ImplicitlySynthesizesNestedRequirementDeclAttrLayout::Code];
-      ImplicitlySynthesizesNestedRequirementDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                                          theAttr->Value);
-      return;
-    }
     }
   }
 

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -15,7 +15,6 @@
 //===----------------------------------------------------------------------===//
 
 /// A type that can encode itself to an external representation.
-@_implicitly_synthesizes_nested_requirement("CodingKeys")
 public protocol Encodable {
   /// Encodes this value into the given encoder.
   ///
@@ -30,7 +29,6 @@ public protocol Encodable {
 }
 
 /// A type that can decode itself from an external representation.
-@_implicitly_synthesizes_nested_requirement("CodingKeys")
 public protocol Decodable {
   /// Creates a new instance by decoding from the given decoder.
   ///

--- a/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
@@ -162,13 +162,17 @@ class NonConformingClass : Codable { // expected-error {{type 'NonConformingClas
   // These lines have to be within the NonConformingClass type because
   // CodingKeys should be private.
   func foo() {
-    let _ = NonConformingClass.CodingKeys.self
-    let _ = NonConformingClass.CodingKeys.x
-    let _ = NonConformingClass.CodingKeys.y
-    let _ = NonConformingClass.CodingKeys.z // expected-error {{type 'NonConformingClass.CodingKeys' has no member 'z'}}
+    // They should not get a CodingKeys type.
+    let _ = NonConformingClass.CodingKeys.self // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+    let _ = NonConformingClass.CodingKeys.x // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+    let _ = NonConformingClass.CodingKeys.y // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+    let _ = NonConformingClass.CodingKeys.z // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
   }
 }
 
 // They should not receive Codable methods.
 let _ = NonConformingClass.init(from:) // expected-error {{type 'NonConformingClass' has no member 'init(from:)'}}
 let _ = NonConformingClass.encode(to:) // expected-error {{type 'NonConformingClass' has no member 'encode(to:)'}}
+
+// They should not get a CodingKeys type.
+let _ = NonConformingClass.CodingKeys.self // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}

--- a/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
@@ -162,13 +162,17 @@ struct NonConformingStruct : Codable { // expected-error {{type 'NonConformingSt
   // These lines have to be within the NonConformingStruct type because
   // CodingKeys should be private.
   func foo() {
-    let _ = NonConformingStruct.CodingKeys.self
-    let _ = NonConformingStruct.CodingKeys.x
-    let _ = NonConformingStruct.CodingKeys.y
-    let _ = NonConformingStruct.CodingKeys.z // expected-error {{type 'NonConformingStruct.CodingKeys' has no member 'z'}}
+    // They should not get a CodingKeys type.
+    let _ = NonConformingStruct.CodingKeys.self // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+    let _ = NonConformingStruct.CodingKeys.x // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+    let _ = NonConformingStruct.CodingKeys.y // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+    let _ = NonConformingStruct.CodingKeys.z // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
   }
 }
 
 // They should not receive Codable methods.
 let _ = NonConformingStruct.init(from:) // expected-error {{type 'NonConformingStruct' has no member 'init(from:)'}}
 let _ = NonConformingStruct.encode(to:) // expected-error {{type 'NonConformingStruct' has no member 'encode(to:)'}}
+
+// They should not get a CodingKeys type.
+let _ = NonConformingStruct.CodingKeys.self // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -771,7 +771,6 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
     }
 
     // Ignore these.
-    case DAK_ImplicitlySynthesizesNestedRequirement:
     case DAK_ShowInInterface:
     case DAK_RawDocComment:
     case DAK_HasInitialValue:


### PR DESCRIPTION
In #28665, @CodaFi tied CodingKeys synthesis to a new attribute and annotated the two declarations that should trigger synthesis with that attribute. This means that a modified compiler would not perform CodingKeys synthesis when used with an unmodified standard library, breaking source compatibility. That kind of change is not necessarily forbidden, but it needs to be carefully considered and staged in when it does happen.

This PR reverts #28665 for now. We should either land the change in three steps—first add support for the attribute, then annotate the standard library protocols with it, then drop support for standard libraries without the annotation—or tie the behavior to these protocols in a way that does not require standard library modifications.

This reverts commit 43a3ab7e359c728b352e9c16eaf087d6467fad8b, reversing changes made to 4f39d9c749bcd8222ddaeb2b7d6091a46036f0ae. The revert was not clean because we've added other attributes since #28665 landed, so I want to run full tests before we merge it.

Fixes rdar://problem/58576551.