### PR TITLE
build-script: use more terse checks

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -854,34 +854,19 @@ if [[ "${SKIP_RECONFIGURE}" ]]; then
     RECONFIGURE=""
 fi
 
-# WORKSPACE, BUILD_DIR and INSTALLABLE_PACKAGE must be absolute paths
-case "${WORKSPACE}" in
-    /*) ;;
-    *)
-        echo "workspace must be an absolute path (was '${WORKSPACE}')"
-        exit 1
-        ;;
-esac
-case "${BUILD_DIR}" in
-    /*) ;;
-    "")
-        echo "the --build-dir option is required"
-        usage
-        exit 1
-        ;;
-    *)
-        echo "build-dir must be an absolute path (was '${BUILD_DIR}')"
-        exit 1
-        ;;
-esac
-case "${INSTALLABLE_PACKAGE}" in
-    /*) ;;
-    "") ;;
-    *)
-        echo "installable-package must be an absolute path (was '${INSTALLABLE_PACKAGE}')"
-        exit 1
-        ;;
-esac
+# WORKSPACE, BUILD_DIR, and INSTALLABLE_PACKAGE must be absolute paths
+if ! [[ ${WORKSPACE} =~ ^/ ]] ; then
+  echo "workspace must be an absolute path (was '${WORKSPACE}')"
+  exit 1
+fi
+if ! [[ ${BUILD_DIR} =~ ^/ ]] ; then
+  echo "build-dir must be an absolute path (was '${BUILD_DIR}')"
+  exit 1
+fi
+if ! [[ ${INSTALLABLE_PACKAGE:-/} =~ ^/ ]] ; then
+  echo "installable-package must be an absolute path (was '${INSTALLABLE_PACKAGE}')"
+  exit 1
+fi
 
 # WORKSPACE must exist
 if [ ! -e "${WORKSPACE}" ] ; then


### PR DESCRIPTION
This uses the bash extension of regex based comparison rather than the
more portable shell approach which is a bit more terse.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
