### PR TITLE
build-script: android does not do multi-arch builds

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1244,9 +1244,6 @@ function common_cross_c_flags() {
         watchos-*)
             echo -n " -arch ${arch}  -mwatchos-version-min=${DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
             ;;
-        android-*)
-            echo -n " -arch ${arch}"
-            ;;
     esac
 
     local build_type=$2


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
