### PR TITLE
[Docs] [AutoDiff] Allow implicitly inherited '@differentiable' on non-public protocol req impls.

### DIFF
--- a/docs/DifferentiableProgramming.md
+++ b/docs/DifferentiableProgramming.md
@@ -1376,11 +1376,12 @@ inheritance must maintain the differentiability.
 
 The `@differentiable` attribute can be used on protocol requirements. A
 `@differentiable` protocol requirement requires that all conforming types
-implement this protocol requirement with a differentiable body with respect to
-the specified parameters.
+implement this requirement with a differentiable body with respect to the
+specified parameters. Conforming implementations are not required to be marked
+with `@differentiable` attribute unless they are `public`.
 
 ```swift
-protocol Layer: Differentiable {
+public protocol Layer: Differentiable {
     associatedtype Input: Differentiable
     associatedtype Output: Differentiable
     @differentiable // w.r.t. `input` and `self`
@@ -1389,7 +1390,7 @@ protocol Layer: Differentiable {
 struct Perceptron: @memberwise Differentiable, Layer {
     var weight: SIMD4<Float>
     var bias: Float
-    @differentiable // w.r.t. `input` and `self`
+
     func callAsFunction(_ input: SIMD4<Float>) -> Float {
         (weight * input).sum() + b
     }
@@ -1401,14 +1402,14 @@ with a `@differentiable` attribute that declares differentiability with respect
 to more parameters.
 
 ```swift
-protocol Module: Differentiable {
+public protocol Module: Differentiable {
     associatedtype Input
     associatedtype Output: Differentiable
     @differentiable(wrt: self)
     func callAsFunction(_: Input) -> Output
 }
 
-protocol Layer: Module where Input: Differentiable {
+public protocol Layer: Module where Input: Differentiable {
     @differentiable(wrt: (self, input))
     func callAsFunction(_: Input) -> Output
 }


### PR DESCRIPTION
Currently, when a conforming type implements a `@differentiable` protocol requirement, the corresponding conforming implementation is required to have at least a `@differentiable` that covers all differentiability parameters in the protocol requirement.  However, this is not a great design for usability because developers almost always start with missing `@differentiable` and getting a compilation error.  This also makes ML models built with libraries that use differentiable programming more verbose than those built with other ML frameworks.

We agreed during this Friday's design review to allow `@differentiable` to be implicitly inherited from protocols when the conforming implementation is non-public.