### PR TITLE
[ConstraintSystem] Fix conversion of variadic/inout closure parameter…

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -942,3 +942,8 @@ class Foo<State: StateType> {
                        })
   }
 }
+
+// Make sure that `String...` is translated into `[String]` in the body
+func test_explicit_variadic_is_interpreted_correctly() {
+  _ = { (T: String...) -> String in T[0] + "" } // Ok
+}


### PR DESCRIPTION
…s for internal use

Delayed constraint generation for the body of the single-statement
closures regressed variadic parameter handling. Fix it by using
`FunctionType::Param::getParameterType` for "internal" version of
the parameter type which translates variadic/inout correctly.

Resolved: rdar://problem/58647769

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
