### PR TITLE
[AutoDiff] #ifdef Float80 derivatives on unsupported platforms

### DIFF
--- a/stdlib/public/Differentiation/FloatingPointTypesDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointTypesDerivatives.swift.gyb
@@ -16,6 +16,10 @@ import SwiftShims
 % for self_type in all_floating_point_types():
 % Self = self_type.stdlib_name
 
+% if self_type.bits == 80:
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+% end
+
 /// Derivatives of standard unary operators.
 extension ${Self} {
   @usableFromInline
@@ -146,4 +150,7 @@ extension ${Self} : VectorProtocol {
   }
 }
 
+% if self_type.bits == 80:
+#endif
+% end
 % end


### PR DESCRIPTION
My PR https://github.com/apple/swift/pull/29134 mistakenly defines derivatives for Float80 on platforms where Float80 doesn't exist. This didn't cause any problems on MacOS and Linux because they have Float80. But it causes problems for Android builds (and I assume also Windows).