### PR TITLE
test: adjust the test use to `ls` instead of `find`

### DIFF
--- a/test/Index/index_swift_only_systemmodule.swift
+++ b/test/Index/index_swift_only_systemmodule.swift
@@ -89,7 +89,7 @@ print(someFunc())
 // RUN:     %s
 //
 // --- Ensure module cache is populated.
-// RUN: find %t/modulecache -maxdepth 1 -name 'SomeModule-*.swiftmodule' | grep .
+// RUN: ls %t/modulecache/SomeModule-*.swiftmodule
 //
 // --- Built with indexing
 // RUN: %target-swift-frontend \


### PR DESCRIPTION
Rely on the `ls` behaviour of returning a non-zero if there is no
matching pattern.  This should help make the test pass on Windows
and the other targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
