### PR TITLE
[CodeCompletion] Handle cases where PersistentParserState is not created

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -171,6 +171,8 @@ bool CompletionInstance::performCachedOperaitonIfPossible(
 
   auto &CI = *CachedCI;
 
+  if (!CI.hasPersistentParserState())
+    return false;
   auto &oldState = CI.getPersistentParserState();
   if (!oldState.hasCodeCompletionDelayedDeclState())
     return false;
@@ -321,7 +323,8 @@ bool CompletionInstance::performNewOperation(
   registerIDERequestFunctions(CI.getASTContext().evaluator);
 
   CI.performParseAndResolveImportsOnly();
-  Callback(CI);
+  if (CI.hasPersistentParserState())
+    Callback(CI);
 
   if (DiagC)
     CI.removeDiagnosticConsumer(DiagC);

--- a/test/SourceKit/CodeComplete/complete_without_stdlib.swift
+++ b/test/SourceKit/CodeComplete/complete_without_stdlib.swift
@@ -1,0 +1,19 @@
+class Str {
+  var value: Str
+}
+
+// rdar://problem/58663066
+// Test a environment where stdlib is not found.
+// Completion should return zero result.
+
+// RUN: %empty-directory(%t/rsrc)
+// RUN: %empty-directory(%t/sdk)
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk | %FileCheck %s
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk | %FileCheck %s
+
+// CHECK: key.results: [
+// CHECK-NOT: key.description:


### PR DESCRIPTION
For example, if stdlib is not found, `CompilerInstance` simply returns before creating `PersistentParserState`. In such cases, completion should just return empty result.

Previously, it caused SourceKit crash.

rdar://problem/58663066
