### PR TITLE
tests: only run a Casts.swift test with a newer runtime

### DIFF
--- a/test/stdlib/Casts.swift
+++ b/test/stdlib/Casts.swift
@@ -84,21 +84,23 @@ CastsTests.test("Optional<T>.none can be casted to Optional<U>.none in generic c
 #if _runtime(_ObjC)
 protocol P2 {}
 CastsTests.test("Cast from ObjC existential to Protocol (SR-3871)") {
-  struct S: P2 {}
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    struct S: P2 {}
 
-  class ObjCWrapper {
-    @objc dynamic let any: Any = S()
-    init() {}
+    class ObjCWrapper {
+      @objc dynamic let any: Any = S()
+      init() {}
+    }
+    let a = ObjCWrapper().any
+    expectTrue(a is P2)
+    // In SR-3871, the following cast failed (everything else here succeeded)
+    expectNotNil(a as? P2)
+    expectNotNil(a as? S)
+    let b = a as AnyObject
+    expectTrue(a is P2)
+    expectNotNil(b as? P2)
+    expectNotNil(b as? S)
   }
-  let a = ObjCWrapper().any
-  expectTrue(a is P2)
-  // In SR-3871, the following cast failed (everything else here succeeded)
-  expectNotNil(a as? P2)
-  expectNotNil(a as? S)
-  let b = a as AnyObject
-  expectTrue(a is P2)
-  expectNotNil(b as? P2)
-  expectNotNil(b as? S)
 }
 #endif
 


### PR DESCRIPTION
... because this test is for a fix in the runtime which will fail if run with an old runtime.
