### PR TITLE
[Diagnostics] Improve member wise and default init access control diags

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -146,6 +146,18 @@ ERROR(init_candidate_inaccessible,none,
       "'%select{private|fileprivate|internal|@_spi|@_spi}1' protection level",
       (Type, AccessLevel))
 
+ERROR(memberwise_init_candidate_inaccessible,none,
+      "%select{default|memberwise|%error}0 initializer of %1 is inaccessible "
+      "due to '%select{private|fileprivate|internal|%error|%error}2' protection"
+      " level%select{|; public %select{default|memberwise|%error}0 initializers"
+      " must be declared explicitly}3",
+      (/*ImplicitConstructorKind*/ unsigned, Type, AccessLevel, bool))
+
+NOTE(memberwise_init_access_level_determined_by_var,none,
+     "'%select{private|fileprivate|internal|%error|%error}0' property %1 "
+     "prevents synthesizing a more accessible memberwise initializer",
+     (AccessLevel, DeclName))
+
 ERROR(cannot_pass_rvalue_mutating_subelement,none,
       "cannot use mutating member on immutable value: %0",
       (StringRef))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7365,6 +7365,7 @@ ConstructorDecl::ConstructorDecl(DeclName Name, SourceLoc ConstructorLoc,
   Bits.ConstructorDecl.ComputedBodyInitKind = 0;
   Bits.ConstructorDecl.HasStubImplementation = 0;
   Bits.ConstructorDecl.Failable = Failable;
+  Bits.ConstructorDecl.ImplicitConstructorKind = 0;
 
   assert(Name.getBaseName() == DeclBaseName::createConstructor());
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -541,7 +541,7 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
                             /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
                             paramPL,
                             /*GenericParams=*/nullptr, enumDecl);
-  ctorDecl->setImplicit();
+  ctorDecl->setImplicit(ImplicitConstructorKind::Imported);
   ctorDecl->setAccess(AccessLevel::Public);
   ctorDecl->setBodySynthesizer(synthesizeEnumRawValueConstructorBody, enumDecl);
   return ctorDecl;
@@ -6483,7 +6483,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
                                    importedType.isImplicitlyUnwrapped());
 
   if (implicit)
-    result->setImplicit();
+    result->setImplicit(ImplicitConstructorKind::Imported);
 
   // Set the kind of initializer.
   result->getASTContext().evaluator.cacheOutput(InitKindRequest{result},

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1387,6 +1387,11 @@ public:
       : FailureDiagnostic(solution, locator), Member(member) {}
 
   bool diagnoseAsError() override;
+
+private:
+  void diagnoseInaccessibleInitializer(ConstructorDecl *CD, SourceLoc Loc,
+                                       DeclNameLoc NameLoc,
+                                       AccessLevel AccessLevel);
 };
 
 /// Diagnose an attempt to reference member marked as `mutating`

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1045,7 +1045,8 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
                               /*Failable=*/false,SourceLoc(),
                               /*Throws=*/true, SourceLoc(), paramList,
                               /*GenericParams=*/nullptr, conformanceDC);
-  initDecl->setImplicit();
+  initDecl->setImplicit(
+      ImplicitConstructorKind::SynthesizedProtocolRequirement);
   initDecl->setSynthesized();
   initDecl->setBodySynthesizer(&deriveBodyDecodable_init);
 

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -134,7 +134,8 @@ static ValueDecl *deriveInitDecl(DerivedConformance &derived, Type paramType,
                             paramList,
                             /*GenericParams=*/nullptr, parentDC);
 
-  initDecl->setImplicit();
+  initDecl->setImplicit(
+      ImplicitConstructorKind::SynthesizedProtocolRequirement);
 
   // Synthesize the body.
   synthesizer(initDecl);

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -425,8 +425,9 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
                             /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
                             paramList,
                             /*GenericParams=*/nullptr, parentDC);
-  
-  initDecl->setImplicit();
+
+  initDecl->setImplicit(
+      ImplicitConstructorKind::SynthesizedProtocolRequirement);
   initDecl->setBodySynthesizer(&deriveBodyRawRepresentable_init);
 
   initDecl->copyFormalAccessFrom(enumDecl, /*sourceIsParentContext*/true);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 558; // SIL function type result differentiability
+const uint16_t SWIFTMODULE_VERSION_MINOR = 559; // ImplicitConstructorKind
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -494,6 +494,17 @@ enum class DefaultArgumentKind : uint8_t {
   StoredProperty,
 };
 using DefaultArgumentField = BCFixed<4>;
+
+// These IDs must \em not be renumbered or reordered without incrementing
+// the module version.
+enum class ImplicitConstructorKind : uint8_t {
+  Default = 0,
+  Memberwise,
+  Imported,
+  SynthesizedProtocolRequirement,
+  Designated,
+};
+using ImplicitConstructorField = BCFixed<3>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
@@ -1222,7 +1233,9 @@ namespace decls_block {
     AccessLevelField, // access level
     BCFixed<1>,   // requires a new vtable slot
     BCFixed<1>,   // 'required' but overridden is not (used for recovery)
+    ImplicitConstructorField,  // Implicit constructor kind.
     BCVBR<5>,     // number of parameter name components
+
     BCArray<IdentifierIDField> // name components,
                                // followed by TypeID dependencies
     // This record is trailed by:

--- a/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/main.swift
+++ b/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/main.swift
@@ -11,7 +11,7 @@ import b
 
 func foo(_ s: Struct) {
   // Without this error, SR-12526 does not trigger.
-  // expected-error @+1 {{'Struct' initializer is inaccessible due to 'internal' protection level}}
+  // expected-error @+1 {{default initializer of 'Struct' is inaccessible due to 'internal' protection level; public default initializers must be declared explicitly}}
   _ = Struct()
   _ = s.method(1)
 }

--- a/test/NameLookup/Inputs/has_accessibility.swift
+++ b/test/NameLookup/Inputs/has_accessibility.swift
@@ -49,3 +49,11 @@ extension InternalProtocol {
 }
 
 extension ImplementsInternalProtocol : InternalProtocol {}
+
+public struct OtherModuleMemberwiseInit {
+  public let x: Int
+}
+
+public struct OtherModuleDefaultInit {
+  let x = 0
+}

--- a/test/NameLookup/accessibility.swift
+++ b/test/NameLookup/accessibility.swift
@@ -63,6 +63,19 @@ _ = { rdar27982012($0.0) }((1, 2)) // expected-error {{initializer is inaccessib
 _ = PrivateInit() // expected-error {{'PrivateInit' initializer is inaccessible due to 'private' protection level}}
 // TESTABLE: :[[@LINE-1]]:{{[^:]+}}: error: 'PrivateInit' initializer is inaccessible due to 'private' protection level
 
+_ = OtherModuleMemberwiseInit(x: 42) // expected-error {{memberwise initializer of 'OtherModuleMemberwiseInit' is inaccessible due to 'internal' protection level; public memberwise initializers must be declared explicitly}}
+
+public struct PrivateMemberwiseInit {
+  private let x: Int // expected-note {{'private' property 'x' prevents synthesizing a more accessible memberwise initializer}}
+  private let z: String // expected-note {{'private' property 'z' prevents synthesizing a more accessible memberwise initializer}}
+  let y: Bool // no note
+  fileprivate let yy: Bool // no note
+}
+
+_ = PrivateMemberwiseInit(x: 42, z: "", y: true, yy: false) // expected-error {{memberwise initializer of 'PrivateMemberwiseInit' is inaccessible due to 'private' protection level}}
+
+_ = OtherModuleDefaultInit() // expected-error {{default initializer of 'OtherModuleDefaultInit' is inaccessible due to 'internal' protection level; public default initializers must be declared explicitly}}
+
 var s = StructWithPrivateSetter()
 // expected-note@-1 3{{did you mean 's'?}}
 s.x = 42 // expected-error {{cannot assign to property: 'x' setter is inaccessible}}


### PR DESCRIPTION
These used to give the standard `x is inaccessible` message which in my experience frequently confuses even experienced Swift developers when they move a struct to another module or add a property with the wrong access level.

The new messages look like:
```swift
_ = OtherModuleMemberwiseInit(x: 42) // error: memberwise initializer of 'OtherModuleMemberwiseInit' is inaccessible due to 'internal' protection level; public memberwise initializers must be declared explicitly

public struct PrivateMemberwiseInit {
  private let x: Int // note: 'private' property 'x' prevents synthesizing a more accessible memberwise initializer
  let y: Bool
}
_ = PrivateMemberwiseInit(x: 42, y: true) // error: memberwise initializer of 'PrivateMemberwiseInit' is inaccessible due to 'private' protection level

_ = OtherModuleDefaultInit() // error: default initializer of 'OtherModuleDefaultInit' is inaccessible due to 'internal' protection level; public default initializers must be declared explicitly
```

The cross-module case is important here, so I did need to change the module serialization format to include the implicit initializer kind. I think it's worth the overhead in this case to produce a much better message.

Mostly resolves SR-11797