### PR TITLE
[ConstraintSystem] Delay closure body constraint generation in a coup…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -228,7 +228,8 @@ bool ConstraintSystem::PotentialBindings::isViable(
   return true;
 }
 
-bool ConstraintSystem::PotentialBindings::favoredOverDisjunction() const {
+bool ConstraintSystem::PotentialBindings::favoredOverDisjunction(
+    Constraint *disjunction) const {
   if (IsHole || FullyBound)
     return false;
 
@@ -238,8 +239,15 @@ bool ConstraintSystem::PotentialBindings::favoredOverDisjunction() const {
   // but we still want to resolve closure body early (instead of
   // attempting any disjunction) to gain additional contextual
   // information.
-  if (TypeVar->getImpl().isClosureType())
-    return true;
+  if (TypeVar->getImpl().isClosureType()) {
+    auto boundType = disjunction->getNestedConstraints()[0]->getFirstType();
+    // If disjunction is attempting to bind a type variable, let's
+    // favor closure because it would add additional context, otherwise
+    // if it's something like a collection (where it has to pick
+    // between a conversion and bridging conversion) or concrete
+    // type let's prefer the disjunction.
+    return boundType->is<TypeVariableType>();
+  }
 
   return !InvolvesTypeVariables;
 }
@@ -559,6 +567,14 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) const {
       // FIXME: Recurse into these constraints to see whether this
       // type variable is fully bound by any of them.
       result.InvolvesTypeVariables = true;
+
+      // If there is additional context available via disjunction
+      // associated with closure literal (e.g. coercion to some other
+      // type) let's delay resolving the closure until the disjunction
+      // is attempted.
+      if (typeVar->getImpl().isClosureType())
+        return {typeVar};
+
       break;
 
     case ConstraintKind::ConformsTo:

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -330,7 +330,7 @@ StepResult ComponentStep::take(bool prevFailed) {
   auto bestBindings = CS.determineBestBindings();
 
   if (bestBindings &&
-      (!disjunction || bestBindings->favoredOverDisjunction())) {
+      (!disjunction || bestBindings->favoredOverDisjunction(disjunction))) {
     // Produce a type variable step.
     return suspend(
         llvm::make_unique<TypeVariableStep>(CS, *bestBindings, Solutions));

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3778,7 +3778,7 @@ private:
 
     /// Check if this binding is favored over a disjunction e.g.
     /// if it has only concrete types or would resolve a closure.
-    bool favoredOverDisjunction() const;
+    bool favoredOverDisjunction(Constraint *disjunction) const;
 
     void dump(llvm::raw_ostream &out,
               unsigned indent = 0) const LLVM_ATTRIBUTE_USED {


### PR DESCRIPTION
…le of specific cases

* If there is a disjunction associated with closure type e.g.
  coercion to some other type `_ = { $0 } as (Int32) -> Void`

* If there is a disjunction associated with a collection which
  could provide more context to the constraint solver.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
