### PR TITLE
build-script: handle special build rules for non-atomic runtime

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -163,11 +163,16 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
     INSTALL_IN_COMPONENT never_install)
 endif()
 
+if(SWIFT_STDLIB_USE_NONATOMIC_RC)
+  set(_RUNTIME_NONATOMIC_FLAGS -DSWIFT_STDLIB_USE_NONATOMIC_RC)
+endif()
 add_swift_target_library(swiftRuntime OBJECT_LIBRARY
   ${swift_runtime_sources}
   ${swift_runtime_objc_sources}
   ${swift_runtime_leaks_sources}
-  C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
+  C_COMPILE_FLAGS
+    ${swift_runtime_library_compile_flags}
+    ${_RUNTIME_NONATOMIC_FLAGS}
   LINK_FLAGS ${swift_runtime_linker_flags}
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT never_install)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1278,9 +1278,6 @@ function swift_c_flags() {
     if [[ $(is_cmake_release_build_type "${SWIFT_BUILD_TYPE}") ]] ; then
         echo -n " -fno-stack-protector"
     fi
-    if [[ "$(true_false "${SWIFT_STDLIB_USE_NONATOMIC_RC}")" == "TRUE" ]]; then
-        echo -n " -DSWIFT_STDLIB_USE_NONATOMIC_RC"
-    fi
 }
 
 function cmake_config_opt() {


### PR DESCRIPTION
Move the special flag handling for the non-atomic runtime into the build
system rather than spreading it across the build system and the helper
utilities.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
