### PR TITLE
Add licence notice to Vim syntax files

### DIFF
--- a/utils/vim/ftdetect/sil.vim
+++ b/utils/vim/ftdetect/sil.vim
@@ -1,1 +1,9 @@
+" This source file is part of the Swift.org open source project
+"
+" Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+" Licensed under Apache License v2.0 with Runtime Library Exception
+"
+" See https://swift.org/LICENSE.txt for license information
+" See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 au BufNewFile,BufRead *.sil set ft=sil

--- a/utils/vim/ftdetect/swift.vim
+++ b/utils/vim/ftdetect/swift.vim
@@ -1,1 +1,9 @@
+" This source file is part of the Swift.org open source project
+"
+" Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+" Licensed under Apache License v2.0 with Runtime Library Exception
+"
+" See https://swift.org/LICENSE.txt for license information
+" See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 au BufNewFile,BufRead *.swift set ft=swift

--- a/utils/vim/ftdetect/swiftgyb.vim
+++ b/utils/vim/ftdetect/swiftgyb.vim
@@ -1,2 +1,9 @@
-au BufNewFile,BufRead *.swift.gyb set ft=swiftgyb
+" This source file is part of the Swift.org open source project
+"
+" Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+" Licensed under Apache License v2.0 with Runtime Library Exception
+"
+" See https://swift.org/LICENSE.txt for license information
+" See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+au BufNewFile,BufRead *.swift.gyb set ft=swiftgyb

--- a/utils/vim/ftplugin/swift.vim
+++ b/utils/vim/ftplugin/swift.vim
@@ -1,3 +1,11 @@
+" This source file is part of the Swift.org open source project
+"
+" Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+" Licensed under Apache License v2.0 with Runtime Library Exception
+"
+" See https://swift.org/LICENSE.txt for license information
+" See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 setlocal comments=s1:/*,mb:*,ex:*/,:///,://
 setlocal expandtab
 setlocal ts=2

--- a/utils/vim/ftplugin/swiftgyb.vim
+++ b/utils/vim/ftplugin/swiftgyb.vim
@@ -1,1 +1,9 @@
+" This source file is part of the Swift.org open source project
+"
+" Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+" Licensed under Apache License v2.0 with Runtime Library Exception
+"
+" See https://swift.org/LICENSE.txt for license information
+" See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 runtime! ftplugin/swift.vim

--- a/utils/vim/syntax/sil.vim
+++ b/utils/vim/syntax/sil.vim
@@ -1,3 +1,11 @@
+" This source file is part of the Swift.org open source project
+"
+" Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+" Licensed under Apache License v2.0 with Runtime Library Exception
+"
+" See https://swift.org/LICENSE.txt for license information
+" See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+"
 " Vim syntax file
 " Language: sil
 

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -1,3 +1,11 @@
+" This source file is part of the Swift.org open source project
+"
+" Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+" Licensed under Apache License v2.0 with Runtime Library Exception
+"
+" See https://swift.org/LICENSE.txt for license information
+" See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+"
 " Vim syntax file
 " Language: swift
 " Maintainer: Joe Groff <jgroff@apple.com>

--- a/utils/vim/syntax/swiftgyb.vim
+++ b/utils/vim/syntax/swiftgyb.vim
@@ -1,3 +1,11 @@
+" This source file is part of the Swift.org open source project
+"
+" Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+" Licensed under Apache License v2.0 with Runtime Library Exception
+"
+" See https://swift.org/LICENSE.txt for license information
+" See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+"
 " Vim syntax file
 " Language: gyb on swift
 


### PR DESCRIPTION
This PR adds Swift licence information to Vim syntax files. A proposal for including these syntax files with the standard Vim install will be introduced to Vim project, but due to project contribution etiquette, the licence headers must be present to make sure that there are no licensing issues.

Thank you for your consideration.