### PR TITLE
[AutoDiff] Add JVPs for tgmath functions.

### DIFF
--- a/stdlib/public/Platform/tgmath_derivatives.swift.gyb
+++ b/stdlib/public/Platform/tgmath_derivatives.swift.gyb
@@ -11,14 +11,17 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+// This file defines derivatives for tgmath functions.
+//===----------------------------------------------------------------------===//
 
 @usableFromInline
-@derivative(of: sqrt)
-func _vjpSqrt<T: FloatingPoint & Differentiable> (
-  _ x: T
-) -> (value: T, pullback: (T) -> T) where T == T.TangentVector {
-  let value = sqrt(x)
-  return (value, { v in v / (2 * value) })
+@derivative(of: fma)
+func _jvpFma<T: FloatingPoint & Differentiable> (
+  _ x: T,
+  _ y: T,
+  _ z: T
+) -> (value: T, differential: (T, T, T) -> T) where T == T.TangentVector {
+  return (fma(x, y, z), { (dx, dy, dz) in dx * y + dy * x + dz })
 }
 
 @usableFromInline
@@ -33,11 +36,35 @@ func _vjpFma<T: FloatingPoint & Differentiable> (
 
 @usableFromInline
 @derivative(of: remainder)
+func _jvpRemainder<T: FloatingPoint & Differentiable> (
+  _ x: T,
+  _ y: T
+) -> (value: T, differential: (T, T) -> T) where T == T.TangentVector {
+  fatalError("""
+    Unimplemented JVP for 'remainder(_:)'. \
+    https://bugs.swift.org/browse/TF-1108 tracks this issue
+    """)
+}
+
+@usableFromInline
+@derivative(of: remainder)
 func _vjpRemainder<T: FloatingPoint & Differentiable> (
   _ x: T,
   _ y: T
 ) -> (value: T, pullback: (T) -> (T, T)) where T == T.TangentVector {
   return (remainder(x, y), { v in (v, -v * ((x / y).rounded(.toNearestOrEven))) })
+}
+
+@usableFromInline
+@derivative(of: fmod)
+func _jvpFmod<T: FloatingPoint & Differentiable> (
+  _ x: T,
+  _ y: T
+) -> (value: T, differential: (T, T) -> T) where T == T.TangentVector {
+  fatalError("""
+    Unimplemented JVP for 'fmod(_:)'. \
+    https://bugs.swift.org/browse/TF-1108 tracks this issue
+    """)
 }
 
 @usableFromInline
@@ -49,173 +76,188 @@ func _vjpFmod<T: FloatingPoint & Differentiable> (
   return (fmod(x, y), { v in (v, -v * ((x / y).rounded(.towardZero))) })
 }
 
+%for derivative_kind in ['jvp', 'vjp']:
+%  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
+@usableFromInline
+@derivative(of: sqrt)
+func _${derivative_kind}Sqrt<T: FloatingPoint & Differentiable> (
+  _ x: T
+) -> (value: T, ${linear_map_kind}: (T) -> T) where T == T.TangentVector {
+  let value = sqrt(x)
+  return (value, { v in v / (2 * value) })
+}
+
 @usableFromInline
 @derivative(of: ceil)
-func _vjpCeil<T: FloatingPoint & Differentiable> (
+func _${derivative_kind}Ceil<T: FloatingPoint & Differentiable> (
   _ x: T
-) -> (value: T, pullback: (T) -> T) where T == T.TangentVector {
+) -> (value: T, ${linear_map_kind}: (T) -> T) where T == T.TangentVector {
   return (ceil(x), { v in 0 })
 }
 
 @usableFromInline
 @derivative(of: floor)
-func _vjpFloor<T: FloatingPoint & Differentiable> (
+func _${derivative_kind}Floor<T: FloatingPoint & Differentiable> (
   _ x: T
-) -> (value: T, pullback: (T) -> T) where T == T.TangentVector {
+) -> (value: T, ${linear_map_kind}: (T) -> T) where T == T.TangentVector {
   return (floor(x), { v in 0 })
 }
 
 @usableFromInline
 @derivative(of: round)
-func _vjpRound<T: FloatingPoint & Differentiable> (
+func _${derivative_kind}Round<T: FloatingPoint & Differentiable> (
   _ x: T
-) -> (value: T, pullback: (T) -> T) where T == T.TangentVector {
+) -> (value: T, ${linear_map_kind}: (T) -> T) where T == T.TangentVector {
   return (round(x), { v in 0 })
 }
 
 @usableFromInline
 @derivative(of: trunc)
-func _vjpTrunc<T: FloatingPoint & Differentiable> (
+func _${derivative_kind}Trunc<T: FloatingPoint & Differentiable> (
   _ x: T
-) -> (value: T, pullback: (T) -> T) where T == T.TangentVector {
+) -> (value: T, ${linear_map_kind}: (T) -> T) where T == T.TangentVector {
   return (trunc(x), { v in 0 })
 }
+%end # for derivative_kind in ['jvp', 'vjp']:
 
-%for T in ['Float', 'Double', 'Float80']:
-%   if T == 'Float80':
+%for derivative_kind in ['jvp', 'vjp']:
+%  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
+%  for T in ['Float', 'Double', 'Float80']:
+%    if T == 'Float80':
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-%   end
+%    end
 @inlinable
 @derivative(of: exp)
-func _vjpExp(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Exp(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   let value = exp(x)
   return (value, { v in value * v })
 }
 
 @inlinable
 @derivative(of: exp2)
-func _vjpExp2(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Exp2(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   let value = exp2(x)
   return (value, { v in v * ${T}(M_LN2) * value })
 }
 
 @inlinable
 @derivative(of: log)
-func _vjpLog(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Log(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (log(x), { v in v / x })
 }
 
 @inlinable
 @derivative(of: log10)
-func _vjpLog10(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Log10(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (log10(x), { v in v * ${T}(M_LOG10E) / x })
 }
 
 @inlinable
 @derivative(of: log2)
-func _vjpLog2(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Log2(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (log2(x), { v in v / (${T}(M_LN2) * x) })
 }
 
 @inlinable
 @derivative(of: sin)
-func _vjpSin(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Sin(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (sin(x), { v in v * cos(x) })
 }
 
 @inlinable
 @derivative(of: cos)
-func _vjpCos(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Cos(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (cos(x), { v in -v * sin(x) })
 }
 
 @inlinable
 @derivative(of: tan)
-func _vjpTan(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Tan(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   let value = tan(x)
   return (value, { v in v * (1 + value * value) })
 }
 
 @inlinable
 @derivative(of: asin)
-func _vjpAsin(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Asin(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (asin(x), { v in v / sqrt(1 - x * x) })
 }
 
 @inlinable
 @derivative(of: acos)
-func _vjpAcos(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Acos(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (acos(x), { v in -v / sqrt(1 - x * x) })
 }
 
 @inlinable
 @derivative(of: atan)
-func _vjpAtan(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Atan(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (atan(x), { v in v / (1 + x * x) })
 }
 
 @inlinable
 @derivative(of: sinh)
-func _vjpSinh(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Sinh(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (sinh(x), { v in v * cosh(x) })
 }
 
 @inlinable
 @derivative(of: cosh)
-func _vjpCosh(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Cosh(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (cosh(x), { v in v * sinh(x) })
 }
 
 @inlinable
 @derivative(of: tanh)
-func _vjpTanh(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Tanh(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   let value = tanh(x)
   return (value, { v in v * (1 - value * value) })
 }
 
 @inlinable
 @derivative(of: asinh)
-func _vjpAsinh(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Asinh(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (asinh(x), { v in v / sqrt(1 + x * x) })
 }
 
 @inlinable
 @derivative(of: acosh)
-func _vjpAcosh(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Acosh(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (acosh(x), { v in v / sqrt(x * x - 1) })
 }
 
 @inlinable
 @derivative(of: atanh)
-func _vjpAtanh(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Atanh(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (atanh(x), { v in v / (1 - x * x) })
 }
 
 @inlinable
 @derivative(of: expm1)
-func _vjpExpm1(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Expm1(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (expm1(x), { v in exp(x) * v })
 }
 
 @inlinable
 @derivative(of: log1p)
-func _vjpLog1p(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Log1p(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (log1p(x), { v in v / (x + 1) })
 }
 
 @inlinable
 @derivative(of: erf)
-func _vjpErf(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Erf(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (erf(x), { v in v * ${T}(M_2_SQRTPI) * exp(-x * x) })
 }
 
 @inlinable
 @derivative(of: erfc)
-func _vjpErfc(_ x: ${T}) -> (value: ${T}, pullback: (${T}) -> ${T}) {
+func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) {
   return (erfc(x), { v in v * -${T}(M_2_SQRTPI) * exp(-x * x) })
 }
 
-%   if T == 'Float80':
+%    if T == 'Float80':
 #endif
-%   end
-%end
+%    end # if T == 'Float80':
+%  end # for T in ['Float', 'Double', 'Float80']:
+%end # for derivative_kind in ['jvp', 'vjp']:

--- a/test/AutoDiff/downstream/forward_mode_runtime.swift
+++ b/test/AutoDiff/downstream/forward_mode_runtime.swift
@@ -1,4 +1,4 @@
-// RUN: %target_run_simple_swift_forward_mode_differentiation
+// RUN: %target-run-simple-swift-forward-mode-differentiation
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/downstream/nonvaried_result.swift
+++ b/test/AutoDiff/downstream/nonvaried_result.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -Xllvm -sil-print-after=differentiation %s -emit-sil -o /dev/null 2>&1 | %FileCheck %s
 // RUN: %target-run-simple-swift
 // TODO: Test forward-mode differentiation when it supports control flow.
-// UN: %target_run_simple_swift_forward_mode_differentiation
+// UN: %target-run-simple-swift-forward-mode-differentiation
 // REQUIRES: executable_test
 
 // Test differentiation edge case: functions with non-varied results.

--- a/test/AutoDiff/downstream/simple_math.swift
+++ b/test/AutoDiff/downstream/simple_math.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // NOTE(TF-813): verify that enabling forward-mode does not affect reverse-mode.
-// RUN: %target_run_simple_swift_forward_mode_differentiation
+// RUN: %target-run-simple-swift-forward-mode-differentiation
 // RUN: %target-swift-frontend -Xllvm -sil-print-after=differentiation %s -emit-sil -o /dev/null 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/AutoDiff/downstream/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/downstream/tgmath_derivatives.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swiftgyb
+// RUN: %target-run-simple-swiftgyb-forward-mode-differentiation
 // REQUIRES: executable_test
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -19,7 +19,7 @@
 
 import StdlibUnittest
 
-let MathTests = TestSuite("TGMath")
+let DerivativeTests = TestSuite("TGMath")
 
 func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
                                  ulps allowed: T = 3,
@@ -50,38 +50,50 @@ where T == T.TangentVector {
   expectEqualWithTolerance(TestLiteralType(dfdy), grad.1, ulps: 192)
 }
 
-% for T in ['Float', 'Float80']:
-MathTests.test("gradient_${T}") {
-  expectEqualWithTolerance(7.3890560989306502274, gradient(at: 2.0 as ${T}, in: exp), ulps: 16)
-  expectEqualWithTolerance(2.772588722239781145, gradient(at: 2.0 as ${T}, in: exp2), ulps: 16)
-  expectEqualWithTolerance(7.3890560989306502274, gradient(at: 2.0 as ${T}, in: expm1), ulps: 16)
-  expectEqualWithTolerance(0.5, gradient(at: 2.0 as ${T}, in: log), ulps: 16)
-  expectEqualWithTolerance(0.21714724095162590833, gradient(at: 2.0 as ${T}, in: log10), ulps: 16)
-  expectEqualWithTolerance(0.7213475204444817278, gradient(at: 2.0 as ${T}, in: log2), ulps: 16)
-  expectEqualWithTolerance(0.33333333333333333334, gradient(at: 2.0 as ${T}, in: log1p), ulps: 16)
-  expectEqualWithTolerance(5.774399204041917612, gradient(at: 2.0 as ${T}, in: tan), ulps: 16)
-  expectEqualWithTolerance(-0.9092974268256816954, gradient(at: 2.0 as ${T}, in: cos), ulps: 16)
-  expectEqualWithTolerance(-0.416146836547142387, gradient(at: 2.0 as ${T}, in: sin), ulps: 16)
-  expectEqualWithTolerance(1.154700538379251529, gradient(at: 0.5 as ${T}, in: asin), ulps: 16)
-  expectEqualWithTolerance(-1.154700538379251529, gradient(at: 0.5 as ${T}, in: acos), ulps: 16)
-  expectEqualWithTolerance(0.8, gradient(at: 0.5 as ${T}, in: atan), ulps: 16)
-  expectEqualWithTolerance(3.7621956910836314597, gradient(at: 2.0 as ${T}, in: sinh), ulps: 16)
-  expectEqualWithTolerance(3.6268604078470187677, gradient(at: 2.0 as ${T}, in: cosh), ulps: 16)
-  expectEqualWithTolerance(0.07065082485316446565, gradient(at: 2.0 as ${T}, in: tanh), ulps: 16)
-  expectEqualWithTolerance(0.44721359549995793928, gradient(at: 2.0 as ${T}, in: asinh), ulps: 16)
-  expectEqualWithTolerance(0.5773502691896257645, gradient(at: 2.0 as ${T}, in: acosh), ulps: 16)
-  expectEqualWithTolerance(1.3333333333333333334, gradient(at: 0.5 as ${T}, in: atanh), ulps: 16)
-  expectEqualWithTolerance(0.020666985354092053575, gradient(at: 2.0 as ${T}, in: erf), ulps: 16)
-  expectEqualWithTolerance(-0.020666985354092053575, gradient(at: 2.0 as ${T}, in: erfc), ulps: 16)
-  expectEqualWithTolerance(0.35355339059327376222, gradient(at: 2.0 as ${T}, in: { sqrt($0) }), ulps: 16)
-  let fmaGrad = gradient(at: 4.0 as ${T}, 5.0 as ${T}, 6.0 as ${T}, in: { x, y, z in fma(x, y, z) })
-  expectEqualWithTolerance(5.0, fmaGrad.0, ulps: 16)
-  expectEqualWithTolerance(4.0, fmaGrad.1, ulps: 16)
-  expectEqualWithTolerance(1.0, fmaGrad.2, ulps: 16)
-  expectEqualWithTolerance(0.0, gradient(at: 2.0 as ${T}, in: { ceil($0) }), ulps: 16)
-  expectEqualWithTolerance(0.0, gradient(at: 2.0 as ${T}, in: { floor($0) }), ulps: 16)
-  expectEqualWithTolerance(0.0, gradient(at: 2.0 as ${T}, in: { round($0) }), ulps: 16)
-  expectEqualWithTolerance(0.0, gradient(at: 2.0 as ${T}, in: { trunc($0) }), ulps: 16)
+%for op in ['derivative', 'gradient']:
+%for T in ['Float', 'Float80']:
+
+DerivativeTests.test("${op}_${T}") {
+  expectEqualWithTolerance(7.3890560989306502274, ${op}(at: 2 as ${T}, in: exp))
+  expectEqualWithTolerance(2.772588722239781145, ${op}(at: 2 as ${T}, in: exp2))
+  expectEqualWithTolerance(7.3890560989306502274, ${op}(at: 2 as ${T}, in: expm1))
+  expectEqualWithTolerance(0.5, ${op}(at: 2 as ${T}, in: log))
+  expectEqualWithTolerance(0.21714724095162590833, ${op}(at: 2 as ${T}, in: log10))
+  expectEqualWithTolerance(0.7213475204444817278, ${op}(at: 2 as ${T}, in: log2))
+  expectEqualWithTolerance(0.33333333333333333334, ${op}(at: 2 as ${T}, in: log1p))
+  expectEqualWithTolerance(5.774399204041917612, ${op}(at: 2 as ${T}, in: tan))
+  expectEqualWithTolerance(-0.9092974268256816954, ${op}(at: 2 as ${T}, in: cos))
+  expectEqualWithTolerance(-0.416146836547142387, ${op}(at: 2 as ${T}, in: sin))
+  expectEqualWithTolerance(1.154700538379251529, ${op}(at: 0.5 as ${T}, in: asin))
+  expectEqualWithTolerance(-1.154700538379251529, ${op}(at: 0.5 as ${T}, in: acos))
+  expectEqualWithTolerance(0.8, ${op}(at: 0.5 as ${T}, in: atan))
+  expectEqualWithTolerance(3.7621956910836314597, ${op}(at: 2 as ${T}, in: sinh))
+  expectEqualWithTolerance(3.6268604078470187677, ${op}(at: 2 as ${T}, in: cosh))
+  expectEqualWithTolerance(0.07065082485316446565, ${op}(at: 2 as ${T}, in: tanh))
+  expectEqualWithTolerance(0.44721359549995793928, ${op}(at: 2 as ${T}, in: asinh))
+  expectEqualWithTolerance(0.5773502691896257645, ${op}(at: 2 as ${T}, in: acosh))
+  expectEqualWithTolerance(1.3333333333333333334, ${op}(at: 0.5 as ${T}, in: atanh))
+  expectEqualWithTolerance(0.020666985354092053575, ${op}(at: 2 as ${T}, in: erf))
+  expectEqualWithTolerance(-0.020666985354092053575, ${op}(at: 2 as ${T}, in: erfc))
+  expectEqualWithTolerance(0.35355339059327376222, ${op}(at: 2 as ${T}, in: { sqrt($0) }))
+  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { ceil($0) }))
+  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { floor($0) }))
+  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { round($0) }))
+  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { trunc($0) }))
+
+  // Differential operator specific tests.
+
+  // fma
+  let dfma = ${op}(at: 4 as ${T}, 5 as ${T}, 6 as ${T}, in: fma)
+%if op == 'gradient':
+  expectEqualWithTolerance(5, dfma.0)
+  expectEqualWithTolerance(4, dfma.1)
+  expectEqualWithTolerance(1, dfma.2)
+%else: # if op == 'derivative'
+  expectEqualWithTolerance(10, dfma)
+%end
+
+  // remainder, fmod
   for a in -10...10 {
     let x = ${T}(a)
     for b in -10...10 {
@@ -89,11 +101,16 @@ MathTests.test("gradient_${T}") {
       guard b != 0 && remainder(x, y).sign == remainder(x + ${T}(0.001), y).sign &&
         remainder(x, y).sign == remainder(x, y + ${T}(0.001)).sign
         else { continue }
+%if op == 'gradient':
       checkGradient({ remainder($0, $1) }, x, y)
       checkGradient({ fmod($0, $1) }, x, y)
+%else: # if op == 'derivative'
+      // TODO(TF-1108): Implement JVPs for `remainder` and `fmod`.
+%end
     }
   }
 }
-%end
+%end # for T in ['Float', 'Float80']:
+%end # for op in ['derivative', 'gradient']:
 
 runAllTests()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1570,6 +1570,16 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_simple_swiftgyb_forward_mode_differentiation = (
+        '%%empty-directory(%%t) && '
+        '%%gyb %%s -o %%t/main.swift && '
+        '%%line-directive %%t/main.swift -- '
+        '%s %s %%t/main.swift -enable-experimental-forward-mode-differentiation -o %%t/a.out -module-name main  && '
+        '%s %%t/a.out && '
+        '%%line-directive %%t/main.swift -- '
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    # SWIFT_ENABLE_TENSORFLOW END
 
 #
 # When changing substitutions, update docs/Testing.md.
@@ -1592,9 +1602,14 @@ config.substitutions.append(('%target-swift-frontend\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%s \1 %s' % (subst_target_swift_frontend_mock_sdk,
                                                                subst_target_swift_frontend_mock_sdk_after))))
 config.substitutions.append(('%target-swift-frontend', config.target_swift_frontend))
+
 # SWIFT_ENABLE_TENSORFLOW
 # TODO: Remove when forward mode AD support is robust.
-config.substitutions.append(('%target_run_simple_swift_forward_mode_differentiation', config.target_run_simple_swift_forward_mode_differentiation))
+config.substitutions.append(('%target-run-simple-swiftgyb-forward-mode-differentiation',
+                            config.target_run_simple_swiftgyb_forward_mode_differentiation))
+config.substitutions.append(('%target-run-simple-swift-forward-mode-differentiation',
+                            config.target_run_simple_swift_forward_mode_differentiation))
+# SWIFT_ENABLE_TENSORFLOW END
 
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
 config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)', config.target_run_simple_swift_parameterized))

--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -53,19 +53,6 @@ func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
              file: file, line: line)
 }
 
-func checkGradient<T: BinaryFloatingPoint & Differentiable>(
-  _ f: @differentiable (T, T) -> T,
-  _ x: T,
-  _ y: T)
-where T == T.TangentVector {
-  let eps = T(0.01)
-  let grad = gradient(at: x, y, in: f)
-  let dfdx = (f(x + eps, y) - f(x, y)) / eps
-  let dfdy = (f(x, y + eps) - f(x, y)) / eps
-  expectEqualWithTolerance(TestLiteralType(dfdx), grad.0, ulps: 192)
-  expectEqualWithTolerance(TestLiteralType(dfdy), grad.1, ulps: 192)
-}
-
 %{
 unary = [
   'acos', 'asin', 'atan',


### PR DESCRIPTION
Add JVPs for tgmath functions except `remainder(_:_:)` and `fmod(_:_:)`.
Add tests.

JVP/VJP functions for unary tgmath functions are identical, but there is no way
to register a derivative function as both a JVP/VJP of the same original
function. TF-1111 tracks this; the issue will naturally resolve when linear
functions and transposition are done and VJPs are removed.

Partially resolves TF-1108.

---

Sorry, I shouldn't have taken on this starter issue. I started setting up the skeleton (with `fatalError`s) and got carried away.

The TF-1107 master issue tracks other JVP definition starter issues.