### PR TITLE
Revert "Reimplement function builders as statement transformations."

### DIFF
--- a/include/swift/AST/ASTTypeIDZone.def
+++ b/include/swift/AST/ASTTypeIDZone.def
@@ -17,7 +17,7 @@
 
 SWIFT_TYPEID(AncestryFlags)
 SWIFT_TYPEID(CtorInitializerKind)
-SWIFT_TYPEID(FunctionBuilderBodyPreCheck)
+SWIFT_TYPEID(FunctionBuilderClosurePreCheck)
 SWIFT_TYPEID(GenericSignature)
 SWIFT_TYPEID(ImplicitMemberAction)
 SWIFT_TYPEID(ParamSpecifier)

--- a/include/swift/AST/ASTTypeIDs.h
+++ b/include/swift/AST/ASTTypeIDs.h
@@ -28,7 +28,7 @@ class ConstructorDecl;
 class CustomAttr;
 class Decl;
 class EnumDecl;
-enum class FunctionBuilderBodyPreCheck : uint8_t;
+enum class FunctionBuilderClosurePreCheck : uint8_t;
 class GenericParamList;
 class GenericSignature;
 class GenericTypeParamType;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3599,10 +3599,7 @@ class ClosureExpr : public AbstractClosureExpr {
   /// the CaptureListExpr which would normally maintain this sort of
   /// information about captured variables), we need to have some way to access
   /// this information directly on the ClosureExpr.
-  ///
-  /// The bit indicates whether this closure has had a function builder
-  /// applied to it.
-  llvm::PointerIntPair<VarDecl *, 1, bool> CapturedSelfDeclAndAppliedBuilder;
+  VarDecl *CapturedSelfDecl;
   
   /// The location of the "throws", if present.
   SourceLoc ThrowsLoc;
@@ -3627,8 +3624,7 @@ public:
               unsigned discriminator, DeclContext *parent)
     : AbstractClosureExpr(ExprKind::Closure, Type(), /*Implicit=*/false,
                           discriminator, parent),
-      BracketRange(bracketRange),
-      CapturedSelfDeclAndAppliedBuilder(capturedSelfDecl, false),
+      BracketRange(bracketRange), CapturedSelfDecl(capturedSelfDecl),
       ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc), InLoc(inLoc),
       ExplicitResultType(explicitResultType), Body(nullptr) {
     setParameterList(params);
@@ -3730,22 +3726,12 @@ public:
   bool hasEmptyBody() const;
 
   /// VarDecl captured by this closure under the literal name \c self , if any.
-  VarDecl *getCapturedSelfDecl() const {
-    return CapturedSelfDeclAndAppliedBuilder.getPointer();
-  }
+  VarDecl *getCapturedSelfDecl() const { return CapturedSelfDecl; }
   
   /// Whether this closure captures the \c self param in its body in such a
   /// way that implicit \c self is enabled within its body (i.e. \c self is
   /// captured non-weakly).
   bool capturesSelfEnablingImplictSelf() const;
-
-  bool hasAppliedFunctionBuilder() const {
-    return CapturedSelfDeclAndAppliedBuilder.getInt();
-  }
-
-  void setAppliedFunctionBuilder(bool flag = true) {
-    CapturedSelfDeclAndAppliedBuilder.setInt(flag);
-  }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Closure;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1750,7 +1750,7 @@ public:
   void cacheResult(Witness value) const;
 };
 
-enum class FunctionBuilderBodyPreCheck : uint8_t {
+enum class FunctionBuilderClosurePreCheck : uint8_t {
   /// There were no problems pre-checking the closure.
   Okay,
 
@@ -1763,7 +1763,7 @@ enum class FunctionBuilderBodyPreCheck : uint8_t {
 
 class PreCheckFunctionBuilderRequest
     : public SimpleRequest<PreCheckFunctionBuilderRequest,
-                           FunctionBuilderBodyPreCheck(AnyFunctionRef),
+                           FunctionBuilderClosurePreCheck(AnyFunctionRef),
                            CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1772,7 +1772,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<FunctionBuilderBodyPreCheck>
+  llvm::Expected<FunctionBuilderClosurePreCheck>
   evaluate(Evaluator &evaluator, AnyFunctionRef fn) const;
 
 public:
@@ -2044,7 +2044,7 @@ AnyValue::Holder<GenericSignature>::equals(const HolderBase &other) const {
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 void simple_display(llvm::raw_ostream &out, ImplicitMemberAction action);
-void simple_display(llvm::raw_ostream &out, FunctionBuilderBodyPreCheck pck);
+void simple_display(llvm::raw_ostream &out, FunctionBuilderClosurePreCheck pck);
 
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1122,15 +1122,15 @@ void ValueWitnessRequest::cacheResult(Witness type) const {
 //----------------------------------------------------------------------------//
 
 void swift::simple_display(llvm::raw_ostream &out,
-                           FunctionBuilderBodyPreCheck value) {
+                           FunctionBuilderClosurePreCheck value) {
   switch (value) {
-  case FunctionBuilderBodyPreCheck::Okay:
+  case FunctionBuilderClosurePreCheck::Okay:
     out << "okay";
     break;
-  case FunctionBuilderBodyPreCheck::HasReturnStmt:
+  case FunctionBuilderClosurePreCheck::HasReturnStmt:
     out << "has return statement";
     break;
-  case FunctionBuilderBodyPreCheck::Error:
+  case FunctionBuilderClosurePreCheck::Error:
     out << "error";
     break;
   }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4596,14 +4596,6 @@ namespace {
       return result;
     }
 
-    const AppliedBuilderTransform *getAppliedBuilderTransform(
-       AnyFunctionRef fn) {
-      auto known = solution.functionBuilderTransformed.find(fn);
-      return known != solution.functionBuilderTransformed.end()
-          ? &known->second
-          : nullptr;
-    }
-
     void finalize() {
       assert(ExprStack.empty());
       assert(OpenedExistentials.empty());
@@ -5775,10 +5767,10 @@ Expr *ExprRewriter::buildObjCBridgeExpr(Expr *expr, Type toType,
   return forceBridgeFromObjectiveC(expr, toType);
 }
 
-Expr *ConstraintSystem::addImplicitLoadExpr(Expr *expr) {
+static Expr *addImplicitLoadExpr(ConstraintSystem &cs, Expr *expr) {
   return TypeChecker::addImplicitLoadExpr(
-      getASTContext(), expr, [this](Expr *expr) { return getType(expr); },
-      [this](Expr *expr, Type type) { setType(expr, type); });
+      cs.getASTContext(), expr, [&cs](Expr *expr) { return cs.getType(expr); },
+      [&cs](Expr *expr, Type type) { cs.setType(expr, type); });
 }
 
 Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
@@ -6035,7 +6027,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     auto fromLValue = cast<LValueType>(desugaredFromType);
     auto toIO = toType->getAs<InOutType>();
     if (!toIO)
-      return coerceToType(cs.addImplicitLoadExpr(expr), toType, locator);
+      return coerceToType(addImplicitLoadExpr(cs, expr), toType, locator);
 
     // In an 'inout' operator like "i += 1", the operand is converted from
     // an implicit lvalue to an inout argument.
@@ -7051,36 +7043,30 @@ namespace {
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         Rewriter.simplifyExprType(expr);
         auto &cs = Rewriter.getConstraintSystem();
+        auto &ctx = cs.getASTContext();
 
         // Coerce the pattern, in case we resolved something.
         auto fnType = cs.getType(closure)->castTo<FunctionType>();
         auto *params = closure->getParameters();
         TypeChecker::coerceParameterListToType(params, closure, fnType);
 
-        if (auto transform =
-                       Rewriter.getAppliedBuilderTransform(closure)) {
-          // Apply the function builder to the closure. We want to be in the
-          // context of the closure for subsequent transforms.
-          llvm::SaveAndRestore<DeclContext *> savedDC(Rewriter.dc, closure);
-          auto newBody = applyFunctionBuilderTransform(
-              Rewriter.solution, *transform, closure->getBody(), closure,
-              [&](Expr *expr) {
-                Expr *result = expr->walk(*this);
-                if (result)
-                  Rewriter.solution.setExprTypes(result);
-                return result;
-              },
-              [&](Expr *expr, Type toType, ConstraintLocator *locator) {
-                return Rewriter.coerceToType(expr, toType, locator);
-              });
-          closure->setBody(newBody, /*isSingleExpression=*/false);
-          closure->setAppliedFunctionBuilder();
+        // If this closure had a function builder applied, rewrite it to a
+        // closure with a single expression body containing the builder
+        // invocations.
+        auto builder = Rewriter.solution.functionBuilderTransformed.find(closure);
+        if (builder != Rewriter.solution.functionBuilderTransformed.end()) {
+          auto singleExpr = builder->second.singleExpr;
+          auto returnStmt = new (ctx) ReturnStmt(
+             singleExpr->getStartLoc(), singleExpr, /*implicit=*/true);
+          auto braceStmt = BraceStmt::create(
+              ctx, returnStmt->getStartLoc(), ASTNode(returnStmt),
+              returnStmt->getEndLoc(), /*implicit=*/true);
+          closure->setBody(braceStmt, /*isSingleExpression=*/true);
+        }
 
-          Rewriter.solution.setExprTypes(closure);
-        } else if (closure->hasSingleExpressionBody()) {
-          // If this is a single-expression closure, convert the expression
-          // in the body to the result type of the closure.
-
+        // If this is a single-expression closure, convert the expression
+        // in the body to the result type of the closure.
+        if (closure->hasSingleExpressionBody()) {
           // Enter the context of the closure when type-checking the body.
           llvm::SaveAndRestore<DeclContext *> savedDC(Rewriter.dc, closure);
           Expr *body = closure->getSingleExpressionBody()->walk(*this);
@@ -7268,25 +7254,27 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
     auto fn = *target.getAsFunction();
 
     // Dig out the function builder transformation we applied.
-    auto transform = rewriter.getAppliedBuilderTransform(fn);
-    assert(transform);
+    auto transformed = solution.functionBuilderTransformed.find(fn);
+    assert(transformed != solution.functionBuilderTransformed.end());
 
-    auto newBody = applyFunctionBuilderTransform(
-        solution, *transform, fn.getBody(), fn.getAsDeclContext(),
-        [&](Expr *expr) {
-          Expr *result = expr->walk(walker);
-          if (result)
-            solution.setExprTypes(result);
-          return result;
-        },
-        [&](Expr *expr, Type toType, ConstraintLocator *locator) {
-          return rewriter.coerceToType(expr, toType, locator);
-        });
-
-    if (!newBody)
+    auto singleExpr = transformed->second.singleExpr;
+    singleExpr = singleExpr->walk(walker);
+    if (!singleExpr)
       return result;
 
-    result = newBody;
+    singleExpr = rewriter.coerceToType(singleExpr,
+                                       transformed->second.bodyResultType,
+                                       getConstraintLocator(singleExpr));
+    if (!singleExpr)
+      return result;
+
+    ASTContext &ctx = getASTContext();
+    auto returnStmt = new (ctx) ReturnStmt(
+       singleExpr->getStartLoc(), singleExpr, /*implicit=*/true);
+    auto braceStmt = BraceStmt::create(
+        ctx, returnStmt->getStartLoc(), ASTNode(returnStmt),
+        returnStmt->getEndLoc(), /*implicit=*/false);
+    result = braceStmt;
   }
 
   if (result.isNull())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1005,7 +1005,7 @@ void MissingOptionalUnwrapFailure::offerDefaultValueUnwrapFixIt(
   // If anchor is n explicit address-of, or expression which produces
   // an l-value (e.g. first argument of `+=` operator), let's not
   // suggest default value here because that would produce r-value type.
-  if (!anchor || isa<InOutExpr>(anchor))
+  if (isa<InOutExpr>(anchor))
     return;
 
   auto &cs = getConstraintSystem();

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -165,13 +165,18 @@ Solution ConstraintSystem::finalize() {
                                        DefaultedConstraints.end());
 
   for (auto &nodeType : addedNodeTypes) {
-    solution.addedNodeTypes.insert(nodeType);
+    solution.addedNodeTypes.push_back(nodeType);
   }
 
   for (auto &e : CheckedConformances)
     solution.Conformances.push_back({e.first, e.second});
 
   for (const auto &transformed : functionBuilderTransformed) {
+    auto known =
+        solution.functionBuilderTransformed.find(transformed.first);
+    if (known != solution.functionBuilderTransformed.end()) {
+      assert(known->second.singleExpr == transformed.second.singleExpr);
+    }
     solution.functionBuilderTransformed.insert(transformed);
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -938,8 +938,8 @@ Type ConstraintSystem::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
   return TypeChecker::getUnopenedTypeOfReference(
       value, baseType, UseDC,
       [&](VarDecl *var) -> Type {
-        if (Type type = getTypeIfAvailable(var))
-          return type;
+        if (auto *param = dyn_cast<ParamDecl>(var))
+          return getType(param);
 
         if (!var->hasInterfaceType()) {
           return ErrorType::get(getASTContext());
@@ -3653,14 +3653,13 @@ ConstraintSystem::getFunctionArgApplyInfo(ConstraintLocator *locator) {
       assert(!shouldHaveDirectCalleeOverload(call) &&
              "Should we have resolved a callee for this?");
       rawFnType = getType(call->getFn());
-    } else if (auto *apply = dyn_cast<ApplyExpr>(anchor)) {
+    } else {
       // FIXME: ArgumentMismatchFailure is currently used from CSDiag, meaning
       // we can end up a BinaryExpr here with an unresolved callee. It should be
       // possible to remove this once we've gotten rid of the old CSDiag logic
       // and just assert that we have a CallExpr.
+      auto *apply = cast<ApplyExpr>(anchor);
       rawFnType = getType(apply->getFn());
-    } else {
-      return None;
     }
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -669,34 +669,12 @@ struct AppliedBuilderTransform {
   /// The builder type that was applied to the closure.
   Type builderType;
 
+  /// The single expression to which the closure was transformed.
+  Expr *singleExpr;
+
   /// The result type of the body, to which the returned expression will be
   /// converted.
   Type bodyResultType;
-
-  /// An expression whose value has been recorded for later use.
-  struct RecordedExpr {
-    /// The temporary value that captures the value of the expression, if
-    /// there is one.
-    VarDecl *temporaryVar;
-
-    /// The expression that results from generating constraints with this
-    /// particular builder.
-    Expr *generatedExpr;
-  };
-
-  /// A mapping from expressions whose values are captured by the builder
-  /// to information about the temporary variable capturing the
-  llvm::DenseMap<Expr *, RecordedExpr> capturedExprs;
-
-  /// A mapping from statements to a pair containing the implicit variable
-  /// declaration that captures the result of that expression, and the
-  /// set of expressions that can be used to produce a value for that
-  /// variable.
-  llvm::DenseMap<Stmt *, std::pair<VarDecl *, llvm::TinyPtrVector<Expr *>>>
-      capturedStmts;
-
-  /// The return expression, capturing the last value to be emitted.
-  Expr *returnExpr = nullptr;
 };
 
 /// Describes the fixed score of a solution to the constraint system.
@@ -847,7 +825,7 @@ public:
   llvm::SmallPtrSet<ConstraintLocator *, 2> DefaultedConstraints;
 
   /// The node -> type mappings introduced by this solution.
-  llvm::MapVector<TypedNode, Type> addedNodeTypes;
+  llvm::SmallVector<std::pair<TypedNode, Type>, 8> addedNodeTypes;
 
   std::vector<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
       Conformances;
@@ -938,13 +916,6 @@ public:
   Type getType(const Expr *E) const;
 
   void setExprTypes(Expr *expr) const;
-
-  /// Retrieve the type of the given node, as recorded in this solution.
-  Type getType(TypedNode node) const {
-    auto known = addedNodeTypes.find(node);
-    assert(known != addedNodeTypes.end());
-    return known->second;
-  }
 
   SWIFT_DEBUG_DUMP;
 
@@ -2057,7 +2028,9 @@ public:
     }
 
     // Record the fact that we ascribed a type to this node.
-    addedNodeTypes.push_back({node, type});
+    if (solverState && solverState->depth > 0) {
+      addedNodeTypes.push_back({node, type});
+    }
   }
 
   /// Set the type in our type map for a given expression. The side
@@ -2138,15 +2111,6 @@ public:
   Type getType(const KeyPathExpr *KP, unsigned I) const {
     assert(hasType(KP, I) && "Expected type to have been set!");
     return KeyPathComponentTypes.find(std::make_pair(KP, I))->second;
-  }
-
-  /// Retrieve the type of the variable, if known.
-  Type getTypeIfAvailable(const VarDecl *VD) const {
-    auto known = VarTypes.find(VD);
-    if (known == VarTypes.end())
-      return Type();
-
-    return known->second;
   }
 
   /// Cache the type of the expression argument and return that same
@@ -2845,9 +2809,6 @@ public:
 
   /// Coerce the given expression to an rvalue, if it isn't already.
   Expr *coerceToRValue(Expr *expr);
-
-  /// Add implicit "load" expressions to the given expression.
-  Expr *addImplicitLoadExpr(Expr *expr);
 
   /// "Open" the given unbound type by introducing fresh type
   /// variables for generic parameters and constructing a bound generic
@@ -4902,29 +4863,6 @@ bool exprNeedsParensOutsideFollowingOperator(
 
 /// Determine whether this is a SIMD operator.
 bool isSIMDOperator(ValueDecl *value);
-
-/// Apply the given function builder transform within a specific solution
-/// to produce the rewritten body.
-///
-/// \param solution The solution to use during application, providing the
-/// specific types for each type variable.
-/// \param applied The applied builder transform.
-/// \param body The body to transform
-/// \param dc The context in which the transform occurs.
-/// \param rewriteExpr Rewrites expressions that show up in the transform
-/// to their final, type-checked versions.
-/// \param coerceToType Coerce the given expression to the specified type,
-/// which may introduce implicit conversions.
-///
-/// \returns the transformed body
-BraceStmt *applyFunctionBuilderTransform(
-    const constraints::Solution &solution,
-    constraints::AppliedBuilderTransform applied,
-    BraceStmt *body,
-    DeclContext *dc,
-    std::function<Expr *(Expr *)> rewriteExpr,
-    std::function<Expr *(Expr *, Type, constraints::ConstraintLocator *)>
-      coerceToType);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -144,10 +144,10 @@ namespace {
           }
         }
 
-        // If the closure has a single expression body or has had a function
-        // builder applied to it, we need to walk into it with a new sequence.
-        // Otherwise, it'll have been separately type-checked.
-        if (CE->hasSingleExpressionBody() || CE->hasAppliedFunctionBuilder())
+        // If the closure has a single expression body, we need to walk into it
+        // with a new sequence.  Otherwise, it'll have been separately
+        // type-checked.
+        if (CE->hasSingleExpressionBody())
           CE->getBody()->walk(ContextualizeClosures(CE));
 
         TypeChecker::computeCaptures(CE);

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -352,20 +352,14 @@ func acceptComponentBuilder(@ComponentBuilder _ body: () -> Component) {
   print(body())
 }
 
-func colorWithAutoClosure(_ color: @autoclosure () -> Color) -> Color {
-  return color()
-}
-
-var trueValue = true
 acceptComponentBuilder {
   "hello"
-  if trueValue {
+  if true {
     3.14159
-    colorWithAutoClosure(.red)
   }
   .red
 }
-// CHECK: array([main.Component.string("hello"), main.Component.optional(Optional(main.Component.array([main.Component.floating(3.14159), main.Component.color(main.Color.red)]))), main.Component.color(main.Color.red)])
+// CHECK: array([main.Component.string("hello"), main.Component.optional(Optional(main.Component.array([main.Component.floating(3.14159)]))), main.Component.color(main.Color.red)])
 
 // rdar://53325810
 

--- a/test/Constraints/function_builder_one_way.swift
+++ b/test/Constraints/function_builder_one_way.swift
@@ -49,16 +49,17 @@ func tuplify<C: Collection, T>(_ collection: C, @TupleBuilder body: (C.Element) 
 }
 
 // CHECK: ---Connected components---
-// CHECK-NEXT:  0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T10 $T11 $T78 $T79 depends on 2
-// CHECK-NEXT:  2: $T13 $T18 $T29 $T42 $T53 $T55 $T56 $T57 $T58 $T59 $T60 $T61 $T62 $T63 $T64 $T65 $T66 $T67 $T69 $T70 $T71 $T72 $T73 $T74 $T75 $T76 $T77 depends on 1, 3, 4, 6, 9
-// CHECK-NEXT:  9: $T48 $T49 $T50 $T51 $T52 depends on 8
-// CHECK-NEXT:  8: $T43 $T44 $T45 $T46 $T47
-// CHECK-NEXT:  6: $T31 $T35 $T36 $T37 $T38 $T39 $T40 $T41 depends on 5, 7
-// CHECK-NEXT:  7: $T32 $T33 $T34
-// CHECK-NEXT:  5: $T30
-// CHECK-NEXT:  4: $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28
-// CHECK-NEXT:  3: $T16 $T17
-// CHECK-NEXT:  1: $T12
+// CHECK-NEXT: 0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T10 $T11 $T69 depends on 1
+// CHECK-NEXT: 1: $T12 $T14 $T19 $T30 $T62 $T63 $T64 $T65 $T66 $T67 $T68 depends on 2, 3, 4, 5
+// CHECK-NEXT: 5: $T32 $T43 $T44 $T45 $T46 $T47 $T57 $T58 $T59 $T60 $T61 depends on 6, 9
+// CHECK-NEXT: 9: $T48 $T54 $T55 $T56 depends on 10
+// CHECK-NEXT: 10: $T49 $T50 $T51 $T52 $T53
+// CHECK-NEXT: 6: $T33 $T35 $T39 $T40 $T41 $T42 depends on 7, 8
+// CHECK-NEXT: 8: $T36 $T37 $T38
+// CHECK-NEXT: 7: $T34
+// CHECK-NEXT: 4: $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28 $T29
+// CHECK-NEXT: 3: $T17 $T18
+// CHECK-NEXT: 2: $T13
 let names = ["Alice", "Bob", "Charlie"]
 let b = true
 var number = 17

--- a/test/Profiler/coverage_function_builder.swift
+++ b/test/Profiler/coverage_function_builder.swift
@@ -13,7 +13,7 @@ struct Summer {
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test0SiyF"
 @Summer
 func test0() -> Int {
-  // CHECK: [[@LINE-1]]:21 -> [[@LINE+3]]:2 : 0
+  // CHECK: [[@LINE-1]]:21 -> [[@LINE+2]]:5 : 0
   18
   12
 }
@@ -21,7 +21,7 @@ func test0() -> Int {
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test1SiyF"
 @Summer
 func test1() -> Int {
-  // CHECK: [[@LINE-1]]:21 -> [[@LINE+7]]:2 : 0
+  // CHECK: [[@LINE-1]]:21 -> [[@LINE+6]]:4 : 0
   18
   12
   if 7 < 23 {

--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -8,7 +8,7 @@ struct ContentView : View {
   @State var foo: [String] = Array(repeating: "", count: 5)
 
   var body: some View {
-    VStack {
+    VStack { // expected-error {{expression type 'VStack<_>' is ambiguous without more context}}
       HStack {
         Text("")
         TextFi // expected-error {{use of unresolved identifier 'TextFi'}}


### PR DESCRIPTION
Reverts apple/swift#29133. It looks like it caused a type checker crash in rdar://problem/58695803