### PR TITLE
[Incremental] Fixes for fine-grained dependencies + tests for them, but off-by-default

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -785,6 +785,8 @@ public:
                llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
                    compoundNamesByRDK);
 
+  static constexpr char noncascadingOrPrivatePrefix = '#';
+
   /// Nodes are owned by the graph.
   ~SourceFileDepGraph() {
     forEachNode([&](SourceFileDepGraphNode *n) { delete n; });
@@ -793,7 +795,7 @@ public:
   /// Goes at the start of an emitted YAML file to help tools recognize it.
   /// May vary in the future according to version, etc.
   std::string yamlProlog(const bool hadCompilationError) const {
-    return std::string("# Experimental\n") +
+    return std::string("# Fine-grained v0\n") +
            (!hadCompilationError ? ""
                                  : "# Dependencies are unknown because a "
                                    "compilation error occurred.\n");

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -529,8 +529,9 @@ public:
   /// sequence of inputs the driver was initially invoked with.
   ///
   /// Also use to write out information in a consistent order.
+  template <typename JobCollection>
   void sortJobsToMatchCompilationInputs(
-      ArrayRef<const Job *> unsortedJobs,
+      const JobCollection &unsortedJobs,
       SmallVectorImpl<const Job *> &sortedJobs) const;
 
 private:

--- a/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
+++ b/lib/AST/FineGrainedDependenciesSourceFileDepGraphConstructor.cpp
@@ -585,14 +585,17 @@ public:
       dynamicLookupDepends.push_back(std::make_pair(p.getFirst().userFacingName(), p.getSecond()));
 
     std::vector<std::pair<std::tuple<std::string, std::string, bool>, bool>> memberDepends;
-    for (const auto &p: SF->getReferencedNameTracker()->getUsedMembers())
+    for (const auto &p: SF->getReferencedNameTracker()->getUsedMembers()) {
+      const auto &member = p.getFirst().second;
+      StringRef emptyOrUserFacingName = member.empty() ? "" : member.userFacingName();
       memberDepends.push_back(
         std::make_pair(
           std::make_tuple(
             mangleTypeAsContext(p.getFirst().first),
-            p.getFirst().second.userFacingName(),
+            emptyOrUserFacingName,
             declIsPrivate(p.getFirst().first)),
           p.getSecond()));
+    }
 
       return SourceFileDepGraphConstructor(
         swiftDeps,
@@ -810,7 +813,8 @@ bool swift::fine_grained_dependencies::emitReferenceDependencies(
         return false;
       });
 
-  assert(g.verifyReadsWhatIsWritten(outputPath));
+  // If path is stdout, cannot read it back, so check for "-"
+  assert(outputPath == "-" || g.verifyReadsWhatIsWritten(outputPath));
 
   if (alsoEmitDotFile) {
     std::string dotFileName = outputPath.str() + ".dot";
@@ -825,12 +829,15 @@ bool swift::fine_grained_dependencies::emitReferenceDependencies(
 //==============================================================================
 // Entry point from the unit tests
 //==============================================================================
+static StringRef stripPrefix(const StringRef name) {
+  return name.ltrim(SourceFileDepGraph::noncascadingOrPrivatePrefix);
+}
 
 static std::vector<ContextNameFingerprint>
 getBaseNameProvides(ArrayRef<std::string> simpleNames) {
   std::vector<ContextNameFingerprint> result;
   for (StringRef n : simpleNames)
-    result.push_back(ContextNameFingerprint("", n.str(), None));
+    result.push_back(ContextNameFingerprint("", stripPrefix(n).str(), None));
   return result;
 }
 
@@ -838,7 +845,7 @@ static std::vector<ContextNameFingerprint>
 getMangledHolderProvides(ArrayRef<std::string> simpleNames) {
   std::vector<ContextNameFingerprint> result;
   for (StringRef n : simpleNames)
-    result.push_back(ContextNameFingerprint(n.str(), "", None));
+    result.push_back(ContextNameFingerprint(stripPrefix(n).str(), "", None));
   return result;
 }
 
@@ -846,23 +853,23 @@ static std::vector<ContextNameFingerprint> getCompoundProvides(
     ArrayRef<std::pair<std::string, std::string>> compoundNames) {
   std::vector<ContextNameFingerprint> result;
   for (const auto &p : compoundNames)
-    result.push_back(ContextNameFingerprint(p.first, p.second, None));
+    result.push_back(ContextNameFingerprint(stripPrefix(p.first),
+                                            stripPrefix(p.second), None));
   return result;
 }
 
-// Use '_' as a prefix indicating non-cascading
-static bool cascades(const std::string &s) { return s.empty() || s[0] != '_'; }
+static bool cascades(const std::string &s) { return s.empty() || s[0] != SourceFileDepGraph::noncascadingOrPrivatePrefix; }
 
 // Use '_' as a prefix for a file-private member
 static bool isPrivate(const std::string &s) {
-  return !s.empty() && s[0] == '_';
+  return !s.empty() && s[0] == SourceFileDepGraph::noncascadingOrPrivatePrefix;
 }
 
 static std::vector<std::pair<std::string, bool>>
 getSimpleDepends(ArrayRef<std::string> simpleNames) {
   std::vector<std::pair<std::string, bool>> result;
   for (std::string n : simpleNames)
-    result.push_back({n, cascades((n))});
+    result.push_back({stripPrefix(n), cascades((n))});
   return result;
 }
 
@@ -881,14 +888,16 @@ getCompoundDepends(
     // (On Linux, the compiler needs more verbosity than:
     //  result.push_back({{n, "", false}, cascades(n)});
     result.push_back(
-        std::make_pair(std::make_tuple(n, std::string(), false), cascades(n)));
+        std::make_pair(std::make_tuple(stripPrefix(n), std::string(), false), cascades(n)));
   }
   for (auto &p : compoundNames) {
     // Likewise, for Linux expand the following out:
     //    result.push_back(
     //        {{p.first, p.second, isPrivate(p.second)}, cascades(p.first)});
     result.push_back(
-        std::make_pair(std::make_tuple(p.first, p.second, isPrivate(p.second)),
+        std::make_pair(std::make_tuple(stripPrefix(p.first),
+                                       stripPrefix(p.second),
+                                       isPrivate(p.second)),
                        cascades(p.first)));
   }
   return result;

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1094,7 +1094,7 @@ namespace driver {
           //
           // As it stands, after this job finishes, this mark will tell the code
           // that this job was known to be "cascading". That knowledge will
-          // cause any dependent jobs to be run if they haven't already been.
+          // cause any dependent jobs to be run if it hasn't already been.
           //
           // TODO: I think this is overly tricky
           markIntransitiveInDepGraph(Cmd, forRanges);

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1094,7 +1094,7 @@ namespace driver {
           //
           // As it stands, after this job finishes, this mark will tell the code
           // that this job was known to be "cascading". That knowledge will
-          // any dependent jobs to be run if they haven't already been.
+          // cause any dependent jobs to be run if they haven't already been.
           //
           // TODO: I think this is overly tricky
           markIntransitiveInDepGraph(Cmd, forRanges);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -236,6 +236,8 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
                        options::OPT_disable_fine_grained_dependencies);
   inputArgs.AddLastArg(arguments,
                        options::OPT_fine_grained_dependency_include_intrafile);
+  inputArgs.AddLastArg(arguments,
+                       options::OPT_emit_fine_grained_dependency_sourcefile_dot_files);
   inputArgs.AddLastArg(arguments, options::OPT_package_description_version);
   inputArgs.AddLastArg(arguments, options::OPT_serialize_diagnostics_path);
   inputArgs.AddLastArg(arguments, options::OPT_debug_diagnostic_names);
@@ -645,12 +647,6 @@ void ToolChain::JobContext::addFrontendCommandLineInputArguments(
     if ((!isPrimary || usePrimaryFileList) && !useFileList)
       arguments.push_back(inputName);
   }
-  if (C.getEnableFineGrainedDependencies())
-    arguments.push_back("-enable-fine-grained-dependencies");
-
-  if (Args.hasArg(
-          options::OPT_emit_fine_grained_dependency_sourcefile_dot_files))
-    arguments.push_back("-emit-fine-grained-dependency-sourcefile-dot-files");
 }
 
 void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(

--- a/test/ClangImporter/pch-bridging-header-deps-fine.swift
+++ b/test/ClangImporter/pch-bridging-header-deps-fine.swift
@@ -1,0 +1,30 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: rm -f %t.*
+//
+// Generate a bridging PCH, use it in a swift file, and check that the swift file's .swiftdeps
+// mention the .h the PCH was generated from, and any .h files included in it.
+//
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-pch -o %t.pch %/S/Inputs/chained-unit-test-bridging-header-to-pch.h
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -module-name test -c -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -primary-file %s -import-objc-header %t.pch
+// RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS --enable-yaml-compatibility %s < %t-processed.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 --enable-yaml-compatibility %s < %t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -module-name test -c -emit-dependencies-path %t.persistent.d -emit-reference-dependencies-path %t.persistent.swiftdeps -primary-file %s -import-objc-header %/S/Inputs/chained-unit-test-bridging-header-to-pch.h -pch-output-dir %t/pch
+// RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.persistent.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.persistent.swiftdeps >%t-processed.persistent.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS  --enable-yaml-compatibility %s < %t-processed.persistent.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 --enable-yaml-compatibility %s < %t-processed.persistent.swiftdeps
+
+print(app_function(1))
+
+// CHECK-DEPS: pch-bridging-header-deps-fine.o : {{.*}}SOURCE_DIR{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}app-bridging-header-to-pch.h {{.*}}SOURCE_DIR{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}chained-unit-test-bridging-header-to-pch.h
+
+// CHECK-SWIFTDEPS: externalDepend {{.*}} 'SOURCE_DIR{{/|\\\\}}test{{/|\\\\}}ClangImporter{{/|\\\\}}Inputs{{/|\\\\}}app-bridging-header-to-pch.h'
+// CHECK-SWIFTDEPS: externalDepend {{.*}} 'SOURCE_DIR{{/|\\\\}}test{{/|\\\\}}ClangImporter{{/|\\\\}}Inputs{{/|\\\\}}chained-unit-test-bridging-header-to-pch.h'
+
+// CHECK-SWIFTDEPS2-NOT: {{.*}}.pch

--- a/test/ClangImporter/pch-bridging-header-deps.swift
+++ b/test/ClangImporter/pch-bridging-header-deps.swift
@@ -3,13 +3,13 @@
 // Generate a bridging PCH, use it in a swift file, and check that the swift file's .swiftdeps
 // mention the .h the PCH was generated from, and any .h files included in it.
 //
-// RUN: %target-swift-frontend -emit-pch -o %t.pch %/S/Inputs/chained-unit-test-bridging-header-to-pch.h
-// RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -primary-file %s -import-objc-header %t.pch
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-pch -o %t.pch %/S/Inputs/chained-unit-test-bridging-header-to-pch.h
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -module-name test -c -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -primary-file %s -import-objc-header %t.pch
 // RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.d
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS --enable-yaml-compatibility %s < %t.swiftdeps
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 --enable-yaml-compatibility %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.persistent.d -emit-reference-dependencies-path %t.persistent.swiftdeps -primary-file %s -import-objc-header %/S/Inputs/chained-unit-test-bridging-header-to-pch.h -pch-output-dir %t/pch
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -module-name test -c -emit-dependencies-path %t.persistent.d -emit-reference-dependencies-path %t.persistent.swiftdeps -primary-file %s -import-objc-header %/S/Inputs/chained-unit-test-bridging-header-to-pch.h -pch-output-dir %t/pch
 // RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.persistent.d
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS --enable-yaml-compatibility %s < %t.persistent.swiftdeps
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 --enable-yaml-compatibility %s < %t.persistent.swiftdeps

--- a/test/Driver/Dependencies/Inputs/chained-additional-kinds-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/chained-additional-kinds-fine/main.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     8276a546203ebde599da50b466729230
+    sequenceNumber:  0
+    defsIDependUpon: [ 4, 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     8276a546203ebde599da50b466729230
+    sequenceNumber:  1
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            dynamicLookup
+      aspect:          interface
+      context:         ''
+      name:            z
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            dynamicLookup
+      aspect:          implementation
+      context:         ''
+      name:            z
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-additional-kinds-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/chained-additional-kinds-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-additional-kinds-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/chained-additional-kinds-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "./yet-another.swift": {
+    "object": "./yet-another.o",
+    "swift-dependencies": "./yet-another.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/chained-additional-kinds-fine/yet-another.swift
+++ b/test/Driver/Dependencies/Inputs/chained-additional-kinds-fine/yet-another.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     f0a22821b1bfd1d40363b3f89c7a7693
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     f0a22821b1bfd1d40363b3f89c7a7693
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            dynamicLookup
+      aspect:          interface
+      context:         ''
+      name:            z
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-after-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/chained-after-fine/main.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     42e5bb8d6f23bfc1b055b85bd466a86c
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     42e5bb8d6f23bfc1b055b85bd466a86c
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-after-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-after-fine/main.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     42e5bb8d6f23bfc1b055b85bd466a86c
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     42e5bb8d6f23bfc1b055b85bd466a86c
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-after-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/chained-after-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-after-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-after-fine/other.swiftdeps
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-after-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/chained-after-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "./yet-another.swift": {
+    "object": "./yet-another.o",
+    "swift-dependencies": "./yet-another.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/chained-after-fine/yet-another.swift
+++ b/test/Driver/Dependencies/Inputs/chained-after-fine/yet-another.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     aae342945c458d008a9989daac618092
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     aae342945c458d008a9989daac618092
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-after-fine/yet-another.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-after-fine/yet-another.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     aae342945c458d008a9989daac618092
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     aae342945c458d008a9989daac618092
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/chained-fine/main.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     279f98f41b2fb1a907b1ce04fa09ce50
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     279f98f41b2fb1a907b1ce04fa09ce50
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/chained-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/chained-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "./yet-another.swift": {
+    "object": "./yet-another.o",
+    "swift-dependencies": "./yet-another.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/chained-fine/yet-another.swift
+++ b/test/Driver/Dependencies/Inputs/chained-fine/yet-another.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     59c8ff39595b320cb70847063b7410b9
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     59c8ff39595b320cb70847063b7410b9
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-fine/main.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f1055a5b16d15cf8a0662ebe1c5108fe
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f1055a5b16d15cf8a0662ebe1c5108fe
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-fine/main.swiftdeps
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f1055a5b16d15cf8a0662ebe1c5108fe
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f1055a5b16d15cf8a0662ebe1c5108fe
+    sequenceNumber:  1
+    defsIDependUpon: [ 4 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-fine/other.swiftdeps
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "./yet-another.swift": {
+    "object": "./yet-another.o",
+    "swift-dependencies": "./yet-another.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/chained-private-after-fine/yet-another.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-fine/yet-another.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     0435fef7d7170574edab927508293b15
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     0435fef7d7170574edab927508293b15
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-fine/yet-another.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-fine/yet-another.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     0435fef7d7170574edab927508293b15
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     0435fef7d7170574edab927508293b15
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/main.swift
@@ -1,0 +1,62 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     a4e513b4b5693bf6f50d6c0d531b542b
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4, 5, 6 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     a4e513b4b5693bf6f50d6c0d531b542b
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            z
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            x
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/main.swiftdeps
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     a4e513b4b5693bf6f50d6c0d531b542b
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4, 5 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     a4e513b4b5693bf6f50d6c0d531b542b
+    sequenceNumber:  1
+    defsIDependUpon: [ 4 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            x
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/other.swiftdeps
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "./yet-another.swift": {
+    "object": "./yet-another.o",
+    "swift-dependencies": "./yet-another.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/yet-another.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/yet-another.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     913de1b71ef48d4c730689fd99d7090e
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     913de1b71ef48d4c730689fd99d7090e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/yet-another.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-fine/yet-another.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     913de1b71ef48d4c730689fd99d7090e
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     913de1b71ef48d4c730689fd99d7090e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/main.swift
@@ -1,0 +1,86 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d281713b8f6ef5935679e8b3cbe6d5ce
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4, 5, 6, 7, 8, 9 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d281713b8f6ef5935679e8b3cbe6d5ce
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1zV
+      name:            z
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1xV
+      name:            ''
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            a
+    sequenceNumber:  8
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1xV
+      name:            x
+    sequenceNumber:  9
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/main.swiftdeps
@@ -1,0 +1,70 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d281713b8f6ef5935679e8b3cbe6d5ce
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4, 5, 6, 7 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d281713b8f6ef5935679e8b3cbe6d5ce
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1xV
+      name:            ''
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            a
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1xV
+      name:            x
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     2221cd1a52ad1f50cba3610cd9d80d45
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     2221cd1a52ad1f50cba3610cd9d80d45
+    sequenceNumber:  1
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            member
+      aspect:          implementation
+      context:         4main1aV
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/other.swiftdeps
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     2221cd1a52ad1f50cba3610cd9d80d45
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     2221cd1a52ad1f50cba3610cd9d80d45
+    sequenceNumber:  1
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            member
+      aspect:          implementation
+      context:         4main1aV
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "./yet-another.swift": {
+    "object": "./yet-another.o",
+    "swift-dependencies": "./yet-another.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/yet-another.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/yet-another.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     d7ad1a83584a3d3976404bcb830d57d1
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     d7ad1a83584a3d3976404bcb830d57d1
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/yet-another.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/chained-private-after-multiple-nominal-members-fine/yet-another.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     d7ad1a83584a3d3976404bcb830d57d1
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     d7ad1a83584a3d3976404bcb830d57d1
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-fine/main.swift
@@ -1,0 +1,47 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ea2e880fb7f4944d6f6093dad31c2ff9
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ea2e880fb7f4944d6f6093dad31c2ff9
+    sequenceNumber:  1
+    defsIDependUpon: [ 4 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/chained-private-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/chained-private-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "./yet-another.swift": {
+    "object": "./yet-another.o",
+    "swift-dependencies": "./yet-another.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/chained-private-fine/yet-another.swift
+++ b/test/Driver/Dependencies/Inputs/chained-private-fine/yet-another.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     59c8ff39595b320cb70847063b7410b9
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            yet-another.swiftdeps
+    fingerprint:     59c8ff39595b320cb70847063b7410b9
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1zV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/check-interface-implementation-fine/a.swift
+++ b/test/Driver/Dependencies/Inputs/check-interface-implementation-fine/a.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            a.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            a.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/check-interface-implementation-fine/bad.swift
+++ b/test/Driver/Dependencies/Inputs/check-interface-implementation-fine/bad.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            b
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/check-interface-implementation-fine/c.swift
+++ b/test/Driver/Dependencies/Inputs/check-interface-implementation-fine/c.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            c
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            c
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            b
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/check-interface-implementation-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/check-interface-implementation-fine/output.json
@@ -1,0 +1,33 @@
+{
+  "./a.swift": {
+    "object": "./a.o",
+    "swift-dependencies": "./a.swiftdeps"
+  },
+  "./b.swift": {
+    "object": "./b.o",
+    "swift-dependencies": "./b.swiftdeps"
+  },
+  "./c.swift": {
+    "object": "./c.o",
+    "swift-dependencies": "./c.swiftdeps"
+  },
+  "./d.swift": {
+    "object": "./d.o",
+    "swift-dependencies": "./d.swiftdeps"
+  },
+  "./e.swift": {
+    "object": "./e.o",
+    "swift-dependencies": "./e.swiftdeps"
+  },
+  "./f.swift": {
+    "object": "./f.o",
+    "swift-dependencies": "./f.swiftdeps"
+  },
+  "./bad.swift": {
+    "object": "./bad.o",
+    "swift-dependencies": "./bad.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/crash-simple-fine/crash.swift
+++ b/test/Driver/Dependencies/Inputs/crash-simple-fine/crash.swift
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+   - key:
+       kind:            sourceFileProvide
+       aspect:          interface
+       context:         ''
+       name:            './crash.swiftdeps'
+     fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+     sequenceNumber:  0
+     defsIDependUpon: [ 5, 4, 2 ]
+     isProvides:      true
+   - key:
+       kind:            sourceFileProvide
+       aspect:          implementation
+       context:         ''
+       name:            './crash.swiftdeps'
+     fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+     sequenceNumber:  1
+     defsIDependUpon: [  ]
+     isProvides:      true
+   - key:
+       kind:            topLevel
+       aspect:          interface
+       context:         ''
+       name:            a
+     sequenceNumber:  2
+     defsIDependUpon: [ 0 ]
+     isProvides:      true
+   - key:
+       kind:            topLevel
+       aspect:          implementation
+       context:         ''
+       name:            a
+     sequenceNumber:  3
+     defsIDependUpon: [  ]
+     isProvides:      true
+   - key:
+       kind:            topLevel
+       aspect:          interface
+       context:         ''
+       name:            IntegerLiteralType
+     sequenceNumber:  4
+     defsIDependUpon: [  ]
+     isProvides:      false
+   - key:
+       kind:            topLevel
+       aspect:          interface
+       context:         ''
+       name:            FloatLiteralType
+     sequenceNumber:  5
+     defsIDependUpon: [  ]
+     isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/crash-simple-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/crash-simple-fine/main.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     316328d5be8544f05f3cc73c32cea2d2
+    sequenceNumber:  0
+    defsIDependUpon: [ 4, 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     316328d5be8544f05f3cc73c32cea2d2
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            M
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            M
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/crash-simple-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/crash-simple-fine/other.swift
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     0665c1c79514536cfd19ee3359008f19
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     0665c1c79514536cfd19ee3359008f19
+    sequenceNumber:  1
+    defsIDependUpon: [ 5 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            F
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            F
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            AssignmentPrecedence
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/crash-simple-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/crash-simple-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./crash.swift": {
+    "object": "./crash.o",
+    "swift-dependencies": "./crash.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/crash.swift
+++ b/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/crash.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            crash.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            crash.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/crash.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/crash.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            crash.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            crash.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/main.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/other.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/other.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/crash-simple-with-swiftdeps-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./crash.swift": {
+    "object": "./crash.o",
+    "swift-dependencies": "./crash.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/fail-chained-fine/a.swift
+++ b/test/Driver/Dependencies/Inputs/fail-chained-fine/a.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            a.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            a.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/fail-chained-fine/b.swift
+++ b/test/Driver/Dependencies/Inputs/fail-chained-fine/b.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            b
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/fail-chained-fine/bad.swift
+++ b/test/Driver/Dependencies/Inputs/fail-chained-fine/bad.swift
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            bad.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            bad.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [ 5 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            bad
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            bad
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-chained-fine/c.swift
+++ b/test/Driver/Dependencies/Inputs/fail-chained-fine/c.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            c
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            c
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            bad
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-chained-fine/d.swift
+++ b/test/Driver/Dependencies/Inputs/fail-chained-fine/d.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            d.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            d.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            d
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            d
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            c
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-chained-fine/e.swift
+++ b/test/Driver/Dependencies/Inputs/fail-chained-fine/e.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            e.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            e.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [ 4 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            e
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            e
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            bad
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-chained-fine/f.swift
+++ b/test/Driver/Dependencies/Inputs/fail-chained-fine/f.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            f.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            f.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            f
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            f
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            e
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-chained-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/fail-chained-fine/output.json
@@ -1,0 +1,33 @@
+{
+  "./a.swift": {
+    "object": "./a.o",
+    "swift-dependencies": "./a.swiftdeps"
+  },
+  "./b.swift": {
+    "object": "./b.o",
+    "swift-dependencies": "./b.swiftdeps"
+  },
+  "./c.swift": {
+    "object": "./c.o",
+    "swift-dependencies": "./c.swiftdeps"
+  },
+  "./d.swift": {
+    "object": "./d.o",
+    "swift-dependencies": "./d.swiftdeps"
+  },
+  "./e.swift": {
+    "object": "./e.o",
+    "swift-dependencies": "./e.swiftdeps"
+  },
+  "./f.swift": {
+    "object": "./f.o",
+    "swift-dependencies": "./f.swiftdeps"
+  },
+  "./bad.swift": {
+    "object": "./bad.o",
+    "swift-dependencies": "./bad.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/bad.swift
+++ b/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/bad.swift
@@ -1,0 +1,39 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            bad.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            bad.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            bad
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            bad
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...
+

--- a/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/bad.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/bad.swiftdeps
@@ -1,0 +1,39 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            bad.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            bad.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            bad
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            bad
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...
+

--- a/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/depends-on-bad.swift
+++ b/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/depends-on-bad.swift
@@ -1,0 +1,31 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            dependsonbad.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            dependsonbad.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            bad
+    sequenceNumber:  2
+    defsIDependUpon: [ ]
+    isProvides:      false
+...
+

--- a/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/depends-on-bad.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/depends-on-bad.swiftdeps
@@ -1,0 +1,31 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            dependsonbad.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            dependsonbad.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            bad
+    sequenceNumber:  2
+    defsIDependUpon: [ ]
+    isProvides:      false
+...
+

--- a/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/depends-on-main.swift
+++ b/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/depends-on-main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            dependsonmain.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            dependsonmain.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            main
+    sequenceNumber:  2
+    defsIDependUpon: [ ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/depends-on-main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/depends-on-main.swiftdeps
@@ -1,0 +1,31 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            dependsonmain.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            dependsonmain.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            main
+    sequenceNumber:  2
+    defsIDependUpon: [ ]
+    isProvides:      false
+...
+

--- a/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/main.swift
@@ -1,0 +1,39 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            main
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            main
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...
+

--- a/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/main.swiftdeps
@@ -1,0 +1,39 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            main
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            main
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...
+

--- a/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/fail-interface-hash-fine/output.json
@@ -1,0 +1,21 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./bad.swift": {
+    "object": "./bad.o",
+    "swift-dependencies": "./bad.swiftdeps"
+  },
+  "./depends-on-main.swift": {
+    "object": "./depends-on-main.o",
+    "swift-dependencies": "./depends-on-main.swiftdeps"
+  },
+  "./depends-on-bad.swift": {
+    "object": "./depends-on-bad.o",
+    "swift-dependencies": "./depends-on-bad.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/fail-simple-fine/bad.swift
+++ b/test/Driver/Dependencies/Inputs/fail-simple-fine/bad.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            bad.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            bad.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/fail-simple-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/fail-simple-fine/main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-simple-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/fail-simple-fine/other.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-simple-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/fail-simple-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./bad.swift": {
+    "object": "./bad.o",
+    "swift-dependencies": "./bad.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/bad.swift
+++ b/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/bad.swift
@@ -1,0 +1,55 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './bad.swiftdeps'
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 5, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './bad.swiftdeps'
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            bad
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            bad
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+garbage: ""
+...

--- a/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/bad.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/bad.swiftdeps
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './bad.swiftdeps'
+    fingerprint:     before
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 5, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './bad.swiftdeps'
+    fingerprint:     before
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            bad
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            bad
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/depends-on-bad.swift
+++ b/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/depends-on-bad.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './depends-on-bad.swiftdeps'
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './depends-on-bad.swiftdeps'
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            DB
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            DB
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            bad
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/depends-on-bad.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/depends-on-bad.swiftdeps
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './depends-on-bad.swiftdeps'
+    fingerprint:       before
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './depends-on-bad.swiftdeps'
+    fingerprint:       before
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            DB
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            DB
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            bad
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/depends-on-main.swift
+++ b/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/depends-on-main.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './depends-on-main.swiftdeps'
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './depends-on-main.swiftdeps'
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            M
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            M
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            main
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/depends-on-main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/depends-on-main.swiftdeps
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './depends-on-main.swiftdeps'
+    fingerprint:     before
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './depends-on-main.swiftdeps'
+    fingerprint:     before
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            M
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            M
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            main
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/main.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './depends-on-main.swiftdeps'
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './depends-on-main.swiftdeps'
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            M
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            M
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            main
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/main.swiftdeps
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     before
+    sequenceNumber:  0
+    defsIDependUpon: [ 5, 4, 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     before
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            main
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            main
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/fail-with-bad-deps-fine/output.json
@@ -1,0 +1,21 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./bad.swift": {
+    "object": "./bad.o",
+    "swift-dependencies": "./bad.swiftdeps"
+  },
+  "./depends-on-main.swift": {
+    "object": "./depends-on-main.o",
+    "swift-dependencies": "./depends-on-main.swiftdeps"
+  },
+  "./depends-on-bad.swift": {
+    "object": "./depends-on-bad.o",
+    "swift-dependencies": "./depends-on-bad.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/independent-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/independent-fine/main.swift
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/independent-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/independent-fine/other.swift
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/independent-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/independent-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/malformed-after-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/malformed-after-fine/main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ec443bb982c3a06a433bdd47b85eeba2
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ec443bb982c3a06a433bdd47b85eeba2
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/malformed-after-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/malformed-after-fine/main.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ec443bb982c3a06a433bdd47b85eeba2
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ec443bb982c3a06a433bdd47b85eeba2
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/malformed-after-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/malformed-after-fine/other.swift
@@ -1,0 +1,2 @@
+# Dependencies after compilation:
+*** This is not a valid YAML file ***

--- a/test/Driver/Dependencies/Inputs/malformed-after-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/malformed-after-fine/other.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/malformed-after-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/malformed-after-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ec443bb982c3a06a433bdd47b85eeba2
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ec443bb982c3a06a433bdd47b85eeba2
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/main.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ec443bb982c3a06a433bdd47b85eeba2
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     ec443bb982c3a06a433bdd47b85eeba2
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/other.swift
@@ -1,0 +1,24 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+bogusEntry:     snort
+...
+

--- a/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/other.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/malformed-but-valid-yaml-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/mutual-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/mutual-fine/main.swift
@@ -1,0 +1,78 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 4, 8, 2, 7, 6 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            A
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            A
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  4
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            b
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  8
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/mutual-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/mutual-fine/other.swift
@@ -1,0 +1,78 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     same
+    sequenceNumber:  0
+    defsIDependUpon: [ 8, 7, 2, 4, 6 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     same
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            B
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            B
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  8
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/mutual-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/mutual-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/does-change.swift
+++ b/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/does-change.swift
@@ -1,0 +1,78 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            does-change.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  0
+    defsIDependUpon: [ 4, 8, 2, 7, 6 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            does-change.swiftdeps
+    fingerprint:     after
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            A
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            A
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  4
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            b
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  8
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/does-change.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/does-change.swiftdeps
@@ -1,0 +1,78 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            does-change.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  0
+    defsIDependUpon: [ 4, 8, 2, 7, 6 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            does-change.swiftdeps
+    fingerprint:     before
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            A
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            A
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  4
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            b
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  8
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/does-not-change.swift
+++ b/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/does-not-change.swift
@@ -1,0 +1,78 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            does-not-change.swiftdeps
+    fingerprint:     same
+    sequenceNumber:  0
+    defsIDependUpon: [ 8, 7, 2, 4, 6 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            does-not-change.swiftdeps
+    fingerprint:     same
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            B
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            B
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  8
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/does-not-change.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/does-not-change.swiftdeps
@@ -1,0 +1,78 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            does-not-change.swiftdeps
+    fingerprint:     same
+    sequenceNumber:  0
+    defsIDependUpon: [ 8, 7, 2, 4, 6 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            does-not-change.swiftdeps
+    fingerprint:     same
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            B
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            B
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  8
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/mutual-interface-hash-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./does-change.swift": {
+    "object": "./does-change.o",
+    "swift-dependencies": "./does-change.swiftdeps"
+  },
+  "./does-not-change.swift": {
+    "object": "./does-not-change.o",
+    "swift-dependencies": "./does-not-change.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/main.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     741650dd633ae2cd89de22c880ddadc9
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     741650dd633ae2cd89de22c880ddadc9
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            b
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/main.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     741650dd633ae2cd89de22c880ddadc9
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     741650dd633ae2cd89de22c880ddadc9
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/other.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     e12419713170057a991bc883225f56fc
+    sequenceNumber:  0
+    defsIDependUpon: [ 4, 2]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     e12419713170057a991bc883225f56fc
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            b
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/other.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     e12419713170057a991bc883225f56fc
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     e12419713170057a991bc883225f56fc
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/mutual-with-swiftdeps-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/nominal-members-fine/a-ext.swift
+++ b/test/Driver/Dependencies/Inputs/nominal-members-fine/a-ext.swift
@@ -1,0 +1,102 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            a-ext.swiftdeps
+    fingerprint:     d19650fa01b61a0a8d27eee5258aa70e
+    sequenceNumber:  0
+    defsIDependUpon: [ 4, 10, 7, 11, 6 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            a-ext.swiftdeps
+    fingerprint:     d19650fa01b61a0a8d27eee5258aa70e
+    sequenceNumber:  1
+    defsIDependUpon: [ 9, 8 ]
+    isProvides:      true
+  - key:
+      kind:            potentialMember
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            potentialMember
+      aspect:          implementation
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            ext
+    sequenceNumber:  4
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            member
+      aspect:          implementation
+      context:         4main1aV
+      name:            ext
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            Int
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            aaa
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  8
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  9
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aaaV
+      name:            ''
+    sequenceNumber:  10
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aaaV
+      name:            Int
+    sequenceNumber:  11
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/nominal-members-fine/a.swift
+++ b/test/Driver/Dependencies/Inputs/nominal-members-fine/a.swift
@@ -1,0 +1,78 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            a.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  0
+    defsIDependUpon: [ 8, 4, 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            a.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            potentialMember
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  6
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            potentialMember
+      aspect:          implementation
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            init
+    sequenceNumber:  8
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/nominal-members-fine/depends-on-a-ext.swift
+++ b/test/Driver/Dependencies/Inputs/nominal-members-fine/depends-on-a-ext.swift
@@ -1,0 +1,70 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            depends-on-a-ext.swiftdeps
+    fingerprint:     eef421a8e034b3c72f85a3106b51620e
+    sequenceNumber:  0
+    defsIDependUpon: [ 6, 5, 7, 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            depends-on-a-ext.swiftdeps
+    fingerprint:     eef421a8e034b3c72f85a3106b51620e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            V
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            V
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            ext
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            init
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/nominal-members-fine/depends-on-a-foo.swift
+++ b/test/Driver/Dependencies/Inputs/nominal-members-fine/depends-on-a-foo.swift
@@ -1,0 +1,70 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            depends-on-a-foo.swiftdeps
+    fingerprint:     341612d23b9b4ab590b3d75e35b5c6e0
+    sequenceNumber:  0
+    defsIDependUpon: [ 6, 5, 4, 7, 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            depends-on-a-foo.swiftdeps
+    fingerprint:     341612d23b9b4ab590b3d75e35b5c6e0
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            Q
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            Q
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            foo
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            member
+      aspect:          interface
+      context:         4main1aV
+      name:            init
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/nominal-members-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/nominal-members-fine/output.json
@@ -1,0 +1,21 @@
+{
+  "./a.swift": {
+    "object": "./a.o",
+    "swift-dependencies": "./a.swiftdeps"
+  },
+  "./a-ext.swift": {
+    "object": "./a-ext.o",
+    "swift-dependencies": "./a-ext.swiftdeps"
+  },
+  "./depends-on-a-ext.swift": {
+    "object": "./depends-on-a-ext.o",
+    "swift-dependencies": "./depends-on-a-ext.swiftdeps"
+  },
+  "./depends-on-a-foo.swift": {
+    "object": "./depends-on-a-foo.o",
+    "swift-dependencies": "./depends-on-a-foo.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     68a74ca633848ae5e65ddc9d5e28b0e6
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     68a74ca633848ae5e65ddc9d5e28b0e6
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/main.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  0
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/other.swiftdeps
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-after-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/main.swift
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  0
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/main.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     68a74ca633848ae5e65ddc9d5e28b0e6
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     68a74ca633848ae5e65ddc9d5e28b0e6
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/other.swiftdeps
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/one-way-depends-before-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/one-way-external-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-external-fine/main.swift
@@ -1,0 +1,62 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  0
+    defsIDependUpon: [ 6, 5, 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            V
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            V
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            externalDepend
+      aspect:          interface
+      context:         ''
+      name:            './main1-external'
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            externalDepend
+      aspect:          interface
+      context:         ''
+      name:            './main2-external'
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-external-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-external-fine/other.swift
@@ -1,0 +1,70 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 6, 7, 2, 5, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            externalDepend
+      aspect:          interface
+      context:         ''
+      name:            './other1-external'
+    sequenceNumber:  6
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            externalDepend
+      aspect:          interface
+      context:         ''
+      name:            './other2-external'
+    sequenceNumber:  7
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-external-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/one-way-external-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/one-way-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-fine/main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     68a74ca633848ae5e65ddc9d5e28b0e6
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './main.swiftdeps'
+    fingerprint:     68a74ca633848ae5e65ddc9d5e28b0e6
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            './other.swiftdeps'
+    fingerprint:     befb33f4269c9adc0644b060f467ef06
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/one-way-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps",
+    "swiftmodule": "./main.swiftmodule",
+    "swiftdoc": "./main.swiftdoc",
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps",
+    "swiftmodule": "./main.swiftmodule",
+    "swiftdoc": "./main.swiftdoc",
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/main.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/other.swift
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            x.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 5, 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            x.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/other.swiftdeps
@@ -1,0 +1,23 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  0
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...
+

--- a/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-after-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/main.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/other.swift
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  0
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     d41d8cd98f00b204e9800998ecf8427e
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/other.swiftdeps
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            x.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 5, 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            x.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            FloatLiteralType
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            IntegerLiteralType
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/one-way-provides-before-fine/output.json
@@ -1,0 +1,13 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/main.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/main.swift
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/main.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/main.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            main.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/other.swift
+++ b/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/other.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     72e95f4a11b98227c1f6ad6ea7f6cdba
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          interface
+      context:         ''
+      name:            a
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            topLevel
+      aspect:          implementation
+      context:         ''
+      name:            a
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/other.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/other.swiftdeps
@@ -1,0 +1,22 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  0
+    defsIDependUpon: [ ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            other.swiftdeps
+    fingerprint:     f216f45027a3fa6bf3d16c1b05dd8feb
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/one-way-with-swiftdeps-fine/output.json
@@ -1,0 +1,17 @@
+{
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps",
+    "swiftmodule": "./main.swiftmodule",
+    "swiftdoc": "./main.swiftdoc",
+  },
+  "./other.swift": {
+    "object": "./other.o",
+    "swift-dependencies": "./other.swiftdeps",
+    "swiftmodule": "./main.swiftmodule",
+    "swiftdoc": "./main.swiftdoc",
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/private-after-fine/a.swift
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/a.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            A.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            A.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/a.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/a.swiftdeps
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            A.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            A.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/b.swift
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/b.swift
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     68e9c0980ab7233dfbd965d8c4354027
+    sequenceNumber:  0
+    defsIDependUpon: [ 5, 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     68e9c0980ab7233dfbd965d8c4354027
+    sequenceNumber:  1
+    defsIDependUpon: [ 4 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1eV
+      name:            ''
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/b.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/b.swiftdeps
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     68e9c0980ab7233dfbd965d8c4354027
+    sequenceNumber:  0
+    defsIDependUpon: [ 5, 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     68e9c0980ab7233dfbd965d8c4354027
+    sequenceNumber:  1
+    defsIDependUpon: [ 4 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1eV
+      name:            ''
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/c.swift
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/c.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1cV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1cV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/c.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/c.swiftdeps
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1cV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1cV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/d.swift
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/d.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            d.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            d.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1dV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1dV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/d.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/d.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            d.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            d.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/e.swift
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/e.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            e.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            e.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1eV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1eV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1dV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/e.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/e.swiftdeps
@@ -1,0 +1,30 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            e.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            e.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1dV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/f.swift
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/f.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            f.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            f.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [ 4  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1fV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1fV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1eV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/f.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/f.swiftdeps
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            f.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            f.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [ 4  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1fV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1fV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1eV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/g.swift
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/g.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            g.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            g.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1gV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1gV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1fV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/g.swiftdeps
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/g.swiftdeps
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            g.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            g.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1gV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1gV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1fV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-after-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/private-after-fine/output.json
@@ -1,0 +1,33 @@
+{
+  "./a.swift": {
+    "object": "./a.o",
+    "swift-dependencies": "./a.swiftdeps"
+  },
+  "./b.swift": {
+    "object": "./b.o",
+    "swift-dependencies": "./b.swiftdeps"
+  },
+  "./c.swift": {
+    "object": "./c.o",
+    "swift-dependencies": "./c.swiftdeps"
+  },
+  "./d.swift": {
+    "object": "./d.o",
+    "swift-dependencies": "./d.swiftdeps"
+  },
+  "./e.swift": {
+    "object": "./e.o",
+    "swift-dependencies": "./e.swiftdeps"
+  },
+  "./f.swift": {
+    "object": "./f.o",
+    "swift-dependencies": "./f.swiftdeps"
+  },
+  "./g.swift": {
+    "object": "./g.o",
+    "swift-dependencies": "./g.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/private-fine/a.swift
+++ b/test/Driver/Dependencies/Inputs/private-fine/a.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            A.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            A.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/private-fine/b.swift
+++ b/test/Driver/Dependencies/Inputs/private-fine/b.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            b.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1aV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-fine/c.swift
+++ b/test/Driver/Dependencies/Inputs/private-fine/c.swift
@@ -1,0 +1,54 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            c.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [ 5 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1cV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1cV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1eV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1bV
+      name:            ''
+    sequenceNumber:  5
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-fine/d.swift
+++ b/test/Driver/Dependencies/Inputs/private-fine/d.swift
@@ -1,0 +1,46 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            d.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  0
+    defsIDependUpon: [ 2, 4 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            d.swiftdeps
+    fingerprint:     9e53bc0d9f7b3db367329e46ec87a57a
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1dV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1dV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1cV
+      name:            ''
+    sequenceNumber:  4
+    defsIDependUpon: [  ]
+    isProvides:      false
+...

--- a/test/Driver/Dependencies/Inputs/private-fine/e.swift
+++ b/test/Driver/Dependencies/Inputs/private-fine/e.swift
@@ -1,0 +1,38 @@
+# Fine-grained v0
+---
+allNodes:
+  - key:
+      kind:            sourceFileProvide
+      aspect:          interface
+      context:         ''
+      name:            e.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  0
+    defsIDependUpon: [ 2 ]
+    isProvides:      true
+  - key:
+      kind:            sourceFileProvide
+      aspect:          implementation
+      context:         ''
+      name:            e.swiftdeps
+    fingerprint:     605b8543d8bbf247217381a68ce188b8
+    sequenceNumber:  1
+    defsIDependUpon: [  ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          interface
+      context:         4main1eV
+      name:            ''
+    sequenceNumber:  2
+    defsIDependUpon: [ 0 ]
+    isProvides:      true
+  - key:
+      kind:            nominal
+      aspect:          implementation
+      context:         4main1eV
+      name:            ''
+    sequenceNumber:  3
+    defsIDependUpon: [  ]
+    isProvides:      true
+...

--- a/test/Driver/Dependencies/Inputs/private-fine/output.json
+++ b/test/Driver/Dependencies/Inputs/private-fine/output.json
@@ -1,0 +1,25 @@
+{
+  "./a.swift": {
+    "object": "./a.o",
+    "swift-dependencies": "./a.swiftdeps"
+  },
+  "./b.swift": {
+    "object": "./b.o",
+    "swift-dependencies": "./b.swiftdeps"
+  },
+  "./c.swift": {
+    "object": "./c.o",
+    "swift-dependencies": "./c.swiftdeps"
+  },
+  "./d.swift": {
+    "object": "./d.o",
+    "swift-dependencies": "./d.swiftdeps"
+  },
+  "./e.swift": {
+    "object": "./e.o",
+    "swift-dependencies": "./e.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/test/Driver/Dependencies/Inputs/touch.py
+++ b/test/Driver/Dependencies/Inputs/touch.py
@@ -23,6 +23,6 @@ timeVal = int(sys.argv[1])
 
 # Update the output file mtime, or create it if necessary.
 # From http://stackoverflow.com/a/1160227.
-for outputFile in sys.argv[1:]:
+for outputFile in sys.argv[2:]:
     with open(outputFile, 'a'):
         os.utime(outputFile, (timeVal, timeVal))

--- a/test/Driver/Dependencies/chained-additional-kinds-fine.swift
+++ b/test/Driver/Dependencies/chained-additional-kinds-fine.swift
@@ -1,0 +1,26 @@
+// other ==> main ==> yet-another
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-additional-kinds-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+// CHECK-FIRST: Handled yet-another.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v  2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD-DAG: Handled other.swift
+// CHECK-THIRD-DAG: Handled main.swift
+// CHECK-THIRD-DAG: Handled yet-another.swift
+
+// RUN: touch -t 201401240007 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v  2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s

--- a/test/Driver/Dependencies/chained-additional-kinds.swift
+++ b/test/Driver/Dependencies/chained-additional-kinds.swift
@@ -4,25 +4,23 @@
 // RUN: cp -r %S/Inputs/chained-additional-kinds/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Handled yet-another.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-DAG: Handled other.swift
 // CHECK-THIRD-DAG: Handled main.swift
 // CHECK-THIRD-DAG: Handled yet-another.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
-
-// RUN: touch -t 201401240008 %t/other.swift
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s

--- a/test/Driver/Dependencies/chained-after-fine.swift
+++ b/test/Driver/Dependencies/chained-after-fine.swift
@@ -1,0 +1,23 @@
+/// other ==> main | yet-another
+/// other ==> main +==> yet-another
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/chained-after-fine/*.swiftdeps %t
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD: Handled main.swift
+// CHECK-THIRD: Handled other.swift
+// CHECK-THIRD: Handled yet-another.swift

--- a/test/Driver/Dependencies/chained-after.swift
+++ b/test/Driver/Dependencies/chained-after.swift
@@ -6,17 +6,17 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/chained-after/*.swiftdeps %t
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift

--- a/test/Driver/Dependencies/chained-fine.swift
+++ b/test/Driver/Dependencies/chained-fine.swift
@@ -1,0 +1,32 @@
+// other ==> main ==> yet-another
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+// CHECK-FIRST: Handled yet-another.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD-DAG: Handled other.swift
+// CHECK-THIRD-DAG: Handled main.swift
+// CHECK-THIRD-DAG: Handled yet-another.swift
+
+// RUN: touch -t 201401240007 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// RUN: touch -t 201401240008 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// RUN: touch -t 201401240009 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./yet-another.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s

--- a/test/Driver/Dependencies/chained-private-after-fine.swift
+++ b/test/Driver/Dependencies/chained-private-after-fine.swift
@@ -1,0 +1,24 @@
+/// other --> main ==> yet-another
+/// other ==>+ main ==> yet-another
+/// Coarse and fine
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/chained-private-after-fine/*.swiftdeps %t
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-DAG: Handled other.swift
+// CHECK-SECOND-DAG: Handled main.swift
+// CHECK-SECOND: Handled yet-another.swift

--- a/test/Driver/Dependencies/chained-private-after-multiple-fine.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple-fine.swift
@@ -1,0 +1,27 @@
+/// other --> main ==> yet-another
+/// other ==>+ main ==> yet-another
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-after-multiple-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+
+
+
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/chained-private-after-multiple-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v  2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v  2>&1 |  %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-DAG: Handled other.swift
+// CHECK-SECOND-DAG: Handled main.swift
+// CHECK-SECOND-DAG: Handled yet-another.swift

--- a/test/Driver/Dependencies/chained-private-after-multiple-nominal-members-fine.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple-nominal-members-fine.swift
@@ -1,0 +1,23 @@
+/// other --> main ==> yet-another
+/// other ==>+ main ==> yet-another
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-after-multiple-nominal-members-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/chained-private-after-multiple-nominal-members-fine/*.swiftdeps %t
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-DAG: Handled other.swift
+// CHECK-SECOND-DAG: Handled main.swift
+// CHECK-SECOND-DAG: Handled yet-another.swift

--- a/test/Driver/Dependencies/chained-private-after-multiple-nominal-members.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple-nominal-members.swift
@@ -6,17 +6,17 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/chained-private-after-multiple-nominal-members/*.swiftdeps %t
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-DAG: Handled other.swift
 // CHECK-SECOND-DAG: Handled main.swift

--- a/test/Driver/Dependencies/chained-private-after-multiple.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple.swift
@@ -6,17 +6,17 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/chained-private-after-multiple/*.swiftdeps %t
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-DAG: Handled other.swift
 // CHECK-SECOND-DAG: Handled main.swift

--- a/test/Driver/Dependencies/chained-private-after.swift
+++ b/test/Driver/Dependencies/chained-private-after.swift
@@ -1,22 +1,23 @@
 /// other --> main ==> yet-another
 /// other ==>+ main ==> yet-another
+/// Coarse and fine
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/chained-private-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/chained-private-after/*.swiftdeps %t
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-DAG: Handled other.swift
 // CHECK-SECOND-DAG: Handled main.swift

--- a/test/Driver/Dependencies/chained-private-fine.swift
+++ b/test/Driver/Dependencies/chained-private-fine.swift
@@ -1,0 +1,30 @@
+/// other --> main ==> yet-another
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+// CHECK-FIRST: Handled yet-another.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v >%t/outputToCheck 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-THIRD %s < %t/outputToCheck
+
+// Driver now schedules jobs in the order the inputs were given, but
+// either order is fine.
+// CHECK-THIRD-DAG: Handled main.swift
+// CHECK-THIRD-DAG: Handled other.swift
+
+// RUN: %FileCheck -check-prefix=CHECK-THIRD-EXCLUSION %s < %t/outputToCheck
+
+// CHECK-THIRD-EXCLUSION-NOT: Handled yet-another.swift
+

--- a/test/Driver/Dependencies/chained-private.swift
+++ b/test/Driver/Dependencies/chained-private.swift
@@ -4,19 +4,19 @@
 // RUN: cp -r %S/Inputs/chained-private/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Handled yet-another.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v >%t/outputToCheck 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v >%t/outputToCheck 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-THIRD %s < %t/outputToCheck
 
 // Driver now schedules jobs in the order the inputs were given, but
@@ -27,3 +27,4 @@
 // RUN: %FileCheck -check-prefix=CHECK-THIRD-EXCLUSION %s < %t/outputToCheck
 
 // CHECK-THIRD-EXCLUSION-NOT: Handled yet-another.swift
+

--- a/test/Driver/Dependencies/chained.swift
+++ b/test/Driver/Dependencies/chained.swift
@@ -4,29 +4,29 @@
 // RUN: cp -r %S/Inputs/chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Handled yet-another.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-DAG: Handled other.swift
 // CHECK-THIRD-DAG: Handled main.swift
 // CHECK-THIRD-DAG: Handled yet-another.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240008 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./yet-another.swift ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240009 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./yet-another.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./yet-another.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s

--- a/test/Driver/Dependencies/check-interface-implementation-fine.swift
+++ b/test/Driver/Dependencies/check-interface-implementation-fine.swift
@@ -1,0 +1,34 @@
+/// The fine-grained dependency graph has implicit dependencies from interfaces to implementations.
+/// These are not presently tested because depends nodes are marked as depending in the interface,
+/// as of 1/9/20. But this test will check fail if those links are not followed.
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/check-interface-implementation-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./c.swift  ./bad.swift -module-name main -j1 -v  2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled a.swift
+// CHECK-FIRST: Handled c.swift
+// CHECK-FIRST: Handled bad.swift
+
+// CHECK-RECORD-CLEAN-DAG: "./a.swift": [
+// CHECK-RECORD-CLEAN-DAG: "./bad.swift": [
+// CHECK-RECORD-CLEAN-DAG: "./c.swift": [
+
+
+// RUN: touch -t 201401240006 %t/a.swift
+// RUN: cd %t &&  not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./bad.swift ./c.swift  -module-name main -j1 -v  -driver-show-incremental > %t/a.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE-A %s < %t/a.txt
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-A %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-A: Handled a.swift
+// CHECK-A: Handled bad.swift
+// NEGATIVE-A-NOT: Handled c.swift
+
+// CHECK-RECORD-A-DAG: "./a.swift": [
+// CHECK-RECORD-A-DAG: "./bad.swift": !dirty [
+// CHECK-RECORD-A-DAG: "./c.swift": !dirty [

--- a/test/Driver/Dependencies/crash-added-fine.swift
+++ b/test/Driver/Dependencies/crash-added-fine.swift
@@ -1,0 +1,32 @@
+/// crash ==> main | crash --> other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -c -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+
+// CHECK-INITIAL-NOT: warning
+// CHECK-INITIAL: Handled main.swift
+// CHECK-INITIAL: Handled other.swift
+
+// RUN: cd %t && not %swiftc_driver -c -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./crash.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-ADDED-NOT: Handled
+// CHECK-ADDED: Handled crash.swift
+// CHECK-ADDED-NOT: Handled
+
+// CHECK-RECORD-ADDED-DAG: "./crash.swift": !dirty [
+// CHECK-RECORD-ADDED-DAG: "./main.swift": [
+// CHECK-RECORD-ADDED-DAG: "./other.swift": [
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -c -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+
+// RUN: cd %t && not %swiftc_driver -c -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/crash-added.swift
+++ b/test/Driver/Dependencies/crash-added.swift
@@ -4,13 +4,13 @@
 // RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -c -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL: Handled main.swift
 // CHECK-INITIAL: Handled other.swift
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./crash.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: cd %t && not %swiftc_driver -c -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./crash.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-ADDED-NOT: Handled
@@ -26,7 +26,7 @@
 // RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -c -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: cd %t && not %swiftc_driver -c -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/crash-new-fine.swift
+++ b/test/Driver/Dependencies/crash-new-fine.swift
@@ -1,0 +1,76 @@
+/// crash ==> main | crash --> other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple-with-swiftdeps-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// Initially compile all inputs, crash will fail.
+
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// CHECK-NOT: warning
+// CHECK: Handled main.swift
+// CHECK: Handled crash.swift
+// CHECK-NOT: Handled other.swift
+
+// Put crash.swift first to assure it gets scheduled first.
+// The others get queued, but not dispatched because crash crashes.
+
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
+
+// CHECK-BAD-ONLY-NOT: warning
+// CHECK-BAD-ONLY-NOT: Handled
+// CHECK-BAD-ONLY: Handled crash.swift
+// CHECK-BAD-ONLY-NOT: Handled
+
+// Make crash succeed and all get compiled, exactly once.
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
+// CHECK-OKAY: Handled main.swift
+// CHECK-OKAY: Handled crash.swift
+// CHECK-OKAY: Handled other.swift
+// CHECK-OKAY-NOT: Handled
+
+// Make crash crash again:
+
+// RUN: touch -t 201401240006 %t/crash.swift
+// RUN: rm %t/crash.swiftdeps
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+
+// And repair crash:
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
+
+// CHECK-OKAY-2-DAG: Handled crash.swift
+// CHECK-OKAY-2-DAG: Handled other.swift
+// CHECK-OKAY-2-DAG: Handled main.swift
+
+// Touch main so its newer, remove main.swiftdeps and make crash crash:
+// Driver will fall back to non-incremental, will compile main,
+// will compile crash, and then stop.
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: rm %t/main.swiftdeps
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-MAIN-SWIFTDEPS %s
+
+// CHECK-NO-MAIN-SWIFTDEPS-NOT: warning
+// CHECK-NO-MAIN-SWIFTDEPS: Handled main.swift
+// CHECK-NO-MAIN-SWIFTDEPS: Handled crash.swift
+// CHECK-NO-MAIN-SWIFTDEPS-NOT: Handled other.swift
+
+
+// Touch all files earlier than last compiled date in the build record.
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 -driver-show-incremental |tee /tmp/out1 | %FileCheck -check-prefix=CHECK-CURRENT-WITH-CRASH %s
+
+// CHECK-CURRENT-WITH-CRASH: Handled main.swift
+// CHECK-CURRENT-WITH-CRASH: Handled crash.swift
+// CHECK-CURRENT-WITH-CRASH: Handled other.swift
+// CHECK-CURRENT-WITH-CRASH-NOT: Handled
+
+// Touch other, but remove its swiftdeps. Should compile everything.
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: rm %t/other.swiftdeps
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/crash-new.swift
+++ b/test/Driver/Dependencies/crash-new.swift
@@ -6,7 +6,7 @@
 
 // Initially compile all inputs, crash will fail.
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 // CHECK-NOT: warning
 // CHECK: Handled main.swift
 // CHECK: Handled crash.swift
@@ -15,7 +15,7 @@
 // Put crash.swift first to assure it gets scheduled first.
 // The others get queued, but not dispatched because crash crashes.
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
 
 // CHECK-BAD-ONLY-NOT: warning
 // CHECK-BAD-ONLY-NOT: Handled
@@ -24,7 +24,7 @@
 
 // Make crash succeed and all get compiled, exactly once.
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
 // CHECK-OKAY: Handled main.swift
 // CHECK-OKAY: Handled crash.swift
 // CHECK-OKAY: Handled other.swift
@@ -34,12 +34,12 @@
 
 // RUN: touch -t 201401240006 %t/crash.swift
 // RUN: rm %t/crash.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 
 // And repair crash:
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
 
 // CHECK-OKAY-2-DAG: Handled crash.swift
 // CHECK-OKAY-2-DAG: Handled other.swift
@@ -51,7 +51,7 @@
 
 // RUN: touch -t 201401240006 %t/main.swift
 // RUN: rm %t/main.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-MAIN-SWIFTDEPS %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-MAIN-SWIFTDEPS %s
 
 // CHECK-NO-MAIN-SWIFTDEPS-NOT: warning
 // CHECK-NO-MAIN-SWIFTDEPS: Handled main.swift
@@ -62,7 +62,7 @@
 // Touch all files earlier than last compiled date in the build record.
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 -driver-show-incremental |tee /tmp/out1 | %FileCheck -check-prefix=CHECK-CURRENT-WITH-CRASH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 -driver-show-incremental |tee /tmp/out1 | %FileCheck -check-prefix=CHECK-CURRENT-WITH-CRASH %s
 
 // CHECK-CURRENT-WITH-CRASH: Handled main.swift
 // CHECK-CURRENT-WITH-CRASH: Handled crash.swift
@@ -73,4 +73,4 @@
 
 // RUN: touch -t 201401240006 %t/other.swift
 // RUN: rm %t/other.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/crash-simple-fine.swift
+++ b/test/Driver/Dependencies/crash-simple-fine.swift
@@ -1,0 +1,25 @@
+/// crash ==> main | crash --> other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled crash.swift
+// CHECK-FIRST: Handled other.swift
+
+// RUN: touch -t 201401240006 %t/crash.swift
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | tee /tmp/1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND: Handled crash.swift
+// CHECK-SECOND-NOT: Handled main.swift
+// CHECK-SECOND-NOT: Handled other.swift
+
+// RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-RECORD-DAG: "./crash.swift": !dirty [
+// CHECK-RECORD-DAG: "./main.swift": !dirty [
+// CHECK-RECORD-DAG: "./other.swift": !private [

--- a/test/Driver/Dependencies/crash-simple.swift
+++ b/test/Driver/Dependencies/crash-simple.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/crash-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -12,7 +12,7 @@
 // CHECK-FIRST: Handled other.swift
 
 // RUN: touch -t 201401240006 %t/crash.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled crash.swift
 // CHECK-SECOND-NOT: Handled main.swift

--- a/test/Driver/Dependencies/dependencies-preservation-fine.swift
+++ b/test/Driver/Dependencies/dependencies-preservation-fine.swift
@@ -1,0 +1,20 @@
+// REQUIRES: shell
+// Verify that the top-level build record file from the last incremental
+// compilation is preserved with the same name, suffixed by a '~'.
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json
+
+// RUN: %FileCheck -check-prefix CHECK-ORIGINAL %s < main~buildrecord.swiftdeps~
+// CHECK-ORIGINAL: inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}
+
+// RUN: %FileCheck -check-prefix CHECK-OVERWRITTEN %s < main~buildrecord.swiftdeps
+// CHECK-OVERWRITTEN: version: "{{.*}}"
+// CHECK-OVERWRITTEN: options: "{{.*}}"
+// CHECK-OVERWRITTEN: build_time: [{{[0-9]*}}, {{[0-9]*}}]
+// CHECK-OVERWRITTEN: inputs:
+// CHECK-OVERWRITTEN: "./main.swift": [443865900, 0]
+// CHECK-OVERWRITTEN: "./other.swift": [443865900, 0]

--- a/test/Driver/Dependencies/dependencies-preservation.swift
+++ b/test/Driver/Dependencies/dependencies-preservation.swift
@@ -6,7 +6,7 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json
 
 // RUN: %FileCheck -check-prefix CHECK-ORIGINAL %s < main~buildrecord.swiftdeps~
 // CHECK-ORIGINAL: inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}

--- a/test/Driver/Dependencies/driver-show-incremental-arguments-fine.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-arguments-fine.swift
@@ -1,0 +1,25 @@
+// REQUIRES: shell
+// Test that when:
+//
+// 1. Using -incremental -v -driver-show-incremental, and...
+// 2. ...the arguments passed to the Swift compiler version differ from the ones
+//    used in the original compilation...
+//
+// ...then the driver prints a message indicating that incremental compilation
+// is disabled.
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-with-swiftdeps-fine/* %t
+// RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-ARGS-MISMATCH %s
+// CHECK-ARGS-MISMATCH: Incremental compilation has been disabled{{.*}}different arguments
+// CHECK-ARGS-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}
+
+

--- a/test/Driver/Dependencies/driver-show-incremental-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-arguments.swift
@@ -14,11 +14,12 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-ARGS-MISMATCH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-ARGS-MISMATCH %s
 // CHECK-ARGS-MISMATCH: Incremental compilation has been disabled{{.*}}different arguments
 // CHECK-ARGS-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}
+
 

--- a/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments-fine.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments-fine.swift
@@ -1,0 +1,32 @@
+// REQUIRES: shell
+// Test that when:
+//
+// 1. Using -incremental -v -driver-show-incremental, but...
+// 2. ...options that disable incremental compilation, such as whole module
+//    optimization or bitcode embedding are specified...
+//
+// ...then the driver prints a message indicating that incremental compilation
+// is disabled. If both are specified, the driver should only print one message.
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-with-swiftdeps-fine/* %t
+// RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO %s
+// CHECK-WMO: Incremental compilation has been disabled{{.*}}whole module optimization
+// CHECK-WMO-NOT: Queuing (initial): {compile: main.o <= main.swift}
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-BITCODE %s
+// CHECK-BITCODE: Incremental compilation has been disabled{{.*}}LLVM IR bitcode
+// CHECK-BITCODE-NOT: Queuing (initial): {compile: main.o <= main.swift}
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO-AND-BITCODE %s
+// CHECK-WMO-AND-BITCODE: Incremental compilation has been disabled{{.*}}whole module optimization
+// CHECK-WMO-AND-BITCODE-NOT: Incremental compilation has been disabled
+// CHECK-WMO-AND-BITCODE-NOT: Queuing (initial): {compile: main.o <= main.swift}

--- a/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
@@ -14,20 +14,19 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO %s
 // CHECK-WMO: Incremental compilation has been disabled{{.*}}whole module optimization
 // CHECK-WMO-NOT: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-BITCODE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-BITCODE %s
 // CHECK-BITCODE: Incremental compilation has been disabled{{.*}}LLVM IR bitcode
 // CHECK-BITCODE-NOT: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO-AND-BITCODE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO-AND-BITCODE %s
 // CHECK-WMO-AND-BITCODE: Incremental compilation has been disabled{{.*}}whole module optimization
 // CHECK-WMO-AND-BITCODE-NOT: Incremental compilation has been disabled
 // CHECK-WMO-AND-BITCODE-NOT: Queuing (initial): {compile: main.o <= main.swift}
-

--- a/test/Driver/Dependencies/driver-show-incremental-inputs-fine.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-inputs-fine.swift
@@ -1,0 +1,24 @@
+// REQUIRES: shell
+// Test that when:
+//
+// 1. Using -incremental -v -driver-show-incremental, and...
+// 2. ...the inputs passed to the Swift compiler version differ from the ones
+//    used in the original compilation...
+//
+// ...then the driver prints a message indicating that incremental compilation
+// is disabled.
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-with-swiftdeps-fine/* %t
+// RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -enable-fine-grained-dependencies -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
+
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -enable-fine-grained-dependencies -c ./main.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INPUTS-MISMATCH %s
+// CHECK-INPUTS-MISMATCH: Incremental compilation has been disabled{{.*}}inputs
+// CHECK-INPUTS-MISMATCH: ./other.swift
+// CHECK-INPUTS-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}

--- a/test/Driver/Dependencies/driver-show-incremental-inputs.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-inputs.swift
@@ -14,12 +14,11 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -disable-fine-grained-dependencies -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INPUTS-MISMATCH %s
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -disable-fine-grained-dependencies -c ./main.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INPUTS-MISMATCH %s
 // CHECK-INPUTS-MISMATCH: Incremental compilation has been disabled{{.*}}inputs
 // CHECK-INPUTS-MISMATCH: ./other.swift
 // CHECK-INPUTS-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}
-

--- a/test/Driver/Dependencies/driver-show-incremental-malformed-fine.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-malformed-fine.swift
@@ -1,0 +1,36 @@
+// REQUIRES: shell
+// Test that when:
+//
+// 1. Using -incremental -v -driver-show-incremental, and...
+// 2. ...the build record file does not contain valid JSON...
+//
+// ...then the driver prints a message indicating that incremental compilation
+// is enabled.
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-with-swiftdeps-fine/* %t
+// RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
+
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// CHECK-INCREMENTAL-NOT: Incremental compilation has been enabled
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
+
+// RUN: rm %t/main~buildrecord.swiftdeps && touch %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
+
+// RUN: echo 'foo' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
+
+// CHECK-MALFORMED: Incremental compilation has been disabled{{.*}}malformed build record file
+// CHECK-MALFORMED-NOT: Queuing (initial): {compile: main.o <= main.swift}
+
+// RUN: echo '{version, inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
+
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
+
+// CHECK-MISSING-KEY: Incremental compilation has been disabled{{.*}}malformed build record file{{.*}}Malformed value for key
+// CHECK-MISSING-KEY-NOT: Queuing (initial): {compile: main.o <= main.swift}

--- a/test/Driver/Dependencies/driver-show-incremental-malformed.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-malformed.swift
@@ -13,25 +13,24 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: rm %t/main~buildrecord.swiftdeps && touch %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
 
 // RUN: echo 'foo' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
 
 // CHECK-MALFORMED: Incremental compilation has been disabled{{.*}}malformed build record file
 // CHECK-MALFORMED-NOT: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: echo '{version, inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
 
 // CHECK-MISSING-KEY: Incremental compilation has been disabled{{.*}}malformed build record file{{.*}}Malformed value for key
 // CHECK-MISSING-KEY-NOT: Queuing (initial): {compile: main.o <= main.swift}
-

--- a/test/Driver/Dependencies/driver-show-incremental-mutual-fine.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-mutual-fine.swift
@@ -1,0 +1,19 @@
+/// main <==> other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mutual-with-swiftdeps-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+// CHECK-FIRST: Disabling incremental build: could not read build record
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// CHECK-SECOND-NOT: Queuing
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// CHECK-THIRD: Queuing (initial): {compile: other.o <= other.swift}
+// CHECK-THIRD: Queuing because of the initial set: {compile: main.o <= main.swift}
+// CHECK-THIRD-NEXT: interface of top-level name 'a' in other.swift -> interface of source file main.swiftdeps

--- a/test/Driver/Dependencies/driver-show-incremental-mutual.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-mutual.swift
@@ -4,17 +4,16 @@
 // RUN: cp -r %S/Inputs/mutual-with-swiftdeps/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Disabling incremental build: could not read build record
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 // CHECK-SECOND-NOT: Queuing
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 // CHECK-THIRD: Queuing (initial): {compile: other.o <= other.swift}
 // CHECK-THIRD: Queuing because of the initial set: {compile: main.o <= main.swift}
 // CHECK-THIRD-NEXT: other.swift provides top-level name 'a'
-

--- a/test/Driver/Dependencies/driver-show-incremental-swift-version-fine.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-swift-version-fine.swift
@@ -1,0 +1,26 @@
+// REQUIRES: shell
+// Test that when:
+//
+// 1. Using -incremental -v -driver-show-incremental, and...
+// 2. ...the Swift compiler version used to perform the incremental
+//    compilation differs the original compilation...
+//
+// ...then the driver prints a message indicating that incremental compilation
+// is enabled.
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-with-swiftdeps-fine/* %t
+// RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
+
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// CHECK-INCREMENTAL-NOT: Incremental compilation has been enabled
+// CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
+
+// RUN: echo '{version: "bogus", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-VERSION-MISMATCH %s
+// CHECK-VERSION-MISMATCH: Incremental compilation has been disabled{{.*}}compiler version mismatch
+// CHECK-VERSION-MISMATCH: Compiling with:
+// CHECK-VERSION-MISMATCH: Previously compiled with: bogus
+// CHECK-VERSION-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}

--- a/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
@@ -14,14 +14,13 @@
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing (initial): {compile: main.o <= main.swift}
 
 // RUN: echo '{version: "bogus", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-VERSION-MISMATCH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-VERSION-MISMATCH %s
 // CHECK-VERSION-MISMATCH: Incremental compilation has been disabled{{.*}}compiler version mismatch
 // CHECK-VERSION-MISMATCH: Compiling with:
 // CHECK-VERSION-MISMATCH: Previously compiled with: bogus
 // CHECK-VERSION-MISMATCH-NOT: Queuing (initial): {compile: main.o <= main.swift}
-

--- a/test/Driver/Dependencies/embed-bitcode-parallel-fine.swift
+++ b/test/Driver/Dependencies/embed-bitcode-parallel-fine.swift
@@ -1,0 +1,91 @@
+// Windows doesn't support parallel execution yet
+// XFAIL: windows
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/fake-build-for-bitcode.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "began"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: ".\/main.swift"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "finished"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: "output": "Handled main.swift\n"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "began"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: ".\/other.swift"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "finished"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: "output": "Handled other.swift\n"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "began"
+// CHECK-FIRST: "name": "backend"
+// CHECK-FIRST: ".\/main.o"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "finished"
+// CHECK-FIRST: "name": "backend"
+// CHECK-FIRST: "output": "Produced main.o\n"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "began"
+// CHECK-FIRST: "name": "backend"
+// CHECK-FIRST: ".\/other.o"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "finished"
+// CHECK-FIRST: "name": "backend"
+// CHECK-FIRST: "output": "Produced other.o\n"
+// CHECK-FIRST: {{^}$}}
+
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/fake-build-for-bitcode.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND: "kind": "began"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: ".\/main.swift"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND-NOT: finished
+
+// CHECK-SECOND: "kind": "began"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: ".\/other.swift"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND-NOT: began
+
+// CHECK-SECOND: "kind": "finished"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: "output": "Handled {{other.swift|main.swift}}\n"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND: "kind": "began"
+// CHECK-SECOND: "name": "backend"
+// CHECK-SECOND: ".\/{{other.o|main.o}}"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND: "kind": "finished"
+// CHECK-SECOND: "name": "backend"
+// CHECK-SECOND: "output": "Produced {{other.o|main.o}}\n"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND-NOT: "skipped"

--- a/test/Driver/Dependencies/embed-bitcode-parallel.swift
+++ b/test/Driver/Dependencies/embed-bitcode-parallel.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/fake-build-for-bitcode.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/fake-build-for-bitcode.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
@@ -57,7 +57,7 @@
 
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/fake-build-for-bitcode.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/fake-build-for-bitcode.py" -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: "kind": "began"
 // CHECK-SECOND: "name": "compile"

--- a/test/Driver/Dependencies/fail-added-fine.swift
+++ b/test/Driver/Dependencies/fail-added-fine.swift
@@ -1,0 +1,32 @@
+/// bad ==> main | bad --> other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+
+// CHECK-INITIAL-NOT: warning
+// CHECK-INITIAL: Handled main.swift
+// CHECK-INITIAL: Handled other.swift
+
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-ADDED-NOT: Handled
+// CHECK-ADDED: Handled bad.swift
+// CHECK-ADDED-NOT: Handled
+
+// CHECK-RECORD-ADDED-DAG: "./bad.swift": !dirty [
+// CHECK-RECORD-ADDED-DAG: "./main.swift": [
+// CHECK-RECORD-ADDED-DAG: "./other.swift": [
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/fail-added.swift
+++ b/test/Driver/Dependencies/fail-added.swift
@@ -4,13 +4,13 @@
 // RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL: Handled main.swift
 // CHECK-INITIAL: Handled other.swift
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-ADDED-NOT: Handled
@@ -26,7 +26,7 @@
 // RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-ADDED %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-ADDED %s < %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/fail-chained-fine.swift
+++ b/test/Driver/Dependencies/fail-chained-fine.swift
@@ -1,0 +1,129 @@
+/// a ==> bad ==> c ==> d | b --> bad --> e ==> f
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-chained-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v  2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled a.swift
+// CHECK-FIRST: Handled b.swift
+// CHECK-FIRST: Handled c.swift
+// CHECK-FIRST: Handled d.swift
+// CHECK-FIRST: Handled e.swift
+// CHECK-FIRST: Handled f.swift
+// CHECK-FIRST: Handled bad.swift
+
+// CHECK-RECORD-CLEAN-DAG: "./a.swift": [
+// CHECK-RECORD-CLEAN-DAG: "./b.swift": [
+// CHECK-RECORD-CLEAN-DAG: "./c.swift": [
+// CHECK-RECORD-CLEAN-DAG: "./d.swift": [
+// CHECK-RECORD-CLEAN-DAG: "./e.swift": [
+// CHECK-RECORD-CLEAN-DAG: "./f.swift": [
+// CHECK-RECORD-CLEAN-DAG: "./bad.swift": [
+
+
+// RUN: touch -t 201401240006 %t/a.swift
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./bad.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v   > %t/a.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE-A %s < %t/a.txt
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-A %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-A: Handled a.swift
+// CHECK-A: Handled bad.swift
+// NEGATIVE-A-NOT: Handled b.swift
+// NEGATIVE-A-NOT: Handled c.swift
+// NEGATIVE-A-NOT: Handled d.swift
+// NEGATIVE-A-NOT: Handled e.swift
+// NEGATIVE-A-NOT: Handled f.swift
+
+// CHECK-RECORD-A-DAG: "./a.swift": [
+// CHECK-RECORD-A-DAG: "./b.swift": [
+// CHECK-RECORD-A-DAG: "./c.swift": !dirty [
+// CHECK-RECORD-A-DAG: "./d.swift": !dirty [
+// CHECK-RECORD-A-DAG: "./e.swift": !private [
+// CHECK-RECORD-A-DAG: "./f.swift": [
+// CHECK-RECORD-A-DAG: "./bad.swift": !dirty [
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/a2.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-A2 %s < %t/a2.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE-A2 %s < %t/a2.txt
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-A2-DAG: Handled c.swift
+// CHECK-A2-DAG: Handled d.swift
+// CHECK-A2-DAG: Handled e.swift
+// CHECK-A2-DAG: Handled bad.swift
+// NEGATIVE-A2-NOT: Handled a.swift
+// NEGATIVE-A2-NOT: Handled b.swift
+// NEGATIVE-A2-NOT: Handled f.swift
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-chained-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// RUN: touch -t 201401240006 %t/b.swift
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-B %s < %t/b.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE-B %s < %t/b.txt
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-B %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-B: Handled b.swift
+// CHECK-B: Handled bad.swift
+// NEGATIVE-B-NOT: Handled a.swift
+// NEGATIVE-B-NOT: Handled c.swift
+// NEGATIVE-B-NOT: Handled d.swift
+// NEGATIVE-B-NOT: Handled e.swift
+// NEGATIVE-B-NOT: Handled f.swift
+
+// CHECK-RECORD-B-DAG: "./a.swift": [
+// CHECK-RECORD-B-DAG: "./b.swift": [
+// CHECK-RECORD-B-DAG: "./c.swift": [
+// CHECK-RECORD-B-DAG: "./d.swift": [
+// CHECK-RECORD-B-DAG: "./e.swift": [
+// CHECK-RECORD-B-DAG: "./f.swift": [
+// CHECK-RECORD-B-DAG: "./bad.swift": !private [
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b2.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-B2 %s < %t/b2.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE-B2 %s < %t/b2.txt
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-B2-DAG: Handled bad.swift
+// NEGATIVE-B2-NOT: Handled a.swift
+// NEGATIVE-B2-NOT: Handled b.swift
+// NEGATIVE-B2-NOT: Handled c.swift
+// NEGATIVE-B2-NOT: Handled d.swift
+// NEGATIVE-B2-NOT: Handled e.swift
+// NEGATIVE-B2-NOT: Handled f.swift
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-chained-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// RUN: touch -t 201401240006 %t/bad.swift
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v > %t/bad.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-BAD %s < %t/bad.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE-BAD %s < %t/bad.txt
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-A %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-BAD: Handled bad.swift
+// NEGATIVE-BAD-NOT: Handled a.swift
+// NEGATIVE-BAD-NOT: Handled b.swift
+// NEGATIVE-BAD-NOT: Handled c.swift
+// NEGATIVE-BAD-NOT: Handled d.swift
+// NEGATIVE-BAD-NOT: Handled e.swift
+// NEGATIVE-BAD-NOT: Handled f.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/bad2.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-A2 %s < %t/bad2.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE-A2 %s < %t/bad2.txt
+// RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/fail-chained.swift
+++ b/test/Driver/Dependencies/fail-chained.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/fail-chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-FIRST-NOT: warning
@@ -26,7 +26,7 @@
 
 
 // RUN: touch -t 201401240006 %t/a.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./bad.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v > %t/a.txt 2>&1
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./bad.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v > %t/a.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-A %s < %t/a.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-A %s < %t/main~buildrecord.swiftdeps
@@ -47,7 +47,7 @@
 // CHECK-RECORD-A-DAG: "./f.swift": [
 // CHECK-RECORD-A-DAG: "./bad.swift": !dirty [
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/a2.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/a2.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A2 %s < %t/a2.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-A2 %s < %t/a2.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
@@ -65,10 +65,10 @@
 // RUN: cp -r %S/Inputs/fail-chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/b.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b.txt 2>&1
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-B %s < %t/b.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-B %s < %t/b.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-B %s < %t/main~buildrecord.swiftdeps
@@ -89,7 +89,7 @@
 // CHECK-RECORD-B-DAG: "./f.swift": [
 // CHECK-RECORD-B-DAG: "./bad.swift": !private [
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b2.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/b2.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-B2 %s < %t/b2.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-B2 %s < %t/b2.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps
@@ -107,10 +107,10 @@
 // RUN: cp -r %S/Inputs/fail-chained/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/bad.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v > %t/bad.txt 2>&1
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift -module-name main -j1 -v > %t/bad.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-BAD %s < %t/bad.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-BAD %s < %t/bad.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-A %s < %t/main~buildrecord.swiftdeps
@@ -123,7 +123,7 @@
 // NEGATIVE-BAD-NOT: Handled e.swift
 // NEGATIVE-BAD-NOT: Handled f.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/bad2.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v > %t/bad2.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A2 %s < %t/bad2.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-A2 %s < %t/bad2.txt
 // RUN: %FileCheck -check-prefix=CHECK-RECORD-CLEAN %s < %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/fail-interface-hash-fine.swift
+++ b/test/Driver/Dependencies/fail-interface-hash-fine.swift
@@ -1,0 +1,30 @@
+/// main ==> depends-on-main | bad ==> depends-on-bad
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-interface-hash-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled bad.swift
+// CHECK-FIRST: Handled depends-on-main.swift
+// CHECK-FIRST: Handled depends-on-bad.swift
+
+// Reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/fail-interface-hash-fine/*.swiftdeps %t
+
+// RUN: touch -t 201401240006 %t/bad.swift %t/main.swift
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-SECOND: Handled main.swift
+// CHECK-SECOND-NOT: Handled depends
+// CHECK-SECOND: Handled bad.swift
+// CHECK-SECOND-NOT: Handled depends
+
+// CHECK-RECORD-DAG: "./bad.swift": !dirty [
+// CHECK-RECORD-DAG: "./main.swift": [
+// CHECK-RECORD-DAG: "./depends-on-main.swift": !dirty [
+// CHECK-RECORD-DAG: "./depends-on-bad.swift": [

--- a/test/Driver/Dependencies/fail-interface-hash.swift
+++ b/test/Driver/Dependencies/fail-interface-hash.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/fail-interface-hash/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -16,7 +16,7 @@
 // RUN: cp -r %S/Inputs/fail-interface-hash/*.swiftdeps %t
 
 // RUN: touch -t 201401240006 %t/bad.swift %t/main.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-SECOND: Handled main.swift

--- a/test/Driver/Dependencies/fail-new-fine.swift
+++ b/test/Driver/Dependencies/fail-new-fine.swift
@@ -1,0 +1,45 @@
+/// bad ==> main | bad --> other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// CHECK-NOT: warning
+// CHECK: Handled main.swift
+// CHECK: Handled bad.swift
+// CHECK-NOT: Handled other.swift
+
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
+
+// CHECK-BAD-ONLY-NOT: warning
+// CHECK-BAD-ONLY-NOT: Handled
+// CHECK-BAD-ONLY: Handled bad.swift
+// CHECK-BAD-ONLY-NOT: Handled
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
+// CHECK-OKAY: Handled main.swift
+// CHECK-OKAY: Handled bad.swift
+// CHECK-OKAY: Handled other.swift
+// CHECK-OKAY-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/bad.swift
+// RUN: rm %t/bad.swiftdeps
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
+
+// CHECK-OKAY-2-DAG: Handled bad.swift
+// CHECK-OKAY-2-DAG: Handled other.swift
+// CHECK-OKAY-2-DAG: Handled main.swift
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: rm %t/main.swiftdeps
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: rm %t/other.swiftdeps
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/fail-new.swift
+++ b/test/Driver/Dependencies/fail-new.swift
@@ -4,20 +4,20 @@
 // RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 // CHECK-NOT: warning
 // CHECK: Handled main.swift
 // CHECK: Handled bad.swift
 // CHECK-NOT: Handled other.swift
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BAD-ONLY %s
 
 // CHECK-BAD-ONLY-NOT: warning
 // CHECK-BAD-ONLY-NOT: Handled
 // CHECK-BAD-ONLY: Handled bad.swift
 // CHECK-BAD-ONLY-NOT: Handled
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
 // CHECK-OKAY: Handled main.swift
 // CHECK-OKAY: Handled bad.swift
 // CHECK-OKAY: Handled other.swift
@@ -25,10 +25,10 @@
 
 // RUN: touch -t 201401240006 %t/bad.swift
 // RUN: rm %t/bad.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY-2 %s
 
 // CHECK-OKAY-2-DAG: Handled bad.swift
 // CHECK-OKAY-2-DAG: Handled other.swift
@@ -36,10 +36,10 @@
 
 // RUN: touch -t 201401240006 %t/main.swift
 // RUN: rm %t/main.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-OKAY %s
 // RUN: touch -t 201401240006 %t/other.swift
 // RUN: rm %t/other.swiftdeps
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/fail-simple-fine.swift
+++ b/test/Driver/Dependencies/fail-simple-fine.swift
@@ -1,0 +1,24 @@
+/// bad ==> main | bad --> other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled bad.swift
+// CHECK-FIRST: Handled other.swift
+
+// RUN: touch -t 201401240006 %t/bad.swift
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-SECOND: Handled bad.swift
+// CHECK-SECOND-NOT: Handled main.swift
+// CHECK-SECOND-NOT: Handled other.swift
+
+// CHECK-RECORD-DAG: "./bad.swift": !dirty [
+// CHECK-RECORD-DAG: "./main.swift": !dirty [
+// CHECK-RECORD-DAG: "./other.swift": !private [

--- a/test/Driver/Dependencies/fail-simple.swift
+++ b/test/Driver/Dependencies/fail-simple.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/fail-simple/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -12,7 +12,7 @@
 // CHECK-FIRST: Handled other.swift
 
 // RUN: touch -t 201401240006 %t/bad.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./bad.swift ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-SECOND: Handled bad.swift

--- a/test/Driver/Dependencies/fail-with-bad-deps-fine.swift
+++ b/test/Driver/Dependencies/fail-with-bad-deps-fine.swift
@@ -1,0 +1,48 @@
+/// main ==> depends-on-main | bad ==> depends-on-bad
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-with-bad-deps-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled bad.swift
+// CHECK-FIRST: Handled depends-on-main.swift
+// CHECK-FIRST: Handled depends-on-bad.swift
+
+// Reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/fail-with-bad-deps-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NONE %s
+// CHECK-NONE-NOT: Handled
+
+// Reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/fail-with-bad-deps-fine/*.swiftdeps %t
+
+// RUN: touch -t 201401240006 %t/bad.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BUILD-ALL %s
+
+// CHECK-BUILD-ALL-NOT: warning
+// CHECK-BUILD-ALL: Handled bad.swift
+// CHECK-BUILD-ALL-DAG: Handled main.swift
+// CHECK-BUILD-ALL-DAG: Handled depends-on-main.swift
+// CHECK-BUILD-ALL-DAG: Handled depends-on-bad.swift
+
+// Reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/fail-with-bad-deps-fine/*.swiftdeps %t
+
+// RUN: touch -t 201401240007 %t/bad.swift %t/main.swift
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-WITH-FAIL %s
+// RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
+
+// CHECK-WITH-FAIL: Handled main.swift
+// CHECK-WITH-FAIL-NOT: Handled depends
+// CHECK-WITH-FAIL: Handled bad.swift
+// CHECK-WITH-FAIL-NOT: Handled depends
+
+// CHECK-RECORD-DAG: "./bad.swift": !private [
+// CHECK-RECORD-DAG: "./main.swift": [
+// CHECK-RECORD-DAG: "./depends-on-main.swift": !dirty [
+// CHECK-RECORD-DAG: "./depends-on-bad.swift": [

--- a/test/Driver/Dependencies/fail-with-bad-deps.swift
+++ b/test/Driver/Dependencies/fail-with-bad-deps.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/fail-with-bad-deps/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -15,14 +15,14 @@
 // Reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/fail-with-bad-deps/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NONE %s
 // CHECK-NONE-NOT: Handled
 
 // Reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/fail-with-bad-deps/*.swiftdeps %t
 
 // RUN: touch -t 201401240006 %t/bad.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BUILD-ALL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-BUILD-ALL %s
 
 // CHECK-BUILD-ALL-NOT: warning
 // CHECK-BUILD-ALL: Handled bad.swift
@@ -34,7 +34,7 @@
 // RUN: cp -r %S/Inputs/fail-with-bad-deps/*.swiftdeps %t
 
 // RUN: touch -t 201401240007 %t/bad.swift %t/main.swift
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-WITH-FAIL %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-WITH-FAIL %s
 // RUN: %FileCheck -check-prefix=CHECK-RECORD %s < %t/main~buildrecord.swiftdeps
 
 // CHECK-WITH-FAIL: Handled main.swift

--- a/test/Driver/Dependencies/file-added-fine.swift
+++ b/test/Driver/Dependencies/file-added-fine.swift
@@ -1,0 +1,20 @@
+/// other ==> main
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled other.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD-NOT: Handled other.swift
+// CHECK-THIRD: Handled main.swift
+// CHECK-THIRD-NOT: Handled other.swift

--- a/test/Driver/Dependencies/file-added.swift
+++ b/test/Driver/Dependencies/file-added.swift
@@ -4,16 +4,16 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled other.swift
 // CHECK-THIRD: Handled main.swift

--- a/test/Driver/Dependencies/independent-fine.swift
+++ b/test/Driver/Dependencies/independent-fine.swift
@@ -1,0 +1,46 @@
+// main | other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: ls %t/main~buildrecord.swiftdeps
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/*
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// RUN: touch -t 201401240007 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+
+// CHECK-FIRST-MULTI: Handled main.swift
+// CHECK-FIRST-MULTI: Handled other.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// RUN: touch -t 201401240006 %t/*
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SINGLE %s
+// CHECK-SINGLE: Handled main.swift
+
+// RUN: ls %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/independent-half-dirty-fine.swift
+++ b/test/Driver/Dependencies/independent-half-dirty-fine.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+
+// RUN: touch -t 201401240005 %t/other.o
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled main.swift
+// CHECK-SECOND: Handled other.swift
+// CHECK-SECOND-NOT: Handled main.swift
+
+// RUN: rm %t/other.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD: Handled main.swift
+// CHECK-THIRD: Handled other.swift

--- a/test/Driver/Dependencies/independent-half-dirty.swift
+++ b/test/Driver/Dependencies/independent-half-dirty.swift
@@ -2,7 +2,7 @@
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -10,14 +10,14 @@
 
 // RUN: touch -t 201401240005 %t/other.o
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled main.swift
 // CHECK-SECOND: Handled other.swift
 // CHECK-SECOND-NOT: Handled main.swift
 
 // RUN: rm %t/other.swiftdeps
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift

--- a/test/Driver/Dependencies/independent-parseable-fine.swift
+++ b/test/Driver/Dependencies/independent-parseable-fine.swift
@@ -1,0 +1,78 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "began"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: ".\/main.swift"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "finished"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-FIRST: {{^}$}}
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND: {{^{$}}
+// CHECK-SECOND: "kind": "skipped"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: ".\/main.swift"
+// CHECK-SECOND: {{^}$}}
+
+// RUN: touch -t 201401240006 %t/*
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+
+// CHECK-FIRST-MULTI: {{^{$}}
+// CHECK-FIRST-MULTI: "kind": "began"
+// CHECK-FIRST-MULTI: "name": "compile"
+// CHECK-FIRST-MULTI: ".\/main.swift"
+// CHECK-FIRST-MULTI: {{^}$}}
+
+// CHECK-FIRST-MULTI: {{^{$}}
+// CHECK-FIRST-MULTI: "kind": "finished"
+// CHECK-FIRST-MULTI: "name": "compile"
+// CHECK-FIRST-MULTI: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-FIRST-MULTI: {{^}$}}
+
+// CHECK-FIRST-MULTI: {{^{$}}
+// CHECK-FIRST-MULTI: "kind": "began"
+// CHECK-FIRST-MULTI: "name": "compile"
+// CHECK-FIRST-MULTI: ".\/other.swift"
+// CHECK-FIRST-MULTI: {{^}$}}
+
+// CHECK-FIRST-MULTI: {{^{$}}
+// CHECK-FIRST-MULTI: "kind": "finished"
+// CHECK-FIRST-MULTI: "name": "compile"
+// CHECK-FIRST-MULTI: "output": "Handled other.swift{{(\\r)?}}\n"
+// CHECK-FIRST-MULTI: {{^}$}}
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND-MULTI %s
+
+// CHECK-SECOND-MULTI: {{^{$}}
+// CHECK-SECOND-MULTI: "kind": "skipped"
+// CHECK-SECOND-MULTI: "name": "compile"
+// CHECK-SECOND-MULTI: ".\/main.swift"
+// CHECK-SECOND-MULTI: {{^}$}}
+
+// CHECK-SECOND-MULTI: {{^{$}}
+// CHECK-SECOND-MULTI: "kind": "skipped"
+// CHECK-SECOND-MULTI: "name": "compile"
+// CHECK-SECOND-MULTI: ".\/other.swift"
+// CHECK-SECOND-MULTI: {{^}$}}
+
+// RUN: touch -t 201401240006 %t/*
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+

--- a/test/Driver/Dependencies/independent-parseable.swift
+++ b/test/Driver/Dependencies/independent-parseable.swift
@@ -2,7 +2,7 @@
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
@@ -17,7 +17,7 @@
 // CHECK-FIRST: "output": "Handled main.swift{{(\\r)?}}\n"
 // CHECK-FIRST: {{^}$}}
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: {{^{$}}
 // CHECK-SECOND: "kind": "skipped"
@@ -26,14 +26,14 @@
 // CHECK-SECOND: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 // CHECK-FIRST-MULTI: {{^{$}}
 // CHECK-FIRST-MULTI: "kind": "began"
@@ -59,7 +59,7 @@
 // CHECK-FIRST-MULTI: "output": "Handled other.swift{{(\\r)?}}\n"
 // CHECK-FIRST-MULTI: {{^}$}}
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND-MULTI %s
 
 // CHECK-SECOND-MULTI: {{^{$}}
 // CHECK-SECOND-MULTI: "kind": "skipped"
@@ -74,5 +74,5 @@
 // CHECK-SECOND-MULTI: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 

--- a/test/Driver/Dependencies/independent.swift
+++ b/test/Driver/Dependencies/independent.swift
@@ -4,43 +4,43 @@
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 // RUN: ls %t/main~buildrecord.swiftdeps
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 // CHECK-FIRST-MULTI: Handled main.swift
 // CHECK-FIRST-MULTI: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // RUN: touch -t 201401240006 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/independent/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SINGLE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SINGLE %s
 // CHECK-SINGLE: Handled main.swift
 
 // RUN: ls %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/malformed-but-valid-yaml-fine.swift
+++ b/test/Driver/Dependencies/malformed-but-valid-yaml-fine.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-but-valid-yaml-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/malformed-after-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND: Handled other.swift
+// CHECK-SECOND: Handled main.swift
+
+// RUN: touch -t 201401240007 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD: Handled main.swift
+// CHECK-THIRD: Handled other.swift
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-but-valid-yaml-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/malformed-after-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// RUN: touch -t 201401240007 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// CHECK-FOURTH-NOT: Handled other.swift
+// CHECK-FOURTH: Handled main.swift
+// CHECK-FOURTH-NOT: Handled other.swift

--- a/test/Driver/Dependencies/malformed-but-valid-yaml.swift
+++ b/test/Driver/Dependencies/malformed-but-valid-yaml.swift
@@ -3,24 +3,24 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/malformed-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled other.swift
 // CHECK-SECOND: Handled main.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
@@ -30,18 +30,18 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/malformed-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/malformed-fine.swift
+++ b/test/Driver/Dependencies/malformed-fine.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/malformed-after-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND: Handled other.swift
+// CHECK-SECOND: Handled main.swift
+
+// RUN: touch -t 201401240007 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD: Handled main.swift
+// CHECK-THIRD: Handled other.swift
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/malformed-after-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// RUN: touch -t 201401240007 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// CHECK-FOURTH-NOT: Handled other.swift
+// CHECK-FOURTH: Handled main.swift
+// CHECK-FOURTH-NOT: Handled other.swift

--- a/test/Driver/Dependencies/malformed.swift
+++ b/test/Driver/Dependencies/malformed.swift
@@ -3,24 +3,24 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/malformed-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled other.swift
 // CHECK-SECOND: Handled main.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
@@ -30,18 +30,18 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/malformed-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/mutual-fine.swift
+++ b/test/Driver/Dependencies/mutual-fine.swift
@@ -1,0 +1,24 @@
+/// main <==> other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mutual-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD: Handled main.swift
+// CHECK-THIRD: Handled other.swift
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/mutual-interface-hash-fine.swift
+++ b/test/Driver/Dependencies/mutual-interface-hash-fine.swift
@@ -1,0 +1,50 @@
+/// does-change <==> does-not-change
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mutual-interface-hash-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/mutual-interface-hash-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
+
+// CHECK-CLEAN-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/does-change.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v  2>&1 | %FileCheck -check-prefix=CHECK-CHANGE %s
+
+// CHECK-CHANGE-DAG: Handled does-change.swift
+// CHECK-CHANGE-DAG: Handled does-not-change.swift
+
+
+// RUN: cp -r %S/Inputs/mutual-interface-hash-fine/*.swiftdeps %t
+
+// RUN: touch -t 201401240006 %t/does-not-change.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-CHANGE %s
+
+// CHECK-NO-CHANGE-NOT: Handled
+// CHECK-NO-CHANGE: Handled does-not-change.swift
+// CHECK-NO-CHANGE-NOT: Handled
+
+
+// RUN: cp -r %S/Inputs/mutual-interface-hash-fine/*.swiftdeps %t
+
+// Make sure the files really were dependent on one another.
+
+// RUN: touch -t 201401240007 %t/does-not-change.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s
+
+// CHECK-REBUILD-DEPENDENTS-DAG: Handled does-not-change.swift
+// CHECK-REBUILD-DEPENDENTS-DAG: Handled does-change.swift
+
+
+// Check that cascading builds triggered by the build record are still
+// considered cascading.
+
+// RUN: cp -r %S/Inputs/mutual-interface-hash-fine/*.swiftdeps %t
+// RUN: sed -E -e 's/"[^"]*does-not-change.swift":/& !dirty/' -i.prev %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s

--- a/test/Driver/Dependencies/mutual-interface-hash.swift
+++ b/test/Driver/Dependencies/mutual-interface-hash.swift
@@ -5,17 +5,17 @@
 // RUN: touch -t 201401240005 %t/*
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/mutual-interface-hash/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
 
 // CHECK-CLEAN-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/does-change.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CHANGE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CHANGE %s
 
 // CHECK-CHANGE: Handled does-change.swift
 // CHECK-CHANGE: Handled does-not-change.swift
@@ -24,7 +24,7 @@
 // RUN: cp -r %S/Inputs/mutual-interface-hash/*.swiftdeps %t
 
 // RUN: touch -t 201401240006 %t/does-not-change.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-CHANGE %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-NO-CHANGE %s
 
 // CHECK-NO-CHANGE-NOT: Handled
 // CHECK-NO-CHANGE: Handled does-not-change.swift
@@ -36,7 +36,7 @@
 // Make sure the files really were dependent on one another.
 
 // RUN: touch -t 201401240007 %t/does-not-change.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s
 
 // CHECK-REBUILD-DEPENDENTS-DAG: Handled does-not-change.swift
 // CHECK-REBUILD-DEPENDENTS-DAG: Handled does-change.swift
@@ -47,4 +47,4 @@
 
 // RUN: cp -r %S/Inputs/mutual-interface-hash/*.swiftdeps %t
 // RUN: sed -E -e 's/"[^"]*does-not-change.swift":/& !dirty/' -i.prev %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental ./does-change.swift ./does-not-change.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REBUILD-DEPENDENTS %s

--- a/test/Driver/Dependencies/mutual.swift
+++ b/test/Driver/Dependencies/mutual.swift
@@ -4,21 +4,21 @@
 // RUN: cp -r %S/Inputs/mutual/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/nominal-members-fine.swift
+++ b/test/Driver/Dependencies/nominal-members-fine.swift
@@ -1,0 +1,39 @@
+/// a ==> depends-on-a-ext, depends-on-a-foo | a-ext ==> depends-on-a-ext
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/nominal-members-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+
+// CHECK-INITIAL-NOT: warning
+// CHECK-INITIAL: Handled a.swift
+// CHECK-INITIAL: Handled a-ext.swift
+// CHECK-INITIAL: Handled depends-on-a-foo.swift
+// CHECK-INITIAL: Handled depends-on-a-ext.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
+
+// CHECK-CLEAN-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/a.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v > %t/touched-a.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-TOUCHED-A %s < %t/touched-a.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE-TOUCHED-A %s < %t/touched-a.txt
+
+// CHECK-TOUCHED-A: Handled a.swift
+// CHECK-TOUCHED-A-DAG: Handled depends-on-a-foo.swift
+// CHECK-TOUCHED-A-DAG: Handled depends-on-a-ext.swift
+// NEGATIVE-TOUCHED-A-NOT: Handled a-ext.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
+
+
+// RUN: touch -t 201401240007 %t/a-ext.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-TOUCHED-EXT %s
+
+// CHECK-TOUCHED-EXT-NOT: Handled
+// CHECK-TOUCHED-EXT: Handled a-ext.swift
+// CHECK-TOUCHED-EXT-NOT: Handled
+// CHECK-TOUCHED-EXT: Handled depends-on-a-ext.swift
+// CHECK-TOUCHED-EXT-NOT: Handled

--- a/test/Driver/Dependencies/nominal-members.swift
+++ b/test/Driver/Dependencies/nominal-members.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/nominal-members/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL: Handled a.swift
@@ -12,12 +12,12 @@
 // CHECK-INITIAL: Handled depends-on-a-foo.swift
 // CHECK-INITIAL: Handled depends-on-a-ext.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
 
 // CHECK-CLEAN-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/a.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v > %t/touched-a.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v > %t/touched-a.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-TOUCHED-A %s < %t/touched-a.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE-TOUCHED-A %s < %t/touched-a.txt
 
@@ -26,11 +26,11 @@
 // CHECK-TOUCHED-A-DAG: Handled depends-on-a-ext.swift
 // NEGATIVE-TOUCHED-A-NOT: Handled a-ext.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-CLEAN %s
 
 
 // RUN: touch -t 201401240007 %t/a-ext.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-TOUCHED-EXT %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift  -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-TOUCHED-EXT %s
 
 // CHECK-TOUCHED-EXT-NOT: Handled
 // CHECK-TOUCHED-EXT: Handled a-ext.swift

--- a/test/Driver/Dependencies/one-way-depends-after-fine.swift
+++ b/test/Driver/Dependencies/one-way-depends-after-fine.swift
@@ -1,0 +1,56 @@
+/// other | main
+/// other ==>+ main
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/one-way-depends-after-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | tee /tmp/1|%FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled main.swift
+// CHECK-SECOND: Handled other.swift
+// CHECK-SECOND-NOT: Handled main.swift
+
+// RUN: touch -t 201401240007 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/one-way-depends-after-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD-NOT: Handled other.swift
+// CHECK-THIRD: Handled main.swift
+// CHECK-THIRD-NOT: Handled other.swift
+
+// RUN: touch -t 201401240007 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// RUN: touch -t 201401240008 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// CHECK-FOURTH-DAG: Handled other.swift
+// CHECK-FOURTH-DAG: Handled main.swift

--- a/test/Driver/Dependencies/one-way-depends-after.swift
+++ b/test/Driver/Dependencies/one-way-depends-after.swift
@@ -6,25 +6,25 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-depends-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled main.swift
 // CHECK-SECOND: Handled other.swift
 // CHECK-SECOND-NOT: Handled main.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 
 // RUN: %empty-directory(%t)
@@ -32,25 +32,25 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-depends-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled other.swift
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD-NOT: Handled other.swift
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240008 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-DAG: Handled other.swift
 // CHECK-FOURTH-DAG: Handled main.swift

--- a/test/Driver/Dependencies/one-way-depends-before-fine.swift
+++ b/test/Driver/Dependencies/one-way-depends-before-fine.swift
@@ -1,0 +1,56 @@
+/// other ==>+ main
+/// other | main
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-before-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/one-way-depends-before-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND: Handled main.swift
+// CHECK-SECOND: Handled other.swift
+
+// RUN: touch -t 201401240007 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD-NOT: Handled main.swift
+// CHECK-THIRD: Handled other.swift
+// CHECK-THIRD-NOT: Handled main.swift
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-before-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/one-way-depends-before-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// CHECK-FOURTH-NOT: Handled other.swift
+// CHECK-FOURTH: Handled main.swift
+// CHECK-FOURTH-NOT: Handled other.swift
+
+// RUN: touch -t 201401240007 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// RUN: touch -t 201401240008 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s

--- a/test/Driver/Dependencies/one-way-depends-before.swift
+++ b/test/Driver/Dependencies/one-way-depends-before.swift
@@ -6,24 +6,24 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-depends-before/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled main.swift
 // CHECK-SECOND: Handled other.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled main.swift
 // CHECK-THIRD: Handled other.swift
@@ -35,22 +35,22 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-depends-before/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift
 // CHECK-FOURTH-NOT: Handled other.swift
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: touch -t 201401240008 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s

--- a/test/Driver/Dependencies/one-way-external-delete-fine.swift
+++ b/test/Driver/Dependencies/one-way-external-delete-fine.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-external-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled
+
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: touch -t 201401240006 %t/*.o
+// RUN: touch -t 201401240004 %t/*-external
+// RUN: rm %t/other1-external
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD-DAG: Handled other.swift
+// CHECK-THIRD-DAG: Handled main.swift
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-external-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: touch -t 201401240006 %t/*.o
+// RUN: touch -t 201401240004 %t/*-external
+// RUN: rm %t/main1-external
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// CHECK-FOURTH-NOT: Handled other.swift
+// CHECK-FOURTH: Handled main.swift
+// CHECK-FOURTH-NOT: Handled other.swift

--- a/test/Driver/Dependencies/one-way-external-delete.swift
+++ b/test/Driver/Dependencies/one-way-external-delete.swift
@@ -2,13 +2,13 @@
 // RUN: cp -r %S/Inputs/one-way-external/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
@@ -17,7 +17,7 @@
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: rm %t/other1-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-DAG: Handled other.swift
 // CHECK-THIRD-DAG: Handled main.swift
@@ -27,14 +27,14 @@
 // RUN: cp -r %S/Inputs/one-way-external/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
 // RUN: touch -t 201401240005 %t/*
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: rm %t/main1-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/one-way-external-fine.swift
+++ b/test/Driver/Dependencies/one-way-external-fine.swift
@@ -1,0 +1,52 @@
+/// other ==> main
+/// "./main1-external" ==> main
+/// "./main2-external" ==> main
+/// "./other1-external" ==> other
+/// "./other2-external" ==> other
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-external-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled
+
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: touch -t 201401240006 %t/*.o
+// RUN: touch -t 201401240004 %t/*-external
+// RUN: touch -t 203704010005 %t/other1-external
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD-DAG: Handled other.swift
+// CHECK-THIRD-DAG: Handled main.swift
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: touch -t 201401240006 %t/*.o
+// RUN: touch -t 201401240004 %t/*-external
+// RUN: touch -t 203704010005 %t/other2-external
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: touch -t 201401240006 %t/*.o
+// RUN: touch -t 201401240004 %t/*-external
+// RUN: touch -t 203704010005 %t/main1-external
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// CHECK-FOURTH-NOT: Handled other.swift
+// CHECK-FOURTH: Handled main.swift
+// CHECK-FOURTH-NOT: Handled other.swift
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: touch -t 201401240006 %t/*.o
+// RUN: touch -t 201401240004 %t/*-external
+// RUN: touch -t 203704010005 %t/main2-external
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s

--- a/test/Driver/Dependencies/one-way-external.swift
+++ b/test/Driver/Dependencies/one-way-external.swift
@@ -8,13 +8,13 @@
 // RUN: cp -r %S/Inputs/one-way-external/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
@@ -23,7 +23,7 @@
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/other1-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-DAG: Handled other.swift
 // CHECK-THIRD-DAG: Handled main.swift
@@ -32,14 +32,14 @@
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/other2-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 
 // RUN: touch -t 201401240005 %t/*
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/main1-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift
@@ -49,4 +49,4 @@
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/main2-external
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s

--- a/test/Driver/Dependencies/one-way-fine.swift
+++ b/test/Driver/Dependencies/one-way-fine.swift
@@ -1,0 +1,75 @@
+/// other ==> main
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD: Handled main.swift
+// CHECK-THIRD: Handled other.swift
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// CHECK-FOURTH-NOT: Handled other.swift
+// CHECK-FOURTH: Handled main.swift
+// CHECK-FOURTH-NOT: Handled other.swift
+
+// RUN: rm %t/main.o
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// RUN: rm %t/other.o
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIFTH %s
+
+// CHECK-FIFTH-NOT: Handled main.swift
+// CHECK-FIFTH: Handled other.swift
+// CHECK-FIFTH-NOT: Handled main.swift
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// Try modifying the inputs /backwards/ in time rather than forwards.
+// RUN: touch -t 201401240004 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// RUN: touch -t 201401240004 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
+
+// CHECK-REV-FIRST: Handled other.swift
+// CHECK-REV-FIRST: Handled main.swift
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-SECOND %s
+
+// CHECK-REV-SECOND-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FOURTH %s
+
+// CHECK-REV-FOURTH-NOT: Handled other.swift
+// CHECK-REV-FOURTH: Handled main.swift
+// CHECK-REV-FOURTH-NOT: Handled other.swift

--- a/test/Driver/Dependencies/one-way-merge-module-fine.swift
+++ b/test/Driver/Dependencies/one-way-merge-module-fine.swift
@@ -1,0 +1,18 @@
+/// other ==> main
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: Handled main.swift
+// CHECK-FIRST: Handled other.swift
+// CHECK-FIRST: Produced master.swiftmodule
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-NOT: warning
+// CHECK-SECOND-NOT: Handled
+// CHECK-SECOND: Produced master.swiftmodule

--- a/test/Driver/Dependencies/one-way-merge-module.swift
+++ b/test/Driver/Dependencies/one-way-merge-module.swift
@@ -4,14 +4,14 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 // CHECK-FIRST: Produced master.swiftmodule
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: warning
 // CHECK-SECOND-NOT: Handled

--- a/test/Driver/Dependencies/one-way-parallel-fine.swift
+++ b/test/Driver/Dependencies/one-way-parallel-fine.swift
@@ -1,0 +1,61 @@
+// Windows doesn't support parallel execution yet
+// XFAIL: windows
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "began"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: ".\/main.swift"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "finished"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: "output": "Handled main.swift\n"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "began"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: ".\/other.swift"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "finished"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: "output": "Handled other.swift\n"
+// CHECK-FIRST: {{^}$}}
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND: {{^{$}}
+// CHECK-SECOND: "kind": "began"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: ".\/other.swift"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND: {{^{$}}
+// CHECK-SECOND: "kind": "began"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: ".\/main.swift"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND: {{^{$}}
+// CHECK-SECOND: "kind": "finished"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: "output": "Handled {{other.swift|main.swift}}\n"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND: {{^{$}}
+// CHECK-SECOND: "kind": "finished"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: "output": "Handled {{main.swift|other.swift}}\n"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND-NOT: "skipped"

--- a/test/Driver/Dependencies/one-way-parallel.swift
+++ b/test/Driver/Dependencies/one-way-parallel.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
@@ -32,7 +32,7 @@
 // CHECK-FIRST: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j2 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: {{^{$}}
 // CHECK-SECOND: "kind": "began"

--- a/test/Driver/Dependencies/one-way-parseable-fine.swift
+++ b/test/Driver/Dependencies/one-way-parseable-fine.swift
@@ -1,0 +1,92 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "began"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: ".\/main.swift"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "finished"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "began"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: ".\/other.swift"
+// CHECK-FIRST: {{^}$}}
+
+// CHECK-FIRST: {{^{$}}
+// CHECK-FIRST: "kind": "finished"
+// CHECK-FIRST: "name": "compile"
+// CHECK-FIRST: "output": "Handled other.swift{{(\\r)?}}\n"
+// CHECK-FIRST: {{^}$}}
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND: {{^{$}}
+// CHECK-SECOND: "kind": "skipped"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: ".\/main.swift"
+// CHECK-SECOND: {{^}$}}
+
+// CHECK-SECOND: {{^{$}}
+// CHECK-SECOND: "kind": "skipped"
+// CHECK-SECOND: "name": "compile"
+// CHECK-SECOND: ".\/other.swift"
+// CHECK-SECOND: {{^}$}}
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD: {{^{$}}
+// CHECK-THIRD: "kind": "began"
+// CHECK-THIRD: "name": "compile"
+// CHECK-THIRD: ".\/main.swift"
+// CHECK-THIRD: {{^}$}}
+
+// CHECK-THIRD: {{^{$}}
+// CHECK-THIRD: "kind": "finished"
+// CHECK-THIRD: "name": "compile"
+// CHECK-THIRD: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-THIRD: {{^}$}}
+
+// CHECK-THIRD: {{^{$}}
+// CHECK-THIRD: "kind": "began"
+// CHECK-THIRD: "name": "compile"
+// CHECK-THIRD: ".\/other.swift"
+// CHECK-THIRD: {{^}$}}
+
+// CHECK-THIRD: {{^{$}}
+// CHECK-THIRD: "kind": "finished"
+// CHECK-THIRD: "name": "compile"
+// CHECK-THIRD: "output": "Handled other.swift{{(\\r)?}}\n"
+// CHECK-THIRD: {{^}$}}
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// CHECK-FOURTH: {{^{$}}
+// CHECK-FOURTH: "kind": "began"
+// CHECK-FOURTH: "name": "compile"
+// CHECK-FOURTH: ".\/main.swift"
+// CHECK-FOURTH: {{^}$}}
+
+// CHECK-FOURTH: {{^{$}}
+// CHECK-FOURTH: "kind": "finished"
+// CHECK-FOURTH: "name": "compile"
+// CHECK-FOURTH: "output": "Handled main.swift{{(\\r)?}}\n"
+// CHECK-FOURTH: {{^}$}}
+
+// CHECK-FOURTH: {{^{$}}
+// CHECK-FOURTH: "kind": "skipped"
+// CHECK-FOURTH: "name": "compile"
+// CHECK-FOURTH: ".\/other.swift"
+// CHECK-FOURTH: {{^}$}}

--- a/test/Driver/Dependencies/one-way-parseable.swift
+++ b/test/Driver/Dependencies/one-way-parseable.swift
@@ -2,7 +2,7 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: {{^{$}}
@@ -29,7 +29,7 @@
 // CHECK-FIRST: "output": "Handled other.swift{{(\\r)?}}\n"
 // CHECK-FIRST: {{^}$}}
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: {{^{$}}
 // CHECK-SECOND: "kind": "skipped"
@@ -44,7 +44,7 @@
 // CHECK-SECOND: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: {{^{$}}
 // CHECK-THIRD: "kind": "began"
@@ -71,7 +71,7 @@
 // CHECK-THIRD: {{^}$}}
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH: {{^{$}}
 // CHECK-FOURTH: "kind": "began"

--- a/test/Driver/Dependencies/one-way-provides-after-fine.swift
+++ b/test/Driver/Dependencies/one-way-provides-after-fine.swift
@@ -1,0 +1,48 @@
+/// other | main
+/// other +==> main
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/one-way-provides-after-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND-DAG: Handled other.swift
+// CHECK-SECOND-DAG: Handled main.swift
+
+// RUN: touch -t 201401240007 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/one-way-provides-after-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// RUN: touch -t 201401240007 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// RUN: touch -t 201401240008 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD-NOT: Handled other.swift
+// CHECK-THIRD: Handled main.swift
+// CHECK-THIRD-NOT: Handled other.swift

--- a/test/Driver/Dependencies/one-way-provides-after.swift
+++ b/test/Driver/Dependencies/one-way-provides-after.swift
@@ -6,42 +6,42 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-provides-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-DAG: Handled other.swift
 // CHECK-SECOND-DAG: Handled main.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-provides-after/* %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-provides-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240008 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled other.swift
 // CHECK-THIRD: Handled main.swift

--- a/test/Driver/Dependencies/one-way-provides-before-fine.swift
+++ b/test/Driver/Dependencies/one-way-provides-before-fine.swift
@@ -1,0 +1,52 @@
+/// other +==> main
+/// other | main
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-before-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/one-way-provides-before-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// CHECK-FIRST-NOT: warning
+// CHECK-FIRST-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+
+// CHECK-SECOND: Handled main.swift
+// CHECK-SECOND: Handled other.swift
+
+// RUN: touch -t 201401240007 %t/other.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+
+// CHECK-THIRD-NOT: Handled main.swift
+// CHECK-THIRD: Handled other.swift
+// CHECK-THIRD-NOT: Handled main.swift
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-before-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/one-way-provides-before-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+
+// RUN: touch -t 201401240006 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// RUN: touch -t 201401240007 %t/main.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+
+// CHECK-FOURTH-NOT: Handled other.swift
+// CHECK-FOURTH: Handled main.swift
+// CHECK-FOURTH-NOT: Handled other.swift

--- a/test/Driver/Dependencies/one-way-provides-before.swift
+++ b/test/Driver/Dependencies/one-way-provides-before.swift
@@ -6,24 +6,24 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-provides-before/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled main.swift
 // CHECK-SECOND: Handled other.swift
 
 // RUN: touch -t 201401240007 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD-NOT: Handled main.swift
 // CHECK-THIRD: Handled other.swift
@@ -34,18 +34,18 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-provides-before/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: touch -t 201401240007 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/one-way-while-editing-fine.swift
+++ b/test/Driver/Dependencies/one-way-while-editing-fine.swift
@@ -1,0 +1,34 @@
+/// other ==> main
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+
+// CHECK: Handled main.swift
+// CHECK: Handled other.swift
+// CHECK-NOT: error
+// CHECK: error: input file 'other.swift' was modified during the build
+// CHECK-NOT: error
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-RECOVER %s
+
+// CHECK-RECOVER: Handled main.swift
+// CHECK-RECOVER: Handled other.swift
+
+
+// RUN: touch -t 201401240005 %t/*
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED %s
+
+// CHECK-REVERSED: Handled other.swift
+// CHECK-REVERSED: Handled main.swift
+// CHECK-REVERSED-NOT: error
+// CHECK-REVERSED: error: input file 'main.swift' was modified during the build
+// CHECK-REVERSED-NOT: error
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED-RECOVER %s
+
+// CHECK-REVERSED-RECOVER-NOT: Handled other.swift
+// CHECK-REVERSED-RECOVER: Handled main.swift
+// CHECK-REVERSED-RECOVER-NOT: Handled other.swift

--- a/test/Driver/Dependencies/one-way-while-editing.swift
+++ b/test/Driver/Dependencies/one-way-while-editing.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s
 
 // CHECK: Handled main.swift
 // CHECK: Handled other.swift
@@ -12,14 +12,14 @@
 // CHECK: error: input file 'other.swift' was modified during the build
 // CHECK-NOT: error
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-RECOVER %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-RECOVER %s
 
 // CHECK-RECOVER: Handled main.swift
 // CHECK-RECOVER: Handled other.swift
 
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED %s
+// RUN: cd %t && not %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/modify-non-primary-files.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED %s
 
 // CHECK-REVERSED: Handled other.swift
 // CHECK-REVERSED: Handled main.swift
@@ -27,7 +27,7 @@
 // CHECK-REVERSED: error: input file 'main.swift' was modified during the build
 // CHECK-REVERSED-NOT: error
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED-RECOVER %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REVERSED-RECOVER %s
 
 // CHECK-REVERSED-RECOVER-NOT: Handled other.swift
 // CHECK-REVERSED-RECOVER: Handled main.swift

--- a/test/Driver/Dependencies/one-way.swift
+++ b/test/Driver/Dependencies/one-way.swift
@@ -4,34 +4,34 @@
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
 // CHECK-FIRST: Handled other.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // CHECK-FOURTH-NOT: Handled other.swift
 // CHECK-FOURTH: Handled main.swift
 // CHECK-FOURTH-NOT: Handled other.swift
 
 // RUN: rm %t/main.o
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 // RUN: rm %t/other.o
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIFTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIFTH %s
 
 // CHECK-FIFTH-NOT: Handled main.swift
 // CHECK-FIFTH: Handled other.swift
@@ -41,34 +41,34 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // Try modifying the inputs /backwards/ in time rather than forwards.
 // RUN: touch -t 201401240004 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 // RUN: touch -t 201401240004 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
 
 // CHECK-REV-FIRST: Handled other.swift
 // CHECK-REV-FIRST: Handled main.swift
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-SECOND %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-SECOND %s
 
 // CHECK-REV-SECOND-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/other.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s
 
 // RUN: touch -t 201401240006 %t/main.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FOURTH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FOURTH %s
 
 // CHECK-REV-FOURTH-NOT: Handled other.swift
 // CHECK-REV-FOURTH: Handled main.swift

--- a/test/Driver/Dependencies/private-after-fine.swift
+++ b/test/Driver/Dependencies/private-after-fine.swift
@@ -1,0 +1,54 @@
+/// a --> b ==> c | a ==> d |    e ==> b |       f ==> g
+/// a --> b ==> c | a ==> d +==> e +==> b, e --> f ==> g
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/private-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/private-after-fine/*.swiftdeps %t
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+
+// CHECK-INITIAL-NOT: warning
+// CHECK-INITIAL-NOT: Handled
+
+// RUN: touch -t 201401240006 %t/a.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/a.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
+// RUN: %FileCheck -check-prefix=CHECK-A-NEG %s < %t/a.txt
+
+// CHECK-A: Handled a.swift
+// CHECK-A-DAG: Handled b.swift
+// CHECK-A-DAG: Handled d.swift
+// CHECK-A: Handled e.swift
+// CHECK-A-DAG: Handled c.swift
+// CHECK-A-DAG: Handled f.swift
+// CHECK-A-NEG-NOT: Handled g.swift
+
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/private-after-fine/* %t
+// RUN: touch -t 201401240005 %t/*.swift
+
+// Generate the build record...
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
+
+// ...then reset the .swiftdeps files.
+// RUN: cp -r %S/Inputs/private-after-fine/*.swiftdeps %t
+
+// RUN: touch -t 201401240006 %t/f.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/f.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-F %s < %t/f.txt
+// RUN: %FileCheck -check-prefix=CHECK-F-NEG %s < %t/f.txt
+
+// CHECK-F: Handled f.swift
+// CHECK-F: Handled g.swift
+// CHECK-F-NEG-NOT: Handled a.swift
+// CHECK-F-NEG-NOT: Handled b.swift
+// CHECK-F-NEG-NOT: Handled c.swift
+// CHECK-F-NEG-NOT: Handled d.swift
+// CHECK-F-NEG-NOT: Handled e.swift

--- a/test/Driver/Dependencies/private-after.swift
+++ b/test/Driver/Dependencies/private-after.swift
@@ -6,18 +6,18 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/private-after/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL-NOT: Handled
 
 // RUN: touch -t 201401240006 %t/a.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/a.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/a.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
 // RUN: %FileCheck -check-prefix=CHECK-A-NEG %s < %t/a.txt
 
@@ -35,13 +35,13 @@
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v
 
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/private-after/*.swiftdeps %t
 
 // RUN: touch -t 201401240006 %t/f.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/f.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./g.swift -module-name main -j1 -v > %t/f.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-F %s < %t/f.txt
 // RUN: %FileCheck -check-prefix=CHECK-F-NEG %s < %t/f.txt
 

--- a/test/Driver/Dependencies/private-fine.swift
+++ b/test/Driver/Dependencies/private-fine.swift
@@ -1,0 +1,87 @@
+// a ==> b --> c ==> d | e ==> c
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/private-fine/* %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+
+// CHECK-INITIAL-NOT: warning
+// CHECK-INITIAL: Handled a.swift
+// CHECK-INITIAL: Handled b.swift
+// CHECK-INITIAL: Handled c.swift
+// CHECK-INITIAL: Handled d.swift
+// CHECK-INITIAL: Handled e.swift
+
+// RUN: touch -t 201401240006 %t/a.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/a.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
+// RUN: %FileCheck -check-prefix=CHECK-A-NEG %s < %t/a.txt
+
+// CHECK-A: Handled a.swift
+// CHECK-A-DAG: Handled b.swift
+// CHECK-A-DAG: Handled c.swift
+// CHECK-A-NEG-NOT: Handled d.swift
+// CHECK-A-NEG-NOT: Handled e.swift
+
+// RUN: touch -t 201401240006 %t/b.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/b.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-B %s < %t/b.txt
+// RUN: %FileCheck -check-prefix=CHECK-B-NEG %s < %t/b.txt
+
+// CHECK-B-NEG-NOT: Handled a.swift
+// CHECK-B: Handled b.swift
+// CHECK-B: Handled c.swift
+// CHECK-B-NEG-NOT: Handled d.swift
+// CHECK-B-NEG-NOT: Handled e.swift
+
+// RUN: touch -t 201401240006 %t/c.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/c.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-C %s < %t/c.txt
+// RUN: %FileCheck -check-prefix=CHECK-C-NEG %s < %t/c.txt
+
+// CHECK-C-NEG-NOT: Handled a.swift
+// CHECK-C-NEG-NOT: Handled b.swift
+// CHECK-C: Handled c.swift
+// CHECK-C: Handled d.swift
+// CHECK-C-NEG-NOT: Handled e.swift
+
+// RUN: touch -t 201401240006 %t/d.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/d.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-D %s < %t/d.txt
+// RUN: %FileCheck -check-prefix=CHECK-D-NEG %s < %t/d.txt
+
+// CHECK-D-NEG-NOT: Handled a.swift
+// CHECK-D-NEG-NOT: Handled b.swift
+// CHECK-D-NEG-NOT: Handled c.swift
+// CHECK-D: Handled d.swift
+// CHECK-D-NEG-NOT: Handled e.swift
+
+// RUN: touch -t 201401240006 %t/e.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/e.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-E %s < %t/e.txt
+// RUN: %FileCheck -check-prefix=CHECK-E-NEG %s < %t/e.txt
+
+// CHECK-E-NEG-NOT: Handled a.swift
+// CHECK-E-NEG-NOT: Handled b.swift
+// CHECK-E: Handled c.swift
+// CHECK-E-NEG-NOT: Handled a.swift
+// CHECK-E-NEG-NOT: Handled b.swift
+// CHECK-E: Handled d.swift
+// CHECK-E-NEG-NOT: Handled a.swift
+// CHECK-E-NEG-NOT: Handled b.swift
+// CHECK-E: Handled e.swift
+// CHECK-E-NEG-NOT: Handled a.swift
+// CHECK-E-NEG-NOT: Handled b.swift
+
+// RUN: touch -t 201401240007 %t/a.swift %t/e.swift
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/ae.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-AE %s < %t/ae.txt
+// RUN: %FileCheck -check-prefix=CHECK-AE-NEG %s < %t/ae.txt
+
+// CHECK-AE: Handled a.swift
+// CHECK-AE: Handled b.swift
+// CHECK-AE: Handled c.swift
+// CHECK-AE: Handled d.swift
+// CHECK-AE: Handled e.swift
+// CHECK-AE-NEG: Handled

--- a/test/Driver/Dependencies/private.swift
+++ b/test/Driver/Dependencies/private.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/private/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL-NOT: warning
 // CHECK-INITIAL: Handled a.swift
@@ -14,7 +14,7 @@
 // CHECK-INITIAL: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/a.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/a.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/a.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-A %s < %t/a.txt
 // RUN: %FileCheck -check-prefix=CHECK-A-NEG %s < %t/a.txt
 
@@ -25,7 +25,7 @@
 // CHECK-A-NEG-NOT: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/b.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/b.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/b.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-B %s < %t/b.txt
 // RUN: %FileCheck -check-prefix=CHECK-B-NEG %s < %t/b.txt
 
@@ -36,7 +36,7 @@
 // CHECK-B-NEG-NOT: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/c.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/c.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/c.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-C %s < %t/c.txt
 // RUN: %FileCheck -check-prefix=CHECK-C-NEG %s < %t/c.txt
 
@@ -47,7 +47,7 @@
 // CHECK-C-NEG-NOT: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/d.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/d.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/d.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-D %s < %t/d.txt
 // RUN: %FileCheck -check-prefix=CHECK-D-NEG %s < %t/d.txt
 
@@ -58,7 +58,7 @@
 // CHECK-D-NEG-NOT: Handled e.swift
 
 // RUN: touch -t 201401240006 %t/e.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/e.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/e.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-E %s < %t/e.txt
 // RUN: %FileCheck -check-prefix=CHECK-E-NEG %s < %t/e.txt
 
@@ -75,7 +75,7 @@
 // CHECK-E-NEG-NOT: Handled b.swift
 
 // RUN: touch -t 201401240007 %t/a.swift %t/e.swift
-// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/ae.txt 2>&1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v > %t/ae.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-AE %s < %t/ae.txt
 // RUN: %FileCheck -check-prefix=CHECK-AE-NEG %s < %t/ae.txt
 

--- a/test/Driver/SourceRanges/range-lifecycle.swift
+++ b/test/Driver/SourceRanges/range-lifecycle.swift
@@ -13,7 +13,7 @@
 // =============================================================================
 
 
-// RUN: cd %t && %swiftc_driver -enable-batch-mode -j2 -incremental -enable-source-range-dependencies -driver-compare-incremental-schemes-path=./comparo -driver-show-incremental -driver-show-job-lifecycle ./main.swift ./fileA.swift ./fileB.swift -module-name main -output-file-map %t/output.json    >& %t/output2
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -enable-batch-mode -j2 -incremental -enable-source-range-dependencies -driver-compare-incremental-schemes-path=./comparo -driver-show-incremental -driver-show-job-lifecycle ./main.swift ./fileA.swift ./fileB.swift -module-name main -output-file-map %t/output.json    >& %t/output2
 
 // RUN: tail -1 %t/comparo | %FileCheck -match-full-lines -check-prefix=CHECK-COMPARO-1 %s
 // CHECK-COMPARO-1: *** Incremental build disabled because different arguments passed to compiler, cannot compare ***
@@ -62,7 +62,7 @@
 // Steady-state: Now, do it again with no changes
 // =============================================================================
 
-// RUN: cd %t && %swiftc_driver -enable-batch-mode -j2 -incremental -enable-source-range-dependencies -driver-compare-incremental-schemes-path=./comparo -driver-show-incremental -driver-show-job-lifecycle ./main.swift ./fileA.swift ./fileB.swift -module-name main -output-file-map %t/output.json  >& %t/output3
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -enable-batch-mode -j2 -incremental -enable-source-range-dependencies -driver-compare-incremental-schemes-path=./comparo -driver-show-incremental -driver-show-job-lifecycle ./main.swift ./fileA.swift ./fileB.swift -module-name main -output-file-map %t/output.json  >& %t/output3
 
 // RUN: tail -1 %t/comparo | %FileCheck -match-full-lines -check-prefix=CHECK-COMPARO-2 %s
 // CHECK-COMPARO-2: *** Range benefit: 0 compilations, 0 stages, without ranges: 0, with ranges: 0, used ranges, total: 3 ***
@@ -100,7 +100,7 @@
 // =============================================================================
 
 // RUN: touch %t/*.swift
-// RUN: cd %t && %swiftc_driver -enable-batch-mode -j2 -incremental -enable-source-range-dependencies -driver-compare-incremental-schemes-path=./comparo -driver-show-incremental -driver-show-job-lifecycle ./main.swift ./fileA.swift ./fileB.swift -module-name main -output-file-map %t/output.json  >& %t/output4
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -enable-batch-mode -j2 -incremental -enable-source-range-dependencies -driver-compare-incremental-schemes-path=./comparo -driver-show-incremental -driver-show-job-lifecycle ./main.swift ./fileA.swift ./fileB.swift -module-name main -output-file-map %t/output.json  >& %t/output4
 
 
 // RUN: %FileCheck -match-full-lines -check-prefix=CHECK-COMPARO-3 %s < %t/comparo
@@ -139,7 +139,7 @@
 // =============================================================================
 
 // RUN: cp %t/fileB{1-internal-change,}.swift
-// RUN: cd %t && %swiftc_driver -driver-compare-incremental-schemes -enable-source-range-dependencies -output-file-map %t/output.json -incremental -enable-batch-mode ./main.swift ./fileA.swift ./fileB.swift -module-name main -j2 -driver-show-job-lifecycle -driver-show-incremental >& %t/output5
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-compare-incremental-schemes -enable-source-range-dependencies -output-file-map %t/output.json -incremental -enable-batch-mode ./main.swift ./fileA.swift ./fileB.swift -module-name main -j2 -driver-show-job-lifecycle -driver-show-incremental >& %t/output5
 
 // RUN: %FileCheck -match-full-lines -check-prefix=CHECK-INTERNAL-CHANGE  %s < %t/output5
 // CHECK-INTERNAL-CHANGE: Skipping <With ranges> : {compile: main.o <= main.swift}
@@ -154,7 +154,7 @@
 // =============================================================================
 
 // RUN: cp %t/fileB{2-external-change,}.swift
-// RUN: cd %t && %swiftc_driver -driver-compare-incremental-schemes -enable-source-range-dependencies -output-file-map %t/output.json -incremental -enable-batch-mode ./main.swift ./fileA.swift ./fileB.swift -module-name main -j2 -driver-show-job-lifecycle -driver-show-incremental >& %t/output6
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -driver-compare-incremental-schemes -enable-source-range-dependencies -output-file-map %t/output.json -incremental -enable-batch-mode ./main.swift ./fileA.swift ./fileB.swift -module-name main -j2 -driver-show-job-lifecycle -driver-show-incremental >& %t/output6
 
 
 // RUN: %FileCheck -match-full-lines -check-prefix=CHECK-EXTERNAL-CHANGE-1  %s < %t/output6

--- a/test/Driver/SourceRanges/range-sourcecomparator.swift
+++ b/test/Driver/SourceRanges/range-sourcecomparator.swift
@@ -14,7 +14,7 @@
 // The lack of a build record or swiftdeps files should disable incremental compilation
 // So, do one run just to build the build record
 
-// RUN: cd %t && %swiftc_driver -output-file-map %t/output.json -incremental -c ./in1.swift ./in2.swift ./in3.swift ./in4.swift ./in5.swift ./in6.swift -module-name main -incremental -enable-source-range-dependencies  -driver-skip-execution -driver-compare-incremental-schemes >& output
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -output-file-map %t/output.json -incremental -c ./in1.swift ./in2.swift ./in3.swift ./in4.swift ./in5.swift ./in6.swift -module-name main -incremental -enable-source-range-dependencies  -driver-skip-execution -driver-compare-incremental-schemes >& output
 
 // RUN: cp %S/Inputs/range-sourcecomparator/dummy.swiftdeps %t/in1.swiftdeps
 // RUN: cp %S/Inputs/range-sourcecomparator/dummy.swiftdeps %t/in2.swiftdeps
@@ -23,7 +23,7 @@
 // RUN: cp %S/Inputs/range-sourcecomparator/dummy.swiftdeps %t/in5.swiftdeps
 // RUN: cp %S/Inputs/range-sourcecomparator/dummy.swiftdeps %t/in6.swiftdeps
 
-// RUN: cd %t && %swiftc_driver -output-file-map %t/output.json -incremental -c ./in1.swift ./in2.swift ./in3.swift ./in4.swift ./in5.swift ./in6.swift -module-name main -incremental -enable-source-range-dependencies -driver-dump-compiled-source-diffs -driver-skip-execution -driver-compare-incremental-schemes >& output1
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -output-file-map %t/output.json -incremental -c ./in1.swift ./in2.swift ./in3.swift ./in4.swift ./in5.swift ./in6.swift -module-name main -incremental -enable-source-range-dependencies -driver-dump-compiled-source-diffs -driver-skip-execution -driver-compare-incremental-schemes >& output1
 
 
 // RUN: %FileCheck  %s <%t/output1 --match-full-lines

--- a/test/Driver/batch_mode_parseable_output-fine.swift
+++ b/test/Driver/batch_mode_parseable_output-fine.swift
@@ -1,0 +1,310 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift
+// RUN: echo 'public func main() {}' >%t/main.swift
+//
+// RUN: %swiftc_driver -enable-fine-grained-dependencies -enable-batch-mode -parseable-output -driver-skip-execution -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift 2>&1 | %FileCheck -check-prefix CHECK %s
+//
+//
+// CHECK: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "began",
+// CHECK-NEXT:   "name": "compile",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -c -primary-file {{.*}}/file-01.swift{{(\\")?}} {{.*}}file-02.swift{{(\\")?}} {{.*}}file-03.swift{{(\\")?}} {{.*}}main.swift{{(\\")?}} -emit-module-path {{.*}}file-01-[[MODULE01:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*}}file-01-[[SWIFTDOC01:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -enable-fine-grained-dependencies {{.*}} -module-name main -o {{.*}}file-01-[[OBJ01:[a-z0-9]+]].o{{(\\")?}}",
+// CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.exe)?}}",
+// CHECK-NEXT:   "command_arguments": [
+// CHECK-NEXT:     "-frontend",
+// CHECK-NEXT:     "-c",
+// CHECK-NEXT:     "-primary-file",
+// CHECK-NEXT:     "{{.*[\\/]}}file-01.swift",
+// CHECK-NEXT:     "{{.*[\\/]}}file-02.swift",
+// CHECK-NEXT:     "{{.*[\\/]}}file-03.swift",
+// CHECK-NEXT:     "{{.*[\\/]}}main.swift",
+// CHECK-NEXT:     "-emit-module-path",
+// CHECK-NEXT:     "{{.*[\\/]}}file-01-[[MODULE01:[a-z0-9]+]].swiftmodule",
+// CHECK-NEXT:     "-emit-module-doc-path",
+// CHECK-NEXT:     "{{.*[\\/]}}file-01-[[SWIFTDOC01:[a-z0-9]+]].swiftdoc",
+// CHECK:          "-enable-fine-grained-dependencies",
+// CHECK:          "-module-name",
+// CHECK-NEXT:     "main",
+// CHECK-NEXT:     "-o",
+// CHECK-NEXT:     "{{.*[\\/]}}file-01-[[OBJ01:[a-z0-9]+]].o"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "inputs": [
+// CHECK-NEXT:     "{{.*[\\/]}}file-01.swift"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "outputs": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "object",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-01-[[OBJ01]].o"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftmodule",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-01-[[MODULE01]].swiftmodule"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftdoc",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-01-[[SWIFTDOC01]].swiftdoc"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftsourceinfo",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-01-[[MODULE01]].swiftsourceinfo"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "pid": -{{[1-9][0-9]*}},
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "began",
+// CHECK-NEXT:   "name": "compile",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -c {{.*}}file-01.swift{{(\\")?}} -primary-file {{.*}}file-02.swift{{(\\")?}} {{.*}}file-03.swift{{(\\")?}} {{.*}}main.swift{{(\\")?}} -emit-module-path {{.*}}file-02-[[MODULE02:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*}}file-02-[[SWIFTDOC02:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -enable-fine-grained-dependencies {{.*}} -module-name main -o {{.*}}file-02-[[OBJ02:[a-z0-9]+]].o{{(\\")?}}",
+// CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}}",
+// CHECK-NEXT:   "command_arguments": [
+// CHECK-NEXT:     "-frontend",
+// CHECK-NEXT:     "-c",
+// CHECK-NEXT:     "{{.*[\\/]}}file-01.swift",
+// CHECK-NEXT:     "-primary-file",
+// CHECK-NEXT:     "{{.*[\\/]}}file-02.swift",
+// CHECK-NEXT:     "{{.*[\\/]}}file-03.swift",
+// CHECK-NEXT:     "{{.*[\\/]}}main.swift",
+// CHECK-NEXT:     "-emit-module-path",
+// CHECK-NEXT:     "{{.*[\\/]}}file-02-[[MODULE02:[a-z0-9]+]].swiftmodule",
+// CHECK-NEXT:     "-emit-module-doc-path",
+// CHECK-NEXT:     "{{.*[\\/]}}file-02-[[SWIFTDOC02:[a-z0-9]+]].swiftdoc",
+// CHECK:          "-enable-fine-grained-dependencies",
+// CHECK:          "-module-name",
+// CHECK-NEXT:     "main",
+// CHECK-NEXT:     "-o",
+// CHECK-NEXT:     "{{.*[\\/]}}file-02-[[OBJ02:[a-z0-9]+]].o"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "inputs": [
+// CHECK-NEXT:     "{{.*[\\/]}}file-02.swift"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "outputs": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "object",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-02-[[OBJ02]].o"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftmodule",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-02-[[MODULE02]].swiftmodule"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftdoc",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-02-[[SWIFTDOC02]].swiftdoc"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftsourceinfo",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-02-[[MODULE02]].swiftsourceinfo"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "pid": -{{[1-9][0-9]*}},
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "began",
+// CHECK-NEXT:   "name": "compile",
+// CHECK-NEXT:   "command": "{{.*}}swift{{c?(\.exe)?(\\")?}} -frontend -c {{.*}}file-01.swift{{(\\")?}} {{.*}}file-02.swift{{(\\")?}} -primary-file {{.*}}file-03.swift{{(\\")?}} {{.*}}main.swift{{(\\")?}} -emit-module-path {{.*}}file-03-[[MODULE03:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*}}file-03-[[SWIFTDOC03:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -enable-fine-grained-dependencies {{.*}} -module-name main -o {{.*}}file-03-[[OBJ03:[a-z0-9]+]].o{{(\\")?}}",
+// CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.exe)?}}",
+// CHECK-NEXT:   "command_arguments": [
+// CHECK-NEXT:     "-frontend",
+// CHECK-NEXT:     "-c",
+// CHECK-NEXT:     "{{.*}}/file-01.swift",
+// CHECK-NEXT:     "{{.*}}/file-02.swift",
+// CHECK-NEXT:     "-primary-file",
+// CHECK-NEXT:     "{{.*}}/file-03.swift",
+// CHECK-NEXT:     "{{.*}}/main.swift",
+// CHECK-NEXT:     "-emit-module-path",
+// CHECK-NEXT:     "{{.*[\\/]}}file-03-[[MODULE03:[a-z0-9]+]].swiftmodule",
+// CHECK-NEXT:     "-emit-module-doc-path",
+// CHECK-NEXT:     "{{.*[\\/]}}file-03-[[SWIFTDOC03:[a-z0-9]+]].swiftdoc",
+// CHECK:          "-enable-fine-grained-dependencies",
+// CHECK:          "-module-name",
+// CHECK-NEXT:     "main",
+// CHECK-NEXT:     "-o",
+// CHECK-NEXT:     "{{.*[\\/]}}file-03-[[OBJ03:[a-z0-9]+]].o"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "inputs": [
+// CHECK-NEXT:     "{{.*[\\/]}}file-03.swift"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "outputs": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "object",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-03-[[OBJ03]].o"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftmodule",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-03-[[MODULE03]].swiftmodule"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftdoc",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-03-[[SWIFTDOC03]].swiftdoc"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftsourceinfo",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}file-03-[[MODULE03]].swiftsourceinfo"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "pid": -{{[1-9][0-9]*}},
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "began",
+// CHECK-NEXT:   "name": "compile",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -c {{.*[\\/]}}file-01.swift{{(\\")?}} {{.*[\\/]}}file-02.swift{{(\\")?}} {{.*[\\/]}}file-03.swift{{(\\")?}} -primary-file {{.*[\\/]}}main.swift{{(\\")?}} -emit-module-path {{.*[\\/]}}main-[[MODULEMAIN:[a-z0-9]+]].swiftmodule{{(\\")?}} -emit-module-doc-path {{.*[\\/]}}main-[[SWIFTDOCMAIN:[a-z0-9]+]].swiftdoc{{(\\")?}} {{.*}} -enable-fine-grained-dependencies {{.*}} -module-name main -o {{.*[\\/]}}main-[[OBJMAIN:[a-z0-9]+]].o{{(\\")?}}",
+// CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.exe)?}}",
+// CHECK-NEXT:   "command_arguments": [
+// CHECK-NEXT:     "-frontend",
+// CHECK-NEXT:     "-c",
+// CHECK-NEXT:     "{{.*[\\/]}}file-01.swift",
+// CHECK-NEXT:     "{{.*[\\/]}}file-02.swift",
+// CHECK-NEXT:     "{{.*[\\/]}}file-03.swift",
+// CHECK-NEXT:     "-primary-file",
+// CHECK-NEXT:     "{{.*[\\/]}}main.swift",
+// CHECK-NEXT:     "-emit-module-path",
+// CHECK-NEXT:     "{{.*[\\/]}}main-[[MODULEMAIN:[a-z0-9]+]].swiftmodule",
+// CHECK-NEXT:     "-emit-module-doc-path",
+// CHECK-NEXT:     "{{.*[\\/]}}main-[[SWIFTDOCMAIN:[a-z0-9]+]].swiftdoc",
+// CHECK:          "-enable-fine-grained-dependencies",
+// CHECK:          "-module-name",
+// CHECK-NEXT:     "main",
+// CHECK-NEXT:     "-o",
+// CHECK-NEXT:     "{{.*[\\/]}}main-[[OBJMAIN:[a-z0-9]+]].o"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "inputs": [
+// CHECK-NEXT:     "{{.*[\\/]}}main.swift"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "outputs": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "object",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}main-[[OBJMAIN]].o"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftmodule",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}main-[[MODULEMAIN]].swiftmodule"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftdoc",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}main-[[SWIFTDOCMAIN]].swiftdoc"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftsourceinfo",
+// CHECK-NEXT:       "path": "{{.*[\\/]}}main-[[MODULEMAIN]].swiftsourceinfo"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "pid": -{{[1-9][0-9]*}},
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "finished",
+// CHECK-NEXT:   "name": "compile",
+// CHECK-NEXT:   "pid": -{{[1-9][0-9]*}},
+// CHECK-NEXT:   "output": "Output placeholder\n",
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   },
+// CHECK-NEXT:   "exit-status": 0
+// CHECK-NEXT: }
+// CHECK-NEXT: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "finished",
+// CHECK-NEXT:   "name": "compile",
+// CHECK-NEXT:   "pid": -{{[1-9][0-9]*}},
+// CHECK-NEXT:   "output": "Output placeholder\n",
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   },
+// CHECK-NEXT:   "exit-status": 0
+// CHECK-NEXT: }
+// CHECK-NEXT: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "finished",
+// CHECK-NEXT:   "name": "compile",
+// CHECK-NEXT:   "pid": -{{[1-9][0-9]*}},
+// CHECK-NEXT:   "output": "Output placeholder\n",
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   },
+// CHECK-NEXT:   "exit-status": 0
+// CHECK-NEXT: }
+// CHECK-NEXT: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "finished",
+// CHECK-NEXT:   "name": "compile",
+// CHECK-NEXT:   "pid": -{{[1-9][0-9]*}},
+// CHECK-NEXT:   "output": "Output placeholder\n",
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   },
+// CHECK-NEXT:   "exit-status": 0
+// CHECK-NEXT: }
+// CHECK-NEXT: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "began",
+// CHECK-NEXT:   "name": "merge-module",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift{{c?(\.exe)?(\\")?}} -frontend -merge-modules -emit-module {{.*[\\/]}}file-01-[[MODULE01]].swiftmodule{{(\\")?}} {{.*[\\/]}}file-02-[[MODULE02]].swiftmodule{{(\\")?}} {{.*[\\/]}}file-03-[[MODULE03]].swiftmodule{{(\\")?}} {{.*[\\/]}}main-[[MODULEMAIN]].swiftmodule{{(\\")?}} {{.*}} -emit-module-doc-path main.swiftdoc -emit-module-source-info-path main.swiftsourceinfo -module-name main -o main.swiftmodule",
+// CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{c?(\.exe)?}}",
+// CHECK-NEXT:   "command_arguments": [
+// CHECK-NEXT:     "-frontend",
+// CHECK-NEXT:     "-merge-modules",
+// CHECK-NEXT:     "-emit-module",
+// CHECK-NEXT:     "{{.*[\\/]}}file-01-[[MODULE01]].swiftmodule",
+// CHECK-NEXT:     "{{.*[\\/]}}file-02-[[MODULE02]].swiftmodule",
+// CHECK-NEXT:     "{{.*[\\/]}}file-03-[[MODULE03]].swiftmodule",
+// CHECK-NEXT:     "{{.*[\\/]}}main-[[MODULEMAIN]].swiftmodule",
+// CHECK:          "-emit-module-doc-path",
+// CHECK-NEXT:     "main.swiftdoc",
+// CHECK:          "-emit-module-source-info-path",
+// CHECK-NEXT:     "main.swiftsourceinfo",
+// CHECK-NEXT:     "-module-name",
+// CHECK-NEXT:     "main",
+// CHECK-NEXT:     "-o",
+// CHECK-NEXT:     "main.swiftmodule"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "inputs": [
+// CHECK-NEXT:     "{{.*[\\/]}}file-01-[[OBJ01]].o",
+// CHECK-NEXT:     "{{.*[\\/]}}file-02-[[OBJ02]].o",
+// CHECK-NEXT:     "{{.*[\\/]}}file-03-[[OBJ03]].o",
+// CHECK-NEXT:     "{{.*[\\/]}}main-[[OBJMAIN]].o"
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "outputs": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftmodule",
+// CHECK-NEXT:       "path": "main.swiftmodule"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftdoc",
+// CHECK-NEXT:       "path": "main.swiftdoc"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "type": "swiftsourceinfo",
+// CHECK-NEXT:       "path": "main.swiftsourceinfo"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "pid": {{[1-9][0-9]*}},
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "finished",
+// CHECK-NEXT:   "name": "merge-module",
+// CHECK-NEXT:   "pid": {{[1-9][0-9]*}},
+// CHECK-NEXT:   "output": "Output placeholder\n",
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": {{[1-9][0-9]*}}
+// CHECK-NEXT:   },
+// CHECK-NEXT:   "exit-status": 0
+// CHECK-NEXT: }

--- a/test/Driver/batch_mode_parseable_output.swift
+++ b/test/Driver/batch_mode_parseable_output.swift
@@ -2,7 +2,7 @@
 // RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift
 // RUN: echo 'public func main() {}' >%t/main.swift
 //
-// RUN: %swiftc_driver -enable-batch-mode -parseable-output -driver-skip-execution -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift 2>&1 | %FileCheck %s
+// RUN: %swiftc_driver -disable-fine-grained-dependencies -enable-batch-mode -parseable-output -driver-skip-execution -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift 2>&1 | %FileCheck %s
 //
 //
 // CHECK: {{[1-9][0-9]*}}

--- a/test/Frontend/dependencies-fine.swift
+++ b/test/Frontend/dependencies-fine.swift
@@ -1,0 +1,117 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-dependencies-path - -resolve-imports "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC %s
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-reference-dependencies-path - -typecheck -primary-file "%S/../Inputs/empty file.swift" > %t.swiftdeps
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-BASIC-YAML %s <%t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file "%S/../Inputs/empty file.swift"
+// RUN: %FileCheck -check-prefix=CHECK-BASIC %s < %t.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-BASIC-YAML %s < %t-processed.swiftdeps
+
+// CHECK-BASIC-LABEL: - :
+// CHECK-BASIC: Inputs/empty\ file.swift
+// CHECK-BASIC: Swift.swiftmodule
+// CHECK-BASIC-NOT: {{ }}:{{ }}
+
+// CHECK-BASIC-YAML-NOT: externalDepend {{.*}}empty
+// CHECK-BASIC-YAML: externalDepend {{.*}} '{{.*}}Swift.swiftmodule{{(/.+[.]swiftmodule)?}}'
+
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck "%S/../Inputs/empty file.swift" 2>&1 | %FileCheck -check-prefix=NO-PRIMARY-FILE %s
+
+// NO-PRIMARY-FILE: warning: ignoring -emit-reference-dependencies (requires -primary-file)
+
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-dependencies-path - -emit-module "%S/../Inputs/empty file.swift" -o "%t/empty file.swiftmodule" -emit-module-doc-path "%t/empty file.swiftdoc" -emit-objc-header-path "%t/empty file.h" -emit-module-interface-path "%t/empty file.swiftinterface" | %FileCheck -check-prefix=CHECK-MULTIPLE-OUTPUTS %s
+
+// CHECK-MULTIPLE-OUTPUTS-LABEL: empty\ file.swiftmodule :
+// CHECK-MULTIPLE-OUTPUTS: Inputs/empty\ file.swift
+// CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
+// CHECK-MULTIPLE-OUTPUTS-LABEL: empty\ file.swiftdoc :
+// CHECK-MULTIPLE-OUTPUTS: Inputs/empty\ file.swift
+// CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
+// CHECK-MULTIPLE-OUTPUTS-LABEL: empty\ file.swiftinterface :
+// CHECK-MULTIPLE-OUTPUTS: Inputs/empty\ file.swift
+// CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
+// CHECK-MULTIPLE-OUTPUTS-LABEL: empty\ file.h :
+// CHECK-MULTIPLE-OUTPUTS: Inputs/empty\ file.swift
+// CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
+// CHECK-MULTIPLE-OUTPUTS-NOT: {{ }}:{{ }}
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-fine-grained-dependencies -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-fine-grained-dependencies -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-fine-grained-dependencies -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file %s
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-IMPORT-YAML %s <%t-processed.swiftdeps
+
+// CHECK-IMPORT-LABEL: - :
+// CHECK-IMPORT: dependencies-fine.swift
+// CHECK-IMPORT-DAG: Swift.swiftmodule
+// CHECK-IMPORT-DAG: Inputs/dependencies/$$$$$$$$$$.h
+// CHECK-IMPORT-DAG: Inputs/dependencies{{/|\\}}UserClangModule.h
+// CHECK-IMPORT-DAG: Inputs/dependencies/extra-header.h
+// CHECK-IMPORT-DAG: Inputs/dependencies{{/|\\}}module.modulemap
+// CHECK-IMPORT-DAG: ObjectiveC.swift
+// CHECK-IMPORT-DAG: Foundation.swift
+// CHECK-IMPORT-DAG: CoreGraphics.swift
+// CHECK-IMPORT-NOT: {{[^\\]}}:
+
+// CHECK-IMPORT-TRACK-SYSTEM-LABEL: - :
+// CHECK-IMPORT-TRACK-SYSTEM: dependencies-fine.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Swift.swiftmodule
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: SwiftOnoneSupport.swiftmodule
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreFoundation.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreGraphics.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Foundation.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: ObjectiveC.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies/$$$$$$$$$$.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies{{/|\\}}UserClangModule.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies/extra-header.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies{{/|\\}}module.modulemap
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: swift{{/|\\}}shims{{/|\\}}module.modulemap
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr{{/|\\}}include{{/|\\}}CoreFoundation.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr{{/|\\}}include{{/|\\}}CoreGraphics.apinotes
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr{{/|\\}}include{{/|\\}}CoreGraphics.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr{{/|\\}}include{{/|\\}}Foundation.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr{{/|\\}}include{{/|\\}}objc{{/|\\}}NSObject.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr{{/|\\}}include{{/|\\}}objc{{/|\\}}ObjectiveC.apinotes
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr{{/|\\}}include{{/|\\}}objc{{/|\\}}module.map
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr{{/|\\}}include{{/|\\}}objc{{/|\\}}objc.h
+// CHECK-IMPORT-TRACK-SYSTEM-NOT: {{[^\\]}}:
+
+// CHECK-IMPORT-YAML-NOT: externalDepend {{.*}}dependencies-fine.swift
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\}}Swift.swiftmodule{{(/.+[.]swiftmodule)?}}'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies/$$$$$.h'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies{{/|\\\\}}UserClangModule.h'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies/extra-header.h'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies{{/|\\\\}}module.modulemap'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\\\}}ObjectiveC.swift'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\\\}}Foundation.swift'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\\\}}CoreGraphics.swift'
+
+// CHECK-ERROR-YAML: # Dependencies are unknown because a compilation error occurred.
+
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-fine-grained-dependencies -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-fine-grained-dependencies -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h  -typecheck -primary-file %s - %FileCheck -check-prefix=CHECK-ERROR-YAML %s
+
+
+import Foundation
+import UserClangModule
+
+class Test: NSObject {}
+
+_ = A()
+_ = USER_VERSION
+_ = EXTRA_VERSION
+_ = MONEY
+
+#if ERROR
+_ = someRandomUndefinedName
+#endif

--- a/test/Frontend/dependencies-preservation-fine.swift
+++ b/test/Frontend/dependencies-preservation-fine.swift
@@ -1,0 +1,29 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// This test verifies that copies of dependency files are preserved after a
+// compilation. For example, if the first compilation produces 'foo.swiftdeps',
+// a second compilation should move 'foo.swiftdeps' to 'foo.swiftdeps~', then
+// overwrite 'foo.swiftdeps' with new dependency information.
+
+// RUN: %empty-directory(%t)
+
+// First, produce the dependency files and verify their contents.
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file "%S/../Inputs/empty file.swift"
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK %s < %t-processed.swiftdeps
+
+// CHECK-NOT: topLevel{{.*}}EmptyStruct{{.*}}true
+
+// Next, produce the dependency files again, but this time using a different
+// Swift source file than before. .swiftdeps~ should contain the same content
+// as before. .swiftdeps should contain content that matches the new source
+// file.
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file %S/../Inputs/global_resilience.swift
+// RUN: %FileCheck -check-prefix=CHECK %s < %t.swiftdeps~
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-OVERWRITTEN %s < %t-processed.swiftdeps
+
+// CHECK-OVERWRITTEN:topLevel{{.*}}EmptyStruct{{.*}}true
+

--- a/test/Frontend/dependencies-preservation.swift
+++ b/test/Frontend/dependencies-preservation.swift
@@ -6,7 +6,7 @@
 // RUN: %empty-directory(%t)
 
 // First, produce the dependency files and verify their contents.
-// RUN: %target-swift-frontend -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file "%S/../Inputs/empty file.swift"
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file "%S/../Inputs/empty file.swift"
 // RUN: %FileCheck -check-prefix=CHECK %s < %t.swiftdeps
 
 // CHECK-LABEL: provides-top-level:
@@ -16,7 +16,7 @@
 // Swift source file than before. .swiftdeps~ should contain the same content
 // as before. .swiftdeps should contain content that matches the new source
 // file.
-// RUN: %target-swift-frontend -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file %S/../Inputs/global_resilience.swift
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file %S/../Inputs/global_resilience.swift
 // RUN: %FileCheck -check-prefix=CHECK %s < %t.swiftdeps~
 // RUN: %FileCheck -check-prefix=CHECK-OVERWRITTEN %s < %t.swiftdeps
 

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-dependencies-path - -resolve-imports "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC %s
-// RUN: %target-swift-frontend -emit-reference-dependencies-path - -typecheck -primary-file "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC-YAML %s
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-dependencies-path - -resolve-imports "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC %s
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-reference-dependencies-path - -typecheck -primary-file "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC-YAML %s
 
-// RUN: %target-swift-frontend -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file "%S/../Inputs/empty file.swift"
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file "%S/../Inputs/empty file.swift"
 // RUN: %FileCheck -check-prefix=CHECK-BASIC %s < %t.d
 // RUN: %FileCheck -check-prefix=CHECK-BASIC-YAML %s < %t.swiftdeps
 
@@ -18,12 +18,12 @@
 // CHECK-BASIC-YAML-NOT: {{:$}}
 
 
-// RUN: %target-swift-frontend -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck "%S/../Inputs/empty file.swift" 2>&1 | %FileCheck -check-prefix=NO-PRIMARY-FILE %s
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck "%S/../Inputs/empty file.swift" 2>&1 | %FileCheck -check-prefix=NO-PRIMARY-FILE %s
 
 // NO-PRIMARY-FILE: warning: ignoring -emit-reference-dependencies (requires -primary-file)
 
 
-// RUN: %target-swift-frontend -emit-dependencies-path - -emit-module "%S/../Inputs/empty file.swift" -o "%t/empty file.swiftmodule" -emit-module-doc-path "%t/empty file.swiftdoc" -emit-objc-header-path "%t/empty file.h" -emit-module-interface-path "%t/empty file.swiftinterface" | %FileCheck -check-prefix=CHECK-MULTIPLE-OUTPUTS %s
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-dependencies-path - -emit-module "%S/../Inputs/empty file.swift" -o "%t/empty file.swiftmodule" -emit-module-doc-path "%t/empty file.swiftdoc" -emit-objc-header-path "%t/empty file.h" -emit-module-interface-path "%t/empty file.swiftinterface" | %FileCheck -check-prefix=CHECK-MULTIPLE-OUTPUTS %s
 
 // CHECK-MULTIPLE-OUTPUTS-LABEL: empty\ file.swiftmodule :
 // CHECK-MULTIPLE-OUTPUTS: Inputs/empty\ file.swift
@@ -39,9 +39,9 @@
 // CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
 // CHECK-MULTIPLE-OUTPUTS-NOT: {{ }}:{{ }}
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-fine-grained-dependencies -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-fine-grained-dependencies -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-fine-grained-dependencies -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 // CHECK-IMPORT-LABEL: - :
 // CHECK-IMPORT: dependencies.swift
@@ -91,8 +91,8 @@
 // CHECK-IMPORT-YAML-NOT: {{^-}}
 // CHECK-IMPORT-YAML-NOT: {{:$}}
 
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT %s
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-fine-grained-dependencies -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-fine-grained-dependencies -DERROR -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 
 import Foundation

--- a/test/Inputs/process_fine_grained_swiftdeps.sh
+++ b/test/Inputs/process_fine_grained_swiftdeps.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Fine-grained swiftdeps files use multiple lines for each graph node.
+# Compress such a file so that each entry is one line of the form:
+# <kind> <aspect> <context> <name> <isProvides>
+# Also sort for consistency, since the node order can vary.
+
+awk '/kind:/ {k = $2}; /aspect:/ {a = $2}; /context:/ {c = $2}; /name/ {n = $2}; /sequenceNumber/ {s = $2}; /isProvides:/ {print k, a, c, n, $2}' | sort

--- a/test/NameBinding/Dependencies/private-function-fine.swift
+++ b/test/NameBinding/Dependencies/private-function-fine.swift
@@ -1,0 +1,19 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+private func testParamType(_: InterestingType) {}
+
+// CHECK-OLD: sil_global hidden @$s4main1x{{[^ ]+}} : ${{(@[a-zA-Z_]+ )?}}(Int) -> ()
+// CHECK-NEW: sil_global hidden @$s4main1x{{[^ ]+}} : ${{(@[a-zA-Z_]+ )?}}(Double) -> ()
+internal var x = testParamType
+
+// CHECK-DEPS: topLevel interface  '' InterestingType false

--- a/test/NameBinding/Dependencies/private-function-return-type-fine.swift
+++ b/test/NameBinding/Dependencies/private-function-return-type-fine.swift
@@ -1,0 +1,19 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+private func testReturnType() -> InterestingType { fatalError() }
+
+// CHECK-OLD: sil_global @$s4main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @$s4main1x{{[^ ]+}} : $Double
+public var x = testReturnType() + 0
+
+// CHECK-DEPS: topLevel interface  '' InterestingType false

--- a/test/NameBinding/Dependencies/private-function-return-type.swift
+++ b/test/NameBinding/Dependencies/private-function-return-type.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
 private func testReturnType() -> InterestingType { fatalError() }

--- a/test/NameBinding/Dependencies/private-function.swift
+++ b/test/NameBinding/Dependencies/private-function.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
 private func testParamType(_: InterestingType) {}

--- a/test/NameBinding/Dependencies/private-protocol-conformer-ext-fine.swift
+++ b/test/NameBinding/Dependencies/private-protocol-conformer-ext-fine.swift
@@ -1,0 +1,24 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+private struct Test {}
+extension Test : InterestingProto {}
+
+// CHECK-OLD: sil_global @$s4main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @$s4main1x{{[^ ]+}} : $Double
+public var x = Test().make() + 0
+
+// CHECK-DEPS-DAG: topLevel interface  '' InterestingProto false
+
+// CHECK-DEPS-DAG: member interface  4main{{8IntMaker|11DoubleMaker}}P make false
+
+// CHECK-DEPS-DAG: nominal interface  4main{{8IntMaker|11DoubleMaker}}P '' false

--- a/test/NameBinding/Dependencies/private-protocol-conformer-ext.swift
+++ b/test/NameBinding/Dependencies/private-protocol-conformer-ext.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
 private struct Test {}

--- a/test/NameBinding/Dependencies/private-protocol-conformer-fine.swift
+++ b/test/NameBinding/Dependencies/private-protocol-conformer-fine.swift
@@ -1,0 +1,23 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+private struct Test : InterestingProto {}
+
+// CHECK-OLD: sil_global @$s4main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @$s4main1x{{[^ ]+}} : $Double
+public var x = Test().make() + 0
+
+// CHECK-DEPS-DAG: topLevel interface  '' InterestingProto false
+
+// CHECK-DEPS-DAG: member interface  4main{{8IntMaker|11DoubleMaker}}P make false
+
+// CHECK-DEPS-DAG: nominal interface  4main{{8IntMaker|11DoubleMaker}}P '' false

--- a/test/NameBinding/Dependencies/private-protocol-conformer.swift
+++ b/test/NameBinding/Dependencies/private-protocol-conformer.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
 private struct Test : InterestingProto {}

--- a/test/NameBinding/Dependencies/private-struct-member-fine.swift
+++ b/test/NameBinding/Dependencies/private-struct-member-fine.swift
@@ -1,0 +1,21 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+private struct Wrapper {
+  static func test() -> InterestingType { fatalError() }
+}
+
+// CHECK-OLD: sil_global @$s4main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @$s4main1x{{[^ ]+}} : $Double
+public var x = Wrapper.test() + 0
+
+/// CHECK-DEPS: topLevel interface  '' InterestingType false

--- a/test/NameBinding/Dependencies/private-struct-member.swift
+++ b/test/NameBinding/Dependencies/private-struct-member.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
 private struct Wrapper {

--- a/test/NameBinding/Dependencies/private-subscript-fine.swift
+++ b/test/NameBinding/Dependencies/private-subscript-fine.swift
@@ -1,0 +1,21 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+struct Wrapper {
+  fileprivate subscript() -> InterestingType { fatalError() }
+}
+
+// CHECK-OLD: sil_global @$s4main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @$s4main1x{{[^ ]+}} : $Double
+public var x = Wrapper()[] + 0
+
+// CHECK-DEPS: topLevel interface  '' InterestingType false

--- a/test/NameBinding/Dependencies/private-subscript.swift
+++ b/test/NameBinding/Dependencies/private-subscript.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
 struct Wrapper {

--- a/test/NameBinding/Dependencies/private-typealias-fine.swift
+++ b/test/NameBinding/Dependencies/private-typealias-fine.swift
@@ -1,0 +1,21 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+private struct Wrapper {
+  static func test() -> InterestingType { fatalError() }
+}
+
+// CHECK-OLD: sil_global @$s4main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @$s4main1x{{[^ ]+}} : $Double
+public var x = Wrapper.test() + 0
+
+// CHECK-DEPS: topLevel interface  '' InterestingType false

--- a/test/NameBinding/Dependencies/private-typealias.swift
+++ b/test/NameBinding/Dependencies/private-typealias.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
 private struct Wrapper {

--- a/test/NameBinding/Dependencies/private-var-fine.swift
+++ b/test/NameBinding/Dependencies/private-var-fine.swift
@@ -1,0 +1,20 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+
+// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
+
+private var privateVar: InterestingType { fatalError() }
+
+// CHECK-OLD: sil_global @$s4main1x{{[^ ]+}} : $Int
+// CHECK-NEW: sil_global @$s4main1x{{[^ ]+}} : $Double
+public var x = privateVar + 0
+
+// CHECK-DEPS: topLevel interface '' InterestingType false

--- a/test/NameBinding/Dependencies/private-var.swift
+++ b/test/NameBinding/Dependencies/private-var.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
-// RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t.swiftdeps
 
 private var privateVar: InterestingType { fatalError() }

--- a/test/NameBinding/reference-dependencies-consistency-fine.swift
+++ b/test/NameBinding/reference-dependencies-consistency-fine.swift
@@ -1,0 +1,19 @@
+// Some types, such as StringLiteralType, used to be cached in the TypeChecker.
+// Consequently, the second primary file (in batch mode) to use that type would
+// hit in the cache and no dependency would be recorded.
+// This test ensures that this bug stays fixed.
+//
+// RUN: %empty-directory(%t)
+//
+// Create two identical inputs, each needing StringLiteralType:
+//
+// RUN: echo 'fileprivate var v: String { return "\(x)" }; fileprivate let x = "a"' >%t/1.swift
+// RUN: echo 'fileprivate var v: String { return "\(x)" }; fileprivate let x = "a"' >%t/2.swift
+//
+// RUN:  %target-swift-frontend -enable-fine-grained-dependencies -typecheck -primary-file %t/1.swift -primary-file %t/2.swift -emit-reference-dependencies-path %t/1.swiftdeps -emit-reference-dependencies-path %t/2.swiftdeps
+//
+// Sequence numbers can vary
+// RUN: sed -e 's/[0-9][0-9]*/N/g' -e 's/N, //g' -e '/^ *$/d' <%t/1.swiftdeps | sort >%t/1-processed.swiftdeps
+// RUN: sed -e 's/[0-9][0-9]*/N/g' -e 's/N, //g' -e '/^ *$/d' <%t/2.swiftdeps | sort >%t/2-processed.swiftdeps
+
+// RUN: cmp -s %t/1-processed.swiftdeps %t/2-processed.swiftdeps

--- a/test/NameBinding/reference-dependencies-consistency.swift
+++ b/test/NameBinding/reference-dependencies-consistency.swift
@@ -10,6 +10,6 @@
 // RUN: echo 'fileprivate var v: String { return "\(x)" }; fileprivate let x = "a"' >%t/1.swift
 // RUN: echo 'fileprivate var v: String { return "\(x)" }; fileprivate let x = "a"' >%t/2.swift
 //
-// RUN:  %target-swift-frontend -typecheck -primary-file %t/1.swift -primary-file %t/2.swift -emit-reference-dependencies-path %t/1.swiftdeps -emit-reference-dependencies-path %t/2.swiftdeps
+// RUN:  %target-swift-frontend -disable-fine-grained-dependencies -typecheck -primary-file %t/1.swift -primary-file %t/2.swift -emit-reference-dependencies-path %t/1.swiftdeps -emit-reference-dependencies-path %t/2.swiftdeps
 //
 // RUN: cmp -s %t/1.swiftdeps %t/2.swiftdeps

--- a/test/NameBinding/reference-dependencies-dynamic-lookup-fine.swift
+++ b/test/NameBinding/reference-dependencies-dynamic-lookup-fine.swift
@@ -1,0 +1,73 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-fine-grained-dependencies -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
+
+// Check that the output is deterministic.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-fine-grained-dependencies -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t-2.swiftdeps >%t-2-processed.swiftdeps
+// RUN: diff %t-processed.swiftdeps %t-2-processed.swiftdeps
+
+// RUN: %FileCheck %s < %t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=DUPLICATE %s < %t-processed.swiftdeps
+
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc @objcMembers class Base : NSObject {
+  // CHECK-DAG:  dynamicLookup implementation  '' foo true
+  // CHECK-DAG:  dynamicLookup interface  '' foo true
+  func foo() {}
+
+  // CHECK-DAG:  dynamicLookup implementation  '' bar true
+  // CHECK-DAG:  dynamicLookup interface  '' bar true
+
+  // DUPLICATE-NOT:  dynamicLookup implementation  '' bar true
+  // DUPLICATE:  dynamicLookup implementation  '' bar true
+  // DUPLICATE-NOT:  dynamicLookup implementation  '' bar true
+  // DUPLICATE-NOT:  dynamicLookup interface  '' bar true
+  // DUPLICATE:  dynamicLookup interface  '' bar true
+  // DUPLICATE-NOT:  dynamicLookup interface  '' bar true
+  func bar(_ x: Int, y: Int) {}
+  func bar(_ str: String) {}
+    
+  // CHECK-DAG:  dynamicLookup implementation  '' prop true
+  // CHECK-DAG:  dynamicLookup interface  '' prop true
+  var prop: String?
+
+  // CHECK-DAG:  dynamicLookup implementation  '' unusedProp true
+  // CHECK-DAG:  dynamicLookup interface  '' unusedProp true
+  var unusedProp: Int = 0
+  
+
+  // CHECK-DAG:  dynamicLookup implementation  '' classFunc true
+  // CHECK-DAG:  dynamicLookup interface  '' classFunc true
+  class func classFunc() {}
+}
+
+func getAnyObject() -> AnyObject? { return nil }
+
+func testDynamicLookup(_ obj: AnyObject) {
+  // CHECK-DAG:  dynamicLookup interface  '' description false
+  _ = obj.description
+  // CHECK-DAG:  dynamicLookup interface  '' method false
+  _ = obj.method(5, with: 5.0 as Double)
+  
+  // TODO: unable to resolve ambiguity
+  // C/HECK-DAG:  dynamicLookup interface  '' subscript false
+  // _ = obj[2] as Any
+  // _ = obj[2] as Any!
+}
+
+// CHECK-DAG:  dynamicLookup interface  '' counter false
+let globalUse = getAnyObject()?.counter
+
+// NEGATIVE-NOT:  dynamicLookup interface  '' cat1Method false
+// NEGATIVE-NOT:  dynamicLookup interface  '' unusedProp false

--- a/test/NameBinding/reference-dependencies-dynamic-lookup.swift
+++ b/test/NameBinding/reference-dependencies-dynamic-lookup.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-fine-grained-dependencies -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
 // RUN: %FileCheck %s < %t.swiftdeps
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftdeps
 // RUN: %FileCheck -check-prefix=DUPLICATE %s < %t.swiftdeps
 
 // Check that the output is deterministic.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-fine-grained-dependencies -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
 // RUN: diff %t.swiftdeps %t-2.swiftdeps
 
 // REQUIRES: objc_interop

--- a/test/NameBinding/reference-dependencies-fine.swift
+++ b/test/NameBinding/reference-dependencies-fine.swift
@@ -1,0 +1,545 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-helper.swift -emit-reference-dependencies-path - > %t.swiftdeps
+
+// Check that the output is deterministic.
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-helper.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
+
+// Merge each entry onto one line and sort to overcome order differences
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t-2.swiftdeps >%t-2-processed.swiftdeps
+// RUN: diff %t-processed.swiftdeps %t-2-processed.swiftdeps
+
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t-processed.swiftdeps
+// RUN: %FileCheck %s -check-prefix=CHECK-TOPLEVEL < %t-processed.swiftdeps
+// RUN: %FileCheck %s -check-prefix=CHECK-MEMBER < %t-processed.swiftdeps
+// RUN: %FileCheck %s -check-prefix=CHECK-NOMINAL < %t-processed.swiftdeps
+// RUN: %FileCheck %s -check-prefix=CHECK-NOMINAL-2 < %t-processed.swiftdeps
+// RUN: %FileCheck %s -check-prefix=CHECK-POTENTIALMEMBER < %t-processed.swiftdeps
+
+
+// CHECK-TOPLEVEL-DAG: topLevel interface '' IntWrapper true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' '==' true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' '<' true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' '***' true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' ^^^ true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' Subclass true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' MyArray true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' someGlobal true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' ExpressibleByExtraFloatLiteral true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' ThreeTilde true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' overloadedOnProto true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' FourTilde true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' FourTildeImpl true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' FiveTildeImpl true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' topLevelComputedProperty true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' lookUpManyTopLevelNames true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' testOperators true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' TopLevelForMemberLookup true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' lookUpMembers true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' publicUseOfMember true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' Outer true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' eof true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' '~~~' true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' '~~~~' true
+// CHECK-TOPLEVEL-DAG: topLevel interface '' '~~~~~' true
+
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' IntWrapper true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' '==' true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' '<' true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' '***' true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' ^^^ true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' Subclass true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' MyArray true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' someGlobal true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' ExpressibleByExtraFloatLiteral true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' ThreeTilde true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' overloadedOnProto true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' FourTilde true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' FourTildeImpl true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' FiveTildeImpl true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' topLevelComputedProperty true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' lookUpManyTopLevelNames true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' testOperators true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' TopLevelForMemberLookup true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' lookUpMembers true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' publicUseOfMember true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' Outer true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' eof true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' '~~~' true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' '~~~~' true
+// CHECK-TOPLEVEL-DAG: topLevel implementation  '' '~~~~~' true
+
+
+// CHECK-NOMINAL-DAG: nominal interface 4main10IntWrapperV '' true
+// CHECK-NOMINAL-DAG: nominal interface 4main10IntWrapperV16InnerForNoReasonV '' true
+// CHECK-NOMINAL-DAG: nominal interface 4main8SubclassC '' true
+// CHECK-NOMINAL-DAG: nominal interface Sb4mainE11InnerToBoolV '' true
+// CHECK-NOMINAL-DAG: nominal interface 4main9Sentinel1V '' true
+// CHECK-NOMINAL-DAG: nominal interface 4main9Sentinel2V '' true
+
+// CHECK-NOMINAL-DAG: nominal implementation  4main10IntWrapperV '' true
+// CHECK-NOMINAL-DAG: nominal implementation  4main10IntWrapperV16InnerForNoReasonV '' true
+// CHECK-NOMINAL-DAG: nominal implementation  4main8SubclassC '' true
+// CHECK-NOMINAL-DAG: nominal implementation  Sb4mainE11InnerToBoolV '' true
+// CHECK-NOMINAL-DAG: nominal implementation  4main9Sentinel1V '' true
+// CHECK-NOMINAL-DAG: nominal implementation  4main9Sentinel2V '' true
+
+
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface 4main10IntWrapperV '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface 4main10IntWrapperV16InnerForNoReasonV '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface 4main8SubclassC '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface s25ExpressibleByArrayLiteralP '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface Sb '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface Sb4mainE11InnerToBoolV '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface 4main9Sentinel1V '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface 4main9Sentinel2V '' true
+
+// CHECK-POTENTIALMEMBER-DAG: potentialMember implementation  4main10IntWrapperV '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember implementation  4main10IntWrapperV16InnerForNoReasonV '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember implementation  4main8SubclassC '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember implementation  s25ExpressibleByArrayLiteralP '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember implementation  Sb '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember implementation  Sb4mainE11InnerToBoolV '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember implementation  4main9Sentinel1V '' true
+// CHECK-POTENTIALMEMBER-DAG: potentialMember implementation  4main9Sentinel2V '' true
+
+
+// CHECK-MEMBER-DAG: member interface s25ExpressibleByArrayLiteralP useless true
+// CHECK-MEMBER-DAG: member interface s25ExpressibleByArrayLiteralP useless2 true
+// CHECK-MEMBER-DAG: member interface Sb InnerToBool true
+// CHECK-MEMBER-DAG: member interface {{.*[0-9]}}FourTildeImplV '~~~~' true
+// CHECK-MEMBER-DAG: member interface {{.*[0-9]}}FiveTildeImplV '~~~~~' true
+
+// CHECK-MEMBER-DAG: member implementation  s25ExpressibleByArrayLiteralP useless true
+// CHECK-MEMBER-DAG: member implementation  s25ExpressibleByArrayLiteralP useless2 true
+// CHECK-MEMBER-DAG: member implementation  Sb InnerToBool true
+// CHECK-MEMBER-DAG: member implementation  {{.*[0-9]}}FourTildeImplV '~~~~' true
+// CHECK-MEMBER-DAG: member implementation  {{.*[0-9]}}FiveTildeImplV '~~~~~' true
+
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' Comparable false
+
+struct IntWrapper: Comparable {
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' Int false
+  var value: Int
+
+  struct InnerForNoReason {}
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' TypeReferencedOnlyBySubscript false
+  subscript(_: TypeReferencedOnlyBySubscript) -> Void { return () }
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' TypeReferencedOnlyByPrivateSubscript false
+  private subscript(_: TypeReferencedOnlyByPrivateSubscript) -> Void { return () }
+}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' Bool false
+func ==(lhs: IntWrapper, rhs: IntWrapper) -> Bool {
+  return lhs.value == rhs.value
+}
+
+func <(lhs: IntWrapper, rhs: IntWrapper) -> Bool {
+  return lhs.value < rhs.value
+}
+
+// Test operator lookup without a use of the same operator.
+// This is declared in the other file.
+prefix func ***(lhs: IntWrapper) {}
+
+// This is provided as an operator but not implemented here.
+prefix operator ^^^
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' ClassFromOtherFile false
+class Subclass : ClassFromOtherFile {}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' Array false
+typealias MyArray = Array<Bool>
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' ExpressibleByArrayLiteral false
+extension ExpressibleByArrayLiteral {
+  func useless() {}
+}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' OtherFileElementType false
+extension ExpressibleByArrayLiteral where ArrayLiteralElement == OtherFileElementType {
+  func useless2() {}
+}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' IntegerLiteralType false
+let someGlobal = 42
+
+extension Bool {
+  struct InnerToBool {}
+}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' ExpressibleByOtherFileAliasForFloatLiteral false
+protocol ExpressibleByExtraFloatLiteral
+    : ExpressibleByOtherFileAliasForFloatLiteral {
+}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' ExpressibleByUnicodeScalarLiteral false
+private protocol ExpressibleByExtraCharLiteral : ExpressibleByUnicodeScalarLiteral {
+}
+
+prefix operator ~~~
+protocol ThreeTilde {
+  prefix static func ~~~(lhs: Self)
+}
+
+private struct ThreeTildeTypeImpl : ThreeTilde {
+}
+
+func overloadedOnProto<T>(_: T) {}
+func overloadedOnProto<T: ThreeTilde>(_: T) {}
+
+private prefix func ~~~(_: ThreeTildeTypeImpl) {}
+
+prefix operator ~~~~
+protocol FourTilde {
+  prefix static func ~~~~(arg: Self)
+}
+struct FourTildeImpl : FourTilde {}
+extension FourTildeImpl {
+  prefix static func ~~~~(arg: FourTildeImpl) {}
+}
+
+// ~~~~~ is declared in the other file.
+struct FiveTildeImpl {}
+extension FiveTildeImpl {
+  prefix static func ~~~~~(arg: FiveTildeImpl) {}
+}
+
+var topLevelComputedProperty: Bool {
+  return true
+}
+
+func lookUpManyTopLevelNames() {
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' Dictionary false
+  let _: Dictionary = [1:1]
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' UInt false
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' '+' false
+  let _: UInt = [1, 2].reduce(0, +)
+  
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' '-' false
+  let _: UInt = 3 - 2 - 1
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' AliasFromOtherFile false
+  let _: AliasFromOtherFile = 1
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' funcFromOtherFile false
+  funcFromOtherFile()
+
+  // "CInt" is not used as a top-level name here.
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' StringLiteralType false
+  // NEGATIVE-NOT: "CInt"
+  _ = "abc"
+
+  // NEGATIVE-NOT: - "max"
+  print(Int.max)
+
+  // NEGATIVE-NOT: - "Stride"
+  let _: Int.Stride = 0
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' OtherFileOuterType false
+  _ = OtherFileOuterType.InnerType.sharedConstant
+  _ = OtherFileOuterType.InnerType()
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' OtherFileAliasForSecret false
+  _ = OtherFileAliasForSecret.constant
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' otherFileUse false
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' otherFileGetImpl false
+  otherFileUse(otherFileGetImpl())
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' otherFileUseGeneric false
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' otherFileGetImpl2 false
+  otherFileUseGeneric(otherFileGetImpl2())
+  
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' getOtherFileIntArray false
+  for _ in getOtherFileIntArray() {}
+  
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' getOtherFileEnum false
+  switch getOtherFileEnum() {
+  case .Value:
+    break
+  default:
+    break
+  }
+
+  _ = .Value as OtherFileEnumWrapper.Enum
+  let _: OtherFileEnumWrapper.Enum = .Value
+  _ = OtherFileEnumWrapper.Enum.Value
+
+  _ = { (_: PrivateTopLevelStruct.ValueType) -> PrivateTopLevelStruct2.ValueType? in
+    return nil
+  }
+  
+  typealias X = OtherFileEnumWrapper.Enum
+  
+  let value: Any = .Value as X
+  switch value {
+  case is OtherFileEnumWrapper.Enum:
+    break
+  default:
+    break
+  }
+
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' '~=' false
+  switch 42 {
+  case 50:
+    break
+  default:
+    break
+  }
+  
+  for _: OtherFileEnumWrapper.Enum in EmptyIterator<X>() {}
+  
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' otherFileGetNonImpl false
+  overloadedOnProto(otherFileGetNonImpl())
+}
+
+func testOperators<T: Starry>(generic: T, specific: Flyswatter) {
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' '****' false
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' '*****' false
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' '******' false
+  ****generic
+  generic*****0
+  0******generic
+
+  ****specific
+  specific*****0
+  0******specific
+}
+
+// CHECK-NOMINAL-DAG: nominal interface 4main23TopLevelForMemberLookupV '' true
+// CHECK-NOMINAL-DAG: nominal implementation  4main23TopLevelForMemberLookupV '' true
+
+struct TopLevelForMemberLookup {
+  static func m1() {}
+  static func m2() {}
+  static func m3() {}
+}
+
+func lookUpMembers() {
+  TopLevelForMemberLookup.m1()
+  TopLevelForMemberLookup.m3()
+}
+public let publicUseOfMember: () = TopLevelForMemberLookup.m2()
+
+struct Outer {
+  struct Inner {
+    func method() {
+      // CHECK-TOPLEVEL-DAG: topLevel interface  '' CUnsignedInt false
+      let _: CUnsignedInt = 5
+    }
+  }
+}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' privateFunc false
+private func privateFunc() {}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' topLevel1 false
+var use1 = topLevel1()
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' topLevel2 false
+var use2 = { topLevel2() }
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' topLevel3 false
+var use3 = { ({ topLevel3() })() }
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' topLevel4 false
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelProto1 false
+struct Use4 : TopLevelProto1 {
+  var use4 = topLevel4()
+}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' '*' false
+_ = 42 * 30
+
+// FIXME: Incorrectly marked non-private dependencies
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' topLevel6 false
+_ = topLevel6()
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' topLevel7 false
+private var use7 = topLevel7()
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' topLevel8 false
+var use8: Int = topLevel8()
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' topLevel9 false
+var use9 = { () -> Int in return topLevel9() }
+
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelTy1 false
+func useTy1(_ x: TopLevelTy1) {}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelTy2 false
+func useTy2() -> TopLevelTy2 {}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelTy3 false
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelProto2 false
+extension Use4 : TopLevelProto2 {
+  var useTy3: TopLevelTy3? { return nil }
+}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelStruct false
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelStruct2 false
+let useTy4 = { (_: TopLevelStruct.ValueType) -> TopLevelStruct2.ValueType? in
+  return nil
+}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelStruct3 false
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelStruct4 false
+typealias useTy5 = TopLevelStruct3.ValueType
+let useTy6: TopLevelStruct4.ValueType = 0
+
+struct StructForDeclaringProperties {
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' TopLevelStruct5 false
+  var prop: TopLevelStruct5.ValueType { return 0 }
+}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' privateTopLevel1 false
+func private1(_ a: Int = privateTopLevel1()) {}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' privateTopLevel2 false
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' PrivateProto1 false
+private struct Private2 : PrivateProto1 {
+  var private2 = privateTopLevel2()
+}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' privateTopLevel3 false
+func outerPrivate3() {
+  let _ = { privateTopLevel3() }
+}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' PrivateTopLevelTy1 false
+private extension Use4 {
+  var privateTy1: PrivateTopLevelTy1? { return nil }
+} 
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' PrivateTopLevelTy2 false
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' PrivateProto2 false
+extension Private2 : PrivateProto2 {
+  // FIXME: This test is supposed to check that we get this behavior /without/
+  // marking the property private, just from the base type.
+  private var privateTy2: PrivateTopLevelTy2? { return nil }
+}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' PrivateTopLevelTy3 false
+func outerPrivateTy3() {
+  func inner(_ a: PrivateTopLevelTy3?) {}
+  inner(nil)
+}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' PrivateTopLevelStruct3 false
+private typealias PrivateTy4 = PrivateTopLevelStruct3.ValueType
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' PrivateTopLevelStruct4 false
+private func privateTy5(_ x: PrivateTopLevelStruct4.ValueType) -> PrivateTopLevelStruct4.ValueType {
+  return x
+}
+
+// Deliberately empty.
+private struct PrivateTy6 {}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' PrivateProto3 false
+extension PrivateTy6 : PrivateProto3 {}
+
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' ProtoReferencedOnlyInGeneric false
+func genericTest<T: ProtoReferencedOnlyInGeneric>(_: T) {}
+// CHECK-TOPLEVEL-DAG: topLevel interface  '' ProtoReferencedOnlyInPrivateGeneric false
+private func privateGenericTest<T: ProtoReferencedOnlyInPrivateGeneric>(_: T) {}
+
+struct PrivateStoredProperty {
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' TypeReferencedOnlyByPrivateVar false
+  private var value: TypeReferencedOnlyByPrivateVar
+}
+class PrivateStoredPropertyRef {
+  // CHECK-TOPLEVEL-DAG: topLevel interface  '' TypeReferencedOnlyByPrivateClassVar false
+  private var value: TypeReferencedOnlyByPrivateClassVar?
+}
+
+struct Sentinel1 {}
+
+private protocol ExtensionProto {}
+extension OtherFileTypeToBeExtended : ExtensionProto {
+  private func foo() {}
+}
+private extension OtherFileTypeToBeExtended {
+  var bar: Bool { return false }
+}
+
+struct Sentinel2 {}
+
+
+
+// CHECK-MEMBER-DAG: member interface  4main10IntWrapperV Int false
+// CHECK-MEMBER-DAG: member interface  4main10IntWrapperV deinit false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  SL '' false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  4main18ClassFromOtherFileC '' false
+// CHECK-MEMBER-DAG: member interface  Si max false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  s25ExpressibleByFloatLiteralP '' false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  s33ExpressibleByUnicodeScalarLiteralP '' false
+// CHECK-MEMBER-DAG: member interface  Sx Stride false
+// CHECK-MEMBER-DAG: member interface  Sa reduce false
+// CHECK-MEMBER-DAG: member interface  4main17OtherFileIntArrayV deinit false
+// CHECK-MEMBER-DAG: member interface  4main18OtherFileOuterTypeV InnerType false
+// CHECK-MEMBER-DAG: member interface  4main18OtherFileOuterTypeV05InnerE0V init false
+// CHECK-MEMBER-DAG: member interface  4main18OtherFileOuterTypeV05InnerE0V sharedConstant false
+// CHECK-MEMBER-DAG: member interface  4main26OtherFileSecretTypeWrapperV0dE0V constant false
+// CHECK-MEMBER-DAG: member interface  4main25OtherFileProtoImplementorV deinit false
+// CHECK-MEMBER-DAG: member interface  4main26OtherFileProtoImplementor2V deinit false
+// CHECK-MEMBER-DAG: member interface  s15EmptyCollectionV8IteratorV init false
+// CHECK-MEMBER-DAG: member interface  4main13OtherFileEnumO Value false
+// CHECK-MEMBER-DAG: member interface  4main20OtherFileEnumWrapperV Enum false
+
+// CHECK-MEMBER-DAG: member interface  4main14TopLevelStructV ValueType false
+// CHECK-MEMBER-DAG: member interface  4main15TopLevelStruct2V ValueType false
+// CHECK-MEMBER-DAG: member interface  4main15TopLevelStruct3V ValueType false
+// CHECK-MEMBER-DAG: member interface  4main15TopLevelStruct4V ValueType false
+// CHECK-MEMBER-DAG: member interface  4main15TopLevelStruct5V ValueType false
+// CHECK-MEMBER-DAG: member interface  4main21PrivateTopLevelStructV ValueType false
+// CHECK-MEMBER-DAG: member interface  4main22PrivateTopLevelStruct2V ValueType false
+// CHECK-MEMBER-DAG: member interface  4main22PrivateTopLevelStruct3V ValueType false
+// CHECK-MEMBER-DAG: member interface  4main22PrivateTopLevelStruct4V ValueType false
+
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  4main14TopLevelProto1P '' false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  4main14TopLevelProto2P '' false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  4main13PrivateProto1P '' false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  4main13PrivateProto2P '' false
+// CHECK-POTENTIALMEMBER-DAG: potentialMember interface  4main13PrivateProto3P '' false
+
+// CHECK-NOMINAL-2-DAG: nominal interface  Sa '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  Sb '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main18ClassFromOtherFileC '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  SL '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  s25ExpressibleByFloatLiteralP '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  s33ExpressibleByUnicodeScalarLiteralP '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main18OtherFileOuterTypeV05InnerE0V '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  Si '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main13OtherFileEnumO '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main20OtherFileEnumWrapperV '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main17OtherFileIntArrayV '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main18OtherFileOuterTypeV '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main25OtherFileProtoImplementorV '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main26OtherFileProtoImplementor2V '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main13PrivateProto1P '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main13PrivateProto2P '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main13PrivateProto3P '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main21PrivateTopLevelStructV '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main22PrivateTopLevelStruct2V '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main22PrivateTopLevelStruct3V '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main22PrivateTopLevelStruct4V '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main26OtherFileSecretTypeWrapperV0dE0V '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  Sx '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main14TopLevelProto1P '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main14TopLevelProto2P '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main14TopLevelStructV '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main15TopLevelStruct2V '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main15TopLevelStruct3V '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main15TopLevelStruct4V '' false
+// CHECK-NOMINAL-2-DAG: nominal interface  4main15TopLevelStruct5V '' false
+
+// String is not used anywhere in this file, though a string literal is.
+// NEGATIVE-NOT: "String"
+// These are used by the other file in this module, but not by this one.
+// NEGATIVE-NOT: "ExpressibleByFloatLiteral"
+// NEGATIVE-NOT: "Int16"
+// NEGATIVE-NOT: "OtherFileProto"
+// NEGATIVE-NOT: "OtherFileProtoImplementor"
+// NEGATIVE-NOT: "OtherFileProto2"
+// NEGATIVE-NOT: "OtherFileProtoImplementor2"
+
+// OtherFileSecretTypeWrapper is never used directly in this file.
+// NEGATIVE-NOT: "OtherFileSecretTypeWrapper"
+// NEGATIVE-NOT: "4main26OtherFileSecretTypeWrapperV"
+
+let eof: () = ()

--- a/test/NameBinding/reference-dependencies-members-fine.swift
+++ b/test/NameBinding/reference-dependencies-members-fine.swift
@@ -1,0 +1,70 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-members-helper.swift -emit-reference-dependencies-path - > %t.swiftdeps
+
+// RUN: %target-swift-frontend -enable-fine-grained-dependencies -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-members-helper.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t.swiftdeps >%t-processed.swiftdeps
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh <%t-2.swiftdeps >%t-2-processed.swiftdeps
+
+// RUN: diff %t-processed.swiftdeps %t-2-processed.swiftdeps
+
+// RUN: %FileCheck -check-prefix=PROVIDES-NOMINAL %s < %t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=PROVIDES-NOMINAL-2 %s < %t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=PROVIDES-NOMINAL-NEGATIVE %s < %t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=PROVIDES-MEMBER %s < %t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=PROVIDES-MEMBER-NEGATIVE %s < %t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=DEPENDS-NOMINAL %s < %t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=DEPENDS-MEMBER %s < %t-processed.swiftdeps
+// RUN: %FileCheck -check-prefix=DEPENDS-MEMBER-NEGATIVE %s < %t-processed.swiftdeps
+
+
+// PROVIDES-NOMINAL-DAG:  nominal implementation  4main4BaseC '' true
+// PROVIDES-NOMINAL-DAG:  nominal interface  4main4BaseC '' true
+class Base {
+  // PROVIDES-MEMBER-DAG:  potentialMember implementation  4main4BaseC '' true
+  // PROVIDES-MEMBER-DAG:  potentialMember interface  4main4BaseC '' true
+  // PROVIDES-MEMBER-NEGATIVE-NOT:  member {{.*}}  4main4BaseC {{[^']]+}} true
+  func foo() {}
+}
+  
+// PROVIDES-NOMINAL-DAG:  nominal implementation  4main3SubC '' true
+// PROVIDES-NOMINAL-DAG:  nominal interface  4main3SubC '' true
+// DEPENDS-NOMINAL-DAG:  nominal interface  4main9OtherBaseC '' false
+class Sub : OtherBase {
+  // PROVIDES-MEMBER-DAG:  potentialMember implementation  4main3SubC '' true
+  // PROVIDES-MEMBER-NEGATIVE-NOT:  {{potentialM|m}}}}ember implementation  4main3SubC {{.+}} true
+  // DEPENDS-MEMBER-DAG:  potentialMember interface  4main9OtherBaseC '' false
+  // DEPENDS-MEMBER-DAG:  member interface  4main9OtherBaseC foo false
+  // DEPENDS-MEMBER-DAG:  member interface  4main9OtherBaseC init false
+  func foo() {}
+}
+
+// PROVIDES-NOMINAL-DAG:  nominal implementation  4main9SomeProtoP '' true
+// PROVIDES-NOMINAL-DAG:  nominal interface  4main9SomeProtoP '' true
+// PROVIDES-MEMBER-DAG:  potentialMember interface  4main9SomeProtoP '' true
+protocol SomeProto {}
+
+// PROVIDES-NOMINAL-DAG:  nominal implementation  4main10OtherClassC '' true
+// PROVIDES-NOMINAL-2-DAG:  nominal interface  4main10OtherClassC '' true
+// PROVIDES-MEMBER-DAG:  potentialMember interface  4main10OtherClassC '' true
+// DEPENDS-MEMBER-DAG:  member interface  4main10OtherClassC deinit false
+extension OtherClass : SomeProto {}
+
+// PROVIDES-NOMINAL-NEGATIVE-NOT:  nominal implementation  4main11OtherStructV '' true
+// PROVIDES-NOMINAL-NEGATIVE-NOT:  nominal interface  4main11OtherStructV '' true
+// DEPENDS-NOMINAL-DAG:  nominal interface  4main11OtherStructV '' false
+extension OtherStruct {
+  // PROVIDES-MEMBER-DAG:  potentialMember interface  4main11OtherStructV '' true
+  // PROVIDES-MEMBER-DAG:  member interface  4main11OtherStructV foo true
+  // PROVIDES-MEMBER-DAG:  member interface  4main11OtherStructV bar true
+  // PROVIDES-MEMBER-NEGATIVE-NOT:  member interface  4main11OtherStructV baz true
+  // DEPENDS-MEMBER-DAG:  member interface  4main11OtherStructV baz false
+  // DEPENDS-MEMBER-NEGATIVE-NOT::  potentialMember interface  4main11OtherStructV baz false
+  func foo() {}
+  var bar: () { return () }
+  private func baz() {}
+}

--- a/test/NameBinding/reference-dependencies-members.swift
+++ b/test/NameBinding/reference-dependencies-members.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-members-helper.swift -emit-reference-dependencies-path - > %t.swiftdeps
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-members-helper.swift -emit-reference-dependencies-path - > %t.swiftdeps
 
 // Check that the output is deterministic.
-// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-members-helper.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-members-helper.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
 // RUN: diff %t.swiftdeps %t-2.swiftdeps
 
 // RUN: %FileCheck -check-prefix=PROVIDES-NOMINAL %s < %t.swiftdeps

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -1,11 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-helper.swift -emit-reference-dependencies-path - > %t.swiftdeps
-// RUN: %FileCheck %s < %t.swiftdeps
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-helper.swift -emit-reference-dependencies-path - > %t.swiftdeps
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftdeps
 
 // Check that the output is deterministic.
-// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-helper.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
+// RUN: %target-swift-frontend -disable-fine-grained-dependencies -typecheck -primary-file %t/main.swift %S/Inputs/reference-dependencies-helper.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
 // RUN: diff %t.swiftdeps %t-2.swiftdeps
 
 // CHECK-LABEL: {{^provides-top-level:$}}

--- a/unittests/Driver/CMakeLists.txt
+++ b/unittests/Driver/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_swift_unittest(SwiftDriverTests
   CoarseGrainedDependencyGraphTests.cpp
+  FineGrainedDependencyGraphTests.cpp
 )
 
 target_link_libraries(SwiftDriverTests
    PRIVATE
    swiftDriver
+   swiftClangImporter
+   swiftAST
 )

--- a/unittests/Driver/CoarseGrainedDependencyGraphTests.cpp
+++ b/unittests/Driver/CoarseGrainedDependencyGraphTests.cpp
@@ -165,9 +165,9 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent) {
   EXPECT_EQ(loadFromString(graph, 1, dependsTopLevel, "x, b, z"),
             LoadResult::UpToDate);
   {
-    auto marked = graph.markTransitive(0);
-    EXPECT_EQ(1u, marked.size());
-    EXPECT_EQ(1u, marked.front());
+    auto found = graph.markTransitive(0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_EQ(1u, found.front());
   }
     EXPECT_TRUE(graph.isMarked(0));
     EXPECT_TRUE(graph.isMarked(1));
@@ -186,9 +186,9 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependentReverse) {
             LoadResult::UpToDate);
 
   {
-  auto marked = graph.markTransitive(1);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(0u, marked.front());
+    auto found = graph.markTransitive(1);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_EQ(0u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -208,9 +208,9 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent2) {
 
 
   {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
+    auto found = graph.markTransitive(0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_EQ(1u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -231,9 +231,9 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent3) {
             LoadResult::UpToDate);
 
 {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(1u, found.size());
+  EXPECT_EQ(1u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -254,9 +254,9 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent4) {
             LoadResult::UpToDate);
 
 {
-  auto marked = graph.markTransitive( 0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(1u, found.size());
+  EXPECT_EQ(1u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -280,14 +280,14 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent5) {
 
 
 {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(1u, found.size());
+  EXPECT_EQ(1u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
 
-  auto marked = graph.markTransitive(0);
+  auto found = graph.markTransitive(0);
   EXPECT_EQ(0u, graph.markTransitive(0).size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -302,9 +302,9 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependent6) {
             LoadResult::UpToDate);
 
   {
-    auto marked = graph.markTransitive(0);
-    EXPECT_EQ(1u, marked.size());
-    EXPECT_EQ(1u, marked.front());
+    auto found = graph.markTransitive(0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_EQ(1u, found.front());
     }
     EXPECT_TRUE(graph.isMarked(0));
     EXPECT_TRUE(graph.isMarked(1));
@@ -326,9 +326,9 @@ TEST(CoarseGrainedDependencyGraph, SimpleDependentMember) {
             LoadResult::UpToDate);
 
 {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(1u, found.size());
+  EXPECT_EQ(1u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -355,10 +355,10 @@ TEST(CoarseGrainedDependencyGraph, MultipleDependentsSame) {
             LoadResult::UpToDate);
 
 {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(2u, marked.size());
-  EXPECT_TRUE(contains(marked, 1));
-  EXPECT_TRUE(contains(marked, 2));
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(2u, found.size());
+  EXPECT_TRUE(contains(found, 1));
+  EXPECT_TRUE(contains(found, 2));
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -381,10 +381,10 @@ TEST(CoarseGrainedDependencyGraph, MultipleDependentsDifferent) {
             LoadResult::UpToDate);
 
 {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(2u, marked.size());
-  EXPECT_TRUE(contains(marked, 1));
-  EXPECT_TRUE(contains(marked, 2));
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(2u, found.size());
+  EXPECT_TRUE(contains(found, 1));
+  EXPECT_TRUE(contains(found, 2));
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -410,10 +410,10 @@ TEST(CoarseGrainedDependencyGraph, ChainedDependents) {
 
 
 {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(2u, marked.size());
-  EXPECT_TRUE(contains(marked, 1));
-  EXPECT_TRUE(contains(marked, 2));
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(2u, found.size());
+  EXPECT_TRUE(contains(found, 1));
+  EXPECT_TRUE(contains(found, 2));
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -423,6 +423,52 @@ TEST(CoarseGrainedDependencyGraph, ChainedDependents) {
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
+}
+
+TEST(CoarseGrainedDependencyGraph, ChainedNoncascadingDependents) {
+  CoarseGrainedDependencyGraph<uintptr_t> graph;
+
+  EXPECT_EQ(loadFromString(graph, 0, providesNominal, "a, b, c"),
+            LoadResult::UpToDate);
+  EXPECT_EQ(
+      loadFromString(graph, 1, dependsNominal, "x, b", providesNominal, "z"),
+      LoadResult::UpToDate);
+  EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "!private z"),
+            LoadResult::UpToDate);
+  {
+    auto found = graph.markTransitive(0);
+    EXPECT_EQ(2u, found.size());
+    EXPECT_TRUE(contains(found, 1));
+    EXPECT_TRUE(contains(found, 2));
+  }
+  EXPECT_TRUE(graph.isMarked(0));
+  EXPECT_TRUE(graph.isMarked(1));
+  EXPECT_FALSE(graph.isMarked(2));
+
+  EXPECT_EQ(0u, graph.markTransitive(0).size());
+  EXPECT_TRUE(graph.isMarked(0));
+  EXPECT_TRUE(graph.isMarked(1));
+  EXPECT_FALSE(graph.isMarked(2));
+}
+
+TEST(CoarseGrainedDependencyGraph, ChainedNoncascadingDependents2) {
+  CoarseGrainedDependencyGraph<uintptr_t> graph;
+
+  EXPECT_EQ(loadFromString(graph, 0, providesTopLevel, "a, b, c"),
+            LoadResult::UpToDate);
+  EXPECT_EQ(loadFromString(graph, 1, dependsTopLevel, "x, !private b",
+                           providesNominal, "z"),
+            LoadResult::UpToDate);
+  EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "z"),
+            LoadResult::UpToDate);
+  {
+    auto found = graph.markTransitive(0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, 1));
+  }
+  EXPECT_TRUE(graph.isMarked(0));
+  EXPECT_FALSE(graph.isMarked(1));
+  EXPECT_FALSE(graph.isMarked(2));
 }
 
 TEST(CoarseGrainedDependencyGraph, MarkTwoNodes) {
@@ -448,10 +494,10 @@ TEST(CoarseGrainedDependencyGraph, MarkTwoNodes) {
       LoadResult::UpToDate);
 
 {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(2u, marked.size());
-  EXPECT_TRUE(contains(marked, 1));
-  EXPECT_TRUE(contains(marked, 2));
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(2u, found.size());
+  EXPECT_TRUE(contains(found, 1));
+  EXPECT_TRUE(contains(found, 2));
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -461,9 +507,9 @@ TEST(CoarseGrainedDependencyGraph, MarkTwoNodes) {
   EXPECT_FALSE(graph.isMarked(12));
 
 {
-  auto marked = graph.markTransitive(10);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(11u, marked.front());
+  auto found = graph.markTransitive(10);
+  EXPECT_EQ(1u, found.size());
+  EXPECT_EQ(11u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -485,9 +531,9 @@ TEST(CoarseGrainedDependencyGraph, MarkOneNodeTwice) {
 
 
 {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(1u, found.size());
+  EXPECT_EQ(1u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -498,9 +544,9 @@ TEST(CoarseGrainedDependencyGraph, MarkOneNodeTwice) {
             LoadResult::UpToDate);
 
  {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(2u, marked.front());
+   auto found = graph.markTransitive(0);
+   EXPECT_EQ(1u, found.size());
+   EXPECT_EQ(2u, found.front());
 }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -518,9 +564,9 @@ TEST(CoarseGrainedDependencyGraph, MarkOneNodeTwice2) {
             LoadResult::UpToDate);
 
 {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
+  auto found = graph.markTransitive(0);
+  EXPECT_EQ(1u, found.size());
+  EXPECT_EQ(1u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -531,10 +577,52 @@ TEST(CoarseGrainedDependencyGraph, MarkOneNodeTwice2) {
             LoadResult::UpToDate);
 
  {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(2u, marked.front());
+   auto found = graph.markTransitive(0);
+   EXPECT_EQ(1u, found.size());
+   EXPECT_EQ(2u, found.front());
   }
+  EXPECT_TRUE(graph.isMarked(0));
+  EXPECT_TRUE(graph.isMarked(1));
+  EXPECT_TRUE(graph.isMarked(2));
+}
+
+TEST(CoarseGrainedDependencyGraph, ReloadDetectsChange) {
+  CoarseGrainedDependencyGraph<uintptr_t> graph;
+
+  EXPECT_EQ(loadFromString(graph, 0, providesNominal, "a"),
+            LoadResult::UpToDate);
+  EXPECT_EQ(loadFromString(graph, 1, dependsNominal, "a"),
+            LoadResult::UpToDate);
+  EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "b"),
+            LoadResult::UpToDate);
+
+  {
+    const auto found = graph.markTransitive(1);
+    EXPECT_EQ(0u, found.size());
+  }
+  EXPECT_FALSE(graph.isMarked(0));
+  EXPECT_TRUE(graph.isMarked(1));
+  EXPECT_FALSE(graph.isMarked(2));
+
+  // Reload 1.
+  EXPECT_EQ(loadFromString(graph, 1, dependsNominal, "a", providesNominal, "b"),
+            LoadResult::UpToDate);
+
+  {
+    auto found = graph.markTransitive(0);
+    EXPECT_EQ(0u, found.size());
+  }
+  EXPECT_TRUE(graph.isMarked(0));
+  EXPECT_TRUE(graph.isMarked(1));
+  EXPECT_FALSE(graph.isMarked(2));
+
+  // Re-mark 1.
+  {
+    auto found = graph.markTransitive(1);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, 2));
+  }
+
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
   EXPECT_TRUE(graph.isMarked(2));
@@ -569,9 +657,9 @@ TEST(CoarseGrainedDependencyGraph, NotTransitiveOnceMarked) {
 
   // Re-mark 1.
   {
-  auto marked = graph.markTransitive(1);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(2u, marked.front());
+    auto found = graph.markTransitive(1);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_EQ(2u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -594,10 +682,10 @@ TEST(CoarseGrainedDependencyGraph, DependencyLoops) {
             LoadResult::UpToDate);
 
   {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(2u, marked.size());
-  EXPECT_TRUE(contains(marked, 1));
-  EXPECT_TRUE(contains(marked, 2));
+    auto found = graph.markTransitive(0);
+    EXPECT_EQ(2u, found.size());
+    EXPECT_TRUE(contains(found, 1));
+    EXPECT_TRUE(contains(found, 2));
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -622,9 +710,9 @@ TEST(CoarseGrainedDependencyGraph, MarkIntransitive) {
   EXPECT_FALSE(graph.isMarked(1));
 
   {
-  auto marked = graph.markTransitive(0);
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
+    auto found = graph.markTransitive(0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_EQ(1u, found.front());
   }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -730,9 +818,9 @@ TEST(CoarseGrainedDependencyGraph, ChainedExternalReverse) {
       LoadResult::UpToDate);
 
   {
-  auto marked = graph.markExternal("/bar");
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(1u, marked.front());
+    auto found = graph.markExternal("/bar");
+    EXPECT_EQ(1u, found.size());
+    EXPECT_EQ(1u, found.front());
   }
   EXPECT_FALSE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -742,9 +830,9 @@ TEST(CoarseGrainedDependencyGraph, ChainedExternalReverse) {
   EXPECT_TRUE(graph.isMarked(1));
 
 {
-  auto marked = graph.markExternal("/foo");
-  EXPECT_EQ(1u, marked.size());
-  EXPECT_EQ(0u, marked.front());
+  auto found = graph.markExternal("/foo");
+  EXPECT_EQ(1u, found.size());
+  EXPECT_EQ(0u, found.front());
 }
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_TRUE(graph.isMarked(1));
@@ -767,4 +855,58 @@ TEST(CoarseGrainedDependencyGraph, ChainedExternalPreMarked) {
   EXPECT_EQ(0u, graph.markExternal("/foo").size());
   EXPECT_TRUE(graph.isMarked(0));
   EXPECT_FALSE(graph.isMarked(1));
+}
+
+TEST(CoarseGrainedDependencyGraph, ChainedPrivateDoesNotCascade) {
+ CoarseGrainedDependencyGraph<uintptr_t> graph;
+  EXPECT_EQ(loadFromString(graph, 0,
+                           providesNominal, "z",
+                           dependsTopLevel, "!private a"),
+                           LoadResult::UpToDate);
+  EXPECT_EQ(loadFromString(graph, 1,
+                           providesTopLevel, "a"),
+                           LoadResult::UpToDate);
+  EXPECT_EQ(loadFromString(graph, 2,
+                           dependsNominal, "z"),
+                           LoadResult::UpToDate);
+
+  const auto nodes = graph.markTransitive(1); // compiled 1
+  EXPECT_EQ(nodes.size(), 1u); // need to compile 0 but not 2
+  EXPECT_TRUE(contains(nodes, 0));
+  EXPECT_FALSE(graph.isMarked(0));
+}
+
+TEST(CoarseGrainedDependencyGraph, CrashSimple) {
+ CoarseGrainedDependencyGraph<uintptr_t> graph;
+  EXPECT_EQ(loadFromString(graph, 0,
+                           providesTopLevel, "a"),
+                           LoadResult::UpToDate);
+  EXPECT_EQ(loadFromString(graph, 1,
+                           dependsTopLevel, "a"),
+                           LoadResult::UpToDate);
+  EXPECT_EQ(loadFromString(graph, 2,
+                           dependsTopLevel, "!private a"),
+                           LoadResult::UpToDate);
+
+  const auto nodes = graph.markTransitive(0);
+  EXPECT_EQ(nodes.size(), 2u); // need to compile 0 but not 2
+  EXPECT_TRUE(contains(nodes, 1));
+  EXPECT_TRUE(contains(nodes, 2));
+  EXPECT_TRUE(graph.isMarked(0));
+  EXPECT_TRUE(graph.isMarked(1));
+  EXPECT_FALSE(graph.isMarked(2));
+}
+
+
+TEST(CoarseGrainedDependencyGraph, MutualInterfaceHash) {
+ CoarseGrainedDependencyGraph<uintptr_t> graph;
+  loadFromString(graph, 0,
+                 providesTopLevel, "a",
+                 dependsTopLevel, "b");
+  loadFromString(graph, 1,
+                 dependsTopLevel, "a",
+                 providesTopLevel, "b");
+
+  const auto nodes = graph.markTransitive(0);
+  EXPECT_TRUE(contains(nodes, 1));
 }

--- a/unittests/Driver/FineGrainedDependencyGraphTests.cpp
+++ b/unittests/Driver/FineGrainedDependencyGraphTests.cpp
@@ -1,0 +1,936 @@
+#include "swift/Basic/ReferenceDependencyKeys.h"
+#include "swift/Driver/CoarseGrainedDependencyGraph.h"
+#include "swift/Driver/FineGrainedDependencyDriverGraph.h"
+#include "swift/Driver/Job.h"
+#include "gtest/gtest.h"
+
+// This file adapts the unit tests from the older, coarse-grained, dependency
+// graph to the new fine-grained graph.
+
+// \c markTransitive and \c markExternal may include jobs in their result
+// that would be excluded in the coarse-grained graph. But since these will be
+// jobs that have already been scheduled, downstream mechanisms will filter
+// them out.
+
+using namespace swift;
+using LoadResult = CoarseGrainedDependencyGraphImpl::LoadResult;
+using namespace reference_dependency_keys;
+using namespace fine_grained_dependencies;
+using Job = driver::Job;
+
+/// Initial underscore makes non-cascading, on member means private.
+static LoadResult
+simulateLoad(ModuleDepGraph &dg, const Job *cmd,
+             llvm::StringMap<std::vector<std::string>> simpleNames,
+             llvm::StringMap<std::vector<std::pair<std::string, std::string>>>
+                 compoundNames = {},
+             const bool includePrivateDeps = false,
+             const bool hadCompilationError = false) {
+  StringRef swiftDeps =
+      cmd->getOutput().getAdditionalOutputForType(file_types::TY_SwiftDeps);
+  assert(!swiftDeps.empty());
+  StringRef interfaceHash = swiftDeps;
+  auto sfdg = SourceFileDepGraph::simulateLoad(
+      swiftDeps, includePrivateDeps, hadCompilationError, interfaceHash,
+      simpleNames, compoundNames);
+
+  return dg.loadFromSourceFileDepGraph(cmd, sfdg);
+}
+
+static std::string noncascading(std::string name) {
+  std::string s{SourceFileDepGraph::noncascadingOrPrivatePrefix};
+  s += name;
+  return s;
+}
+
+LLVM_ATTRIBUTE_UNUSED
+static std::string privatize(std::string name) {
+  std::string s{SourceFileDepGraph::noncascadingOrPrivatePrefix};
+  s += name;
+  return s;
+}
+
+LLVM_ATTRIBUTE_UNUSED
+static std::vector<const Job *>
+printForDebugging(std::vector<const Job *> jobs) {
+  llvm::errs() << "\nprintForDebugging: ";
+  for (auto *j : jobs) {
+    const auto swiftDeps =
+        j->getOutput().getAdditionalOutputForType(file_types::TY_SwiftDeps);
+    assert(!swiftDeps.empty());
+    llvm::errs() << "job" << swiftDeps << ", ";
+  }
+  llvm::errs() << "\n";
+  return jobs;
+}
+
+static OutputFileMap OFM;
+
+static Job job0(OFM, "0"), job1(OFM, "1"), job2(OFM, "2"), job3(OFM, "3"),
+    job4(OFM, "4"), job5(OFM, "5"), job6(OFM, "6"), job7(OFM, "7"),
+    job8(OFM, "8"), job9(OFM, "9"), job10(OFM, "10"), job11(OFM, "11"),
+    job12(OFM, "12");
+
+template <typename Range, typename T>
+static bool contains(const Range &range, const T &value) {
+  return std::find(std::begin(range), std::end(range), value) !=
+         std::end(range);
+}
+
+TEST(ModuleDepGraph, BasicLoad) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsTopLevel, {"a", "b"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"c", "d"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{providesTopLevel, {"e", "f"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job3, {{providesNominal, {"g", "h"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job4, {{providesDynamicLookup, {"i", "j"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job5, {{dependsDynamicLookup, {"k", "l"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job6, {},
+                         {{providesMember, {{"m", "mm"}, {"n", "nn"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job7, {},
+                         {{dependsMember, {{"o", "oo"}, {"p", "pp"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job8, {{dependsExternal, {"/foo", "/bar"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(simulateLoad(graph, &job9,
+                         {{providesNominal, {"a", "b"}},
+                          {providesTopLevel, {"b", "c"}},
+                          {dependsNominal, {"c", "d"}},
+                          {dependsTopLevel, {"d", "a"}}}),
+            LoadResult::AffectsDownstream);
+}
+
+TEST(ModuleDepGraph, IndependentNodes) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0,
+                   {{dependsTopLevel, {"a"}}, {providesTopLevel, {"a0"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsTopLevel, {"b"}}, {providesTopLevel, {"b0"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job2,
+                   {{dependsTopLevel, {"c"}}, {providesTopLevel, {"c0"}}}),
+      LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Mark 0 again -- should be no change.
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job2).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, IndependentDepKinds) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, IndependentDepKinds2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsTopLevel, {"b"}}, {providesTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, IndependentMembers) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {}, {{providesMember, {{"a", "aa"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {}, {{dependsMember, {{"a", "bb"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {}, {{dependsMember, {{"a", ""}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job3, {}, {{dependsMember, {{"b", "aa"}}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job4, {}, {{dependsMember, {{"b", "bb"}}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+  EXPECT_FALSE(graph.isMarked(&job3));
+  EXPECT_FALSE(graph.isMarked(&job4));
+}
+
+TEST(ModuleDepGraph, SimpleDependent) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependentReverse) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{providesTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job1);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job0));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent3) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent4) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsNominal, {"a"}}, {dependsTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent5) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{providesNominal, {"a"}}, {providesTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsNominal, {"a"}}, {dependsTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  auto found = graph.markTransitive(&job0);
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependent6) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0, {{providesDynamicLookup, {"a", "b", "c"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1, {{dependsDynamicLookup, {"x", "b", "z"}}}),
+      LoadResult::AffectsDownstream);
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleDependentMember) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0, {},
+                   {{providesMember, {{"a", "aa"}, {"b", "bb"}, {"c", "cc"}}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1, {},
+                   {{dependsMember, {{"x", "xx"}, {"b", "bb"}, {"z", "zz"}}}}),
+      LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, MultipleDependentsSame) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"q", "b", "s"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+    EXPECT_TRUE(contains(found, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MultipleDependentsDifferent) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"q", "r", "c"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+    EXPECT_TRUE(contains(found, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedDependents) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsNominal, {"x", "b"}}, {providesNominal, {"z"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"z"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+    EXPECT_TRUE(contains(found, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedNoncascadingDependents) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsNominal, {"x", "b"}}, {providesNominal, {"z"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {noncascading("z")}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+    EXPECT_TRUE(contains(found, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ChainedNoncascadingDependents2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsTopLevel, {"x", noncascading("b")}}, {providesNominal, {"z"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"z"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MarkTwoNodes) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsTopLevel, {"a"}}, {providesTopLevel, {"z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsTopLevel, {"z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job10,
+                   {{providesTopLevel, {"y", "z"}}, {dependsTopLevel, {"q"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job11, {{dependsTopLevel, {"y"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job12,
+                         {{dependsTopLevel, {"q"}}, {providesTopLevel, {"q"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+    EXPECT_TRUE(contains(found, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+  EXPECT_FALSE(graph.isMarked(&job10));
+  EXPECT_FALSE(graph.isMarked(&job11));
+  EXPECT_FALSE(graph.isMarked(&job12));
+
+  {
+    auto found = graph.markTransitive(&job10);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job11));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+  EXPECT_TRUE(graph.isMarked(&job10));
+  EXPECT_TRUE(graph.isMarked(&job11));
+  EXPECT_FALSE(graph.isMarked(&job12));
+}
+
+TEST(ModuleDepGraph, MarkOneNodeTwice) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 0.
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MarkOneNodeTwice2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 0.
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a", "b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, ReloadDetectsChange) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    const auto found = graph.markTransitive(&job1);
+    EXPECT_EQ(0u, found.size());
+  }
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 1.
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(0u, found.size());
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Re-mark 1.
+  {
+    auto found = graph.markTransitive(&job1);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job2));
+  }
+
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, NotTransitiveOnceMarked) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsNominal, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job1).size());
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Reload 1.
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{dependsNominal, {"a"}}, {providesNominal, {"b"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+
+  // Re-mark 1.
+  {
+    auto found = graph.markTransitive(&job1);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, DependencyLoops) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0,
+                         {{providesTopLevel, {"a", "b", "c"}},
+                          {dependsTopLevel, {"a"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1,
+                         {{providesTopLevel, {"x"}},
+                          {dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job2, {{dependsTopLevel, {"x"}}}),
+            LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(2u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+    EXPECT_TRUE(contains(found, &job2));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_TRUE(graph.isMarked(&job2));
+}
+
+TEST(ModuleDepGraph, MarkIntransitive) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(graph.markIntransitive(&job0));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+
+  {
+    auto found = graph.markTransitive(&job0);
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, MarkIntransitiveTwice) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(graph.markIntransitive(&job0));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+
+  EXPECT_FALSE(graph.markIntransitive(&job0));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, MarkIntransitiveThenIndirect) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{providesTopLevel, {"a", "b", "c"}}}),
+            LoadResult::AffectsDownstream);
+  EXPECT_EQ(simulateLoad(graph, &job1, {{dependsTopLevel, {"x", "b", "z"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(graph.markIntransitive(&job1));
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markTransitive(&job0).size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, SimpleExternal) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsExternal, {"/foo", "/bar"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
+
+  EXPECT_EQ(1u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+}
+
+TEST(ModuleDepGraph, SimpleExternal2) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(simulateLoad(graph, &job0, {{dependsExternal, {"/foo", "/bar"}}}),
+            LoadResult::AffectsDownstream);
+
+  EXPECT_EQ(1u, graph.markExternal("/bar").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+
+  EXPECT_EQ(0u, graph.markExternal("/bar").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+}
+
+TEST(ModuleDepGraph, ChainedExternal) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0,
+                   {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
+  EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
+
+  EXPECT_EQ(2u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, ChainedExternalReverse) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0,
+                   {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+
+  {
+    auto found = graph.markExternal("/bar");
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job1));
+  }
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  EXPECT_EQ(0u, graph.markExternal("/bar").size());
+  EXPECT_FALSE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+
+  {
+    auto found = graph.markExternal("/foo");
+    EXPECT_EQ(1u, found.size());
+    EXPECT_TRUE(contains(found, &job0));
+  }
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, ChainedExternalPreMarked) {
+  ModuleDepGraph graph;
+
+  EXPECT_EQ(
+      simulateLoad(graph, &job0,
+                   {{dependsExternal, {"/foo"}}, {providesTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+  EXPECT_EQ(
+      simulateLoad(graph, &job1,
+                   {{dependsExternal, {"/bar"}}, {dependsTopLevel, {"a"}}}),
+      LoadResult::AffectsDownstream);
+
+  graph.markIntransitive(&job0);
+
+  EXPECT_EQ(0u, graph.markExternal("/foo").size());
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_FALSE(graph.isMarked(&job1));
+}
+
+TEST(ModuleDepGraph, ChainedPrivateDoesNotCascade) {
+  ModuleDepGraph graph;
+  simulateLoad(graph, &job0, {
+    {providesNominal, {"z"}},
+    {dependsTopLevel, {noncascading("a")}}
+  });
+  simulateLoad(graph, &job1, {{providesTopLevel, {"a"}}});
+  simulateLoad(graph, &job2, {{dependsNominal, {"z"}}});
+  
+  const auto jobs1 = graph.markTransitive(&job1);
+  EXPECT_EQ(1u, jobs1.size());
+  EXPECT_TRUE(contains(jobs1, &job0));
+  EXPECT_FALSE(graph.isMarked(&job0));
+}
+
+TEST(ModuleDepGraph, CrashSimple) {
+  ModuleDepGraph graph;
+  simulateLoad(graph, &job0, {
+    {providesTopLevel, {"a"}}
+  });
+  simulateLoad(graph, &job1, {{dependsTopLevel, {"a"}}});
+  simulateLoad(graph, &job2, {{dependsTopLevel, {privatize("a")}}});
+
+  const auto nodes = graph.markTransitive(&job0);
+  EXPECT_EQ(nodes.size(), 2u); // need to compile 0 but not 2
+  EXPECT_TRUE(contains(nodes, &job1));
+  EXPECT_TRUE(contains(nodes, &job2));
+  EXPECT_TRUE(graph.isMarked(&job0));
+  EXPECT_TRUE(graph.isMarked(&job1));
+  EXPECT_FALSE(graph.isMarked(&job2));
+}
+
+
+TEST(ModuleDepGraph, MutualInterfaceHash) {
+  ModuleDepGraph graph;
+  simulateLoad(graph, &job0, {
+    {providesTopLevel, {"a"}},
+    {dependsTopLevel, {"b"}}
+  });
+  simulateLoad(graph, &job1, {
+    {dependsTopLevel, {"a"}},
+    {providesTopLevel, {"b"}}
+  });
+
+  const auto nodes = graph.markTransitive(&job0);
+  EXPECT_TRUE(contains(nodes, &job1));
+}


### PR DESCRIPTION
Includes all fixes required, and tests, too, before turning on fine-grained-dependencies:

1. Better file header for fine-grained swiftdeps
2. Sorts jobs when scheduling for ease of testing
3. Fixes bugs in fine-grained transitive marking
4. Uses swiftdeps path from Job instead of the one in the fine-grained swiftdeps file. (Better for testing)
5. Does not try to read back swiftdeps (for assertion) when sent to stdout.
6. Fixes dependence on argument-evaluation order that caused a Windows bug in fine-grained dependency code
7. Fixes fine-grained issue writing empty name as underscore instead of empty string.
8. Moves where driver passed fine-grained options to frontend.
9. Fixes tests to also test fine-grained-dependencies, no matter which is the default:
  - adds -disable-fine-grained-dependencies flag to old tests, and
  - adds new tests for each such old test, named with "-fine" suffix and enabling fine grained dependencies.
10. Adds more dependency unit tests, and creates corresponding unit tests for fine-grained dependencies.

