### PR TITLE
[cmake] Honour CMAKE_CXX_STANDARD when performing test for check_cxx_native_regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ if(POLICY CMP0068)
   cmake_policy(SET CMP0068 OLD)
 endif()
 
+# Honour CMAKE_CXX_STANDARD in try_compile(), needed for check_cxx_native_regex.
+if(POLICY CMP0067)
+  cmake_policy(SET CMP0067 NEW)
+endif()
+
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")


### PR DESCRIPTION
In the rebranch, we move to using CMAKE_CXX_STANDARD to set C++14, which
doesn't work out of the box with try_compile() tests, so set the
required CMake policy. Was causing tests to XPASS instead of PASS.

rdar://58632606