### PR TITLE
[stdlib] Make KeyValuePairs conditionally conform to Equatable and Hashable

### DIFF
--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -125,6 +125,56 @@ extension KeyValuePairs: RandomAccessCollection {
   }
 }
 
+extension KeyValuePairs: Equatable where Key: Equatable, Value: Equatable {
+    /// Returns a Boolean value indicating whether two `KeyValuePairs` instances
+    /// contain the same elements in the same order.
+    ///
+    /// You can use the equal-to operator (`==`) to compare any two `KeyValuePairs` instances
+    /// that store the same, `Equatable`-conforming `Key` and `Value` types.
+    ///
+    /// - Parameters:
+    ///   - lhs: An `KeyValuePairs` instance to compare.
+    ///   - rhs: Another `KeyValuePairs` instance to compare.
+    @inlinable
+    public static func ==(lhs: KeyValuePairs<Key, Value>, rhs: KeyValuePairs<Key, Value>) -> Bool {
+        let lhsCount = lhs.count
+        if lhsCount != rhs.count {
+          return false
+        }
+        
+        _internalInvariant(lhs.startIndex == 0 && rhs.startIndex == 0)
+        _internalInvariant(lhs.endIndex == lhsCount && rhs.endIndex == lhsCount)
+        
+        // We know that lhs.count == rhs.count, compare element wise.
+        for idx in 0..<lhsCount {
+            let (lhsPairKey, lhsPairValue) = lhs[idx]
+            let (rhsPairKey, rhsPairValue) = rhs[idx]
+            
+            if lhsPairKey != rhsPairKey || lhsPairValue != rhsPairValue {
+                return false
+            }
+        }
+        
+        return true
+    }
+}
+
+extension KeyValuePairs: Hashable where Key: Hashable, Value: Hashable {
+    /// Hashes the essential components of this value by feeding them into the
+    /// given hasher.
+    ///
+    /// - Parameter hasher: The hasher to use when combining the components
+    ///   of this instance.
+    @inlinable
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(count) // discriminator
+        for (key, value) in self {
+            hasher.combine(key)
+            hasher.combine(value)
+        }
+    }
+}
+
 extension KeyValuePairs: CustomStringConvertible {
   /// A string that represents the contents of the dictionary.
   public var description: String {

--- a/test/stdlib/KeyValuePairs.swift
+++ b/test/stdlib/KeyValuePairs.swift
@@ -37,17 +37,39 @@ func checkAssociatedTypes() {
     indicesType: CountableRange<Int>.self)
 }
 
-var strings: KeyValuePairs = ["a": "1", "b": "Foo"]
-expectType(KeyValuePairs<String, String>.self, &strings)
+var tests = TestSuite("KeyValuePairs")
 
-var stringNSStringLiteral: KeyValuePairs = [
-  "a": "1", "b": "Foo" as NSString]
-expectType(KeyValuePairs<String, NSString>.self, &stringNSStringLiteral)
+tests.test("TypeInference") {
+  var strings: KeyValuePairs = ["a": "1", "b": "Foo"]
+  expectType(KeyValuePairs<String, String>.self, &strings)
 
-let aString = "1"
-let anNSString = "Foo" as NSString
-var stringNSStringLet: KeyValuePairs = [ "a": aString as NSString, "b": anNSString]
-expectType(KeyValuePairs<String, NSString>.self, &stringNSStringLet)
+  var stringNSStringLiteral: KeyValuePairs = [
+    "a": "1", "b": "Foo" as NSString]
+  expectType(KeyValuePairs<String, NSString>.self, &stringNSStringLiteral)
 
-var hetero: KeyValuePairs = ["a": 1 as NSNumber, "b": "Foo" as NSString]
-expectType(KeyValuePairs<String, NSObject>.self, &hetero)
+  let aString = "1"
+  let anNSString = "Foo" as NSString
+  var stringNSStringLet: KeyValuePairs = [ "a": aString as NSString, "b": anNSString]
+  expectType(KeyValuePairs<String, NSString>.self, &stringNSStringLet)
+
+  var hetero: KeyValuePairs = ["a": 1 as NSNumber, "b": "Foo" as NSString]
+  expectType(KeyValuePairs<String, NSObject>.self, &hetero)
+}
+
+tests.test("EquatableConformance") {
+  let exampleOne: KeyValuePairs<String, String> = ["a": "1", "b": "2"]
+  let exampleTwo: KeyValuePairs<String, String> = ["a": "1", "b": "2"]
+  let exampleThree: KeyValuePairs<String, String> = ["b": "2", "c": "3"]
+  expectEqual(true, exampleOne == exampleTwo)
+  expectEqual(false, exampleOne == exampleThree)
+}
+
+tests.test("HashableConformance") {
+  let keyValuePairs: KeyValuePairs<String, String> = ["d": "4", "e": "5"]
+  var hasher = Hasher()
+  hasher.combine(keyValuePairs)
+  var result = hasher.finalize()
+  expectType(Int.self, &result)
+}
+
+runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR makes the standard library type `KeyValuePairs` conditionally conform to `Equatable` and `Hashable`:

```swift
extension KeyValuePairs: Equatable where Key: Equatable, Value: Equatable { /* ... */ }
extension KeyValuePairs: Hashable where Key: Hashable, Value: Hashable { /* ... */ }
```

Does this seem like it could be added without a formal Swift Evolution review cycle? It affects the public API of a type, but it also seems like the obviously correct behavior.

[This SE thread](https://forums.swift.org/t/keyvaluepairs-conditional-conformance-to-equatable-hashable/32730) noted that this change would require support for [Backwards-deployable Conformances](https://forums.swift.org/t/backwards-deployable-conformances/29876). Do we have any mechanisms for that at this time? Any guidance would be appreciated!