### PR TITLE
[Build System: build-script] Shell module.

### DIFF
--- a/utils/build_swift/build_swift/shell.py
+++ b/utils/build_swift/build_swift/shell.py
@@ -1,0 +1,568 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Shell utilities wrapper module.
+"""
+
+
+from __future__ import absolute_import, unicode_literals
+
+import abc
+import collections
+import functools
+import itertools
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from copy import copy as _copy
+from shlex import split
+from subprocess import CalledProcessError
+
+import six
+from six.moves import map
+
+
+try:
+    # Python 2
+    from pipes import quote as _quote
+except ImportError:
+    from shutil import quote as _quote
+
+
+try:
+    # Python 3.4
+    from pathlib import Path
+except ImportError:
+    Path = None
+
+
+__all__ = [
+    'CalledProcessError',
+    'AbstractWrapper',
+    'CommandWrapper',
+    'ExecutableWrapper',
+
+    'quote',
+    'split',
+    'rerun_as_root',
+
+    'Popen',
+    'call',
+    'check_call',
+    'check_output',
+
+    'copy',
+    'pushd',
+    'makedirs',
+    'move',
+    'remove',
+    'symlink',
+    'which',
+
+    'wraps',
+
+    'ECHO_PREFIX',
+    'PIPE',
+    'STDOUT',
+    'DEVNULL',
+]
+
+
+_PY_VERSION = (sys.version_info.major, sys.version_info.minor)
+
+ECHO_PREFIX = '>>> '
+
+# Re-export subprocess constants
+PIPE = subprocess.PIPE
+STDOUT = subprocess.STDOUT
+
+try:
+    DEVNULL = subprocess.DEVNULL
+except AttributeError:
+    DEVNULL = -3
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+
+def _flatmap(func, *iterables):
+    """Helper function that maps the given func over the iterables and then
+    creates a single flat iterable from the results.
+    """
+
+    return itertools.chain.from_iterable(map(func, *iterables))
+
+
+def _convert_pathlib_path(path):
+    """Helper function used to convert an instance of pathlib.Path into a
+    unicode string.
+    """
+
+    if Path is None:
+        return path
+
+    if isinstance(path, Path):
+        return six.text_type(path)
+
+    return path
+
+
+def _get_stream_file(stream):
+    """Helper function used to decode the standard PIPE and STDOUT constants
+    into actual file objects.
+    """
+
+    if stream == PIPE:
+        return sys.stdout
+    if stream == STDOUT:
+        return sys.stdout
+    if stream == DEVNULL:
+        raise ValueError('DEVNULL should be replaced by now!')
+
+    return stream
+
+
+def _echo_command(command, stream, prefix=ECHO_PREFIX):
+    """Helper function used to echo a given command to some stream. An optional
+    command prefix can be provided.
+    """
+
+    if stream == DEVNULL:
+        return
+
+    stream = _get_stream_file(stream)
+
+    stream.write('{}{}\n'.format(prefix, quote(command)))
+    stream.flush()
+
+
+def _normalize_args(args):
+    """Normalizes a list of arguments containing one or more strings and
+    CommandWrapper instances into a one-dimensional list of strings.
+    """
+
+    if isinstance(args, six.string_types):
+        return shlex.split(args)
+
+    def normalize_arg(arg):
+        arg = _convert_pathlib_path(arg)
+
+        if isinstance(arg, six.string_types):
+            return [six.text_type(arg)]
+        if isinstance(arg, AbstractWrapper):
+            return list(map(_convert_pathlib_path, arg.command))
+
+        raise ValueError('Invalid argument type: {}'.format(
+            type(arg).__name__))
+
+    if isinstance(args, AbstractWrapper):
+        return normalize_arg(args)
+
+    return list(_flatmap(normalize_arg, args))
+
+
+# -----------------------------------------------------------------------------
+# Decorators
+
+def _backport_devnull(func):
+    """Decorator used to backport the subprocess.DEVNULL functionality from
+    Python 3 to Python 2.
+    """
+
+    # DEVNULL was introduced in Python 3.3
+    if _PY_VERSION >= (3, 3):
+        return func
+
+    @functools.wraps(func)
+    def wrapper(command, **kwargs):
+        stdout = kwargs.get('stdout', sys.stdout)
+        stderr = kwargs.get('stderr', sys.stderr)
+
+        if stdout != DEVNULL and stderr != DEVNULL:
+            return func(command, **kwargs)
+
+        with open(os.devnull, 'w') as devnull:
+            if stdout == DEVNULL:
+                kwargs['stdout'] = devnull
+            if stderr == DEVNULL:
+                kwargs['stderr'] = devnull
+
+            return func(command, **kwargs)
+
+    return wrapper
+
+
+def _normalize_command(func):
+    """Decorator used to uniformly normalize the input command of the
+    subprocess wrappers.
+    """
+
+    @functools.wraps(func)
+    def wrapper(command, **kwargs):
+        if not isinstance(command, six.string_types):
+            command = _normalize_args(command)
+
+        return func(command, **kwargs)
+
+    return wrapper
+
+
+def _add_echo_kwarg(func):
+    """Decorator used to add the 'echo' keyword-only argument that echos the
+    input command to whatever stdout the user passes (or sys.stdout if not
+    supplied).
+    """
+
+    @functools.wraps(func)
+    def wrapper(command, **kwargs):
+        if kwargs.pop('echo', False):
+            stdout = kwargs.get('stdout', sys.stdout)
+            _echo_command(command, stdout)
+
+        return func(command, **kwargs)
+
+    return wrapper
+
+
+# -----------------------------------------------------------------------------
+# Public Functions
+
+def quote(command):
+    """Extension of the standard pipes.quote (Python 2) or shutil.quote
+    (Python 3) that handles both strings and lists of strings. This mirrors
+    how the subprocess package can handle commands as both a standalone string
+    or list of strings.
+
+    >>> quote('/Applications/App Store.app')
+    "'/Applications/App Store.app'"
+
+    >>> quote(['rm', '-rf', '~/Documents/My Homework'])
+    "rm -rf '~/Documents/My Homework'"
+    """
+
+    if isinstance(command, six.string_types):
+        return _quote(command)
+
+    if isinstance(command, collections.Iterable):
+        return ' '.join([_quote(arg) for arg in _normalize_args(command)])
+
+    raise ValueError('Invalid command type: {}'.format(type(command).__name__))
+
+
+def rerun_as_root():
+    """Replace the current process with itself running with root permissions.
+    Prompt the user for their password to support this.
+    """
+
+    euid = os.geteuid()
+    if euid == 0:
+        return
+
+    args = ['sudo', sys.executable] + sys.argv + [os.environ]
+    os.execlpe('sudo', *args)
+
+
+# -----------------------------------------------------------------------------
+# Subprocess Wrappers
+
+class Popen(subprocess.Popen):
+    """Wrapper around subprocess.Popen which allows for a more flexible command
+    type and echoing the input command to stdout.
+    """
+
+    def __init__(self, command, **kwargs):
+        """In order to utilize the same function decorators used to back-port
+        devnull support and add new features, we create a closure to capture
+        the input 'self' value while retaining a standard function signature.
+
+        Django has a really nice (and relatively simple) general purpose
+        solution to this problem in the form of their `method_decorator`.
+        """
+
+        @_backport_devnull
+        @_normalize_command
+        @_add_echo_kwarg
+        def closure(command, **kwargs):
+            super(Popen, self).__init__(command, **kwargs)
+
+        closure(command, **kwargs)
+
+    # Back-port the context manager behavior for Python 3.1 and below.
+    if _PY_VERSION < (3, 2):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.wait()
+
+
+@_backport_devnull
+@_normalize_command
+@_add_echo_kwarg
+def call(command, **kwargs):
+    """Simple wrapper around subprocess.call which backports DEVNULL support
+    and adds support for the echo keyword-only argument.
+    """
+
+    return subprocess.call(command, **kwargs)
+
+
+@_backport_devnull
+@_normalize_command
+@_add_echo_kwarg
+def check_call(command, **kwargs):
+    """Simple wrapper around subprocess.check_call which backports DEVNULL
+    support and adds support for the echo keyword-only argument.
+    """
+
+    return subprocess.check_call(command, **kwargs)
+
+
+@_backport_devnull
+@_normalize_command
+@_add_echo_kwarg
+def check_output(command, **kwargs):
+    """Simple wrapper around subprocess.check_output which backports DEVNULL
+    support and adds support for the echo keyword-only argument.
+
+    Output is returned as a unicode string.
+    """
+
+    output = subprocess.check_output(command, **kwargs)
+
+    if _PY_VERSION >= (3, 0):
+        return output
+
+    # Return unicode string rather than bytes in Python 2.
+    return six.text_type(output, errors='ignore')
+
+
+# -----------------------------------------------------------------------------
+# Shell Utilities
+
+def copy(source, dest, echo=False):
+    """Emulates the `cp` command to copy a file or directory.
+    """
+
+    source = _convert_pathlib_path(source)
+    dest = _convert_pathlib_path(dest)
+
+    if os.path.isfile(source):
+        if echo:
+            _echo_command(['cp', source, dest], sys.stdout)
+        return shutil.copyfile(source, dest)
+
+    if os.path.isdir(source):
+        if echo:
+            _echo_command(['cp', '-R', source, dest], sys.stdout)
+        return shutil.copytree(source, dest)
+
+
+class pushd(object):
+    """Context manager to mimic the behavior of pushd and popd, moving the
+    current working directory to a new path and then restoring it when exiting
+    the current block.
+    """
+
+    def __init__(self, path, echo=False):
+        path = _convert_pathlib_path(path)
+
+        self.cwd = os.getcwd()
+        self.path = os.path.expanduser(path)
+        self.echo = echo
+
+    def __enter__(self):
+        if self.echo:
+            _echo_command(['pushd', self.path], sys.stdout)
+
+        os.chdir(self.path)
+        return self.path
+
+    def __exit__(self, *args):
+        if self.echo:
+            _echo_command(['popd'], sys.stdout)
+
+        os.chdir(self.cwd)
+
+
+def makedirs(path, echo=False):
+    """Emulates the `mkdir -p` command to recursively create directories for
+    the path given if it doesn't already exist.
+    """
+
+    path = _convert_pathlib_path(path)
+    if os.path.exists(path):
+        return
+
+    if echo:
+        _echo_command(['mkdir', '-p', path], sys.stdout)
+
+    os.makedirs(path)
+
+
+def move(source, dest, echo=False):
+    """Emulates the `mv` command to move files or directories.
+    """
+
+    source = _convert_pathlib_path(source)
+    dest = _convert_pathlib_path(dest)
+
+    if echo:
+        _echo_command(['mv', source, dest], sys.stdout)
+
+    return shutil.move(source, dest)
+
+
+def remove(path, echo=False):
+    """Emulates the `rm` command for both files and directories.
+    """
+
+    path = _convert_pathlib_path(path)
+
+    if os.path.isfile(path):
+        if echo:
+            _echo_command(['rm', path], sys.stdout)
+        return os.remove(path)
+
+    if os.path.isdir(path):
+        if echo:
+            _echo_command(['rm', '-rf', path], sys.stdout)
+        return shutil.rmtree(path, ignore_errors=True)
+
+
+def symlink(source, dest, echo=False):
+    """Emulates the `ln` command to symlink a file or directory.
+    """
+
+    source = _convert_pathlib_path(source)
+    dest = _convert_pathlib_path(dest)
+
+    if echo:
+        _echo_command(['ln', '-s', source, dest], sys.stdout)
+
+    return os.symlink(source, dest)
+
+
+def which(command, mode=os.F_OK | os.X_OK, path=None):
+    """Polyfill for the Python 3 shutil.which function. Does not support
+    Windows platforms.
+    """
+
+    # Default to environment PATH or os.defpath
+    path = path or os.environ.get('PATH', os.defpath)
+
+    for location in path.split(os.pathsep):
+        # If command is a full path then candidate will be just command
+        candidate = os.path.join(location, command)
+
+        if os.path.isfile(candidate) and os.access(candidate, mode):
+            return candidate
+
+    return None
+
+
+# -----------------------------------------------------------------------------
+# Wrappers
+
+def wraps(command):
+    """Simple utility function to instantiate a CommandWrapper instance in a
+    more fluent way.
+    """
+
+    return CommandWrapper(command)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AbstractWrapper(object):
+    """Abstract base class for implementing wrappers around command line
+    utilities and executables. Subclasses must implement the `command` method
+    which returns a command list suitable for use with executor instances.
+    """
+
+    def __call__(self, *args, **kwargs):
+        return self.check_call(*args, **kwargs)
+
+    @abc.abstractproperty
+    @property
+    def command(self):
+        """Subclasses must implement a command property.
+        """
+
+        raise NotImplementedError()
+
+    def __build_command(self, args):
+        args = _normalize_args(args)
+
+        return self.command + _normalize_args(args)
+
+    # -------------------------------------------------------------------------
+
+    def Popen(self, args, **kwargs):
+        return Popen(self.__build_command(args), **kwargs)
+
+    def call(self, args, **kwargs):
+        return call(self.__build_command(args), **kwargs)
+
+    def check_call(self, args, **kwargs):
+        return check_call(self.__build_command(args), **kwargs)
+
+    def check_output(self, args, **kwargs):
+        return check_output(self.__build_command(args), **kwargs)
+
+
+class CommandWrapper(AbstractWrapper):
+    """Wrapper class for command line utilities which can be initialized
+    on-demand for the desired command.
+    """
+
+    __slots__ = ('_command')
+
+    def __init__(self, command):
+        super(CommandWrapper, self).__init__()
+
+        self._command = _normalize_args(command)
+
+    @property
+    def command(self):
+        return _copy(self._command)
+
+
+class ExecutableWrapper(AbstractWrapper):
+    """Wrapper class for executable utilities. This class is suitable as a base
+    class for implementing wrapper classes around executables, simply subclass
+    and define the `EXECUTABLE` attribute to the correct executable name or
+    path.
+    """
+
+    EXECUTABLE = None
+
+    def __init__(self):
+        if self.EXECUTABLE is None:
+            raise AttributeError('{}.EXECUTABLE cannot be None'.format(
+                type(self).__name__))
+
+        self.EXECUTABLE = _convert_pathlib_path(self.EXECUTABLE)
+
+        if not isinstance(self.EXECUTABLE, six.string_types):
+            raise AttributeError(
+                '{}.EXECUTABLE must be an executable name or path'.format(
+                    type(self).__name__))
+
+        super(ExecutableWrapper, self).__init__()
+
+    @property
+    def command(self):
+        return [_copy(self.EXECUTABLE)]
+
+    @property
+    def path(self):
+        return which(self.EXECUTABLE)

--- a/utils/build_swift/tests/test_shell.py
+++ b/utils/build_swift/tests/test_shell.py
@@ -1,0 +1,845 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from __future__ import absolute_import, unicode_literals
+
+import collections
+import sys
+import unittest
+
+import six
+from six import StringIO
+
+from ..build_swift import shell
+
+
+try:
+    # Python 3.4
+    from pathlib import Path
+except ImportError:
+    Path = None
+
+try:
+    # Python 3.3
+    from unittest import mock
+    from unittest.mock import patch, mock_open, MagicMock
+except ImportError:
+    mock, mock_open = None, None
+
+    class MagicMock(object):
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def patch(*args, **kwargs):
+        return _id
+
+
+# -----------------------------------------------------------------------------
+# Constants
+
+_OPEN_NAME = '{}.open'.format(six.moves.builtins.__name__)
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+
+def _id(obj):
+    return obj
+
+
+def _requires_mock(func):
+    return unittest.skipIf(
+        mock is None, 'mock module is not available')(func)
+
+
+def _requires_pathlib(func):
+    return unittest.skipIf(
+        Path is None, 'pathlib module is not available')(func)
+
+
+# -----------------------------------------------------------------------------
+# Test Cases
+
+class TestHelpers(unittest.TestCase):
+    """Unit tests for the helper functions defined in the build_swift.shell
+    module.
+    """
+
+    # -------------------------------------------------------------------------
+    # _flatmap
+
+    def test_flatmap(self):
+        def duplicate(x):
+            return [x, x]
+
+        result = shell._flatmap(duplicate, [1, 2, 3])
+
+        self.assertIsInstance(result, collections.Iterable)
+        self.assertEqual(list(result), [1, 1, 2, 2, 3, 3])
+
+    # -------------------------------------------------------------------------
+    # _convert_pathlib_path
+
+    @_requires_mock
+    @_requires_pathlib
+    @patch('build_swift.build_swift.shell.Path', None)
+    def test_convert_pathlib_path_pathlib_not_imported(self):
+        path = Path('/path/to/file.txt')
+
+        self.assertEqual(shell._convert_pathlib_path(path), path)
+
+    @_requires_pathlib
+    def test_convert_pathlib_path(self):
+        path = Path('/path/to/file.txt')
+
+        self.assertEqual(shell._convert_pathlib_path(''), '')
+
+        self.assertEqual(
+            shell._convert_pathlib_path(path),
+            six.text_type(path))
+
+    # -------------------------------------------------------------------------
+    # _get_stream_file
+
+    def test_get_stream_file(self):
+        self.assertEqual(shell._get_stream_file(shell.PIPE), sys.stdout)
+        self.assertEqual(shell._get_stream_file(shell.STDOUT), sys.stdout)
+
+        self.assertEqual(shell._get_stream_file(sys.stdout), sys.stdout)
+        self.assertEqual(shell._get_stream_file(sys.stderr), sys.stderr)
+
+    def test_get_stream_file_raises_devnull(self):
+        with self.assertRaises(ValueError):
+            shell._get_stream_file(shell.DEVNULL)
+
+    # -------------------------------------------------------------------------
+    # _echo_command
+
+    @_requires_mock
+    def test_echo_command(self):
+        test_command = ['sudo', 'rm', '-rf', '/tmp/*']
+        mock_stream = MagicMock()
+
+        shell._echo_command(test_command, mock_stream)
+
+        mock_stream.write.assert_called_with(
+            '>>> {}\n'.format(shell.quote(test_command)))
+        mock_stream.flush.assert_called()
+
+    @_requires_mock
+    def test_echo_command_custom_prefix(self):
+        mock_stream = MagicMock()
+
+        shell._echo_command('ls', mock_stream, prefix='$ ')
+
+        mock_stream.write.assert_called_with('$ ls\n')
+        mock_stream.flush.assert_called()
+
+    # -------------------------------------------------------------------------
+    # _normalize_args
+
+    def test_normalize_args_splits_basestring(self):
+        command = 'rm -rf /Applications/Xcode.app'
+
+        self.assertEqual(
+            shell._normalize_args(command),
+            ['rm', '-rf', '/Applications/Xcode.app'])
+
+    def test_normalize_args_list_str(self):
+        command = ['rm', '-rf', '/Applications/Xcode.app']
+
+        self.assertEqual(shell._normalize_args(command), command)
+
+    def test_normalize_args_converts_wrappers(self):
+        sudo = shell.wraps('sudo')
+        rm = shell.wraps('rm')
+
+        command = [sudo, rm, '-rf', '/Applications/Xcode.app']
+
+        self.assertEqual(
+            shell._normalize_args(command),
+            ['sudo', 'rm', '-rf', '/Applications/Xcode.app'])
+
+    def test_normalize_args_converts_complex_wrapper_commands(self):
+        sudo_rm_rf = shell.wraps('sudo rm -rf')
+
+        command = [sudo_rm_rf, '/Applications/Xcode.app']
+
+        self.assertEqual(
+            shell._normalize_args(command),
+            ['sudo', 'rm', '-rf', '/Applications/Xcode.app'])
+
+    @_requires_pathlib
+    def test_normalize_args_accepts_single_wrapper_arg(self):
+        rm_xcode = shell.wraps(['rm', '-rf', Path('/Applications/Xcode.app')])
+
+        self.assertEqual(
+            shell._normalize_args(rm_xcode),
+            ['rm', '-rf', '/Applications/Xcode.app'])
+
+    @_requires_pathlib
+    def test_normalize_args_converts_pathlib_path(self):
+        command = ['rm', '-rf', Path('/Applications/Xcode.app')]
+
+        self.assertEqual(
+            shell._normalize_args(command),
+            ['rm', '-rf', '/Applications/Xcode.app'])
+
+    @_requires_pathlib
+    def test_normalize_args_converts_pathlib_path_in_wrapper_commands(self):
+        rm_xcode = shell.wraps(['rm', '-rf', Path('/Applications/Xcode.app')])
+
+        self.assertEqual(
+            shell._normalize_args([rm_xcode]),
+            ['rm', '-rf', '/Applications/Xcode.app'])
+
+
+class TestDecorators(unittest.TestCase):
+    """Unit tests for the decorators defined in the build_swift.shell module
+    used to backport or add functionality to the subprocess wrappers.
+    """
+
+    # -------------------------------------------------------------------------
+    # _backport_devnull
+
+    @_requires_mock
+    @patch(_OPEN_NAME, new_callable=mock_open)
+    @patch('build_swift.build_swift.shell._PY_VERSION', (3, 2))
+    def test_backport_devnull_stdout_kwarg(self, mock_open):
+        mock_file = MagicMock()
+        mock_open.return_value.__enter__.return_value = mock_file
+
+        @shell._backport_devnull
+        def func(command, **kwargs):
+            self.assertEqual(kwargs['stdout'], mock_file)
+
+        func('', stdout=shell.DEVNULL)
+        mock_open.return_value.__enter__.assert_called()
+        mock_open.return_value.__exit__.assert_called()
+
+    @_requires_mock
+    @patch(_OPEN_NAME, new_callable=mock_open)
+    @patch('build_swift.build_swift.shell._PY_VERSION', (3, 2))
+    def test_backport_devnull_stderr_kwarg(self, mock_open):
+        mock_file = MagicMock()
+        mock_open.return_value.__enter__.return_value = mock_file
+
+        @shell._backport_devnull
+        def func(command, **kwargs):
+            self.assertEqual(kwargs['stderr'], mock_file)
+
+        func('', stderr=shell.DEVNULL)
+        mock_open.return_value.__enter__.assert_called()
+        mock_open.return_value.__exit__.assert_called()
+
+    @_requires_mock
+    @patch(_OPEN_NAME, new_callable=mock_open)
+    def test_backport_devnull_does_not_open(self, mock_open):
+        @shell._backport_devnull
+        def func(command):
+            pass
+
+        func('')
+        mock_open.return_value.__enter__.assert_not_called()
+        mock_open.return_value.__exit__.assert_not_called()
+
+    @_requires_mock
+    @patch('build_swift.build_swift.shell._PY_VERSION', (3, 3))
+    def test_backport_devnull_noop_starting_with_python_3_3(self):
+        def func():
+            pass
+
+        self.assertEqual(shell._backport_devnull(func), func)
+
+    # -------------------------------------------------------------------------
+    # _normalize_command
+
+    def test_normalize_command_basestring_command_noop(self):
+        test_command = 'touch test.txt'
+
+        @shell._normalize_command
+        def func(command):
+            self.assertEqual(command, test_command)
+
+        func(test_command)
+
+    @_requires_mock
+    @patch('build_swift.build_swift.shell._normalize_args')
+    def test_normalize_command(self, mock_normalize_args):
+        test_command = ['rm', '-rf', '/tmp/*']
+
+        @shell._normalize_command
+        def func(command):
+            pass
+
+        func(test_command)
+        mock_normalize_args.assert_called_with(test_command)
+
+    # -------------------------------------------------------------------------
+    # _add_echo_kwarg
+
+    @_requires_mock
+    @patch('build_swift.build_swift.shell._echo_command')
+    def test_add_echo_kwarg_calls_echo_command(self, mock_echo_command):
+        test_command = ['rm', '-rf', '/tmp/*']
+
+        @shell._add_echo_kwarg
+        def func(command, **kwargs):
+            pass
+
+        mock_stream = mock.mock_open()
+
+        func(test_command, echo=True, stdout=mock_stream)
+        mock_echo_command.assert_called_with(test_command, mock_stream)
+
+    @_requires_mock
+    @patch('build_swift.build_swift.shell._echo_command')
+    def test_add_echo_kwarg_noop_echo_false(self, mock_echo_command):
+        test_command = ['rm', '-rf', '/tmp/*']
+
+        @shell._add_echo_kwarg
+        def func(command):
+            pass
+
+        func(test_command)
+        func(test_command, echo=False)
+        mock_echo_command.assert_not_called()
+
+
+class TestPublicFunctions(unittest.TestCase):
+    """Unit tests for the public functions defined in the build_swift.shell
+    module.
+    """
+
+    # -------------------------------------------------------------------------
+    # quote
+
+    def test_quote_string(self):
+        self.assertEqual(
+            shell.quote('/Applications/App Store.app'),
+            "'/Applications/App Store.app'")
+
+    def test_quote_iterable(self):
+        self.assertEqual(
+            shell.quote(['rm', '-rf', '~/Documents/My Homework']),
+            "rm -rf '~/Documents/My Homework'")
+
+    # -------------------------------------------------------------------------
+    # rerun_as_root
+
+    def test_rerun_as_root(self):
+        pass
+
+
+class TestSubprocessWrappers(unittest.TestCase):
+    """Unit tests for the subprocess wrappers defined in the build_swift.shell
+    module.
+    """
+
+    # -------------------------------------------------------------------------
+    # Popen
+
+    # NOTE: Testing the Popen class is harder than it might appear. We're not
+    # able to mock out the subprocess.Popen superclass as one might initially
+    # expect. Rather that shell.Popen class object already exists and inherts
+    # from subprocess.Popen, thus mocking it out does not change the behavior.
+    # Ultimately this class is merely a wrapper that uses already tested
+    # decorators to add functionality so testing here might not provide any
+    # benefit.
+
+    # -------------------------------------------------------------------------
+    # call
+
+    @_requires_mock
+    @patch('subprocess.call')
+    def test_call(self, mock_call):
+        shell.call('ls')
+
+        mock_call.assert_called_with('ls')
+
+    # -------------------------------------------------------------------------
+    # check_call
+
+    @_requires_mock
+    @patch('subprocess.check_call')
+    def test_check_call(self, mock_check_call):
+        shell.check_call('ls')
+
+        mock_check_call.assert_called_with('ls')
+
+    # -------------------------------------------------------------------------
+    # check_output
+
+    @_requires_mock
+    @patch('subprocess.check_output')
+    def test_check_output(self, mock_check_output):
+        # Before Python 3 the subprocess.check_output function returned bytes.
+        if six.PY2:
+            mock_check_output.return_value = b''
+        else:
+            mock_check_output.return_value = ''
+
+        output = shell.check_output('ls')
+
+        # We always expect str (utf-8) output
+        self.assertIsInstance(output, six.text_type)
+
+        mock_check_output.assert_called_with('ls')
+
+
+class TestShellUtilities(unittest.TestCase):
+    """Unit tests for the shell utility wrappers defined in the
+    build_swift.shell module.
+    """
+
+    # -------------------------------------------------------------------------
+    # copy
+
+    @_requires_mock
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('shutil.copyfile', MagicMock())
+    @patch('build_swift.build_swift.shell._convert_pathlib_path')
+    def test_copy_converts_pathlib_paths(self, mock_convert):
+        source = Path('/source/path')
+        dest = Path('/dest/path')
+
+        shell.copy(source, dest)
+
+        mock_convert.assert_has_calls([
+            mock.call(source),
+            mock.call(dest),
+        ])
+
+    @_requires_mock
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('shutil.copyfile')
+    def test_copy_files(self, mock_copyfile):
+        source = '/source/path'
+        dest = '/dest/path'
+
+        shell.copy(source, dest)
+
+        mock_copyfile.assert_called_with(source, dest)
+
+    @_requires_mock
+    @patch('os.path.isfile', MagicMock(return_value=False))
+    @patch('os.path.isdir', MagicMock(return_value=True))
+    @patch('shutil.copytree')
+    def test_copy_directories(self, mock_copytree):
+        source = '/source/path'
+        dest = '/dest/path'
+
+        shell.copy(source, dest)
+
+        mock_copytree.assert_called_with(source, dest)
+
+    @_requires_mock
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('shutil.copyfile', MagicMock())
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_copy_echos_fake_cp_file_command(self, mock_stdout):
+        source = '/source/path'
+        dest = '/dest/path'
+
+        shell.copy(source, dest, echo=True)
+
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            '>>> cp {} {}\n'.format(source, dest))
+
+    @_requires_mock
+    @patch('os.path.isfile', MagicMock(return_value=False))
+    @patch('os.path.isdir', MagicMock(return_value=True))
+    @patch('shutil.copytree', MagicMock())
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_copy_echos_fake_cp_directory_command(self, mock_stdout):
+        source = '/source/path'
+        dest = '/dest/path'
+
+        shell.copy(source, dest, echo=True)
+
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            '>>> cp -R {} {}\n'.format(source, dest))
+
+    # -------------------------------------------------------------------------
+    # pushd
+
+    @_requires_mock
+    @_requires_pathlib
+    @patch('os.getcwd', MagicMock(return_value='/start/path'))
+    @patch('build_swift.build_swift.shell._convert_pathlib_path')
+    def test_pushd_converts_pathlib_path(self, mock_convert):
+        path = Path('/other/path')
+        mock_convert.return_value = six.text_type(path)
+
+        shell.pushd(path)
+
+        mock_convert.assert_called_with(path)
+
+    @_requires_mock
+    @patch('os.getcwd', MagicMock(return_value='/start/path'))
+    @patch('os.chdir')
+    def test_pushd_restores_cwd(self, mock_chdir):
+        with shell.pushd('/other/path'):
+            mock_chdir.assert_called_with('/other/path')
+
+        mock_chdir.assert_called_with('/start/path')
+
+    @_requires_mock
+    @patch('os.getcwd', MagicMock(return_value='/start/path'))
+    @patch('os.chdir', MagicMock())
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_pushd_echos_fake_pushd_popd_commands(self, mock_stdout):
+        with shell.pushd('/other/path', echo=True):
+            pass
+
+        self.assertEqual(mock_stdout.getvalue().splitlines(), [
+            '>>> pushd /other/path',
+            '>>> popd'
+        ])
+
+    # -------------------------------------------------------------------------
+    # makedirs
+
+    @_requires_mock
+    @_requires_pathlib
+    @patch('os.path.exists', MagicMock(return_value=False))
+    @patch('os.makedirs', MagicMock())
+    @patch('build_swift.build_swift.shell._convert_pathlib_path')
+    def test_makedirs_converts_pathlib_path(self, mock_convert):
+        path = Path('/some/directory')
+
+        shell.makedirs(path)
+
+        mock_convert.assert_called_with(path)
+
+    @_requires_mock
+    @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('os.makedirs')
+    def test_makedirs_noop_path_exists(self, mock_makedirs):
+        shell.makedirs('/some/directory')
+
+        mock_makedirs.assert_not_called()
+
+    @_requires_mock
+    @patch('os.path.exists', MagicMock(return_value=False))
+    @patch('os.makedirs')
+    def test_makedirs_creates_path(self, mock_makedirs):
+        path = '/some/directory'
+
+        shell.makedirs(path)
+
+        mock_makedirs.assert_called_with(path)
+
+    @_requires_mock
+    @patch('os.path.exists', MagicMock(return_value=False))
+    @patch('os.makedirs', MagicMock())
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_makedirs_echos_fake_mkdir_command(self, mock_stdout):
+        path = '/some/directory'
+
+        shell.makedirs(path, echo=True)
+
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            '>>> mkdir -p {}\n'.format(path))
+
+    # -------------------------------------------------------------------------
+    # move
+
+    @_requires_mock
+    @_requires_pathlib
+    @patch('shutil.move', MagicMock())
+    @patch('build_swift.build_swift.shell._convert_pathlib_path')
+    def test_move_converts_pathlib_paths(self, mock_convert):
+        source = Path('/source/path')
+        dest = Path('/dest/path')
+
+        shell.move(source, dest)
+
+        mock_convert.assert_has_calls([
+            mock.call(source),
+            mock.call(dest),
+        ])
+
+    @_requires_mock
+    @patch('shutil.move')
+    def test_move(self, mock_move):
+        source = '/source/path'
+        dest = '/dest/path'
+
+        shell.move(source, dest)
+
+        mock_move.assert_called_with(source, dest)
+
+    @_requires_mock
+    @patch('shutil.move', MagicMock())
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_move_echos_fake_mv_command(self, mock_stdout):
+        source = '/source/path'
+        dest = '/dest/path'
+
+        shell.move(source, dest, echo=True)
+
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            '>>> mv {} {}\n'.format(source, dest))
+
+    # -------------------------------------------------------------------------
+    # remove
+
+    @_requires_mock
+    @_requires_pathlib
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('os.remove', MagicMock())
+    @patch('build_swift.build_swift.shell._convert_pathlib_path')
+    def test_remove_converts_pathlib_paths(self, mock_convert):
+        path = Path('/path/to/remove')
+
+        shell.remove(path)
+
+        mock_convert.assert_called_with(path)
+
+    @_requires_mock
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('os.remove')
+    def test_remove_files(self, mock_remove):
+        path = '/path/to/remove'
+
+        shell.remove(path)
+
+        mock_remove.assert_called_with(path)
+
+    @_requires_mock
+    @patch('os.path.isfile', MagicMock(return_value=False))
+    @patch('os.path.isdir', MagicMock(return_value=True))
+    @patch('shutil.rmtree')
+    def test_remove_directories(self, mock_rmtree):
+        path = '/path/to/remove'
+
+        shell.remove(path)
+
+        mock_rmtree.assert_called_with(path, ignore_errors=True)
+
+    @_requires_mock
+    @patch('os.path.isfile', MagicMock(return_value=True))
+    @patch('os.remove', MagicMock())
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_remove_echos_fake_rm_file_command(self, mock_stdout):
+        path = '/path/to/remove'
+
+        shell.remove(path, echo=True)
+
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            '>>> rm {}\n'.format(path))
+
+    @_requires_mock
+    @patch('os.path.isfile', MagicMock(return_value=False))
+    @patch('os.path.isdir', MagicMock(return_value=True))
+    @patch('shutil.rmtree', MagicMock())
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_remove_echos_fake_rm_directory_command(self, mock_stdout):
+        path = '/path/to/remove'
+
+        shell.remove(path, echo=True)
+
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            '>>> rm -rf {}\n'.format(path))
+
+    # -------------------------------------------------------------------------
+    # symlink
+
+    @_requires_mock
+    @_requires_pathlib
+    @patch('os.symlink', MagicMock())
+    @patch('build_swift.build_swift.shell._convert_pathlib_path')
+    def test_symlink_converts_pathlib_paths(self, mock_convert):
+        source = Path('/source/path')
+        dest = Path('/dest/path')
+
+        shell.symlink(source, dest)
+
+        mock_convert.assert_has_calls([
+            mock.call(source),
+            mock.call(dest),
+        ])
+
+    @_requires_mock
+    @patch('os.symlink')
+    def test_symlink(self, mock_symlink):
+        source = '/source/path'
+        dest = '/dest/path'
+
+        shell.symlink(source, dest)
+
+        mock_symlink.assert_called_with(source, dest)
+
+    @_requires_mock
+    @patch('os.symlink', MagicMock())
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_symlink_echos_fake_ln_command(self, mock_stdout):
+        source = '/source/path'
+        dest = '/dest/path'
+
+        shell.symlink(source, dest, echo=True)
+
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            '>>> ln -s {} {}\n'.format(source, dest))
+
+    # -------------------------------------------------------------------------
+    # which
+
+    # NOTE: We currently have a polyfill for the shutil.which function. This
+    # will be swapped out for the real-deal as soon as we convert to Python 3,
+    # which should be in the near future. We could also use a backport package
+    # from pypi, but we rely on the shell module working in scripting that does
+    # not use a virtual environment at the moment. Until we either adopt
+    # Python 3 by default _or_ enforce virtual environments for all our scripts
+    # we are stuck with the polyfill.
+
+    def test_which(self):
+        pass
+
+
+class TestAbstractWrapper(unittest.TestCase):
+    """Unit tests for the AbstractWrapper class defined in the build_swift.shell
+    module.
+    """
+
+    def test_cannot_be_instantiated(self):
+        with self.assertRaises(TypeError):
+            shell.AbstractWrapper()
+
+
+class TestCommandWrapper(unittest.TestCase):
+    """Unit tests for the CommandWrapper class defined in the build_swift.shell
+    module.
+    """
+
+    # -------------------------------------------------------------------------
+    # wraps
+
+    def test_wraps(self):
+        sudo = shell.wraps('sudo')
+
+        self.assertIsInstance(sudo, shell.CommandWrapper)
+        self.assertEqual(sudo.command, ['sudo'])
+
+    # -------------------------------------------------------------------------
+
+    @_requires_pathlib
+    def test_command_normalized(self):
+        wrapper = shell.CommandWrapper(['ls', '-al', Path('/tmp')])
+
+        self.assertEqual(wrapper._command, ['ls', '-al', '/tmp'])
+
+    def test_command_property(self):
+        git = shell.CommandWrapper('git')
+
+        self.assertEqual(git.command, ['git'])
+
+    @_requires_mock
+    def test_callable(self):
+        ls = shell.CommandWrapper('ls')
+
+        with patch.object(ls, 'check_call') as mock_check_call:
+            ls('-al')
+
+        mock_check_call.assert_called_with('-al')
+
+    # -------------------------------------------------------------------------
+    # Subprocess Wrappers
+
+    @_requires_mock
+    @patch('build_swift.build_swift.shell.Popen')
+    def test_Popen(self, mock_popen):
+        ls = shell.CommandWrapper('ls')
+
+        ls.Popen('-al')
+
+        mock_popen.assert_called_with(['ls', '-al'])
+
+    @_requires_mock
+    @patch('build_swift.build_swift.shell.call')
+    def test_call(self, mock_call):
+        ls = shell.CommandWrapper('ls')
+
+        ls.call('-al')
+
+        mock_call.assert_called_with(['ls', '-al'])
+
+    @_requires_mock
+    @patch('build_swift.build_swift.shell.check_call')
+    def test_check_call(self, mock_check_call):
+        ls = shell.CommandWrapper('ls')
+
+        ls.check_call('-al')
+
+        mock_check_call.assert_called_with(['ls', '-al'])
+
+    @_requires_mock
+    @patch('build_swift.build_swift.shell.check_output')
+    def test_check_output(self, mock_check_output):
+        ls = shell.CommandWrapper('ls')
+
+        ls.check_output('-al')
+
+        mock_check_output.assert_called_with(['ls', '-al'])
+
+
+class TestExecutableWrapper(unittest.TestCase):
+    """Unit tests for the ExecutableWrapper class defined in the
+    build_swift.shell module.
+    """
+
+    def test_raises_without_executable(self):
+        class MyWrapper(shell.ExecutableWrapper):
+            pass
+
+        with self.assertRaises(AttributeError):
+            MyWrapper()
+
+    def test_raises_complex_executable(self):
+        class MyWrapper(shell.ExecutableWrapper):
+            EXECUTABLE = ['xcrun', 'swiftc']
+
+        with self.assertRaises(AttributeError):
+            MyWrapper()
+
+    @_requires_pathlib
+    def test_converts_pathlib_path(self):
+        class MyWrapper(shell.ExecutableWrapper):
+            EXECUTABLE = Path('/usr/local/bin/xbs')
+
+        wrapper = MyWrapper()
+
+        self.assertEqual(wrapper.EXECUTABLE, '/usr/local/bin/xbs')
+
+    def test_command_property(self):
+        class MyWrapper(shell.ExecutableWrapper):
+            EXECUTABLE = 'test'
+
+        wrapper = MyWrapper()
+
+        self.assertEqual(wrapper.command, ['test'])
+
+    @_requires_mock
+    @patch('build_swift.build_swift.shell.which')
+    def test_path_property(self, mock_which):
+        class MyWrapper(shell.ExecutableWrapper):
+            EXECUTABLE = 'test'
+
+        wrapper = MyWrapper()
+        wrapper.path
+
+        mock_which.assert_called_with('test')


### PR DESCRIPTION
Adds a new `shell` module to `build_swift` which wraps the standard `subprocess` module and provides convenience functions for common shell tasks.

Builds on changes in #29244