### PR TITLE
tests: exclude some very long running tests from jobs with a non-optimized stdlib

### DIFF
--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -6,6 +6,9 @@
 // RUN: %line-directive %t/FloatingPointPrinting.swift -- %target-run %t/main.out --locale ru_RU.UTF-8
 // REQUIRES: executable_test
 
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin

--- a/validation-test/stdlib/Collection/LazyMapBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/LazyMapBidirectionalCollection.swift
@@ -8,6 +8,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/LazyMapCollection.swift
+++ b/validation-test/stdlib/Collection/LazyMapCollection.swift
@@ -8,6 +8,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Collection/LazyMapRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/LazyMapRandomAccessCollection.swift
@@ -8,6 +8,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -12,6 +12,9 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
 %{
 
 from gyb_stdlib_support import (

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -12,6 +12,9 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -7,6 +7,9 @@
 // REQUIRES: executable_test
 // XFAIL: interpret
 
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/Unicode.swift.gyb
+++ b/validation-test/stdlib/Unicode.swift.gyb
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
 import SwiftPrivate
 import StdlibUnittest
 import StdlibUnicodeUnittest

--- a/validation-test/stdlib/UnicodeUTFEncoders.swift
+++ b/validation-test/stdlib/UnicodeUTFEncoders.swift
@@ -5,6 +5,9 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
 import SwiftPrivate
 import StdlibUnittest
 


### PR DESCRIPTION
Those are tests which take > 1000s on some simulator configurations with a non-optimized stdlib.
We run those tests anyway with an optimized stdlib. So we don’t lose test coverage by disabling them for debug-stdlib.

This fixes some sporadic time outs on the CI jobs.
