### PR TITLE
[Runtime] Scrap metadata allocation pool

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5114,95 +5114,18 @@ void swift::checkMetadataDependencyCycle(const Metadata *startMetadata,
 /*** Allocator implementation **********************************************/
 /***************************************************************************/
 
-namespace {
-  struct PoolRange {
-    static constexpr uintptr_t PageSize = 16 * 1024;
-    static constexpr uintptr_t MaxPoolAllocationSize = PageSize / 2;
-
-    /// The start of the allocation.
-    char *Begin;
-
-    /// The number of bytes remaining.
-    size_t Remaining;
-  };
-} // end anonymous namespace
-
-// A statically-allocated pool.  It's zero-initialized, so this
-// doesn't cost us anything in binary size.
-alignas(void *) static char InitialAllocationPool[64 * 1024];
-static std::atomic<PoolRange>
-AllocationPool{PoolRange{InitialAllocationPool,
-                         sizeof(InitialAllocationPool)}};
-
 void *MetadataAllocator::Allocate(size_t size, size_t alignment) {
   assert(alignment <= alignof(void*));
   assert(size % alignof(void*) == 0);
 
-  // If the size is larger than the maximum, just use malloc.
-  if (size > PoolRange::MaxPoolAllocationSize)
-    return malloc(size);
-
-  // Allocate out of the pool.
-  PoolRange curState = AllocationPool.load(std::memory_order_relaxed);
-  while (true) {
-    char *allocation;
-    PoolRange newState;
-    bool allocatedNewPage;
-
-    // Try to allocate out of the current page.
-    if (size <= curState.Remaining) {
-      allocatedNewPage = false;
-      allocation = curState.Begin;
-      newState = PoolRange{curState.Begin + size, curState.Remaining - size};
-    } else {
-      allocatedNewPage = true;
-      allocation = new char[PoolRange::PageSize];
-      newState = PoolRange{allocation + size, PoolRange::PageSize - size};
-      __asan_poison_memory_region(allocation, PoolRange::PageSize);
-    }
-
-    // Swap in the new state.
-    if (std::atomic_compare_exchange_weak_explicit(&AllocationPool,
-                                                   &curState, newState,
-                                              std::memory_order_relaxed,
-                                              std::memory_order_relaxed)) {
-      // If that succeeded, we've successfully allocated.
-      __msan_allocated_memory(allocation, size);
-      __asan_unpoison_memory_region(allocation, size);
-      return allocation;
-    }
-
-    // If it failed, go back to a neutral state and try again.
-    if (allocatedNewPage) {
-      delete[] allocation;
-    }
-  }
+  return malloc(size);
 }
 
 void MetadataAllocator::Deallocate(const void *allocation, size_t size) {
   __asan_poison_memory_region(allocation, size);
 
-  if (size > PoolRange::MaxPoolAllocationSize) {
-    free(const_cast<void*>(allocation));
-    return;
-  }
-
-  // Check whether the allocation pool is still in the state it was in
-  // immediately after the given allocation.
-  PoolRange curState = AllocationPool.load(std::memory_order_relaxed);
-  if (reinterpret_cast<const char*>(allocation) + size != curState.Begin) {
-    return;
-  }
-
-  // Try to swap back to the pre-allocation state.  If this fails,
-  // don't bother trying again; we'll just leak the allocation.
-  PoolRange newState = { reinterpret_cast<char*>(const_cast<void*>(allocation)),
-                         curState.Remaining + size };
-  (void)
-    std::atomic_compare_exchange_strong_explicit(&AllocationPool,
-                                                 &curState, newState,
-                                                 std::memory_order_relaxed,
-                                                 std::memory_order_relaxed);
+  free(const_cast<void*>(allocation));
+  return;
 }
 
 void *swift::allocateMetadata(size_t size, size_t alignment) {


### PR DESCRIPTION
It's unclear if this is actually helpful. It might lead to slightly faster launch times (needs some testing) but it makes it harder to see the actual metadata usage for small programs using `heap`, and for really small programs it rounds metadata dirty memory up to page size unnecessarily.