### PR TITLE
[Parse] Emit a fix-it to move 'some' to the beginning of protocol composition

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -841,10 +841,11 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
     // Diagnose invalid `some` after an ampersand.
     if (Tok.is(tok::identifier) && Tok.getRawText() == "some") {
       auto badLoc = consumeToken();
-      
-      // TODO: Fixit to move to beginning of composition.
-      diagnose(badLoc, diag::opaque_mid_composition);
-      
+
+      diagnose(badLoc, diag::opaque_mid_composition)
+          .fixItRemove(badLoc)
+          .fixItInsert(FirstTypeLoc, "some ");
+
       if (opaqueLoc.isInvalid())
         opaqueLoc = badLoc;
     }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -475,3 +475,8 @@ dynamic func foo<S>(_ s: S) -> some Proto {
 func foo_repl<S>(_ s: S) -> some Proto {
  return   I()
 }
+
+protocol SomeProtocolA {}
+protocol SomeProtocolB {}
+struct SomeStructC: SomeProtocolA, SomeProtocolB {}
+let someProperty: SomeProtocolA & some SomeProtocolB = SomeStructC() // expected-error {{'some' should appear at the beginning of a composition}}{{35-40=}}{{19-19=some }}


### PR DESCRIPTION
Addresses a TODO.

Emit a fix-it to move `some` from the middle of the composition to the beginning of the composition.