### PR TITLE
build: remove SWIFT_PATH_TO_CMARK_{SOURCE,BUILD}

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -171,30 +171,6 @@ macro(swift_common_standalone_build_config_clang product)
 endmacro()
 
 macro(swift_common_standalone_build_config_cmark product)
-  set(${product}_PATH_TO_CMARK_SOURCE "${${product}_PATH_TO_CMARK_SOURCE}"
-    CACHE PATH "Path to CMark source code.")
-  set(${product}_PATH_TO_CMARK_BUILD "${${product}_PATH_TO_CMARK_BUILD}"
-    CACHE PATH "Path to the directory where CMark was built.")
-  set(${product}_CMARK_LIBRARY_DIR "${${product}_CMARK_LIBRARY_DIR}" CACHE PATH
-    "Path to the directory where CMark was installed.")
-  get_filename_component(PATH_TO_CMARK_BUILD "${${product}_PATH_TO_CMARK_BUILD}"
-    ABSOLUTE)
-  get_filename_component(CMARK_MAIN_SRC_DIR "${${product}_PATH_TO_CMARK_SOURCE}"
-    ABSOLUTE)
-  get_filename_component(CMARK_LIBRARY_DIR "${${product}_CMARK_LIBRARY_DIR}"
-    ABSOLUTE)
-
-  set(CMARK_MAIN_INCLUDE_DIR "${CMARK_MAIN_SRC_DIR}/src")
-  set(CMARK_BUILD_INCLUDE_DIR "${PATH_TO_CMARK_BUILD}/src")
-
-  file(TO_CMAKE_PATH "${CMARK_MAIN_INCLUDE_DIR}" CMARK_MAIN_INCLUDE_DIR)
-  file(TO_CMAKE_PATH "${CMARK_BUILD_INCLUDE_DIR}" CMARK_BUILD_INCLUDE_DIR)
-
-  include_directories("${CMARK_MAIN_INCLUDE_DIR}"
-                      "${CMARK_BUILD_INCLUDE_DIR}")
-
-  include(${PATH_TO_CMARK_BUILD}/src/cmarkTargets.cmake)
-  add_definitions(-DCMARK_STATIC_DEFINE)
 endmacro()
 
 # Common cmake project config for standalone builds.
@@ -207,7 +183,7 @@ macro(swift_common_standalone_build_config product)
   swift_common_standalone_build_config_llvm(${product})
   if(SWIFT_INCLUDE_TOOLS)
     swift_common_standalone_build_config_clang(${product})
-    swift_common_standalone_build_config_cmark(${product})
+    find_package(cmark CONFIG REQUIRED NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   endif()
 
   # Enable groups for IDE generators (Xcode and MSVC).

--- a/lib/Markup/CMakeLists.txt
+++ b/lib/Markup/CMakeLists.txt
@@ -4,7 +4,6 @@ add_swift_host_library(swiftMarkup STATIC
   Markup.cpp)
 target_link_libraries(swiftMarkup PRIVATE
   libcmark_static)
-target_compile_definitions(swiftMarkup
-                           PRIVATE
-                             CMARK_STATIC_DEFINE)
+target_compile_definitions(swiftMarkup PRIVATE
+  CMARK_STATIC_DEFINE)
 

--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -63,4 +63,6 @@ target_link_libraries(SourceKitSwiftLang PRIVATE
   clangAST
   clangAPINotes
   clangBasic)
+target_compile_definitions(SourceKitSwiftLang PRIVATE
+  CMARK_STATIC_DEFINE)
 add_dependencies(SourceKitSwiftLang clang-tablegen-targets)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1773,8 +1773,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
                     -DClang_DIR:PATH=${llvm_build_dir}/lib/cmake/clang
                     -DLLVM_DIR:PATH=${llvm_build_dir}/lib/cmake/llvm
-                    -DSWIFT_PATH_TO_CMARK_SOURCE:PATH="${CMARK_SOURCE_DIR}"
-                    -DSWIFT_PATH_TO_CMARK_BUILD:PATH="$(build_directory ${host} cmark)"
+                    -Dcmark_DIR:PATH=$(build_directory ${host} cmark)/src
                     -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE:PATH="${LIBDISPATCH_SOURCE_DIR}"
                     -DSWIFT_PATH_TO_LIBDISPATCH_BUILD:PATH="$(build_directory ${host} libdispatch)"
                 )
@@ -1789,18 +1788,6 @@ for host in "${ALL_HOSTS[@]}"; do
                         -DSWIFT_${SWIFT_HOST_VARIANT_SDK}_${SWIFT_HOST_VARIANT_ARCH}_ICU_UC_INCLUDE:STRING="${ICU_TMPINSTALL}/include"
                         -DSWIFT_${SWIFT_HOST_VARIANT_SDK}_${SWIFT_HOST_VARIANT_ARCH}_ICU_I18N_INCLUDE:STRING="${ICU_TMPINSTALL}/include"
                         -DSWIFT_${SWIFT_HOST_VARIANT_SDK}_${SWIFT_HOST_VARIANT_ARCH}_ICU_STATICLIB:BOOL=TRUE
-                    )
-                fi
-
-                if [[ "${CMAKE_GENERATOR}" == "Xcode" ]] ; then
-                    cmake_options=(
-                        "${cmake_options[@]}"
-                        -DSWIFT_CMARK_LIBRARY_DIR:PATH=$(build_directory ${host} cmark)/src/${CMARK_BUILD_TYPE}
-                    )
-                else
-                    cmake_options=(
-                        "${cmake_options[@]}"
-                        -DSWIFT_CMARK_LIBRARY_DIR:PATH=$(build_directory ${host} cmark)/src
                     )
                 fi
 


### PR DESCRIPTION
This replaces the custom handling for CMark with the standard CMake
handling for dependencies.  CMark now provides a `cmarkConfig` upstream
and even has proper export targets for dependency tracking.  This moves
the standalone builds to use this.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
