### PR TITLE
TBDGen: when previous install name map is specified, emit $ld$previous linker directives.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1607,6 +1607,7 @@ public:
   const llvm::VersionTuple MovedVersion;
 
   struct ActiveVersion {
+    StringRef ModuleName;
     PlatformKind Platform;
     bool IsSimulator;
     llvm::VersionTuple Version;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -753,6 +753,11 @@ public:
     return Attrs;
   }
 
+  /// Returns the introduced OS version in the given platform kind specified
+  /// by @available attribute.
+  /// This function won't consider the parent context to get the information.
+  Optional<llvm::VersionTuple> getIntroducedOSVersion(PlatformKind Kind) const;
+
   /// Returns the starting location of the entire declaration.
   SourceLoc getStartLoc() const { return getSourceRange().Start; }
 

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -282,6 +282,9 @@ REMARK(platform_previous_install_name, none,
 ERROR(unknown_platform_name, none,
       "unkown platform name %0", (StringRef))
 
+ERROR(cannot_find_install_name, none,
+      "cannot find previous install name for module %0 in %1", (StringRef, StringRef))
+
 ERROR(symbol_in_tbd_not_in_ir,none,
       "symbol '%0' (%1) is in TBD file, but not in generated IR",
       (StringRef, StringRef))

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1291,6 +1291,7 @@ OriginallyDefinedInAttr::isActivePlatform(const ASTContext &ctx) const {
   OriginallyDefinedInAttr::ActiveVersion Result;
   Result.Platform = Platform;
   Result.Version = MovedVersion;
+  Result.ModuleName = OriginalModuleName;
   if (isPlatformActive(Platform, ctx.LangOpts)) {
     Result.IsSimulator = ctx.LangOpts.Target.isSimulatorEnvironment();
     return Result;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -331,6 +331,18 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   llvm_unreachable("bad DescriptiveDeclKind");
 }
 
+Optional<llvm::VersionTuple>
+Decl::getIntroducedOSVersion(PlatformKind Kind) const {
+  for (auto *attr: getAttrs()) {
+    if (auto *ava = dyn_cast<AvailableAttr>(attr)) {
+      if (ava->Platform == Kind && ava->Introduced) {
+        return ava->Introduced;
+      }
+    }
+  }
+  return None;
+}
+
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
                                      StaticSpellingKind SSK) {
   switch (SSK) {

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -78,7 +78,8 @@ private:
     parsePreviousModuleInstallNameMap();
   void addSymbolInternal(StringRef name, llvm::MachO::SymbolKind kind,
                          bool isLinkerDirective = false);
-  void addLinkerDirectiveSymbols(StringRef name, llvm::MachO::SymbolKind kind);
+  void addLinkerDirectiveSymbolsLdHide(StringRef name, llvm::MachO::SymbolKind kind);
+  void addLinkerDirectiveSymbolsLdPrevious(StringRef name, llvm::MachO::SymbolKind kind);
   void addSymbol(StringRef name, llvm::MachO::SymbolKind kind =
                                      llvm::MachO::SymbolKind::GlobalSymbol);
 

--- a/test/TBD/Inputs/install-name-map-toasterkit.json
+++ b/test/TBD/Inputs/install-name-map-toasterkit.json
@@ -1,0 +1,12 @@
+[
+  {
+    "module": "ToasterKit",
+    "install_name": "/System/Previous/macOS/ToasterKit.dylib",
+    "platforms": ["macOS"]
+  },
+  {
+    "module": "ToasterKit",
+    "install_name": "/System/Previous/iOS/ToasterKit.dylib",
+    "platforms": ["iOS"]
+  }
+]

--- a/test/TBD/Inputs/linker-directive.swift
+++ b/test/TBD/Inputs/linker-directive.swift
@@ -1,0 +1,9 @@
+@available(OSX 10.8, iOS 10.2, *)
+@_originallyDefinedIn(module: "ToasterKit", macOS 10.15, iOS 13)
+public func toast() {}
+
+@available(OSX 10.8, iOS 10.2, *)
+@_originallyDefinedIn(module: "ToasterKit", macOS 10.15, iOS 13)
+public struct Vehicle {
+  public func move() {}
+}

--- a/test/TBD/linker-directives-ld-previous-ios.swift
+++ b/test/TBD/linker-directives-ld-previous-ios.swift
@@ -1,0 +1,14 @@
+// REQUIRES: OS=ios
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -tbd-is-installapi -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
+// RUN: %FileCheck %s < %t/linker_directives.tbd
+// RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
+// RUN: %FileCheck %s < %t/linker_directives.tbd
+
+// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit5toastyyF$
+// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleV4moveyyF$
+// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVMa$
+// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVMn$
+// CHECK: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit7VehicleVN$

--- a/test/TBD/linker-directives-ld-previous-macos.swift
+++ b/test/TBD/linker-directives-ld-previous-macos.swift
@@ -1,0 +1,14 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -tbd-is-installapi -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
+// RUN: %FileCheck %s < %t/linker_directives.tbd
+// RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
+// RUN: %FileCheck %s < %t/linker_directives.tbd
+
+// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit5toastyyF$
+// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleV4moveyyF$
+// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMa$
+// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMn$
+// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVN$


### PR DESCRIPTION
Progress towards: rdar://58281536