### PR TITLE
Reinstate "Reimplement function builders as statement transformations.""

### DIFF
--- a/include/swift/AST/ASTTypeIDZone.def
+++ b/include/swift/AST/ASTTypeIDZone.def
@@ -17,7 +17,7 @@
 
 SWIFT_TYPEID(AncestryFlags)
 SWIFT_TYPEID(CtorInitializerKind)
-SWIFT_TYPEID(FunctionBuilderClosurePreCheck)
+SWIFT_TYPEID(FunctionBuilderBodyPreCheck)
 SWIFT_TYPEID(GenericSignature)
 SWIFT_TYPEID(ImplicitMemberAction)
 SWIFT_TYPEID(ParamSpecifier)

--- a/include/swift/AST/ASTTypeIDs.h
+++ b/include/swift/AST/ASTTypeIDs.h
@@ -28,7 +28,7 @@ class ConstructorDecl;
 class CustomAttr;
 class Decl;
 class EnumDecl;
-enum class FunctionBuilderClosurePreCheck : uint8_t;
+enum class FunctionBuilderBodyPreCheck : uint8_t;
 class GenericParamList;
 class GenericSignature;
 class GenericTypeParamType;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3599,7 +3599,10 @@ class ClosureExpr : public AbstractClosureExpr {
   /// the CaptureListExpr which would normally maintain this sort of
   /// information about captured variables), we need to have some way to access
   /// this information directly on the ClosureExpr.
-  VarDecl *CapturedSelfDecl;
+  ///
+  /// The bit indicates whether this closure has had a function builder
+  /// applied to it.
+  llvm::PointerIntPair<VarDecl *, 1, bool> CapturedSelfDeclAndAppliedBuilder;
   
   /// The location of the "throws", if present.
   SourceLoc ThrowsLoc;
@@ -3624,7 +3627,8 @@ public:
               unsigned discriminator, DeclContext *parent)
     : AbstractClosureExpr(ExprKind::Closure, Type(), /*Implicit=*/false,
                           discriminator, parent),
-      BracketRange(bracketRange), CapturedSelfDecl(capturedSelfDecl),
+      BracketRange(bracketRange),
+      CapturedSelfDeclAndAppliedBuilder(capturedSelfDecl, false),
       ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc), InLoc(inLoc),
       ExplicitResultType(explicitResultType), Body(nullptr) {
     setParameterList(params);
@@ -3726,12 +3730,22 @@ public:
   bool hasEmptyBody() const;
 
   /// VarDecl captured by this closure under the literal name \c self , if any.
-  VarDecl *getCapturedSelfDecl() const { return CapturedSelfDecl; }
+  VarDecl *getCapturedSelfDecl() const {
+    return CapturedSelfDeclAndAppliedBuilder.getPointer();
+  }
   
   /// Whether this closure captures the \c self param in its body in such a
   /// way that implicit \c self is enabled within its body (i.e. \c self is
   /// captured non-weakly).
   bool capturesSelfEnablingImplictSelf() const;
+
+  bool hasAppliedFunctionBuilder() const {
+    return CapturedSelfDeclAndAppliedBuilder.getInt();
+  }
+
+  void setAppliedFunctionBuilder(bool flag = true) {
+    CapturedSelfDeclAndAppliedBuilder.setInt(flag);
+  }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Closure;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1755,7 +1755,7 @@ public:
   void cacheResult(Witness value) const;
 };
 
-enum class FunctionBuilderClosurePreCheck : uint8_t {
+enum class FunctionBuilderBodyPreCheck : uint8_t {
   /// There were no problems pre-checking the closure.
   Okay,
 
@@ -1768,7 +1768,7 @@ enum class FunctionBuilderClosurePreCheck : uint8_t {
 
 class PreCheckFunctionBuilderRequest
     : public SimpleRequest<PreCheckFunctionBuilderRequest,
-                           FunctionBuilderClosurePreCheck(AnyFunctionRef),
+                           FunctionBuilderBodyPreCheck(AnyFunctionRef),
                            CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1777,7 +1777,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<FunctionBuilderClosurePreCheck>
+  llvm::Expected<FunctionBuilderBodyPreCheck>
   evaluate(Evaluator &evaluator, AnyFunctionRef fn) const;
 
 public:
@@ -2078,7 +2078,7 @@ AnyValue::Holder<GenericSignature>::equals(const HolderBase &other) const {
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 void simple_display(llvm::raw_ostream &out, ImplicitMemberAction action);
-void simple_display(llvm::raw_ostream &out, FunctionBuilderClosurePreCheck pck);
+void simple_display(llvm::raw_ostream &out, FunctionBuilderBodyPreCheck pck);
 
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1125,15 +1125,15 @@ void ValueWitnessRequest::cacheResult(Witness type) const {
 //----------------------------------------------------------------------------//
 
 void swift::simple_display(llvm::raw_ostream &out,
-                           FunctionBuilderClosurePreCheck value) {
+                           FunctionBuilderBodyPreCheck value) {
   switch (value) {
-  case FunctionBuilderClosurePreCheck::Okay:
+  case FunctionBuilderBodyPreCheck::Okay:
     out << "okay";
     break;
-  case FunctionBuilderClosurePreCheck::HasReturnStmt:
+  case FunctionBuilderBodyPreCheck::HasReturnStmt:
     out << "has return statement";
     break;
-  case FunctionBuilderClosurePreCheck::Error:
+  case FunctionBuilderBodyPreCheck::Error:
     out << "error";
     break;
   }

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -39,24 +39,36 @@ namespace {
 
 /// Visitor to classify the contents of the given closure.
 class BuilderClosureVisitor
-    : public StmtVisitor<BuilderClosureVisitor, Expr *> {
+    : private StmtVisitor<BuilderClosureVisitor, VarDecl *> {
+
+  friend StmtVisitor<BuilderClosureVisitor, VarDecl *>;
+
   ConstraintSystem *cs;
+  DeclContext *dc;
   ASTContext &ctx;
-  bool wantExpr;
   Type builderType;
   NominalTypeDecl *builder = nullptr;
   llvm::SmallDenseMap<Identifier, bool> supportedOps;
 
-public:
   SkipUnhandledConstructInFunctionBuilder::UnhandledNode unhandledNode;
 
-private:
-  /// Produce a builder call to the given named function with the given arguments.
+  /// Whether an error occurred during application of the builder closure,
+  /// e.g., during constraint generation.
+  bool hadError = false;
+
+  /// Counter used to give unique names to the variables that are
+  /// created implicitly.
+  unsigned varCounter = 0;
+
+  /// The record of what happened when we applied the builder transform.
+  AppliedBuilderTransform applied;
+
+  /// Produce a builder call to the given named function with the given
+  /// arguments.
   Expr *buildCallIfWanted(SourceLoc loc,
                           Identifier fnName, ArrayRef<Expr *> args,
-                          ArrayRef<Identifier> argLabels,
-                          bool oneWay) {
-    if (!wantExpr)
+                          ArrayRef<Identifier> argLabels) {
+    if (!cs)
       return nullptr;
 
     // FIXME: Setting a TypeLoc on this expression is necessary in order
@@ -69,10 +81,8 @@ private:
     }
 
     auto typeExpr = new (ctx) TypeExpr(typeLoc);
-    if (cs) {
-      cs->setType(typeExpr, MetatypeType::get(builderType));
-      cs->setType(&typeExpr->getTypeLoc(), builderType);
-    }
+    cs->setType(typeExpr, MetatypeType::get(builderType));
+    cs->setType(&typeExpr->getTypeLoc(), builderType);
 
     SmallVector<SourceLoc, 4> argLabelLocs;
     for (auto i : indices(argLabels)) {
@@ -83,17 +93,13 @@ private:
     auto memberRef = new (ctx) UnresolvedDotExpr(
         typeExpr, loc, DeclNameRef(fnName), DeclNameLoc(loc),
         /*implicit=*/true);
+    memberRef->setFunctionRefKind(FunctionRefKind::SingleApply);
     SourceLoc openLoc = args.empty() ? loc : args.front()->getStartLoc();
     SourceLoc closeLoc = args.empty() ? loc : args.back()->getEndLoc();
     Expr *result = CallExpr::create(ctx, memberRef, openLoc, args,
                                     argLabels, argLabelLocs, closeLoc,
                                     /*trailing closure*/ nullptr,
                                     /*implicit*/true);
-
-    if (oneWay) {
-      // Form a one-way constraint to prevent backward propagation.
-      result = new (ctx) OneWayExpr(result);
-    }
 
     return result;
   }
@@ -130,31 +136,116 @@ private:
     return supportedOps[fnName] = found;
   }
 
+  /// Build an implicit variable in this context.
+  VarDecl *buildVar(SourceLoc loc) {
+    // Create the implicit variable.
+    Identifier name = ctx.getIdentifier(
+        ("$__builder" + Twine(varCounter++)).str());
+    auto var = new (ctx) VarDecl(/*isStatic=*/false, VarDecl::Introducer::Var,
+                                 /*isCaptureList=*/false, loc, name, dc);
+    var->setImplicit();
+    return var;
+  }
+
+  /// Capture the given expression into an implicitly-generated variable.
+  VarDecl *captureExpr(Expr *expr, bool oneWay,
+                       llvm::PointerUnion<Stmt *, Expr *> forEntity = nullptr) {
+    if (!cs)
+      return nullptr;
+
+    Expr *origExpr = expr;
+
+    if (oneWay) {
+      // Form a one-way constraint to prevent backward propagation.
+      expr = new (ctx) OneWayExpr(expr);
+    }
+
+    // Generate constraints for this expression.
+    expr = cs->generateConstraints(expr, dc);
+    if (!expr) {
+      hadError = true;
+      return nullptr;
+    }
+
+    // Create the implicit variable.
+    auto var = buildVar(expr->getStartLoc());
+
+    // Record the new variable and its corresponding expression & statement.
+    if (auto forStmt = forEntity.dyn_cast<Stmt *>()) {
+      applied.capturedStmts.insert({forStmt, { var, { expr } }});
+    } else {
+      if (auto forExpr = forEntity.dyn_cast<Expr *>())
+        origExpr = forExpr;
+
+      applied.capturedExprs.insert({origExpr, {var, expr}});
+    }
+
+    cs->setType(var, cs->getType(expr));
+    return var;
+  }
+
+  /// Build an implicit reference to the given variable.
+  DeclRefExpr *buildVarRef(VarDecl *var, SourceLoc loc) {
+    return new (ctx) DeclRefExpr(var, DeclNameLoc(loc), /*Implicit=*/true);
+  }
+
 public:
   BuilderClosureVisitor(ASTContext &ctx, ConstraintSystem *cs,
-                        bool wantExpr, Type builderType)
-      : cs(cs), ctx(ctx), wantExpr(wantExpr), builderType(builderType) {
+                        DeclContext *dc, Type builderType,
+                        Type bodyResultType)
+      : cs(cs), dc(dc), ctx(ctx), builderType(builderType) {
     assert((cs || !builderType->hasTypeVariable()) &&
            "cannot handle builder type with type variables without "
            "constraint system");
     builder = builderType->getAnyNominal();
+    applied.builderType = builderType;
+    applied.bodyResultType = bodyResultType;
   }
 
-#define CONTROL_FLOW_STMT(StmtClass)                      \
-  Expr *visit##StmtClass##Stmt(StmtClass##Stmt *stmt) { \
-    if (!unhandledNode)                                 \
-      unhandledNode = stmt;                             \
-                                                        \
-    return nullptr;                                     \
+  /// Apply the builder transform to the given statement.
+  Optional<AppliedBuilderTransform> apply(Stmt *stmt) {
+    VarDecl *bodyVar = visit(stmt);
+    if (!bodyVar)
+      return None;
+
+    applied.returnExpr = buildVarRef(bodyVar, stmt->getEndLoc());
+    applied.returnExpr = cs->generateConstraints(applied.returnExpr, dc);
+    if (!applied.returnExpr) {
+      hadError = true;
+      return None;
+    }
+
+    return std::move(applied);
   }
 
-  Expr *visitBraceStmt(BraceStmt *braceStmt) {
+  /// Check whether the function builder can be applied to this statement.
+  /// \returns the node that cannot be handled by this builder on failure.
+  SkipUnhandledConstructInFunctionBuilder::UnhandledNode check(Stmt *stmt) {
+    (void)visit(stmt);
+    return unhandledNode;
+  }
+
+protected:
+#define CONTROL_FLOW_STMT(StmtClass)                       \
+  VarDecl *visit##StmtClass##Stmt(StmtClass##Stmt *stmt) { \
+    if (!unhandledNode)                                    \
+      unhandledNode = stmt;                                \
+                                                           \
+    return nullptr;                                        \
+  }
+
+  VarDecl *visitBraceStmt(BraceStmt *braceStmt) {
     SmallVector<Expr *, 4> expressions;
+    auto addChild = [&](VarDecl *childVar) {
+      if (!childVar)
+        return;
+
+      expressions.push_back(buildVarRef(childVar, childVar->getLoc()));
+    };
+
     for (const auto &node : braceStmt->getElements()) {
       if (auto stmt = node.dyn_cast<Stmt *>()) {
-        auto expr = visit(stmt);
-        if (expr)
-          expressions.push_back(expr);
+        addChild(visit(stmt));
         continue;
       }
 
@@ -165,9 +256,8 @@ public:
         if (isa<IfConfigDecl>(decl))
           continue;
 
-        // Emit #warning/#error but don't build anything for it.
+        // Skip #warning/#error; we'll handle them when applying the builder.
         if (auto poundDiag = dyn_cast<PoundDiagnosticDecl>(decl)) {
-          TypeChecker::typeCheckDecl(poundDiag);
           continue;
         }
 
@@ -178,27 +268,28 @@ public:
       }
 
       auto expr = node.get<Expr *>();
-      if (wantExpr) {
-        if (builderSupports(ctx.Id_buildExpression)) {
-          expr = buildCallIfWanted(expr->getLoc(), ctx.Id_buildExpression,
-                                   { expr }, { Identifier() },
-                                   /*oneWay=*/false);
-        }
-
-        expr = new (ctx) OneWayExpr(expr);
+      if (cs && builderSupports(ctx.Id_buildExpression)) {
+        expr = buildCallIfWanted(expr->getLoc(), ctx.Id_buildExpression,
+                                 { expr }, { Identifier() });
       }
 
-      expressions.push_back(expr);
+      addChild(captureExpr(expr, /*oneWay=*/true, node.get<Expr *>()));
     }
 
+    if (!cs)
+      return nullptr;
+
     // Call Builder.buildBlock(... args ...)
-    return buildCallIfWanted(braceStmt->getStartLoc(),
-                             ctx.Id_buildBlock, expressions,
-                             /*argLabels=*/{ },
-                             /*oneWay=*/true);
+    auto call = buildCallIfWanted(braceStmt->getStartLoc(),
+                                  ctx.Id_buildBlock, expressions,
+                                  /*argLabels=*/{ });
+    if (!call)
+      return nullptr;
+
+    return captureExpr(call, /*oneWay=*/true, braceStmt);
   }
 
-  Expr *visitReturnStmt(ReturnStmt *stmt) {
+  VarDecl *visitReturnStmt(ReturnStmt *stmt) {
     // Allow implicit returns due to 'return' elision.
     if (!stmt->isImplicit() || !stmt->hasResult()) {
       if (!unhandledNode)
@@ -206,22 +297,27 @@ public:
       return nullptr;
     }
 
-    return stmt->getResult();
+    return captureExpr(stmt->getResult(), /*oneWay=*/true);
   }
 
-  Expr *visitDoStmt(DoStmt *doStmt) {
+  VarDecl *visitDoStmt(DoStmt *doStmt) {
     if (!builderSupports(ctx.Id_buildDo)) {
       if (!unhandledNode)
         unhandledNode = doStmt;
       return nullptr;
     }
 
-    auto arg = visit(doStmt->getBody());
-    if (!arg)
+    auto childVar = visit(doStmt->getBody());
+    if (!childVar)
       return nullptr;
 
-    return buildCallIfWanted(doStmt->getStartLoc(), ctx.Id_buildDo, arg,
-                             /*argLabels=*/{ }, /*oneWay=*/true);
+    auto childRef = buildVarRef(childVar, doStmt->getEndLoc());
+    auto call = buildCallIfWanted(doStmt->getStartLoc(), ctx.Id_buildDo,
+                                  childRef, /*argLabels=*/{ });
+    if (!call)
+      return nullptr;
+
+    return captureExpr(call, /*oneWay=*/true, doStmt);
   }
 
   CONTROL_FLOW_STMT(Yield)
@@ -283,7 +379,7 @@ public:
     return true;
   }
 
-  Expr *visitIfStmt(IfStmt *ifStmt) {
+  VarDecl *visitIfStmt(IfStmt *ifStmt) {
     // Check whether the chain is buildable and whether it terminates
     // without an `else`.
     bool isOptional = false;
@@ -296,74 +392,56 @@ public:
 
     // Attempt to build the chain, propagating short-circuits, which
     // might arise either do to error or not wanting an expression.
-    auto chainExpr =
-      buildIfChainRecursive(ifStmt, 0, numPayloads, isOptional);
-    if (!chainExpr)
-      return nullptr;
-    assert(wantExpr);
-
-    // The operand should have optional type if we had optional results,
-    // so we just need to call `buildIf` now, since we're at the top level.
-    if (isOptional) {
-      chainExpr = buildCallIfWanted(ifStmt->getStartLoc(),
-                                    ctx.Id_buildIf, chainExpr,
-                                    /*argLabels=*/{ },
-                                    /*oneWay=*/true);
-    } else {
-      // Form a one-way constraint to prevent backward propagation.
-      chainExpr = new (ctx) OneWayExpr(chainExpr);
-    }
-
-    return chainExpr;
+    return buildIfChainRecursive(ifStmt, 0, numPayloads, isOptional,
+                                 /*isTopLevel=*/true);
   }
 
   /// Recursively build an if-chain: build an expression which will have
   /// a value of the chain result type before any call to `buildIf`.
   /// The expression will perform any necessary calls to `buildEither`,
   /// and the result will have optional type if `isOptional` is true.
-  Expr *buildIfChainRecursive(IfStmt *ifStmt, unsigned payloadIndex,
-                              unsigned numPayloads, bool isOptional) {
+  VarDecl *buildIfChainRecursive(IfStmt *ifStmt, unsigned payloadIndex,
+                                 unsigned numPayloads, bool isOptional,
+                                 bool isTopLevel = false) {
     assert(payloadIndex < numPayloads);
     // Make sure we recursively visit both sides even if we're not
     // building expressions.
 
     // Build the then clause.  This will have the corresponding payload
     // type (i.e. not wrapped in any way).
-    Expr *thenArg = visit(ifStmt->getThenStmt());
+    VarDecl *thenVar = visit(ifStmt->getThenStmt());
 
     // Build the else clause, if present.  If this is from an else-if,
     // this will be fully wrapped; otherwise it will have the corresponding
     // payload type (at index `payloadIndex + 1`).
     assert(ifStmt->getElseStmt() || isOptional);
     bool isElseIf = false;
-    Optional<Expr *> elseChain;
+    Optional<VarDecl *> elseChainVar;
     if (auto elseStmt = ifStmt->getElseStmt()) {
       if (auto elseIfStmt = dyn_cast<IfStmt>(elseStmt)) {
         isElseIf = true;
-        elseChain = buildIfChainRecursive(elseIfStmt, payloadIndex + 1,
-                                          numPayloads, isOptional);
+        elseChainVar = buildIfChainRecursive(elseIfStmt, payloadIndex + 1,
+                                             numPayloads, isOptional);
       } else {
-        elseChain = visit(elseStmt);
+        elseChainVar = visit(elseStmt);
       }
     }
 
     // Short-circuit if appropriate.
-    if (!wantExpr || !thenArg || (elseChain && !*elseChain))
+    if (!cs || !thenVar || (elseChainVar && !*elseChainVar))
       return nullptr;
 
-    // Okay, build the conditional expression.
-
     // Prepare the `then` operand by wrapping it to produce a chain result.
-    SourceLoc thenLoc = ifStmt->getThenStmt()->getStartLoc();
-    Expr *thenExpr = buildWrappedChainPayload(thenArg, payloadIndex,
-                                              numPayloads, isOptional);
+    Expr *thenExpr = buildWrappedChainPayload(
+        buildVarRef(thenVar, ifStmt->getThenStmt()->getEndLoc()),
+        payloadIndex, numPayloads, isOptional);
 
     // Prepare the `else operand:
     Expr *elseExpr;
     SourceLoc elseLoc;
 
     // - If there's no `else` clause, use `Optional.none`.
-    if (!elseChain) {
+    if (!elseChainVar) {
       assert(isOptional);
       elseLoc = ifStmt->getEndLoc();
       elseExpr = buildNoneExpr(elseLoc);
@@ -371,24 +449,75 @@ public:
     // - If there's an `else if`, the chain expression from that
     //   should already be producing a chain result.
     } else if (isElseIf) {
-      elseExpr = *elseChain;
+      elseExpr = buildVarRef(*elseChainVar, ifStmt->getEndLoc());
       elseLoc = ifStmt->getElseLoc();
 
     // - Otherwise, wrap it to produce a chain result.
     } else {
       elseLoc = ifStmt->getElseLoc();
-      elseExpr = buildWrappedChainPayload(*elseChain,
-                                          payloadIndex + 1, numPayloads,
-                                          isOptional);
+      elseExpr = buildWrappedChainPayload(
+          buildVarRef(*elseChainVar, ifStmt->getEndLoc()),
+          payloadIndex + 1, numPayloads, isOptional);
     }
 
-    Expr *condition = getTrivialBooleanCondition(ifStmt->getCond());
-    assert(condition && "checked by isBuildableIfChain");
+    // Generate constraints for the various subexpressions.
+    auto condExpr = getTrivialBooleanCondition(ifStmt->getCond());
+    assert(condExpr && "Cannot get here without a trivial Boolean condition");
+    condExpr = cs->generateConstraints(condExpr, dc);
+    if (!condExpr) {
+      hadError = true;
+      return nullptr;
+    }
 
-    auto ifExpr = new (ctx) IfExpr(condition, thenLoc, thenExpr,
-                                   elseLoc, elseExpr);
-    ifExpr->setImplicit();
-    return ifExpr;
+    // Condition must convert to Bool.
+    // FIXME: This should be folded into constraint generation for conditions.
+    auto boolDecl = ctx.getBoolDecl();
+    if (!boolDecl) {
+      hadError = true;
+      return nullptr;
+    }
+    cs->addConstraint(ConstraintKind::Conversion,
+                      cs->getType(condExpr),
+                      boolDecl->getDeclaredType(),
+                      cs->getConstraintLocator(condExpr));
+
+    // The operand should have optional type if we had optional results,
+    // so we just need to call `buildIf` now, since we're at the top level.
+    if (isOptional && isTopLevel) {
+      thenExpr = buildCallIfWanted(ifStmt->getEndLoc(), ctx.Id_buildIf,
+                                   thenExpr,  /*argLabels=*/{ });
+      elseExpr = buildCallIfWanted(ifStmt->getEndLoc(), ctx.Id_buildIf,
+                                   elseExpr,  /*argLabels=*/{ });
+    }
+
+    thenExpr = cs->generateConstraints(thenExpr, dc);
+    if (!thenExpr) {
+      hadError = true;
+      return nullptr;
+    }
+
+    elseExpr = cs->generateConstraints(elseExpr, dc);
+    if (!elseExpr) {
+      hadError = true;
+      return nullptr;
+    }
+
+    // FIXME: Need a locator for the "if" statement.
+    Type resultType = cs->addJoinConstraint(nullptr,
+        {
+          { cs->getType(thenExpr), cs->getConstraintLocator(thenExpr) },
+          { cs->getType(elseExpr), cs->getConstraintLocator(elseExpr) }
+        });
+    if (!resultType) {
+      hadError = true;
+      return nullptr;
+    }
+
+    // Create a variable to capture the result of this expression.
+    auto ifVar = buildVar(ifStmt->getStartLoc());
+    cs->setType(ifVar, resultType);
+    applied.capturedStmts.insert({ifStmt, { ifVar, { thenExpr, elseExpr }}});
+    return ifVar;
   }
 
   /// Wrap a payload value in an expression which will produce a chain
@@ -431,8 +560,7 @@ public:
       bool isSecond = (path & 1);
       operand = buildCallIfWanted(operand->getStartLoc(),
                                   ctx.Id_buildEither, operand,
-                                  {isSecond ? ctx.Id_second : ctx.Id_first},
-                                  /*oneWay=*/false);
+                                  {isSecond ? ctx.Id_second : ctx.Id_first});
     }
 
     // Inject into Optional if required.  We'll be adding the call to
@@ -486,7 +614,367 @@ public:
 #undef CONTROL_FLOW_STMT
 };
 
+/// Describes the target into which the result of a particular statement in
+/// a closure involving a function builder should be written.
+struct FunctionBuilderTarget {
+  enum Kind {
+    /// The resulting value is returned from the closure.
+    ReturnValue,
+    /// The temporary variable into which the result should be assigned.
+    TemporaryVar,
+  } kind;
+
+  /// Captured variable information.
+  std::pair<VarDecl *, llvm::TinyPtrVector<Expr *>> captured;
+
+  static FunctionBuilderTarget forReturn(Expr *expr) {
+    return FunctionBuilderTarget{ReturnValue, {nullptr, {expr}}};
+  }
+
+  static FunctionBuilderTarget forAssign(VarDecl *temporaryVar,
+                                         llvm::TinyPtrVector<Expr *> exprs) {
+    return FunctionBuilderTarget{TemporaryVar, {temporaryVar, exprs}};
+  }
+};
+
+/// Handles the rewrite of the body of a closure to which a function builder
+/// has been applied.
+class BuilderClosureRewriter
+    : public StmtVisitor<BuilderClosureRewriter, Stmt *, FunctionBuilderTarget> {
+  ASTContext &ctx;
+  const Solution &solution;
+  DeclContext *dc;
+  AppliedBuilderTransform builderTransform;
+  std::function<Expr *(Expr *)> rewriteExpr;
+  std::function<Expr *(Expr *, Type, ConstraintLocator *)> coerceToType;
+
+  /// Retrieve the temporary variable that will be used to capture the
+  /// value of the given expression.
+  AppliedBuilderTransform::RecordedExpr takeCapturedExpr(Expr *expr) {
+    auto found = builderTransform.capturedExprs.find(expr);
+    assert(found != builderTransform.capturedExprs.end());
+
+    // Set the type of the temporary variable.
+    auto recorded = found->second;
+    if (auto temporaryVar = recorded.temporaryVar) {
+      Type type = solution.simplifyType(solution.getType(temporaryVar));
+      temporaryVar->setInterfaceType(type->mapTypeOutOfContext());
+    }
+
+    // Erase the captured expression, so we're sure we never do this twice.
+    builderTransform.capturedExprs.erase(found);
+    return recorded;
+  }
+
+public:
+  /// Retrieve information about a captured statement.
+  std::pair<VarDecl *, llvm::TinyPtrVector<Expr *>>
+  takeCapturedStmt(Stmt *stmt) {
+    auto found = builderTransform.capturedStmts.find(stmt);
+    assert(found != builderTransform.capturedStmts.end());
+
+    // Set the type of the temporary variable.
+    auto temporaryVar = found->second.first;
+    Type type = solution.simplifyType(solution.getType(temporaryVar));
+    temporaryVar->setInterfaceType(type->mapTypeOutOfContext());
+
+    // Take the expressions.
+    auto exprs = std::move(found->second.second);
+
+    // Erase the statement, so we're sure we never do this twice.
+    builderTransform.capturedStmts.erase(found);
+    return std::make_pair(temporaryVar, std::move(exprs));
+  }
+
+private:
+  /// Build the statement or expression to initialize the target.
+  ASTNode initializeTarget(FunctionBuilderTarget target) {
+    assert(target.captured.second.size() == 1);
+    auto capturedExpr = target.captured.second.front();
+    auto finalCapturedExpr = rewriteExpr(capturedExpr);
+    SourceLoc implicitLoc = capturedExpr->getEndLoc();
+    switch (target.kind) {
+    case FunctionBuilderTarget::ReturnValue: {
+      // Return the expression.
+      ConstraintSystem &cs = solution.getConstraintSystem();
+      Type bodyResultType =
+          solution.simplifyType(builderTransform.bodyResultType);
+      finalCapturedExpr = coerceToType(
+          finalCapturedExpr,
+          bodyResultType,
+          cs.getConstraintLocator(capturedExpr));
+      return new (ctx) ReturnStmt(implicitLoc, finalCapturedExpr);
+    }
+
+    case FunctionBuilderTarget::TemporaryVar: {
+      // Assign the expression into a variable.
+      auto temporaryVar = target.captured.first;
+      auto declRef = new (ctx) DeclRefExpr(
+          temporaryVar, DeclNameLoc(implicitLoc), /*implicit=*/true);
+      declRef->setType(LValueType::get(temporaryVar->getType()));
+
+      // Load the right-hand side if needed.
+      if (finalCapturedExpr->getType()->is<LValueType>()) {
+        auto &cs = solution.getConstraintSystem();
+        finalCapturedExpr = cs.addImplicitLoadExpr(finalCapturedExpr);
+      }
+
+      auto assign = new (ctx) AssignExpr(
+          declRef, implicitLoc, finalCapturedExpr, /*implicit=*/true);
+      assign->setType(TupleType::getEmpty(ctx));
+      return assign;
+    }
+    }
+  }
+
+  /// Declare the given temporary variable, adding the appropriate
+  /// entries to the elements of a brace stmt.
+  void declareTemporaryVariable(VarDecl *temporaryVar,
+                                std::vector<ASTNode> &elements) {
+    if (!temporaryVar)
+      return;
+
+    // Form a new pattern binding to bind the temporary variable to the
+    // transformed expression.
+    auto pattern = new (ctx) NamedPattern(temporaryVar,/*implicit=*/true);
+    pattern->setType(temporaryVar->getType());
+
+    auto pbd = PatternBindingDecl::createImplicit(ctx, StaticSpellingKind::None, pattern, nullptr, dc);
+    elements.push_back(temporaryVar);
+    elements.push_back(pbd);
+  }
+
+public:
+  BuilderClosureRewriter(
+      const Solution &solution,
+      DeclContext *dc,
+      const AppliedBuilderTransform &builderTransform,
+      std::function<Expr *(Expr *)> rewriteExpr,
+      std::function<Expr *(Expr *, Type, ConstraintLocator *)> coerceToType
+    ) : ctx(solution.getConstraintSystem().getASTContext()),
+        solution(solution), dc(dc), builderTransform(builderTransform),
+        rewriteExpr(rewriteExpr),
+        coerceToType(coerceToType){ }
+
+  Stmt *visitBraceStmt(BraceStmt *braceStmt, FunctionBuilderTarget target,
+                       Optional<FunctionBuilderTarget> innerTarget = None) {
+    std::vector<ASTNode> newElements;
+
+    // If there is an "inner" target corresponding to this brace, declare
+    // it's temporary variable if needed.
+    if (innerTarget) {
+      declareTemporaryVariable(innerTarget->captured.first, newElements);
+    }
+
+    for (auto node : braceStmt->getElements()) {
+      // Implicit returns in single-expression function bodies are treated
+      // as the expression.
+      if (auto returnStmt =
+              dyn_cast_or_null<ReturnStmt>(node.dyn_cast<Stmt *>())) {
+        assert(returnStmt->isImplicit());
+        node = returnStmt->getResult();
+      }
+
+      if (auto expr = node.dyn_cast<Expr *>()) {
+        // Skip error expressions.
+        if (isa<ErrorExpr>(expr))
+          continue;
+
+        // Each expression turns into a 'let' that captures the value of
+        // the expression.
+        auto recorded = takeCapturedExpr(expr);
+
+        // Rewrite the expression
+        Expr *finalExpr = rewriteExpr(recorded.generatedExpr);
+
+        // Form a new pattern binding to bind the temporary variable to the
+        // transformed expression.
+        auto pattern = new (ctx) NamedPattern(
+            recorded.temporaryVar, /*implicit=*/true);
+        pattern->setType(recorded.temporaryVar->getType());
+        newElements.push_back(recorded.temporaryVar);
+
+        auto pbd = PatternBindingDecl::createImplicit(ctx, StaticSpellingKind::None, pattern, finalExpr, dc);
+        newElements.push_back(pbd);
+        continue;
+      }
+
+      if (auto stmt = node.dyn_cast<Stmt *>()) {
+        // Each statement turns into a (potential) temporary variable
+        // binding followed by the statement itself.
+        auto captured = takeCapturedStmt(stmt);
+
+        declareTemporaryVariable(captured.first, newElements);
+
+        Stmt *finalStmt = visit(
+            stmt,
+            FunctionBuilderTarget{FunctionBuilderTarget::TemporaryVar,
+                                  std::move(captured)});
+        newElements.push_back(finalStmt);
+        continue;
+      }
+
+      auto decl = node.get<Decl *>();
+
+      // Skip #if declarations.
+      if (isa<IfConfigDecl>(decl))
+        continue;
+
+      // Diagnose #warning / #error during application.
+      if (auto poundDiag = dyn_cast<PoundDiagnosticDecl>(decl)) {
+        TypeChecker::typeCheckDecl(poundDiag);
+        continue;
+      }
+
+      llvm_unreachable("Cannot yet handle declarations");
+    }
+
+    // If there is an "inner" target corresponding to this brace, initialize
+    // it.
+    if (innerTarget) {
+      newElements.push_back(initializeTarget(*innerTarget));
+    }
+
+    // Capture the result of the buildBlock() call in the manner requested
+    // by the caller.
+    newElements.push_back(initializeTarget(target));
+
+    return BraceStmt::create(ctx, braceStmt->getLBraceLoc(), newElements,
+                             braceStmt->getRBraceLoc());
+  }
+
+  Stmt *visitIfStmt(IfStmt *ifStmt, FunctionBuilderTarget target) {
+    // Rewrite the condition.
+    // FIXME: We should handle the whole condition within the type system.
+    auto cond = ifStmt->getCond();
+    auto condExpr = cond.front().getBoolean();
+    auto finalCondExpr = rewriteExpr(condExpr);
+
+    // Load the condition if needed.
+    if (finalCondExpr->getType()->is<LValueType>()) {
+      auto &cs = solution.getConstraintSystem();
+      finalCondExpr = cs.addImplicitLoadExpr(finalCondExpr);
+    }
+
+    cond.front().setBoolean(finalCondExpr);
+    ifStmt->setCond(cond);
+
+    assert(target.kind == FunctionBuilderTarget::TemporaryVar);
+    auto temporaryVar = target.captured.first;
+
+    // Translate the "then" branch.
+    auto capturedThen = takeCapturedStmt(ifStmt->getThenStmt());
+    auto newThen = visitBraceStmt(cast<BraceStmt>(ifStmt->getThenStmt()),
+          FunctionBuilderTarget::forAssign(
+            temporaryVar, {target.captured.second[0]}),
+          FunctionBuilderTarget::forAssign(
+            capturedThen.first, {capturedThen.second.front()}));
+    ifStmt->setThenStmt(newThen);
+
+    if (auto elseBraceStmt =
+            dyn_cast_or_null<BraceStmt>(ifStmt->getElseStmt())) {
+      // Translate the "else" branch when it's a stmt-brace.
+      auto capturedElse = takeCapturedStmt(elseBraceStmt);
+      Stmt *newElse = visitBraceStmt(
+          elseBraceStmt,
+          FunctionBuilderTarget::forAssign(
+            temporaryVar, {target.captured.second[1]}),
+          FunctionBuilderTarget::forAssign(
+            capturedElse.first, {capturedElse.second.front()}));
+      ifStmt->setElseStmt(newElse);
+    } else if (auto elseIfStmt = cast_or_null<IfStmt>(ifStmt->getElseStmt())){
+      // Translate the "else" branch when it's an else-if.
+      auto capturedElse = takeCapturedStmt(elseIfStmt);
+      std::vector<ASTNode> newElseElements;
+      declareTemporaryVariable(capturedElse.first, newElseElements);
+      newElseElements.push_back(
+          visitIfStmt(
+            elseIfStmt,
+            FunctionBuilderTarget::forAssign(
+              capturedElse.first, capturedElse.second)));
+      newElseElements.push_back(
+          initializeTarget(
+            FunctionBuilderTarget::forAssign(
+              temporaryVar, {target.captured.second[1]})));
+
+      Stmt *newElse = BraceStmt::create(
+          ctx, elseIfStmt->getStartLoc(), newElseElements,
+          elseIfStmt->getEndLoc());
+      ifStmt->setElseStmt(newElse);
+    } else {
+      // Form an "else" brace containing an assignment to the temporary
+      // variable.
+      auto init = initializeTarget(
+          FunctionBuilderTarget::forAssign(
+            temporaryVar, {target.captured.second[1]}));
+      auto newElse = BraceStmt::create(
+          ctx, ifStmt->getEndLoc(), { init }, ifStmt->getEndLoc());
+      ifStmt->setElseStmt(newElse);
+    }
+
+    return ifStmt;
+  }
+
+  Stmt *visitDoStmt(DoStmt *doStmt, FunctionBuilderTarget target) {
+    // Each statement turns into a (potential) temporary variable
+    // binding followed by the statement itself.
+    auto body = cast<BraceStmt>(doStmt->getBody());
+    auto captured = takeCapturedStmt(body);
+
+    auto newInnerBody = cast<BraceStmt>(
+        visitBraceStmt(
+          body,
+          target,
+          FunctionBuilderTarget::forAssign(
+            captured.first, {captured.second.front()})));
+    doStmt->setBody(newInnerBody);
+    return doStmt;
+  }
+
+#define UNHANDLED_FUNCTION_BUILDER_STMT(STMT) \
+  Stmt *visit##STMT##Stmt(STMT##Stmt *stmt, FunctionBuilderTarget target) { \
+    llvm_unreachable("Function builders do not allow statement of kind " \
+                     #STMT); \
+  }
+
+  UNHANDLED_FUNCTION_BUILDER_STMT(Return)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Yield)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Guard)
+  UNHANDLED_FUNCTION_BUILDER_STMT(While)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Defer)
+  UNHANDLED_FUNCTION_BUILDER_STMT(DoCatch)
+  UNHANDLED_FUNCTION_BUILDER_STMT(RepeatWhile)
+  UNHANDLED_FUNCTION_BUILDER_STMT(ForEach)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Switch)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Case)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Catch)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Break)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Continue)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Fallthrough)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Fail)
+  UNHANDLED_FUNCTION_BUILDER_STMT(Throw)
+  UNHANDLED_FUNCTION_BUILDER_STMT(PoundAssert)
+#undef UNHANDLED_FUNCTION_BUILDER_STMT
+};
+
 } // end anonymous namespace
+
+BraceStmt *swift::applyFunctionBuilderTransform(
+    const Solution &solution,
+    AppliedBuilderTransform applied,
+    BraceStmt *body,
+    DeclContext *dc,
+    std::function<Expr *(Expr *)> rewriteExpr,
+    std::function<Expr *(Expr *, Type, ConstraintLocator *)> coerceToType) {
+  BuilderClosureRewriter rewriter(solution, dc, applied, rewriteExpr, coerceToType);
+  auto captured = rewriter.takeCapturedStmt(body);
+  return cast<BraceStmt>(
+    rewriter.visitBraceStmt(
+      body,
+      FunctionBuilderTarget::forReturn(applied.returnExpr),
+      FunctionBuilderTarget::forAssign(
+        captured.first, captured.second)));
+}
 
 /// Find the return statements in the given body, which block the application
 /// of a function builder.
@@ -502,15 +990,15 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
   auto &ctx = func->getASTContext();
   auto request = PreCheckFunctionBuilderRequest{func};
   switch (evaluateOrDefault(
-              ctx.evaluator, request, FunctionBuilderClosurePreCheck::Error)) {
-  case FunctionBuilderClosurePreCheck::Okay:
+              ctx.evaluator, request, FunctionBuilderBodyPreCheck::Error)) {
+  case FunctionBuilderBodyPreCheck::Okay:
     // If the pre-check was okay, apply the function-builder transform.
     break;
 
-  case FunctionBuilderClosurePreCheck::Error:
+  case FunctionBuilderBodyPreCheck::Error:
     return nullptr;
 
-  case FunctionBuilderClosurePreCheck::HasReturnStmt: {
+  case FunctionBuilderBodyPreCheck::HasReturnStmt: {
     // One or more explicit 'return' statements were encountered, which
     // disables the function builder transform. Warn when we do this.
     auto returnStmts = findReturnStatements(func);
@@ -527,7 +1015,7 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
         attr = accessor->getStorage()->getAttachedFunctionBuilder();
       }
     }
-    
+
     if (attr) {
       ctx.Diags.diagnose(
           attr->getLocation(), diag::function_builder_remove_attr)
@@ -566,11 +1054,33 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
   // Build a constraint system in which we can check the body of the function.
   ConstraintSystem cs(func, options);
 
+  // Find an expression... any expression... to use for a locator.
+  // FIXME: This is a hack because we don't have the notion of locators that
+  // refer to statements.
+  Expr *fakeAnchor = nullptr;
+  {
+    class FindExprWalker : public ASTWalker {
+      Expr *&fakeAnchor;
+
+    public:
+      explicit FindExprWalker(Expr *&fakeAnchor) : fakeAnchor(fakeAnchor) { }
+
+      std::pair<bool, Expr *> walkToExprPre(Expr *E) {
+        if (!fakeAnchor)
+          fakeAnchor = E;
+
+        return { false, nullptr };
+      }
+    } walker(fakeAnchor);
+
+    func->getBody()->walk(walker);
+  }
+
   // FIXME: check the result
   cs.matchFunctionBuilder(func, builderType, resultContextType,
                           resultConstraintKind,
-                          /*calleeLocator=*/nullptr,
-                          /*FIXME:*/ConstraintLocatorBuilder(nullptr));
+                          /*calleeLocator=*/cs.getConstraintLocator(fakeAnchor),
+                          /*FIXME:*/cs.getConstraintLocator(fakeAnchor));
 
   // Solve the constraint system.
   SmallVector<Solution, 4> solutions;
@@ -619,32 +1129,32 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionBuilder(
   // for return statements.
   auto request = PreCheckFunctionBuilderRequest{fn};
   switch (evaluateOrDefault(getASTContext().evaluator, request,
-                            FunctionBuilderClosurePreCheck::Error)) {
-  case FunctionBuilderClosurePreCheck::Okay:
+                            FunctionBuilderBodyPreCheck::Error)) {
+  case FunctionBuilderBodyPreCheck::Okay:
     // If the pre-check was okay, apply the function-builder transform.
     break;
 
-  case FunctionBuilderClosurePreCheck::Error:
+  case FunctionBuilderBodyPreCheck::Error:
     // If the pre-check had an error, flag that.
     return getTypeMatchFailure(locator);
 
-  case FunctionBuilderClosurePreCheck::HasReturnStmt:
-    // If the closure has a return statement, suppress the transform but
+  case FunctionBuilderBodyPreCheck::HasReturnStmt:
+    // If the body has a return statement, suppress the transform but
     // continue solving the constraint system.
     return getTypeMatchSuccess();
   }
 
-  // Check the form of this closure to see if we can apply the
+  // Check the form of this body to see if we can apply the
   // function-builder translation at all.
+  auto dc = fn.getAsDeclContext();
   {
     // Check whether we can apply this specific function builder.
-    BuilderClosureVisitor visitor(getASTContext(), this,
-                                  /*wantExpr=*/false, builderType);
-    (void)visitor.visit(fn.getBody());
+    BuilderClosureVisitor visitor(getASTContext(), nullptr, dc, builderType,
+                                  bodyResultType);
 
     // If we saw a control-flow statement or declaration that the builder
     // cannot handle, we don't have a well-formed function builder application.
-    if (visitor.unhandledNode) {
+    if (auto unhandledNode = visitor.check(fn.getBody())) {
       // If we aren't supposed to attempt fixes, fail.
       if (!shouldAttemptFixes()) {
         return getTypeMatchFailure(locator);
@@ -653,7 +1163,7 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionBuilder(
       // Record the first unhandled construct as a fix.
       if (recordFix(
               SkipUnhandledConstructInFunctionBuilder::create(
-                *this, visitor.unhandledNode, builder,
+                *this, unhandledNode, builder,
                 getConstraintLocator(locator)))) {
         return getTypeMatchFailure(locator);
       }
@@ -676,24 +1186,14 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionBuilder(
     assert(!builderType->hasTypeParameter());
   }
 
-  BuilderClosureVisitor visitor(getASTContext(), this,
-                                /*wantExpr=*/true, builderType);
-  Expr *singleExpr = visitor.visit(fn.getBody());
+  BuilderClosureVisitor visitor(getASTContext(), this, dc, builderType,
+                                bodyResultType);
 
-  // We've already pre-checked all the original expressions, but do the
-  // pre-check to the generated expression just to set up any preconditions
-  // that CSGen might have.
-  //
-  // TODO: just build the AST the way we want it in the first place.
-  auto dc = fn.getAsDeclContext();
-  if (ConstraintSystem::preCheckExpression(singleExpr, dc))
+  auto applied = visitor.apply(fn.getBody());
+  if (!applied)
     return getTypeMatchFailure(locator);
 
-  singleExpr = generateConstraints(singleExpr, dc);
-  if (!singleExpr)
-    return getTypeMatchFailure(locator);
-
-  Type transformedType = getType(singleExpr);
+  Type transformedType = getType(applied->returnExpr);
   assert(transformedType && "Missing type");
 
   // Record the transformation.
@@ -703,11 +1203,9 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionBuilder(
       [&](const std::pair<AnyFunctionRef, AppliedBuilderTransform> &elt) {
         return elt.first == fn;
       }) == functionBuilderTransformed.end() &&
-         "already transformed this closure along this path!?!");
+         "already transformed this body along this path!?!");
   functionBuilderTransformed.push_back(
-      std::make_pair(
-        fn,
-        AppliedBuilderTransform{builderType, singleExpr, bodyResultType}));
+      std::make_pair(fn, std::move(*applied)));
 
   // If builder is applied to the closure expression then
   // `closure body` to `closure result` matching should
@@ -723,7 +1221,7 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionBuilder(
 
 namespace {
 
-/// Pre-check all the expressions in the closure body.
+/// Pre-check all the expressions in the body.
 class PreCheckFunctionBuilderApplication : public ASTWalker {
   AnyFunctionRef Fn;
   bool SkipPrecheck = false;
@@ -738,7 +1236,7 @@ public:
 
   const std::vector<ReturnStmt *> getReturnStmts() const { return ReturnStmts; }
 
-  FunctionBuilderClosurePreCheck run() {
+  FunctionBuilderBodyPreCheck run() {
     Stmt *oldBody = Fn.getBody();
 
     Stmt *newBody = oldBody->walk(*this);
@@ -747,14 +1245,14 @@ public:
     assert((newBody == nullptr) == HasError &&
            "unexpected short-circuit while walking body");
     if (HasError)
-      return FunctionBuilderClosurePreCheck::Error;
+      return FunctionBuilderBodyPreCheck::Error;
 
     if (hasReturnStmt())
-      return FunctionBuilderClosurePreCheck::HasReturnStmt;
+      return FunctionBuilderBodyPreCheck::HasReturnStmt;
 
     assert(oldBody == newBody && "pre-check walk wasn't in-place?");
 
-    return FunctionBuilderClosurePreCheck::Okay;
+    return FunctionBuilderBodyPreCheck::Okay;
   }
 
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
@@ -786,13 +1284,13 @@ public:
 
 }
 
-llvm::Expected<FunctionBuilderClosurePreCheck>
+llvm::Expected<FunctionBuilderBodyPreCheck>
 PreCheckFunctionBuilderRequest::evaluate(Evaluator &eval,
                                          AnyFunctionRef fn) const {
   // Single-expression closures should already have been pre-checked.
   if (auto closure = fn.getAbstractClosureExpr()) {
     if (closure->hasSingleExpressionBody())
-      return FunctionBuilderClosurePreCheck::Okay;
+      return FunctionBuilderBodyPreCheck::Okay;
   }
 
   return PreCheckFunctionBuilderApplication(fn, false).run();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4596,6 +4596,14 @@ namespace {
       return result;
     }
 
+    const AppliedBuilderTransform *getAppliedBuilderTransform(
+       AnyFunctionRef fn) {
+      auto known = solution.functionBuilderTransformed.find(fn);
+      return known != solution.functionBuilderTransformed.end()
+          ? &known->second
+          : nullptr;
+    }
+
     void finalize() {
       assert(ExprStack.empty());
       assert(OpenedExistentials.empty());
@@ -5767,10 +5775,10 @@ Expr *ExprRewriter::buildObjCBridgeExpr(Expr *expr, Type toType,
   return forceBridgeFromObjectiveC(expr, toType);
 }
 
-static Expr *addImplicitLoadExpr(ConstraintSystem &cs, Expr *expr) {
+Expr *ConstraintSystem::addImplicitLoadExpr(Expr *expr) {
   return TypeChecker::addImplicitLoadExpr(
-      cs.getASTContext(), expr, [&cs](Expr *expr) { return cs.getType(expr); },
-      [&cs](Expr *expr, Type type) { cs.setType(expr, type); });
+      getASTContext(), expr, [this](Expr *expr) { return getType(expr); },
+      [this](Expr *expr, Type type) { setType(expr, type); });
 }
 
 Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
@@ -6027,7 +6035,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     auto fromLValue = cast<LValueType>(desugaredFromType);
     auto toIO = toType->getAs<InOutType>();
     if (!toIO)
-      return coerceToType(addImplicitLoadExpr(cs, expr), toType, locator);
+      return coerceToType(cs.addImplicitLoadExpr(expr), toType, locator);
 
     // In an 'inout' operator like "i += 1", the operand is converted from
     // an implicit lvalue to an inout argument.
@@ -7043,30 +7051,36 @@ namespace {
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         Rewriter.simplifyExprType(expr);
         auto &cs = Rewriter.getConstraintSystem();
-        auto &ctx = cs.getASTContext();
 
         // Coerce the pattern, in case we resolved something.
         auto fnType = cs.getType(closure)->castTo<FunctionType>();
         auto *params = closure->getParameters();
         TypeChecker::coerceParameterListToType(params, closure, fnType);
 
-        // If this closure had a function builder applied, rewrite it to a
-        // closure with a single expression body containing the builder
-        // invocations.
-        auto builder = Rewriter.solution.functionBuilderTransformed.find(closure);
-        if (builder != Rewriter.solution.functionBuilderTransformed.end()) {
-          auto singleExpr = builder->second.singleExpr;
-          auto returnStmt = new (ctx) ReturnStmt(
-             singleExpr->getStartLoc(), singleExpr, /*implicit=*/true);
-          auto braceStmt = BraceStmt::create(
-              ctx, returnStmt->getStartLoc(), ASTNode(returnStmt),
-              returnStmt->getEndLoc(), /*implicit=*/true);
-          closure->setBody(braceStmt, /*isSingleExpression=*/true);
-        }
+        if (auto transform =
+                       Rewriter.getAppliedBuilderTransform(closure)) {
+          // Apply the function builder to the closure. We want to be in the
+          // context of the closure for subsequent transforms.
+          llvm::SaveAndRestore<DeclContext *> savedDC(Rewriter.dc, closure);
+          auto newBody = applyFunctionBuilderTransform(
+              Rewriter.solution, *transform, closure->getBody(), closure,
+              [&](Expr *expr) {
+                Expr *result = expr->walk(*this);
+                if (result)
+                  Rewriter.solution.setExprTypes(result);
+                return result;
+              },
+              [&](Expr *expr, Type toType, ConstraintLocator *locator) {
+                return Rewriter.coerceToType(expr, toType, locator);
+              });
+          closure->setBody(newBody, /*isSingleExpression=*/false);
+          closure->setAppliedFunctionBuilder();
 
-        // If this is a single-expression closure, convert the expression
-        // in the body to the result type of the closure.
-        if (closure->hasSingleExpressionBody()) {
+          Rewriter.solution.setExprTypes(closure);
+        } else if (closure->hasSingleExpressionBody()) {
+          // If this is a single-expression closure, convert the expression
+          // in the body to the result type of the closure.
+
           // Enter the context of the closure when type-checking the body.
           llvm::SaveAndRestore<DeclContext *> savedDC(Rewriter.dc, closure);
           Expr *body = closure->getSingleExpressionBody()->walk(*this);
@@ -7254,27 +7268,25 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
     auto fn = *target.getAsFunction();
 
     // Dig out the function builder transformation we applied.
-    auto transformed = solution.functionBuilderTransformed.find(fn);
-    assert(transformed != solution.functionBuilderTransformed.end());
+    auto transform = rewriter.getAppliedBuilderTransform(fn);
+    assert(transform);
 
-    auto singleExpr = transformed->second.singleExpr;
-    singleExpr = singleExpr->walk(walker);
-    if (!singleExpr)
+    auto newBody = applyFunctionBuilderTransform(
+        solution, *transform, fn.getBody(), fn.getAsDeclContext(),
+        [&](Expr *expr) {
+          Expr *result = expr->walk(walker);
+          if (result)
+            solution.setExprTypes(result);
+          return result;
+        },
+        [&](Expr *expr, Type toType, ConstraintLocator *locator) {
+          return rewriter.coerceToType(expr, toType, locator);
+        });
+
+    if (!newBody)
       return result;
 
-    singleExpr = rewriter.coerceToType(singleExpr,
-                                       transformed->second.bodyResultType,
-                                       getConstraintLocator(singleExpr));
-    if (!singleExpr)
-      return result;
-
-    ASTContext &ctx = getASTContext();
-    auto returnStmt = new (ctx) ReturnStmt(
-       singleExpr->getStartLoc(), singleExpr, /*implicit=*/true);
-    auto braceStmt = BraceStmt::create(
-        ctx, returnStmt->getStartLoc(), ASTNode(returnStmt),
-        returnStmt->getEndLoc(), /*implicit=*/false);
-    result = braceStmt;
+    result = newBody;
   }
 
   if (result.isNull())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1005,7 +1005,7 @@ void MissingOptionalUnwrapFailure::offerDefaultValueUnwrapFixIt(
   // If anchor is n explicit address-of, or expression which produces
   // an l-value (e.g. first argument of `+=` operator), let's not
   // suggest default value here because that would produce r-value type.
-  if (isa<InOutExpr>(anchor))
+  if (!anchor || isa<InOutExpr>(anchor))
     return;
 
   auto &cs = getConstraintSystem();

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1323,17 +1323,60 @@ namespace {
     }
 
     Type visitDeclRefExpr(DeclRefExpr *E) {
-      // If this is a ParamDecl for a closure argument that has an Unresolved
-      // type, then this is a situation where CSDiags is trying to perform
-      // error recovery within a ClosureExpr.  Just create a new type variable
-      // for the decl that isn't bound to anything.  This will ensure that it
-      // is considered ambiguous.
+      auto locator = CS.getConstraintLocator(E);
+
+      Type knownType;
       if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
-        if (VD->hasInterfaceType() &&
-            VD->getInterfaceType()->is<UnresolvedType>()) {
-          return CS.createTypeVariable(CS.getConstraintLocator(E),
-                                       TVO_CanBindToLValue |
-                                       TVO_CanBindToNoEscape);
+        knownType = CS.getTypeIfAvailable(VD);
+        if (!knownType &&
+            !(isa<ParamDecl>(VD) &&
+              isa<ClosureExpr>(VD->getDeclContext()) &&
+              CS.Options.contains(
+                ConstraintSystemFlags::SubExpressionDiagnostics)))
+          knownType = VD->getInterfaceType();
+
+        if (knownType) {
+          // If this is a ParamDecl for a closure argument that is a hole,
+          // then this is a situation where CSDiags is trying to perform
+          // error recovery within a ClosureExpr.  Just create a new type
+          // variable for the decl that isn't bound to anything.
+          // This will ensure that it is considered ambiguous.
+          if (knownType && knownType->isHole()) {
+            return CS.createTypeVariable(locator,
+                                         TVO_CanBindToLValue |
+                                         TVO_CanBindToNoEscape);
+          }
+
+          // If the known type has an error, bail out.
+          if (knownType->hasError()) {
+            if (!CS.hasType(E))
+              CS.setType(E, knownType);
+            return nullptr;
+          }
+
+          // Set the favored type for this expression to the known type.
+          if (knownType->hasTypeParameter())
+            knownType = VD->getDeclContext()->mapTypeIntoContext(knownType);
+          CS.setFavoredType(E, knownType.getPointer());
+        }
+
+        // This can only happen when failure diagnostics is trying
+        // to type-check expressions inside of a single-statement
+        // closure which refer to anonymous parameters, in this case
+        // let's either use type as written or allocate a fresh type
+        // variable, just like we do for closure type.
+        // FIXME: We should eliminate this case.
+        if (auto *PD = dyn_cast<ParamDecl>(VD)) {
+          if (!CS.hasType(PD)) {
+            if (knownType && knownType->hasUnboundGenericType())
+              knownType = CS.openUnboundGenericType(knownType, locator);
+
+            CS.setType(
+                PD, knownType ? knownType
+                         : CS.createTypeVariable(locator,
+                                                 TVO_CanBindToLValue |
+                                                 TVO_CanBindToNoEscape));
+          }
         }
       }
 
@@ -1342,42 +1385,9 @@ namespace {
       // FIXME: If the decl is in error, we get no information from this.
       // We may, alternatively, want to use a type variable in that case,
       // and possibly infer the type of the variable that way.
-      auto oldInterfaceTy = E->getDecl()->getInterfaceType();
-      if (E->getDecl()->isInvalid()) {
-        CS.setType(E, oldInterfaceTy);
+      if (!knownType && E->getDecl()->isInvalid()) {
+        CS.setType(E, E->getDecl()->getInterfaceType());
         return nullptr;
-      }
-
-      auto locator = CS.getConstraintLocator(E);
-
-      // If this is a 'var' or 'let' declaration with already
-      // resolved type, let's favor it.
-      if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
-        Type type;
-        if (VD->hasInterfaceType()) {
-          type = VD->getInterfaceType();
-          if (type->hasTypeParameter())
-            type = VD->getDeclContext()->mapTypeIntoContext(type);
-          CS.setFavoredType(E, type.getPointer());
-        }
-
-        // This can only happen when failure diangostics is trying
-        // to type-check expressions inside of a single-statement
-        // closure which refer to anonymous parameters, in this case
-        // let's either use type as written or allocate a fresh type
-        // variable, just like we do for closure type.
-        if (auto *PD = dyn_cast<ParamDecl>(VD)) {
-          if (!CS.hasType(PD)) {
-            if (type && type->hasUnboundGenericType())
-              type = CS.openUnboundGenericType(type, locator);
-
-            CS.setType(
-                PD, type ? type
-                         : CS.createTypeVariable(locator,
-                                                 TVO_CanBindToLValue |
-                                                 TVO_CanBindToNoEscape));
-          }
-        }
       }
 
       // Create an overload choice referencing this declaration and immediately

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -165,18 +165,13 @@ Solution ConstraintSystem::finalize() {
                                        DefaultedConstraints.end());
 
   for (auto &nodeType : addedNodeTypes) {
-    solution.addedNodeTypes.push_back(nodeType);
+    solution.addedNodeTypes.insert(nodeType);
   }
 
   for (auto &e : CheckedConformances)
     solution.Conformances.push_back({e.first, e.second});
 
   for (const auto &transformed : functionBuilderTransformed) {
-    auto known =
-        solution.functionBuilderTransformed.find(transformed.first);
-    if (known != solution.functionBuilderTransformed.end()) {
-      assert(known->second.singleExpr == transformed.second.singleExpr);
-    }
     solution.functionBuilderTransformed.insert(transformed);
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -938,8 +938,8 @@ Type ConstraintSystem::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
   return TypeChecker::getUnopenedTypeOfReference(
       value, baseType, UseDC,
       [&](VarDecl *var) -> Type {
-        if (auto *param = dyn_cast<ParamDecl>(var))
-          return getType(param);
+        if (Type type = getTypeIfAvailable(var))
+          return type;
 
         if (!var->hasInterfaceType()) {
           return ErrorType::get(getASTContext());
@@ -3653,13 +3653,14 @@ ConstraintSystem::getFunctionArgApplyInfo(ConstraintLocator *locator) {
       assert(!shouldHaveDirectCalleeOverload(call) &&
              "Should we have resolved a callee for this?");
       rawFnType = getType(call->getFn());
-    } else {
+    } else if (auto *apply = dyn_cast<ApplyExpr>(anchor)) {
       // FIXME: ArgumentMismatchFailure is currently used from CSDiag, meaning
       // we can end up a BinaryExpr here with an unresolved callee. It should be
       // possible to remove this once we've gotten rid of the old CSDiag logic
       // and just assert that we have a CallExpr.
-      auto *apply = cast<ApplyExpr>(anchor);
       rawFnType = getType(apply->getFn());
+    } else {
+      return None;
     }
   }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -144,10 +144,10 @@ namespace {
           }
         }
 
-        // If the closure has a single expression body, we need to walk into it
-        // with a new sequence.  Otherwise, it'll have been separately
-        // type-checked.
-        if (CE->hasSingleExpressionBody())
+        // If the closure has a single expression body or has had a function
+        // builder applied to it, we need to walk into it with a new sequence.
+        // Otherwise, it'll have been separately type-checked.
+        if (CE->hasSingleExpressionBody() || CE->hasAppliedFunctionBuilder())
           CE->getBody()->walk(ContextualizeClosures(CE));
 
         TypeChecker::computeCaptures(CE);

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -352,14 +352,20 @@ func acceptComponentBuilder(@ComponentBuilder _ body: () -> Component) {
   print(body())
 }
 
+func colorWithAutoClosure(_ color: @autoclosure () -> Color) -> Color {
+  return color()
+}
+
+var trueValue = true
 acceptComponentBuilder {
   "hello"
-  if true {
+  if trueValue {
     3.14159
+    colorWithAutoClosure(.red)
   }
   .red
 }
-// CHECK: array([main.Component.string("hello"), main.Component.optional(Optional(main.Component.array([main.Component.floating(3.14159)]))), main.Component.color(main.Color.red)])
+// CHECK: array([main.Component.string("hello"), main.Component.optional(Optional(main.Component.array([main.Component.floating(3.14159), main.Component.color(main.Color.red)]))), main.Component.color(main.Color.red)])
 
 // rdar://53325810
 

--- a/test/Constraints/function_builder_one_way.swift
+++ b/test/Constraints/function_builder_one_way.swift
@@ -49,17 +49,16 @@ func tuplify<C: Collection, T>(_ collection: C, @TupleBuilder body: (C.Element) 
 }
 
 // CHECK: ---Connected components---
-// CHECK-NEXT: 0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T10 $T11 $T69 depends on 1
-// CHECK-NEXT: 1: $T12 $T14 $T19 $T30 $T62 $T63 $T64 $T65 $T66 $T67 $T68 depends on 2, 3, 4, 5
-// CHECK-NEXT: 5: $T32 $T43 $T44 $T45 $T46 $T47 $T57 $T58 $T59 $T60 $T61 depends on 6, 9
-// CHECK-NEXT: 9: $T48 $T54 $T55 $T56 depends on 10
-// CHECK-NEXT: 10: $T49 $T50 $T51 $T52 $T53
-// CHECK-NEXT: 6: $T33 $T35 $T39 $T40 $T41 $T42 depends on 7, 8
-// CHECK-NEXT: 8: $T36 $T37 $T38
-// CHECK-NEXT: 7: $T34
-// CHECK-NEXT: 4: $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28 $T29
-// CHECK-NEXT: 3: $T17 $T18
-// CHECK-NEXT: 2: $T13
+// CHECK-NEXT:  0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T10 $T11 $T78 $T79 depends on 2
+// CHECK-NEXT:  2: $T13 $T18 $T29 $T42 $T53 $T55 $T56 $T57 $T58 $T59 $T60 $T61 $T62 $T63 $T64 $T65 $T66 $T67 $T69 $T70 $T71 $T72 $T73 $T74 $T75 $T76 $T77 depends on 1, 3, 4, 6, 9
+// CHECK-NEXT:  9: $T48 $T49 $T50 $T51 $T52 depends on 8
+// CHECK-NEXT:  8: $T43 $T44 $T45 $T46 $T47
+// CHECK-NEXT:  6: $T31 $T35 $T36 $T37 $T38 $T39 $T40 $T41 depends on 5, 7
+// CHECK-NEXT:  7: $T32 $T33 $T34
+// CHECK-NEXT:  5: $T30
+// CHECK-NEXT:  4: $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28
+// CHECK-NEXT:  3: $T16 $T17
+// CHECK-NEXT:  1: $T12
 let names = ["Alice", "Bob", "Charlie"]
 let b = true
 var number = 17

--- a/test/Profiler/coverage_function_builder.swift
+++ b/test/Profiler/coverage_function_builder.swift
@@ -13,7 +13,7 @@ struct Summer {
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test0SiyF"
 @Summer
 func test0() -> Int {
-  // CHECK: [[@LINE-1]]:21 -> [[@LINE+2]]:5 : 0
+  // CHECK: [[@LINE-1]]:21 -> [[@LINE+3]]:2 : 0
   18
   12
 }
@@ -21,7 +21,7 @@ func test0() -> Int {
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test1SiyF"
 @Summer
 func test1() -> Int {
-  // CHECK: [[@LINE-1]]:21 -> [[@LINE+6]]:4 : 0
+  // CHECK: [[@LINE-1]]:21 -> [[@LINE+7]]:2 : 0
   18
   12
   if 7 < 23 {

--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -8,7 +8,7 @@ struct ContentView : View {
   @State var foo: [String] = Array(repeating: "", count: 5)
 
   var body: some View {
-    VStack { // expected-error {{expression type 'VStack<_>' is ambiguous without more context}}
+    VStack {
       HStack {
         Text("")
         TextFi // expected-error {{use of unresolved identifier 'TextFi'}}


### PR DESCRIPTION
Reverts apple/swift#29292, reinstating the reimplementation of function builders.