### PR TITLE
[Build System: build-script] Version module.

### DIFF
--- a/utils/build_swift/build_swift/argparse/__init__.py
+++ b/utils/build_swift/build_swift/argparse/__init__.py
@@ -24,8 +24,8 @@ from argparse import ONE_OR_MORE, OPTIONAL, SUPPRESS, ZERO_OR_MORE
 
 from .actions import Action, Nargs
 from .parser import ArgumentParser
-from .types import (BoolType, ClangVersionType, CompilerVersion, PathType,
-                    RegexType, ShellSplitType, SwiftVersionType)
+from .types import (BoolType, ClangVersionType, PathType, RegexType,
+                    ShellSplitType, SwiftVersionType)
 
 
 __all__ = [
@@ -40,7 +40,6 @@ __all__ = [
     'RawDescriptionHelpFormatter',
     'RawTextHelpFormatter',
 
-    'CompilerVersion',
     'BoolType',
     'FileType',
     'PathType',

--- a/utils/build_swift/build_swift/argparse/types.py
+++ b/utils/build_swift/build_swift/argparse/types.py
@@ -19,14 +19,11 @@ import os.path
 import re
 import shlex
 
-import six
-
 from . import ArgumentTypeError
+from ..versions import Version
 
 
 __all__ = [
-    'CompilerVersion',
-
     'BoolType',
     'PathType',
     'RegexType',
@@ -34,31 +31,6 @@ __all__ = [
     'SwiftVersionType',
     'ShellSplitType',
 ]
-
-
-# -----------------------------------------------------------------------------
-
-class CompilerVersion(object):
-    """Wrapper type around compiler version strings.
-    """
-
-    def __init__(self, *components):
-        if len(components) == 1:
-            if isinstance(components[0], six.string_types):
-                components = components[0].split('.')
-            elif isinstance(components[0], (list, tuple)):
-                components = components[0]
-
-        if len(components) == 0:
-            raise ValueError('compiler version cannot be empty')
-
-        self.components = tuple(int(part) for part in components)
-
-    def __eq__(self, other):
-        return self.components == other.components
-
-    def __str__(self):
-        return '.'.join([six.text_type(part) for part in self.components])
 
 
 # -----------------------------------------------------------------------------
@@ -175,10 +147,8 @@ class ClangVersionType(RegexType):
             ClangVersionType.ERROR_MESSAGE)
 
     def __call__(self, value):
-        matches = super(ClangVersionType, self).__call__(value)
-        components = filter(lambda x: x is not None, matches.group(1, 2, 3, 5))
-
-        return CompilerVersion(components)
+        super(ClangVersionType, self).__call__(value)
+        return Version(value)
 
 
 class SwiftVersionType(RegexType):
@@ -195,10 +165,8 @@ class SwiftVersionType(RegexType):
             SwiftVersionType.ERROR_MESSAGE)
 
     def __call__(self, value):
-        matches = super(SwiftVersionType, self).__call__(value)
-        components = filter(lambda x: x is not None, matches.group(1, 2, 4))
-
-        return CompilerVersion(components)
+        super(SwiftVersionType, self).__call__(value)
+        return Version(value)
 
 
 class ShellSplitType(object):

--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -14,7 +14,7 @@ Default option value definitions.
 
 from __future__ import absolute_import, unicode_literals
 
-from .argparse import CompilerVersion
+from .versions import Version
 
 
 __all__ = [
@@ -42,8 +42,8 @@ BUILD_VARIANT = 'Debug'
 CMAKE_GENERATOR = 'Ninja'
 
 COMPILER_VENDOR = 'none'
-SWIFT_USER_VISIBLE_VERSION = CompilerVersion('5.2')
-CLANG_USER_VISIBLE_VERSION = CompilerVersion('7.0.0')
+SWIFT_USER_VISIBLE_VERSION = Version('5.2')
+CLANG_USER_VISIBLE_VERSION = Version('7.0.0')
 SWIFT_ANALYZE_CODE_COVERAGE = 'false'
 
 DARWIN_XCRUN_TOOLCHAIN = 'default'

--- a/utils/build_swift/build_swift/versions.py
+++ b/utils/build_swift/build_swift/versions.py
@@ -1,0 +1,210 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Version parsing classes.
+"""
+
+
+from __future__ import absolute_import, unicode_literals
+
+import functools
+
+import six
+
+
+__all__ = [
+    'InvalidVersionError',
+    'Version',
+]
+
+
+# -----------------------------------------------------------------------------
+# Version Parsing
+
+class _ComponentType(object):
+    """Poor-man's enum representing all valid version character groups.
+    """
+
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, other):
+        if not isinstance(other, _ComponentType):
+            return NotImplemented
+
+        return self.name == other.name
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    @classmethod
+    def _register(cls, name):
+        setattr(cls, name, cls(name))
+
+
+_ComponentType._register('ALPHA_LOWER')
+_ComponentType._register('ALPHA_UPPER')
+_ComponentType._register('DOT')
+_ComponentType._register('NUMERIC')
+_ComponentType._register('OTHER')
+
+
+def _get_component_type(component):
+    """Classifies a component into one of the registered component types.
+    """
+
+    if len(component) <= 0:
+        raise ValueError('Empty component')
+
+    if component == '.':
+        return _ComponentType.DOT
+
+    if component.isdigit():
+        return _ComponentType.NUMERIC
+
+    if component.isalpha():
+        if component.isupper():
+            return _ComponentType.ALPHA_UPPER
+        elif component.islower():
+            return _ComponentType.ALPHA_LOWER
+        else:
+            raise ValueError('Unknown component type for {!r}'.format(
+                component))
+
+    return _ComponentType.OTHER
+
+
+def _try_cast(obj, cls):
+    """Attempts to cast an object to a class, returning the resulting casted
+    object or the original object if the cast raises a ValueError.
+    """
+
+    try:
+        return cls(obj)
+    except ValueError:
+        return obj
+
+
+def _split_version(version):
+    """Splits a version string into a tuple of components using similar rules
+    to distutils.version.LooseVersion. All version strings are valid, but the
+    outcome will only split on boundries between:
+
+        * lowercase alpha characters
+        * uppercase alpha characters
+        * numeric characters
+        * the literal '.' (dot) character
+
+    All other characters are grouped into an "other" category.
+
+    Numeric components are converted into integers in the resulting tuple.
+
+    An empty tuple is returned for the empty string.
+
+    ```
+    >>> _split_version('1000.2.108')
+    (1000, 2, 28)
+
+    >>> _split_version('10A23b')
+    (10, 'A', 23, 'b')
+
+    >>> _split_version('10.23-beta4')
+    (10, 23, '-', 'beta', 4)
+
+    >>> _split_version('FOObarBAZqux')
+    ('FOO', 'bar', 'BAZ', 'qux')
+    ```
+    """
+
+    if len(version) < 1:
+        return tuple()
+
+    components = []
+
+    part = version[0]
+    part_type = _get_component_type(part)
+
+    for char in version[1:]:
+        char_type = _get_component_type(char)
+
+        if part_type == char_type:
+            part += char
+        else:
+            components.append(part)
+            part = char
+            part_type = char_type
+
+    # Add last part
+    components.append(part)
+
+    # Remove '.' groups and try casting components to ints
+    components = (_try_cast(c, int) for c in components if c != '.')
+
+    return tuple(components)
+
+
+# -----------------------------------------------------------------------------
+# Versions
+
+class InvalidVersionError(Exception):
+    """Error indicating an invalid version was encountered.
+    """
+
+    def __init__(self, version, msg=None):
+        self.version = version
+
+        if msg is None:
+            msg = 'Invalid version: {}'.format(self.version)
+
+        super(InvalidVersionError, self).__init__(msg)
+
+
+@functools.total_ordering
+class Version(object):
+    """Similar to the standard distutils.versons.LooseVersion, but with a
+    little more wiggle-room for alpha characters.
+    """
+
+    __slots__ = ('components', '_str')
+
+    def __init__(self, version):
+        version = six.text_type(version)
+
+        # Save the version string since it's impossible to reconstruct it from
+        # just the parsed components
+        self._str = version
+
+        # Parse version components
+        self.components = _split_version(version)
+
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            return NotImplemented
+
+        return self.components == other.components
+
+    # NOTE: Python 2 compatibility.
+    def __ne__(self, other):
+        return not self == other
+
+    def __lt__(self, other):
+        if not isinstance(other, Version):
+            return NotImplemented
+
+        return self.components < other.components
+
+    def __hash__(self):
+        return hash(self.components)
+
+    def __str__(self):
+        return self._str
+
+    def __repr__(self):
+        return '{}({!r})'.format(type(self).__name__, self._str)

--- a/utils/build_swift/tests/argparse/test_types.py
+++ b/utils/build_swift/tests/argparse/test_types.py
@@ -12,70 +12,12 @@ from __future__ import absolute_import, unicode_literals
 import os.path
 import platform
 
-import six
-
 from ..utils import TestCase
 from ...build_swift.argparse import ArgumentTypeError, types
+from ...build_swift.versions import Version
 
 
 # -----------------------------------------------------------------------------
-
-class TestCompilerVersion(TestCase):
-
-    def test_init_valid_value(self):
-        version = types.CompilerVersion(1, 0, 0, 1)
-        self.assertEqual(version.components, (1, 0, 0, 1))
-
-    def test_init_list(self):
-        version = types.CompilerVersion([1, 0, 0])
-        self.assertEqual(version.components, (1, 0, 0))
-
-        types.CompilerVersion([1, 0])
-        types.CompilerVersion([2, 3, 4])
-        types.CompilerVersion([3, 1, 4, 1, 5, 9])
-
-    def test_init_tuple(self):
-        version = types.CompilerVersion((1, 0, 0))
-        self.assertEqual(version.components, (1, 0, 0))
-
-        types.CompilerVersion((1, 0))
-        types.CompilerVersion((2, 3, 4))
-        types.CompilerVersion((3, 1, 4, 1, 5, 9))
-
-    def test_init_str(self):
-        version = types.CompilerVersion('1.0.0')
-        self.assertEqual(version.components, (1, 0, 0))
-
-        types.CompilerVersion('1.0')
-        types.CompilerVersion('2.3.4')
-        types.CompilerVersion('3.1.4.1.5.9')
-
-    def test_init_invalid_value(self):
-        with self.assertRaises(ValueError):
-            types.CompilerVersion()
-            types.CompilerVersion([])
-            types.CompilerVersion(())
-            types.CompilerVersion('')
-            types.CompilerVersion(True)
-            types.CompilerVersion('a')
-            types.CompilerVersion(dict())
-
-    def test_eq(self):
-        v1 = types.CompilerVersion('1.0.0')
-        v2 = types.CompilerVersion('1.2.4.8')
-
-        self.assertEqual(v1, v1)
-        self.assertEqual(v2, v2)
-        self.assertNotEqual(v1, v2)
-        self.assertNotEqual(v2, v1)
-
-    def test_str(self):
-        version = types.CompilerVersion('1.0.0')
-        self.assertEqual(six.text_type(version), '1.0.0')
-
-        version = types.CompilerVersion('1.0.0.1')
-        self.assertEqual(six.text_type(version), '1.0.0.1')
-
 
 class TestBoolType(TestCase):
 
@@ -206,11 +148,11 @@ class TestClangVersionType(TestCase):
         clang_version_type = types.ClangVersionType()
 
         version = clang_version_type('1.0.0')
-        self.assertIsInstance(version, types.CompilerVersion)
+        self.assertIsInstance(version, types.Version)
         self.assertEqual(version.components, (1, 0, 0))
 
         version = clang_version_type('1.0.0.1')
-        self.assertIsInstance(version, types.CompilerVersion)
+        self.assertIsInstance(version, types.Version)
         self.assertEqual(version.components, (1, 0, 0, 1))
 
         clang_version_type('1.0.0')
@@ -234,11 +176,11 @@ class TestSwiftVersionType(TestCase):
         swift_version_type = types.SwiftVersionType()
 
         version = swift_version_type('1.0')
-        self.assertIsInstance(version, types.CompilerVersion)
+        self.assertIsInstance(version, Version)
         self.assertEqual(version.components, (1, 0))
 
         version = swift_version_type('1.0.1')
-        self.assertIsInstance(version, types.CompilerVersion)
+        self.assertIsInstance(version, Version)
         self.assertEqual(version.components, (1, 0, 1))
 
         swift_version_type('1.0')

--- a/utils/build_swift/tests/test_versions.py
+++ b/utils/build_swift/tests/test_versions.py
@@ -1,0 +1,95 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from __future__ import absolute_import, unicode_literals
+
+import six
+
+from .utils import TestCase
+from ..build_swift.versions import Version
+
+
+class TestVersion(TestCase):
+    """Unit tests for the Version class.
+    """
+
+    VERSION_COMPONENTS = {
+        '': (),
+        'a': ('a',),
+        '0': (0,),
+        'a0': ('a', 0),
+        'a0b1': ('a', 0, 'b', 1),
+        '1.0': (1, 0),
+        '1.2.3': (1, 2, 3),
+        'foo': ('foo',),
+    }
+
+    # -------------------------------------------------------------------------
+    # Helpers
+
+    def assertVersionEqual(self, v1, v2):
+        v1 = Version(v1)
+        v2 = Version(v2)
+
+        self.assertEqual(v1, v2)
+        self.assertEqual(v2, v1)
+
+    def assertVersionNotEqual(self, v1, v2):
+        v1 = Version(v1)
+        v2 = Version(v2)
+
+        self.assertNotEqual(v1, v2)
+        self.assertNotEqual(v2, v1)
+
+    def assertVersionLess(self, v1, v2):
+        v1 = Version(v1)
+        v2 = Version(v2)
+
+        self.assertLess(v1, v2)
+        self.assertGreater(v2, v1)
+        self.assertNotEqual(v1, v2)
+
+    # -------------------------------------------------------------------------
+
+    def test_parse(self):
+        for string, components in six.iteritems(self.VERSION_COMPONENTS):
+            # Version parses
+            version = Version(string)
+
+            self.assertEqual(version.components, components)
+
+    def test_equal(self):
+        self.assertVersionEqual('', '')
+        self.assertVersionEqual('a', 'a')
+        self.assertVersionEqual('0', '0')
+        self.assertVersionEqual('a0', 'a0')
+        self.assertVersionEqual('1.0', '1.0')
+        self.assertVersionEqual('foo', 'foo')
+
+    def test_not_equal(self):
+        self.assertVersionNotEqual('a', 'b')
+        self.assertVersionNotEqual('0', '1')
+        self.assertVersionNotEqual('a', '0')
+        self.assertVersionNotEqual('0a', 'a0')
+        self.assertVersionNotEqual('1.0', '1.1')
+        self.assertVersionNotEqual('foo', 'bar')
+
+    def test_less_than(self):
+        self.assertVersionLess('0', '1')
+        self.assertVersionLess('a', 'b')
+        self.assertVersionLess('1.0', '1.1')
+        self.assertVersionLess('1a', '1b')
+        self.assertVersionLess('1aa', '1b')
+        self.assertVersionLess('a0b', 'a1')
+
+    def test_str(self):
+        for string in six.iterkeys(self.VERSION_COMPONENTS):
+            version = Version(string)
+
+            self.assertEqual(six.text_type(version), string)

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -16,7 +16,7 @@ import platform
 import unittest
 from argparse import Namespace
 
-from build_swift.build_swift.argparse import CompilerVersion
+from build_swift.build_swift.versions import Version
 
 from swift_build_support.cmake import CMake, CMakeOptions
 from swift_build_support.toolchain import host_toolchain
@@ -254,7 +254,7 @@ class CMakeTestCase(unittest.TestCase):
 
     def test_common_options_clang_compiler_version(self):
         args = self.default_args()
-        args.clang_compiler_version = CompilerVersion("999.0.999")
+        args.clang_compiler_version = Version("999.0.999")
         cmake = self.cmake(args)
         self.assertEqual(
             list(cmake.common_options()),
@@ -266,7 +266,7 @@ class CMakeTestCase(unittest.TestCase):
 
     def test_common_options_clang_user_visible_version(self):
         args = self.default_args()
-        args.clang_user_visible_version = CompilerVersion("9.0.0")
+        args.clang_user_visible_version = Version("9.0.0")
         cmake = self.cmake(args)
         self.assertEqual(
             list(cmake.common_options()),
@@ -301,8 +301,8 @@ class CMakeTestCase(unittest.TestCase):
         args.export_compile_commands = True
         args.distcc = True
         args.cmake_generator = 'Xcode'
-        args.clang_user_visible_version = CompilerVersion("9.0.0")
-        args.clang_compiler_version = CompilerVersion("999.0.900")
+        args.clang_user_visible_version = Version("9.0.0")
+        args.clang_compiler_version = Version("999.0.900")
         args.build_ninja = True
         cmake = self.cmake(args)
         self.assertEqual(


### PR DESCRIPTION
Add a new versions module to `build_swift` which provides the `Version` class. The `Version` class acts very similarly to `distutils.version.LooseVersion`, but with some more flexibility around character group boundaries.

Builds on changes in #29244