### PR TITLE
Generic metadata prespecialization: enums

### DIFF
--- a/lib/IRGen/EnumMetadataVisitor.h
+++ b/lib/IRGen/EnumMetadataVisitor.h
@@ -62,6 +62,14 @@ public:
            Target->getDeclaredTypeInContext()->getCanonicalType());
     if (strategy.needsPayloadSizeInMetadata())
       asImpl().addPayloadSize();
+
+    if (asImpl().hasTrailingFlags())
+      asImpl().addTrailingFlags();
+  }
+
+  bool hasTrailingFlags() {
+    return Target->isGenericContext() &&
+           IGM.shouldPrespecializeGenericMetadata();
   }
 };
 
@@ -86,6 +94,7 @@ public:
   void addGenericWitnessTable(GenericRequirement requirement) { addPointer(); }
   void addPayloadSize() { addPointer(); }
   void noteStartOfTypeSpecificMembers() {}
+  void addTrailingFlags() { addPointer(); }
 
 private:
   void addPointer() {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1859,7 +1859,21 @@ void irgen::emitLazyMetadataAccessor(IRGenModule &IGM,
 
 void irgen::emitLazySpecializedGenericTypeMetadata(IRGenModule &IGM,
                                                    CanType type) {
-  emitSpecializedGenericStructMetadata(IGM, type);
+  switch (type->getKind()) {
+  case TypeKind::Struct:
+  case TypeKind::BoundGenericStruct:
+    emitSpecializedGenericStructMetadata(IGM, type,
+                                         *type.getStructOrBoundGenericStruct());
+    break;
+  case TypeKind::Enum:
+  case TypeKind::BoundGenericEnum:
+    emitSpecializedGenericEnumMetadata(IGM, type,
+                                       *type.getEnumOrBoundGenericEnum());
+    break;
+  default:
+    llvm_unreachable("Cannot statically specialize types of kind other than "
+                     "struct and enum.");
+  }
 }
 
 llvm::Constant *
@@ -3472,8 +3486,12 @@ namespace {
          : public ValueMetadataBuilderBase<StructMetadataVisitor<Impl>> {
     using super = ValueMetadataBuilderBase<StructMetadataVisitor<Impl>>;
 
+    bool HasUnfilledFieldOffset = false;
+
   protected:
-    ConstantStructBuilder &B;
+    using ConstantBuilder = ConstantStructBuilder;
+    ConstantBuilder &B;
+    using NominalDecl = StructDecl;
     using super::IGM;
     using super::Target;
     using super::asImpl;
@@ -3562,16 +3580,6 @@ namespace {
 
       return flags;
     }
-  };
-
-  class StructMetadataBuilder :
-    public StructMetadataBuilderBase<StructMetadataBuilder> {
-
-    bool HasUnfilledFieldOffset = false;
-  public:
-    StructMetadataBuilder(IRGenModule &IGM, StructDecl *theStruct,
-                          ConstantStructBuilder &B)
-      : StructMetadataBuilderBase(IGM, theStruct, B) {}
 
     void flagUnfilledFieldOffset() {
       HasUnfilledFieldOffset = true;
@@ -3580,13 +3588,21 @@ namespace {
     bool canBeConstant() {
       return !HasUnfilledFieldOffset;
     }
+  };
+
+  class StructMetadataBuilder
+      : public StructMetadataBuilderBase<StructMetadataBuilder> {
+  public:
+    StructMetadataBuilder(IRGenModule &IGM, StructDecl *theStruct,
+                          ConstantStructBuilder &B)
+        : StructMetadataBuilderBase(IGM, theStruct, B) {}
 
     void createMetadataAccessFunction() {
       createNonGenericMetadataAccessFunction(IGM, Target);
       maybeCreateSingletonMetadataInitialization();
     }
   };
-  
+
   /// Emit a value witness table for a fixed-layout generic type, or a template
   /// if the value witness table is dependent on generic parameters.
   static ConstantReference
@@ -3710,24 +3726,25 @@ namespace {
     }
   };
 
-  class SpecializedGenericStructMetadataBuilder
-      : public StructMetadataBuilderBase<
-            SpecializedGenericStructMetadataBuilder> {
-    using super =
-        StructMetadataBuilderBase<SpecializedGenericStructMetadataBuilder>;
+  template <template <typename> class MetadataBuilderBase, typename Impl>
+  class SpecializedGenericNominalMetadataBuilderBase
+      : public MetadataBuilderBase<Impl> {
+    using super = MetadataBuilderBase<Impl>;
+
     CanType type;
-    bool HasUnfilledFieldOffset = false;
 
   protected:
     using super::asImpl;
     using super::getLoweredType;
     using super::IGM;
     using super::Target;
+    using typename super::ConstantBuilder;
+    using typename super::NominalDecl;
 
   public:
-    SpecializedGenericStructMetadataBuilder(IRGenModule &IGM, CanType type,
-                                            StructDecl &decl,
-                                            ConstantStructBuilder &B)
+    SpecializedGenericNominalMetadataBuilderBase(IRGenModule &IGM, CanType type,
+                                                 NominalDecl &decl,
+                                                 ConstantBuilder &B)
         : super(IGM, &decl, B), type(type) {}
 
     void noteStartOfTypeSpecificMembers() {}
@@ -3750,7 +3767,7 @@ namespace {
       auto t = requirement.TypeParameter.subst(genericSubstitutions());
       ConstantReference ref = IGM.getAddrOfTypeMetadata(
           CanType(t), SymbolReferenceKind::Relative_Direct);
-      B.add(ref.getDirectValue());
+      this->B.add(ref.getDirectValue());
     }
 
     void addGenericWitnessTable(GenericRequirement requirement) {
@@ -3773,7 +3790,7 @@ namespace {
         addr = IGM.getAddrOfWitnessTable(rootConformance);
       }
 
-      B.add(addr);
+      this->B.add(addr);
     }
 
     SubstitutionMap genericSubstitutions() {
@@ -3789,10 +3806,20 @@ namespace {
 
       return flags;
     }
+  };
 
-    void flagUnfilledFieldOffset() { HasUnfilledFieldOffset = true; }
+  class SpecializedGenericStructMetadataBuilder
+      : public SpecializedGenericNominalMetadataBuilderBase<
+            StructMetadataBuilderBase,
+            SpecializedGenericStructMetadataBuilder> {
+    using super = SpecializedGenericNominalMetadataBuilderBase<
+        StructMetadataBuilderBase, SpecializedGenericStructMetadataBuilder>;
 
-    bool canBeConstant() { return !HasUnfilledFieldOffset; }
+  public:
+    SpecializedGenericStructMetadataBuilder(IRGenModule &IGM, CanType type,
+                                            StructDecl &decl,
+                                            ConstantStructBuilder &B)
+        : super(IGM, type, decl, B) {}
   };
 
 } // end anonymous namespace
@@ -3828,8 +3855,8 @@ void irgen::emitStructMetadata(IRGenModule &IGM, StructDecl *structDecl) {
                          init.finishAndCreateFuture());
 }
 
-void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM,
-                                                 CanType type) {
+void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type,
+                                                 StructDecl &decl) {
   Type ty = type.getPointer();
   auto &context = type->getNominalOrBoundGenericNominal()->getASTContext();
   PrettyStackTraceType stackTraceRAII(
@@ -3840,7 +3867,6 @@ void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM,
 
   bool isPattern = false;
 
-  auto &decl = *type.getStructOrBoundGenericStruct();
   SpecializedGenericStructMetadataBuilder builder(IGM, type, decl, init);
   builder.layout();
 
@@ -3871,9 +3897,13 @@ namespace {
   class EnumMetadataBuilderBase
          : public ValueMetadataBuilderBase<EnumMetadataVisitor<Impl>> {
     using super = ValueMetadataBuilderBase<EnumMetadataVisitor<Impl>>;
+    bool HasUnfilledPayloadSize = false;
 
   protected:
-    ConstantStructBuilder &B;
+    using ConstantBuilder = ConstantStructBuilder;
+    using NominalDecl = EnumDecl;
+    ConstantBuilder &B;
+    using super::asImpl;
     using super::IGM;
     using super::Target;
 
@@ -3894,8 +3924,12 @@ namespace {
       return irgen::emitValueWitnessTable(IGM, type, false, relativeReference);
     }
 
+    ConstantReference getValueWitnessTable(bool relativeReference) {
+      return emitValueWitnessTable(relativeReference);
+    }
+
     void addValueWitnessTable() {
-      B.add(emitValueWitnessTable(/*relative*/ false).getValue());
+      B.add(asImpl().getValueWitnessTable(false).getValue());
     }
 
     llvm::Constant *emitNominalTypeDescriptor() {
@@ -3904,8 +3938,12 @@ namespace {
       return descriptor;
     }
 
+    llvm::Constant *getNominalTypeDescriptor() {
+      return emitNominalTypeDescriptor();
+    }
+
     void addNominalTypeDescriptor() {
-      B.add(emitNominalTypeDescriptor());
+      B.add(asImpl().getNominalTypeDescriptor());
     }
 
     void addGenericArgument(GenericRequirement requirement) {
@@ -3915,16 +3953,22 @@ namespace {
     void addGenericWitnessTable(GenericRequirement requirement) {
       llvm_unreachable("Concrete type metadata cannot have generic requirements");
     }
-  };
 
-  class EnumMetadataBuilder
-    : public EnumMetadataBuilderBase<EnumMetadataBuilder> {
-    bool HasUnfilledPayloadSize = false;
+    bool hasTrailingFlags() {
+      return IGM.shouldPrespecializeGenericMetadata();
+    }
 
-  public:
-    EnumMetadataBuilder(IRGenModule &IGM, EnumDecl *theEnum,
-                        ConstantStructBuilder &B)
-      : EnumMetadataBuilderBase(IGM, theEnum, B) {}
+    void addTrailingFlags() {
+      auto flags = asImpl().getTrailingFlags();
+
+      B.addInt(IGM.Int64Ty, flags.getOpaqueValue());
+    }
+
+    MetadataTrailingFlags getTrailingFlags() {
+      MetadataTrailingFlags flags;
+
+      return flags;
+    }
 
     void addPayloadSize() {
       auto payloadSize = getConstantPayloadSize(IGM, Target);
@@ -3940,6 +3984,26 @@ namespace {
     bool canBeConstant() {
       return !HasUnfilledPayloadSize;
     }
+  };
+
+  class SpecializedGenericEnumMetadataBuilder
+      : public SpecializedGenericNominalMetadataBuilderBase<
+            EnumMetadataBuilderBase, SpecializedGenericEnumMetadataBuilder> {
+    using super = SpecializedGenericNominalMetadataBuilderBase<
+        EnumMetadataBuilderBase, SpecializedGenericEnumMetadataBuilder>;
+
+  public:
+    SpecializedGenericEnumMetadataBuilder(IRGenModule &IGM, CanType type,
+                                          EnumDecl &decl, ConstantBuilder &B)
+        : super(IGM, type, decl, B){};
+  };
+
+  class EnumMetadataBuilder
+      : public EnumMetadataBuilderBase<EnumMetadataBuilder> {
+  public:
+    EnumMetadataBuilder(IRGenModule &IGM, EnumDecl *theEnum,
+                        ConstantStructBuilder &B)
+        : EnumMetadataBuilderBase(IGM, theEnum, B) {}
 
     void createMetadataAccessFunction() {
       createNonGenericMetadataAccessFunction(IGM, Target);
@@ -3990,6 +4054,16 @@ namespace {
       return EnumContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
     }
 
+    GenericMetadataPatternFlags getPatternFlags() {
+      auto flags = super::getPatternFlags();
+
+      if (IGM.shouldPrespecializeGenericMetadata()) {
+        flags.setHasTrailingFlags(true);
+      }
+
+      return flags;
+    }
+
     ConstantReference emitValueWitnessTable(bool relativeReference) {
       assert(relativeReference && "should only relative reference");
       return getValueWitnessTableForGenericValueType(IGM, Target,
@@ -4030,6 +4104,26 @@ void irgen::emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum) {
   CanType declaredType = theEnum->getDeclaredType()->getCanonicalType();
 
   IGM.defineTypeMetadata(declaredType, isPattern, canBeConstant,
+                         init.finishAndCreateFuture());
+}
+
+void irgen::emitSpecializedGenericEnumMetadata(IRGenModule &IGM, CanType type,
+                                               EnumDecl &decl) {
+  Type ty = type.getPointer();
+  auto &context = type->getNominalOrBoundGenericNominal()->getASTContext();
+  PrettyStackTraceType stackTraceRAII(
+      context, "emitting prespecialized metadata for", ty);
+  ConstantInitBuilder initBuilder(IGM);
+  auto init = initBuilder.beginStruct();
+  init.setPacked(true);
+
+  bool isPattern = false;
+
+  SpecializedGenericEnumMetadataBuilder builder(IGM, type, decl, init);
+  builder.layout();
+
+  bool canBeConstant = builder.canBeConstant();
+  IGM.defineTypeMetadata(type, isPattern, canBeConstant,
                          init.finishAndCreateFuture());
 }
 

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -85,7 +85,11 @@ namespace irgen {
   /// Emit the metadata associated with the given enum declaration.
   void emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum);
 
-  void emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type);
+  void emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type,
+                                            StructDecl &decl);
+
+  void emitSpecializedGenericEnumMetadata(IRGenModule &IGM, CanType type,
+                                          EnumDecl &decl);
 
   /// Get what will be the index into the generic type argument array at the end
   /// of a nominal type's metadata.

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -684,11 +684,6 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
     return false;
   }
 
-  if (isa<EnumType>(type) || isa<BoundGenericEnumType>(type)) {
-    // TODO: Support enums.
-    return false;
-  }
-
   if (isa<ClassType>(type) || isa<BoundGenericClassType>(type)) {
     // TODO: Support classes.
     return false;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5223,6 +5223,8 @@ template <>
 bool Metadata::isCanonicalStaticallySpecializedGenericMetadata() const {
   if (auto *metadata = dyn_cast<StructMetadata>(this))
     return metadata->isCanonicalStaticallySpecializedGenericMetadata();
+  if (auto *metadata = dyn_cast<EnumMetadata>(this))
+    return metadata->isCanonicalStaticallySpecializedGenericMetadata();
 
   return false;
 }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
@@ -1,0 +1,41 @@
+// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOySiGWV" = linkonce_odr hidden constant %swift.enum_vwtable { i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOySiGwet" to i8*), i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOySiGwst" to i8*), [[INT]] [[ALIGNMENT]], [[INT]] [[ALIGNMENT]], i32 {{[0-9]+}}, i32 0, i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOySiGwug" to i8*), i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOySiGwup" to i8*), i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOySiGwui" to i8*) }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOySiGMf" = internal constant <{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i64 }> <{ i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0), [[INT]] 513, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), %swift.type* @"$sSiN", i64 3 }>, align [[ALIGNMENT]]
+enum Value<First> {
+  case only(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i64 }>* @"$s4main5ValueOySiGMf" to %swift.full_type*), i32 0, i32 1))
+// CHECK: }
+func doit() {
+  consume( Value.only(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]], %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i64 }>* @"$s4main5ValueOySiGMf" to %swift.full_type*), i32 0, i32 1), [[INT]] 0 }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* %2, i8* undef, i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }


### PR DESCRIPTION
Continuing the work started in https://github.com/apple/swift/pull/28610 , prespecializes generic metadata for enums under limited circumstances.  Specifically, prespecialization only occurs for usages within the same module where the type itself is defined and for specializations all of whose type arguments are themselves concrete types.