### PR TITLE
[NFC-ish] Simplify module loader filename handling

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -148,7 +148,7 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
   ArrayRef<std::string> PreferInterfaceForModules;
 
   std::error_code findModuleFilesInDirectory(
-    AccessPathElem ModuleID, StringRef DirPath,
+    AccessPathElem ModuleID,
     const SerializedModuleBaseName &BaseName,
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -148,8 +148,8 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
   ArrayRef<std::string> PreferInterfaceForModules;
 
   std::error_code findModuleFilesInDirectory(
-    AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
-    StringRef ModuleDocFilename,
+    AccessPathElem ModuleID, StringRef DirPath,
+    const SerializedModuleBaseName &BaseName,
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -150,7 +150,6 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
   std::error_code findModuleFilesInDirectory(
     AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
     StringRef ModuleDocFilename,
-    StringRef ModuleSourceInfoFilename,
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -73,7 +73,6 @@ protected:
   virtual std::error_code findModuleFilesInDirectory(
       AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
       StringRef ModuleDocFilename,
-      StringRef ModuleSourceInfoFilename,
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
@@ -82,7 +81,6 @@ protected:
   std::error_code
   openModuleFiles(AccessPathElem ModuleID,
                   StringRef ModulePath, StringRef ModuleDocPath,
-                  StringRef ModuleSourceInfoName,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
@@ -96,7 +94,6 @@ protected:
   openModuleSourceInfoFileIfPresent(
       AccessPathElem ModuleID,
       StringRef ModulePath,
-      StringRef ModuleSourceInfoFileName,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
 
   /// If the module loader subclass knows that all options have been tried for
@@ -180,7 +177,6 @@ class SerializedModuleLoader : public SerializedModuleLoaderBase {
   std::error_code findModuleFilesInDirectory(
       AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
       StringRef ModuleDocFilename,
-      StringRef ModuleSourceInfoFilename,
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
@@ -226,7 +222,6 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
   std::error_code findModuleFilesInDirectory(
       AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
       StringRef ModuleDocFilename,
-      StringRef ModuleSourceInfoFilename,
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -20,6 +20,9 @@
 
 namespace swift {
 class ModuleFile;
+namespace file_types {
+  enum ID : uint8_t;
+}
 
 /// Spceifies how to load modules when both a module interface and serialized
 /// AST are present, or whether to disallow one format or the other altogether.
@@ -28,6 +31,23 @@ enum class ModuleLoadingMode {
   PreferSerialized,
   OnlyInterface,
   OnlySerialized
+};
+
+/// Helper type used to pass and compute the sets of related filenames used by
+/// \c SerializedModuleLoader subclasses.
+struct SerializedModuleBaseName {
+  /// The base filename, wtihout any extension.
+  std::string baseName;
+
+  /// Creates a \c SerializedModuleBaseName.
+  SerializedModuleBaseName(std::string baseName) : baseName(baseName) { }
+
+  /// Gets the filename with a particular extension appended to it.
+  std::string getName(file_types::ID fileTy) const;
+
+  /// Gets the filename in a particular directory with a particular extension
+  /// appended to it.
+  std::string getName(StringRef parentDir, file_types::ID fileTy) const;
 };
 
 /// Common functionality shared between \c SerializedModuleLoader,
@@ -71,8 +91,8 @@ protected:
   ///   modules and will defer to the remaining module loaders to look up this
   ///   module.
   virtual std::error_code findModuleFilesInDirectory(
-      AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
-      StringRef ModuleDocFilename,
+      AccessPathElem ModuleID, StringRef DirPath,
+      const SerializedModuleBaseName &BaseName,
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
@@ -175,8 +195,8 @@ class SerializedModuleLoader : public SerializedModuleLoaderBase {
   {}
 
   std::error_code findModuleFilesInDirectory(
-      AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
-      StringRef ModuleDocFilename,
+      AccessPathElem ModuleID, StringRef DirPath,
+      const SerializedModuleBaseName &BaseName,
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
@@ -220,8 +240,8 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
                                    IgnoreSwiftSourceInfo) {}
 
   std::error_code findModuleFilesInDirectory(
-      AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
-      StringRef ModuleDocFilename,
+      AccessPathElem ModuleID, StringRef DirPath,
+      const SerializedModuleBaseName &BaseName,
       SmallVectorImpl<char> *ModuleInterfacePath,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -100,18 +100,18 @@ protected:
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) = 0;
 
   std::error_code
-  openModuleFiles(AccessPathElem ModuleID,
-                  const SerializedModuleBaseName &BaseName,
-                  std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-                  std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-                  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
+  openModuleFile(
+       AccessPathElem ModuleID,
+       const SerializedModuleBaseName &BaseName,
+       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer);
 
   std::error_code
-  openModuleDocFile(AccessPathElem ModuleID,
-                    const SerializedModuleBaseName &BaseName,
-                    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer);
+  openModuleDocFileIfPresent(
+      AccessPathElem ModuleID,
+      const SerializedModuleBaseName &BaseName,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer);
 
-  void
+  std::error_code
   openModuleSourceInfoFileIfPresent(
       AccessPathElem ModuleID,
       const SerializedModuleBaseName &BaseName,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1036,9 +1036,6 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
       *ModuleInterfacePath = InPath;
   }
 
-  // FIXME: A test breaks if we respect IgnoreSwiftSourceInfoFile here. Why?
-  llvm::SaveAndRestore<bool> fixme(IgnoreSwiftSourceInfoFile, false);
-
   // Open .swiftsourceinfo file if it's present.
   if (auto SourceInfoError = openModuleSourceInfoFileIfPresent(ModuleID,
                                                                BaseName,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -989,7 +989,6 @@ bool ModuleInterfaceLoader::isCached(StringRef DepPath) {
 std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
   StringRef ModuleDocFilename,
-  StringRef ModuleSourceInfoFilename,
   SmallVectorImpl<char> *ModuleInterfacePath,
   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
   std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
@@ -1043,7 +1042,6 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   // Open .swiftsourceinfo file if it's present.
   SerializedModuleLoaderBase::openModuleSourceInfoFileIfPresent(ModuleID,
                                                                 ModPath,
-                                                       ModuleSourceInfoFilename,
                                                        ModuleSourceInfoBuffer);
   // Delegate back to the serialized module loader to load the module doc.
   llvm::SmallString<256> DocPath{DirPath};

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -987,7 +987,7 @@ bool ModuleInterfaceLoader::isCached(StringRef DepPath) {
 /// cache or by converting it in a subordinate \c CompilerInstance, caching
 /// the results.
 std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
-  AccessPathElem ModuleID, StringRef DirPath,
+  AccessPathElem ModuleID,
   const SerializedModuleBaseName &BaseName,
   SmallVectorImpl<char> *ModuleInterfacePath,
   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -999,8 +999,8 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   assert(LoadMode != ModuleLoadingMode::OnlySerialized);
 
   llvm::SmallString<256>
-  ModPath{ BaseName.getName(DirPath, file_types::TY_SwiftModuleFile) },
-  InPath{  BaseName.getName(DirPath, file_types::TY_SwiftModuleInterfaceFile) };
+  ModPath{ BaseName.getName(file_types::TY_SwiftModuleFile) },
+  InPath{  BaseName.getName(file_types::TY_SwiftModuleInterfaceFile) };
 
   // First check to see if the .swiftinterface exists at all. Bail if not.
   auto &fs = *Ctx.SourceMgr.getFileSystem();
@@ -1037,13 +1037,11 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   }
   // Open .swiftsourceinfo file if it's present.
   SerializedModuleLoaderBase::openModuleSourceInfoFileIfPresent(ModuleID,
-                                                                ModPath,
+                                                                BaseName,
                                                        ModuleSourceInfoBuffer);
   // Delegate back to the serialized module loader to load the module doc.
-  llvm::SmallString<256>
-  DocPath{BaseName.getName(DirPath, file_types::TY_SwiftModuleDocFile)};
   auto DocLoadErr =
-    SerializedModuleLoaderBase::openModuleDocFile(ModuleID, DocPath,
+    SerializedModuleLoaderBase::openModuleDocFile(ModuleID, BaseName,
                                                   ModuleDocBuffer);
   if (DocLoadErr)
     return DocLoadErr;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -269,7 +269,6 @@ void
 SerializedModuleLoaderBase::openModuleSourceInfoFileIfPresent(
     AccessPathElem ModuleID,
     StringRef ModulePath,
-    StringRef ModuleSourceInfoFilename,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
   if (!ModuleSourceInfoBuffer)
     return;
@@ -298,7 +297,6 @@ SerializedModuleLoaderBase::openModuleSourceInfoFileIfPresent(
 
 std::error_code SerializedModuleLoaderBase::openModuleFiles(
     AccessPathElem ModuleID, StringRef ModulePath, StringRef ModuleDocPath,
-    StringRef ModuleSourceInfoFileName,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
@@ -331,7 +329,6 @@ std::error_code SerializedModuleLoaderBase::openModuleFiles(
   if (!IgnoreSwiftSourceInfoFile) {
     // Open .swiftsourceinfo file if it's present.
     openModuleSourceInfoFileIfPresent(ModuleID, ModulePath,
-                                      ModuleSourceInfoFileName,
                                       ModuleSourceInfoBuffer);
   }
   auto ModuleDocErr =
@@ -346,7 +343,7 @@ std::error_code SerializedModuleLoaderBase::openModuleFiles(
 
 std::error_code SerializedModuleLoader::findModuleFilesInDirectory(
     AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
-    StringRef ModuleDocFilename, StringRef ModuleSourceInfoFileName,
+    StringRef ModuleDocFilename,
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
@@ -361,7 +358,6 @@ std::error_code SerializedModuleLoader::findModuleFilesInDirectory(
   return SerializedModuleLoaderBase::openModuleFiles(ModuleID,
                                                      ModulePath,
                                                      ModuleDocPath,
-                                                     ModuleSourceInfoFileName,
                                                      ModuleBuffer,
                                                      ModuleDocBuffer,
                                                      ModuleSourceInfoBuffer);
@@ -450,7 +446,6 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
     for (const auto &targetFileNames : targetFileNamePairs) {
       auto result = findModuleFilesInDirectory(moduleID, currPath,
                         targetFileNames.module, targetFileNames.moduleDoc,
-                        targetFileNames.moduleSourceInfo,
                         moduleInterfacePath,
                         moduleBuffer, moduleDocBuffer,
                         moduleSourceInfoBuffer);
@@ -505,7 +500,7 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
 
           auto result = findModuleFilesInDirectory(
               moduleID, path, fileNames.module.str(), fileNames.moduleDoc.str(),
-              fileNames.moduleSourceInfo.str(), moduleInterfacePath,
+              moduleInterfacePath,
               moduleBuffer, moduleDocBuffer, moduleSourceInfoBuffer);
           if (!result)
             return true;
@@ -957,7 +952,7 @@ void SerializedModuleLoaderBase::loadObjCMethods(
 
 std::error_code MemoryBufferSerializedModuleLoader::findModuleFilesInDirectory(
     AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
-    StringRef ModuleDocFilename, StringRef ModuleSourceInfoFilename,
+    StringRef ModuleDocFilename,
     SmallVectorImpl<char> *ModuleInterfacePath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,

--- a/test/Serialization/comments.swift
+++ b/test/Serialization/comments.swift
@@ -97,4 +97,4 @@ extension first_decl_class_1 : P1 {}
 // RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/Hidden/comments.swiftmodule -emit-module-interface-path %t/comments.swiftinterface -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -emit-module-source-info-path %t/comments.swiftsourceinfo %s -enable-library-evolution -swift-version 5
 // RUN: llvm-bcanalyzer %t/comments.swiftdoc | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: llvm-bcanalyzer %t/comments.swiftsourceinfo | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t -swift-version 5 | %FileCheck %s -check-prefix=FIRST
+// RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -enable-swiftsourceinfo -source-filename %s -I %t -swift-version 5 | %FileCheck %s -check-prefix=FIRST

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -114,7 +114,7 @@ protected:
 
     auto error =
       loader->findModuleFilesInDirectory({moduleName, SourceLoc()}, tempDir,
-        "Library.swiftmodule", "Library.swiftdoc", "Library.swiftsourceinfo",
+        SerializedModuleBaseName("Library"),
         /*ModuleInterfacePath*/nullptr,
         &moduleBuffer, &moduleDocBuffer, &moduleSourceInfoBuffer);
     ASSERT_FALSE(error);

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -113,8 +113,8 @@ protected:
     std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoBuffer;
 
     auto error =
-      loader->findModuleFilesInDirectory({moduleName, SourceLoc()}, tempDir,
-        SerializedModuleBaseName("Library"),
+      loader->findModuleFilesInDirectory({moduleName, SourceLoc()},
+        SerializedModuleBaseName(tempDir, SerializedModuleBaseName("Library")),
         /*ModuleInterfacePath*/nullptr,
         &moduleBuffer, &moduleDocBuffer, &moduleSourceInfoBuffer);
     ASSERT_FALSE(error);


### PR DESCRIPTION
This PR refactors `SerializedModuleLoaderBase` and its subclasses to clean up the tangle of functions and parameters that are used to load the constituents of a Swift module. Specifically, it:

* Introduces a new type, `SerializedModuleBaseName`, which represents a module name and is used to derive the individual filenames.
* Simplifies the `open*File` functions and gives them common patterns.
* Cleans up some weird quirks of the implementation.
* Moves a number of details down into leaf functions.

This PR is not quite NFC. It makes two changes:

1. While "no such file" errors when opening `.swiftsourceinfo` files will still be ignored, other I/O errors will not be.
2. The module interface loader will now respect the `IgnoreSwiftSourceInfoFile` flag; it previously ignored it.

@nkcsgexi I believe this second change is correct, but I had to change a test to make it happen, so I'm not sure. Should we always use a `.swiftsourceinfo` if it's present beside a `.swiftinterface` regardless of the `-ignore-module-source-info` flag, or was that a bug?