### PR TITLE
Fix Python 3.x error in Tuple.swift.gyb due concatenating "range + list"

### DIFF
--- a/stdlib/public/core/Tuple.swift.gyb
+++ b/stdlib/public/core/Tuple.swift.gyb
@@ -111,7 +111,7 @@ public func >=(lhs: (), rhs: ()) -> Bool {
 %   equatableTypeParams = ", ".join(["{}: Equatable".format(c) for c in typeParams])
 
 %   originalTuple = "(\"a\", {})".format(", ".join(map(str, range(1, arity))))
-%   greaterTuple = "(\"a\", {})".format(", ".join(map(str, range(1, arity - 1) + [arity])))
+%   greaterTuple = "(\"a\", {})".format(", ".join(map(str, list(range(1, arity - 1)) + [arity])))
 
 /// Returns a Boolean value indicating whether the corresponding components of
 /// two tuples are equal.


### PR DESCRIPTION
This was failing with the following error on my Python3 system:
```
FAILED: stdlib/public/core/8/Tuple.swift
cd /home/teemperor/work/swift/swift/stdlib/public/core && /usr/bin/cmake -E make_directory /home/teemperor/work/swift/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8 && /usr/bin/python /home/teemperor/work/swift/swift/utils/gyb -DunicodeGraphemeBreakPropertyFile=/home/teemperor/work/swift/swift/utils/UnicodeData/GraphemeBreakProperty.txt -DunicodeGraphemeBreakTestFile=/home/teemperor/work/swift/swift/utils/UnicodeData/GraphemeBreakTest.txt -DCMAKE_SIZEOF_VOID_P=8 -o /home/teemperor/work/swift/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Tuple.swift.tmp Tuple.swift.gyb && /usr/bin/cmake -E copy_if_different /home/teemperor/work/swift/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Tuple.swift.tmp /home/teemperor/work/swift/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Tuple.swift && /usr/bin/cmake -E remove /home/teemperor/work/swift/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Tuple.swift.tmp
Traceback (most recent call last):
  File "/home/teemperor/work/swift/swift/utils/gyb", line 3, in <module>
    gyb.main()
  File "/home/teemperor/work/swift/swift/utils/gyb.py", line 1263, in main
    args.target.write(execute_template(ast, args.line_directive, **bindings))
  File "/home/teemperor/work/swift/swift/utils/gyb.py", line 1131, in execute_template
    ast.execute(execution_context)
  File "/home/teemperor/work/swift/swift/utils/gyb.py", line 635, in execute
    x.execute(context)
  File "/home/teemperor/work/swift/swift/utils/gyb.py", line 721, in execute
    result = eval(self.code, context.local_bindings)
  File "/home/teemperor/work/swift/swift/stdlib/public/core/Tuple.swift.gyb", line 109, in <module>
    %   typeParams = [chr(ord("A") + i) for i in range(arity)]
  File "/home/teemperor/work/swift/swift/utils/gyb.py", line 635, in execute
    x.execute(context)
  File "/home/teemperor/work/swift/swift/utils/gyb.py", line 721, in execute
    result = eval(self.code, context.local_bindings)
  File "/home/teemperor/work/swift/swift/stdlib/public/core/Tuple.swift.gyb", line 114, in <module>
    %   greaterTuple = "(\"a\", {})".format(", ".join(map(str, range(1, arity - 1) + [arity])))
TypeError: unsupported operand type(s) for +: 'range' and 'list'
```

This commit just converts the range to a list so we can concatenate this on Python 3.x (where
the implicit conversion from range to list is no longer possible).
