### PR TITLE
[Build System: build-script] Module importer for build_swift.

### DIFF
--- a/utils/build-parser-lib
+++ b/utils/build-parser-lib
@@ -30,8 +30,8 @@ import os
 import platform
 import sys
 
-from build_swift.build_swift import argparse, defaults
-from build_swift.build_swift.wrappers import xcrun
+from build_swift import argparse, defaults
+from build_swift.wrappers import xcrun
 
 from swift_build_support.swift_build_support import shell
 from swift_build_support.swift_build_support.SwiftBuildSupport import (

--- a/utils/build-script
+++ b/utils/build-script
@@ -18,11 +18,11 @@ import platform
 import sys
 import time
 
-from build_swift.build_swift import argparse
-from build_swift.build_swift import defaults
-from build_swift.build_swift import driver_arguments
-from build_swift.build_swift import migration
-from build_swift.build_swift import presets
+from build_swift import argparse
+from build_swift import defaults
+from build_swift import driver_arguments
+from build_swift import migration
+from build_swift import presets
 
 import six
 

--- a/utils/build_swift/__init__.py
+++ b/utils/build_swift/__init__.py
@@ -5,3 +5,91 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from __future__ import absolute_import, unicode_literals
+
+import sys
+from importlib import import_module as _import_module
+
+from .build_swift import __name__ as _build_swift__name__
+
+
+_SUBMODULES = [
+    'argparse',
+    'class_utils',
+    'defaults',
+    'driver_arguments',
+    'migration',
+    'presets',
+    'shell',
+    'versions',
+    'wrappers',
+]
+
+
+class _UnloadedModule(object):
+    """Class used to delay loading modules until users explicitly import them.
+    """
+
+    def __init__(self, import_name):
+        self._import_name = import_name
+
+    def load(self):
+        return _import_module(self._import_name)
+
+
+class _ModuleImporter(object):
+    """Module importer used to re-export nested submodules.
+
+    Implements the importer protocol specified in PEP302.
+        https://www.python.org/dev/peps/pep-0302/
+
+    NOTE: The `six` package uses a similar trick to pull off the super nifty
+    `six.moves` module namespace. Our use-case is much less sophisticated, we
+    just want to expose a flat module structure for `build_swift`.
+    """
+
+    def __init__(self, name):
+        self._name = name
+        self._known_modules = {}
+
+    def _add_module(self, fullname, module):
+        self._known_modules['{}.{}'.format(self._name, fullname)] = module
+
+    def _get_module(self, fullname):
+        if fullname not in self._known_modules:
+            raise ImportError('No module named {}'.format(fullname))
+
+        module = self._known_modules[fullname]
+        if isinstance(module, _UnloadedModule):
+            self._known_modules[fullname] = module.load()
+
+        return self._known_modules[fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self._known_modules:
+            return self
+
+        return None
+
+    def load_module(self, fullname):
+        if fullname in sys.modules:
+            return sys.modules[fullname]
+
+        module = self._get_module(fullname)
+        sys.modules[fullname] = module
+        return module
+
+
+_importer = _ModuleImporter(__name__)
+
+for name in _SUBMODULES:
+    module = _UnloadedModule('{}.{}'.format(_build_swift__name__, name))
+    _importer._add_module(name, module)
+
+sys.meta_path.append(_importer)
+
+del _build_swift__name__
+del _importer
+del _SUBMODULES

--- a/utils/run-test
+++ b/utils/run-test
@@ -16,7 +16,7 @@ import os
 import shutil
 import sys
 
-from build_swift.build_swift import argparse
+from build_swift import argparse
 
 from swift_build_support.swift_build_support import shell
 from swift_build_support.swift_build_support.SwiftBuildSupport import \

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -28,7 +28,7 @@ import tempfile
 from collections import namedtuple
 from operator import attrgetter
 
-from build_swift.build_swift import shell
+from build_swift import shell
 
 import gyb
 

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -18,7 +18,7 @@ import os.path
 import platform
 import sys
 
-from build_swift.build_swift.wrappers import xcrun
+from build_swift.wrappers import xcrun
 
 from . import product
 from .. import cache_util

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -18,8 +18,8 @@ from __future__ import absolute_import
 
 import platform
 
-from build_swift.build_swift.shell import which
-from build_swift.build_swift.wrappers import xcrun
+from build_swift.shell import which
+from build_swift.wrappers import xcrun
 
 from . import cache_util
 from . import shell

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -23,7 +23,7 @@ except ImportError:
     # py3
     from io import StringIO
 
-from build_swift.build_swift.wrappers import xcrun
+from build_swift.wrappers import xcrun
 
 from swift_build_support import shell
 from swift_build_support.products import Ninja

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -16,7 +16,7 @@ import platform
 import unittest
 from argparse import Namespace
 
-from build_swift.build_swift.versions import Version
+from build_swift.versions import Version
 
 from swift_build_support.cmake import CMake, CMakeOptions
 from swift_build_support.toolchain import host_toolchain


### PR DESCRIPTION
Implemented a module importer for the `build_swift` module which allows for a flattened API when external modules import submodules.

```Python
# Previously callers needed to import the nested path
from build_swift.build_swift import defaults
from build_swift.build_swift.argparse import types

# Now callers can import as if the module were flat
from build_swift import defaults
from build_swift.argparse import types
```