### PR TITLE
[5.2][CodeCompletion] Handle cases where PersistentParserState is not created

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -170,6 +170,8 @@ bool CompletionInstance::performCachedOperaitonIfPossible(
 
   auto &CI = *CachedCI;
 
+  if (!CI.hasPersistentParserState())
+    return false;
   auto &oldState = CI.getPersistentParserState();
   if (!oldState.hasCodeCompletionDelayedDeclState())
     return false;
@@ -290,7 +292,8 @@ bool CompletionInstance::performNewOperation(
   registerIDERequestFunctions(CI.getASTContext().evaluator);
 
   CI.performParseAndResolveImportsOnly();
-  Callback(CI);
+  if (CI.hasPersistentParserState())
+    Callback(CI);
 
   if (DiagC)
     CI.removeDiagnosticConsumer(DiagC);

--- a/test/SourceKit/CodeComplete/complete_without_stdlib.swift
+++ b/test/SourceKit/CodeComplete/complete_without_stdlib.swift
@@ -1,0 +1,19 @@
+class Str {
+  var value: Str
+}
+
+// rdar://problem/58663066
+// Test a environment where stdlib is not found.
+// Completion should return zero result.
+
+// RUN: %empty-directory(%t/rsrc)
+// RUN: %empty-directory(%t/sdk)
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk | %FileCheck %s
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk | %FileCheck %s
+
+// CHECK: key.results: [
+// CHECK-NOT: key.description:


### PR DESCRIPTION
Cherry-pick of #29269 into `swift-5.2-branch`

- **Explanation**: When stdlib is not found (e.g. correct `-sdk` is not passed), code completion used to crash. In such case, `CompilerInstance` simply returns before creating an object which is required by code-completion. Handle it by adding check for the case.
- **Scope**: Code completion
- **Risk**: Very low. Just added a couple of guard-return
- **Issue**: rdar://problem/58663066
- **Testing**: Added regression test cases
- **Reviewer**: Ben Langmuir (@benlangmuir)