### PR TITLE
[android] Get build scripts working natively, fix tests and install

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -99,9 +99,11 @@ foreach(sdk ${SWIFT_SDKS})
 
     list(APPEND glibc_modulemap_target_list ${glibc_modulemap_target})
 
-    # If this SDK is a target for a non-native host, create a native modulemap
-    # without a sysroot prefix. This is the one we'll install instead.
-    if(NOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${arch}_PATH}" STREQUAL "/")
+    # If this SDK is a target for a non-native host, except if it's for Android
+    # with its own native sysroot, create a native modulemap without a sysroot
+    # prefix. This is the one we'll install instead.
+    if(NOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${arch}_PATH}" STREQUAL "/" AND
+       NOT (${sdk} STREQUAL ANDROID AND NOT "${SWIFT_ANDROID_NATIVE_SYSROOT}" STREQUAL ""))
       set(glibc_sysroot_relative_modulemap_out "${module_dir}/sysroot-relative-modulemaps/glibc.modulemap")
 
       string(REPLACE "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${arch}_PATH}"

--- a/test/ClangImporter/Dispatch_test.swift
+++ b/test/ClangImporter/Dispatch_test.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: libdispatch
 // UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-android
 
 import Dispatch
 

--- a/test/Sanitizers/asan_recover.swift
+++ b/test/Sanitizers/asan_recover.swift
@@ -30,7 +30,7 @@
 
 // FIXME: We need this so we can flush stdout but this won't
 // work on other Platforms (e.g. Windows).
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
 #else
     import Darwin.C

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 // REQUIRES: libdispatch
 // UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-android
 
 import Dispatch
 import StdlibUnittest

--- a/test/stdlib/DispatchTypes.swift
+++ b/test/stdlib/DispatchTypes.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: libdispatch
 // UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-android
 
 import Dispatch
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -321,7 +321,11 @@ def apply_default_arguments(toolchain, args):
     android_tgts = [tgt for tgt in args.stdlib_deployment_targets
                     if StdlibDeploymentTarget.Android.contains(tgt)]
     if not args.android and len(android_tgts) > 0:
-        args.android = True
+        # If building natively on an Android host, avoid the NDK
+        # cross-compilation configuration.
+        if not StdlibDeploymentTarget.Android.contains(StdlibDeploymentTarget
+                                                       .host_target().name):
+            args.android = True
         args.build_android = False
 
     # Include the Darwin supported architectures in the CMake options.
@@ -657,6 +661,10 @@ class BuildScriptInvocation(object):
                 "--android-icu-i18n-include", args.android_icu_i18n_include,
                 "--android-icu-data", args.android_icu_data,
             ]
+        # If building natively on an Android host, only pass the API level.
+        if StdlibDeploymentTarget.Android.contains(StdlibDeploymentTarget
+                                                   .host_target().name):
+            impl_args += ["--android-api-level", args.android_api_level]
         if args.android_deploy_device_path:
             impl_args += [
                 "--android-deploy-device-path",

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -460,6 +460,10 @@ function set_build_options_for_host() {
     SWIFT_HOST_VARIANT_ARCH=$architecture
 
     case ${host} in
+        android-aarch64)
+            SWIFT_HOST_TRIPLE="aarch64-unknown-linux-android"
+            llvm_target_arch="AArch64"
+            ;;
         linux-armv6)
             SWIFT_HOST_TRIPLE="armv6-unknown-linux-gnueabihf"
             llvm_target_arch="ARM"
@@ -1553,12 +1557,18 @@ for host in "${ALL_HOSTS[@]}"; do
 
             swift)
 
+                if [[ "${ANDROID_API_LEVEL}" ]]; then
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DSWIFT_ANDROID_API_LEVEL:STRING="${ANDROID_API_LEVEL}"
+                    )
+                fi
+
                 if [[ ! "${SKIP_BUILD_ANDROID}" ]]; then
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DSWIFT_ANDROID_NDK_PATH:STRING="${ANDROID_NDK}"
                         -DSWIFT_ANDROID_NDK_GCC_VERSION:STRING="${ANDROID_NDK_GCC_VERSION}"
-                        -DSWIFT_ANDROID_API_LEVEL:STRING="${ANDROID_API_LEVEL}"
                         -DSWIFT_ANDROID_${ANDROID_ARCH}_ICU_UC:STRING="${ANDROID_ICU_UC}"
                         -DSWIFT_ANDROID_${ANDROID_ARCH}_ICU_UC_INCLUDE:STRING="${ANDROID_ICU_UC_INCLUDE}"
                         -DSWIFT_ANDROID_${ANDROID_ARCH}_ICU_I18N:STRING="${ANDROID_ICU_I18N}"
@@ -2192,6 +2202,8 @@ for host in "${ALL_HOSTS[@]}"; do
               HOST_CXX_HEADERS_DIR="$HOST_CXX_DIR/../../usr/include/c++"
             elif [[ "$(uname -s)" == "Haiku" ]] ; then
               HOST_CXX_HEADERS_DIR="/boot/system/develop/headers/c++"
+            elif [[ "${ANDROID_DATA}" ]] ; then
+              HOST_CXX_HEADERS_DIR="$PREFIX/include/c++"
             else # Linux
               HOST_CXX_HEADERS_DIR="/usr/include/c++"
             fi

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -223,7 +223,11 @@ def _apply_default_arguments(args):
         args.test_watchos_simulator = False
 
     if not args.build_android:
-        args.test_android = False
+        # If building natively on an Android host, allow running the test suite
+        # without the NDK config.
+        if not StdlibDeploymentTarget.Android.contains(StdlibDeploymentTarget
+                                                       .host_target().name):
+            args.test_android = False
         args.test_android_host = False
 
     if not args.test_android:


### PR DESCRIPTION
The build scripts assume Android cross-compilation using the NDK, so avoid that configuration if building on an Android host. Fix or disable several tests, and don't install a glibc.modulemap without a sysroot prefix.

Along with this remaining patch to supply an rpath and replace a couple Bionic headers that [the Termux app](https://termux.com/) removes, the Swift validation and test suite is down to only 11 failing tests:
```
diff --git a/lib/Driver/UnixToolChains.cpp b/lib/Driver/UnixToolChains.cpp
index 07a19d9e54..7f79062bd1 100644
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -381,7 +381,13 @@ std::string toolchains::Android::getTargetForLinker() const {
   }
 }
 
-bool toolchains::Android::shouldProvideRPathToLinker() const { return false; }
+bool toolchains::Android::shouldProvideRPathToLinker() const {
+#if defined(__ANDROID__)
+  return true;
+#else
+  return false;
+#endif
+}
 
 std::string toolchains::Cygwin::getDefaultLinker() const {
   // Cygwin uses the default BFD linker, even on ARM.
diff --git a/stdlib/public/Platform/bionic.modulemap.gyb b/stdlib/public/Platform/bionic.modulemap.gyb
index e44f908265..da77854eb7 100644
--- a/stdlib/public/Platform/bionic.modulemap.gyb
+++ b/stdlib/public/Platform/bionic.modulemap.gyb
@@ -291,11 +291,11 @@ module SwiftGlibc [system] {
         export *
       }
       module sem {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/sem.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/linux/sem.h"
         export *
       }
       module shm {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/shm.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/linux/shm.h"
         export *
       }
       module inotify {
diff --git a/test/Driver/linker.swift b/test/Driver/linker.swift
index 7b5f0c3425..fd94906760 100644
--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -29,7 +29,6 @@
 
 // RUN: %swiftc_driver -driver-print-jobs -target armv7-none-linux-androideabi -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.android.txt
 // RUN: %FileCheck -check-prefix ANDROID-armv7 %s < %t.android.txt
-// RUN: %FileCheck -check-prefix ANDROID-armv7-NEGATIVE %s < %t.android.txt
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-cygnus -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.cygwin.txt
 // RUN: %FileCheck -check-prefix CYGWIN-x86_64 %s < %t.cygwin.txt
@@ -228,13 +227,13 @@
 // ANDROID-armv7-DAG: -lswiftCore
 // ANDROID-armv7-DAG: -L [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift]]
 // ANDROID-armv7-DAG: -target armv7-unknown-linux-androideabi
+// ANDROID-armv7-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
 // ANDROID-armv7-DAG: -F foo -iframework car -F cdr
 // ANDROID-armv7-DAG: -framework bar
 // ANDROID-armv7-DAG: -L baz
 // ANDROID-armv7-DAG: -lboo
 // ANDROID-armv7-DAG: -Xlinker -undefined
 // ANDROID-armv7: -o linker
-// ANDROID-armv7-NEGATIVE-NOT: -Xlinker -rpath
 
 // CYGWIN-x86_64: swift
 // CYGWIN-x86_64: -o [[OBJECTFILE:.*]]
```
The remaining failures are all related to `RUNPATH` issues discussed in #23208 and the Termux clang not coming with asan/tsan sanitizer support. I can add a couple tests for the new build-script build path if wanted.