### PR TITLE
[AutoDiff] Add `@differentiable` fixit for protocols/classes.

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -613,8 +613,8 @@ static bool hasOverridingDifferentiableAttribute(ValueDecl *derivedDecl,
           .getAttributes<DifferentiableAttr, /*AllowInvalid*/ true>();
   auto baseDAs = baseAFD->getAttrs().getAttributes<DifferentiableAttr>();
 
-  // Make sure all the `@differentiable` attributes in `baseDecl` are
-  // also declared in `derivedDecl`.
+  // Make sure all the `@differentiable` attributes on `baseDecl` are
+  // also declared on `derivedDecl`.
   bool diagnosed = false;
   for (auto *baseDA : baseDAs) {
     auto baseParameters = baseDA->getParameterIndices();
@@ -640,21 +640,26 @@ static bool hasOverridingDifferentiableAttribute(ValueDecl *derivedDecl,
     if (defined)
       continue;
     diagnosed = true;
-    // Omit printing wrt clause if attribute differentiation parameters match
-    // inferred differentiation parameters.
+    // Emit an error and fix-it showing the missing base declaration's
+    // `@differentiable` attribute.
+    // Omit printing `wrt:` clause if attribute's differentiability parameters
+    // match inferred differentiability parameters.
     auto *inferredParameters =
         TypeChecker::inferDifferentiabilityParameters(derivedAFD, nullptr);
     bool omitWrtClause =
         !baseParameters ||
         baseParameters->getNumIndices() == inferredParameters->getNumIndices();
     // Get `@differentiable` attribute description.
-    std::string baseDAString;
-    llvm::raw_string_ostream stream(baseDAString);
-    baseDA->print(stream, derivedDecl, omitWrtClause,
+    std::string baseDiffAttrString;
+    llvm::raw_string_ostream os(baseDiffAttrString);
+    baseDA->print(os, derivedDecl, omitWrtClause,
                   /*omitDerivativeFunctions*/ true);
-    diags.diagnose(derivedDecl,
-                   diag::overriding_decl_missing_differentiable_attr,
-                   StringRef(stream.str()).trim());
+    os.flush();
+    diags
+        .diagnose(derivedDecl,
+                  diag::overriding_decl_missing_differentiable_attr,
+                  baseDiffAttrString)
+        .fixItInsert(derivedDecl->getStartLoc(), baseDiffAttrString + ' ');
     diags.diagnose(baseDecl, diag::overridden_here);
   }
   // If a diagnostic was produced, return false.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2319,13 +2319,12 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     diags.diagnose(match.Witness, diag::protocol_witness_not_objc);
     break;
   case MatchKind::DifferentiableConflict: {
-    // Emit a note showing the missing requirement `@differentiable` attribute.
+    // Emit a note and fix-it showing the missing requirement `@differentiable`
+    // attribute.
     auto *reqAttr = cast<DifferentiableAttr>(match.UnmetAttribute);
     assert(reqAttr);
-    if (!reqAttr->getParameterIndices())
-      break;
-    // Omit printing wrt clause if attribute differentiation parameters match
-    // inferred differentiation parameters.
+    // Omit printing `wrt:` clause if attribute's differentiability
+    // parameters match inferred differentiability parameters.
     auto *original = cast<AbstractFunctionDecl>(match.Witness);
     auto *whereClauseGenEnv =
         reqAttr->getDerivativeGenericEnvironment(original);
@@ -2333,14 +2332,15 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
         original, whereClauseGenEnv);
     bool omitWrtClause = reqAttr->getParameterIndices()->getNumIndices() ==
                          inferredParameters->getNumIndices();
-    // Get `@differentiable` attribute description.
     std::string reqDiffAttrString;
-    llvm::raw_string_ostream stream(reqDiffAttrString);
-    reqAttr->print(stream, req, omitWrtClause,
-                   /*omitDerivativeFunctions*/ true);
-    diags.diagnose(match.Witness,
-                   diag::protocol_witness_missing_differentiable_attr,
-                   StringRef(stream.str()).trim());
+    llvm::raw_string_ostream os(reqDiffAttrString);
+    reqAttr->print(os, req, omitWrtClause, /*omitDerivativeFunctions*/ true);
+    os.flush();
+    diags
+        .diagnose(match.Witness,
+                  diag::protocol_witness_missing_differentiable_attr,
+                  reqDiffAttrString)
+        .fixItInsert(match.Witness->getStartLoc(), reqDiffAttrString + ' ');
     break;
   }
   }

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -706,7 +706,7 @@ protocol ProtocolRequirements: Differentiable {
 }
 
 protocol ProtocolRequirementsRefined: ProtocolRequirements {
-  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable'}}
+  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   func f1(_ x: Float) -> Float
 }
 
@@ -719,7 +719,7 @@ struct DiffAttrConformanceErrors: ProtocolRequirements {
   var y: Float
 
   // FIXME(TF-284): Fix unexpected diagnostic.
-  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Float)'}}
   init(x: Float, y: Float) {
     self.x = x
@@ -727,31 +727,31 @@ struct DiffAttrConformanceErrors: ProtocolRequirements {
   }
 
   // FIXME(TF-284): Fix unexpected diagnostic.
-  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   // expected-note @+1 {{candidate has non-matching type '(x: Float, y: Int)'}}
   init(x: Float, y: Int) {
     self.x = x
     self.y = Float(y)
   }
 
-  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   // expected-note @+1 {{candidate has non-matching type '(Float, Float) -> Float'}}
   func amb(x: Float, y: Float) -> Float {
     return x
   }
 
-  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: x)'}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: x)'}} {{3-3=@differentiable(wrt: x) }}
   // expected-note @+1 {{candidate has non-matching type '(Float, Int) -> Float'}}
   func amb(x: Float, y: Int) -> Float {
     return x
   }
 
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   func f1(_ x: Float) -> Float {
     return x
   }
 
-  // expected-note @+2 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+2 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   @differentiable(wrt: (self, x))
   func f2(_ x: Float, _ y: Float) -> Float {
     return x + y
@@ -774,7 +774,7 @@ protocol ProtocolRequirementsWithDefault {
   func f1(_ x: Float) -> Float
 }
 extension ProtocolRequirementsWithDefault {
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   func f1(_ x: Float) -> Float { x }
 }
 // expected-error @+1 {{type 'DiffAttrConformanceErrors2' does not conform to protocol 'ProtocolRequirementsWithDefault'}}
@@ -782,7 +782,7 @@ struct DiffAttrConformanceErrors2: ProtocolRequirementsWithDefault {
   typealias TangentVector = DummyTangentVector
   mutating func move(along _: TangentVector) {}
 
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   func f1(_ x: Float) -> Float { x }
 }
 
@@ -794,7 +794,7 @@ protocol NotRefiningDiffable {
 
 // expected-error @+1 {{type 'CertainlyNotDiffableWrtSelf' does not conform to protocol 'NotRefiningDiffable'}}
 struct CertainlyNotDiffableWrtSelf: NotRefiningDiffable {
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}} {{3-3=@differentiable }}
   func a(_ x: Float) -> Float { return x * 5.0 }
 }
 
@@ -813,7 +813,7 @@ struct TF285MissingOneDiffAttr: TF285 {
 
   // Requirement is missing an attribute.
   @differentiable(wrt: x)
-  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x, y))}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x, y))}} {{3-3=@differentiable(wrt: (x, y)) }}
   func foo(x: Float, y: Float) -> Float {
     return x
   }
@@ -1047,7 +1047,7 @@ public protocol DifferentiableDistribution: Differentiable, Distribution {
 // Adding a more general `@differentiable` attribute.
 public protocol DoubleDifferentiableDistribution: DifferentiableDistribution
   where Value: Differentiable {
-  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable(wrt: self)'}}
+  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable(wrt: self)'}} {{3-3=@differentiable(wrt: self) }}
   func logProbability(of value: Value) -> Float
 }
 
@@ -1137,8 +1137,8 @@ class Super: Differentiable {
 }
 
 class Sub: Super {
-  // expected-error @+2 {{overriding declaration is missing attribute '@differentiable(wrt: x)'}}
-  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable'}}
+  // expected-error @+2 {{overriding declaration is missing attribute '@differentiable(wrt: x)'}} {{12-12=@differentiable(wrt: x) }}
+  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable'}} {{12-12=@differentiable }}
   override func testMissingAttributes(_ x: Float) -> Float { x }
 
   // expected-warning @+2 {{'jvp:' and 'vjp:' arguments in '@differentiable' attribute are deprecated}}


### PR DESCRIPTION
For protocol requirements and class members with `@differentiable` attribute,
conforming types and subclasses must have the same `@differentiable` attribute
(or one with a superset of differentiability parameters) on implementing/
overriding declarations.

For implementing/overriding declarations that are missing a `@differentiable`
attribute, emit a fixit that adds the missing attribute.

Resolves TF-1118.

This `@differentiable` attribute usability improvement was discussed at the
[1/17/2020 Swift for TensorFlow open design meeting](https://docs.google.com/document/d/1Fm56p5rV1t2Euh6WLtBFKGqI43ozC3EIjReyLk-LCLU/edit#bookmark=id.rrfb0uhvuzry).

---

Example:
```swift
import _Differentiation
public protocol Layer {
  @differentiable
  func callAsFunction(_ input: Float) -> Float
}
public struct DummyLayer: Layer {
  public func callAsFunction(_ input: Float) -> Float { input }
}
```

Before:
```console
$ swift -Xfrontend -enable-experimental-differentiable-programming toy.swift
toy.swift:6:15: error: type 'DummyLayer' does not conform to protocol 'Layer'
public struct DummyLayer: Layer {
              ^
toy.swift:7:8: note: candidate is missing attribute '@differentiable'
  func callAsFunction(_ input: Float) -> Float { input }
       ^
toy.swift:4:8: note: protocol requires function 'callAsFunction' with type '(Float) -> Float'; do you want to add a stub?
  func callAsFunction(_ input: Float) -> Float
       ^
```

After:
```console
$ swift -Xfrontend -enable-experimental-differentiable-programming toy.swift
toy.swift:6:15: error: type 'DummyLayer' does not conform to protocol 'Layer'
public struct DummyLayer: Layer {
              ^
toy.swift:7:15: note: candidate is missing attribute '@differentiable'
  public func callAsFunction(_ input: Float) -> Float { input }
              ^
         @differentiable
toy.swift:4:8: note: protocol requires function 'callAsFunction' with type '(Float) -> Float'; do you want to add a stub?
  func callAsFunction(_ input: Float) -> Float
       ^
```

The second note `protocol requires function 'callAsFunction' with type '(Float) -> Float'; do you want to add a stub?` is a bit confusing. Disabling it would be ideal.