### PR TITLE
build-script: remove dead CMake options for Swift

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1751,23 +1751,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${swift_cmake_options[@]}"
                 )
 
-                if [[ "${BUILD_TOOLCHAIN_ONLY}" ]]; then
-                    cmake_options+=(
-                    -DSWIFT_TOOL_SIL_OPT_BUILD=FALSE
-                    -DSWIFT_TOOL_SWIFT_IDE_TEST_BUILD=FALSE
-                    -DSWIFT_TOOL_SWIFT_REMOTEAST_TEST_BUILD=FALSE
-                    -DSWIFT_TOOL_LLDB_MODULEIMPORT_TEST_BUILD=FALSE
-                    -DSWIFT_TOOL_SIL_EXTRACT_BUILD=FALSE
-                    -DSWIFT_TOOL_SWIFT_LLVM_OPT_BUILD=FALSE
-                    -DSWIFT_TOOL_SWIFT_SDK_ANALYZER_BUILD=FALSE
-                    -DSWIFT_TOOL_SWIFT_SDK_DIGESTER_BUILD=FALSE
-                    -DSWIFT_TOOL_SOURCEKITD_TEST_BUILD=FALSE
-                    -DSWIFT_TOOL_SOURCEKITD_REPL_BUILD=FALSE
-                    -DSWIFT_TOOL_COMPLETE_TEST_BUILD=FALSE
-                    -DSWIFT_TOOL_SWIFT_REFLECTION_DUMP_BUILD=FALSE
-                    )
-                fi
-
                 cmake_options=(
                     "${cmake_options[@]}"
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"


### PR DESCRIPTION
The build system does not support fine grained control over the tools.
Ideally we would do this by hooking into the llvm distribution
mechanism.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
