### PR TITLE
[ConstraintSystem] Remove `BindParam` and infer `inout` based on context

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2852,6 +2852,10 @@ public:
     Param getWithoutLabel() const { return Param(Ty, Identifier(), Flags); }
 
     Param withType(Type newType) const { return Param(newType, Label, Flags); }
+
+    Param withFlags(ParameterTypeFlags flags) const {
+      return Param(Ty, Label, flags);
+    }
   };
 
   class CanParam : public Param {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1620,7 +1620,6 @@ void ConstraintSystem::ArgumentInfoCollector::walk(Type argType) {
       case ConstraintKind::ArgumentConversion:
       case ConstraintKind::Conversion:
       case ConstraintKind::BridgingConversion:
-      case ConstraintKind::BindParam:
       case ConstraintKind::OpaqueUnderlyingType: {
         auto secondTy = constraint->getSecondType();
         if (secondTy->is<TypeVariableType>()) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -441,6 +441,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numFunctionBuilderTransformed = cs.functionBuilderTransformed.size();
   numResolvedOverloads = cs.ResolvedOverloads.size();
   numInferredClosureTypes = cs.ClosureTypes.size();
+  numModifiedSpecifiers = cs.ModifiedSpecifiers.size();
 
   PreviousScore = cs.CurrentScore;
 
@@ -509,6 +510,11 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any inferred closure types (e.g. used in function builder body).
   truncate(cs.ClosureTypes, numInferredClosureTypes);
+
+  while (cs.ModifiedSpecifiers.size() > numModifiedSpecifiers) {
+    auto PD = cs.ModifiedSpecifiers.pop_back_val();
+    PD.first->setSpecifier(PD.second);
+  }
 
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -88,8 +88,6 @@ void SplitterStep::computeFollowupSteps(
   // algorithm tells us is splittable.
 
   auto &CG = CS.getConstraintGraph();
-  // Contract the edges of the constraint graph.
-  CG.optimize();
 
   // Compute the connected components of the constraint graph.
   auto components = CG.computeConnectedComponents(CS.getTypeVariables());

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -47,7 +47,6 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   switch (Kind) {
   case ConstraintKind::Bind:
   case ConstraintKind::Equal:
-  case ConstraintKind::BindParam:
   case ConstraintKind::BindToPointerType:
   case ConstraintKind::Subtype:
   case ConstraintKind::Conversion:
@@ -111,7 +110,6 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   switch (Kind) {
   case ConstraintKind::Bind:
   case ConstraintKind::Equal:
-  case ConstraintKind::BindParam:
   case ConstraintKind::BindToPointerType:
   case ConstraintKind::Subtype:
   case ConstraintKind::Conversion:
@@ -243,7 +241,6 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   switch (getKind()) {
   case ConstraintKind::Bind:
   case ConstraintKind::Equal:
-  case ConstraintKind::BindParam:
   case ConstraintKind::BindToPointerType:
   case ConstraintKind::Subtype:
   case ConstraintKind::Conversion:
@@ -328,7 +325,6 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
   switch (Kind) {
   case ConstraintKind::Bind: Out << " bind "; break;
   case ConstraintKind::Equal: Out << " equal "; break;
-  case ConstraintKind::BindParam: Out << " bind param "; break;
   case ConstraintKind::BindToPointerType: Out << " bind to pointer "; break;
   case ConstraintKind::Subtype: Out << " subtype "; break;
   case ConstraintKind::Conversion: Out << " conv "; break;
@@ -543,7 +539,6 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::ApplicableFunction:
   case ConstraintKind::DynamicCallableApplicableFunction:
   case ConstraintKind::Bind:
-  case ConstraintKind::BindParam:
   case ConstraintKind::BindToPointerType:
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::Conversion:

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -54,12 +54,6 @@ enum class ConstraintKind : char {
   /// The two types must be bound to the same type, dropping
   /// lvalueness when comparing a type variable to a type.
   Equal,
-  /// The first type is the type of a function parameter; the second
-  /// type is the type of a reference to that parameter from within the
-  /// function body. Specifically, the left type is an inout type iff the right
-  /// type is an lvalue type with the same object type. Otherwise, the two
-  /// types must be the same type.
-  BindParam,
   /// Binds the first type to the element type of the second type.
   BindToPointerType,
   /// The first type is a subtype of the second type, i.e., a value
@@ -532,7 +526,6 @@ public:
     switch (Kind) {
     case ConstraintKind::Bind:
     case ConstraintKind::Equal:
-    case ConstraintKind::BindParam:
     case ConstraintKind::BindToPointerType:
     case ConstraintKind::Subtype:
     case ConstraintKind::Conversion:

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -347,10 +347,6 @@ public:
   /// Verify the invariants of the graph.
   void verify();
 
-  /// Optimize the constraint graph by eliminating simple transitive
-  /// connections between nodes.
-  void optimize();
-
 private:
   /// Remove the node corresponding to the given type variable.
   ///
@@ -367,10 +363,6 @@ private:
   /// Note that this change is not recorded and cannot be undone. Use with
   /// caution.
   void unbindTypeVariable(TypeVariableType *typeVar, Type fixedType);
-
-  /// Perform edge contraction on the constraint graph, merging equivalence
-  /// classes until a fixed point is reached.
-  bool contractEdges();
 
   /// To support edge contraction, remove a constraint from both the constraint
   /// graph and its enclosing constraint system.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1300,6 +1300,9 @@ private:
   llvm::DenseMap<std::pair<const KeyPathExpr *, unsigned>, TypeBase *>
       KeyPathComponentTypes;
 
+  llvm::SmallVector<std::pair<ParamDecl *, ParamSpecifier>, 4>
+      ModifiedSpecifiers;
+
   /// Maps closure parameters to type variables.
   llvm::DenseMap<const ParamDecl *, TypeVariableType *>
     OpenedParameterTypes;
@@ -1879,6 +1882,9 @@ public:
 
     /// The length of \c ClosureTypes.
     unsigned numInferredClosureTypes;
+
+    /// The length of \c ModifiedSpecifiers.
+    unsigned numModifiedSpecifiers;
 
     /// The previous score.
     Score PreviousScore;


### PR DESCRIPTION
Since constraint generation from closure bodies is delayed until context is available
(or it's determined that there is no context e.g. `_ = { $0 = 1 }`), it's possible to use 
contextual function type to determine whether anonymous (or simplify untyped) 
closure parameters are expected to be `inout` which allows us to avoid using special 
constraint from `inout -> lvalue` conversion and as a result makes edge contraction obsolete.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
