### PR TITLE
Fix build after removal of PointerUnion3/4

### DIFF
--- a/include/swift/AST/ClangNode.h
+++ b/include/swift/AST/ClangNode.h
@@ -48,8 +48,8 @@ class ClangNode {
   template <typename T>
   using Box = detail::ClangNodeBox<T>;
 
-  llvm::PointerUnion4<Box<clang::Decl>, Box<clang::MacroInfo>,
-                      Box<clang::ModuleMacro>, Box<clang::Module>> Ptr;
+  llvm::PointerUnion<Box<clang::Decl>, Box<clang::MacroInfo>,
+                     Box<clang::ModuleMacro>, Box<clang::Module>> Ptr;
 
 public:
   ClangNode() = default;

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -65,7 +65,7 @@ private:
     using type = Pattern;
   };
 
-  using ASTNodeTy = llvm::PointerUnion4<Stmt *, Expr *, Decl *, Pattern *>;
+  using ASTNodeTy = llvm::PointerUnion<Stmt *, Expr *, Decl *, Pattern *>;
 
 public:
   enum LocationKind : unsigned {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -749,8 +749,8 @@ struct Score {
 
 /// An AST node that can gain type information while solving.
 using TypedNode =
-    llvm::PointerUnion3<const Expr *, const TypeLoc *,
-                        const VarDecl *>;
+    llvm::PointerUnion<const Expr *, const TypeLoc *,
+                       const VarDecl *>;
 
 /// Display a score.
 llvm::raw_ostream &operator<<(llvm::raw_ostream &out, const Score &score);


### PR DESCRIPTION
Commit 2948ec5ca98f8593584f2117bc92fe8d75f6f098 removed the
PointerUnion3 and PointerUnion4 aliases and migrated everything
to the variadic template. Let's do the same here to get the
build running.