### PR TITLE
Propagate Clang types through SIL

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -576,6 +576,10 @@ public:
   Type getBridgedToObjC(const DeclContext *dc, Type type,
                         Type *bridgedValueType = nullptr) const;
 
+private:
+  void initializeClangTypeConverter();
+
+public:
   /// Get the Clang type corresponding to a Swift function type.
   ///
   /// \param params The function parameters.
@@ -588,6 +592,15 @@ public:
   getClangFunctionType(ArrayRef<AnyFunctionType::Param> params, Type resultTy,
                        const FunctionType::ExtInfo incompleteExtInfo,
                        FunctionTypeRepresentation trueRep);
+
+  /// Get the canonical Clang type corresponding to a SIL function type.
+  ///
+  /// SIL analog of \c ASTContext::getClangFunctionType .
+  const clang::Type *
+  getCanonicalClangFunctionType(
+    ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
+    const SILFunctionType::ExtInfo incompleteExtInfo,
+    SILFunctionType::Representation trueRep);
 
   /// Determine whether the given Swift type is representable in a
   /// given foreign language.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -564,7 +564,7 @@ struct PrintOptions {
   static PrintOptions printDocInterface();
 
   /// Retrieve the set of options suitable for printing SIL functions.
-  static PrintOptions printSIL() {
+  static PrintOptions printSIL(bool printFullConvention = false) {
     PrintOptions result;
     result.PrintLongAttrsOnSeparateLines = true;
     result.PrintStorageRepresentationAttrs = true;
@@ -575,6 +575,9 @@ struct PrintOptions {
     result.PrintIfConfig = false;
     result.OpaqueReturnTypePrinting =
         OpaqueReturnTypePrintingMode::StableReference;
+    if (printFullConvention)
+      result.PrintFunctionRepresentationAttrs =
+        PrintOptions::FunctionRepresentationMode::Full;
     return result;
   }
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -78,6 +78,9 @@ public:
   /// variables by name when we print it out. This eases diffing of SIL files.
   bool EmitSortedSIL = false;
 
+  /// See \ref FrontendOptions.PrintFullConvention
+  bool PrintFullConvention = false;
+
   /// Whether to stop the optimization pipeline after serializing SIL.
   bool StopOptimizationAfterSerialization = false;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2969,7 +2969,7 @@ public:
     static void assertIsFunctionType(const clang::Type *);
 
     ExtInfo(unsigned Bits, Uncommon Other) : Bits(Bits), Other(Other) {
-      // TODO: [store-sil-clang-function-type] Once we start serializing
+      // TODO: [clang-function-type-serialization] Once we start serializing
       // the Clang type, we should also assert that the pointer is non-null.
       auto Rep = Representation(Bits & RepresentationMask);
       if ((Rep == Representation::CFunctionPointer) && Other.ClangFunctionType)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -44,7 +44,6 @@
 
 namespace clang {
 class Type;
-class FunctionType;
 } // namespace clang
 
 namespace llvm {
@@ -2947,6 +2946,7 @@ public:
       friend ExtInfo;
       friend class AnyFunctionType;
       friend class FunctionType;
+      friend class SILUncommonInfo;
       // We preserve a full clang::Type *, not a clang::FunctionType * as:
       // 1. We need to keep sugar in case we need to present an error to the user.
       // 2. The actual type being stored is [ignoring sugar] either a
@@ -3917,6 +3917,24 @@ namespace Lowering {
   class TypeConverter;
 };
 
+class SILUncommonInfo {
+  friend class SILFunctionType;
+
+  // Invariant: The FunctionType is canonical.
+  // We store a clang::FunctionType * instead of a clang::CanQualType to
+  // avoid depending on the Clang AST in this header.
+  const clang::Type *ClangFunctionType;
+
+  bool empty() const { return !ClangFunctionType; }
+  SILUncommonInfo(const clang::Type *type) : ClangFunctionType(type) {}
+  SILUncommonInfo(AnyFunctionType::ExtInfo::Uncommon uncommon);
+
+public:
+  /// Analog of AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType.
+  void printClangFunctionType(ClangModuleLoader *cml,
+                              llvm::raw_ostream &os) const;
+};
+
 /// SILFunctionType - The lowered type of a function value, suitable
 /// for use by SIL.
 ///
@@ -3925,7 +3943,8 @@ namespace Lowering {
 /// function parameter and result types.
 class SILFunctionType final : public TypeBase, public llvm::FoldingSetNode,
     private llvm::TrailingObjects<SILFunctionType, SILParameterInfo,
-                                  SILResultInfo, SILYieldInfo, CanType> {
+                                  SILResultInfo, SILYieldInfo, CanType,
+                                  SILUncommonInfo> {
   friend TrailingObjects;
 
   size_t numTrailingObjects(OverloadToken<SILParameterInfo>) const {
@@ -3942,6 +3961,10 @@ class SILFunctionType final : public TypeBase, public llvm::FoldingSetNode,
 
   size_t numTrailingObjects(OverloadToken<CanType>) const {
     return hasResultCache() ? 2 : 0;
+  }
+
+  size_t numTrailingObjects(OverloadToken<SILUncommonInfo>) const {
+    return Bits.SILFunctionType.HasUncommonInfo ? 1 : 0;
   }
 
 public:
@@ -3968,27 +3991,31 @@ public:
 
     unsigned Bits; // Naturally sized for speed.
 
-    class Uncommon {
-      friend ExtInfo;
-      friend class SILFunctionType;
-
-      // Invariant: The FunctionType is canonical.
-      // We store a clang::FunctionType * instead of a clang::CanQualType to
-      // avoid depending on the Clang AST in this header.
-      const clang::FunctionType *ClangFunctionType;
-
-      bool empty() const { return !ClangFunctionType; }
-      Uncommon(const clang::FunctionType *type) : ClangFunctionType(type) {}
-
-    public:
-      /// Analog of AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType.
-      void printClangFunctionType(ClangModuleLoader *cml,
-                                  llvm::raw_ostream &os) const;
-    };
+    // For symmetry with AnyFunctionType::Uncommon
+    using Uncommon = SILUncommonInfo;
 
     Uncommon Other;
 
-    ExtInfo(unsigned Bits, Uncommon Other) : Bits(Bits), Other(Other) {}
+    static void assertIsFunctionType(const clang::Type *);
+
+    ExtInfo(unsigned Bits, Uncommon Other) : Bits(Bits), Other(Other) {
+      auto Rep = Representation(Bits & RepresentationMask);
+      // TODO: [clang-function-type-serialization] Once we start serializing
+      // the Clang type, we should also assert that the pointer is non-null.
+      if ((Rep == Representation::CFunctionPointer) && Other.ClangFunctionType)
+        assertIsFunctionType(Other.ClangFunctionType);
+    }
+
+    static constexpr unsigned makeBits(Representation rep,
+                                       bool isPseudogeneric,
+                                       bool isNoEscape,
+                                       DifferentiabilityKind diffKind) {
+      return ((unsigned) rep)
+              | (isPseudogeneric ? PseudogenericMask : 0)
+              | (isNoEscape ? NoEscapeMask : 0)
+              | (((unsigned)diffKind << DifferentiabilityMaskOffset)
+                 & DifferentiabilityMask);
+    }
 
     friend class SILFunctionType;
   public:
@@ -3998,13 +4025,19 @@ public:
     // Constructor for polymorphic type.
     ExtInfo(Representation rep, bool isPseudogeneric, bool isNoEscape,
             DifferentiabilityKind diffKind,
-            const clang::FunctionType *type)
-      : ExtInfo(((unsigned) rep)
-                  | (isPseudogeneric ? PseudogenericMask : 0)
-                  | (isNoEscape ? NoEscapeMask : 0)
-                  | (((unsigned)diffKind << DifferentiabilityMaskOffset)
-                     & DifferentiabilityMask),
+            const clang::Type *type)
+      : ExtInfo(makeBits(rep, isPseudogeneric, isNoEscape, diffKind),
                 Uncommon(type)) {
+    }
+
+    ExtInfo(AnyFunctionType::ExtInfo info, bool isPseudogeneric)
+      : ExtInfo(makeBits(info.getSILRepresentation(),
+                         isPseudogeneric,
+                         info.isNoEscape(),
+                         info.getDifferentiabilityKind()),
+                info.getUncommonInfo().hasValue()
+                ? Uncommon(info.getUncommonInfo().getValue())
+                : Uncommon(nullptr)) {
     }
 
     static ExtInfo getThin() {
@@ -4092,6 +4125,9 @@ public:
     ExtInfo withNoEscape(bool NoEscape = true) const {
       return ExtInfo(NoEscape ? (Bits | NoEscapeMask) : (Bits & ~NoEscapeMask),
                      Other);
+    }
+    ExtInfo withClangFunctionType(const clang::Type *type) const {
+      return ExtInfo(Bits, Uncommon(type));
     }
 
     std::pair<unsigned, const void *> getFuncAttrKey() const {
@@ -4388,7 +4424,7 @@ public:
     return WitnessMethodConformance;
   }
 
-  const clang::FunctionType *getClangFunctionType() const;
+  const clang::Type *getClangFunctionType() const;
 
   ExtInfo getExtInfo() const {
     return ExtInfo(Bits.SILFunctionType.ExtInfoBits, getClangFunctionType());

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -253,6 +253,9 @@ public:
   /// See the \ref SILOptions.EmitSortedSIL flag.
   bool EmitSortedSIL = false;
 
+  /// Should we emit the cType when printing @convention(c) or no?
+  bool PrintFullConvention = false;
+
   /// Indicates whether the dependency tracker should track system
   /// dependencies as well.
   bool TrackSystemDeps = false;

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -31,8 +31,8 @@ struct ModuleInterfaceOptions {
   /// interface, or should we fully-qualify them?
   bool PreserveTypesAsWritten = false;
 
-  /// Should we emit the cType when printing @convention(c) or no?
-  /// FIXME: [clang-function-type-serialization] This check should go away.
+  /// See \ref FrontendOptions.PrintFullConvention.
+  /// FIXME: [clang-function-type-serialization] This flag should go away.
   bool PrintFullConvention = false;
 
   /// Copy of all the command-line flags passed at .swiftinterface

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -608,10 +608,12 @@ def module_interface_preserve_types_as_written :
   HelpText<"When emitting a module interface, preserve types as they were "
            "written in the source">;
 
+// FIXME: [clang-function-type-serialization] Make this a SIL-only option once we
+// start unconditionally emitting non-canonical Clang types in swiftinterfaces.
 def experimental_print_full_convention :
  Flag<["-"], "experimental-print-full-convention">,
- HelpText<"When emitting a module interface, emit additional @convention "
-          "arguments, regardless of whether they were written in the source">;
+ HelpText<"When emitting a module interface or SIL, emit additional @convention"
+          " arguments, regardless of whether they were written in the source">;
 
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -647,10 +647,11 @@ public:
   /// \param ShouldSort If set to true sorts functions, vtables, sil global
   ///        variables, and witness tables by name to ease diffing.
   /// \param PrintASTDecls If set to true print AST decls.
-  void print(raw_ostream &OS, bool Verbose = false,
-             ModuleDecl *M = nullptr, bool ShouldSort = false,
+  void print(raw_ostream &OS,
+             ModuleDecl *M = nullptr,
+             const SILOptions &Opts = SILOptions(),
              bool PrintASTDecls = true) const {
-    SILPrintContext PrintCtx(OS, Verbose, ShouldSort);
+    SILPrintContext PrintCtx(OS, Opts);
     print(PrintCtx, M, PrintASTDecls);
   }
 

--- a/include/swift/SIL/SILPrintContext.h
+++ b/include/swift/SIL/SILPrintContext.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SIL_PRINTCONTEXT_H
 #define SWIFT_SIL_PRINTCONTEXT_H
 
+#include "swift/AST/SILOptions.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/DenseMap.h"
@@ -65,12 +66,20 @@ protected:
   /// Print debug locations and scopes.
   bool DebugInfo;
 
+  /// See \ref FrontendOptions.PrintFullConvention.
+  bool PrintFullConvention;
+
 public:
   /// Constructor with default values for options.
   ///
   /// DebugInfo will be set according to the -sil-print-debuginfo option.
   SILPrintContext(llvm::raw_ostream &OS, bool Verbose = false,
                   bool SortedSIL = false);
+
+  /// Constructor based on SILOptions.
+  ///
+  /// DebugInfo will be set according to the -sil-print-debuginfo option.
+  SILPrintContext(llvm::raw_ostream &OS, const SILOptions &Opts);
 
   SILPrintContext(llvm::raw_ostream &OS, bool Verbose,
                   bool SortedSIL, bool DebugInfo);
@@ -93,6 +102,9 @@ public:
 
   /// Returns true if debug locations and scopes should be printed.
   bool printDebugInfo() const { return DebugInfo; }
+
+  /// Returns true if the entire @convention(c, cType: ..) should be printed.
+  bool printFullConvention() const { return PrintFullConvention; }
 
   SILPrintContext::ID getID(const SILBasicBlock *Block);
 

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -581,7 +581,8 @@ public:
 
   std::string getAsString() const;
   void dump() const;
-  void print(raw_ostream &OS) const;
+  void print(raw_ostream &OS,
+             const PrintOptions &PO = PrintOptions::printSIL()) const;
 };
 
 // Statically prevent SILTypes from being directly cast to a type

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4372,17 +4372,35 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
   return Type();
 }
 
-const clang::Type *
-ASTContext::getClangFunctionType(ArrayRef<AnyFunctionType::Param> params,
-                                 Type resultTy,
-                                 FunctionType::ExtInfo incompleteExtInfo,
-                                 FunctionTypeRepresentation trueRep) {
+void
+ASTContext::initializeClangTypeConverter() {
   auto &impl = getImpl();
   if (!impl.Converter) {
     auto *cml = getClangModuleLoader();
     impl.Converter.emplace(*this, cml->getClangASTContext(), LangOpts.Target);
   }
-  return impl.Converter.getValue().getFunctionType(params, resultTy, trueRep);
+}
+
+const clang::Type *
+ASTContext::getClangFunctionType(ArrayRef<AnyFunctionType::Param> params,
+                                 Type resultTy,
+                                 FunctionType::ExtInfo incompleteExtInfo,
+                                 FunctionTypeRepresentation trueRep) {
+  initializeClangTypeConverter();
+  return getImpl().Converter.getValue().getFunctionType(params, resultTy,
+                                                        trueRep);
+}
+
+const clang::Type *
+ASTContext::getCanonicalClangFunctionType(
+    ArrayRef<SILParameterInfo> params,
+    Optional<SILResultInfo> result,
+    SILFunctionType::ExtInfo incompleteExtInfo,
+    SILFunctionType::Representation trueRep) {
+  initializeClangTypeConverter();
+  auto *ty = getImpl().Converter.getValue().getFunctionType(params, result,
+                                                            trueRep);
+  return ty ? ty->getCanonicalTypeInternal().getTypePtr() : nullptr;
 }
 
 CanGenericSignature ASTContext::getSingleGenericParameterSignature() const {

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -488,12 +488,6 @@ Type ASTBuilder::createImplFunctionType(
     break;
   }
 
-  // TODO: [store-sil-clang-function-type]
-  auto einfo = SILFunctionType::ExtInfo(
-      representation, flags.isPseudogeneric(), !flags.isEscaping(),
-      DifferentiabilityKind::NonDifferentiable,
-      /*clangFunctionType*/ nullptr);
-
   llvm::SmallVector<SILParameterInfo, 8> funcParams;
   llvm::SmallVector<SILYieldInfo, 8> funcYields;
   llvm::SmallVector<SILResultInfo, 8> funcResults;
@@ -516,6 +510,26 @@ Type ASTBuilder::createImplFunctionType(
     auto conv = getResultConvention(errorResult->getConvention());
     funcErrorResult.emplace(type, conv);
   }
+
+  const clang::Type *clangFnType = nullptr;
+  auto incompleteExtInfo = SILFunctionType::ExtInfo(
+      SILFunctionType::Representation::Thick, flags.isPseudogeneric(),
+      !flags.isEscaping(), DifferentiabilityKind::NonDifferentiable,
+      clangFnType);
+
+  if (representation == SILFunctionType::Representation::CFunctionPointer) {
+    assert(funcResults.size() <= 1 && funcYields.size() == 0
+           && "@convention(c) functions have at most 1 result and 0 yields.");
+    auto result = funcResults.empty() ? Optional<SILResultInfo>()
+                                      : funcResults[0];
+    auto &Context = getASTContext();
+    clangFnType = Context.getCanonicalClangFunctionType(funcParams, result,
+                                                        incompleteExtInfo,
+                                                        representation);
+  }
+  auto einfo = incompleteExtInfo.withRepresentation(representation)
+                                .withClangFunctionType(clangFnType);
+
   return SILFunctionType::get(genericSig, einfo, funcCoroutineKind,
                               funcCalleeConvention, funcParams, funcYields,
                               funcResults, funcErrorResult,

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -570,12 +570,19 @@ clang::QualType ClangTypeConverter::visitFunctionType(FunctionType *type) {
 }
 
 clang::QualType ClangTypeConverter::visitSILFunctionType(SILFunctionType *type) {
-  llvm::report_fatal_error("Expected only AST types but found a SIL function.");
+  // We must've already computed it before if applicable.
+  return clang::QualType(type->getClangFunctionType(), 0);
 }
 
 clang::QualType
 ClangTypeConverter::visitSILBlockStorageType(SILBlockStorageType *type) {
-  llvm::report_fatal_error("Expected only AST types but found a SIL block.");
+  // We'll select (void)(^)(). This isn't correct for all blocks, but block
+  // storage type should only be converted for function signature lowering,
+  // where the parameter types do not matter.
+  auto &clangCtx = ClangASTContext;
+  auto fnTy = clangCtx.getFunctionNoProtoType(clangCtx.VoidTy);
+  auto blockTy = clangCtx.getBlockPointerType(fnTy);
+  return clangCtx.getCanonicalType(blockTy);
 }
 
 clang::QualType

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -73,6 +73,10 @@ public:
     ArrayRef<AnyFunctionType::Param> params, Type resultTy,
     AnyFunctionType::Representation repr);
 
+  const clang::Type *getFunctionType(
+    ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
+    SILFunctionType::Representation repr);
+
 private:
   clang::QualType convert(Type type);
   clang::QualType convertMemberType(NominalTypeDecl *DC,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -416,12 +416,11 @@ namespace {
       
       if (pointeeQualType->isFunctionType()) {
         auto funcTy = pointeeType->castTo<FunctionType>();
-        return {
-          FunctionType::get(funcTy->getParams(), funcTy->getResult(),
-            funcTy->getExtInfo()
-              .withRepresentation(
+        auto extInfo = funcTy->getExtInfo().withRepresentation(
                 AnyFunctionType::Representation::CFunctionPointer)
-              .withClangFunctionType(type)),
+                                           .withClangFunctionType(type);
+        return {
+          FunctionType::get(funcTy->getParams(), funcTy->getResult(), extInfo),
           ImportHint::CFunctionPointer
         };
       }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -68,6 +68,8 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);
+  Opts.PrintFullConvention |=
+    Args.hasArg(OPT_experimental_print_full_convention);
 
   Opts.EnableTesting |= Args.hasArg(OPT_enable_testing);
   Opts.EnablePrivateImports |= Args.hasArg(OPT_enable_private_imports);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -942,6 +942,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.DebugSerialization |= Args.hasArg(OPT_sil_debug_serialization);
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);
+  Opts.PrintFullConvention |=
+    Args.hasArg(OPT_experimental_print_full_convention);
   Opts.PrintInstCounts |= Args.hasArg(OPT_print_inst_counts);
   if (const Arg *A = Args.getLastArg(OPT_external_pass_pipeline_filename))
     Opts.ExternalPassPipelineFilename = A->getValue();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -499,20 +499,19 @@ static bool emitSyntax(SourceFile *SF, StringRef OutputFilename) {
 }
 
 /// Writes SIL out to the given file.
-static bool writeSIL(SILModule &SM, ModuleDecl *M, bool EmitVerboseSIL,
-                     StringRef OutputFilename, bool SortSIL) {
+static bool writeSIL(SILModule &SM, ModuleDecl *M, const SILOptions &Opts,
+                     StringRef OutputFilename) {
   auto OS = getFileOutputStream(OutputFilename, M->getASTContext());
   if (!OS) return true;
-  SM.print(*OS, EmitVerboseSIL, M, SortSIL);
+  SM.print(*OS, M, Opts);
 
   return M->getASTContext().hadError();
 }
 
 static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
                      const CompilerInstance &Instance,
-                     const SILOptions &opts) {
-  return writeSIL(SM, Instance.getMainModule(), opts.EmitVerboseSIL,
-                  PSPs.OutputFilename, opts.EmitSortedSIL);
+                     const SILOptions &Opts) {
+  return writeSIL(SM, Instance.getMainModule(), Opts, PSPs.OutputFilename);
 }
 
 /// Prints the Objective-C "generated header" interface for \p M to \p

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1266,10 +1266,7 @@ static CanSILFunctionType getSILFunctionType(
 
   // NOTE: SILFunctionType::ExtInfo doesn't track everything that
   // AnyFunctionType::ExtInfo tracks. For example: 'throws' or 'auto-closure'
-  auto silExtInfo = SILFunctionType::ExtInfo()
-    .withRepresentation(extInfo.getSILRepresentation())
-    .withIsPseudogeneric(pseudogeneric)
-    .withNoEscape(extInfo.isNoEscape());
+  SILFunctionType::ExtInfo silExtInfo(extInfo, pseudogeneric);
   
   // Build the substituted generic signature we extracted.
   bool impliedSignature = false;

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -577,20 +577,21 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     CanType anyObjectMetaTy = CanExistentialMetatypeType::get(anyObjectTy,
                                                   MetatypeRepresentation::ObjC);
 
-    auto NSStringFromClassType = SILFunctionType::get(nullptr,
-                  SILFunctionType::ExtInfo()
-                    .withRepresentation(SILFunctionType::Representation::
-                                        CFunctionPointer),
-                  SILCoroutineKind::None,
-                  ParameterConvention::Direct_Unowned,
-                  SILParameterInfo(anyObjectMetaTy,
-                                   ParameterConvention::Direct_Unowned),
-                  /*yields*/ {},
-                  SILResultInfo(OptNSStringTy,
-                                ResultConvention::Autoreleased),
-                  /*error result*/ None,
-                  SubstitutionMap(), false,
-                  ctx);
+    auto paramConvention = ParameterConvention::Direct_Unowned;
+    auto params = {SILParameterInfo(anyObjectMetaTy, paramConvention)};
+    ArrayRef<SILResultInfo> resultInfos =
+        {SILResultInfo(OptNSStringTy, ResultConvention::Autoreleased)};
+    auto incompleteExtInfo = SILFunctionType::ExtInfo();
+    auto repr = SILFunctionType::Representation::CFunctionPointer;
+    auto *clangFnType = ctx.getCanonicalClangFunctionType(params,
+        resultInfos[0], incompleteExtInfo, repr);
+    auto extInfo = incompleteExtInfo.withRepresentation(repr)
+                                    .withClangFunctionType(clangFnType);
+
+    auto NSStringFromClassType = SILFunctionType::get(
+        nullptr, extInfo, SILCoroutineKind::None, paramConvention, params,
+        /*yields*/ {}, resultInfos, /*error result*/ None, SubstitutionMap(),
+        false, ctx);
     auto NSStringFromClassFn = builder.getOrCreateFunction(
         mainClass, "NSStringFromClass", SILLinkage::PublicExternal,
         NSStringFromClassType, IsBare, IsTransparent, IsNotSerialized,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1814,8 +1814,12 @@ namespace {
                                 TypeResolutionOptions options,
                                 SILCoroutineKind coroutineKind
                                   = SILCoroutineKind::None,
-                                SILFunctionType::ExtInfo extInfo
+                                SILFunctionType::ExtInfo incompleteExtInfo
                                   = SILFunctionType::ExtInfo(),
+                                SILFunctionType::Representation representation
+                                  = SILFunctionType::Representation::Thick,
+                                const clang::Type *parsedClangType
+                                  = nullptr,
                                 ParameterConvention calleeConvention
                                   = DefaultParameterConvention,
                                 TypeRepr *witnessmethodProtocol = nullptr);
@@ -2265,13 +2269,14 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
                                 : DifferentiabilityKind::Normal;
       }
 
-      // Resolve the function type directly with these attributes.
-      // TODO: [store-sil-clang-function-type]
-      SILFunctionType::ExtInfo extInfo(rep, attrs.has(TAK_pseudogeneric),
-                                       attrs.has(TAK_noescape), diffKind,
-                                       nullptr);
+      SILFunctionType::ExtInfo incompleteExtInfo(
+        SILFunctionType::Representation::Thick,
+        attrs.has(TAK_pseudogeneric), attrs.has(TAK_noescape), diffKind,
+        /*clangFunctionType*/ nullptr);
 
-      ty = resolveSILFunctionType(fnRepr, options, coroutineKind, extInfo,
+      ty = resolveSILFunctionType(fnRepr, options, coroutineKind,
+                                  incompleteExtInfo, rep,
+                                  /*parsedClangType*/nullptr,
                                   calleeConvention, witnessMethodProtocol);
       if (!ty || ty->hasError())
         return ty;
@@ -2772,12 +2777,15 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
   return SILBoxType::get(Context, layout, subMap);
 }
 
-Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
-                                          TypeResolutionOptions options,
-                                          SILCoroutineKind coroutineKind,
-                                          SILFunctionType::ExtInfo extInfo,
-                                          ParameterConvention callee,
-                                          TypeRepr *witnessMethodProtocol) {
+Type TypeResolver::resolveSILFunctionType(
+    FunctionTypeRepr *repr,
+    TypeResolutionOptions options,
+    SILCoroutineKind coroutineKind,
+    SILFunctionType::ExtInfo incompleteExtInfo,
+    SILFunctionType::Representation representation,
+    const clang::Type *parsedClangType,
+    ParameterConvention callee,
+    TypeRepr *witnessMethodProtocol) {
   options.setContext(None);
 
   bool hasError = false;
@@ -2921,6 +2929,20 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
     assert(witnessMethodConformance &&
            "found witness_method without matching conformance");
   }
+
+  const clang::Type *clangFnType = parsedClangType;
+  if ((representation == SILFunctionType::Representation::CFunctionPointer)
+      && !clangFnType) {
+    assert(results.size() <= 1 && yields.size() == 0
+           && "@convention(c) functions have at most 1 result and 0 yields.");
+    auto result = results.empty() ? Optional<SILResultInfo>() : results[0];
+    clangFnType = Context.getCanonicalClangFunctionType(interfaceParams, result,
+                                                        incompleteExtInfo,
+                                                        representation);
+  }
+
+  auto extInfo = incompleteExtInfo.withRepresentation(representation)
+                                  .withClangFunctionType(clangFnType);
 
   return SILFunctionType::get(genericSig, extInfo, coroutineKind,
                               callee,

--- a/test/SIL/clang-function-types.swift
+++ b/test/SIL/clang-function-types.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend %s -emit-sil -swift-version 5 -use-clang-function-types -experimental-print-full-convention -o - | %FileCheck %s
+
+public func f(g: @convention(c) () -> ()) { g() }
+
+// CHECK: sil @$s4main1f1gyyyXC_tF : $@convention(thin) (@convention(c, cType: "void (*)(void)") @noescape () -> ()) -> () {
+// CHECK: bb0(%0 : $@convention(c, cType: "void (*)(void)") @noescape () -> ()):
+// CHECK:   debug_value %0 : $@convention(c, cType: "void (*)(void)") @noescape () -> (), let, name "g", argno 1 // id: %1
+// CHECK:   %2 = apply %0() : $@convention(c, cType: "void (*)(void)") @noescape () -> ()

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -101,10 +101,10 @@ static llvm::cl::opt<std::string> Triple("target",
                                          llvm::cl::desc("target triple"));
 
 static llvm::cl::opt<bool>
-EnableSILSortOutput("emit-sorted-sil", llvm::cl::Hidden,
-                    llvm::cl::init(false),
-                    llvm::cl::desc("Sort Functions, VTables, Globals, "
-                                   "WitnessTables by name to ease diffing."));
+EmitSortedSIL("emit-sorted-sil", llvm::cl::Hidden,
+              llvm::cl::init(false),
+              llvm::cl::desc("Sort Functions, VTables, Globals, "
+                             "WitnessTables by name to ease diffing."));
 
 static llvm::cl::opt<bool>
 DisableASTDump("sil-disable-ast-dump", llvm::cl::Hidden,
@@ -250,6 +250,10 @@ int main(int argc, char **argv) {
   Invocation.getLangOptions().EnableAccessControl = false;
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
 
+  SILOptions &Opts = Invocation.getSILOptions();
+  Opts.EmitVerboseSIL = EmitVerboseSIL;
+  Opts.EmitSortedSIL = EmitSortedSIL;
+
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
       Invocation.setUpInputForSILTool(InputFilename, ModuleName,
@@ -356,8 +360,8 @@ int main(int argc, char **argv) {
         OutputFilename.size() ? StringRef(OutputFilename) : "-";
 
     if (OutputFile == "-") {
-      CI.getSILModule()->print(llvm::outs(), EmitVerboseSIL, CI.getMainModule(),
-                               EnableSILSortOutput, !DisableASTDump);
+      CI.getSILModule()->print(llvm::outs(), CI.getMainModule(),
+                               Invocation.getSILOptions(), !DisableASTDump);
     } else {
       std::error_code EC;
       llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
@@ -366,8 +370,8 @@ int main(int argc, char **argv) {
                      << '\n';
         return 1;
       }
-      CI.getSILModule()->print(OS, EmitVerboseSIL, CI.getMainModule(),
-                               EnableSILSortOutput, !DisableASTDump);
+      CI.getSILModule()->print(OS, CI.getMainModule(),
+                               Invocation.getSILOptions(), !DisableASTDump);
     }
   }
 }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -196,10 +196,10 @@ static llvm::cl::opt<std::string>
 ModuleCachePath("module-cache-path", llvm::cl::desc("Clang module cache path"));
 
 static llvm::cl::opt<bool>
-EnableSILSortOutput("emit-sorted-sil", llvm::cl::Hidden,
-                    llvm::cl::init(false),
-                    llvm::cl::desc("Sort Functions, VTables, Globals, "
-                                   "WitnessTables by name to ease diffing."));
+EmitSortedSIL("emit-sorted-sil", llvm::cl::Hidden,
+              llvm::cl::init(false),
+              llvm::cl::desc("Sort Functions, VTables, Globals, "
+                             "WitnessTables by name to ease diffing."));
 
 static llvm::cl::opt<bool>
 DisableASTDump("sil-disable-ast-dump", llvm::cl::Hidden,
@@ -375,6 +375,8 @@ int main(int argc, char **argv) {
       break;
     }
   }
+  SILOpts.EmitVerboseSIL |= EmitVerboseSIL;
+  SILOpts.EmitSortedSIL |= EmitSortedSIL;
 
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
@@ -481,8 +483,8 @@ int main(int argc, char **argv) {
                                    StringRef(OutputFilename) : "-";
 
     if (OutputFile == "-") {
-      CI.getSILModule()->print(llvm::outs(), EmitVerboseSIL, CI.getMainModule(),
-                               EnableSILSortOutput, !DisableASTDump);
+      CI.getSILModule()->print(llvm::outs(), CI.getMainModule(),
+                               Invocation.getSILOptions(), !DisableASTDump);
     } else {
       std::error_code EC;
       llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
@@ -491,8 +493,8 @@ int main(int argc, char **argv) {
                      << EC.message() << '\n';
         return 1;
       }
-      CI.getSILModule()->print(OS, EmitVerboseSIL, CI.getMainModule(),
-                               EnableSILSortOutput, !DisableASTDump);
+      CI.getSILModule()->print(OS, CI.getMainModule(),
+                               Invocation.getSILOptions(), !DisableASTDump);
     }
   }
 


### PR DESCRIPTION
~~First commit is from #29210.~~

This PR allows us to use the Clang type in IRGen going forward.