### PR TITLE
[CodeCompletion] Don't discard parsed expression in incomplete ternary

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -645,6 +645,18 @@ class ExprContextAnalyzer {
       }
       break;
     }
+    case ExprKind::If: {
+      auto *IE = cast<IfExpr>(Parent);
+      if (SM.rangeContains(IE->getCondExpr()->getSourceRange(),
+                           ParsedExpr->getSourceRange())) {
+        recordPossibleType(Context.getBoolDecl()->getDeclaredInterfaceType());
+        break;
+      }
+      ExprContextInfo ternaryCtxtInfo(DC, Parent);
+      for (auto ternaryT : ternaryCtxtInfo.getPossibleTypes())
+        recordPossibleType(ternaryT);
+      break;
+    }
     case ExprKind::Assign: {
       auto *AE = cast<AssignExpr>(Parent);
 
@@ -861,7 +873,7 @@ public:
         case ExprKind::Assign:
         case ExprKind::Array:
         case ExprKind::Dictionary:
-          return true;
+        case ExprKind::If:
         case ExprKind::UnresolvedMember:
           return true;
         case ExprKind::Tuple: {

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -115,6 +115,11 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPEPARAM_IN_CONTEXTTYPE_1 | %FileCheck %s -check-prefix=TYPEPARAM_IN_CONTEXTTYPE_1
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_1 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_2 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_3 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_4 | %FileCheck %s -check-prefix=UNRESOLVED_3
+
 enum SomeEnum1 {
   case South
   case North
@@ -731,4 +736,14 @@ func testTypeParamInContextType() {
 // TYPEPARAM_IN_CONTEXTTYPE_1-DAG: Decl[Constructor]/CurrNominal:      init()[#MyStruct<MyProtocol>#];
 // TYPEPARAM_IN_CONTEXTTYPE_1-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: myProtocolOption[#MyStruct<ConcreteMyProtocol>#];
 // TYPEPARAM_IN_CONTEXTTYPE_1: End completions
+}
+
+func testTernaryOperator() {
+  let _: SomeEnum1 = true ? .#^TERNARY_1^#
+  func sync(){}
+  let _: SomeEnum1 = true ? .#^TERNARY_2^# :
+  func sync(){}
+  let _: SomeEnum1 = true ? .#^TERNARY_3^# : .South
+  func sync(){}
+  let _: SomeEnum1 = true ? .South : .#^TERNARY_4^#
 }

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -119,6 +119,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_2 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_3 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_4 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_5 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_6 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TERNARY_CONDITION | %FileCheck %s -check-prefix=TERNARY_CONDITION
 
 enum SomeEnum1 {
   case South
@@ -738,12 +741,23 @@ func testTypeParamInContextType() {
 // TYPEPARAM_IN_CONTEXTTYPE_1: End completions
 }
 
-func testTernaryOperator() {
-  let _: SomeEnum1 = true ? .#^TERNARY_1^#
+func testTernaryOperator(cond: Bool) {
+  let _: SomeEnum1 = cond ? .#^TERNARY_1^#
   func sync(){}
-  let _: SomeEnum1 = true ? .#^TERNARY_2^# :
+  let _: SomeEnum1 = cond ? .#^TERNARY_2^# :
   func sync(){}
-  let _: SomeEnum1 = true ? .#^TERNARY_3^# : .South
+  let _: SomeEnum1 = cond ? .#^TERNARY_3^# : .South
   func sync(){}
-  let _: SomeEnum1 = true ? .South : .#^TERNARY_4^#
+  let _: SomeEnum1 = cond ? .South : .#^TERNARY_4^#
+}
+
+func testTernaryOperator2(cond: Bool) {
+  let _: SomeEnum1 = cond ? .#^TERNARY_5^# : .bogus
+  func sync(){}
+  let _: SomeEnum1 = cond ? .bogus : .#^TERNARY_6^#
+  func sync(){}
+  let _: SomeEnum1 = .#^TERNARY_CONDITION^# ? .bogus : .bogus
+// TERNARY_CONDITION: Begin completions
+// TERNARY_CONDITION-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#Bool#]; name=init()
+// TERNARY_CONDITION: End completions
 }


### PR DESCRIPTION
If we are in code-completion, we need to keep the parsed expression in the AST. Don't discard the parsed expression if the middle expression in a ternary expression has code-completion token. This improves the completions for:

```swift
    let _: MyEnum = condition ? .<HERE>
    let _: MyEnum = condition ? .<HERE> :
```

rdar://problem/54132682