### PR TITLE
[5.2][CodeCompletion] Improve context type analysis for dictionary literals

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -600,9 +600,46 @@ class ExprContextAnalyzer {
       // Check context types of the array literal expression.
       ExprContextInfo arrayCtxtInfo(DC, Parent);
       for (auto arrayT : arrayCtxtInfo.getPossibleTypes()) {
-        if (auto boundGenericT = arrayT->getAs<BoundGenericType>())
+        if (auto boundGenericT = arrayT->getAs<BoundGenericType>()) {
+          // let _: [Element] = [#HERE#]
+          // In this case, 'Element' is the expected type.
           if (boundGenericT->getDecl() == Context.getArrayDecl())
             recordPossibleType(boundGenericT->getGenericArgs()[0]);
+
+          // let _: [Key : Value] = [#HERE#]
+          // In this case, 'Key' is the expected type.
+          if (boundGenericT->getDecl() == Context.getDictionaryDecl())
+            recordPossibleType(boundGenericT->getGenericArgs()[0]);
+        }
+      }
+      break;
+    }
+    case ExprKind::Dictionary: {
+      // Check context types of the dictionary literal expression.
+      ExprContextInfo dictCtxtInfo(DC, Parent);
+
+      for (auto dictT : dictCtxtInfo.getPossibleTypes()) {
+        if (auto boundGenericT = dictT->getAs<BoundGenericType>()) {
+          if (boundGenericT->getDecl() == Context.getDictionaryDecl()) {
+            if (ParsedExpr->isImplicit() && isa<TupleExpr>(ParsedExpr)) {
+              // let _: [Key : Value] = [#HERE#:]
+              // let _: [Key : Value] = [#HERE#:val]
+              // let _: [Key : Value] = [key:#HERE#]
+              // In this case, this is called by 'ExprKind::Tuple' case. Return
+              // '(Key,Value)' here, 'ExprKind::Tuple' branch can decide which
+              // type in the tuple type is the exprected type.
+              SmallVector<TupleTypeElt, 2> elts;
+              for (auto genericArg : boundGenericT->getGenericArgs())
+                elts.emplace_back(genericArg);
+              recordPossibleType(TupleType::get(elts, DC->getASTContext()));
+            } else {
+              // let _: [Key : Value] = [key: val, #HERE#]
+              // In this case, assume 'Key' is the expected type.
+              if (boundGenericT->getDecl() == Context.getDictionaryDecl())
+                recordPossibleType(boundGenericT->getGenericArgs()[0]);
+            }
+          }
+        }
       }
       break;
     }
@@ -627,13 +664,25 @@ class ExprContextAnalyzer {
       break;
     }
     case ExprKind::Tuple: {
-      if (!Parent->getType() || !Parent->getType()->is<TupleType>())
-        return;
+      TupleType *tupleT = nullptr;
+      if (Parent->getType() && Parent->getType()->is<TupleType>()) {
+        tupleT = Parent->getType()->castTo<TupleType>();
+      } else {
+        ExprContextInfo tupleCtxtInfo(DC, Parent);
+        for (auto possibleT : tupleCtxtInfo.getPossibleTypes()) {
+          if (auto possibleTupleT = possibleT->getAs<TupleType>()) {
+            tupleT = possibleTupleT;
+            break;
+          }
+        }
+        if (!tupleT)
+          return;
+      }
+
       unsigned Position = 0;
       bool HasName;
       if (getPositionInArgs(*DC, Parent, ParsedExpr, Position, HasName)) {
-        recordPossibleType(
-            Parent->getType()->castTo<TupleType>()->getElementType(Position));
+        recordPossibleType(tupleT->getElementType(Position));
       }
       break;
     }
@@ -809,6 +858,7 @@ public:
         case ExprKind::PrefixUnary:
         case ExprKind::Assign:
         case ExprKind::Array:
+        case ExprKind::Dictionary:
           return true;
         case ExprKind::UnresolvedMember:
           return true;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3483,8 +3483,14 @@ Parser::parseExprCollectionElement(Optional<bool> &isDictionary) {
   // Parse the value.
   auto Value = parseExpr(diag::expected_value_in_dictionary_literal);
 
-  if (Value.isNull())
-    Value = makeParserResult(Value, new (Context) ErrorExpr(PreviousLoc));
+  if (Value.isNull()) {
+    if (!Element.hasCodeCompletion()) {
+      Value = makeParserResult(Value, new (Context) ErrorExpr(PreviousLoc));
+    } else {
+      Value = makeParserResult(Value,
+                               new (Context) CodeCompletionExpr(PreviousLoc));
+    }
+  }
 
   // Make a tuple of Key Value pair.
   return makeParserResult(

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3471,6 +3471,11 @@ Parser::parseExprCollectionElement(Optional<bool> &isDictionary) {
 
   // Parse the ':'.
   if (!consumeIf(tok::colon)) {
+    if (Element.hasCodeCompletion()) {
+      // Return the completion expression itself so we can analyze the type
+      // later.
+      return Element;
+    }
     diagnose(Tok, diag::expected_colon_in_dictionary_literal);
     return ParserStatus(Element) | makeParserError();
   }

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -64,10 +64,10 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_5 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_6 | %FileCheck %s -check-prefix=IN_FOR_EACH_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_7 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_8 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_8 | %FileCheck %s -check-prefix=IN_FOR_EACH_4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_9 | %FileCheck %s -check-prefix=IN_FOR_EACH_4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_10 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_11 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_11 | %FileCheck %s -check-prefix=IN_FOR_EACH_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_12 | %FileCheck %s -check-prefix=IN_FOR_EACH_2
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPRECATED_1 | %FileCheck %s -check-prefix=DEPRECATED_1

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -45,8 +45,13 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_34 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_35 | %FileCheck %s -check-prefix=UNRESOLVED_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_36 | %FileCheck %s -check-prefix=UNRESOLVED_3
-// RUN-FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_37 | %FileCheck %s -check-prefix=UNRESOLVED_3
-// RUN-FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_38 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_37 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_38 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_39 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_40 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_41 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_42 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN-FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_43 | %FileCheck %s -check-prefix=UNRESOLVED_3
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_AVAIL_1 | %FileCheck %s -check-prefix=ENUM_AVAIL_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OPTIONS_AVAIL_1 | %FileCheck %s -check-prefix=OPTIONS_AVAIL_1
@@ -119,7 +124,7 @@ enum SomeEnum2 {
   case West
 }
 
-enum SomeEnum3 {
+enum SomeEnum3: Hashable {
   case Payload(SomeEnum1)
 }
 
@@ -388,6 +393,11 @@ let _: [SomeEnum1:SomeOptions1] = [.South:.Option1, .South:.#^UNRESOLVED_35^#]
 let _: [SomeEnum1:SomeOptions1] = [.South:.Option1, .#^UNRESOLVED_36^#:.Option1]
 let _: [SomeEnum1:SomeOptions1] = [.South:.Option1, .#^UNRESOLVED_37^#]
 let _: [SomeEnum1:SomeOptions1] = [.South:.Option1, .#^UNRESOLVED_38^#:]
+let _: [SomeEnum1:SomeOptions1] = [.#^UNRESOLVED_39^#]
+let _: [SomeEnum1:SomeOptions1] = [.#^UNRESOLVED_40^#:]
+let _: [SomeEnum1:SomeEnum3] = [.South:.Payload(.South), .South: .Payload(.#^UNRESOLVED_41^#)]
+let _: [SomeEnum3:SomeEnum1] = [.Payload(.South):.South, .Payload(.#^UNRESOLVED_42^#):.South]
+let _: [SomeEnum3:SomeEnum1] = [.Payload(.South):.South, .Payload(.#^UNRESOLVED_43^#)]
 
 func testAvail1(_ x: EnumAvail1) {
   testAvail1(.#^ENUM_AVAIL_1^#)

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -51,7 +51,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_40 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_41 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_42 | %FileCheck %s -check-prefix=UNRESOLVED_3
-// RUN-FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_43 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_43 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN-FIXME: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_44 | %FileCheck %s -check-prefix=UNRESOLVED_3
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_AVAIL_1 | %FileCheck %s -check-prefix=ENUM_AVAIL_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OPTIONS_AVAIL_1 | %FileCheck %s -check-prefix=OPTIONS_AVAIL_1
@@ -397,7 +398,8 @@ let _: [SomeEnum1:SomeOptions1] = [.#^UNRESOLVED_39^#]
 let _: [SomeEnum1:SomeOptions1] = [.#^UNRESOLVED_40^#:]
 let _: [SomeEnum1:SomeEnum3] = [.South:.Payload(.South), .South: .Payload(.#^UNRESOLVED_41^#)]
 let _: [SomeEnum3:SomeEnum1] = [.Payload(.South):.South, .Payload(.#^UNRESOLVED_42^#):.South]
-let _: [SomeEnum3:SomeEnum1] = [.Payload(.South):.South, .Payload(.#^UNRESOLVED_43^#)]
+let _: [SomeEnum3:SomeEnum1] = [.Payload(.South):.South, .Payload(.#^UNRESOLVED_43^#):]
+let _: [SomeEnum3:SomeEnum1] = [.Payload(.South):.South, .Payload(.#^UNRESOLVED_44^#)]
 
 func testAvail1(_ x: EnumAvail1) {
   testAvail1(.#^ENUM_AVAIL_1^#)


### PR DESCRIPTION
Cherry-pick of #29258 into `swift-5.2-branch`

- **Explanation**: If dictionary literal aren't well formed, implicit-member completion didn't use to work because it doesn't type check. This patch improves context type analysis for *failed* dictionary literal elements, so it increases the chance to successfully suggest completion inside dictionary literals. E.g. `let dict: [SomeEnum: String] = [.foo: bar, <HERE>]`
- **Scope**: Code completion inside dictionary literals
- **Risk**: Low
- **Issue**: rdar://problem/57096392
- **Testing**: Added regression test cases
- **Reviewer**: Ben Langmuir (@benlangmuir)