### PR TITLE
EscapeAnalysis verification: fix false positives.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -721,15 +721,12 @@ public:
       }
     }
 
-    // Helper for getNode and getValueContent.
-    CGNode *getOrCreateNode(ValueBase *V, PointerKind pointerKind);
-
     /// Gets or creates a node for a value \p V.
     /// If V is a projection(-path) then the base of the projection(-path) is
     /// taken. This means the node is always created for the "outermost" value
     /// where V is contained.
-    /// Returns null, if V is not a "pointer".
-    CGNode *getNode(ValueBase *V, bool createIfNeeded = true);
+    /// Returns null, if V (or its base value) is not a "pointer".
+    CGNode *getNode(SILValue V);
 
     // Helper for getValueContent to create and return a content node with the
     // given \p isInterior and \p hasReferenceOnly flags. \p addrNode
@@ -780,15 +777,6 @@ public:
       return ReturnNode;
     }
 
-    /// Returns the node of the "exact" value \p V (no projections are skipped)
-    /// if one exists.
-    CGNode *lookupNode(ValueBase *V) {
-      CGNode *Node = Values2Nodes.lookup(V);
-      if (Node)
-        return Node->getMergeTarget();
-      return nullptr;
-    }
-    
     /// Re-uses a node for another SIL value.
     void setNode(ValueBase *V, CGNode *Node) {
       assert(Values2Nodes.find(V) == Values2Nodes.end());
@@ -871,13 +859,6 @@ public:
     bool forwardTraverseDefer(CGNode *startNode, CGNodeVisitor &&visitor);
 
   public:
-    /// Gets or creates a node for a value \p V.
-    /// If V is a projection(-path) then the base of the projection(-path) is
-    /// taken. This means the node is always created for the "outermost" value
-    /// where V is contained.
-    /// Returns null, if V is not a "pointer".
-    CGNode *getNodeOrNull(ValueBase *V) { return getNode(V, false); }
-
     /// Get the content node pointed to by \p ptrVal.
     ///
     /// If \p ptrVal cannot be mapped to a node, return nullptr.

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -688,7 +688,6 @@ public:
       CGNode *FromMergeTarget = From->getMergeTarget();
       CGNode *ToMergeTarget = To->getMergeTarget();
       if (FromMergeTarget != ToMergeTarget) {
-        ToMergeTarget->mergeProperties(FromMergeTarget);
         FromMergeTarget->mergeTo = ToMergeTarget;
         ToMerge.push_back(FromMergeTarget);
       }

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -13,6 +13,7 @@
 #define DEBUG_TYPE "sil-escape"
 #include "swift/SILOptimizer/Analysis/EscapeAnalysis.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
@@ -2345,6 +2346,8 @@ void EscapeAnalysis::recompute(FunctionInfo *Initial) {
         LLVM_DEBUG(llvm::dbgs() << "  create summary graph for "
                                 << FInfo->Graph.F->getName() << '\n');
 
+        PrettyStackTraceSILFunction
+          callerTraceRAII("merging escape summary", FInfo->Graph.F);
         FInfo->Graph.propagateEscapeStates();
 
         // Derive the summary graph of the current function. Even if the
@@ -2365,7 +2368,11 @@ void EscapeAnalysis::recompute(FunctionInfo *Initial) {
 
             // Only include callers which we are actually recomputing.
             if (BottomUpOrder.wasRecomputedWithCurrentUpdateID(E.Caller)) {
-              LLVM_DEBUG(llvm::dbgs() << "  merge  "
+              PrettyStackTraceSILFunction
+                calleeTraceRAII("merging escape graph", FInfo->Graph.F);
+              PrettyStackTraceSILFunction
+                callerTraceRAII("...into", E.Caller->Graph.F);
+              LLVM_DEBUG(llvm::dbgs() << "  merge "
                                       << FInfo->Graph.F->getName()
                                       << " into "
                                       << E.Caller->Graph.F->getName() << '\n');

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1022,7 +1022,7 @@ bool EscapeAnalysis::ConnectionGraph::mergeFrom(ConnectionGraph *SourceGraph,
       // Just set global escaping in the caller node and that's it.
       Changed |= DestNd->mergeEscapeState(EscapeState::Global);
       // If DestNd is an interior node, its content still needs to be created.
-      if (!DestNd->isInterior())
+      if (!DestNd->isInterior() || DestNd->pointsTo)
         continue;
     }
 

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -363,7 +363,10 @@ bool EscapeAnalysis::CGNode::visitSuccessors(Visitor &&visitor) const {
 
 template <typename Visitor>
 bool EscapeAnalysis::CGNode::visitDefers(Visitor &&visitor) const {
-  for (Predecessor pred : Preds) {
+  // Save predecessors before calling `visitor` which may assign pointsTo edges
+  // which invalidates the predecessor iterator.
+  SmallVector<Predecessor, 4> predVector(Preds.begin(), Preds.end());
+  for (Predecessor pred : predVector) {
     if (!pred.is(EdgeType::Defer))
       continue;
     if (!visitor(pred.getPredNode(), false))

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -389,34 +389,24 @@ void EscapeAnalysis::ConnectionGraph::clear() {
   assert(ToMerge.empty());
 }
 
+// This never returns an interior node. It should never be called directly on an
+// address projection of a reference. To get the interior node for an address
+// projection, always ask for the content of the projection's base instead using
+// getValueContent() or getReferenceContent().
+//
+// Address phis are not allowed, so merging an unknown address with a reference
+// address projection is rare. If that happens, then the projection's node loses
+// it's interior property.
 EscapeAnalysis::CGNode *
-EscapeAnalysis::ConnectionGraph::getOrCreateNode(ValueBase *V,
-                                                 PointerKind pointerKind) {
-  assert(pointerKind != EscapeAnalysis::NoPointer);
-
+EscapeAnalysis::ConnectionGraph::getNode(SILValue V) {
+  // Early filter obvious non-pointer opcodes.
   if (isa<FunctionRefInst>(V) || isa<DynamicFunctionRefInst>(V) ||
       isa<PreviousDynamicFunctionRefInst>(V))
     return nullptr;
 
-  CGNode * &Node = Values2Nodes[V];
-  // Nodes mapped to values must have an indirect pointsTo. Nodes that don't
-  // have an indirect pointsTo are imaginary nodes that don't directly represnt
-  // a SIL value.
-  bool hasReferenceOnly = canOnlyContainReferences(pointerKind);
-  if (!Node) {
-    if (isa<SILFunctionArgument>(V)) {
-      Node = allocNode(V, NodeType::Argument, false, hasReferenceOnly);
-      if (!isSummaryGraph)
-        Node->mergeEscapeState(EscapeState::Arguments);
-    } else {
-      Node = allocNode(V, NodeType::Value, false, hasReferenceOnly);
-    }
-  }
-  return Node->getMergeTarget();
-}
-
-EscapeAnalysis::CGNode *
-EscapeAnalysis::ConnectionGraph::getNode(ValueBase *V, bool createIfNeeded) {
+  // Create the node flags based on the derived value's kind. If the pointer
+  // base type has non-reference pointers but they are never accessed in the
+  // current function, then ignore them.
   PointerKind pointerKind = EA->getPointerKind(V);
   if (pointerKind == EscapeAnalysis::NoPointer)
     return nullptr;
@@ -424,12 +414,30 @@ EscapeAnalysis::ConnectionGraph::getNode(ValueBase *V, bool createIfNeeded) {
   // Look past address projections, pointer casts, and the like within the same
   // object. Does not look past a dereference such as ref_element_addr, or
   // project_box.
-  V = EA->getPointerRoot(V);
+  SILValue ptrBase = EA->getPointerRoot(V);
+  // Do not create a node for undef values so we can verify that node values
+  // have the correct pointer kind.
+  if (!ptrBase->getFunction())
+    return nullptr;
 
-  if (!createIfNeeded)
-    return lookupNode(V);
+  assert(EA->isPointer(ptrBase) &&
+         "The base for derived pointer must also be a pointer type");
 
-  return getOrCreateNode(V, pointerKind);
+  bool hasReferenceOnly = canOnlyContainReferences(pointerKind);
+  // Update the value-to-node map.
+  CGNode *&Node = Values2Nodes[ptrBase];
+  if (Node) {
+    CGNode *targetNode = Node->getMergeTarget();
+    targetNode->mergeFlags(false /*isInterior*/, hasReferenceOnly);
+    return targetNode;
+  }
+  if (isa<SILFunctionArgument>(ptrBase)) {
+    Node = allocNode(ptrBase, NodeType::Argument, false, hasReferenceOnly);
+    if (!isSummaryGraph)
+      Node->mergeEscapeState(EscapeState::Arguments);
+  } else
+    Node = allocNode(ptrBase, NodeType::Value, false, hasReferenceOnly);
+  return Node;
 }
 
 /// Adds an argument/instruction in which the node's memory is released.
@@ -916,8 +924,8 @@ EscapeAnalysis::ConnectionGraph::getOrCreateAddressContent(SILValue addrVal,
 
   bool contentHasReferenceOnly =
       EA->hasReferenceOnly(addrVal->getType().getObjectType(), *F);
-  // Address content always has an indirect pointsTo (only reference content can
-  // have a non-indirect pointsTo).
+  // Address content is never an interior node (only reference content can
+  // be an interior node).
   return getOrCreateContentNode(addrNode, false, contentHasReferenceOnly);
 }
 
@@ -926,12 +934,14 @@ EscapeAnalysis::ConnectionGraph::getOrCreateAddressContent(SILValue addrVal,
 CGNode *
 EscapeAnalysis::ConnectionGraph::getOrCreateReferenceContent(SILValue refVal,
                                                              CGNode *refNode) {
-  // The object node points to internal fields. It neither has indirect pointsTo
-  // nor reference-only pointsTo.
+  // The object node created here points to internal fields. It neither has
+  // indirect pointsTo nor reference-only pointsTo.
   CGNode *objNode = getOrCreateContentNode(refNode, true, false);
   if (!objNode->isInterior())
     return objNode;
 
+  // Determine whether the object that refVal refers to only contains
+  // references.
   bool contentHasReferenceOnly = false;
   if (refVal) {
     SILType refType = refVal->getType();
@@ -972,24 +982,19 @@ EscapeAnalysis::ConnectionGraph::getOrCreateUnknownContent(CGNode *addrNode) {
 // on-the-fly.
 EscapeAnalysis::CGNode *
 EscapeAnalysis::ConnectionGraph::getValueContent(SILValue ptrVal) {
-  // Look past address projections, pointer casts, and the like within the same
-  // object. Does not look past a dereference such as ref_element_addr, or
-  // project_box.
-  SILValue ptrBase = EA->getPointerRoot(ptrVal);
-
-  PointerKind pointerKind = EA->getPointerKind(ptrBase);
-  if (pointerKind == EscapeAnalysis::NoPointer)
-    return nullptr;
-
-  CGNode *addrNode = getOrCreateNode(ptrBase, pointerKind);
+  CGNode *addrNode = getNode(ptrVal);
   if (!addrNode)
     return nullptr;
 
-  if (ptrBase->getType().isAddress())
-    return getOrCreateAddressContent(ptrBase, addrNode);
+  // Create content based on the derived pointer. If the base pointer contains
+  // other types of references, then the content node will be merged when those
+  // references are accessed. If the other references types are never accessed
+  // in this function, then they are ignored.
+  if (ptrVal->getType().isAddress())
+    return getOrCreateAddressContent(ptrVal, addrNode);
 
-  if (canOnlyContainReferences(pointerKind))
-    return getOrCreateReferenceContent(ptrBase, addrNode);
+  if (addrNode->hasReferenceOnly())
+    return getOrCreateReferenceContent(ptrVal, addrNode);
 
   // The pointer value may contain raw pointers.
   return getOrCreateUnknownContent(addrNode);
@@ -2075,10 +2080,12 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       // that may eventually be associated with 'fieldContent', so we must
       // assume here that 'fieldContent2' could hold raw pointers. This is
       // implied by passing in invalid SILValue.
-      CGNode *objNode2 =
+      CGNode *escapingNode =
           ConGraph->getOrCreateReferenceContent(SILValue(), fieldNode);
-      CGNode *fieldNode2 = objNode2->getContentNodeOrNull();
-      ConGraph->getOrCreateUnknownContent(fieldNode2)->markEscaping();
+      if (CGNode *indirectFieldNode = escapingNode->getContentNodeOrNull())
+        escapingNode = indirectFieldNode;
+
+      ConGraph->getOrCreateUnknownContent(escapingNode)->markEscaping();
       return;
     }
     case SILInstructionKind::DestroyAddrInst: {

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1891,7 +1891,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
           if (LoadedElement) {
             if (CGNode *arrayElementStorage =
                     ConGraph->getFieldContent(ArrayObjNode)) {
-              ConGraph->defer(LoadedElement, arrayElementStorage);
+              ConGraph->defer(arrayElementStorage, LoadedElement);
               return;
             }
           }
@@ -1902,7 +1902,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         // returned address point to the same element storage.
         if (CGNode *ArrayObjNode = ConGraph->getValueContent(ASC.getSelf())) {
           CGNode *arrayElementAddress = ConGraph->getNode(ASC.getCallResult());
-          ConGraph->defer(arrayElementAddress, ArrayObjNode);
+          ConGraph->defer(ArrayObjNode, arrayElementAddress);
           return;
         }
         break;

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -323,7 +323,7 @@ bb0(%0 : $Pointer):
 // CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
 // CHECK-NEXT:    Con [ref] %1.1 Esc: G, Succ: %4
 // CHECK-NEXT:    Con [int] %3 Esc: A, Succ: (%4)
-// CHECK-NEXT:    Con %4 Esc: G, Succ:
+// CHECK-NEXT:    Con [ref] %4 Esc: G, Succ:
 // CHECK-NEXT:  End
 sil  @store_content : $@convention(thin) (@owned Pointer) -> () {
 bb0(%0 : $Pointer):
@@ -896,7 +896,7 @@ bb0:
 // CHECK-NEXT:    Val [ref] %4 Esc: , Succ: %0, %1
 // CHECK-NEXT:    Val [ref] %7 Esc: , Succ: (%7.1), %4
 // CHECK-NEXT:    Con [int] %7.1 Esc: A, Succ: (%7.2)
-// CHECK-NEXT:    Con %7.2 Esc: A, Succ: 
+// CHECK-NEXT:    Con [ref] %7.2 Esc: A, Succ: 
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %7
 // CHECK-NEXT:  End
 sil @pointer_types : $@convention(thin) (@owned Y, @owned Y) -> @owned Y {
@@ -1107,7 +1107,7 @@ bb0(%0 : $*X, %1 : $X):
 // CHECK-LABEL: CG of test_casts
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ:
 // CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2)
-// CHECK-NEXT:    Con %0.2 Esc: A, Succ: 
+// CHECK-NEXT:    Con [ref] %0.2 Esc: A, Succ: 
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %0
 // CHECK-NEXT:  End
 sil @test_casts : $@convention(thin) (@owned AnyObject) -> @owned X {
@@ -1816,4 +1816,31 @@ bb0(%0 : $IntWrapper):
   strong_release %0 : $IntWrapper
   %tuple = tuple (%bridge : $Builtin.BridgeObject, %ump : $UnsafeMutablePointer<Int64>)
   return %tuple : $(Builtin.BridgeObject, UnsafeMutablePointer<Int64>)
+}
+
+// Test undef -> struct_extract -> bbarg
+// CHECK-LABEL: CG of testMappedUndef
+// CHECK-NEXT:   Val [ref] %4 Esc: , Succ: (%4.1)
+// CHECK-NEXT:   Con [int] %4.1 Esc: G, Succ: (%4.2)
+// CHECK-NEXT:   Con %4.2 Esc: G, Succ:
+// CHECK-LABEL: End
+struct StructWithObject {
+  @_hasStorage var obj: AnyObject { get set }
+  init(obj: AnyObject)
+}
+
+sil @testMappedUndef : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(undef : $AnyObject)
+
+bb2:
+  %2 = struct_extract undef : $StructWithObject, #StructWithObject.obj
+  br bb3(%2 : $AnyObject)
+
+bb3(%4 : $AnyObject):
+  %5 = tuple ()
+  return %5 : $()
 }

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -escapes-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -escapes-dump -escapes-internal-verify -o /dev/null | %FileCheck %s
 
 // REQUIRES: asserts
 
@@ -594,7 +594,7 @@ sil_global @global_ln : $LinkedNode
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%1)
 // CHECK-NEXT:    Con [int] %1 Esc: A, Succ: (%2)
 // CHECK-NEXT:    Con [ref] %2 Esc: G, Succ:
-// CHECK-NEXT:    Val [ref] %4 Esc: , Succ: (%4.1), %2
+// CHECK-NEXT:    Val [ref] %4 Esc: G, Succ: (%4.1), %2
 // CHECK-NEXT:    Con [int] %4.1 Esc: G, Succ: (%4.2)
 // CHECK-NEXT:    Con [ref] %4.2 Esc: G, Succ: 
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
@@ -614,7 +614,7 @@ bb0(%0 : $LinkedNode):
 // CHECK-NEXT:    Con [ref] %0.2 Esc: G, Succ:
 // CHECK-NEXT:    Val %1 Esc: , Succ: (%1.1)
 // CHECK-NEXT:    Con [ref] %1.1 Esc: G, Succ: %0
-// CHECK-NEXT:    Val [ref] %4 Esc: , Succ: (%0.1), %0
+// CHECK-NEXT:    Val [ref] %4 Esc: G, Succ: (%0.1), %0
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %4
 // CHECK-NEXT:  End
 sil @let_escape : $@convention(thin) (@owned LinkedNode) -> @owned LinkedNode {
@@ -628,7 +628,7 @@ bb0(%0 : $LinkedNode):
 
 // CHECK-LABEL: CG of return_same
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%5.1)
-// CHECK-NEXT:    Val [ref] %3 Esc: , Succ: (%5.1), %5.2
+// CHECK-NEXT:    Val [ref] %3 Esc: G, Succ: (%5.1), %5.2
 // CHECK-NEXT:    Val [ref] %5 Esc: , Succ: (%5.1), %0, %3
 // CHECK-NEXT:    Con [int] %5.1 Esc: G, Succ: (%5.2)
 // CHECK-NEXT:    Con [ref] %5.2 Esc: G, Succ: (%5.1)

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1212,10 +1212,10 @@ bb0(%0 : $Array<X>):
 
 // CHECK-LABEL: CG of arraysemantics_get_element
 // CHECK-NEXT:    Arg %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con [ref] %0.1 Esc: A, Succ: %1.2
+// CHECK-NEXT:    Con [ref] %0.1 Esc: A, Succ:
 // CHECK-NEXT:    Arg [ref] %1 Esc: A, Succ: (%1.1)
 // CHECK-NEXT:    Con [int] %1.1 Esc: A, Succ: (%1.2)
-// CHECK-NEXT:    Con %1.2 Esc: A, Succ: 
+// CHECK-NEXT:    Con %1.2 Esc: A, Succ: %0.1
 // CHECK-NEXT:  End
 sil @arraysemantics_get_element : $@convention(thin) (Array<X>) -> @out X {
 bb0(%io : $*X, %1 : $Array<X>):
@@ -1246,9 +1246,9 @@ bb0(%0 : $*Array<X>):
 
 // CHECK-LABEL: CG of arraysemantics_get_element_address
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: (%0.1)
-// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: 
+// CHECK-NEXT:    Con [int] %0.1 Esc: A, Succ: (%0.2), %4
 // CHECK-NEXT:    Con %0.2 Esc: A, Succ: 
-// CHECK-NEXT:    Val %4 Esc: , Succ: %0.1
+// CHECK-NEXT:    Val %4 Esc: A, Succ: (%0.2)
 // CHECK-NEXT:  End
 sil @arraysemantics_get_element_address : $@convention(thin) (Array<X>) -> () {
 bb0(%0 : $Array<X>):

--- a/test/SILOptimizer/escape_analysis_dead_store.sil
+++ b/test/SILOptimizer/escape_analysis_dead_store.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -dead-store-elim -enable-sil-verify-all | %FileCheck %s
+// RUN: %target-sil-opt %s -dead-store-elim -enable-sil-verify-all -escapes-internal-verify | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/escape_analysis_invalidate.sil
+++ b/test/SILOptimizer/escape_analysis_invalidate.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -temp-rvalue-opt -enable-sil-verify-all | %FileCheck %s
+// RUN: %target-sil-opt %s -temp-rvalue-opt -enable-sil-verify-all -escapes-internal-verify | %FileCheck %s
 //
 // TempRValue iteratively uses EscapeAnalysis and deletes
 // instructions. Make sure that the connection graph remains valid

--- a/test/SILOptimizer/escape_analysis_reduced.sil
+++ b/test/SILOptimizer/escape_analysis_reduced.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -escapes-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt %s -escapes-dump -escapes-internal-verify -o /dev/null | %FileCheck %s
 
 // REQUIRES: asserts
 // REQUIRES: OS=macosx
@@ -11,7 +11,7 @@ import Swift
 import SwiftShims
 
 // =============================================================================
-// Test call to array.uninitialized that has extra release_value uses
+// Test call to array.uninitialized that has "extra" release_value uses
 
 class C {
   var c: C
@@ -213,4 +213,349 @@ bb5:                                              // Preds: bb4
 bb6:                                              // Preds: bb5
   %61 = tuple ()                                  // user: %62
   return %61 : $()                                // id: %62
+}
+
+// =============================================================================
+// Test merging an interior node with a non-interior
+// node. Verification can fail in the time between when the properties
+// are merged and when the edges are merged.
+
+struct Poly {
+  @_hasStorage var points: Array<Int64> { get set }
+  @_hasStorage var length: Int64 { get set }
+  init(points: Array<Int64>, length: Int64)
+}
+
+// CHECK-LABEL: CG of testMergeInteriorPointsTo
+// CHECK-NEXT:  Arg [ref] %0 Esc: A, Succ: (%6.2)
+// CHECK-NEXT:  Val %1 Esc: , Succ: (%1.1)
+// CHECK-NEXT:  Con [ref] %1.1 Esc: , Succ: %0, %12.1
+// CHECK-NEXT:  Val %6 Esc: , Succ: (%6.1)
+// CHECK-NEXT:  Con [ref] %6.1 Esc: , Succ: (%6.2)
+// CHECK-NEXT:  Con [int] %6.2 Esc: G, Succ: (%6.3)
+// CHECK-NEXT:  Con %6.3 Esc: G, Succ: (%6.4)
+// CHECK-NEXT:  Con [int] %6.4 Esc: G, Succ: (%6.5)
+// CHECK-NEXT:  Con %6.5 Esc: G, Succ: (%6.6)
+// CHECK-NEXT:  Con %6.6 Esc: G, Succ:
+// CHECK-NEXT:  Val %8 Esc: , Succ: (%8.1)
+// CHECK-NEXT:  Con [ref] %8.1 Esc: , Succ: %6.1
+// CHECK-NEXT:  Val %12 Esc: , Succ: (%12.1)
+// CHECK-NEXT:  Con [ref] %12.1 Esc: , Succ: %6.1
+// CHECK-LABEL: End
+sil [serialized] @testMergeInteriorPointsTo : $@convention(method) (@owned Array<Int64>) -> () {
+bb0(%0 : $Array<Int64>):
+  %1 = alloc_stack $Poly, var, name "self"
+  %2 = struct_element_addr %1 : $*Poly, #Poly.points
+  retain_value %0 : $Array<Int64>
+  retain_value %0 : $Array<Int64>
+  store %0 to %2 : $*Array<Int64>
+  %6 = alloc_stack $Int64, var, name "length"
+  release_value %0 : $Array<Int64>
+  %8 = alloc_stack $Int64
+  copy_addr %6 to [initialization] %8 : $*Int64
+  destroy_addr %8 : $*Int64
+  dealloc_stack %8 : $*Int64
+  %12 = alloc_stack $Int64
+  copy_addr %6 to [initialization] %12 : $*Int64
+  %14 = struct_element_addr %1 : $*Poly, #Poly.length
+  copy_addr [take] %12 to [initialization] %14 : $*Int64
+  dealloc_stack %12 : $*Int64
+  destroy_addr %6 : $*Int64
+  dealloc_stack %6 : $*Int64
+  dealloc_stack %1 : $*Poly
+  %20 = tuple ()
+  return %20 : $()
+}
+
+// =============================================================================
+// Test merging a callee graph such that when merging pointsTo nodes
+// for defer edges in the caller graph, the new pointsTo node has
+// already been merged and the deferred node has both a defer edge and
+// pointsTo edge to the same node.
+
+public protocol ProceduralOp : AnyObject {}
+
+public class OptypeBase {
+  @_hasStorage var name : String { get set }
+  @_hasStorage var id : Int { get set }
+}
+
+public class OptypeDependent : OptypeBase {
+  @_hasStorage var _enable : Bool { get set }
+  @_hasStorage var _ops : Array<ProceduralOp>
+}
+
+public class CombineAnyOp : OptypeDependent {
+  @_hasStorage var _sources : Array<(ProceduralOp, Bool)>
+}
+
+sil_global @_swiftEmptyArrayStorage : $_SwiftEmptyArrayStorage
+
+sil @$sSa28_allocateBufferUninitialized15minimumCapacitys06_ArrayB0VyxGSi_tFZ : $@convention(method) <τ_0_0> (Int, @thin Array<τ_0_0>.Type) -> @owned _ArrayBuffer<τ_0_0>
+
+// specialized static Array._allocateUninitialized(_:)
+sil shared [_semantics "array.uninitialized"] @$sSa22_allocateUninitializedySayxG_SpyxGtSiFZ12ProceduralOp_p_Tg5 : $@convention(method) (Int, @thin Array<ProceduralOp>.Type) -> (@owned Array<ProceduralOp>, UnsafeMutablePointer<ProceduralOp>) {
+// %0
+bb0(%0 : $Int, %1 : $@thin Array<ProceduralOp>.Type):
+  %2 = global_addr @_swiftEmptyArrayStorage : $*_SwiftEmptyArrayStorage
+  %3 = address_to_pointer %2 : $*_SwiftEmptyArrayStorage to $Builtin.RawPointer
+  %4 = raw_pointer_to_ref %3 : $Builtin.RawPointer to $__EmptyArrayStorage
+  %5 = unchecked_ref_cast %4 : $__EmptyArrayStorage to $Builtin.BridgeObject
+  %6 = integer_literal $Builtin.Int64, 0
+  %7 = struct_extract %0 : $Int, #Int._value
+  %8 = builtin "cmp_slt_Int64"(%6 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %8, bb1, bb2
+
+bb1:
+  %10 = metatype $@thin Array<ProceduralOp>.Type
+  // function_ref static Array._allocateBufferUninitialized(minimumCapacity:)
+  %11 = function_ref @$sSa28_allocateBufferUninitialized15minimumCapacitys06_ArrayB0VyxGSi_tFZ : $@convention(method) <τ_0_0> (Int, @thin Array<τ_0_0>.Type) -> @owned _ArrayBuffer<τ_0_0>
+  %12 = apply %11<ProceduralOp>(%0, %10) : $@convention(method) <τ_0_0> (Int, @thin Array<τ_0_0>.Type) -> @owned _ArrayBuffer<τ_0_0>
+  %13 = struct_extract %12 : $_ArrayBuffer<ProceduralOp>, #_ArrayBuffer._storage
+  %14 = struct_extract %13 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
+  %15 = unchecked_ref_cast %14 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  %16 = ref_element_addr %15 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %17 = struct_element_addr %16 : $*_ArrayBody, #_ArrayBody._storage
+  %18 = struct_element_addr %17 : $*_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  store %0 to %18 : $*Int
+  br bb3(%14 : $Builtin.BridgeObject)
+
+bb2:
+  strong_retain %4 : $__EmptyArrayStorage
+  br bb3(%5 : $Builtin.BridgeObject)
+
+// %23
+bb3(%23 : $Builtin.BridgeObject):
+  %24 = struct $_BridgeStorage<__ContiguousArrayStorageBase> (%23 : $Builtin.BridgeObject)
+  %25 = struct $_ArrayBuffer<ProceduralOp> (%24 : $_BridgeStorage<__ContiguousArrayStorageBase>)
+  %26 = struct $Array<ProceduralOp> (%25 : $_ArrayBuffer<ProceduralOp>)
+  %27 = unchecked_ref_cast %23 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  %28 = ref_tail_addr %27 : $__ContiguousArrayStorageBase, $ProceduralOp
+  %29 = address_to_pointer %28 : $*ProceduralOp to $Builtin.RawPointer
+  %30 = struct $UnsafeMutablePointer<ProceduralOp> (%29 : $Builtin.RawPointer)
+  %31 = tuple (%26 : $Array<ProceduralOp>, %30 : $UnsafeMutablePointer<ProceduralOp>)
+  return %31 : $(Array<ProceduralOp>, UnsafeMutablePointer<ProceduralOp>)
+}
+
+sil shared [_semantics "array.uninitialized"] @$sSa22_allocateUninitializedySayxG_SpyxGtSiFZ12ProceduralOp_p_Sbt_Tg5 : $@convention(method) (Int, @thin Array<(ProceduralOp, Bool)>.Type) -> (@owned Array<(ProceduralOp, Bool)>, UnsafeMutablePointer<(ProceduralOp, Bool)>) {
+// %0
+bb0(%0 : $Int, %1 : $@thin Array<(ProceduralOp, Bool)>.Type):
+  %2 = global_addr @_swiftEmptyArrayStorage : $*_SwiftEmptyArrayStorage
+  %3 = address_to_pointer %2 : $*_SwiftEmptyArrayStorage to $Builtin.RawPointer
+  %4 = raw_pointer_to_ref %3 : $Builtin.RawPointer to $__EmptyArrayStorage
+  %5 = unchecked_ref_cast %4 : $__EmptyArrayStorage to $Builtin.BridgeObject
+  %6 = integer_literal $Builtin.Int64, 0
+  %7 = struct_extract %0 : $Int, #Int._value
+  %8 = builtin "cmp_slt_Int64"(%6 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %8, bb1, bb2
+
+bb1:
+  %10 = metatype $@thin Array<(ProceduralOp, Bool)>.Type
+  // function_ref static Array._allocateBufferUninitialized(minimumCapacity:)
+  %11 = function_ref @$sSa28_allocateBufferUninitialized15minimumCapacitys06_ArrayB0VyxGSi_tFZ : $@convention(method) <τ_0_0> (Int, @thin Array<τ_0_0>.Type) -> @owned _ArrayBuffer<τ_0_0>
+  %12 = apply %11<(ProceduralOp, Bool)>(%0, %10) : $@convention(method) <τ_0_0> (Int, @thin Array<τ_0_0>.Type) -> @owned _ArrayBuffer<τ_0_0>
+  %13 = struct_extract %12 : $_ArrayBuffer<(ProceduralOp, Bool)>, #_ArrayBuffer._storage
+  %14 = struct_extract %13 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
+  %15 = unchecked_ref_cast %14 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  %16 = ref_element_addr %15 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %17 = struct_element_addr %16 : $*_ArrayBody, #_ArrayBody._storage
+  %18 = struct_element_addr %17 : $*_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  store %0 to %18 : $*Int
+  br bb3(%14 : $Builtin.BridgeObject)
+
+bb2:
+  strong_retain %4 : $__EmptyArrayStorage
+  br bb3(%5 : $Builtin.BridgeObject)
+
+// %23
+bb3(%23 : $Builtin.BridgeObject):
+  %24 = struct $_BridgeStorage<__ContiguousArrayStorageBase> (%23 : $Builtin.BridgeObject)
+  %25 = struct $_ArrayBuffer<(ProceduralOp, Bool)> (%24 : $_BridgeStorage<__ContiguousArrayStorageBase>)
+  %26 = struct $Array<(ProceduralOp, Bool)> (%25 : $_ArrayBuffer<(ProceduralOp, Bool)>)
+  %27 = unchecked_ref_cast %23 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  %28 = ref_tail_addr %27 : $__ContiguousArrayStorageBase, $(ProceduralOp, Bool)
+  %29 = address_to_pointer %28 : $*(ProceduralOp, Bool) to $Builtin.RawPointer
+  %30 = struct $UnsafeMutablePointer<(ProceduralOp, Bool)> (%29 : $Builtin.RawPointer)
+  %31 = tuple (%26 : $Array<(ProceduralOp, Bool)>, %30 : $UnsafeMutablePointer<(ProceduralOp, Bool)>)
+  return %31 : $(Array<(ProceduralOp, Bool)>, UnsafeMutablePointer<(ProceduralOp, Bool)>)
+}
+
+sil @testMergePointsTo_OptypeDependent_init : $@convention(method) (@owned String, @owned OptypeDependent) -> @owned OptypeDependent {
+bb0(%0 : $String, %1 : $OptypeDependent):
+  %3 = integer_literal $Builtin.Int64, 0
+  %4 = struct $Int (%3 : $Builtin.Int64)
+  %5 = metatype $@thin Array<ProceduralOp>.Type
+  // function_ref specialized static Array._allocateUninitialized(_:)
+  %6 = function_ref @$sSa22_allocateUninitializedySayxG_SpyxGtSiFZ12ProceduralOp_p_Tg5 : $@convention(method) (Int, @thin Array<ProceduralOp>.Type) -> (@owned Array<ProceduralOp>, UnsafeMutablePointer<ProceduralOp>)
+  strong_retain %1 : $OptypeDependent             // id: %7
+  %8 = apply %6(%4, %5) : $@convention(method) (Int, @thin Array<ProceduralOp>.Type) -> (@owned Array<ProceduralOp>, UnsafeMutablePointer<ProceduralOp>)
+  %9 = tuple_extract %8 : $(Array<ProceduralOp>, UnsafeMutablePointer<ProceduralOp>), 0
+  %10 = ref_element_addr %1 : $OptypeDependent, #OptypeDependent._ops
+  store %9 to %10 : $*Array<ProceduralOp>
+  %12 = integer_literal $Builtin.Int1, -1
+  %13 = struct $Bool (%12 : $Builtin.Int1)
+  %14 = ref_element_addr %1 : $OptypeDependent, #OptypeDependent._enable
+  store %13 to %14 : $*Bool
+  strong_release %1 : $OptypeDependent
+  %17 = upcast %1 : $OptypeDependent to $OptypeBase
+  %19 = ref_element_addr %17 : $OptypeBase, #OptypeBase.name
+  store %0 to %19 : $*String
+  return %1 : $OptypeDependent
+}
+
+// CHECK-LABEL: CG of testMergePointsTo_CombineAnyOp_init
+// CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ: (%7.1)
+// CHECK-NEXT:   Arg [ref] %1 Esc: A, Succ: (%9)
+// CHECK-NEXT:   Val %7 Esc: A, Succ: (%7.1), %7.1
+// CHECK-NEXT:   Con [int] %7.1 Esc: G, Succ: (%7.1)
+// CHECK-NEXT:   Con [int] %9 Esc: A, Succ: (%9.1)
+// CHECK-NEXT:   Con [ref] %9.1 Esc: A, Succ: %0, %7, %7.1
+// CHECK-NEXT:   Val [ref] %18 Esc: , Succ: (%9), %1
+// CHECK-NEXT:   Ret [ref] return Esc: , Succ: %18
+// CHECK-LABEL: End
+sil @testMergePointsTo_CombineAnyOp_init : $@convention(method) (@owned String, @owned CombineAnyOp) -> @owned CombineAnyOp {
+bb0(%0 : $String, %1 : $CombineAnyOp):
+  strong_retain %1 : $CombineAnyOp
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = struct $Int (%4 : $Builtin.Int64)
+  %6 = metatype $@thin Array<(ProceduralOp, Bool)>.Type
+  // function_ref specialized static Array._allocateUninitialized(_:)
+  %7 = function_ref @$sSa22_allocateUninitializedySayxG_SpyxGtSiFZ12ProceduralOp_p_Sbt_Tg5 : $@convention(method) (Int, @thin Array<(ProceduralOp, Bool)>.Type) -> (@owned Array<(ProceduralOp, Bool)>, UnsafeMutablePointer<(ProceduralOp, Bool)>)
+  %8 = apply %7(%5, %6) : $@convention(method) (Int, @thin Array<(ProceduralOp, Bool)>.Type) -> (@owned Array<(ProceduralOp, Bool)>, UnsafeMutablePointer<(ProceduralOp, Bool)>)
+  %9 = tuple_extract %8 : $(Array<(ProceduralOp, Bool)>, UnsafeMutablePointer<(ProceduralOp, Bool)>), 0
+  %10 = ref_element_addr %1 : $CombineAnyOp, #CombineAnyOp._sources
+  store %9 to %10 : $*Array<(ProceduralOp, Bool)>
+  strong_release %1 : $CombineAnyOp
+  %13 = struct_extract %0 : $String, #String._guts
+  %14 = struct_extract %13 : $_StringGuts, #_StringGuts._object
+  %15 = struct_extract %14 : $_StringObject, #_StringObject._object
+  strong_retain %15 : $Builtin.BridgeObject
+  %18 = upcast %1 : $CombineAnyOp to $OptypeDependent
+  %19 = function_ref @testMergePointsTo_OptypeDependent_init : $@convention(method) (@owned String, @owned OptypeDependent) -> @owned OptypeDependent
+  %20 = apply %19(%0, %18) : $@convention(method) (@owned String, @owned OptypeDependent) -> @owned OptypeDependent
+  %21 = unchecked_ref_cast %20 : $OptypeDependent to $CombineAnyOp
+  strong_release %15 : $Builtin.BridgeObject
+  return %21 : $CombineAnyOp
+}
+
+// =============================================================================
+// Test calling ConnectionGraph::initializePointsTo from
+// mergeAllScheduledNodes when multiple merges are pending.  In this
+// case, initializePointsTo is called and a node in the
+// to-be-initialized defer web already pointsTo a node that has been
+// marked for merging.
+
+public protocol ASTNode {}
+
+public struct AssignmentNode : ASTNode {
+  @_hasStorage public let variable: ASTNode { get }
+  @_hasStorage public let value: ASTNode { get }
+  @_hasStorage public let range: Range<Int>? { get }
+  @_hasStorage public let documentation: String? { get }
+  public init(variable: ASTNode, value: ASTNode, range: Range<Int>?, documentation: String?) throws
+  public var childNodes: [ASTNode] { get }
+}
+
+public struct VariableNode : ASTNode {
+  @_hasStorage public let name: String { get }
+  @_hasStorage public let range: Range<Int>? { get }
+  public init(name: String, range: Range<Int>?)
+  public var childNodes: [ASTNode] { get }
+  public var description: String { get }
+  public var nodeDescription: String? { get }
+}
+
+// CHECK-LABEL: CG of testPendingMergeHelper
+// CHECK-NEXT:   Arg %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:   Con %0.1 Esc: A, Succ: %3.1
+// CHECK-NEXT:   Arg %1 Esc: A, Succ: (%1.1)
+// CHECK-NEXT:   Con %1.1 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:   Arg [ref] %2 Esc: A, Succ: (%2.1)
+// CHECK-NEXT:   Con %2.1 Esc: G, Succ:
+// CHECK-NEXT:   Val %3 Esc: , Succ: (%3.1)
+// CHECK-NEXT:   Con %3.1 Esc: A, Succ: %1.1, %2
+// CHECK-LABEL: End
+sil @testPendingMergeHelper : $@convention(method) (@in ASTNode, @owned Optional<String>) -> (@out AssignmentNode, @error Error) {
+bb0(%0 : $*AssignmentNode, %1 : $*ASTNode, %4 : $Optional<String>):
+  %6 = alloc_stack $AssignmentNode, var, name "self"
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_addr %1 : $*ASTNode
+  dealloc_stack %6 : $*AssignmentNode
+  throw undef : $Error
+
+bb2:
+  %160 = struct_element_addr %6 : $*AssignmentNode, #AssignmentNode.variable
+  copy_addr [take] %1 to [initialization] %160 : $*ASTNode
+  %162 = struct_element_addr %6 : $*AssignmentNode, #AssignmentNode.value
+  %164 = struct_element_addr %6 : $*AssignmentNode, #AssignmentNode.range
+  %166 = struct_element_addr %6 : $*AssignmentNode, #AssignmentNode.documentation
+  store %4 to %166 : $*Optional<String>
+  copy_addr [take] %6 to [initialization] %0 : $*AssignmentNode
+  dealloc_stack %6 : $*AssignmentNode
+  %171 = tuple ()
+  return %171 : $()
+}
+
+// CHECK-LABEL: CG of testPendingMerge
+// CHECK-NEXT:   Arg %0 Esc: A, Succ: (%22)
+// CHECK-NEXT:   Arg [ref] %1 Esc: G, Succ: (%9.1)
+// CHECK-NEXT:   Val %2 Esc: , Succ: (%9)
+// CHECK-NEXT:   Val %4 Esc: , Succ: (%4.1)
+// CHECK-NEXT:   Con %4.1 Esc: A, Succ: (%9.1), %7, %9
+// CHECK-NEXT:   Val %5 Esc: , Succ: (%7)
+// CHECK-NEXT:   Con %7 Esc: A, Succ: (%9.1)
+// CHECK-NEXT:   Con [ref] %9 Esc: A, Succ: (%9.1)
+// CHECK-NEXT:   Con [int] %9.1 Esc: G, Succ: (%9.1), %1
+// CHECK-NEXT:   Con %22 Esc: A, Succ: (%22.1)
+// CHECK-NEXT:   Con %22.1 Esc: A, Succ: %1, %4.1
+// CHECK-LABEL: End
+sil private @testPendingMerge : $@convention(thin) (@owned VariableNode) -> (@out ASTNode, @error Error) {
+bb0(%0 : $*ASTNode, %1 : $VariableNode):
+  %9 = alloc_stack $Optional<String>, var, name "documentation"
+  cond_br undef, bb12, bb14
+
+bb12:
+  %113 = alloc_stack $AssignmentNode, let, name "assign"
+  %115 = alloc_stack $ASTNode
+  retain_value %1 : $VariableNode
+  %117 = init_existential_addr %115 : $*ASTNode, $VariableNode
+  store %1 to %117 : $*VariableNode
+  %122 = load %9 : $*Optional<String>
+
+  %123 = function_ref @testPendingMergeHelper : $@convention(method) (@in ASTNode, @owned Optional<String>) -> (@out AssignmentNode, @error Error)
+  try_apply %123(%113, %115, %122) : $@convention(method) (@in ASTNode, @owned Optional<String>) -> (@out AssignmentNode, @error Error), normal bb13, error bb65
+
+bb13(%125 : $()):
+  dealloc_stack %115 : $*ASTNode
+  %128 = init_existential_addr %0 : $*ASTNode, $AssignmentNode
+  copy_addr %113 to [initialization] %128 : $*AssignmentNode
+  destroy_addr %113 : $*AssignmentNode
+  dealloc_stack %113 : $*AssignmentNode
+  release_value %1 : $VariableNode
+  dealloc_stack %9 : $*Optional<String>
+  br bb61
+
+bb14:
+  destroy_addr %9 : $*Optional<String>
+  %584 = init_existential_addr %0 : $*ASTNode, $VariableNode
+  store %1 to %584 : $*VariableNode
+  dealloc_stack %9 : $*Optional<String>
+  br bb61
+
+bb61:
+  %589 = tuple ()
+  return %589 : $()
+
+
+bb65(%614 : $Error):
+  dealloc_stack %115 : $*ASTNode
+  dealloc_stack %113 : $*AssignmentNode
+  dealloc_stack %9 : $*Optional<String>
+  br bb72(undef : $Error)
+
+
+bb72(%681 : $Error):
+  throw %681 : $Error
 }


### PR DESCRIPTION
This is a collection of EscapeAnalysis commits related to verification. It fixes some false positives while making the analysis results a bit more precise and consistent.

They are easier to review independently, but easier to push through as one PR. An open bug is waiting on the last commit in the series.

Fixes <rdar://58445744> swiftc assert during EscapeAnalysis verification: (EA->isPointer(Nd->mappedValue)), function verify