### PR TITLE
[Preset] Update the macOS pull request preset to not build and test t…

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1459,13 +1459,17 @@ playgroundsupport
 
 dash-dash
 
+# Skip build and test for tvOS
+skip-build-tvos
+skip-test-tvos
+skip-test-tvos-host
+
 # Run the SIL verifier after each transform when building swift files
 sil-verify-all
 
 # Don't run host tests for iOS, tvOS and watchOS platforms to make the build
 # faster.
 skip-test-ios-host
-skip-test-tvos-host
 skip-test-watchos-host
 
 


### PR DESCRIPTION
…vOS platform to get faster trun around

```
Without tvOS 
00:06:57.127 - Build started 
01:11:59.861 - Build finished 
Total time to build 1hr 5min

With tvOS
00:04:13.084 - Build started
01:14:35.865 - Build finished
Total time to build 1hr 10min 
tvOS test time: 9min 21sec
```

We should see about 14-15min improvement on PR testing turn around 