### PR TITLE
[AutoDiff] NFC: clang-format.

### DIFF
--- a/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/ADContext.h
@@ -130,8 +130,9 @@ public:
 
   /// Pops and returns a `differentiable_function` instruction from the
   /// worklist. Returns nullptr if the worklist is empty.
-  DifferentiableFunctionInst* popDifferentiableFunctionInstFromWorklist() {
-    if (differentiableFunctionInsts.empty()) return nullptr;
+  DifferentiableFunctionInst *popDifferentiableFunctionInstFromWorklist() {
+    if (differentiableFunctionInsts.empty())
+      return nullptr;
     return differentiableFunctionInsts.pop_back_val();
   }
 
@@ -206,8 +207,8 @@ public:
   /// TODO(TF-784): The pointer reuse is a real concern and the use of
   /// `CanonicalizeInstruction` may get rid of the need for this workaround.
   DifferentiableFunctionInst *createDifferentiableFunction(
-      SILBuilder &builder, SILLocation loc,
-      IndexSubset *parameterIndices, SILValue original,
+      SILBuilder &builder, SILLocation loc, IndexSubset *parameterIndices,
+      SILValue original,
       Optional<std::pair<SILValue, SILValue>> derivativeFunctions = None);
 
   // Given an `differentiable_function` instruction, finds the corresponding
@@ -216,9 +217,9 @@ public:
   DifferentiableFunctionExpr *
   findDifferentialOperator(DifferentiableFunctionInst *inst);
 
-  template <typename ...T, typename ...U>
+  template <typename... T, typename... U>
   InFlightDiagnostic diagnose(SourceLoc loc, Diag<T...> diag,
-                              U &&...args) const {
+                              U &&... args) const {
     return getASTContext().Diags.diagnose(loc, diag, std::forward<U>(args)...);
   }
 
@@ -226,33 +227,34 @@ public:
   /// parent function, emits a "not differentiable" error based on the task. If
   /// the task is indirect, emits notes all the way up to the outermost task,
   /// and emits an error at the outer task. Otherwise, emits an error directly.
-  template<typename ...T, typename ...U>
-  InFlightDiagnostic emitNondifferentiabilityError(
-      SILInstruction *inst, DifferentiationInvoker invoker,
-      Diag<T...> diag, U &&...args);
+  template <typename... T, typename... U>
+  InFlightDiagnostic
+  emitNondifferentiabilityError(SILInstruction *inst,
+                                DifferentiationInvoker invoker, Diag<T...> diag,
+                                U &&... args);
 
   /// Given a value and a differentiation task associated with the parent
   /// function, emits a "not differentiable" error based on the task. If the
   /// task is indirect, emits notes all the way up to the outermost task, and
   /// emits an error at the outer task. Otherwise, emits an error directly.
-  template<typename ...T, typename ...U>
-  InFlightDiagnostic emitNondifferentiabilityError(
-      SILValue value, DifferentiationInvoker invoker,
-      Diag<T...> diag, U &&...args);
+  template <typename... T, typename... U>
+  InFlightDiagnostic
+  emitNondifferentiabilityError(SILValue value, DifferentiationInvoker invoker,
+                                Diag<T...> diag, U &&... args);
 
   /// Emit a "not differentiable" error based on the given differentiation task
   /// and diagnostic.
-  template<typename ...T, typename ...U>
-  InFlightDiagnostic emitNondifferentiabilityError(
-      SourceLoc loc, DifferentiationInvoker invoker,
-      Diag<T...> diag, U &&...args);
+  template <typename... T, typename... U>
+  InFlightDiagnostic
+  emitNondifferentiabilityError(SourceLoc loc, DifferentiationInvoker invoker,
+                                Diag<T...> diag, U &&... args);
 };
 
-template<typename ...T, typename ...U>
+template <typename... T, typename... U>
 InFlightDiagnostic
 ADContext::emitNondifferentiabilityError(SILValue value,
                                          DifferentiationInvoker invoker,
-                                         Diag<T...> diag, U &&...args) {
+                                         Diag<T...> diag, U &&... args) {
   LLVM_DEBUG({
     getADDebugStream() << "Diagnosing non-differentiability.\n";
     getADDebugStream() << "For value:\n" << value;
@@ -267,11 +269,11 @@ ADContext::emitNondifferentiabilityError(SILValue value,
                                        std::forward<U>(args)...);
 }
 
-template<typename ...T, typename ...U>
+template <typename... T, typename... U>
 InFlightDiagnostic
 ADContext::emitNondifferentiabilityError(SILInstruction *inst,
                                          DifferentiationInvoker invoker,
-                                         Diag<T...> diag, U &&...args) {
+                                         Diag<T...> diag, U &&... args) {
   LLVM_DEBUG({
     getADDebugStream() << "Diagnosing non-differentiability.\n";
     getADDebugStream() << "For instruction:\n" << *inst;
@@ -287,11 +289,11 @@ ADContext::emitNondifferentiabilityError(SILInstruction *inst,
                                        std::forward<U>(args)...);
 }
 
-template<typename ...T, typename ...U>
+template <typename... T, typename... U>
 InFlightDiagnostic
 ADContext::emitNondifferentiabilityError(SourceLoc loc,
                                          DifferentiationInvoker invoker,
-                                         Diag<T...> diag, U &&...args) {
+                                         Diag<T...> diag, U &&... args) {
   switch (invoker.getKind()) {
   // For `differentiable_function` instructions: if the
   // `differentiable_function` instruction comes from a differential operator,
@@ -339,7 +341,8 @@ ADContext::emitNondifferentiabilityError(SourceLoc loc,
     std::tie(inst, witness) = invoker.getIndirectDifferentiation();
     auto invokerLookup = invokers.find(witness);
     assert(invokerLookup != invokers.end() && "Expected parent invoker");
-    emitNondifferentiabilityError(inst, invokerLookup->second,
+    emitNondifferentiabilityError(
+        inst, invokerLookup->second,
         diag::autodiff_expression_not_differentiable_note);
     return diagnose(loc, diag::autodiff_when_differentiating_function_call);
   }

--- a/include/swift/SILOptimizer/Utils/Differentiation/AdjointValue.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/AdjointValue.h
@@ -139,20 +139,21 @@ public:
     case AdjointValueKind::Aggregate:
       s << "Aggregate<";
       if (auto *decl =
-            getType().getASTType()->getStructOrBoundGenericStruct()) {
+              getType().getASTType()->getStructOrBoundGenericStruct()) {
         s << "Struct>(";
-        interleave(llvm::zip(decl->getStoredProperties(),
-                             base->value.aggregate),
-                             [&s](std::tuple<VarDecl *,
-                                             const AdjointValue &> elt) {
-                               s << std::get<0>(elt)->getName() << ": ";
-                               std::get<1>(elt).print(s);
-                             }, [&s] { s << ", "; });
+        interleave(
+            llvm::zip(decl->getStoredProperties(), base->value.aggregate),
+            [&s](std::tuple<VarDecl *, const AdjointValue &> elt) {
+              s << std::get<0>(elt)->getName() << ": ";
+              std::get<1>(elt).print(s);
+            },
+            [&s] { s << ", "; });
       } else if (auto tupleType = getType().getAs<TupleType>()) {
         s << "Tuple>(";
-        interleave(base->value.aggregate,
-                   [&s](const AdjointValue &elt) { elt.print(s); },
-                   [&s] { s << ", "; });
+        interleave(
+            base->value.aggregate,
+            [&s](const AdjointValue &elt) { elt.print(s); },
+            [&s] { s << ", "; });
       } else {
         llvm_unreachable("Invalid aggregate");
       }

--- a/include/swift/SILOptimizer/Utils/Differentiation/Common.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/Common.h
@@ -113,8 +113,7 @@ void collectAllActualResultsInTypeOrder(
 
 /// Returns the underlying instruction for the given SILValue, if it exists,
 /// peering through function conversion instructions.
-template<class Inst>
-Inst *peerThroughFunctionConversions(SILValue value) {
+template <class Inst> Inst *peerThroughFunctionConversions(SILValue value) {
   if (auto *inst = dyn_cast<Inst>(value))
     return inst;
   if (auto *cvi = dyn_cast<CopyValueInst>(value))
@@ -139,7 +138,6 @@ void collectMinimalIndicesForFunctionCall(
     const DifferentiableActivityInfo &activityInfo,
     SmallVectorImpl<SILValue> &results, SmallVectorImpl<unsigned> &paramIndices,
     SmallVectorImpl<unsigned> &resultIndices);
-
 
 /// Emit a zero value into the given buffer access by calling
 /// `AdditiveArithmetic.zero`. The given type must conform to

--- a/include/swift/SILOptimizer/Utils/Differentiation/DifferentiationInvoker.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/DifferentiationInvoker.h
@@ -19,8 +19,8 @@
 #ifndef SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_DIFFERENTIATIONINVOKER_H
 #define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_DIFFERENTIATIONINVOKER_H
 
-#include <utility>
 #include "swift/Basic/SourceLoc.h"
+#include <utility>
 
 namespace swift {
 

--- a/include/swift/SILOptimizer/Utils/Differentiation/JVPEmitter.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/JVPEmitter.h
@@ -19,8 +19,8 @@
 #ifndef SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_JVPEMITTER_H
 #define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_JVPEMITTER_H
 
-#include "swift/SIL/TypeSubstCloner.h"
 #include "swift/SIL/SILValue.h"
+#include "swift/SIL/TypeSubstCloner.h"
 #include "swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h"
 #include "swift/SILOptimizer/Utils/Differentiation/AdjointValue.h"
 #include "swift/SILOptimizer/Utils/Differentiation/DifferentiationInvoker.h"
@@ -116,13 +116,12 @@ private:
     return witness->getSILAutoDiffIndices();
   }
   SILBuilder &getDifferentialBuilder() { return differentialBuilder; }
-  SILFunction &getDifferential() {
-    return differentialBuilder.getFunction();
-  }
+  SILFunction &getDifferential() { return differentialBuilder.getFunction(); }
   SILArgument *getDifferentialStructArgument(SILBasicBlock *origBB) {
 #ifndef NDEBUG
-    auto *diffStruct = differentialStructArguments[origBB]->getType()
-        .getStructOrBoundGenericStruct();
+    auto *diffStruct = differentialStructArguments[origBB]
+                           ->getType()
+                           .getStructOrBoundGenericStruct();
     assert(diffStruct == differentialInfo.getLinearMapStruct(origBB));
 #endif
     return differentialStructArguments[origBB];
@@ -177,8 +176,7 @@ private:
   // Tangent materialization
   //--------------------------------------------------------------------------//
 
-  void emitZeroIndirect(CanType type, SILValue bufferAccess,
-                        SILLocation loc);
+  void emitZeroIndirect(CanType type, SILValue bufferAccess, SILLocation loc);
 
   SILValue emitZeroDirect(CanType type, SILLocation loc);
 
@@ -355,12 +353,10 @@ public:
   void emitTangentForApplyInst(ApplyInst *ai, SILAutoDiffIndices actualIndices,
                                CanSILFunctionType originalDifferentialType);
 
-
   /// Generate a `return` instruction in the current differential basic block.
   void emitReturnInstForDifferential();
 
 private:
-
   /// Set up the differential function. This includes:
   /// - Creating all differential blocks.
   /// - Creating differential entry block arguments based on the function type.

--- a/include/swift/SILOptimizer/Utils/Differentiation/LinearMapInfo.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/LinearMapInfo.h
@@ -19,6 +19,7 @@
 #define SWIFT_SILOPTIMIZER_UTILS_DIFFERENTIATION_LINEARMAPINFO_H
 
 #include "swift/AST/AutoDiff.h"
+#include "swift/SIL/ApplySite.h"
 #include "swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h"
 #include "llvm/ADT/DenseMap.h"
 
@@ -107,8 +108,7 @@ private:
 
   /// Computes and sets the access level for the given nominal type, given the
   /// original function linkage.
-  void computeAccessLevel(
-      NominalTypeDecl *nominal, SILLinkage originalLinkage);
+  void computeAccessLevel(NominalTypeDecl *nominal, SILLinkage originalLinkage);
 
   /// Creates an enum declaration with the given JVP/VJP generic signature,
   /// whose cases represent the predecessors/successors of the given original
@@ -121,9 +121,9 @@ private:
   /// Creates a struct declaration with the given JVP/VJP generic signature, for
   /// storing the linear map values and predecessor/successor basic block of the
   /// given original block.
-  StructDecl *
-  createLinearMapStruct(SILBasicBlock *originalBB, SILAutoDiffIndices indices,
-                        CanGenericSignature genericSig);
+  StructDecl *createLinearMapStruct(SILBasicBlock *originalBB,
+                                    SILAutoDiffIndices indices,
+                                    CanGenericSignature genericSig);
 
   /// Adds a linear map field to the linear map struct.
   VarDecl *addLinearMapDecl(ApplyInst *ai, SILType linearMapType);

--- a/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h
@@ -90,7 +90,8 @@ private:
   /// Mapping from original basic blocks to local temporary values to be cleaned
   /// up. This is populated when pullback emission is run on one basic block and
   /// cleaned before processing another basic block.
-  llvm::DenseMap<SILBasicBlock *, SmallSetVector<SILValue, 64>> blockTemporaries;
+  llvm::DenseMap<SILBasicBlock *, SmallSetVector<SILValue, 64>>
+      blockTemporaries;
 
   /// The main builder.
   SILBuilder builder;
@@ -143,7 +144,7 @@ private:
 
   AdjointValue makeConcreteAdjointValue(SILValue value);
 
-  template<typename EltRange>
+  template <typename EltRange>
   AdjointValue makeAggregateAdjointValue(SILType type, EltRange elements);
 
   //--------------------------------------------------------------------------//
@@ -197,9 +198,8 @@ private:
 
   /// Given two materialized adjoint values, accumulate them using
   /// `AdditiveArithmetic.+`, depending on the differentiation mode.
-  void accumulateIndirect(SILValue resultBufAccess,
-                          SILValue lhsBufAccess, SILValue rhsBufAccess,
-                          SILLocation loc);
+  void accumulateIndirect(SILValue resultBufAccess, SILValue lhsBufAccess,
+                          SILValue rhsBufAccess, SILLocation loc);
 
   /// Given two buffers of an `AdditiveArithmetic` type, accumulate the right
   /// hand side into the left hand side using `+=`.
@@ -258,8 +258,7 @@ private:
   // Buffer mapping
   //--------------------------------------------------------------------------//
 
-  void setAdjointBuffer(SILBasicBlock *origBB,
-                        SILValue originalBuffer,
+  void setAdjointBuffer(SILBasicBlock *origBB, SILValue originalBuffer,
                         SILValue adjointBuffer);
 
   SILValue getAdjointProjection(SILBasicBlock *origBB,
@@ -296,8 +295,8 @@ private:
     return pullbackBBMap.lookup(originalBlock);
   }
 
-  SILBasicBlock *getPullbackTrampolineBlock(
-      SILBasicBlock *originalBlock, SILBasicBlock *successorBlock) {
+  SILBasicBlock *getPullbackTrampolineBlock(SILBasicBlock *originalBlock,
+                                            SILBasicBlock *successorBlock) {
     return pullbackTrampolineBBMap.lookup({originalBlock, successorBlock});
   }
 
@@ -387,12 +386,12 @@ public:
   /// Handle `store` or `store_borrow` instruction.
   ///   Original: store/store_borrow x to y
   ///    Adjoint: adj[x] += load adj[y]; adj[y] = 0
-  void visitStoreOperation(SILBasicBlock *bb, SILLocation loc,
-                           SILValue origSrc, SILValue origDest);
+  void visitStoreOperation(SILBasicBlock *bb, SILLocation loc, SILValue origSrc,
+                           SILValue origDest);
   void visitStoreInst(StoreInst *si);
   void visitStoreBorrowInst(StoreBorrowInst *sbi) {
-    visitStoreOperation(
-        sbi->getParent(), sbi->getLoc(), sbi->getSrc(), sbi->getDest());
+    visitStoreOperation(sbi->getParent(), sbi->getLoc(), sbi->getSrc(),
+                        sbi->getDest());
   }
 
   /// Handle `copy_addr` instruction.
@@ -426,7 +425,7 @@ public:
   NOT_DIFFERENTIABLE(RefElementAddr, autodiff_class_property_not_supported)
 #undef NOT_DIFFERENTIABLE
 
-#define NO_ADJOINT(INST) \
+#define NO_ADJOINT(INST)                                                       \
   void visit##INST##Inst(INST##Inst *inst) {}
   // Terminators.
   NO_ADJOINT(Return)

--- a/include/swift/SILOptimizer/Utils/Differentiation/Thunk.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/Thunk.h
@@ -64,25 +64,29 @@ enum class DifferentiationThunkKind {
   IndexSubset
 };
 
-CanGenericSignature buildThunkSignature(
-    SILFunction *fn, bool inheritGenericSig,
-    OpenedArchetypeType *openedExistential, GenericEnvironment *&genericEnv,
-    SubstitutionMap &contextSubs, SubstitutionMap &interfaceSubs,
-    ArchetypeType *&newArchetype);
+CanGenericSignature buildThunkSignature(SILFunction *fn, bool inheritGenericSig,
+                                        OpenedArchetypeType *openedExistential,
+                                        GenericEnvironment *&genericEnv,
+                                        SubstitutionMap &contextSubs,
+                                        SubstitutionMap &interfaceSubs,
+                                        ArchetypeType *&newArchetype);
 
 /// Build the type of a function transformation thunk.
-CanSILFunctionType buildThunkType(
-    SILFunction *fn, CanSILFunctionType &sourceType,
-    CanSILFunctionType &expectedType, GenericEnvironment *&genericEnv,
-    SubstitutionMap &interfaceSubs, bool withoutActuallyEscaping,
-    DifferentiationThunkKind thunkKind);
+CanSILFunctionType buildThunkType(SILFunction *fn,
+                                  CanSILFunctionType &sourceType,
+                                  CanSILFunctionType &expectedType,
+                                  GenericEnvironment *&genericEnv,
+                                  SubstitutionMap &interfaceSubs,
+                                  bool withoutActuallyEscaping,
+                                  DifferentiationThunkKind thunkKind);
 
 /// Get or create a reabstraction thunk from `fromType` to `toType`, to be
 /// called in `caller`.
-SILFunction *getOrCreateReabstractionThunk(
-    SILOptFunctionBuilder &fb, SILModule &module, SILLocation loc,
-    SILFunction *caller, CanSILFunctionType fromType,
-    CanSILFunctionType toType);
+SILFunction *getOrCreateReabstractionThunk(SILOptFunctionBuilder &fb,
+                                           SILModule &module, SILLocation loc,
+                                           SILFunction *caller,
+                                           CanSILFunctionType fromType,
+                                           CanSILFunctionType toType);
 
 /// Get or create a derivative function parameter index subset thunk from
 /// `actualIndices` to `desiredIndices` for the given associated function
@@ -93,9 +97,9 @@ SILFunction *getOrCreateReabstractionThunk(
 /// map returned by the derivative function.
 std::pair<SILFunction *, SubstitutionMap>
 getOrCreateSubsetParametersThunkForDerivativeFunction(
-    SILOptFunctionBuilder &fb, SILValue origFnOperand,
-    SILValue derivativeFn, AutoDiffDerivativeFunctionKind kind,
-    SILAutoDiffIndices desiredIndices, SILAutoDiffIndices actualIndices);
+    SILOptFunctionBuilder &fb, SILValue origFnOperand, SILValue derivativeFn,
+    AutoDiffDerivativeFunctionKind kind, SILAutoDiffIndices desiredIndices,
+    SILAutoDiffIndices actualIndices);
 
 /// Get or create a derivative function parameter index subset thunk from
 /// `actualIndices` to `desiredIndices` for the given associated function

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -449,10 +449,18 @@ void DifferentiableActivityInfo::dump(SILValue value,
   s << '[';
   auto activity = getActivity(value, indices);
   switch (activity.toRaw()) {
-  case 0: s << "NONE"; break;
-  case (unsigned)ActivityFlags::Varied: s << "VARIED"; break;
-  case (unsigned)ActivityFlags::Useful: s << "USEFUL"; break;
-  case (unsigned)ActivityFlags::Active: s << "ACTIVE"; break;
+  case 0:
+    s << "NONE";
+    break;
+  case (unsigned)ActivityFlags::Varied:
+    s << "VARIED";
+    break;
+  case (unsigned)ActivityFlags::Useful:
+    s << "USEFUL";
+    break;
+  case (unsigned)ActivityFlags::Active:
+    s << "ACTIVE";
+    break;
   }
   s << "] " << value;
 }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -48,13 +48,13 @@
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
-#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/Differentiation/ADContext.h"
 #include "swift/SILOptimizer/Utils/Differentiation/Common.h"
 #include "swift/SILOptimizer/Utils/Differentiation/JVPEmitter.h"
 #include "swift/SILOptimizer/Utils/Differentiation/LinearMapInfo.h"
 #include "swift/SILOptimizer/Utils/Differentiation/Thunk.h"
 #include "swift/SILOptimizer/Utils/Differentiation/VJPEmitter.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/BreadthFirstIterator.h"
 #include "llvm/ADT/DenseSet.h"
@@ -91,9 +91,10 @@ template <typename T> static inline void debugDump(T &v) {
 /// - Additional derivative requirements (optional).
 /// The constrained derivative generic signature constrains all wrt parameters
 /// to conform to `Differentiable`.
-static GenericSignature getConstrainedDerivativeGenericSignature(
-    CanSILFunctionType originalFnTy, IndexSubset *paramIndexSet,
-    GenericSignature derivativeGenSig) {
+static GenericSignature
+getConstrainedDerivativeGenericSignature(CanSILFunctionType originalFnTy,
+                                         IndexSubset *paramIndexSet,
+                                         GenericSignature derivativeGenSig) {
   if (!derivativeGenSig)
     derivativeGenSig = originalFnTy->getSubstGenericSignature();
   if (!derivativeGenSig)
@@ -110,10 +111,9 @@ static GenericSignature getConstrainedDerivativeGenericSignature(
   }
   return evaluateOrDefault(
       ctx.evaluator,
-      AbstractGenericSignatureRequest{
-          derivativeGenSig.getPointer(),
-          /*addedGenericParams*/ {},
-          std::move(requirements)},
+      AbstractGenericSignatureRequest{derivativeGenSig.getPointer(),
+                                      /*addedGenericParams*/ {},
+                                      std::move(requirements)},
       nullptr);
 }
 
@@ -129,14 +129,14 @@ private:
 
   /// Promotes the given `differentiable_function` instruction to a valid
   /// `@differentiable` function-typed value.
-  SILValue promoteToDifferentiableFunction(
-      DifferentiableFunctionInst *inst, SILBuilder &builder, SILLocation loc,
-      DifferentiationInvoker invoker);
+  SILValue promoteToDifferentiableFunction(DifferentiableFunctionInst *inst,
+                                           SILBuilder &builder, SILLocation loc,
+                                           DifferentiationInvoker invoker);
 
 public:
   /// Construct an `DifferentiationTransformer` for the given module.
   explicit DifferentiationTransformer(SILModuleTransform &transform)
-       : transform(transform), context(transform) {}
+      : transform(transform), context(transform) {}
 
   ADContext &getContext() { return context; }
 
@@ -306,9 +306,10 @@ static bool diagnoseUnsatisfiedRequirements(ADContext &context,
   // Diagnose unsatisfied requirements.
   std::string reqText;
   llvm::raw_string_ostream stream(reqText);
-  interleave(unsatisfiedRequirements,
-             [&](Requirement req) { req.print(stream, PrintOptions()); },
-             [&] { stream << ", "; });
+  interleave(
+      unsatisfiedRequirements,
+      [&](Requirement req) { req.print(stream, PrintOptions()); },
+      [&] { stream << ", "; });
   context.emitNondifferentiabilityError(
       loc, invoker, diag::autodiff_function_assoc_func_unmet_requirements,
       stream.str());
@@ -318,7 +319,6 @@ static bool diagnoseUnsatisfiedRequirements(ADContext &context,
 //===----------------------------------------------------------------------===//
 // Code emission utilities
 //===----------------------------------------------------------------------===//
-
 
 /// Given an apply site, emit copies of all parameters and place them in
 /// `copiedArgs`. Any buffers that need to be destroyed will be added to
@@ -363,8 +363,7 @@ static void copyParameterArgumentsForApply(
     // `copy_addr`.
     auto *argCopy = copyBuilder.createAllocStack(loc, arg->getType());
     newBuffersToDealloc.push_back(argCopy);
-    copyBuilder.createCopyAddr(loc, arg, argCopy, IsNotTake,
-                               IsInitialization);
+    copyBuilder.createCopyAddr(loc, arg, argCopy, IsNotTake, IsInitialization);
     collectNewArg(argCopy);
   }
 }
@@ -481,10 +480,9 @@ static SILValue reapplyFunctionConversion(
 /// FIXME: This is too complicated and needs to be rewritten.
 static Optional<std::pair<SILValue, SILAutoDiffIndices>>
 emitDerivativeFunctionReference(
-    DifferentiationTransformer &transformer,
-    SILBuilder &builder, SILAutoDiffIndices desiredIndices,
-    AutoDiffDerivativeFunctionKind kind, SILValue original,
-    DifferentiationInvoker invoker,
+    DifferentiationTransformer &transformer, SILBuilder &builder,
+    SILAutoDiffIndices desiredIndices, AutoDiffDerivativeFunctionKind kind,
+    SILValue original, DifferentiationInvoker invoker,
     SmallVectorImpl<AllocStackInst *> &newBuffersToDealloc) {
 
   SILValue functionSource = original;
@@ -497,7 +495,7 @@ emitDerivativeFunctionReference(
   if (auto *inst = original->getDefiningInstruction())
     if (auto *dfei = dyn_cast<DifferentiableFunctionExtractInst>(inst))
       if (dfei->getExtractee() ==
-              NormalDifferentiableFunctionTypeComponent::Original)
+          NormalDifferentiableFunctionTypeComponent::Original)
         functionSource = dfei->getFunctionOperand();
 
   // If `functionSource` is a `@differentiable` function, just extract the
@@ -508,8 +506,10 @@ emitDerivativeFunctionReference(
       auto paramIndices = diffableFnType->getDifferentiationParameterIndices();
       for (auto i : desiredIndices.parameters->getIndices()) {
         if (!paramIndices->contains(i)) {
-          context.emitNondifferentiabilityError(functionSource, invoker,
-              diag::autodiff_function_noderivative_parameter_not_differentiable);
+          context.emitNondifferentiabilityError(
+              functionSource, invoker,
+              diag::
+                  autodiff_function_noderivative_parameter_not_differentiable);
           return None;
         }
       }
@@ -556,7 +556,8 @@ emitDerivativeFunctionReference(
       // If the function is intentionally marked as being opaque to
       // differentiation, then we should not create a task for it.
       if (originalFn->hasSemanticsAttr("autodiff.opaque")) {
-        context.emitNondifferentiabilityError(original, invoker,
+        context.emitNondifferentiabilityError(
+            original, invoker,
             diag::autodiff_opaque_function_not_differentiable);
         return None;
       }
@@ -592,8 +593,9 @@ emitDerivativeFunctionReference(
       GenericSignature contextualDerivativeGenSig = GenericSignature();
       if (invoker.getKind() ==
           DifferentiationInvoker::Kind::IndirectDifferentiation)
-        contextualDerivativeGenSig = invoker.getIndirectDifferentiation().second
-            ->getDerivativeGenericSignature();
+        contextualDerivativeGenSig =
+            invoker.getIndirectDifferentiation()
+                .second->getDerivativeGenericSignature();
       auto derivativeConstrainedGenSig =
           getConstrainedDerivativeGenericSignature(
               originalFn->getLoweredFunctionType(), desiredParameterIndices,
@@ -696,8 +698,8 @@ emitDerivativeFunctionReference(
     // Emit a `witness_method` instruction for the derivative function.
     auto originalType = witnessMethod->getType().castTo<SILFunctionType>();
     auto assocType = originalType->getAutoDiffDerivativeFunctionType(
-        minimalIndices.parameters, minimalIndices.source,
-        kind, context.getTypeConverter(),
+        minimalIndices.parameters, minimalIndices.source, kind,
+        context.getTypeConverter(),
         LookUpConformanceInModule(builder.getModule().getSwiftModule()));
     auto *autoDiffFuncId = AutoDiffDerivativeFunctionIdentifier::get(
         kind, minimalASTParamIndices, minimalConfig->derivativeGenericSignature,
@@ -758,8 +760,8 @@ emitDerivativeFunctionReference(
   }
 
   // Emit the general opaque function error.
-  context.emitNondifferentiabilityError(original, invoker,
-      diag::autodiff_opaque_function_not_differentiable);
+  context.emitNondifferentiabilityError(
+      original, invoker, diag::autodiff_opaque_function_not_differentiable);
   return None;
 }
 
@@ -853,7 +855,7 @@ static SILFunction *createEmptyJVP(ADContext &context, SILFunction *original,
   jvp->setDebugScope(new (module) SILDebugScope(original->getLocation(), jvp));
 
   LLVM_DEBUG(llvm::dbgs() << "JVP type: " << jvp->getLoweredFunctionType()
-             << "\n");
+                          << "\n");
   return jvp;
 }
 
@@ -876,7 +878,8 @@ bool DifferentiationTransformer::canonicalizeDifferentiabilityWitness(
     // Diagnose:
     // - Functions with no return.
     // - Functions with unsupported control flow.
-    if (context.getASTContext().LangOpts.EnableExperimentalForwardModeDifferentiation &&
+    if (context.getASTContext()
+            .LangOpts.EnableExperimentalForwardModeDifferentiation &&
         (diagnoseNoReturn(context, original, invoker) ||
          diagnoseUnsupportedControlFlow(context, original, invoker)))
       return true;
@@ -889,7 +892,8 @@ bool DifferentiationTransformer::canonicalizeDifferentiabilityWitness(
     // does not exist. If custom VJP exists but custom JVP does not, skip JVP
     // generation because generated JVP may not match semantics of custom VJP.
     // Instead, create an empty JVP.
-    if (context.getASTContext().LangOpts.EnableExperimentalForwardModeDifferentiation &&
+    if (context.getASTContext()
+            .LangOpts.EnableExperimentalForwardModeDifferentiation &&
         !witness->getVJP()) {
       // JVP and differential generation do not currently support functions with
       // multiple basic blocks.
@@ -900,13 +904,13 @@ bool DifferentiationTransformer::canonicalizeDifferentiabilityWitness(
         return true;
       }
 
-      JVPEmitter emitter(context, original, witness, witness->getJVP(), invoker);
+      JVPEmitter emitter(context, original, witness, witness->getJVP(),
+                         invoker);
       if (emitter.run())
         return true;
     } else {
-      LLVM_DEBUG(getADDebugStream()
-                 << "Generating empty JVP for original @"
-                 << original->getName() << '\n');
+      LLVM_DEBUG(getADDebugStream() << "Generating empty JVP for original @"
+                                    << original->getName() << '\n');
       // Create empty JVP body since custom VJP exists.
       auto *entry = witness->getJVP()->createBasicBlock();
       createEntryArguments(witness->getJVP());
@@ -919,8 +923,9 @@ bool DifferentiationTransformer::canonicalizeDifferentiabilityWitness(
           builder.emitDestroyOperation(loc, arg);
 
       // Fatal error in case this JVP is called by the user.
-      auto neverResultInfo = SILResultInfo(
-        context.getModule().getASTContext().getNeverType(), ResultConvention::Unowned);
+      auto neverResultInfo =
+          SILResultInfo(context.getModule().getASTContext().getNeverType(),
+                        ResultConvention::Unowned);
       auto fatalErrorJVPType = SILFunctionType::get(
           /*genericSig*/ nullptr,
           SILFunctionType::ExtInfo().withRepresentation(
@@ -991,7 +996,8 @@ SILValue DifferentiationTransformer::promoteToDifferentiableFunction(
       auto *thunk = thunkRef->getReferencedFunctionOrNull();
       // TODO(TF-685): Use more principled mangling for thunks.
       auto newThunkName = "AD__" + thunk->getName().str() +
-          "__differentiable_curry_thunk_" + desiredIndices.mangle();
+                          "__differentiable_curry_thunk_" +
+                          desiredIndices.mangle();
 
       auto thunkTy = thunk->getLoweredFunctionType();
       auto thunkResult = thunkTy->getSingleResult();
@@ -1058,9 +1064,9 @@ SILValue DifferentiationTransformer::promoteToDifferentiableFunction(
         SmallVector<AllocStackInst *, 1> newBuffersToDealloc;
         copyParameterArgumentsForApply(ai, newArgs, newArgsToDestroy,
                                        newBuffersToDealloc);
-        auto *newApply = builder.createApply(
-            ai->getLoc(), newThunkRef, ai->getSubstitutionMap(), newArgs,
-            ai->isNonThrowing());
+        auto *newApply = builder.createApply(ai->getLoc(), newThunkRef,
+                                             ai->getSubstitutionMap(), newArgs,
+                                             ai->isNonThrowing());
         for (auto arg : newArgsToDestroy)
           builder.emitDestroyOperation(loc, arg);
         for (auto *alloc : newBuffersToDealloc)
@@ -1076,8 +1082,8 @@ SILValue DifferentiationTransformer::promoteToDifferentiableFunction(
   for (auto derivativeFnKind : {AutoDiffDerivativeFunctionKind::JVP,
                                 AutoDiffDerivativeFunctionKind::VJP}) {
     auto derivativeFnAndIndices = emitDerivativeFunctionReference(
-        *this, builder, desiredIndices, derivativeFnKind, origFnOperand, invoker,
-        newBuffersToDealloc);
+        *this, builder, desiredIndices, derivativeFnKind, origFnOperand,
+        invoker, newBuffersToDealloc);
     // Show an error at the operator, highlight the argument, and show a note
     // at the definition site of the argument.
     if (!derivativeFnAndIndices)
@@ -1135,24 +1141,27 @@ SILValue DifferentiationTransformer::promoteToDifferentiableFunction(
       auto *thunkFRI = builder.createFunctionRef(loc, thunk);
       if (auto genSig =
               thunk->getLoweredFunctionType()->getSubstGenericSignature()) {
-        derivativeFn = builder.createPartialApply(
-            loc, thunkFRI, interfaceSubs, {},
-            ParameterConvention::Direct_Guaranteed);
+        derivativeFn =
+            builder.createPartialApply(loc, thunkFRI, interfaceSubs, {},
+                                       ParameterConvention::Direct_Guaranteed);
       } else {
         derivativeFn = thunkFRI;
       }
     }
     auto expectedDerivativeFnTy = origFnTy->getAutoDiffDerivativeFunctionType(
-        parameterIndices, resultIndex, derivativeFnKind, context.getTypeConverter(),
+        parameterIndices, resultIndex, derivativeFnKind,
+        context.getTypeConverter(),
         LookUpConformanceInModule(context.getModule().getSwiftModule()));
     // If `derivativeFn` is `@convention(thin)` but is expected to be
     // `@convention(thick)`, emit a `thin_to_thick` instruction.
-    if (expectedDerivativeFnTy->getRepresentation()
-            == SILFunctionTypeRepresentation::Thick &&
-        derivativeFn->getType().castTo<SILFunctionType>()->getRepresentation()
-            == SILFunctionTypeRepresentation::Thin) {
+    if (expectedDerivativeFnTy->getRepresentation() ==
+            SILFunctionTypeRepresentation::Thick &&
+        derivativeFn->getType()
+                .castTo<SILFunctionType>()
+                ->getRepresentation() == SILFunctionTypeRepresentation::Thin) {
       derivativeFn = builder.createThinToThickFunction(
-          loc, derivativeFn, SILType::getPrimitiveObjectType(expectedDerivativeFnTy));
+          loc, derivativeFn,
+          SILType::getPrimitiveObjectType(expectedDerivativeFnTy));
     }
 
     derivativeFns.push_back(derivativeFn);
@@ -1192,7 +1201,7 @@ void DifferentiationTransformer::foldDifferentiableFunctionExtraction(
       continue;
     // Fold original function extractors.
     if (dfei->getExtractee() ==
-            NormalDifferentiableFunctionTypeComponent::Original) {
+        NormalDifferentiableFunctionTypeComponent::Original) {
       auto originalFnValue = source->getOriginalFunction();
       dfei->replaceAllUsesWith(originalFnValue);
       dfei->eraseFromParent();
@@ -1252,8 +1261,8 @@ bool DifferentiationTransformer::processDifferentiableFunctionInst(
     if (auto *newDFI =
             dyn_cast<DifferentiableFunctionInst>(differentiableFnValue))
       foldDifferentiableFunctionExtraction(newDFI);
-  transform.invalidateAnalysis(
-      parent, SILAnalysis::InvalidationKind::FunctionBody);
+  transform.invalidateAnalysis(parent,
+                               SILAnalysis::InvalidationKind::FunctionBody);
   return false;
 }
 
@@ -1326,7 +1335,8 @@ void Differentiation::run() {
   // Iteratively process `differentiable_function` instruction worklist.
   while (auto *dfi = context.popDifferentiableFunctionInstFromWorklist()) {
     // Skip instructions that have been already been processed.
-    if (context.isDifferentiableFunctionInstProcessed(dfi)) continue;
+    if (context.isDifferentiableFunctionInstProcessed(dfi))
+      continue;
     errorOccurred |= transformer.processDifferentiableFunctionInst(dfi);
   }
 
@@ -1344,6 +1354,4 @@ void Differentiation::run() {
 // Pass creation
 //===----------------------------------------------------------------------===//
 
-SILTransform *swift::createDifferentiation() {
-  return new Differentiation;
-}
+SILTransform *swift::createDifferentiation() { return new Differentiation; }

--- a/lib/SILOptimizer/Utils/Differentiation/ADContext.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/ADContext.cpp
@@ -17,9 +17,9 @@
 
 #define DEBUG_TYPE "differentiation"
 
+#include "swift/SILOptimizer/Utils/Differentiation/ADContext.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
-#include "swift/SILOptimizer/Utils/Differentiation/ADContext.h"
 
 using llvm::DenseMap;
 using llvm::SmallPtrSet;
@@ -61,8 +61,8 @@ ADContext::ADContext(SILModuleTransform &transform)
 
 FuncDecl *ADContext::getPlusDecl() const {
   if (!cachedPlusFn) {
-    cachedPlusFn = findOperatorDeclInProtocol(
-      astCtx.getIdentifier("+"), additiveArithmeticProtocol);
+    cachedPlusFn = findOperatorDeclInProtocol(astCtx.getIdentifier("+"),
+                                              additiveArithmeticProtocol);
     assert(cachedPlusFn && "AdditiveArithmetic.+ not found");
   }
   return cachedPlusFn;
@@ -70,8 +70,8 @@ FuncDecl *ADContext::getPlusDecl() const {
 
 FuncDecl *ADContext::getPlusEqualDecl() const {
   if (!cachedPlusEqualFn) {
-    cachedPlusEqualFn = findOperatorDeclInProtocol(
-      astCtx.getIdentifier("+="), additiveArithmeticProtocol);
+    cachedPlusEqualFn = findOperatorDeclInProtocol(astCtx.getIdentifier("+="),
+                                                   additiveArithmeticProtocol);
     assert(cachedPlusEqualFn && "AdditiveArithmetic.+= not found");
   }
   return cachedPlusEqualFn;
@@ -81,16 +81,15 @@ void ADContext::cleanUp() {
   // Delete all references to generated functions.
   for (auto fnRef : generatedFunctionReferences) {
     if (auto *fnRefInst =
-        peerThroughFunctionConversions<FunctionRefInst>(fnRef)) {
+            peerThroughFunctionConversions<FunctionRefInst>(fnRef)) {
       fnRefInst->replaceAllUsesWithUndef();
       fnRefInst->eraseFromParent();
     }
   }
   // Delete all generated functions.
   for (auto *generatedFunction : generatedFunctions) {
-    LLVM_DEBUG(getADDebugStream()
-               << "Deleting generated function "
-               << generatedFunction->getName() << '\n');
+    LLVM_DEBUG(getADDebugStream() << "Deleting generated function "
+                                  << generatedFunction->getName() << '\n');
     generatedFunction->dropAllReferences();
     transform.notifyWillDeleteFunction(generatedFunction);
     module.eraseFunction(generatedFunction);
@@ -98,11 +97,11 @@ void ADContext::cleanUp() {
 }
 
 DifferentiableFunctionInst *ADContext::createDifferentiableFunction(
-  SILBuilder &builder, SILLocation loc,
-  IndexSubset *parameterIndices, SILValue original,
-  Optional<std::pair<SILValue, SILValue>> derivativeFunctions) {
+    SILBuilder &builder, SILLocation loc, IndexSubset *parameterIndices,
+    SILValue original,
+    Optional<std::pair<SILValue, SILValue>> derivativeFunctions) {
   auto *dfi = builder.createDifferentiableFunction(
-    loc, parameterIndices, original, derivativeFunctions);
+      loc, parameterIndices, original, derivativeFunctions);
   processedDifferentiableFunctionInsts.erase(dfi);
   return dfi;
 }

--- a/lib/SILOptimizer/Utils/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/Common.cpp
@@ -17,9 +17,9 @@
 
 #define DEBUG_TYPE "differentiation"
 
+#include "swift/SILOptimizer/Utils/Differentiation/Common.h"
 #include "swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
-#include "swift/SILOptimizer/Utils/Differentiation/Common.h"
 
 namespace swift {
 namespace autodiff {
@@ -38,8 +38,7 @@ ApplyInst *getAllocateUninitializedArrayIntrinsic(SILValue v) {
   return nullptr;
 }
 
-ApplyInst *
-getAllocateUninitializedArrayIntrinsicElementAddress(SILValue v) {
+ApplyInst *getAllocateUninitializedArrayIntrinsicElementAddress(SILValue v) {
   // Find the `pointer_to_address` result, peering through `index_addr`.
   auto *ptai = dyn_cast<PointerToAddressInst>(v);
   if (auto *iai = dyn_cast<IndexAddrInst>(v))
@@ -221,11 +220,10 @@ void emitZeroIntoBuffer(SILBuilder &builder, CanType type,
   auto silFnType = typeConverter.getConstantType(
       TypeExpansionContext::minimal(), accessorDeclRef);
   // %wm = witness_method ...
-  auto *getter = builder.createWitnessMethod(
-      loc, type, confRef, accessorDeclRef, silFnType);
+  auto *getter = builder.createWitnessMethod(loc, type, confRef,
+                                             accessorDeclRef, silFnType);
   // %metatype = metatype $T
-  auto metatypeType = CanMetatypeType::get(
-      type, MetatypeRepresentation::Thick);
+  auto metatypeType = CanMetatypeType::get(type, MetatypeRepresentation::Thick);
   auto metatype = builder.createMetatype(
       loc, SILType::getPrimitiveObjectType(metatypeType));
   auto subMap = SubstitutionMap::getProtocolSubstitutions(

--- a/lib/SILOptimizer/Utils/Differentiation/DifferentiationInvoker.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/DifferentiationInvoker.cpp
@@ -16,10 +16,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/SIL/SILDifferentiabilityWitness.h"
-#include "swift/SIL/SILInstruction.h"
-#include "swift/SIL/SILFunction.h"
 #include "swift/SILOptimizer/Utils/Differentiation/DifferentiationInvoker.h"
+#include "swift/SIL/SILDifferentiabilityWitness.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
 
 namespace swift {
 namespace autodiff {
@@ -32,9 +32,9 @@ SourceLoc DifferentiationInvoker::getLocation() const {
     return getIndirectDifferentiation().first->getLoc().getSourceLoc();
   case Kind::SILDifferentiabilityWitnessInvoker:
     return getSILDifferentiabilityWitnessInvoker()
-      ->getOriginalFunction()
-      ->getLocation()
-      .getSourceLoc();
+        ->getOriginalFunction()
+        ->getLocation()
+        .getSourceLoc();
   }
 }
 

--- a/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
+++ b/lib/SILOptimizer/Utils/Differentiation/VJPEmitter.cpp
@@ -18,13 +18,13 @@
 
 #define DEBUG_TYPE "differentiation"
 
+#include "swift/SILOptimizer/Utils/Differentiation/VJPEmitter.h"
 #include "swift/SILOptimizer/PassManager/PrettyStackTrace.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
-#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/Differentiation/ADContext.h"
 #include "swift/SILOptimizer/Utils/Differentiation/PullbackEmitter.h"
-#include "swift/SILOptimizer/Utils/Differentiation/VJPEmitter.h"
 #include "swift/SILOptimizer/Utils/Differentiation/Thunk.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 
 namespace swift {
 namespace autodiff {
@@ -675,9 +675,8 @@ void VJPEmitter::visitDifferentiableFunctionInst(
 
 bool VJPEmitter::run() {
   PrettyStackTraceSILFunction trace("generating VJP for", original);
-  LLVM_DEBUG(getADDebugStream()
-             << "Cloning original @" << original->getName()
-             << " to vjp @" << vjp->getName() << '\n');
+  LLVM_DEBUG(getADDebugStream() << "Cloning original @" << original->getName()
+                                << " to vjp @" << vjp->getName() << '\n');
 
   // Create entry BB and arguments.
   auto *entry = vjp->createBasicBlock();
@@ -704,8 +703,9 @@ bool VJPEmitter::run() {
     errorOccurred = true;
     return true;
   }
-  LLVM_DEBUG(getADDebugStream() << "Generated VJP for "
-                                << original->getName() << ":\n" << *vjp);
+  LLVM_DEBUG(getADDebugStream()
+             << "Generated VJP for " << original->getName() << ":\n"
+             << *vjp);
   return errorOccurred;
 }
 


### PR DESCRIPTION
Apply `clang-format` to all differentiation-related SILOptimizer files.

---

Motivation: I noticed some lines are longer than 80 columns, due to lack of care during `master -> tensorflow` merges. Rather than fixing just those lines, we might as well auto-format everything.