### PR TITLE
[DNM] Proof of conforming protocol extensions concept

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -308,6 +308,9 @@ public:
       llvm::SmallPtrSet<DerivativeAttr *, 1>>
       DerivativeAttrs;
 
+  /// Track protocol extensions that inherit to determine witness tables to emit.
+  mutable SmallVector<ExtensionDecl *, 2> ProtocolExtsWithConformances;
+
 private:
   /// The current generation number, which reflects the number of
   /// times that external modules have been loaded.
@@ -715,6 +718,11 @@ public:
   /// contains extensions loaded from any generation up to and including this
   /// one.
   void loadExtensions(NominalTypeDecl *nominal, unsigned previousGeneration);
+
+  /// Returns the current list of protocol extensions with conformances
+  SmallVector<ExtensionDecl *, 2> &getProtocolExtsWithConformances() const {
+    return ProtocolExtsWithConformances;
+  }
 
   /// Load the methods within the given class that produce
   /// Objective-C class or instance methods with the given selector.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -309,7 +309,7 @@ public:
       DerivativeAttrs;
 
   /// Track protocol extensions that inherit to determine witness tables to emit.
-  mutable SmallVector<ExtensionDecl *, 2> ProtocolExtsWithConformances;
+  mutable SmallVector<ExtensionDecl *, 2> ExtensionsWithConformances;
 
 private:
   /// The current generation number, which reflects the number of
@@ -719,10 +719,9 @@ public:
   /// one.
   void loadExtensions(NominalTypeDecl *nominal, unsigned previousGeneration);
 
-  /// Returns the current list of protocol extensions with conformances
-  SmallVector<ExtensionDecl *, 2> &getProtocolExtsWithConformances() const {
-    return ProtocolExtsWithConformances;
-  }
+  /// Iterate over conformances arising from protocol extensions
+  void forEachExtendedConformance(
+                std::function<void (NormalProtocolConformance *)> emitWitness);
 
   /// Load the methods within the given class that produce
   /// Objective-C class or instance methods with the given selector.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4280,6 +4280,9 @@ public:
   /// An extension has inherited a new protocol
   void inheritedProtocolsChanged();
 
+  //// Has a conformance come about from an extension?
+  bool isExtendedConformance(ProtocolDecl *proto);
+
   /// Determine whether this protocol has a superclass.
   bool hasSuperclass() const { return (bool)getSuperclassDecl(); }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -78,7 +78,6 @@ namespace swift {
   class EnumElementDecl;
   class ParameterList;
   class ParameterTypeFlags;
-  class ConformanceLookupTable;
   class Pattern;
   struct PrintOptions;
   struct PropertyWrapperBackingPropertyInfo;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -78,6 +78,7 @@ namespace swift {
   class EnumElementDecl;
   class ParameterList;
   class ParameterTypeFlags;
+  class ConformanceLookupTable;
   class Pattern;
   struct PrintOptions;
   struct PropertyWrapperBackingPropertyInfo;
@@ -1735,7 +1736,7 @@ public:
   MutableArrayRef<TypeLoc> getInherited() { return Inherited; }
   ArrayRef<TypeLoc> getInherited() const { return Inherited; }
 
-  void setInherited(MutableArrayRef<TypeLoc> i) { Inherited = i; }
+  void setInherited(MutableArrayRef<TypeLoc> i);
 
   bool hasDefaultAccessLevel() const {
     return Bits.ExtensionDecl.DefaultAndMaxAccessLevel != 0;
@@ -3338,9 +3339,6 @@ class NominalTypeDecl : public GenericTypeDecl, public IterableDeclContext {
   /// a given nominal type.
   mutable ConformanceLookupTable *ConformanceTable = nullptr;
 
-  /// Prepare the conformance table.
-  void prepareConformanceTable() const;
-
   /// Returns the protocol requirements that \c Member conforms to.
   ArrayRef<ValueDecl *>
     getSatisfiedProtocolRequirementsForMember(const ValueDecl *Member,
@@ -3449,6 +3447,9 @@ public:
   /// Collect the set of protocols to which this type should implicitly
   /// conform, such as AnyObject (for classes).
   void getImplicitProtocols(SmallVectorImpl<ProtocolDecl *> &protocols);
+
+  /// Prepare the conformance table (also acts as accessor).
+  ConformanceLookupTable *prepareConformanceTable() const;
 
   /// Look for conformances of this nominal type to the given
   /// protocol.
@@ -4276,6 +4277,9 @@ public:
 
     return const_cast<ProtocolDecl *>(this)->getInheritedProtocolsSlow();
   }
+
+  /// An extension has inherited a new protocol
+  void inheritedProtocolsChanged();
 
   /// Determine whether this protocol has a superclass.
   bool hasSuperclass() const { return (bool)getSuperclassDecl(); }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1711,6 +1711,8 @@ NOTE(composition_in_extended_type_alternative,none,
 ERROR(extension_access_with_conformances,none,
       "%0 modifier cannot be used with extensions that declare "
       "protocol conformances", (DeclAttribute))
+ERROR(protocol_extension_access_with_conformances,none,
+      "protocol extensions with conformances must currently be public", ())
 ERROR(extension_metatype,none,
       "cannot extend a metatype %0", (Type))
 ERROR(extension_specialization,none,
@@ -1723,8 +1725,10 @@ NOTE(extension_stored_property_fixit,none,
 ERROR(extension_nongeneric_trailing_where,none,
       "trailing 'where' clause for extension of non-generic type %0",
       (DeclName))
-ERROR(extension_protocol_inheritance,none,
-      "extension of protocol %0 cannot have an inheritance clause", (DeclName))
+WARNING(extension_protocol_inheritance,none,
+      "inheritance clause in extension of protocol %0. "
+      "use -enable-conforming-protocol-extensions to remove this warning",
+      (DeclName))
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -112,6 +112,9 @@ namespace swift {
     /// Detect and automatically import modules' cross-import overlays.
     bool EnableCrossImportOverlays = false;
 
+    /// Gate for conforming protocol extensions code.
+    bool EnableConformingExtensions = false;
+
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -504,6 +504,11 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
+def enable_conforming_protocol_extensions : Flag<["-"],
+    "enable-conforming-protocol-extensions">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable experimental feature to allow protocol extensions to conform to protocols">;
+
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,
   Flags<[FrontendOption]>,

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2620,7 +2620,8 @@ public:
       }
 
       auto proto = conformance->getProtocol();
-      if (normal->getDeclContext() != conformingDC) {
+      if (normal->getDeclContext() != conformingDC &&
+          !isa<ExtensionDecl>(conformingDC)) {
         Out << "AST verification error: conformance of "
             << nominal->getName().str() << " to protocol "
             << proto->getName().str() << " is in the wrong context.\n"

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -1279,7 +1279,7 @@ void ProtocolDecl::inheritedProtocolsChanged() {
 void ExtensionDecl::setInherited(MutableArrayRef<TypeLoc> i) {
   Inherited = i;
   if (!Inherited.empty()) {
-    getASTContext().ProtocolExtsWithConformances.emplace_back(this);
+    getASTContext().ExtensionsWithConformances.emplace_back(this);
 
     if (hasBeenBound())
       if (auto *proto = getExtendedProtocolDecl())
@@ -1287,17 +1287,17 @@ void ExtensionDecl::setInherited(MutableArrayRef<TypeLoc> i) {
   }
 }
 
-void ConformanceLookupTable::forEachExtendedConformance(ASTContext &ctx,
+void ASTContext::forEachExtendedConformance(
                 std::function<void (NormalProtocolConformance *)> emitWitness) {
-  for (ExtensionDecl *ext : ctx.getProtocolExtsWithConformances())
+  for (ExtensionDecl *ext : ExtensionsWithConformances)
     if (ext->hasBeenBound())
       if (ProtocolDecl *proto = ext->getExtendedProtocolDecl()) {
         SmallVector<ProtocolConformance *, 2> result;
         proto->prepareConformanceTable()->addExtendedConformances(ext, result);
         for (auto conformance : result)
-            if (auto *normal = dyn_cast<NormalProtocolConformance>(conformance))
-              if (!conformance->getType()->getCanonicalType()
-                    ->getAnyNominal()->getSelfProtocolDecl())
-                emitWitness(normal);
+          if (auto *normal = dyn_cast<NormalProtocolConformance>(conformance))
+            if (!conformance->getType()->getCanonicalType()
+                  ->getAnyNominal()->getSelfProtocolDecl())
+              emitWitness(normal);
       }
 }

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -1282,10 +1282,19 @@ void ProtocolDecl::inheritedProtocolsChanged() {
   RequirementSignature = nullptr;
 }
 
+bool ProtocolDecl::isExtendedConformance(ProtocolDecl *proto) {
+  if (!Bits.ProtocolDecl.InheritedProtocolsValid)
+    (void)getInheritedProtocolsSlow();
+  auto &extendedProtocols = getASTContext().ExtendedConformances;
+  auto extendedProto = extendedProtocols.find(this);
+  return extendedProto != extendedProtocols.end() &&
+    extendedProto->second.find(proto) != extendedProto->second.end();
+}
+
 void ExtensionDecl::setInherited(MutableArrayRef<TypeLoc> i) {
   Inherited = i;
   if (!Inherited.empty()) {
-    getASTContext().ExtensionsWithConformances.emplace_back(this);
+    getASTContext().addExtensionWithConformances(this);
 
     if (hasBeenBound())
       if (auto *proto = getExtendedProtocolDecl())

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -464,7 +464,7 @@ public:
 
   /// Add conformances implied by an inheriting protocol extension
   void addExtendedConformances(const ExtensionDecl *ext,
-                       SmallVectorImpl<ProtocolConformance *> &conformances);
+                          SmallVectorImpl<ProtocolConformance *> &conformances);
 
   /// Retrieve the complete set of protocols to which this nominal
   /// type conforms.
@@ -489,10 +489,6 @@ public:
   getSatisfiedProtocolRequirementsForMember(const ValueDecl *member,
                                             NominalTypeDecl *nominal,
                                             bool sorted);
-
-  /// Enumate conformances inferred from protocol extensions with new conformances
-  static void forEachExtendedConformance(ASTContext &ctx,
-                 std::function<void (NormalProtocolConformance *)> emitWitness);
 
   // Only allow allocation of conformance lookup tables using the
   // allocator in ASTContext or by doing a placement new.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4456,17 +4456,16 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
         anyErrors = true;
     }
 
-    // Protocol extensions with inheritance.
+    // Protocol extensions with conformances.
     if (auto *protoTy = dyn_cast_or_null<ProtocolDecl>(constraintType->getAnyNominal()))
       for (auto *ext : protoTy->getExtensions())
         for (auto inheritedTy : ext->getInherited())
           if (auto ty = inheritedTy.getType())
-            if (auto protoDecl = dyn_cast<ProtocolDecl>(ty->getAnyNominal())) {
-              if (isErrorResult(addConformanceRequirement(resolvedSubject,
-                                                          protoDecl,
-                                                          source)))
-                anyErrors = true;
-            }
+            if (auto *nomial = ty->getAnyNominal())
+              if (auto *protoDecl = dyn_cast<ProtocolDecl>(nomial))
+                if (isErrorResult(addConformanceRequirement(resolvedSubject,
+                                                            protoDecl, source)))
+                  anyErrors = true;
 
     return anyErrors ? ConstraintResult::Conflicting
                      : ConstraintResult::Resolved;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4456,6 +4456,18 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
         anyErrors = true;
     }
 
+    // Protocol extensions with inheritance.
+    if (auto *protoTy = dyn_cast_or_null<ProtocolDecl>(constraintType->getAnyNominal()))
+      for (auto *ext : protoTy->getExtensions())
+        for (auto inheritedTy : ext->getInherited())
+          if (auto ty = inheritedTy.getType())
+            if (auto protoDecl = dyn_cast<ProtocolDecl>(ty->getAnyNominal())) {
+              if (isErrorResult(addConformanceRequirement(resolvedSubject,
+                                                          protoDecl,
+                                                          source)))
+                anyErrors = true;
+            }
+
     return anyErrors ? ConstraintResult::Conflicting
                      : ConstraintResult::Resolved;
   }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1221,9 +1221,9 @@ ProtocolConformance::getInheritedConformance(ProtocolDecl *protocol) const {
 }
 
 #pragma mark Protocol conformance lookup
-void NominalTypeDecl::prepareConformanceTable() const {
+ConformanceLookupTable *NominalTypeDecl::prepareConformanceTable() const {
   if (ConformanceTable)
-    return;
+    return ConformanceTable;
 
   auto mutableThis = const_cast<NominalTypeDecl *>(this);
   ASTContext &ctx = getASTContext();
@@ -1236,7 +1236,7 @@ void NominalTypeDecl::prepareConformanceTable() const {
   if (file->getKind() != FileUnitKind::Source &&
       file->getKind() != FileUnitKind::ClangModule &&
       file->getKind() != FileUnitKind::DWARFModule) {
-    return;
+    return ConformanceTable;
   }
 
   SmallPtrSet<ProtocolDecl *, 2> protocols;
@@ -1270,6 +1270,8 @@ void NominalTypeDecl::prepareConformanceTable() const {
       addSynthesized(KnownProtocolKind::RawRepresentable);
     }
   }
+
+  return ConformanceTable;
 }
 
 bool NominalTypeDecl::lookupConformance(

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -256,6 +256,8 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
                        options::OPT_enable_experimental_concise_pound_file);
   inputArgs.AddLastArg(arguments,
                        options::OPT_verify_incremental_dependencies);
+  inputArgs.AddLastArg(arguments,
+                       options::OPT_enable_conforming_protocol_extensions);
   
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -536,6 +536,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableConcisePoundFile =
       Args.hasArg(OPT_enable_experimental_concise_pound_file);
+  Opts.EnableConformingExtensions =
+      Args.hasArg(OPT_enable_conforming_protocol_extensions);
 
   Opts.EnableCrossImportOverlays =
       Args.hasFlag(OPT_enable_cross_import_overlays,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -42,9 +42,6 @@
 #include "swift/Subsystems.h"
 #include "llvm/ProfileData/InstrProfReader.h"
 #include "llvm/Support/Debug.h"
-
-#include "../AST/ConformanceLookupTable.h"
-
 using namespace swift;
 using namespace Lowering;
 
@@ -1835,8 +1832,8 @@ public:
       SGM.visit(TD);
     }
 
-    ConformanceLookupTable::forEachExtendedConformance(getASTContext(),
-                                   [&](NormalProtocolConformance *normal) {
+    SGM.getASTContext()
+      .forEachExtendedConformance([&](NormalProtocolConformance *normal) {
       getWitnessTable(normal, /*emitAsPrivate*/true);
     });
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1834,13 +1834,9 @@ public:
 
     SGM.getASTContext()
       .forEachExtendedConformance([&](NormalProtocolConformance *normal) {
-      getWitnessTable(normal, /*emitAsPrivate*/true);
+      SGM.getWitnessTable(normal, /*emitAsPrivate*/true);
     });
   }
-
-//===----------------------------------------------------------------------===//
-// SILModule::constructSIL method implementation
-//===----------------------------------------------------------------------===//
 
   SILGenModuleRAII(SILModule &M, ModuleDecl *SM) : SGM{M, SM} {}
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -42,6 +42,9 @@
 #include "swift/Subsystems.h"
 #include "llvm/ProfileData/InstrProfReader.h"
 #include "llvm/Support/Debug.h"
+
+#include "../AST/ConformanceLookupTable.h"
+
 using namespace swift;
 using namespace Lowering;
 
@@ -1831,7 +1834,16 @@ public:
         continue;
       SGM.visit(TD);
     }
+
+    ConformanceLookupTable::forEachExtendedConformance(getASTContext(),
+                                   [&](NormalProtocolConformance *normal) {
+      getWitnessTable(normal, /*emitAsPrivate*/true);
+    });
   }
+
+//===----------------------------------------------------------------------===//
+// SILModule::constructSIL method implementation
+//===----------------------------------------------------------------------===//
 
   SILGenModuleRAII(SILModule &M, ModuleDecl *SM) : SGM{M, SM} {}
 

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -333,7 +333,8 @@ public:
   void emitObjCDestructorThunk(DestructorDecl *destructor);
 
   /// Get or emit the witness table for a protocol conformance.
-  SILWitnessTable *getWitnessTable(NormalProtocolConformance *conformance);
+  SILWitnessTable *getWitnessTable(NormalProtocolConformance *conformance,
+                                   bool emitAsPrivate = false);
 
   /// Emit a protocol witness entry point.
   SILFunction *

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -615,13 +615,17 @@ public:
 } // end anonymous namespace
 
 SILWitnessTable *
-SILGenModule::getWitnessTable(NormalProtocolConformance *conformance) {
+SILGenModule::getWitnessTable(NormalProtocolConformance *conformance,
+                            bool emitAsPrivate) {
   // If we've already emitted this witness table, return it.
   auto found = emittedWitnessTables.find(conformance);
   if (found != emittedWitnessTables.end())
     return found->second;
 
-  SILWitnessTable *table = SILGenConformance(*this, conformance).emit();
+  SILGenConformance conf(*this, conformance);
+  if (emitAsPrivate)
+    conf.Linkage = SILLinkage::Private;
+  SILWitnessTable *table = conf.emit();
   emittedWitnessTables.insert({conformance, table});
 
   return table;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6883,8 +6883,12 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
     // Extract the literal type.
     Type builtinLiteralType =
         conformance.getTypeWitnessByName(type, literalType);
-    if (builtinLiteralType->hasError())
+    if (builtinLiteralType->hasError()) {
+      cs.getASTContext().Diags.diagnose(literal->getLoc(),
+                                        diag::type_does_not_conform,
+                                        type, protocol->getDeclaredType());
       return nullptr;
+    }
 
     // Perform the builtin conversion.
     if (!convertLiteralInPlace(literal, builtinLiteralType, nullptr,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -707,8 +707,10 @@ bool AttributeChecker::visitAbstractAccessControlAttr(
 
   if (auto extension = dyn_cast<ExtensionDecl>(D)) {
     if (!extension->getInherited().empty()) {
-      diagnoseAndRemoveAttr(attr, diag::extension_access_with_conformances,
-                            attr);
+      if (!extension->getExtendedProtocolDecl())
+        diagnoseAndRemoveAttr(attr, diag::extension_access_with_conformances, attr);
+      else if (!(attr->getAccess() == AccessLevel::Public))
+        diagnoseAndRemoveAttr(attr, diag::protocol_extension_access_with_conformances);
       return true;
     }
   }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -90,7 +90,8 @@ static void checkInheritanceClause(
 
         auto *attr = ext->getAttrs().getAttribute<AccessControlAttr>();
         if (!attr || attr->getAccess() < AccessLevel::Public)
-          ext->diagnose(diag::protocol_extension_access_with_conformances);
+          ext->diagnose(diag::protocol_extension_access_with_conformances)
+                              .fixItInsert(ext->getStartLoc(), "public ");
 
         // Warning (eventually error?) here is now gated
         if (!ext->getASTContext().LangOpts.EnableConformingExtensions)

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -85,11 +85,14 @@ static void checkInheritanceClause(
     // Protocol extensions cannot have inheritance clauses.
     if (auto proto = ext->getExtendedProtocolDecl()) {
       if (!inheritedClause.empty()) {
-        ext->diagnose(diag::extension_protocol_inheritance,
-                 proto->getName())
-          .highlight(SourceRange(inheritedClause.front().getSourceRange().Start,
-                                 inheritedClause.back().getSourceRange().End));
-        return;
+        // Force recalculation conformance table
+        ext->setInherited(inheritedClause);
+
+        // Warning(eventaully error?) here is now gated
+        if (!ext->getASTContext().LangOpts.EnableConformingExtensions)
+          ext->diagnose(diag::extension_protocol_inheritance, proto->getName())
+            .highlight(SourceRange(inheritedClause.front().getSourceRange().Start,
+                                   inheritedClause.back().getSourceRange().End));
       }
     }
   } else {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -88,7 +88,7 @@ static void checkInheritanceClause(
         // Force recalculation conformance table
         ext->setInherited(inheritedClause);
 
-        // Warning(eventaully error?) here is now gated
+        // Warning (eventually error?) here is now gated
         if (!ext->getASTContext().LangOpts.EnableConformingExtensions)
           ext->diagnose(diag::extension_protocol_inheritance, proto->getName())
             .highlight(SourceRange(inheritedClause.front().getSourceRange().Start,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -88,6 +88,10 @@ static void checkInheritanceClause(
         // Force recalculation conformance table
         ext->setInherited(inheritedClause);
 
+        auto *attr = ext->getAttrs().getAttribute<AccessControlAttr>();
+        if (!attr || attr->getAccess() < AccessLevel::Public)
+          ext->diagnose(diag::protocol_extension_access_with_conformances);
+
         // Warning (eventually error?) here is now gated
         if (!ext->getASTContext().LangOpts.EnableConformingExtensions)
           ext->diagnose(diag::extension_protocol_inheritance, proto->getName())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -39,6 +39,7 @@
 #include "swift/AST/TypeDeclFinder.h"
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/TypeWalker.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
@@ -1382,48 +1383,6 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
 
 # pragma mark Witness resolution
 
-/// This is a wrapper of multiple instances of ConformanceChecker to allow us
-/// to diagnose and fix code from a more global perspective; for instance,
-/// having this wrapper can help issue a fixit that inserts protocol stubs from
-/// multiple protocols under checking.
-class swift::MultiConformanceChecker {
-  ASTContext &Context;
-  llvm::SmallVector<ValueDecl*, 16> UnsatisfiedReqs;
-  llvm::SmallVector<ConformanceChecker, 4> AllUsedCheckers;
-  llvm::SmallVector<NormalProtocolConformance*, 4> AllConformances;
-  llvm::SetVector<ValueDecl*> MissingWitnesses;
-  llvm::SmallPtrSet<ValueDecl *, 8> CoveredMembers;
-
-  /// Check one conformance.
-  ProtocolConformance * checkIndividualConformance(
-    NormalProtocolConformance *conformance, bool issueFixit);
-
-  /// Determine whether the given requirement was left unsatisfied.
-  bool isUnsatisfiedReq(NormalProtocolConformance *conformance, ValueDecl *req);
-public:
-  MultiConformanceChecker(ASTContext &ctx) : Context(ctx) {}
-
-  ASTContext &getASTContext() const { return Context; }
-
-  /// Add a conformance into the batched checker.
-  void addConformance(NormalProtocolConformance *conformance) {
-    AllConformances.push_back(conformance);
-  }
-
-  /// Peek the unsatisfied requirements collected during conformance checking.
-  ArrayRef<ValueDecl*> getUnsatisfiedRequirements() {
-    return llvm::makeArrayRef(UnsatisfiedReqs);
-  }
-
-  /// Whether this member is "covered" by one of the conformances.
-  bool isCoveredMember(ValueDecl *member) const {
-    return CoveredMembers.count(member) > 0;
-  }
-
-  /// Check all conformances and emit diagnosis globally.
-  void checkAllConformances();
-};
-
 bool MultiConformanceChecker::
 isUnsatisfiedReq(NormalProtocolConformance *conformance, ValueDecl *req) {
   if (conformance->isInvalid()) return false;
@@ -1449,7 +1408,7 @@ isUnsatisfiedReq(NormalProtocolConformance *conformance, ValueDecl *req) {
   return false;
 }
 
-void MultiConformanceChecker::checkAllConformances() {
+bool MultiConformanceChecker::checkAllConformances() {
   bool anyInvalid = false;
   for (unsigned I = 0, N = AllConformances.size(); I < N; I ++) {
     auto *conformance = AllConformances[I];
@@ -1474,7 +1433,7 @@ void MultiConformanceChecker::checkAllConformances() {
   }
   // If all missing witnesses are issued with fixits, we are done.
   if (MissingWitnesses.empty())
-    return;
+    return false;
 
   // Otherwise, backtrack to the last checker that has missing witnesses
   // and diagnose missing witnesses from there.
@@ -1484,6 +1443,8 @@ void MultiConformanceChecker::checkAllConformances() {
       It->diagnoseMissingWitnesses(MissingWitnessDiagnosisKind::FixItOnly);
     }
   }
+
+  return true;
 }
 
 static void diagnoseConformanceImpliedByConditionalConformance(

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -39,7 +39,6 @@
 #include "swift/AST/TypeDeclFinder.h"
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/TypeWalker.h"
-#include "swift/AST/GenericSignature.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
@@ -1433,7 +1432,7 @@ bool MultiConformanceChecker::checkAllConformances() {
   }
   // If all missing witnesses are issued with fixits, we are done.
   if (MissingWitnesses.empty())
-    return false;
+    return anyInvalid;
 
   // Otherwise, backtrack to the last checker that has missing witnesses
   // and diagnose missing witnesses from there.

--- a/test/decl/conforming_extensions.swift
+++ b/test/decl/conforming_extensions.swift
@@ -1,0 +1,96 @@
+// RUN: %target-run-simple-swift -enable-conforming-protocol-extensions %s | %FileCheck %s
+
+public extension FixedWidthInteger: ExpressibleByUnicodeScalarLiteral {
+    @_transparent
+  init(unicodeScalarLiteral value: Unicode.Scalar) {
+    self = Self(value.value)
+  }
+  func foo() -> String {
+    return "Foo!"
+  }
+}
+
+let a: [Int16] = ["a", "b", "c", "d", "e"]
+let b: [UInt32] = ["a", "b", "c", "d", "e"]
+
+protocol Q {
+  var bar: Double { get }
+  func foo2() -> String
+}
+public protocol P {
+}
+public extension P: Q {
+  var bar: Double { return -888 }
+  func foo2() -> String {
+    return "Foo2 \(self)!"
+  }
+}
+class C {}
+struct S {
+  let a = 99
+}
+public protocol P2: P {}
+
+extension C: P2 {}
+extension S: P2 {}
+//extension FixedWidthInteger: P2 {}
+extension Numeric: P2 {}
+
+//extension P2 {}
+
+//var a2: String?
+//_ = a2!
+
+// CHECK: Foo2 main.C!
+print(C().foo2())
+// CHECK: Foo2 S(a: 99)!
+print(S().foo2())
+// CHECK: Foo2 99!
+print(Int8(99).foo2())
+// CHECK: Foo2 99!
+//extension UInt32: P2 {}
+print(UInt32(99).foo2())
+// CHECK: Foo!
+print(Int8(99).foo())
+// CHECK: Foo!
+print(Int32(99).foo())
+// CHECK: Foo!
+print(UInt32(99).foo())
+
+// CHECK: [97, 98, 99, 100, 101]
+print(a)
+// CHECK: [97, 98, 99, 100, 101]
+print(b)
+// CHECK: ["Foo2 97!", "Foo2 98!", "Foo2 99!", "Foo2 100!", "Foo2 101!"]
+print(a.map {$0.foo2()})
+// CHECK: ["Foo!", "Foo!", "Foo!", "Foo!", "Foo!"]
+print(b.map {$0.foo()})
+// CHECK: ["Foo2 97!", "Foo2 98!", "Foo2 99!", "Foo2 100!", "Foo2 101!"]
+print(b.map {$0.foo2()})
+
+public func use(_ value: Int) -> Int {
+    return value + "1" // ← Used ExpressibleByUnicodeScalarLiteral
+}
+//public func use<T>(_ value: T) -> T
+//  where T : FixedWidthInteger {
+//    return value + "1" // ← Used ExpressibleByUnicodeScalarLiteral
+//}
+
+print(use(1))
+
+let u = UInt32(99)
+
+func aaa(_ b: P2) {
+  print(b.foo2())
+}
+
+aaa(u)
+
+aaa(88.0)
+
+print(99.0.foo2())
+
+let v = b.map { $0 as P2 }.map { $0.foo2() }
+print(v)
+
+print(99.bar)

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -947,7 +947,7 @@ enum Foo : Int, ReallyRaw {
 protocol BadProto1 { }
 protocol BadProto2 { }
 
-extension BadProto1 : BadProto2 { } // expected-error{{extension of protocol 'BadProto1' cannot have an inheritance clause}}
+extension BadProto1 : BadProto2 { } // expected-warning{{inheritance clause in extension of protocol 'BadProto1'. use -enable-conforming-protocol-extensions to remove this warning}}
 
 extension BadProto2 {
   struct S { } // expected-error{{type 'S' cannot be nested in protocol extension of 'BadProto2'}}


### PR DESCRIPTION
Hi Apple,

This is a follow-up to https://github.com/apple/swift/pull/25786 attempting to remove the constraint that extensions of protocols cannot have conformances. It's in reasonably good shape working across modules, not involving major surgery on the compiler and working well enough to be able to build a toolchain. Only a handful of tests are broken at the moment. Most of the implementation is localised to the source file [ConformanceLookupTable.cpp](https://github.com/johnno1962/swift/blob/protocol-extension-conformances/lib/AST/ConformanceLookupTable.cpp) with small targeted changes elsewhere as required. It works by recursively resolving conformances each time the conformances of a nominal are looked up and tracking which inferred (implied?) conformances are used so they can trigger the generation of witness tables. As multiple source files can force the generation of a witness table they are emitted private to the file to avoid duplicate symbols.  This results in a certain amount of duplication but witness tables don't occupy much memory and is less of a problem if you use whole module optimisation for your build. The Swift runtime doesn't seem to mind.

I'm filing this PR now in order to get some initial feedback and I'll be posting to swift evolution to gather some more test code to see if people can break the implementation as is. Compiler crashes are not unheard of and error messages could be better but if a program compiles I haven't seen any misbehaviour at run time as yet. I hope to be able to demonstrate it is viable to implement this functionality mentioned in the [generics manifesto](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#conditional-conformances-via-protocol-extensions) and I'd personally very much like to see this as a part of the Swift language (subject to review).

There is a [toolchain available here](http://johnholdsworth.com/swift-LOCAL-2020-01-17-a-osx.tar.gz) to evaluate.

Addresses https://bugs.swift.org/browse/SR-11013.
