### PR TITLE
Add the target list to build-script --help.

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -525,8 +525,10 @@ def create_argument_parser():
     option('--stdlib-deployment-targets', store,
            type=argparse.ShellSplitType(),
            default=None,
-           help='list of targets to compile or cross-compile the Swift '
-                'standard library for. %(default)s by default.')
+           help='The targets to compile or cross-compile the Swift standard '
+                'library for. %(default)s by default.'
+                ' Comma separated list: {}'.format(
+                    ' '.join(StdlibDeploymentTarget.get_target_names())))
 
     option('--build-stdlib-deployment-targets', store,
            type=argparse.ShellSplitType(),

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -244,6 +244,11 @@ class StdlibDeploymentTarget(object):
     def get_targets_by_name(cls, names):
         return [cls.get_target_for_name(name) for name in names]
 
+    @classmethod
+    def get_target_names(cls):
+        return sorted([name for (name, target) in
+                       cls._targets_by_name.items()])
+
 
 def install_prefix():
     """


### PR DESCRIPTION
Teach build-script to print the list of valid targets for the
--stdlib-deployment-targets option. Unfortunately, passing all
supported targets to this option is the only way to force
configuration of those targets. Simply using --ios is no longer
sufficient--none of the iOS targets are actually configured unless you
ask them to be built.

(The reasonable way to use a build config script is to first configure
for all supported platforms, but only build the platforms/targets one
by one when you actually need them).

This currently prints:

  --stdlib-deployment-targets STDLIB_DEPLOYMENT_TARGETS
                        The targets to compile or cross-compile the Swift
                        standard library for. None by default. Comma separated
                        list: android-aarch64 android-armv7 appletvos-arm64
                        appletvsimulator-x86_64 cygwin-x86_64 freebsd-x86_64
                        haiku-x86_64 iphoneos-arm64 iphoneos-armv7 iphoneos-
                        armv7s iphonesimulator-i386 iphonesimulator-x86_64
                        linux-aarch64 linux-armv6 linux-armv7 linux-i686
                        linux-powerpc64 linux-powerpc64le linux-s390x linux-
                        x86_64 macosx-x86_64 watchos-armv7k
                        watchsimulator-i386 windows-x86_64

