### PR TITLE
[AST|ASTWalker] Fix assertion hit walking an invalid AST with a protocol decl inside an extension

### DIFF
--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -223,9 +223,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitTypeAliasDecl(TypeAliasDecl *TAD) {
-    if (TAD->getGenericParams() &&
-        Walker.shouldWalkIntoGenericParams()) {
-
+    if (Walker.shouldWalkIntoGenericParams() && TAD->getGenericParams()) {
       if (visitGenericParamList(TAD->getGenericParams()))
         return true;
     }
@@ -237,8 +235,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
   
   bool visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {
-    if (OTD->getGenericParams() &&
-        Walker.shouldWalkIntoGenericParams()) {
+    if (Walker.shouldWalkIntoGenericParams() && OTD->getGenericParams()) {
       if (visitGenericParamList(OTD->getGenericParams()))
         return true;
     }
@@ -272,16 +269,15 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     }
 
     // Visit requirements
-    if (auto *Protocol = dyn_cast<ProtocolDecl>(NTD)) {
-      if (auto *WhereClause = Protocol->getTrailingWhereClause()) {
-        for (auto &Req: WhereClause->getRequirements()) {
-          if (doIt(Req))
-            return true;
-        }
-      }
-    }
     if (WalkGenerics) {
-      for (auto Req: NTD->getGenericParams()->getTrailingRequirements()) {
+      ArrayRef<swift::RequirementRepr> Reqs = None;
+      if (auto *Protocol = dyn_cast<ProtocolDecl>(NTD)) {
+        if (auto *WhereClause = Protocol->getTrailingWhereClause())
+          Reqs = WhereClause->getRequirements();
+      } else {
+        Reqs = NTD->getGenericParams()->getTrailingRequirements();
+      }
+      for (auto Req: Reqs) {
         if (doIt(Req))
           return true;
       }
@@ -1329,7 +1325,6 @@ public:
 
 private:
   bool visitGenericParamListIfNeeded(GenericContext *gc) {
-    // Must check this first in case extensions have not been bound yet
     if (Walker.shouldWalkIntoGenericParams()) {
       if (auto *params = gc->getGenericParams()) {
         visitGenericParamList(params);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3613,7 +3613,7 @@ static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
   // Get the parent type.
   Type Ty;
   DeclContext *dc = decl->getDeclContext();
-  if (dc->isTypeContext()) {
+  if (!isa<ProtocolDecl>(decl) && dc->isTypeContext()) {
     switch (kind) {
     case DeclTypeKind::DeclaredType: {
       auto *nominal = dc->getSelfNominalTypeDecl();

--- a/test/IDE/coloring_invalid.swift
+++ b/test/IDE/coloring_invalid.swift
@@ -1,5 +1,13 @@
 // RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
 
+public enum Foo {}
+// CHECK: <attr-builtin>public</attr-builtin> <kw>enum</kw> Foo {}
+public extension Foo {
+// CHECK: <attr-builtin>public</attr-builtin> <kw>extension</kw> <type>Foo</type> {
+	protocol Bar {}
+// CHECK: <kw>protocol</kw> Bar {}
+}
+
 public enum Result {
 // CHECK: <attr-builtin>public</attr-builtin> <kw>enum</kw> Result {
   case success(a b = {


### PR DESCRIPTION
The AST walker calling `getGenericParams()` on a protocol decl would eventually call `computeNominalType`. `computeNominalType` checks that the protocol (as a nominal type decl) appears within a type context, and if so, asks for the `SelfNominalTypeDecl` of that context. If the context is an extension, that ends up asking for its extended nominal, which is a problem if we're walking a pre-typechecked AST – we hit the assertion "Extension must have already been bound (by bindExtensions)").

Unlike other nominal types, it's not valid Swift for protocols to appear within type contexts, so exclude protocol decls from taking this code path. This results in us providing `Type()` as the parent type of the produced `NominalType`, just like we do for protocols inside functions or other invalid contexts.

Resolves <rdar://problem/58549036>