### PR TITLE
Generic metadata prespecialization: enums

### DIFF
--- a/lib/IRGen/EnumMetadataVisitor.h
+++ b/lib/IRGen/EnumMetadataVisitor.h
@@ -62,6 +62,14 @@ public:
            Target->getDeclaredTypeInContext()->getCanonicalType());
     if (strategy.needsPayloadSizeInMetadata())
       asImpl().addPayloadSize();
+
+    if (asImpl().hasTrailingFlags())
+      asImpl().addTrailingFlags();
+  }
+
+  bool hasTrailingFlags() {
+    return Target->isGenericContext() &&
+           IGM.shouldPrespecializeGenericMetadata();
   }
 };
 
@@ -86,6 +94,7 @@ public:
   void addGenericWitnessTable(GenericRequirement requirement) { addPointer(); }
   void addPayloadSize() { addPointer(); }
   void noteStartOfTypeSpecificMembers() {}
+  void addTrailingFlags() { addPointer(); }
 
 private:
   void addPointer() {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1859,7 +1859,21 @@ void irgen::emitLazyMetadataAccessor(IRGenModule &IGM,
 
 void irgen::emitLazySpecializedGenericTypeMetadata(IRGenModule &IGM,
                                                    CanType type) {
-  emitSpecializedGenericStructMetadata(IGM, type);
+  switch (type->getKind()) {
+  case TypeKind::Struct:
+  case TypeKind::BoundGenericStruct:
+    emitSpecializedGenericStructMetadata(IGM, type,
+                                         *type.getStructOrBoundGenericStruct());
+    break;
+  case TypeKind::Enum:
+  case TypeKind::BoundGenericEnum:
+    emitSpecializedGenericEnumMetadata(IGM, type,
+                                       *type.getEnumOrBoundGenericEnum());
+    break;
+  default:
+    llvm_unreachable("Cannot statically specialize types of kind other than "
+                     "struct and enum.");
+  }
 }
 
 llvm::Constant *
@@ -3472,8 +3486,12 @@ namespace {
          : public ValueMetadataBuilderBase<StructMetadataVisitor<Impl>> {
     using super = ValueMetadataBuilderBase<StructMetadataVisitor<Impl>>;
 
+    bool HasUnfilledFieldOffset = false;
+
   protected:
-    ConstantStructBuilder &B;
+    using ConstantBuilder = ConstantStructBuilder;
+    ConstantBuilder &B;
+    using NominalDecl = StructDecl;
     using super::IGM;
     using super::Target;
     using super::asImpl;
@@ -3562,16 +3580,6 @@ namespace {
 
       return flags;
     }
-  };
-
-  class StructMetadataBuilder :
-    public StructMetadataBuilderBase<StructMetadataBuilder> {
-
-    bool HasUnfilledFieldOffset = false;
-  public:
-    StructMetadataBuilder(IRGenModule &IGM, StructDecl *theStruct,
-                          ConstantStructBuilder &B)
-      : StructMetadataBuilderBase(IGM, theStruct, B) {}
 
     void flagUnfilledFieldOffset() {
       HasUnfilledFieldOffset = true;
@@ -3580,13 +3588,21 @@ namespace {
     bool canBeConstant() {
       return !HasUnfilledFieldOffset;
     }
+  };
+
+  class StructMetadataBuilder
+      : public StructMetadataBuilderBase<StructMetadataBuilder> {
+  public:
+    StructMetadataBuilder(IRGenModule &IGM, StructDecl *theStruct,
+                          ConstantStructBuilder &B)
+        : StructMetadataBuilderBase(IGM, theStruct, B) {}
 
     void createMetadataAccessFunction() {
       createNonGenericMetadataAccessFunction(IGM, Target);
       maybeCreateSingletonMetadataInitialization();
     }
   };
-  
+
   /// Emit a value witness table for a fixed-layout generic type, or a template
   /// if the value witness table is dependent on generic parameters.
   static ConstantReference
@@ -3710,24 +3726,25 @@ namespace {
     }
   };
 
-  class SpecializedGenericStructMetadataBuilder
-      : public StructMetadataBuilderBase<
-            SpecializedGenericStructMetadataBuilder> {
-    using super =
-        StructMetadataBuilderBase<SpecializedGenericStructMetadataBuilder>;
+  template <template <typename> class MetadataBuilderBase, typename Impl>
+  class SpecializedGenericNominalMetadataBuilderBase
+      : public MetadataBuilderBase<Impl> {
+    using super = MetadataBuilderBase<Impl>;
+
     CanType type;
-    bool HasUnfilledFieldOffset = false;
 
   protected:
     using super::asImpl;
     using super::getLoweredType;
     using super::IGM;
     using super::Target;
+    using typename super::ConstantBuilder;
+    using typename super::NominalDecl;
 
   public:
-    SpecializedGenericStructMetadataBuilder(IRGenModule &IGM, CanType type,
-                                            StructDecl &decl,
-                                            ConstantStructBuilder &B)
+    SpecializedGenericNominalMetadataBuilderBase(IRGenModule &IGM, CanType type,
+                                                 NominalDecl &decl,
+                                                 ConstantBuilder &B)
         : super(IGM, &decl, B), type(type) {}
 
     void noteStartOfTypeSpecificMembers() {}
@@ -3750,7 +3767,7 @@ namespace {
       auto t = requirement.TypeParameter.subst(genericSubstitutions());
       ConstantReference ref = IGM.getAddrOfTypeMetadata(
           CanType(t), SymbolReferenceKind::Relative_Direct);
-      B.add(ref.getDirectValue());
+      this->B.add(ref.getDirectValue());
     }
 
     void addGenericWitnessTable(GenericRequirement requirement) {
@@ -3773,7 +3790,7 @@ namespace {
         addr = IGM.getAddrOfWitnessTable(rootConformance);
       }
 
-      B.add(addr);
+      this->B.add(addr);
     }
 
     SubstitutionMap genericSubstitutions() {
@@ -3789,10 +3806,39 @@ namespace {
 
       return flags;
     }
+  };
 
-    void flagUnfilledFieldOffset() { HasUnfilledFieldOffset = true; }
+  // FIXME: rdar://problem/58884416:
+  //
+  //        Without this template typealias, the following errors are produced
+  //        when compiling on Linux and Windows, respectively:
+  //
+  //        template argument for template template parameter must be a class
+  //        template or type alias template
+  //
+  //        invalid template argument for template parameter
+  //        'MetadataBuilderBase', expected a class template
+  //
+  //        Once those issues are resolved, delete this typealias and directly
+  //        use StructMetadataBuilderBase in
+  //        SpecializedGenericNominalMetadataBuilderBase.
+  template <typename T>
+  using WorkaroundRestateStructMetadataBuilderBase =
+      StructMetadataBuilderBase<T>;
 
-    bool canBeConstant() { return !HasUnfilledFieldOffset; }
+  class SpecializedGenericStructMetadataBuilder
+      : public SpecializedGenericNominalMetadataBuilderBase<
+            WorkaroundRestateStructMetadataBuilderBase,
+            SpecializedGenericStructMetadataBuilder> {
+    using super = SpecializedGenericNominalMetadataBuilderBase<
+        WorkaroundRestateStructMetadataBuilderBase,
+        SpecializedGenericStructMetadataBuilder>;
+
+  public:
+    SpecializedGenericStructMetadataBuilder(IRGenModule &IGM, CanType type,
+                                            StructDecl &decl,
+                                            ConstantStructBuilder &B)
+        : super(IGM, type, decl, B) {}
   };
 
 } // end anonymous namespace
@@ -3828,8 +3874,8 @@ void irgen::emitStructMetadata(IRGenModule &IGM, StructDecl *structDecl) {
                          init.finishAndCreateFuture());
 }
 
-void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM,
-                                                 CanType type) {
+void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type,
+                                                 StructDecl &decl) {
   Type ty = type.getPointer();
   auto &context = type->getNominalOrBoundGenericNominal()->getASTContext();
   PrettyStackTraceType stackTraceRAII(
@@ -3840,7 +3886,6 @@ void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM,
 
   bool isPattern = false;
 
-  auto &decl = *type.getStructOrBoundGenericStruct();
   SpecializedGenericStructMetadataBuilder builder(IGM, type, decl, init);
   builder.layout();
 
@@ -3852,17 +3897,23 @@ void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM,
 // Enums
 
 static Optional<Size> getConstantPayloadSize(IRGenModule &IGM,
-                                             EnumDecl *enumDecl) {
-  auto enumTy = enumDecl->getDeclaredTypeInContext()->getCanonicalType();
+                                             EnumDecl *enumDecl,
+                                             CanType enumTy) {
   auto &enumTI = IGM.getTypeInfoForUnlowered(enumTy);
   if (!enumTI.isFixedSize(ResilienceExpansion::Maximal)) {
     return None;
   }
 
-  assert(!enumTI.isFixedSize(ResilienceExpansion::Minimal) &&
+  assert((!enumTI.isFixedSize(ResilienceExpansion::Minimal) || enumDecl->isGenericContext()) &&
          "non-generic, non-resilient enums don't need payload size in metadata");
   auto &strategy = getEnumImplStrategy(IGM, enumTy);
   return Size(strategy.getPayloadSizeForMetadata());
+}
+
+static Optional<Size> getConstantPayloadSize(IRGenModule &IGM,
+                                             EnumDecl *enumDecl) {
+  auto enumTy = enumDecl->getDeclaredTypeInContext()->getCanonicalType();
+  return getConstantPayloadSize(IGM, enumDecl, enumTy);
 }
 
 namespace {
@@ -3871,9 +3922,13 @@ namespace {
   class EnumMetadataBuilderBase
          : public ValueMetadataBuilderBase<EnumMetadataVisitor<Impl>> {
     using super = ValueMetadataBuilderBase<EnumMetadataVisitor<Impl>>;
+    bool HasUnfilledPayloadSize = false;
 
   protected:
-    ConstantStructBuilder &B;
+    using ConstantBuilder = ConstantStructBuilder;
+    using NominalDecl = EnumDecl;
+    ConstantBuilder &B;
+    using super::asImpl;
     using super::IGM;
     using super::Target;
 
@@ -3894,8 +3949,12 @@ namespace {
       return irgen::emitValueWitnessTable(IGM, type, false, relativeReference);
     }
 
+    ConstantReference getValueWitnessTable(bool relativeReference) {
+      return emitValueWitnessTable(relativeReference);
+    }
+
     void addValueWitnessTable() {
-      B.add(emitValueWitnessTable(/*relative*/ false).getValue());
+      B.add(asImpl().getValueWitnessTable(false).getValue());
     }
 
     llvm::Constant *emitNominalTypeDescriptor() {
@@ -3904,8 +3963,12 @@ namespace {
       return descriptor;
     }
 
+    llvm::Constant *getNominalTypeDescriptor() {
+      return emitNominalTypeDescriptor();
+    }
+
     void addNominalTypeDescriptor() {
-      B.add(emitNominalTypeDescriptor());
+      B.add(asImpl().getNominalTypeDescriptor());
     }
 
     void addGenericArgument(GenericRequirement requirement) {
@@ -3915,19 +3978,27 @@ namespace {
     void addGenericWitnessTable(GenericRequirement requirement) {
       llvm_unreachable("Concrete type metadata cannot have generic requirements");
     }
-  };
 
-  class EnumMetadataBuilder
-    : public EnumMetadataBuilderBase<EnumMetadataBuilder> {
-    bool HasUnfilledPayloadSize = false;
+    bool hasTrailingFlags() { return IGM.shouldPrespecializeGenericMetadata(); }
 
-  public:
-    EnumMetadataBuilder(IRGenModule &IGM, EnumDecl *theEnum,
-                        ConstantStructBuilder &B)
-      : EnumMetadataBuilderBase(IGM, theEnum, B) {}
+    void addTrailingFlags() {
+      auto flags = asImpl().getTrailingFlags();
+
+      B.addInt(IGM.Int64Ty, flags.getOpaqueValue());
+    }
+
+    MetadataTrailingFlags getTrailingFlags() {
+      MetadataTrailingFlags flags;
+
+      return flags;
+    }
+
+    Optional<Size> getPayloadSize() {
+      return getConstantPayloadSize(IGM, Target);
+    }
 
     void addPayloadSize() {
-      auto payloadSize = getConstantPayloadSize(IGM, Target);
+      auto payloadSize = asImpl().getPayloadSize();
       if (!payloadSize) {
         B.addInt(IGM.IntPtrTy, 0);
         HasUnfilledPayloadSize = true;
@@ -3940,6 +4011,52 @@ namespace {
     bool canBeConstant() {
       return !HasUnfilledPayloadSize;
     }
+  };
+
+  // FIXME: rdar://problem/58884416
+  //
+  //        Without this template typealias, the following errors are produced
+  //        when compiling on Linux and Windows, respectively:
+  //
+  //        template argument for template template parameter must be a class
+  //        template or type alias template
+  //
+  //        invalid template argument for template parameter
+  //        'MetadataBuilderBase', expected a class template
+  //
+  //        Once those issues are resolved, delete this typealias and directly
+  //        use EnumMetadataBuilderBase in
+  //        SpecializedGenericNominalMetadataBuilderBase.
+  template <typename T>
+  using WorkaroundRestateEnumMetadataBuilderBase = EnumMetadataBuilderBase<T>;
+
+  class SpecializedGenericEnumMetadataBuilder
+      : public SpecializedGenericNominalMetadataBuilderBase<
+            WorkaroundRestateEnumMetadataBuilderBase,
+            SpecializedGenericEnumMetadataBuilder> {
+
+    using super = SpecializedGenericNominalMetadataBuilderBase<
+        WorkaroundRestateEnumMetadataBuilderBase,
+        SpecializedGenericEnumMetadataBuilder>;
+
+    CanType type;
+
+  public:
+    SpecializedGenericEnumMetadataBuilder(IRGenModule &IGM, CanType type,
+                                          EnumDecl &decl, ConstantBuilder &B)
+        : super(IGM, type, decl, B), type(type) {};
+
+    Optional<Size> getPayloadSize() {
+      return getConstantPayloadSize(IGM, Target, type);
+    }
+  };
+
+  class EnumMetadataBuilder
+      : public EnumMetadataBuilderBase<EnumMetadataBuilder> {
+  public:
+    EnumMetadataBuilder(IRGenModule &IGM, EnumDecl *theEnum,
+                        ConstantStructBuilder &B)
+        : EnumMetadataBuilderBase(IGM, theEnum, B) {}
 
     void createMetadataAccessFunction() {
       createNonGenericMetadataAccessFunction(IGM, Target);
@@ -3990,6 +4107,16 @@ namespace {
       return EnumContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
     }
 
+    GenericMetadataPatternFlags getPatternFlags() {
+      auto flags = super::getPatternFlags();
+
+      if (IGM.shouldPrespecializeGenericMetadata()) {
+        flags.setHasTrailingFlags(true);
+      }
+
+      return flags;
+    }
+
     ConstantReference emitValueWitnessTable(bool relativeReference) {
       assert(relativeReference && "should only relative reference");
       return getValueWitnessTableForGenericValueType(IGM, Target,
@@ -4030,6 +4157,26 @@ void irgen::emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum) {
   CanType declaredType = theEnum->getDeclaredType()->getCanonicalType();
 
   IGM.defineTypeMetadata(declaredType, isPattern, canBeConstant,
+                         init.finishAndCreateFuture());
+}
+
+void irgen::emitSpecializedGenericEnumMetadata(IRGenModule &IGM, CanType type,
+                                               EnumDecl &decl) {
+  Type ty = type.getPointer();
+  auto &context = type->getNominalOrBoundGenericNominal()->getASTContext();
+  PrettyStackTraceType stackTraceRAII(
+      context, "emitting prespecialized metadata for", ty);
+  ConstantInitBuilder initBuilder(IGM);
+  auto init = initBuilder.beginStruct();
+  init.setPacked(true);
+
+  bool isPattern = false;
+
+  SpecializedGenericEnumMetadataBuilder builder(IGM, type, decl, init);
+  builder.layout();
+
+  bool canBeConstant = builder.canBeConstant();
+  IGM.defineTypeMetadata(type, isPattern, canBeConstant,
                          init.finishAndCreateFuture());
 }
 

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -85,7 +85,11 @@ namespace irgen {
   /// Emit the metadata associated with the given enum declaration.
   void emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum);
 
-  void emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type);
+  void emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type,
+                                            StructDecl &decl);
+
+  void emitSpecializedGenericEnumMetadata(IRGenModule &IGM, CanType type,
+                                          EnumDecl &decl);
 
   /// Get what will be the index into the generic type argument array at the end
   /// of a nominal type's metadata.

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -684,11 +684,6 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
     return false;
   }
 
-  if (isa<EnumType>(type) || isa<BoundGenericEnumType>(type)) {
-    // TODO: Support enums.
-    return false;
-  }
-
   if (isa<ClassType>(type) || isa<BoundGenericClassType>(type)) {
     // TODO: Support classes.
     return false;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5223,6 +5223,8 @@ template <>
 bool Metadata::isCanonicalStaticallySpecializedGenericMetadata() const {
   if (auto *metadata = dyn_cast<StructMetadata>(this))
     return metadata->isCanonicalStaticallySpecializedGenericMetadata();
+  if (auto *metadata = dyn_cast<EnumMetadata>(this))
+    return metadata->isCanonicalStaticallySpecializedGenericMetadata();
 
   return false;
 }

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -1,9 +1,13 @@
 // #if directives don't work with SIL keywords, therefore please put ObjC tests
 // in `enum_objc.sil`.
-// RUN: %target-swift-frontend %s -disable-generic-metadata-prespecialization -disable-generic-metadata-prespecialization -gnone -emit-ir -disable-diagnostic-passes -enable-objc-interop  | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize-simulator-%target-is-simulator -DWORD=i%target-ptrsize
-// RUN: %target-swift-frontend %s -disable-generic-metadata-prespecialization -gnone -emit-ir -disable-diagnostic-passes -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend %s -target %module-target-future -gnone -emit-ir -disable-diagnostic-passes -enable-objc-interop  | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize-simulator-%target-is-simulator -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend %s -target %module-target-future -gnone -emit-ir -disable-diagnostic-passes -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize -DWORD=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
 
 // We have to claim this is raw SIL because there are critical edges from non
 // cond_br instructions.
@@ -13,42 +17,42 @@ import Builtin
 import Swift
 
 // -- Singleton enum. The representation is just the singleton payload.
-// CHECK: %T4enum9SingletonO = type <{ <{ i64, i64 }> }>
+// CHECK: %T11enum_future9SingletonO = type <{ <{ i64, i64 }> }>
 
 // -- Singleton enum with heap object ref payload. <rdar://problem/15679353>
-// CHECK: %T4enum12SingletonRefO = type <{ %swift.refcounted* }>
+// CHECK: %T11enum_future12SingletonRefO = type <{ %swift.refcounted* }>
 
 // -- No-payload enums. The representation is just an enum tag.
-// CHECK: %T4enum10NoPayloadsO = type <{ i8 }>
-// CHECK: %T4enum11NoPayloads2O = type <{ i8 }>
+// CHECK: %T11enum_future10NoPayloadsO = type <{ i8 }>
+// CHECK: %T11enum_future11NoPayloads2O = type <{ i8 }>
 
 // -- Single-payload enum, no extra inhabitants in the payload type. The
 //    representation adds a tag bit to distinguish payload from enum tag:
 //      case x(i64): X0 X1 X2 ... X63 | 0, where X0...X63 are the payload bits
 //      case y:      0  0  0  ... 0   | 1
 //      case z:      1  0  0  ... 0   | 1
-// CHECK-64: %T4enum17SinglePayloadNoXIO = type <{ [8 x i8], [1 x i8] }>
-// CHECK-64: %T4enum18SinglePayloadNoXI2O = type <{ [8 x i8], [1 x i8] }>
-// CHECK-32: %T4enum17SinglePayloadNoXIO = type <{ [4 x i8], [1 x i8] }>
-// CHECK-32: %T4enum18SinglePayloadNoXI2O = type <{ [4 x i8], [1 x i8] }>
+// CHECK-64: %T11enum_future17SinglePayloadNoXIO = type <{ [8 x i8], [1 x i8] }>
+// CHECK-64: %T11enum_future18SinglePayloadNoXI2O = type <{ [8 x i8], [1 x i8] }>
+// CHECK-32: %T11enum_future17SinglePayloadNoXIO = type <{ [4 x i8], [1 x i8] }>
+// CHECK-32: %T11enum_future18SinglePayloadNoXI2O = type <{ [4 x i8], [1 x i8] }>
 
 // -- Single-payload enum, spare bits. The representation uses a tag bit
 //    out of the payload to distinguish payload from enum tag:
 //      case x(i3): X0 X1 X2 0 0 0 0 0
 //      case y:     0  0  0  1 0 0 0 0
 //      case z:     1  0  0  1 0 0 0 0
-// CHECK: %T4enum21SinglePayloadSpareBitO = type <{ [8 x i8] }>
+// CHECK: %T11enum_future21SinglePayloadSpareBitO = type <{ [8 x i8] }>
 
 // -- Single-payload enum containing a no-payload enum as its payload.
 //    The representation takes extra inhabitants starting after the greatest
 //    discriminator value used by the nested no-payload enum.
-// CHECK: %T4enum19SinglePayloadNestedO = type <{ [1 x i8] }>
+// CHECK: %T11enum_future19SinglePayloadNestedO = type <{ [1 x i8] }>
 
 // -- Single-payload enum containing another single-payload enum as its
 //    payload.
 //    The representation takes extra inhabitants from the nested enum's payload
 //    that were unused by the nested enum.
-// CHECK: %T4enum019SinglePayloadNestedD0O = type <{ [1 x i8] }>
+// CHECK: %T11enum_future019SinglePayloadNestedE0O = type <{ [1 x i8] }>
 
 // -- Multi-payload enum, no spare bits. The representation adds tag bits
 //    to discriminate payloads. No-payload cases all share a tag.
@@ -58,7 +62,7 @@ import Swift
 //      case a:     0  0  0  ... 0  0  | 1 1
 //      case b:     1  0  0  ... 0  0  | 1 1
 //      case c:     0  1  0  ... 0  0  | 1 1
-// CHECK: %T4enum23MultiPayloadNoSpareBitsO = type <{ [8 x i8], [1 x i8] }>
+// CHECK: %T11enum_future23MultiPayloadNoSpareBitsO = type <{ [8 x i8], [1 x i8] }>
 
 // -- Multi-payload enum, one spare bit. The representation uses spare bits
 //    common to all payloads to partially discriminate payloads, with added
@@ -69,7 +73,7 @@ import Swift
 //      case a:     0  0  0  0  0  0  0  1 | 1
 //      case b:     1  0  0  0  0  0  0  1 | 1
 //      case c:     0  1  0  0  0  0  0  1 | 1
-// CHECK: %T4enum23MultiPayloadOneSpareBitO = type <{ [8 x i8], [1 x i8] }>
+// CHECK: %T11enum_future23MultiPayloadOneSpareBitO = type <{ [8 x i8], [1 x i8] }>
 
 // -- Multi-payload enum, two spare bits. Same as above, except we have enough
 //    spare bits not to require any added tag bits.
@@ -79,65 +83,65 @@ import Swift
 //      case a:     0  0  0  0  0  0  1  1
 //      case b:     1  0  0  0  0  0  1  1
 //      case c:     0  1  0  0  0  0  1  1
-// CHECK: %T4enum24MultiPayloadTwoSpareBitsO = type <{ [8 x i8] }>
+// CHECK: %T11enum_future24MultiPayloadTwoSpareBitsO = type <{ [8 x i8] }>
 
-// CHECK-64: %T4enum30MultiPayloadSpareBitAggregatesO = type <{ [16 x i8] }>
+// CHECK-64: %T11enum_future30MultiPayloadSpareBitAggregatesO = type <{ [16 x i8] }>
 
-// CHECK-64: %T4enum18MultiPayloadNestedO = type <{ [9 x i8] }>
-// CHECK-32: %T4enum18MultiPayloadNestedO = type <{ [5 x i8] }>
+// CHECK-64: %T11enum_future18MultiPayloadNestedO = type <{ [9 x i8] }>
+// CHECK-32: %T11enum_future18MultiPayloadNestedO = type <{ [5 x i8] }>
 
 // 32-bit object references don't have enough spare bits.
-// CHECK-64: %T4enum27MultiPayloadNestedSpareBitsO = type <{ [8 x i8] }>
+// CHECK-64: %T11enum_future27MultiPayloadNestedSpareBitsO = type <{ [8 x i8] }>
 
 // -- Dynamic enums. The type layout is opaque; we dynamically bitcast to
 //    the element type.
-// CHECK: %T4enum20DynamicSinglePayloadO = type <{}>
-// CHECK: [[DYNAMIC_SINGLE_EMPTY_PAYLOAD:%T4enum20DynamicSinglePayloadOyytG]] = type <{ [1 x i8] }>
+// CHECK: %T11enum_future20DynamicSinglePayloadO = type <{}>
+// CHECK: [[DYNAMIC_SINGLE_EMPTY_PAYLOAD:%T11enum_future20DynamicSinglePayloadOyytG]] = type <{ [1 x i8] }>
 
 // -- Address-only multi-payload enums. We can't use spare bits.
-// CHECK-64: %T4enum32MultiPayloadAddressOnlySpareBitsO = type <{ [16 x i8], [1 x i8] }>
-// CHECK-32: %T4enum32MultiPayloadAddressOnlySpareBitsO = type <{ [8 x i8], [1 x i8] }>
+// CHECK-64: %T11enum_future32MultiPayloadAddressOnlySpareBitsO = type <{ [16 x i8], [1 x i8] }>
+// CHECK-32: %T11enum_future32MultiPayloadAddressOnlySpareBitsO = type <{ [8 x i8], [1 x i8] }>
 
-// CHECK: [[DYNAMIC_SINGLETON:%T4enum16DynamicSingletonO.*]] = type <{}>
+// CHECK: [[DYNAMIC_SINGLETON:%T11enum_future16DynamicSingletonO.*]] = type <{}>
 
-// CHECK: %T4enum40MultiPayloadLessThan32BitsWithEmptyCasesO = type <{ [1 x i8], [1 x i8] }>
+// CHECK: %T11enum_future40MultiPayloadLessThan32BitsWithEmptyCasesO = type <{ [1 x i8], [1 x i8] }>
 
 // -- Dynamic metadata template carries a value witness table pattern
 //    we fill in on instantiation.
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
-// CHECK: @"$s4enum16DynamicSingletonOWV" =
+// CHECK: @"$s11enum_future16DynamicSingletonOWV" =
 // CHECK-SAME:   [[WORD]] 0,
 // CHECK-SAME:   [[WORD]] 0,
 //   6291456 == 0x600000 (enum, incomplete)
 // CHECK-SAME:   i32 6291456,
 // CHECK-SAME:   i32 0,
 //   Enum witnesses.
-// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4enum16DynamicSingletonOwug" to i8*)
-// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4enum16DynamicSingletonOwup" to i8*)
-// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4enum16DynamicSingletonOwui" to i8*)
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s11enum_future16DynamicSingletonOwug" to i8*)
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s11enum_future16DynamicSingletonOwup" to i8*)
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s11enum_future16DynamicSingletonOwui" to i8*)
 
 // CHECK: [[DYNAMICSINGLETON_NAME:@.*]] = private constant [17 x i8] c"DynamicSingleton\00"
-// CHECK: @"$s4enum16DynamicSingletonOMn" = hidden constant <{
+// CHECK: @"$s11enum_future16DynamicSingletonOMn" = hidden constant <{
 // CHECK-SAME:   [17 x i8]* [[DYNAMICSINGLETON_NAME]]
 // --       One payload
 // CHECK-SAME:   i32 1,
 // --       No empty cases
 // CHECK-SAME:   i32 0,
 // --       generic instantiation pattern
-// CHECK-SAME:   @"$s4enum16DynamicSingletonOMP"
+// CHECK-SAME:   @"$s11enum_future16DynamicSingletonOMP"
 // --       generic parameters, requirements, key, extra
 // CHECK-SAME:   i16 1, i16 0, i16 1, i16 0
 // --       generic param
 // CHECK-SAME:   i8 -128,
 // CHECK-SAME: }>
 
-// CHECK: @"$s4enum16DynamicSingletonOMP" = internal constant <{ {{.*}} }> <{
-// CHECK-SAME:   @"$s4enum16DynamicSingletonOMi"
-// CHECK-SAME:   %swift.enum_vwtable* @"$s4enum16DynamicSingletonOWV"
+// CHECK: @"$s11enum_future16DynamicSingletonOMP" = internal constant <{ {{.*}} }> <{
+// CHECK-SAME:   @"$s11enum_future16DynamicSingletonOMi"
+// CHECK-SAME:   %swift.enum_vwtable* @"$s11enum_future16DynamicSingletonOWV"
 
 // -- No-payload enums have extra inhabitants in
 //    their value witness table.
-// CHECK: @"$s4enum10NoPayloadsOWV" = internal constant %swift.enum_vwtable {
+// CHECK: @"$s11enum_future10NoPayloadsOWV" = internal constant %swift.enum_vwtable {
 // -- ...
 // -- size
 // CHECK-SAME:   [[WORD]] 1,
@@ -151,7 +155,7 @@ import Swift
 
 // -- Single-payload enums take unused extra inhabitants from their payload
 //    as their own.
-// CHECK: @"$s4enum19SinglePayloadNestedOWV" = internal constant %swift.enum_vwtable {
+// CHECK: @"$s11enum_future19SinglePayloadNestedOWV" = internal constant %swift.enum_vwtable {
 // -- ...
 // -- size
 // CHECK-SAME:   [[WORD]] 1,
@@ -163,17 +167,17 @@ import Swift
 // CHECK-SAME:   i32 250,
 // CHECK-SAME: }
 
-// CHECK: @"$s4enum20DynamicSinglePayloadOWV" = internal constant %swift.enum_vwtable {
+// CHECK: @"$s11enum_future20DynamicSinglePayloadOWV" = internal constant %swift.enum_vwtable {
 // -- flags (0x60_0000: alignment 1, incomplete, enum witnesses)
 // CHECK-SAME:   i32 6291456,
 // -- num extra inhabitants (253 from payload - 3 empty cases)
 // CHECK-SAME:   i32 0,
 
-// CHECK: @"$s4enum20DynamicSinglePayloadOMP" = internal constant <{ {{.*}} }> <{
-// CHECK-SAME:   @"$s4enum20DynamicSinglePayloadOMi"
-// CHECK-SAME:   %swift.enum_vwtable* @"$s4enum20DynamicSinglePayloadOWV"
+// CHECK: @"$s11enum_future20DynamicSinglePayloadOMP" = internal constant <{ {{.*}} }> <{
+// CHECK-SAME:   @"$s11enum_future20DynamicSinglePayloadOMi"
+// CHECK-SAME:   %swift.enum_vwtable* @"$s11enum_future20DynamicSinglePayloadOWV"
 
-// CHECK: @"$s4enum18MultiPayloadNestedOWV" = internal constant %swift.enum_vwtable {
+// CHECK: @"$s11enum_future18MultiPayloadNestedOWV" = internal constant %swift.enum_vwtable {
 // -- size
 // CHECK-32-SAME:   [[WORD]] 5,
 // CHECK-64-SAME:   [[WORD]] 9,
@@ -202,7 +206,7 @@ enum DynamicSingleton<T> {
 }
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(i64 %0, i64 %1) {{.*}} {
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(%T4enum9SingletonO* noalias nocapture dereferenceable(16) %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(%T11enum_future9SingletonO* noalias nocapture dereferenceable(16) %0) {{.*}} {
 sil @singleton_switch : $(Singleton) -> () {
 // CHECK-64: entry:
 // CHECK-32: entry:
@@ -221,12 +225,12 @@ dest:
 }
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(i64 %0, i64 %1) {{.*}} {
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(%T4enum9SingletonO* noalias nocapture dereferenceable(16) %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(%T11enum_future9SingletonO* noalias nocapture dereferenceable(16) %0) {{.*}} {
 sil @singleton_switch_arg : $(Singleton) -> () {
 // CHECK-64: entry:
 // CHECK-32: entry:
 entry(%u : $Singleton):
-// CHECK-32:  call %T4enum9SingletonO* @"$s4enum9SingletonOWOb"
+// CHECK-32:  call %T11enum_future9SingletonO* @"$s11enum_future9SingletonOWOb"
 // CHECK-64:   br label %[[PREDEST:[0-9]+]]
 // CHECK-32:   br label %[[PREDEST:[0-9]+]]
   switch_enum %u : $Singleton, case #Singleton.value!enumelt.1: dest
@@ -242,11 +246,11 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(%T4enum9SingletonO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(%T11enum_future9SingletonO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
 // CHECK: [[DEST]]:
-// CHECK:   [[ADDR:%.*]] = bitcast %T4enum9SingletonO* %0 to <{ i64, i64 }>*
+// CHECK:   [[ADDR:%.*]] = bitcast %T11enum_future9SingletonO* %0 to <{ i64, i64 }>*
 // CHECK:   ret void
 // CHECK: }
 sil @singleton_switch_indirect : $(@inout Singleton) -> () {
@@ -264,9 +268,9 @@ dest:
 // CHECK-64:   [[B:%.*]] = insertvalue { i64, i64 } [[A]], i64 %1, 1
 // CHECK-64:   ret { i64, i64 } [[B]]
 // CHECK-64: }
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject(%T4enum9SingletonO* noalias nocapture sret %0, i64 %1, i64 %2) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject(%T11enum_future9SingletonO* noalias nocapture sret %0, i64 %1, i64 %2) {{.*}} {
 // CHECK-32: entry:
-// CHECK-32:  [[CAST:%.*]] = bitcast %T4enum9SingletonO* %0 to <{ i64, i64 }>*
+// CHECK-32:  [[CAST:%.*]] = bitcast %T11enum_future9SingletonO* %0 to <{ i64, i64 }>*
 // CHECK-32:  [[GEP1:%.*]] = getelementptr inbounds <{ i64, i64 }>, <{ i64, i64 }>* [[CAST]], i32 0, i32 0
 // CHECK-32:                 store i64 %1, i64* [[GEP1]]
 // CHECK-32:  [[GEP2:%.*]] = getelementptr inbounds <{ i64, i64 }>, <{ i64, i64 }>* [[CAST]], i32 0, i32 1
@@ -280,9 +284,9 @@ entry(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
   return %u : $Singleton
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, %T4enum9SingletonO* nocapture dereferenceable({{.*}}) %2) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64 %0, i64 %1, %T11enum_future9SingletonO* nocapture dereferenceable({{.*}}) %2) {{.*}} {
 // CHECK: entry:
-// CHECK:   [[DATA_ADDR:%.*]] = bitcast %T4enum9SingletonO* %2 to <{ i64, i64 }>*
+// CHECK:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future9SingletonO* %2 to <{ i64, i64 }>*
 // CHECK:   [[DATA_0_ADDR:%.*]] = getelementptr inbounds <{ i64, i64 }>, <{ i64, i64 }>* [[DATA_ADDR]], i32 0, i32 0
 // CHECK:   store i64 %0, i64* [[DATA_0_ADDR]]
 // CHECK:   [[DATA_1_ADDR:%.*]] = getelementptr inbounds <{ i64, i64 }>, <{ i64, i64 }>* [[DATA_ADDR]], i32 0, i32 1
@@ -356,10 +360,10 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(%T4enum10NoPayloadsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(%T11enum_future10NoPayloadsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 sil @no_payload_switch_indirect : $@convention(thin) (@inout NoPayloads) -> () {
 entry(%u : $*NoPayloads):
-// CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %T4enum10NoPayloadsO, %T4enum10NoPayloadsO* %0, i32 0, i32 0
+// CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %T11enum_future10NoPayloadsO, %T11enum_future10NoPayloadsO* %0, i32 0, i32 0
 // CHECK:   [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]]
 // CHECK:   switch i8 [[TAG]]
   switch_enum_addr %u : $*NoPayloads, case #NoPayloads.x!enumelt: x_dest, case #NoPayloads.y!enumelt: y_dest, case #NoPayloads.z!enumelt: z_dest
@@ -405,9 +409,9 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(%T4enum10NoPayloadsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(%T11enum_future10NoPayloadsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
-// CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %T4enum10NoPayloadsO, %T4enum10NoPayloadsO* %0, i32 0, i32 0
+// CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %T11enum_future10NoPayloadsO, %T11enum_future10NoPayloadsO* %0, i32 0, i32 0
 // CHECK:   store i8 2, i8* [[TAG_ADDR]]
 // CHECK:   ret void
 // CHECK: }
@@ -636,11 +640,11 @@ entry(%0 : $Builtin.Word):
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, %T4enum18SinglePayloadNoXI2O* nocapture dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]] %0, %T11enum_future18SinglePayloadNoXI2O* nocapture dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK: entry:
-// CHECK:   [[DATA_ADDR:%.*]] = bitcast %T4enum18SinglePayloadNoXI2O* %1 to [[WORD]]*
+// CHECK:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future18SinglePayloadNoXI2O* %1 to [[WORD]]*
 // CHECK:   store [[WORD]] %0, [[WORD]]* [[DATA_ADDR]]
-// CHECK:   [[T0:%.*]] = getelementptr inbounds %T4enum18SinglePayloadNoXI2O, %T4enum18SinglePayloadNoXI2O* %1, i32 0, i32 1
+// CHECK:   [[T0:%.*]] = getelementptr inbounds %T11enum_future18SinglePayloadNoXI2O, %T11enum_future18SinglePayloadNoXI2O* %1, i32 0, i32 1
 // CHECK:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i1*
 // CHECK:   store i1 false, i1* [[TAG_ADDR]]
 // CHECK:   ret void
@@ -664,11 +668,11 @@ entry:
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(%T4enum18SinglePayloadNoXI2O* nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(%T11enum_future18SinglePayloadNoXI2O* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK: entry:
-// CHECK:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum18SinglePayloadNoXI2O* %0 to [[WORD]]*
+// CHECK:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future18SinglePayloadNoXI2O* %0 to [[WORD]]*
 // CHECK:   store [[WORD]] 0, [[WORD]]* [[PAYLOAD_ADDR]]
-// CHECK:   [[T0:%.*]] = getelementptr inbounds %T4enum18SinglePayloadNoXI2O, %T4enum18SinglePayloadNoXI2O* %0, i32 0, i32 1
+// CHECK:   [[T0:%.*]] = getelementptr inbounds %T11enum_future18SinglePayloadNoXI2O, %T11enum_future18SinglePayloadNoXI2O* %0, i32 0, i32 1
 // CHECK:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i1*
 // CHECK:   store i1 true, i1* [[TAG_ADDR]]
 // CHECK:   ret void
@@ -763,7 +767,7 @@ enum AggregateSinglePayload2 {
 }
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_unpack_2([[WORD]] %0, [[WORD]] %1, [[WORD]] %2, [[WORD]] %3) {{.*}} {
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(%T4enum23AggregateSinglePayload2O* noalias nocapture dereferenceable(16) %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(%T11enum_future23AggregateSinglePayload2O* noalias nocapture dereferenceable(16) %0) {{.*}} {
 sil @aggregate_single_payload_unpack_2 : $@convention(thin) (AggregateSinglePayload2) -> () {
 entry(%u : $AggregateSinglePayload2):
   switch_enum %u : $AggregateSinglePayload2, case #AggregateSinglePayload2.x!enumelt.1: x_dest, default default_dest
@@ -794,10 +798,10 @@ end:
 // CHECK-64:  %9 = insertvalue { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } %8, [[WORD]] %3, 3
 // CHECK-64:  ret { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } %9
 
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_2_inject(%T4enum23AggregateSinglePayload2O* noalias nocapture sret %0, i32 %1, i32 %2, i32 %3, i32 %4) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_2_inject(%T11enum_future23AggregateSinglePayload2O* noalias nocapture sret %0, i32 %1, i32 %2, i32 %3, i32 %4) {{.*}} {
 // CHECK-32:  [[TRUNC:%.*]] = trunc i32 %1 to i21
 // CHECK-32:  [[ZEXT:%.*]] = zext i21 [[TRUNC]] to i32
-// CHECK-32:  [[CAST:%.*]] = bitcast %T4enum23AggregateSinglePayload2O* %0 to { i32, i32, i32, i32 }*
+// CHECK-32:  [[CAST:%.*]] = bitcast %T11enum_future23AggregateSinglePayload2O* %0 to { i32, i32, i32, i32 }*
 // CHECK-32:  [[GEP:%.*]] = getelementptr inbounds {{.*}} [[CAST]], i32 0, i32 0
 // CHECK-32:  store i32 [[ZEXT]], i32* [[GEP]]
 // CHECK-32:  store i32 %2, i32*
@@ -970,13 +974,13 @@ end:
 
 sil @single_payload_spare_bit_switch_indirect : $@convention(thin) (@inout SinglePayloadSpareBit) -> () {
 entry(%u : $*SinglePayloadSpareBit):
-// CHECK-64:  [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %0 to i64*
+// CHECK-64:  [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future21SinglePayloadSpareBitO* %0 to i64*
 // CHECK-64:  [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // CHECK-64:  switch i64 [[PAYLOAD]], label %[[DFLT:[0-9]+]] [
   switch_enum_addr %u : $*SinglePayloadSpareBit, case #SinglePayloadSpareBit.x!enumelt.1: x_dest, case #SinglePayloadSpareBit.y!enumelt: y_dest, case #SinglePayloadSpareBit.z!enumelt: z_dest
 
 // CHECK-64: [[DFLT]]:
-// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %0 to i63*
+// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future21SinglePayloadSpareBitO* %0 to i63*
 x_dest:
   %u2 = unchecked_take_enum_data_addr %u : $*SinglePayloadSpareBit, #SinglePayloadSpareBit.x!enumelt.1
   %a = function_ref @a : $@convention(thin) () -> ()
@@ -1006,10 +1010,10 @@ entry(%0 : $Builtin.Int63):
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, %T4enum21SinglePayloadSpareBitO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64 %0, %T11enum_future21SinglePayloadSpareBitO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
-// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %1 to i63*
+// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future21SinglePayloadSpareBitO* %1 to i63*
 // CHECK-64:   store i63 [[T]], i63* [[DATA_ADDR]]
 // CHECK-64:   ret void
 // CHECK-64: }
@@ -1033,9 +1037,9 @@ entry:
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(%T4enum21SinglePayloadSpareBitO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(%T11enum_future21SinglePayloadSpareBitO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %0 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future21SinglePayloadSpareBitO* %0 to i64*
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, i64* [[PAYLOAD_ADDR]]
 // CHECK-64:   ret void
@@ -1125,7 +1129,7 @@ end:
 class C {}
 sil_vtable C {}
 
-sil @$s4enum1CCfD : $@convention(method) (C) -> ()
+sil @$s11enum_future1CCfD : $@convention(method) (C) -> ()
 
 enum SinglePayloadClass {
   case x(C)
@@ -1146,7 +1150,7 @@ enum SinglePayloadClass {
 // CHECK-native-64: i64 2, label {{%.*}}
 // CHECK-64:   ]
 // CHECK-64: [[DFLT]]:
-// CHECK-64:   inttoptr [[WORD]] %0 to %T4enum1CC*
+// CHECK-64:   inttoptr [[WORD]] %0 to %T11enum_future1CC*
 
 // CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(i32 %0) {{.*}} {
 // CHECK-32: entry:
@@ -1156,7 +1160,7 @@ enum SinglePayloadClass {
 // CHECK-32:     i32 2, label {{%.*}}
 // CHECK-32:   ]
 // CHECK-32: [[DFLT]]:
-// CHECK-32:   inttoptr [[WORD]] %0 to %T4enum1CC*
+// CHECK-32:   inttoptr [[WORD]] %0 to %T11enum_future1CC*
 
 sil @single_payload_class_switch : $(SinglePayloadClass) -> () {
 entry(%c : $SinglePayloadClass):
@@ -1232,8 +1236,8 @@ enum DynamicSinglePayload<T> {
   case w
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_switch(%T4enum20DynamicSinglePayloadO* noalias nocapture %0, %swift.type* %T) {{.*}} {
-// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* %0 to %swift.opaque*
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_switch(%T11enum_future20DynamicSinglePayloadO* noalias nocapture %0, %swift.type* %T) {{.*}} {
+// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T11enum_future20DynamicSinglePayloadO* %0 to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[TMP2]]
@@ -1263,8 +1267,8 @@ end:
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(%T4enum20DynamicSinglePayloadO* noalias nocapture sret %0, %swift.opaque* noalias nocapture %1, %swift.type* %T) {{.*}} {
-// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* %0 to %swift.opaque*
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(%T11enum_future20DynamicSinglePayloadO* noalias nocapture sret %0, %swift.opaque* noalias nocapture %1, %swift.type* %T) {{.*}} {
+// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T11enum_future20DynamicSinglePayloadO* %0 to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[TMP2]]
@@ -1279,8 +1283,8 @@ entry(%r : $*DynamicSinglePayload<T>, %t : $*T):
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(%T4enum20DynamicSinglePayloadO* noalias nocapture sret %0, %swift.type* %T) {{.*}} {
-// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* %0 to %swift.opaque*
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(%T11enum_future20DynamicSinglePayloadO* noalias nocapture sret %0, %swift.type* %T) {{.*}} {
+// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T11enum_future20DynamicSinglePayloadO* %0 to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[TMP2]]
@@ -1466,12 +1470,12 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(%T4enum23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(%T11enum_future23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 sil @multi_payload_no_spare_bits_switch_indirect : $(@inout MultiPayloadNoSpareBits) -> () {
 entry(%u : $*MultiPayloadNoSpareBits):
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadNoSpareBitsO* %0 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
-// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T4enum23MultiPayloadNoSpareBitsO, %T4enum23MultiPayloadNoSpareBitsO* %0, i32 0, i32 1
+// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T11enum_future23MultiPayloadNoSpareBitsO, %T11enum_future23MultiPayloadNoSpareBitsO* %0, i32 0, i32 1
 // CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i8*
 // CHECK-64:   [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]]
 // CHECK-64:   switch i8 [[TAG]]
@@ -1481,11 +1485,11 @@ entry(%u : $*MultiPayloadNoSpareBits):
   switch_enum_addr %u : $*MultiPayloadNoSpareBits, case #MultiPayloadNoSpareBits.x!enumelt.1: x_dest, case #MultiPayloadNoSpareBits.y!enumelt.1: y_dest, case #MultiPayloadNoSpareBits.z!enumelt.1: z_dest, case #MultiPayloadNoSpareBits.a!enumelt: a_dest, case #MultiPayloadNoSpareBits.b!enumelt: b_dest, case #MultiPayloadNoSpareBits.c!enumelt: c_dest
 
 // CHECK-64: [[X_DEST:[0-9]+]]:
-// CHECK-64:   bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i64*
+// CHECK-64:   bitcast %T11enum_future23MultiPayloadNoSpareBitsO* %0 to i64*
 // CHECK-64: [[Y_DEST:[0-9]+]]:
-// CHECK-64:   bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i32*
+// CHECK-64:   bitcast %T11enum_future23MultiPayloadNoSpareBitsO* %0 to i32*
 // CHECK-64: [[Z_DEST:[0-9]+]]:
-// CHECK-64:   bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i63*
+// CHECK-64:   bitcast %T11enum_future23MultiPayloadNoSpareBitsO* %0 to i63*
 
 x_dest:
   %x = unchecked_take_enum_data_addr %u : $*MultiPayloadNoSpareBits, #MultiPayloadNoSpareBits.x!enumelt.1
@@ -1525,11 +1529,11 @@ entry(%0 : $Builtin.Int64):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, %T4enum23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64 %0, %T11enum_future23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum23MultiPayloadNoSpareBitsO* %1 to i64*
+// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadNoSpareBitsO* %1 to i64*
 // CHECK-64:   store i64 %0, i64* [[DATA_ADDR]]
-// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T4enum23MultiPayloadNoSpareBitsO, %T4enum23MultiPayloadNoSpareBitsO* %1, i32 0, i32 1
+// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T11enum_future23MultiPayloadNoSpareBitsO, %T11enum_future23MultiPayloadNoSpareBitsO* %1, i32 0, i32 1
 // CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i8*
 // CHECK-64:   store i8 0, i8* [[TAG_ADDR]]
 // CHECK-64:   ret void
@@ -1580,11 +1584,11 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(%T4enum23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(%T11enum_future23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadNoSpareBitsO* %0 to i64*
 // CHECK-64:   store i64 0, i64* [[PAYLOAD_ADDR]]
-// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T4enum23MultiPayloadNoSpareBitsO, %T4enum23MultiPayloadNoSpareBitsO* %0, i32 0, i32 1
+// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T11enum_future23MultiPayloadNoSpareBitsO, %T11enum_future23MultiPayloadNoSpareBitsO* %0, i32 0, i32 1
 // CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i8*
 // CHECK-64:   store i8 3, i8* [[TAG_ADDR]]
 // CHECK-64:   ret void
@@ -1714,9 +1718,9 @@ end:
 
 sil @multi_payload_one_spare_bit_switch_indirect : $(@inout MultiPayloadOneSpareBit) -> () {
 entry(%u : $*MultiPayloadOneSpareBit):
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %0 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
-// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T4enum23MultiPayloadOneSpareBitO, %T4enum23MultiPayloadOneSpareBitO* %0, i32 0, i32 1
+// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T11enum_future23MultiPayloadOneSpareBitO, %T11enum_future23MultiPayloadOneSpareBitO* %0, i32 0, i32 1
 // CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i1*
 // CHECK-64:   [[TAG:%.*]] = load i1, i1* [[TAG_ADDR]]
 // CHECK-64:   switch i8 {{%.*}}
@@ -1726,19 +1730,19 @@ entry(%u : $*MultiPayloadOneSpareBit):
   switch_enum_addr %u : $*MultiPayloadOneSpareBit, case #MultiPayloadOneSpareBit.x!enumelt.1: x_dest, case #MultiPayloadOneSpareBit.y!enumelt.1: y_dest, case #MultiPayloadOneSpareBit.z!enumelt.1: z_dest, case #MultiPayloadOneSpareBit.a!enumelt: a_dest, case #MultiPayloadOneSpareBit.b!enumelt: b_dest, case #MultiPayloadOneSpareBit.c!enumelt: c_dest
 
 // CHECK-64: [[X_PREDEST:[0-9]+]]:
-// CHECK-64:   bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i62*
+// CHECK-64:   bitcast %T11enum_future23MultiPayloadOneSpareBitO* %0 to i62*
 
 // CHECK-64: [[Y_PREDEST:[0-9]+]]:
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %0 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x7FFF_FFFF_FFFF_FFFF
 // CHECK-64:   [[PAYLOAD_MASKED:%.*]] = and i64 [[PAYLOAD]], 9223372036854775807
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %0 to i64*
 // CHECK-64:   store i64 [[PAYLOAD_MASKED]], i64* [[PAYLOAD_ADDR]]
-// CHECK-64:   bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i63*
+// CHECK-64:   bitcast %T11enum_future23MultiPayloadOneSpareBitO* %0 to i63*
 
 // CHECK-64: [[Z_PREDEST:[0-9]+]]:
-// CHECK-64:   bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i61*
+// CHECK-64:   bitcast %T11enum_future23MultiPayloadOneSpareBitO* %0 to i61*
 
 x_dest:
   %x = unchecked_take_enum_data_addr %u : $*MultiPayloadOneSpareBit, #MultiPayloadOneSpareBit.x!enumelt.1
@@ -1780,18 +1784,18 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, %T4enum23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64 %0, %T11enum_future23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
-// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i62*
+// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i62*
 // CHECK-64:   store i62 [[NATIVECC_TRUNC]], i62* [[DATA_ADDR]]
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x7FFF_FFFF_FFFF_FFFF
 // CHECK-64:   [[PAYLOAD_MASKED:%.*]] = and i64 [[PAYLOAD]], 9223372036854775807
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i64*
 // CHECK-64:   store i64 [[PAYLOAD_MASKED]], i64* [[PAYLOAD_ADDR]]
-// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T4enum23MultiPayloadOneSpareBitO, %T4enum23MultiPayloadOneSpareBitO* %1, i32 0, i32 1
+// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T11enum_future23MultiPayloadOneSpareBitO, %T11enum_future23MultiPayloadOneSpareBitO* %1, i32 0, i32 1
 // CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i1*
 // CHECK-64:   store i1 false, i1* [[TAG_ADDR]]
 // CHECK-64:   ret void
@@ -1821,20 +1825,20 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, %T4enum23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64 %0, %T11enum_future23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
-// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i63*
+// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i63*
 // CHECK-64:   store i63 [[NATIVECC_TRUNC]], i63* [[DATA_ADDR]]
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x7FFF_FFFF_FFFF_FFFF
 // CHECK-64:   [[PAYLOAD_MASKED:%.*]] = and i64 [[PAYLOAD]], 9223372036854775807
 // --                                                          0x8000_0000_0000_0000
 // CHECK-64:   [[PAYLOAD_TAGGED:%.*]] = or i64 [[PAYLOAD_MASKED]], -9223372036854775808
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %1 to i64*
 // CHECK-64:   store i64 [[PAYLOAD_TAGGED]], i64* [[PAYLOAD_ADDR]]
-// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T4enum23MultiPayloadOneSpareBitO, %T4enum23MultiPayloadOneSpareBitO* %1, i32 0, i32 1
+// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T11enum_future23MultiPayloadOneSpareBitO, %T11enum_future23MultiPayloadOneSpareBitO* %1, i32 0, i32 1
 // CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i1*
 // CHECK-64:   store i1 false, i1* [[TAG_ADDR]]
 // CHECK-64:   ret void
@@ -1874,12 +1878,12 @@ entry:
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(%T4enum23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(%T11enum_future23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future23MultiPayloadOneSpareBitO* %0 to i64*
 // --                0x8000_0000_0000_0000
 // CHECK-64:   store i64 -9223372036854775808, i64* [[PAYLOAD_ADDR]]
-// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T4enum23MultiPayloadOneSpareBitO, %T4enum23MultiPayloadOneSpareBitO* %0, i32 0, i32 1
+// CHECK-64:   [[T0:%.*]] = getelementptr inbounds %T11enum_future23MultiPayloadOneSpareBitO, %T11enum_future23MultiPayloadOneSpareBitO* %0, i32 0, i32 1
 // CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i1*
 // CHECK-64:   store i1 true, i1* [[TAG_ADDR]]
 // CHECK-64:   ret void
@@ -2020,16 +2024,16 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, %T4enum24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64 %0, %T11enum_future24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
-// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i62*
+// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i62*
 // CHECK-64:   store i62 [[NATIVECC_TRUNC]], i62* [[DATA_ADDR]]
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x3FFF_FFFF_FFFF_FFFF
 // CHECK-64:   [[PAYLOAD_MASKED:%.*]] = and i64 [[PAYLOAD]], 4611686018427387903
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i64*
 // CHECK-64:   store i64 [[PAYLOAD_MASKED]], i64* [[PAYLOAD_ADDR]]
 // CHECK-64:   ret void
 // CHECK-64: }
@@ -2056,18 +2060,18 @@ entry(%0 : $Builtin.Int60):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, %T4enum24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64 %0, %T11enum_future24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}}) %1) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i60
-// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i60*
+// CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i60*
 // CHECK-64:   store i60 [[NATIVECC_TRUNC]], i60* [[DATA_ADDR]]
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // --                                                   0x3FFF_FFFF_FFFF_FFFF
 // CHECK-64:   [[PAYLOAD_MASKED:%.*]] = and i64 [[PAYLOAD]], 4611686018427387903
 // --                                                         0x4000_0000_0000_0000
 // CHECK-64:   [[PAYLOAD_TAGGED:%.*]] = or i64 [[PAYLOAD_MASKED]], 4611686018427387904
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %1 to i64*
 // CHECK-64:   store i64 [[PAYLOAD_TAGGED]], i64* [[PAYLOAD_ADDR]]
 // CHECK-64:   ret void
 // CHECK-64: }
@@ -2105,9 +2109,9 @@ entry:
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(%T4enum24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(%T11enum_future24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %0 to i64*
+// CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T11enum_future24MultiPayloadTwoSpareBitsO* %0 to i64*
 // --                0xC000_0000_0000_0000
 // CHECK-64:   store i64 -4611686018427387904, i64* [[PAYLOAD_ADDR]]
 // CHECK-64:   ret void
@@ -2144,7 +2148,7 @@ entry:
 class D {}
 sil_vtable D {}
 
-sil @$s4enum1DCfD : $@convention(method) (D) -> ()
+sil @$s11enum_future1DCfD : $@convention(method) (D) -> ()
 
 enum MultiPayloadClasses {
   case x(C)
@@ -2169,11 +2173,11 @@ enum MultiPayloadClasses {
 // CHECK-64:     i64 -9223372036854775800, label {{%.*}}
 // CHECK-64:   ]
 // -- Extract x(C)
-// CHECK-64:   inttoptr i64 %0 to %T4enum1CC*
+// CHECK-64:   inttoptr i64 %0 to %T11enum_future1CC*
 // -- Extract y(D)
 // --                                     0x3fffffffffffffff
 // CHECK-64:   [[MASKED:%.*]] = and i64 %0, 4611686018427387903
-// CHECK-64:   inttoptr i64 [[MASKED]] to %T4enum1DC*
+// CHECK-64:   inttoptr i64 [[MASKED]] to %T11enum_future1DC*
 
 // CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_classes_switch(i32 %0) {{.*}} {
 // CHECK-32:   %1 = trunc i32 %0 to i8
@@ -2188,10 +2192,10 @@ enum MultiPayloadClasses {
 // CHECK-32:     i32 6, label {{%.*}}
 // CHECK-32:   ]
 // -- Extract x(C)
-// CHECK-32:   inttoptr i32 %0 to %T4enum1CC*
+// CHECK-32:   inttoptr i32 %0 to %T11enum_future1CC*
 // -- Extract y(D)
 // CHECK-32:   [[MASKED:%.*]] = and i32 %0, -4
-// CHECK-32:   inttoptr i32 [[MASKED]] to %T4enum1DC*
+// CHECK-32:   inttoptr i32 [[MASKED]] to %T11enum_future1DC*
 
 sil @multi_payload_classes_switch : $(MultiPayloadClasses) -> () {
 entry(%c : $MultiPayloadClasses):
@@ -2241,8 +2245,8 @@ enum MultiPayloadSpareBitAggregates {
 // CHECK-64: [[Y_DEST]]:
 // --                                        0x3fffffffffffffff
 // CHECK-64:   [[Y_MASKED:%.*]] = and i64 %0, 4611686018427387903
-// CHECK-64:   [[Y_0:%.*]] = inttoptr i64 [[Y_MASKED]] to %T4enum1CC*
-// CHECK-64:   [[Y_1:%.*]] = inttoptr i64 %1 to %T4enum1CC*
+// CHECK-64:   [[Y_0:%.*]] = inttoptr i64 [[Y_MASKED]] to %T11enum_future1CC*
+// CHECK-64:   [[Y_1:%.*]] = inttoptr i64 %1 to %T11enum_future1CC*
 // CHECK-64: [[Z_DEST]]:
 // --                                        0x3fffffffffffffff
 // CHECK-64:   [[Z_MASKED:%.*]] = and i64 %0, 4611686018427387903
@@ -2277,7 +2281,7 @@ enum MultiPayloadNested {
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_nested_switch
-// CHECK:   %1 = bitcast %T4enum18MultiPayloadNestedO* %0 to { [[WORD]], i8 }*
+// CHECK:   %1 = bitcast %T11enum_future18MultiPayloadNestedO* %0 to { [[WORD]], i8 }*
 // CHECK:   %2 = getelementptr
 // CHECK:   %3 = load [[WORD]], [[WORD]]* %2
 // CHECK:   %4 = getelementptr
@@ -2311,9 +2315,9 @@ enum MultiPayloadNestedSpareBits {
   case B(MultiPayloadInnerSpareBits)
 }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_nested_spare_bits_switch(%T4enum27MultiPayloadNestedSpareBitsO* noalias nocapture dereferenceable({{.*}}) %0) {{.*}} {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_nested_spare_bits_switch(%T11enum_future27MultiPayloadNestedSpareBitsO* noalias nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   %1 = bitcast %T4enum27MultiPayloadNestedSpareBitsO* %0 to [[WORD]]*
+// CHECK-64:   %1 = bitcast %T11enum_future27MultiPayloadNestedSpareBitsO* %0 to [[WORD]]*
 // CHECK-64:   %2 = load [[WORD]], [[WORD]]* %1
 // CHECK-64:   %3 = lshr [[WORD]] %2, 61
 // CHECK-64:   %4 = trunc [[WORD]] %3 to i1
@@ -2382,7 +2386,7 @@ enum MultiPayloadAddressOnlyFixed {
   case Y(Builtin.Int32)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_destroy(%T4enum28MultiPayloadAddressOnlyFixedO* noalias nocapture dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_destroy(%T11enum_future28MultiPayloadAddressOnlyFixedO* noalias nocapture dereferenceable({{.*}}) %0)
 sil @multi_payload_address_only_destroy : $@convention(thin) (@in MultiPayloadAddressOnlyFixed) -> () {
 entry(%m : $*MultiPayloadAddressOnlyFixed):
   destroy_addr %m : $*MultiPayloadAddressOnlyFixed
@@ -2402,7 +2406,7 @@ enum MultiPayloadAddressOnlySpareBits {
   case Y(AddressOnlySpareBitsPayload)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_spare_bits(%T4enum32MultiPayloadAddressOnlySpareBitsO* noalias nocapture dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_spare_bits(%T11enum_future32MultiPayloadAddressOnlySpareBitsO* noalias nocapture dereferenceable({{.*}}) %0)
 sil @multi_payload_address_only_spare_bits : $@convention(thin) (@in MultiPayloadAddressOnlySpareBits) -> () {
 entry(%m : $*MultiPayloadAddressOnlySpareBits):
   destroy_addr %m : $*MultiPayloadAddressOnlySpareBits
@@ -2538,7 +2542,7 @@ struct StructWithWeakVar {
 weak var delegate: delegateProtocol?
 }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @weak_optional(%T4enum17StructWithWeakVarVSg* noalias nocapture dereferenceable({{.*}}) %0)
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @weak_optional(%T11enum_future17StructWithWeakVarVSg* noalias nocapture dereferenceable({{.*}}) %0)
 sil @weak_optional : $@convention(thin) (@in StructWithWeakVar?) -> () {
 entry(%x : $*StructWithWeakVar?):
   // CHECK-64:      icmp eq [[WORD]] {{%.*}}, 0
@@ -2568,7 +2572,7 @@ public enum Result<T, Error: Swift.Error> {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_inject_enum_addr_with_bound_generic
 sil @test_inject_enum_addr_with_bound_generic : $@convention(thin) <T> () -> @out Result<T, AnyError> {
 bb0(%0 : $*Result<T, AnyError>):
-// CHECK: call {{.*}} @"$s4enum6ResultOMa"
+// CHECK: call {{.*}} @"$s11enum_future6ResultOMa"
 // CHECK: call void @swift_storeEnumTagMultiPayload
   inject_enum_addr %0 : $*Result<T, AnyError>, #Result.success!enumelt.1
   %r = tuple ()
@@ -2653,13 +2657,13 @@ entry(%x : $*MyOptional):
 }
 
 // -- Fill function for dynamic singleton.
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s4enum16DynamicSingletonOMi"(%swift.type_descriptor* %0, i8** %1, i8* %2) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s11enum_future16DynamicSingletonOMi"(%swift.type_descriptor* %0, i8** %1, i8* %2) {{.*}} {
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   [[T:%T]] = load %swift.type*, %swift.type** [[T0]],
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2, [[WORD]] {{4|8}})
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2, [[WORD]] {{4|8|16}})
 // CHECK-NEXT: ret %swift.type* [[METADATA]]
 
-// CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$s4enum16DynamicSingletonOMr"
+// CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$s11enum_future16DynamicSingletonOMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8* %0, i8** %1) {{.*}} {
 // CHECK:   [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState([[WORD]] 319, %swift.type* [[T]])
 // CHECK:   [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -2684,10 +2688,10 @@ entry(%x : $*MyOptional):
 
 // -- Fill function for dynamic single-payload. Call into the runtime to
 //    calculate the size.
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s4enum20DynamicSinglePayloadOMi"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$s11enum_future20DynamicSinglePayloadOMi"
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc %swift.metadata_response @"$s4enum20DynamicSinglePayloadOMr"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc %swift.metadata_response @"$s11enum_future20DynamicSinglePayloadOMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8* %0, i8** %1) {{.*}} {
 // CHECK:   [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState([[WORD]] 319, %swift.type* [[T]])
 // CHECK:   [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -2700,7 +2704,7 @@ entry(%x : $*MyOptional):
 // CHECK:   [[T_LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[T_VWT]], i32 8
 // CHECK:   call void @swift_initEnumMetadataSinglePayload(%swift.type* [[METADATA]], [[WORD]] 0, i8** [[T_LAYOUT]], i32 3)
 
-// CHECK-64-LABEL: define internal void @"$s4enum17StructWithWeakVarVwst"(%swift.opaque* noalias %value, i32 %whichCase, i32 %numEmptyCases, %swift.type* %StructWithWeakVar)
+// CHECK-64-LABEL: define internal void @"$s11enum_future17StructWithWeakVarVwst"(%swift.opaque* noalias %value, i32 %whichCase, i32 %numEmptyCases, %swift.type* %StructWithWeakVar)
 // -- TODO: some pointless masking here.
 // -- TODO: should use EnumPayload word-chunking.
 // CHECK-64:         [[INDEX:%.*]] = sub i32 %whichCase, 1
@@ -2714,9 +2718,9 @@ entry(%x : $*MyOptional):
 // --                             0x1__0000_0000_0000_0000
 // CHECK-64:         [[T5:%.*]] = or i128 [[T4]], 18446744073709551616
 
-// CHECK-LABEL: define internal i32 @"$s4enum40MultiPayloadLessThan32BitsWithEmptyCasesOwug"(%swift.opaque* noalias %value
-// CHECK:  [[VAL00:%.*]] = bitcast %swift.opaque* %value to %T4enum40MultiPayloadLessThan32BitsWithEmptyCasesO*
-// CHECK:  [[VAL01:%.*]] = bitcast %T4enum40MultiPayloadLessThan32BitsWithEmptyCasesO* [[VAL00]] to i8*
+// CHECK-LABEL: define internal i32 @"$s11enum_future40MultiPayloadLessThan32BitsWithEmptyCasesOwug"(%swift.opaque* noalias %value
+// CHECK:  [[VAL00:%.*]] = bitcast %swift.opaque* %value to %T11enum_future40MultiPayloadLessThan32BitsWithEmptyCasesO*
+// CHECK:  [[VAL01:%.*]] = bitcast %T11enum_future40MultiPayloadLessThan32BitsWithEmptyCasesO* [[VAL00]] to i8*
 // CHECK:  [[VAL02:%.*]] = load {{.*}} [[VAL01]]
 // CHECK:  [[VAL03:%.*]] = getelementptr inbounds {{.*}} [[VAL00]], i32 0, i32 1
 // CHECK:  [[VAL04:%.*]] = bitcast {{.*}} [[VAL03]] to i8*
@@ -2729,7 +2733,7 @@ entry(%x : $*MyOptional):
 // CHECK:  [[VAL11:%.*]] = select i1 [[VAL10]], i32 [[VAL09]], i32 [[VAL06]]
 // CHECK:  ret i32 [[VAL11]]
 
-// CHECK-LABEL: define internal void @"$s4enum40MultiPayloadLessThan32BitsWithEmptyCasesOwui"(%swift.opaque* noalias %value, i32 %tag
+// CHECK-LABEL: define internal void @"$s11enum_future40MultiPayloadLessThan32BitsWithEmptyCasesOwui"(%swift.opaque* noalias %value, i32 %tag
 // CHECK: entry:
 // CHECK:  [[VAL00:%.*]] = bitcast %swift.opaque* %value
 // CHECK:  [[VAL01:%.*]] = icmp uge i32 %tag, 2
@@ -2738,7 +2742,7 @@ entry(%x : $*MyOptional):
 // CHECK: [[TLABEL]]:
 // CHECK:  [[VAL02:%.*]] = sub i32 %tag, 2
 // CHECK:  [[VAL03:%.*]] = trunc i32 [[VAL02]] to i8
-// CHECK:  [[VAL04:%.*]] = bitcast %T4enum40MultiPayloadLessThan32BitsWithEmptyCasesO* [[VAL00]] to i8*
+// CHECK:  [[VAL04:%.*]] = bitcast %T11enum_future40MultiPayloadLessThan32BitsWithEmptyCasesO* [[VAL00]] to i8*
 // CHECK:  store i8 [[VAL03]], i8* [[VAL04]]
 // CHECK:  [[VAL05:%.*]] = getelementptr inbounds {{.*}} [[VAL00]], i32 0, i32 1
 // CHECK:  [[VAL06:%.*]] = bitcast [1 x i8]* [[VAL05]] to i8*

--- a/test/IRGen/enum_value_semantics_future.sil
+++ b/test/IRGen/enum_value_semantics_future.sil
@@ -1,7 +1,11 @@
-// RUN: %target-swift-frontend %s -disable-generic-metadata-prespecialization -gnone -emit-ir -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-simulator-%target-is-simulator --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-objc-%target-os
-// RUN: %target-swift-frontend %s -disable-generic-metadata-prespecialization -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-native-%target-os
+// RUN: %target-swift-frontend %s -target %module-target-future -gnone -emit-ir -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-simulator-%target-is-simulator --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-objc-%target-os
+// RUN: %target-swift-frontend %s -target %module-target-future -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-native-%target-os
 
 // REQUIRES: CPU=x86_64
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
 
 import Builtin
 
@@ -95,40 +99,40 @@ enum GenericFixedLayout<T> {
 }
 
 
-// CHECK-LABEL: @"$s20enum_value_semantics20SinglePayloadTrivialOWV" = internal constant %swift.enum_vwtable {
+// CHECK-LABEL: @"$s27enum_value_semantics_future20SinglePayloadTrivialOWV" = internal constant %swift.enum_vwtable {
 // CHECK:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy9_8 to i8*),
 // CHECK:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy9_8 to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy9_8 to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy9_8 to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy9_8 to i8*),
-// CHECK:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s20enum_value_semantics20SinglePayloadTrivialOwet" to i8*),
-// CHECK:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s20enum_value_semantics20SinglePayloadTrivialOwst" to i8*),
+// CHECK:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s27enum_value_semantics_future20SinglePayloadTrivialOwet" to i8*),
+// CHECK:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s27enum_value_semantics_future20SinglePayloadTrivialOwst" to i8*),
 // CHECK:   i64 9,
 // CHECK:   i64 16,
 // CHECK:   i32 2097159,
 // CHECK:   i32 0,
-// CHECK:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s20enum_value_semantics20SinglePayloadTrivialOwug" to i8*),
-// CHECK:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s20enum_value_semantics20SinglePayloadTrivialOwup" to i8*),
-// CHECK:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s20enum_value_semantics20SinglePayloadTrivialOwui" to i8*)
+// CHECK:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s27enum_value_semantics_future20SinglePayloadTrivialOwug" to i8*),
+// CHECK:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s27enum_value_semantics_future20SinglePayloadTrivialOwup" to i8*),
+// CHECK:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s27enum_value_semantics_future20SinglePayloadTrivialOwui" to i8*)
 // CHECK: }
 
 
-// CHECK-LABEL: @"$s20enum_value_semantics20SinglePayloadTrivialOMf" =
+// CHECK-LABEL: @"$s27enum_value_semantics_future20SinglePayloadTrivialOMf" =
 // CHECK-SAME:   internal constant <{ {{.*}} }> <{
-// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s20enum_value_semantics20SinglePayloadTrivialOWV", i32 0, i32 0),
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s27enum_value_semantics_future20SinglePayloadTrivialOWV", i32 0, i32 0),
 // CHECK-SAME:   i64 513,
-// CHECK-SAME:   {{.*}}* @"$s20enum_value_semantics20SinglePayloadTrivialOMn"
+// CHECK-SAME:   {{.*}}* @"$s27enum_value_semantics_future20SinglePayloadTrivialOMn"
 // CHECK-SAME: }>
 
 
-// CHECK-LABEL: @"$s20enum_value_semantics23SinglePayloadNontrivialOWV" = internal constant %swift.enum_vwtable {
-// CHECK:   i8* bitcast (%swift.opaque* ([24 x i8]*, [24 x i8]*, %swift.type*)* @"$s20enum_value_semantics23SinglePayloadNontrivialOwCP" to i8*),
-// CHECK:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s20enum_value_semantics23SinglePayloadNontrivialOwxx" to i8*),
-// CHECK:   i8* bitcast (%swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)* @"$s20enum_value_semantics23SinglePayloadNontrivialOwcp" to i8*),
-// CHECK:   i8* bitcast (%swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)* @"$s20enum_value_semantics23SinglePayloadNontrivialOwca" to i8*),
+// CHECK-LABEL: @"$s27enum_value_semantics_future23SinglePayloadNontrivialOWV" = internal constant %swift.enum_vwtable {
+// CHECK:   i8* bitcast (%swift.opaque* ([24 x i8]*, [24 x i8]*, %swift.type*)* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwCP" to i8*),
+// CHECK:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwxx" to i8*),
+// CHECK:   i8* bitcast (%swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwcp" to i8*),
+// CHECK:   i8* bitcast (%swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwca" to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy8_8 to i8*),
-// CHECK:   i8* bitcast (%swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)* @"$s20enum_value_semantics23SinglePayloadNontrivialOwta" to i8*),
+// CHECK:   i8* bitcast (%swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwta" to i8*),
 // CHECK:   i64 8,
 // CHECK:   i64 8,
 // --           0x210007
@@ -143,33 +147,33 @@ enum GenericFixedLayout<T> {
 // CHECK-native-linux-gnu: i32 4093
 // CHECK-objc-windows:     i32 2045
 // CHECK-native-windows:   i32 4093
-// CHECK:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s20enum_value_semantics23SinglePayloadNontrivialOwug" to i8*),
-// CHECK:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s20enum_value_semantics23SinglePayloadNontrivialOwup" to i8*)
-// CHECK:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s20enum_value_semantics23SinglePayloadNontrivialOwui" to i8*)
+// CHECK:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwug" to i8*),
+// CHECK:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwup" to i8*)
+// CHECK:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwui" to i8*)
 // CHECK: ]
 
 
-// CHECK-LABEL: @"$s20enum_value_semantics23SinglePayloadNontrivialOMf" =
+// CHECK-LABEL: @"$s27enum_value_semantics_future23SinglePayloadNontrivialOMf" =
 // CHECK-SAME: internal constant <{ {{.*}} }> <{
-// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s20enum_value_semantics23SinglePayloadNontrivialOWV", i32 0, i32 0),
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOWV", i32 0, i32 0),
 // CHECK-SAME:   i64 513,
-// CHECK-SAME:   {{.*}}* @"$s20enum_value_semantics23SinglePayloadNontrivialOMn"
+// CHECK-SAME:   {{.*}}* @"$s27enum_value_semantics_future23SinglePayloadNontrivialOMn"
 // CHECK-SAME: }>
 
 
-// CHECK-LABEL: @"$s20enum_value_semantics18GenericFixedLayoutOMn" = hidden constant
-// CHECK-SAME:    [16 x i8*]* @"$s20enum_value_semantics18GenericFixedLayoutOMI"
-// CHECK-SAME:    @"$s20enum_value_semantics18GenericFixedLayoutOMP"
+// CHECK-LABEL: @"$s27enum_value_semantics_future18GenericFixedLayoutOMn" = hidden constant
+// CHECK-SAME:    [16 x i8*]* @"$s27enum_value_semantics_future18GenericFixedLayoutOMI"
+// CHECK-SAME:    @"$s27enum_value_semantics_future18GenericFixedLayoutOMP"
 
-// CHECK-LABEL: @"$s20enum_value_semantics18GenericFixedLayoutOMP" = internal constant <{ {{.*}} }> <{
+// CHECK-LABEL: @"$s27enum_value_semantics_future18GenericFixedLayoutOMP" = internal constant <{ {{.*}} }> <{
 //   Instantiation function.
-// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s20enum_value_semantics18GenericFixedLayoutOMi" to i64), i64 ptrtoint (<{ i32, i32, i32, i32 }>* @"$s20enum_value_semantics18GenericFixedLayoutOMP" to i64)) to i32),
+// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s27enum_value_semantics_future18GenericFixedLayoutOMi" to i64), i64 ptrtoint (<{ i32, i32, i32, i32 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP" to i64)) to i32),
 //   Completion function.
 // CHECK-SAME:    i32 0,
-//   Pattern flags.  0x4020_0000 == (MetadataKind::Enum << 21).
-// CHECK-SAME:    i32 1075838976,
+//   Pattern flags.  0x4020_0002 == (MetadataKind::Enum << 21 | HasTrailingFlags).
+// CHECK-SAME:    i32 1075838978,
 //   Value witness table.
-// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.enum_vwtable* @"$s20enum_value_semantics18GenericFixedLayoutOWV" to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32, i32 }>, <{ i32, i32, i32, i32 }>* @"$s20enum_value_semantics18GenericFixedLayoutOMP", i32 0, i32 3) to i64)) to i32)
+// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.enum_vwtable* @"$s27enum_value_semantics_future18GenericFixedLayoutOWV" to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32, i32 }>, <{ i32, i32, i32, i32 }>* @"$s27enum_value_semantics_future18GenericFixedLayoutOMP", i32 0, i32 3) to i64)) to i32)
 // CHECK-SAME:  }>
 
 sil @single_payload_nontrivial_copy_destroy : $(@owned SinglePayloadNontrivial) -> () {
@@ -183,9 +187,9 @@ bb0(%0 : $SinglePayloadNontrivial):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_nontrivial_copy_destroy(i64 %0)
-// CHECK:      call void @"$s20enum_value_semantics23SinglePayloadNontrivialOWOy"
+// CHECK:      call void @"$s27enum_value_semantics_future23SinglePayloadNontrivialOWOy"
 // CHECK-NEXT: call swiftcc void @single_payload_nontrivial_user
-// CHECK-NEXT: call void @"$s20enum_value_semantics23SinglePayloadNontrivialOWOe"
+// CHECK-NEXT: call void @"$s27enum_value_semantics_future23SinglePayloadNontrivialOWOe"
 // CHECK-NEXT: ret void
 
 //
@@ -194,24 +198,24 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 
 // -- NoPayload getEnumTag
-// CHECK-LABEL: define internal i32 @"$s20enum_value_semantics9NoPayloadOwug"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics9NoPayloadO*
-// CHECK-NEXT: [[TAG_ADDR:%.*]] = getelementptr inbounds %T20enum_value_semantics9NoPayloadO, %T20enum_value_semantics9NoPayloadO* [[SELF]], i32 0, i32 0
+// CHECK-LABEL: define internal i32 @"$s27enum_value_semantics_future9NoPayloadOwug"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future9NoPayloadO*
+// CHECK-NEXT: [[TAG_ADDR:%.*]] = getelementptr inbounds %T27enum_value_semantics_future9NoPayloadO, %T27enum_value_semantics_future9NoPayloadO* [[SELF]], i32 0, i32 0
 // CHECK-NEXT: [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]], align 1
 // CHECK-NEXT: [[RESULT:%.*]] = zext i8 %2 to i32
 // CHECK-NEXT: ret i32 [[RESULT]]
 
 
 // -- NoPayload destructiveProjectEnumData
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics9NoPayloadOwup"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future9NoPayloadOwup"
 // CHECK:      ret void
 
 
 // -- NoPayload destructiveInjectEnumTag
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics9NoPayloadOwui"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics9NoPayloadO*
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future9NoPayloadOwui"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future9NoPayloadO*
 // CHECK-NEXT: [[TAG:%.*]] = trunc i32 %tag to i8
-// CHECK-NEXT: [[TAG_ADDR:%.*]] = getelementptr inbounds %T20enum_value_semantics9NoPayloadO, %T20enum_value_semantics9NoPayloadO* [[SELF]], i32 0, i32 0
+// CHECK-NEXT: [[TAG_ADDR:%.*]] = getelementptr inbounds %T27enum_value_semantics_future9NoPayloadO, %T27enum_value_semantics_future9NoPayloadO* [[SELF]], i32 0, i32 0
 // CHECK-NEXT: store i8 [[TAG]], i8* [[TAG_ADDR]], align 1
 // CHECK-NEXT: ret void
 
@@ -222,32 +226,32 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 
 // -- SingletonPayload getEnumTag
-// CHECK-LABEL: define internal i32 @"$s20enum_value_semantics16SingletonPayloadOwug"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics16SingletonPayloadO*
+// CHECK-LABEL: define internal i32 @"$s27enum_value_semantics_future16SingletonPayloadOwug"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future16SingletonPayloadO*
 // CHECK-NEXT: ret i32 0
 
 
 // -- SingletonPayload destructiveProjectEnumData
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics16SingletonPayloadOwup"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future16SingletonPayloadOwup"
 // CHECK:      ret void
 
 
 // -- SingletonPayload destructiveInjectEnumTag
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics16SingletonPayloadOwui"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics16SingletonPayloadO*
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future16SingletonPayloadOwui"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future16SingletonPayloadO*
 // CHECK-NEXT: ret void
 
 
 // -- SinglePayloadTrivial getEnumTag
-// CHECK-LABEL: define internal i32 @"$s20enum_value_semantics20SinglePayloadTrivialOwug"
-// CHECK:  [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics20SinglePayloadTrivialO*
-// CHECK:  [[OPAQUE:%.*]] = bitcast %T20enum_value_semantics20SinglePayloadTrivialO* [[SELF]] to %swift.opaque*
+// CHECK-LABEL: define internal i32 @"$s27enum_value_semantics_future20SinglePayloadTrivialOwug"
+// CHECK:  [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future20SinglePayloadTrivialO*
+// CHECK:  [[OPAQUE:%.*]] = bitcast %T27enum_value_semantics_future20SinglePayloadTrivialO* [[SELF]] to %swift.opaque*
 // CHECK:  [[TAG:%.*]] = call i32 %getEnumTagSinglePayload(%swift.opaque* noalias [[OPAQUE]], i32 3, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @"$sBi64_N", i32 0, i32 1))
 // CHECK:  ret i32 [[TAG]]
 
 
 // -- SinglePayloadTrivial destructiveProjectEnumData
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics20SinglePayloadTrivialOwup"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future20SinglePayloadTrivialOwup"
 // CHECK:      ret void
 
 
@@ -257,17 +261,17 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 
 // -- SinglePayloadTrivial destructiveInjectEnumTag
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics20SinglePayloadTrivialOwui"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics20SinglePayloadTrivialO*
-// CHECK-NEXT: [[OPAQUE:%.*]] = bitcast %T20enum_value_semantics20SinglePayloadTrivialO* [[SELF]] to %swift.opaque*
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future20SinglePayloadTrivialOwui"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future20SinglePayloadTrivialO*
+// CHECK-NEXT: [[OPAQUE:%.*]] = bitcast %T27enum_value_semantics_future20SinglePayloadTrivialO* [[SELF]] to %swift.opaque*
 // CHECK: call void %storeEnumTagSinglePayload(%swift.opaque* noalias [[OPAQUE]], i32 %tag, i32 3, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @"$sBi64_N", i32 0, i32 1))
 // CHECK-NEXT: ret void
 
 
 // -- SinglePayloadNontrivial destroyBuffer
-// CHECK: define internal void @"$s20enum_value_semantics23SinglePayloadNontrivialOwxx"(%swift.opaque* noalias [[OBJ:%.*]], %swift.type* %SinglePayloadNontrivial) {{.*}} {
-// CHECK:      [[ADDR:%.*]] = bitcast %swift.opaque* [[OBJ]] to %T20enum_value_semantics23SinglePayloadNontrivialO*
-// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T20enum_value_semantics23SinglePayloadNontrivialO* [[ADDR]] to i64*
+// CHECK: define internal void @"$s27enum_value_semantics_future23SinglePayloadNontrivialOwxx"(%swift.opaque* noalias [[OBJ:%.*]], %swift.type* %SinglePayloadNontrivial) {{.*}} {
+// CHECK:      [[ADDR:%.*]] = bitcast %swift.opaque* [[OBJ]] to %T27enum_value_semantics_future23SinglePayloadNontrivialO*
+// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T27enum_value_semantics_future23SinglePayloadNontrivialO* [[ADDR]] to i64*
 // CHECK-NEXT: [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]], align 8
 // CHECK-NEXT: switch i64 %2, label %[[RELEASE_PAYLOAD:[0-9]+]] [
 // CHECK:        i64 0, label %[[DONE:[0-9]+]]
@@ -280,7 +284,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK:      ]
 
 // CHECK:      [[RELEASE_PAYLOAD]]:
-// CHECK-NEXT: [[DATA_ADDR:%.*]] = bitcast %T20enum_value_semantics23SinglePayloadNontrivialO* [[ADDR]] to %swift.refcounted**
+// CHECK-NEXT: [[DATA_ADDR:%.*]] = bitcast %T27enum_value_semantics_future23SinglePayloadNontrivialO* [[ADDR]] to %swift.refcounted**
 // CHECK-NEXT: [[DATA:%.*]] = load %swift.refcounted*, %swift.refcounted** [[DATA_ADDR]], align 8
 // CHECK-NEXT: call void @swift_release(%swift.refcounted* [[DATA]])
 // CHECK-NEXT: br label %[[DONE]]
@@ -295,16 +299,16 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 
 // -- MultiPayloadTrivial getEnumTag
-// CHECK-LABEL: define internal i32 @"$s20enum_value_semantics19MultiPayloadTrivialOwug"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics19MultiPayloadTrivialO*
-// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T20enum_value_semantics19MultiPayloadTrivialO* [[SELF]] to i64*
+// CHECK-LABEL: define internal i32 @"$s27enum_value_semantics_future19MultiPayloadTrivialOwug"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future19MultiPayloadTrivialO*
+// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T27enum_value_semantics_future19MultiPayloadTrivialO* [[SELF]] to i64*
 
 
 //   -- Load the low bits of the tag from the payload area
 // CHECK-NEXT: [[NO_PAYLOAD_TAG_TMP:%.*]] = load i64, i64* [[PAYLOAD]], align 8
 
 //   -- Load the high bits of the tag from the extra tag area
-// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T20enum_value_semantics19MultiPayloadTrivialO, %T20enum_value_semantics19MultiPayloadTrivialO* [[SELF]], i32 0, i32 1
+// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T27enum_value_semantics_future19MultiPayloadTrivialO, %T27enum_value_semantics_future19MultiPayloadTrivialO* [[SELF]], i32 0, i32 1
 // CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i8*
 // CHECK-NEXT: [[EXTRA_TAG_TMP:%.*]] = load i8, i8* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: [[EXTRA_TAG:%.*]] = zext i8 [[EXTRA_TAG_TMP]] to i32
@@ -320,13 +324,13 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: ret i32 [[TAG]]
 
 // -- MultiPayloadTrivial destructiveProjectEnumData
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics19MultiPayloadTrivialOwup"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future19MultiPayloadTrivialOwup"
 // CHECK:      ret void
 
 
 // -- MultiPayloadTrivial destructiveInjectEnumTag
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics19MultiPayloadTrivialOwui"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics19MultiPayloadTrivialO*
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future19MultiPayloadTrivialOwui"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future19MultiPayloadTrivialO*
 // CHECK-NEXT: [[IS_PAYLOAD:%.*]] = icmp uge i32 %tag, 2
 // CHECK-NEXT: br i1 [[IS_PAYLOAD]], label %[[HAS_NO_PAYLOAD:.*]], label %[[HAS_PAYLOAD:.*]]
 
@@ -335,13 +339,13 @@ bb0(%0 : $SinglePayloadNontrivial):
 //   -- Compute the no-payload tag
 // CHECK-NEXT: [[NO_PAYLOAD_TAG:%.*]] = sub i32 %tag, 2
 // CHECK-NEXT: [[NO_PAYLOAD_TAG2:%.*]] = zext i32 [[NO_PAYLOAD_TAG]] to i64
-// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T20enum_value_semantics19MultiPayloadTrivialO* [[SELF]] to i64*
+// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T27enum_value_semantics_future19MultiPayloadTrivialO* [[SELF]] to i64*
 
 //   -- Store the low bits of the tag in the payload area
 // CHECK-NEXT: store i64 [[NO_PAYLOAD_TAG2]], i64* [[PAYLOAD]], align 8
 
 //   -- Store the high bits of the tag in the extra tag area
-// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T20enum_value_semantics19MultiPayloadTrivialO, %T20enum_value_semantics19MultiPayloadTrivialO* [[SELF]], i32 0, i32 1
+// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T27enum_value_semantics_future19MultiPayloadTrivialO, %T27enum_value_semantics_future19MultiPayloadTrivialO* [[SELF]], i32 0, i32 1
 // CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i8*
 // CHECK-NEXT: store i8 2, i8* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: br label %[[DONE:.*]]
@@ -350,7 +354,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 //   -- Store the tag in the extra tag area
 // CHECK-NEXT: [[TAG:%.*]] = trunc i32 %tag to i8
-// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T20enum_value_semantics19MultiPayloadTrivialO, %T20enum_value_semantics19MultiPayloadTrivialO* [[SELF]], i32 0, i32 1
+// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T27enum_value_semantics_future19MultiPayloadTrivialO, %T27enum_value_semantics_future19MultiPayloadTrivialO* [[SELF]], i32 0, i32 1
 // CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i8*
 // CHECK-NEXT: store i8 [[TAG]], i8* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: br label %[[DONE]]
@@ -365,31 +369,31 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 
 // -- MultiPayloadNoEmptyCases getEnumTag
-// CHECK-LABEL: define internal i32 @"$s20enum_value_semantics24MultiPayloadNoEmptyCasesOwug"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics24MultiPayloadNoEmptyCasesO*
-// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T20enum_value_semantics24MultiPayloadNoEmptyCasesO* [[SELF]] to i64*
+// CHECK-LABEL: define internal i32 @"$s27enum_value_semantics_future24MultiPayloadNoEmptyCasesOwug"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future24MultiPayloadNoEmptyCasesO*
+// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T27enum_value_semantics_future24MultiPayloadNoEmptyCasesO* [[SELF]] to i64*
 // CHECK-NEXT: [[NO_PAYLOAD_TAG_TMP:%.*]] = load i64, i64* [[PAYLOAD]], align 8
 
 //   -- The payload has no spare bits and there are no empty cases, so the tag
 //      is entirely contained in the extra tag area
-// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T20enum_value_semantics24MultiPayloadNoEmptyCasesO, %T20enum_value_semantics24MultiPayloadNoEmptyCasesO* [[SELF]], i32 0, i32 1
+// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T27enum_value_semantics_future24MultiPayloadNoEmptyCasesO, %T27enum_value_semantics_future24MultiPayloadNoEmptyCasesO* [[SELF]], i32 0, i32 1
 // CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i1*
 // CHECK-NEXT: [[EXTRA_TAG_TMP:%.*]] = load i1, i1* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: [[EXTRA_TAG:%.*]] = zext i1 [[EXTRA_TAG_TMP]] to i32
 // CHECK-NEXT: ret i32 [[EXTRA_TAG]]
 
 // -- MultiPayloadNoEmptyCases destructiveProjectEnumData
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics24MultiPayloadNoEmptyCasesOwup"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future24MultiPayloadNoEmptyCasesOwup"
 // CHECK:      ret void
 
 
 // -- MultiPayloadNoEmptyCases destructiveInjectEnumTag
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics24MultiPayloadNoEmptyCasesOwui"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics24MultiPayloadNoEmptyCasesO*
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future24MultiPayloadNoEmptyCasesOwui"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future24MultiPayloadNoEmptyCasesO*
 // CHECK-NEXT: [[TAG:%.*]] = trunc i32 %tag to i1
 
 //   -- Store the tag in the extra tag area
-// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T20enum_value_semantics24MultiPayloadNoEmptyCasesO, %T20enum_value_semantics24MultiPayloadNoEmptyCasesO* [[SELF]], i32 0, i32 1
+// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T27enum_value_semantics_future24MultiPayloadNoEmptyCasesO, %T27enum_value_semantics_future24MultiPayloadNoEmptyCasesO* [[SELF]], i32 0, i32 1
 // CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i1*
 // CHECK-NEXT: store i1 [[TAG]], i1* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: ret void
@@ -401,28 +405,28 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 
 // -- MultiPayloadEmptyPayload getEnumTag
-// CHECK-LABEL: define internal i32 @"$s20enum_value_semantics017MultiPayloadEmptyE0Owug"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics017MultiPayloadEmptyE0O*
+// CHECK-LABEL: define internal i32 @"$s27enum_value_semantics_future017MultiPayloadEmptyF0Owug"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future017MultiPayloadEmptyF0O*
 
 //   -- Load the tag from the extra tag area
-// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = getelementptr inbounds %T20enum_value_semantics017MultiPayloadEmptyE0O, %T20enum_value_semantics017MultiPayloadEmptyE0O* [[SELF]], i32 0, i32 0
+// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = getelementptr inbounds %T27enum_value_semantics_future017MultiPayloadEmptyF0O, %T27enum_value_semantics_future017MultiPayloadEmptyF0O* [[SELF]], i32 0, i32 0
 // CHECK-NEXT: [[EXTRA_TAG_TMP:%.*]] = load i8, i8* [[EXTRA_TAG_ADDR]], align 1
 // CHECK-NEXT: [[EXTRA_TAG:%.*]] = zext i8 [[EXTRA_TAG_TMP]] to i32
 // CHECK-NEXT: ret i32 [[EXTRA_TAG]]
 
 
 // -- MultiPayloadEmptyPayload destructiveProjectEnumData
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics017MultiPayloadEmptyE0Owup"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future017MultiPayloadEmptyF0Owup"
 // CHECK:      ret void
 
 
 // -- MultiPayloadEmptyPayload destructiveInjectEnumTag
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics017MultiPayloadEmptyE0Owui"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics017MultiPayloadEmptyE0O*
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future017MultiPayloadEmptyF0Owui"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future017MultiPayloadEmptyF0O*
 
 //   -- Store the tag in the extra tag area
 // CHECK-NEXT: [[TAG:%.*]] = trunc i32 %tag to i8
-// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = getelementptr inbounds %T20enum_value_semantics017MultiPayloadEmptyE0O, %T20enum_value_semantics017MultiPayloadEmptyE0O* [[SELF]], i32 0, i32 0
+// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = getelementptr inbounds %T27enum_value_semantics_future017MultiPayloadEmptyF0O, %T27enum_value_semantics_future017MultiPayloadEmptyF0O* [[SELF]], i32 0, i32 0
 // CHECK-NEXT: store i8 [[TAG]], i8* [[EXTRA_TAG_ADDR]], align 1
 // CHECK-NEXT: ret void
 
@@ -433,17 +437,17 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 
 // -- MultiPayloadNontrivial destroyBuffer
-// CHECK: define internal void @"$s20enum_value_semantics22MultiPayloadNontrivialOwxx"(%swift.opaque* noalias [[OBJ:%.*]], %swift.type* %MultiPayloadNontrivial)
-// CHECK:      [[ADDR:%.*]] = bitcast %swift.opaque* [[OBJ]] to %T20enum_value_semantics22MultiPayloadNontrivialO*
-// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T20enum_value_semantics22MultiPayloadNontrivialO* [[ADDR]] to { i64, i64 }*
+// CHECK: define internal void @"$s27enum_value_semantics_future22MultiPayloadNontrivialOwxx"(%swift.opaque* noalias [[OBJ:%.*]], %swift.type* %MultiPayloadNontrivial)
+// CHECK:      [[ADDR:%.*]] = bitcast %swift.opaque* [[OBJ]] to %T27enum_value_semantics_future22MultiPayloadNontrivialO*
+// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T27enum_value_semantics_future22MultiPayloadNontrivialO* [[ADDR]] to { i64, i64 }*
 // CHECK-NEXT: [[PAYLOAD_0_ADDR:%.*]] = getelementptr
 // CHECK-NEXT: [[PAYLOAD_0:%.*]] = load i64, i64* [[PAYLOAD_0_ADDR]], align 8
 // CHECK-NEXT: [[PAYLOAD_1_ADDR:%.*]] = getelementptr
 // CHECK-NEXT: [[PAYLOAD_1:%.*]] = load i64, i64* [[PAYLOAD_1_ADDR]], align 8
-// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T20enum_value_semantics22MultiPayloadNontrivialO, %T20enum_value_semantics22MultiPayloadNontrivialO* %0, i32 0, i32 1
+// CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %T27enum_value_semantics_future22MultiPayloadNontrivialO, %T27enum_value_semantics_future22MultiPayloadNontrivialO* %0, i32 0, i32 1
 // CHECK-NEXT: [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i8*
 // CHECK-NEXT: [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]], align 8
-// CHECK-NEXT: @"$s20enum_value_semantics22MultiPayloadNontrivialOWOe"
+// CHECK-NEXT: @"$s27enum_value_semantics_future22MultiPayloadNontrivialOWOe"
 // CHECK-NEXT: ret void
 
 
@@ -452,20 +456,20 @@ bb0(%0 : $SinglePayloadNontrivial):
 //
 
 
-// CHECK-LABEL: define internal i32 @"$s20enum_value_semantics19MultiPayloadGenericOwug"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics19MultiPayloadGenericO*
-// CHECK-NEXT: [[OPAQUE:%.*]] = bitcast %T20enum_value_semantics19MultiPayloadGenericO* [[SELF]] to %swift.opaque*
+// CHECK-LABEL: define internal i32 @"$s27enum_value_semantics_future19MultiPayloadGenericOwug"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future19MultiPayloadGenericO*
+// CHECK-NEXT: [[OPAQUE:%.*]] = bitcast %T27enum_value_semantics_future19MultiPayloadGenericO* [[SELF]] to %swift.opaque*
 // CHECK-NEXT: [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload(%swift.opaque* [[OPAQUE]], %swift.type* %"MultiPayloadGeneric<T>")
 // CHECK-NEXT: ret i32 [[TAG]]
 
 
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics19MultiPayloadGenericOwup"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future19MultiPayloadGenericOwup"
 // CHECK:      ret void
 
 
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics19MultiPayloadGenericOwui"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics19MultiPayloadGenericO*
-// CHECK:      [[OPAQUE:%.*]] = bitcast %T20enum_value_semantics19MultiPayloadGenericO* [[SELF]] to %swift.opaque*
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future19MultiPayloadGenericOwui"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future19MultiPayloadGenericO*
+// CHECK:      [[OPAQUE:%.*]] = bitcast %T27enum_value_semantics_future19MultiPayloadGenericO* [[SELF]] to %swift.opaque*
 // CHECK-NEXT: call void @swift_storeEnumTagMultiPayload(%swift.opaque* [[OPAQUE]], %swift.type* %"MultiPayloadGeneric<T>", i32 %tag)
 // CHECK-NEXT: ret void
 
@@ -476,23 +480,23 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 
 // -- MultiPayloadNontrivialSpareBits destroyBuffer
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics31MultiPayloadNontrivialSpareBitsOwxx"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsOwxx"
 // CHECK-SAME: (%swift.opaque* noalias [[OBJ:%.*]], %swift.type* %MultiPayloadNontrivialSpareBits) {{.*}} {
-// CHECK:      [[ADDR:%.*]] = bitcast %swift.opaque* [[OBJ]] to %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO*
-// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO* [[ADDR]] to { i64, i64 }*
+// CHECK:      [[ADDR:%.*]] = bitcast %swift.opaque* [[OBJ]] to %T27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsO*
+// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsO* [[ADDR]] to { i64, i64 }*
 // CHECK-NEXT: [[PAYLOAD_0_ADDR:%.*]] = getelementptr
 // CHECK-NEXT: [[PAYLOAD_0:%.*]] = load i64, i64* [[PAYLOAD_0_ADDR]], align 8
 // CHECK-NEXT: [[PAYLOAD_1_ADDR:%.*]] = getelementptr
 // CHECK-NEXT: [[PAYLOAD_1:%.*]] = load i64, i64* [[PAYLOAD_1_ADDR]], align 8
-// CHECK:      call void @"$s20enum_value_semantics31MultiPayloadNontrivialSpareBitsOWOe"
+// CHECK:      call void @"$s27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsOWOe"
 // CHECK-NEXT: ret void
 
 
-// CHECK-LABEL: define internal i32 @"$s20enum_value_semantics31MultiPayloadNontrivialSpareBitsOwug"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO*
+// CHECK-LABEL: define internal i32 @"$s27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsOwug"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsO*
 
 //   -- Load the payload
-// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
+// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
 // CHECK-NEXT: [[FIRST_ADDR:%.*]] = getelementptr inbounds { i64, i64 }, { i64, i64 }* [[PAYLOAD]], i32 0, i32 0
 // CHECK-NEXT: [[FIRST:%.*]] = load i64, i64* [[FIRST_ADDR]], align 8
 // CHECK-NEXT: [[SECOND_ADDR:%.*]] = getelementptr inbounds { i64, i64 }, { i64, i64 }* [[PAYLOAD]], i32 0, i32 1
@@ -515,7 +519,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[TAG:%.*]] = select i1 [[IS_PAYLOAD]], i32 [[NO_PAYLOAD_TAG2]], i32 [[SPARE_TAG]]
 // CHECK-NEXT: ret i32 [[TAG]]
 
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics31MultiPayloadNontrivialSpareBitsOwup"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsOwup"
 // CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to { i64, i64 }*
 
 //   -- Load the payload
@@ -536,8 +540,8 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: ret void
 
 
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics31MultiPayloadNontrivialSpareBitsOwui"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO*
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsOwui"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsO*
 // CHECK-NEXT: [[IS_PAYLOAD:%.*]] = icmp uge i32 %tag, 3
 // CHECK-NEXT: br i1 [[IS_PAYLOAD]], label %[[HAS_NO_PAYLOAD:.*]], label %[[HAS_PAYLOAD:.*]]
 
@@ -548,7 +552,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[NO_PAYLOAD_TAG2:%.*]] = zext i32 [[NO_PAYLOAD_TAG]] to i64
 
 //   -- Store the low bits of the tag into the payload
-// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
+// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
 // CHECK-NEXT: [[FIRST_ADDR:%.*]] = getelementptr inbounds { i64, i64 }, { i64, i64 }* [[PAYLOAD]], i32 0, i32 0
 // CHECK-NEXT: store i64 [[NO_PAYLOAD_TAG2]], i64* [[FIRST_ADDR]], align 8
 
@@ -564,7 +568,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[TAG_TMP:%.*]] = and i32 %tag, 3
 
 //   -- Load the payload
-// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
+// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
 // CHECK-NEXT: [[FIRST_ADDR:%.*]] = getelementptr inbounds { i64, i64 }, { i64, i64 }* [[PAYLOAD]], i32 0, i32 0
 // CHECK-NEXT: [[FIRST:%.*]] = load i64, i64* [[FIRST_ADDR]], align 8
 // CHECK-NEXT: [[SECOND_ADDR:%.*]] = getelementptr inbounds { i64, i64 }, { i64, i64 }* [[PAYLOAD]], i32 0, i32 1
@@ -584,7 +588,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[SECOND_NEW:%.*]] = or i64 [[SPARE_TAG_TMP]], [[SECOND_PROJ]]
 
 //   -- Store the payload back
-// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
+// CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T27enum_value_semantics_future31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
 // CHECK-NEXT: [[FIRST_ADDR:%.*]] = getelementptr inbounds { i64, i64 }, { i64, i64 }* [[PAYLOAD]], i32 0, i32 0
 // CHECK-NEXT: store i64 [[FIRST]], i64* [[FIRST_ADDR]], align 8
 // CHECK-NEXT: [[SECOND_ADDR:%.*]] = getelementptr inbounds { i64, i64 }, { i64, i64 }* [[PAYLOAD]], i32 0, i32 1
@@ -595,15 +599,15 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: ret void
 
 
-// CHECK-LABEL: define internal i32 @"$s20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0Owug"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O*
+// CHECK-LABEL: define internal i32 @"$s27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0Owug"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0O*
 
 //   -- Load the payload
-// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O* [[SELF]] to i64*
+// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0O* [[SELF]] to i64*
 // CHECK-NEXT: [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]], align 8
 
 //   -- Load the load bits of the tag from the extra tag area
-// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O, %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O* [[SELF]], i32 0, i32 1
+// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0O, %T27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0O* [[SELF]], i32 0, i32 1
 // CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i1*
 // CHECK-NEXT: [[EXTRA_TAG_TMP:%.*]] = load i1, i1* [[EXTRA_TAG_ADDR]], align 8
 
@@ -620,7 +624,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: ret i32 [[RESULT]]
 
 
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0Owup"
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0Owup"
 // CHECK:      [[PAYLOAD_ADDR:%.*]] = bitcast %swift.opaque* %value to i64*
 // CHECK-NEXT: [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]], align 8
 //                                                         -- 0x7fffffffffffffff
@@ -630,12 +634,12 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: ret void
 
 
-// CHECK-LABEL: define internal void @"$s20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0Owui"
-// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O*
+// CHECK-LABEL: define internal void @"$s27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0Owui"
+// CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %T27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0O*
 // CHECK-NEXT: [[SPARE_TAG_TMP3:%.*]] = and i32 %tag, 1
 
 //   -- Load the payload
-// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O* %0 to i64*
+// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0O* %0 to i64*
 // CHECK-NEXT: [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]], align 8
 
 //   -- Mask off the spare bits
@@ -650,13 +654,13 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[PAYLOAD_NEW:%.*]] = or i64 [[SPARE_TAG]], [[PAYLOAD_PROJ]]
 
 //   -- Store the payload
-// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O* %0 to i64*
+// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0O* %0 to i64*
 // CHECK-NEXT: store i64 [[PAYLOAD_NEW]], i64* [[PAYLOAD_ADDR]], align 8
 
 //   -- Store high bits of tag in extra tag area
 // CHECK-NEXT: [[EXTRA_TAG_TMP:%.*]] = lshr i32 %tag, 1
 // CHECK-NEXT: [[EXTRA_TAG:%.*]] = trunc i32 [[EXTRA_TAG_TMP]] to i1
-// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O, %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O* [[SELF]], i32 0, i32 1
+// CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %T27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0O, %T27enum_value_semantics_future029MultiPayloadSpareBitsAndExtraH0O* [[SELF]], i32 0, i32 1
 // CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i1*
 // CHECK-NEXT: store i1 [[EXTRA_TAG]], i1* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: ret void

--- a/test/IRGen/prespecialized-metadata/Inputs/protocol-public.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/protocol-public.swift
@@ -1,0 +1,2 @@
+public protocol P {
+}

--- a/test/IRGen/prespecialized-metadata/Inputs/struct-public-frozen-0argument.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/struct-public-frozen-0argument.swift
@@ -1,0 +1,8 @@
+@frozen
+public struct Integer {
+  public let value: Int
+
+  public init(_ value: Int) {
+    self.value = value
+  }
+}

--- a/test/IRGen/prespecialized-metadata/Inputs/struct-public-nonfrozen-0argument.swift
+++ b/test/IRGen/prespecialized-metadata/Inputs/struct-public-nonfrozen-0argument.swift
@@ -1,0 +1,7 @@
+public struct Integer {
+  public let value: Int
+
+  public init(_ value: Int) {
+    self.value = value
+  }
+}

--- a/test/IRGen/prespecialized-metadata/enum-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -1,0 +1,88 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5Value[[UNIQUE_ID_1:[0-9A-Z_]+]]OySiGMf" = internal constant <{
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    [[INT]],
+// CHECK-SAME:    %swift.type_descriptor*,
+// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    i64
+// CHECK-SAME: }> <{
+//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5Value[[UNIQUE_ID_1]]OySiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
+// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5Value[[UNIQUE_ID_1]]OMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    i64 3
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+fileprivate enum Value<First> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5Value[[UNIQUE_ID_1]]OySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]OMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5Value[[UNIQUE_ID_1]]OySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5Value[[UNIQUE_ID_1]]OMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -1,0 +1,95 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main9NamespaceC5ValueOySi_GMf" = internal constant <{
+// CHECk-SAME:    i8**,
+// CHECK-SAME:    [[INT]],
+// CHECK-SAME:    %swift.type_descriptor*,
+// CHECK-SAME:    %swift.type*,
+// CHECK-SAME: }> <{
+//                i8** getelementptr inbounds (
+//                  %swift.enum_vwtable, 
+//                  %swift.enum_vwtable* @"$s4main9NamespaceC5ValueOySi_GWV", 
+//                  i32 0, 
+//                  i32 0
+//                ),
+// CHECK-SAME:    [[INT]] 513,
+// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceC5ValueOMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    i64 3
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+
+final class Namespace<First> {
+  enum Value {
+    case first(First)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySi_GMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Namespace.Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_1]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*,  
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySi_GMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:   [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* undef, i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceC5ValueOMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-0distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-0distinct_use.swift
@@ -1,0 +1,40 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+enum Value<First> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK: }
+func doit() {
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main5ValueOMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-1distinct_use.swift
@@ -1,0 +1,97 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_type
+
+// CHECK: @"$s4main5ValueOySiGMf" = internal constant <{
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    [[INT]],
+// CHECK-SAME:    %swift.type_descriptor*,
+// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    i64
+// CHECK-SAME: }> <{
+// CHECK-SAME:    i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
+// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
+// CHECK-SAME:    i64 3
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+protocol P {}
+extension Int : P {}
+enum Value<First : P> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* [[ERASED_TABLE]], i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*))
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
@@ -1,0 +1,71 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/protocol-public.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+import TestModule
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_type
+
+// CHECK-NOT: @"$s4main5ValueOySiGMf"
+
+extension Int : P {}
+enum Value<First : P> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOyS2i10TestModule1PAAyHCg_GMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* [[ERASED_TABLE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME:   )
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_resilient-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_resilient-1distinct_use.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -enable-library-evolution -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/protocol-public.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+import TestModule
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_type
+
+// CHECK-NOT: @"$s4main5ValueOySiGMf"
+
+extension Int : P {}
+enum Value<First : P> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[DEMANGLED_TYPE:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s4main5ValueOyS2i10TestModule1PAAyHCg_GMD") #{{[0-9]+}}
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* [[DEMANGLED_TYPE]]
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* [[ERASED_TABLE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME:   )
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-public-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-public-1distinct_use.swift
@@ -1,0 +1,97 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$sytN" = external{{( dllimport)?}} global %swift.full_type
+
+// CHECK: @"$s4main5ValueOySiGMf" = internal constant <{
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    [[INT]],
+// CHECK-SAME:    %swift.type_descriptor*,
+// CHECK-SAME:    %swift.type*,
+// CHECK-SAME:    i8**,
+// CHECK-SAME:    i64
+// CHECK-SAME: }> <{
+// CHECK-SAME:    i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
+// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type* @"$sSiN",
+// CHECK-SAME:    i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$sSi4main1PAAWP", i32 0, i32 0),
+// CHECK-SAME:    i64 3
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+public protocol P {}
+extension Int : P {}
+enum Value<First : P> {
+  case first(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Value.first(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TABLE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* [[ERASED_TABLE]], i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*))
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
@@ -1,0 +1,44 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK-NOT: @"$s4main5ValueOyAA7IntegerVGMf"
+enum Value<First : Equatable> {
+  case first(First)
+}
+
+struct Integer : Equatable {
+  let value: Int
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+func doit() {
+  consume( Value.first(Integer(value: 13)) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, i8** %2) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_CONFORMANCE:%[0-9]+]] = bitcast i8** %2 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* [[ERASED_CONFORMANCE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* @"$s4main5ValueOMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_generic_use.swift
@@ -1,0 +1,101 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5OuterOyAA5InnerVySiGGWV" = linkonce_odr hidden constant %swift.enum_vwtable
+// CHECK: @"$s4main5OuterOyAA5InnerVySiGGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME: }> <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (
+// CHECK-SAME:     %swift.enum_vwtable, 
+// CHECK-SAME:     %swift.enum_vwtable* @"$s4main5OuterOyAA5InnerVySiGGWV", 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 0
+// CHECK-SAME:   ), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (
+// CHECK-SAME:     <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5OuterOMn" 
+// CHECK-SAME:     to %swift.type_descriptor*
+// CHECK-SAME:   ), 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         i32, 
+// CHECK-SAME:         {{(\[4 x i8\],)?}}
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5InnerVySiGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   ), 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Outer<First> {
+  case first(First)
+}
+
+struct Inner<First> {
+  let first: First
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5OuterOyAA5InnerVySiGGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Outer.first(Inner(first: 13)) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5OuterOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main5OuterOMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
@@ -1,0 +1,78 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOySiGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOySiGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOySiGwst" to i8*), 
+// CHECK-SAME:   [[INT]] [[ALIGNMENT]], 
+// CHECK-SAME:   [[INT]] [[ALIGNMENT]], 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 0, i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOySiGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOySiGwup" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOySiGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOySiGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME: }> <{ 
+// CHECK-SAME: i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOySiGWV", i32 0, i32 0), 
+// CHECK-SAME: [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First> {
+  case only(First)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i64 }>* @"$s4main5ValueOySiGMf" to %swift.full_type*), i32 0, i32 1)
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.only(13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, i64 }>* @"$s4main5ValueOySiGMf" to %swift.full_type*), i32 0, i32 1), [[INT]] 0 }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   i8* %2, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-class-1argument-1distinct_use.swift
@@ -5,32 +5,29 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK: @"$s4main9NamespaceC5ValueVySS_SiGMf" = internal constant <{
+// CHECK: @"$s4main9NamespaceC5ValueOySS_SiGMf" = internal constant <{
 // CHECK-SAME:    i8**,
 // CHECK-SAME:    [[INT]],
 // CHECK-SAME:    %swift.type_descriptor*,
 // CHECK-SAME:    %swift.type*,
 // CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceC5ValueVySS_SiGWV", i32 0, i32 0),
-// CHECK-SAME:    [[INT]] 512,
+//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main9NamespaceC5ValueOySS_SiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
 // CHECK-SAME:    %swift.type_descriptor* bitcast (
 // CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:      @"$s4main9NamespaceC5ValueVMn" 
+// CHECK-SAME:      @"$s4main9NamespaceC5ValueOMn" 
 // CHECK-SAME:      to %swift.type_descriptor*
 // CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
 final class Namespace<Arg> {
-  struct Value<First> {
-    let first: First
+  enum Value<First> {
+    case first(First)
   }
 }
 
@@ -52,9 +49,8 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -63,12 +59,12 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {
-  consume( Namespace<String>.Value(first: 13) )
+  consume( Namespace<String>.Value.first(13) )
 }
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {
 // CHECK: entry:
 // CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
@@ -90,9 +86,8 @@ doit()
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -108,7 +103,7 @@ doit()
 // CHECK-SAME:     i8* undef, 
 // CHECK-SAME:     %swift.type_descriptor* bitcast (
 // CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:       @"$s4main9NamespaceC5ValueVMn" 
+// CHECK-SAME:       @"$s4main9NamespaceC5ValueOMn" 
 // CHECK-SAME:       to %swift.type_descriptor*
 // CHECK-SAME:     )
 // CHECK-SAME:   ) #{{[0-9]+}}

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -5,32 +5,29 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK: @"$s4main9NamespaceC5ValueVySS_SiGMf" = internal constant <{
+// CHECK: @"$s4main9NamespaceO5ValueOySS_SiGMf" = internal constant <{
 // CHECK-SAME:    i8**,
 // CHECK-SAME:    [[INT]],
 // CHECK-SAME:    %swift.type_descriptor*,
 // CHECK-SAME:    %swift.type*,
 // CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceC5ValueVySS_SiGWV", i32 0, i32 0),
-// CHECK-SAME:    [[INT]] 512,
+//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main9NamespaceO5ValueOySS_SiGWV", i32 0, i32 0)
+// CHECK-SAME:    [[INT]] 513,
 // CHECK-SAME:    %swift.type_descriptor* bitcast (
 // CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:      @"$s4main9NamespaceC5ValueVMn" 
+// CHECK-SAME:      @"$s4main9NamespaceO5ValueOMn" 
 // CHECK-SAME:      to %swift.type_descriptor*
 // CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
-final class Namespace<Arg> {
-  struct Value<First> {
-    let first: First
+enum Namespace<Arg> {
+  enum Value<First> {
+    case first(First)
   }
 }
 
@@ -52,9 +49,8 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -63,12 +59,12 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {
-  consume( Namespace<String>.Value(first: 13) )
+  consume( Namespace<String>.Value.first(13) )
 }
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceO5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {
 // CHECK: entry:
 // CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
@@ -90,9 +86,8 @@ doit()
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -108,7 +103,7 @@ doit()
 // CHECK-SAME:     i8* undef, 
 // CHECK-SAME:     %swift.type_descriptor* bitcast (
 // CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:       @"$s4main9NamespaceC5ValueVMn" 
+// CHECK-SAME:       @"$s4main9NamespaceO5ValueOMn" 
 // CHECK-SAME:       to %swift.type_descriptor*
 // CHECK-SAME:     )
 // CHECK-SAME:   ) #{{[0-9]+}}

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-struct-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-struct-1argument-1distinct_use.swift
@@ -5,32 +5,29 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-// CHECK: @"$s4main9NamespaceC5ValueVySS_SiGMf" = internal constant <{
+// CHECK: @"$s4main9NamespaceV5ValueOySS_SiGMf" = internal constant <{
 // CHECK-SAME:    i8**,
 // CHECK-SAME:    [[INT]],
 // CHECK-SAME:    %swift.type_descriptor*,
 // CHECK-SAME:    %swift.type*,
 // CHECK-SAME:    %swift.type*,
-// CHECK-SAME:    i32{{(, \[4 x i8\])?}},
 // CHECK-SAME:    i64
 // CHECK-SAME: }> <{
-//                i8** @"$sB[[INT]]_WV",
-//                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceC5ValueVySS_SiGWV", i32 0, i32 0),
-// CHECK-SAME:    [[INT]] 512,
+//                i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main9NamespaceV5ValueOySS_SiGWV", i32 0, i32 0),
+// CHECK-SAME:    [[INT]] 513,
 // CHECK-SAME:    %swift.type_descriptor* bitcast (
 // CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:      @"$s4main9NamespaceC5ValueVMn" 
+// CHECK-SAME:      @"$s4main9NamespaceV5ValueOMn" 
 // CHECK-SAME:      to %swift.type_descriptor*
 // CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
-// CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
 // CHECK-SAME:    i64 3
 // CHECK-SAME: }>, align [[ALIGNMENT]]
 
-final class Namespace<Arg> {
-  struct Value<First> {
-    let first: First
+struct Namespace<Arg> {
+  enum Value<First> {
+    case first(First)
   }
 }
 
@@ -52,9 +49,8 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -63,12 +59,12 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK: }
 func doit() {
-  consume( Namespace<String>.Value(first: 13) )
+  consume( Namespace<String>.Value.first(13) )
 }
 doit()
 
 // CHECK: ; Function Attrs: noinline nounwind readnone
-// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceC5ValueVMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceV5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {
 // CHECK: entry:
 // CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
 // CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
@@ -88,11 +84,9 @@ doit()
 // CHECK-SAME:           i8**, 
 // CHECK-SAME:           [[INT]], 
 // CHECK-SAME:           %swift.type_descriptor*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           %swift.type*, 
-// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           %swift.type*, %swift.type*, 
 // CHECK-SAME:           i64 
-// CHECK-SAME:         }>* @"$s4main9NamespaceC5ValueVySS_SiGMf" 
+// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueOySS_SiGMf" 
 // CHECK-SAME:         to %swift.full_type*
 // CHECK-SAME:       ), 
 // CHECK-SAME:       i32 0, 
@@ -108,7 +102,7 @@ doit()
 // CHECK-SAME:     i8* undef, 
 // CHECK-SAME:     %swift.type_descriptor* bitcast (
 // CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
-// CHECK-SAME:       @"$s4main9NamespaceC5ValueVMn" 
+// CHECK-SAME:       @"$s4main9NamespaceV5ValueOMn" 
 // CHECK-SAME:       to %swift.type_descriptor*
 // CHECK-SAME:     )
 // CHECK-SAME:   ) #{{[0-9]+}}

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-2argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-2argument-1distinct_use.swift
@@ -1,0 +1,118 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOyS2iGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS2iGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOyS2iGwst" to i8*), 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS2iGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS2iGwup" to i8*), 
+// CHECK-SAME    i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS2iGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOyS2iGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME:   }> <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS2iGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   [[INT]] {{16|8}}, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First, Second> {
+  case first(First)
+  case second(First, Second)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOyS2iGMf" 
+// CHECK-SAME:       to %swift.full_type*), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.second(13, 13) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   [[EQUAL_TYPE_1_2:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_2]]
+// CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_2]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, %swift.type*, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOyS2iGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME: [[INT]] %0, 
+// CHECK-SAME: i8* [[ERASED_TYPE_1]], 
+// CHECK-SAME: i8* [[ERASED_TYPE_2]], 
+// CHECK-SAME: i8* undef, 
+// CHECK-SAME: %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-3argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-3argument-1distinct_use.swift
@@ -1,0 +1,127 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOyS3iGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS3iGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOyS3iGwst" to i8*), 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS3iGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS3iGwup" to i8*), 
+// CHECK-SAME    i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS3iGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOyS3iGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME:   }> <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS3iGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   [[INT]] {{24|12}}, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First, Second, Third> {
+  case first(First)
+  case second(First, Second)
+  case third(First, Second, Third)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOyS3iGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.third(13, 14, 15) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1, %swift.type* %2, %swift.type* %3) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
+// CHECK:   [[ERASED_TYPE_3:%[0-9]+]] = bitcast %swift.type* %3 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   [[EQUAL_TYPE_1_2:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_2]]
+// CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
+// CHECK:   [[EQUAL_TYPE_1_3:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_3]]
+// CHECK:   [[EQUAL_TYPES_1_3:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_2]], [[EQUAL_TYPE_1_3]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_3]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOyS3iGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME: [[INT]] %0, 
+// CHECK-SAME: i8* [[ERASED_TYPE_1]], 
+// CHECK-SAME: i8* [[ERASED_TYPE_2]], 
+// CHECK-SAME: i8* [[ERASED_TYPE_3]], 
+// CHECK-SAME: %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-4argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-4argument-1distinct_use.swift
@@ -1,0 +1,137 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOyS4iGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS4iGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOyS4iGwst" to i8*), 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS4iGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS4iGwup" to i8*), 
+// CHECK-SAME    i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS4iGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOyS4iGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME:   }> <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS4iGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   [[INT]] {{32|16}},
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First, Second, Third, Fourth> {
+  case first(First)
+  case second(First, Second)
+  case third(First, Second, Third)
+  case fourth(First, Second, Third, Fourth)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOyS4iGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.fourth(13, 14, 15, 16) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, i8** %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_BUFFER:%[0-9]+]] = bitcast i8** %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[ERASED_TYPE_ADDRESS_1:%[0-9]+]] = getelementptr i8*, i8** %1, i64 0
+// CHECK:   [[ERASED_TYPE_1:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_1]]
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_2:%[0-9]+]] = getelementptr i8*, i8** %1, i64 1
+// CHECK:   [[ERASED_TYPE_2:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_2]]
+// CHECK:   [[EQUAL_TYPE_1_2:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_2]]
+// CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_3:%[0-9]+]] = getelementptr i8*, i8** %1, i64 2
+// CHECK:   [[ERASED_TYPE_3:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_3]]
+// CHECK:   [[EQUAL_TYPE_1_3:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_3]]
+// CHECK:   [[EQUAL_TYPES_1_3:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_2]], [[EQUAL_TYPE_1_3]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_4:%[0-9]+]] = getelementptr i8*, i8** %1, i64 3
+// CHECK:   [[ERASED_TYPE_4:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_4]]
+// CHECK:   [[EQUAL_TYPE_1_4:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_4]]
+// CHECK:   [[EQUAL_TYPES_1_4:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_3]], [[EQUAL_TYPE_1_4]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_4]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOyS4iGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getGenericMetadata(
+// CHECK-SAME: [[INT]] %0, 
+// CHECK-SAME: i8* [[ERASED_BUFFER]], 
+// CHECK-SAME: %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-5argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-5argument-1distinct_use.swift
@@ -1,0 +1,141 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main5ValueOyS5iGWV" = linkonce_odr hidden constant %swift.enum_vwtable { 
+// CHECK-SAME:   i8* bitcast ({{(%swift.opaque\* \(\[[0-9]+ x i8\]\*, \[[0-9]+ x i8\]\*, %swift.type\*\)\* @"\$[a-zA-Z0-9_]+" to i8\*|i8\* \(i8\*, i8\*, %swift.type\*\)\* @__swift_memcpy[0-9]+_[0-9]+ to i8\*)}}), 
+// CHECK-SAME:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy{{[0-9]+}}_{{[0-9]+}} to i8*), 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS5iGwet" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, i32, %swift.type*)* @"$s4main5ValueOyS5iGwst" to i8*), 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   [[INT]] {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i32 {{[0-9]+}}, 
+// CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS5iGwug" to i8*), 
+// CHECK-SAME:   i8* bitcast (void (%swift.opaque*, %swift.type*)* @"$s4main5ValueOyS5iGwup" to i8*), 
+// CHECK-SAME    i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$s4main5ValueOyS5iGwui" to i8*) 
+// CHECK-SAME: }, align [[ALIGNMENT]]
+// CHECK: @"$s4main5ValueOyS5iGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME:   }> <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOyS5iGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   [[INT]] {{40|20}}, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+enum Value<First, Second, Third, Fourth, Fifth> {
+  case first(First)
+  case second(First, Second)
+  case third(First, Second, Third)
+  case fourth(First, Second, Third, Fourth)
+  case fifth(First, Second, Third, Fourth, Fifth)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOyS5iGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.fifth(13, 14, 15, 16, 17) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, i8** %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_BUFFER:%[0-9]+]] = bitcast i8** %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[ERASED_TYPE_ADDRESS_1:%[0-9]+]] = getelementptr i8*, i8** %1, i64 0
+// CHECK:   [[ERASED_TYPE_1:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_1]]
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_2:%[0-9]+]] = getelementptr i8*, i8** %1, i64 1
+// CHECK:   [[ERASED_TYPE_2:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_2]]
+// CHECK:   [[EQUAL_TYPE_1_2:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_2]]
+// CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_3:%[0-9]+]] = getelementptr i8*, i8** %1, i64 2
+// CHECK:   [[ERASED_TYPE_3:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_3]]
+// CHECK:   [[EQUAL_TYPE_1_3:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_3]]
+// CHECK:   [[EQUAL_TYPES_1_3:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_2]], [[EQUAL_TYPE_1_3]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_4:%[0-9]+]] = getelementptr i8*, i8** %1, i64 3
+// CHECK:   [[ERASED_TYPE_4:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_4]]
+// CHECK:   [[EQUAL_TYPE_1_4:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_4]]
+// CHECK:   [[EQUAL_TYPES_1_4:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_3]], [[EQUAL_TYPE_1_4]]
+// CHECK:   [[ERASED_TYPE_ADDRESS_5:%[0-9]+]] = getelementptr i8*, i8** %1, i64 4
+// CHECK:   [[ERASED_TYPE_5:%\".*\"]] = load i8*, i8** [[ERASED_TYPE_ADDRESS_5]]
+// CHECK:   [[EQUAL_TYPE_1_5:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_5]]
+// CHECK:   [[EQUAL_TYPES_1_5:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_4]], [[EQUAL_TYPE_1_5]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_5]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOyS5iGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @swift_getGenericMetadata(
+// CHECK-SAME: [[INT]] %0, 
+// CHECK-SAME: i8* [[ERASED_BUFFER]], 
+// CHECK-SAME: %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-frozen.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-frozen.swift
@@ -1,0 +1,100 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -enable-library-evolution -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/struct-public-frozen-0argument.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+import TestModule
+
+// CHECK: @"$s4main5ValueOy10TestModule7IntegerVGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i64 
+// CHECK-SAME: }> 
+// CHECK-SAME: <{ 
+// CHECK-SAME:   i8** getelementptr inbounds (%swift.enum_vwtable, %swift.enum_vwtable* @"$s4main5ValueOy10TestModule7IntegerVGWV", i32 0, i32 0), 
+// CHECK-SAME:   [[INT]] 513, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*), 
+// CHECK-SAME:   %swift.type* @"$s10TestModule7IntegerVN", 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, align [[ALIGNMENT]]
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+enum Value<First> {
+  case only(First)
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5ValueOy10TestModule7IntegerVGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   )
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.only(Integer(13)) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$s10TestModule7IntegerVN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5ValueOy10TestModule7IntegerVGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:   [[INT]] %0, 
+// CHECK-SAME:   i8* %2, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   i8* undef, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME: ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -enable-library-evolution -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/struct-public-nonfrozen-0argument.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+import TestModule
+
+// CHECK-NOT: @"$s4main5ValueOy10TestModule7IntegerVGMf"
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+enum Value<First> {
+  case only(First)
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   [[DEMANGLED_TYPE:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s4main5ValueOy10TestModule7IntegerVGMD") #{{[0-9]+}}
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   %swift.type* [[DEMANGLED_TYPE]]
+// CHECK-SAME: )
+// CHECK: }
+func doit() {
+  consume( Value.only(Integer(13)) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5ValueOMa"([[INT]] %0, %swift.type* %1) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5ValueOMn" to %swift.type_descriptor*)
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-stdlib_equatable-1distinct_use.swift
@@ -6,11 +6,11 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 // CHECK-NOT: @"$s4main5ValueVyAA7IntegerVGMf"
-struct Value<First : Hashable> {
+struct Value<First : Equatable> {
   let first: First
 }
 
-struct Integer : Hashable {
+struct Integer : Equatable {
   let value: Int
 }
 

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -17,7 +17,11 @@
 //                i8** @"$sB[[INT]]_WV",
 //                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceO5ValueVySS_SiGWV", i32 0, i32 0)
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceO5ValueVMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type_descriptor* bitcast (
+// CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:      @"$s4main9NamespaceO5ValueVMn" 
+// CHECK-SAME:      to %swift.type_descriptor*
+// CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
 // CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
@@ -37,7 +41,26 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main9NamespaceO5ValueVySS_SiGMf" to %swift.full_type*), i32 0, i32 1))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueVySS_SiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( Namespace<String>.Value(first: 13) )
@@ -57,8 +80,37 @@ doit()
 // CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
 // CHECK:   br i1 [[EQUAL_TYPES_1_2]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
 // CHECK: [[EXIT_PRESPECIALIZED_1]]:
-// CHECK:   ret %swift.metadata_response { %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main9NamespaceO5ValueVySS_SiGMf" to %swift.full_type*), i32 0, i32 1), [[INT]] 0 }
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceO5ValueVySS_SiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
 // CHECK: [[EXIT_NORMAL]]:
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceO5ValueVMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main9NamespaceO5ValueVMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
@@ -17,7 +17,11 @@
 //                i8** @"$sB[[INT]]_WV",
 //                i8** getelementptr inbounds (%swift.vwtable, %swift.vwtable* @"$s4main9NamespaceV5ValueVySS_SiGWV", i32 0, i32 0),
 // CHECK-SAME:    [[INT]] 512,
-// CHECK-SAME:    %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceV5ValueVMn" to %swift.type_descriptor*),
+// CHECK-SAME:    %swift.type_descriptor* bitcast (
+// CHECK-SAME:      <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:      @"$s4main9NamespaceV5ValueVMn" 
+// CHECK-SAME:      to %swift.type_descriptor*
+// CHECK-SAME:    ),
 // CHECK-SAME:    %swift.type* @"$sSSN",
 // CHECK-SAME:    %swift.type* @"$sSiN",
 // CHECK-SAME:    i32 0{{(, \[4 x i8\] zeroinitializer)?}},
@@ -37,7 +41,26 @@ func consume<T>(_ t: T) {
 }
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" to %swift.full_type*), i32 0, i32 1))
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
 // CHECK: }
 func doit() {
   consume( Namespace<String>.Value(first: 13) )
@@ -57,8 +80,36 @@ doit()
 // CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
 // CHECK:   br i1 [[EQUAL_TYPES_1_2]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
 // CHECK: [[EXIT_PRESPECIALIZED_1]]:
-// CHECK:   ret %swift.metadata_response { %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, [[INT]], %swift.type_descriptor*, %swift.type*, %swift.type*, i32{{(, \[4 x i8\])?}}, i64 }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" to %swift.full_type*), i32 0, i32 1), [[INT]] 0 }
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, %swift.type*, 
+// CHECK-SAME:           i32{{(, \[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceV5ValueVySS_SiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
 // CHECK: [[EXIT_NORMAL]]:
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE_1]], i8* [[ERASED_TYPE_2]], i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main9NamespaceV5ValueVMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main9NamespaceV5ValueVMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/synthesized_conformance_future.swift
+++ b/test/IRGen/synthesized_conformance_future.swift
@@ -62,7 +62,26 @@ public func equality() {
     // CHECK-SAME: )
     doEquality(Struct(x: 1))
     // CHECK: [[Enum_Equatable:%.*]] = call i8** @"$s30synthesized_conformance_future4EnumOySiGACyxGSQAASQRzlWl"()
-    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future10doEqualityyyxSQRzlF"(%swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}}, i8** [[Enum_Equatable]])
+    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future10doEqualityyyxSQRzlF"(
+    // CHECK-SAME:   %swift.opaque* noalias nocapture {{%[^,]+}}, 
+    // CHECK-SAME:   %swift.type* getelementptr inbounds (
+    // CHECK-SAME:     %swift.full_type, 
+    // CHECK-SAME:     %swift.full_type* bitcast (
+    // CHECK-SAME:       <{ 
+    // CHECK-SAME:         i8**, 
+    // CHECK-SAME:         [[INT]], 
+    // CHECK-SAME:         %swift.type_descriptor*, 
+    // CHECK-SAME:         %swift.type*, 
+    // CHECK-SAME:         [[INT]], 
+    // CHECK-SAME:         i64 
+    // CHECK-SAME:       }>* @"$s30synthesized_conformance_future4EnumOySiGMf" 
+    // CHECK-SAME:       to %swift.full_type*
+    // CHECK-SAME:     ), 
+    // CHECK-SAME:     i32 0,
+    // CHECK-SAME:     i32 1
+    // CHECK-SAME:   ), 
+    // CHECK-SAME:   i8** [[Enum_Equatable]]
+    // CHECK-SAME: )
     doEquality(Enum.a(1))
 }
 

--- a/test/Interpreter/enum_equatable_hashable_correctness_future.swift
+++ b/test/Interpreter/enum_equatable_hashable_correctness_future.swift
@@ -1,0 +1,114 @@
+// RUN: %target-run-simple-swift -target %module-target-future
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+enum Token: Hashable {
+  case string(String)
+  case number(Int)
+  case comma
+  case colon
+}
+
+enum Combo<T: Hashable, U: Hashable>: Hashable {
+  case none
+  case first(T)
+  case second(U)
+  case both(T, U)
+}
+
+var EnumSynthesisTests = TestSuite("EnumSynthesis")
+
+EnumSynthesisTests.test("BasicEquatability/Hashability") {
+  checkHashable([
+    Token.string("foo"),
+    Token.number(10),
+    Token.comma,
+    Token.colon,
+  ], equalityOracle: { $0 == $1 })
+}
+
+// Not guaranteed by the semantics of Hashable, but we sanity check that the
+// synthesized hash function is good enough to not let nearby values collide.
+EnumSynthesisTests.test("CloseValuesDoNotCollide") {
+  expectNotEqual(Token.string("foo").hashValue, Token.string("goo").hashValue)
+  expectNotEqual(Token.number(10).hashValue, Token.number(11).hashValue)
+}
+
+EnumSynthesisTests.test("GenericEquatability/Hashability") {
+  checkHashable([
+    Combo<String, Int>.none,
+    Combo<String, Int>.first("a"),
+    Combo<String, Int>.second(5),
+    Combo<String, Int>.both("foo", 5),
+  ], equalityOracle: { $0 == $1 })
+}
+
+EnumSynthesisTests.test("CloseGenericValuesDoNotCollide") {
+  expectNotEqual(Combo<String, Int>.first("foo").hashValue, Combo<String, Int>.first("goo").hashValue)
+  expectNotEqual(Combo<String, Int>.second(3).hashValue, Combo<String, Int>.second(4).hashValue)
+  expectNotEqual(Combo<String, Int>.both("foo", 3).hashValue, Combo<String, Int>.both("goo", 3).hashValue)
+  expectNotEqual(Combo<String, Int>.both("foo", 3).hashValue, Combo<String, Int>.both("foo", 4).hashValue)
+  expectNotEqual(Combo<String, Int>.both("foo", 3).hashValue, Combo<String, Int>.both("goo", 4).hashValue)
+}
+
+func hashEncode(_ body: (inout Hasher) -> ()) -> Int {
+  var hasher = Hasher()
+  body(&hasher)
+  return hasher.finalize()
+}
+
+// Make sure that if the user overrides the synthesized member, that one gets
+// used instead.
+enum Overrides: Hashable {
+  case a(Int), b(String)
+  var hashValue: Int { return 2 }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(2)
+  }
+  static func == (lhs: Overrides, rhs: Overrides) -> Bool { return true }
+}
+
+EnumSynthesisTests.test("ExplicitOverridesSynthesized") {
+  checkHashable(expectedEqual: true, Overrides.a(4), .b("foo"))
+  expectEqual(Overrides.a(4).hashValue, 2)
+  expectEqual(
+    hashEncode { $0.combine(Overrides.a(4)) },
+    hashEncode { $0.combine(2) })
+}
+
+// ...even in an extension.
+enum OverridesInExtension: Hashable {
+  case a(Int), b(String)
+}
+extension OverridesInExtension {
+  var hashValue: Int { return 2 }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(2)
+  }
+  static func == (lhs: OverridesInExtension, rhs: OverridesInExtension) -> Bool { return true }
+}
+
+EnumSynthesisTests.test("ExplicitOverridesSynthesizedInExtension") {
+  checkHashable(expectedEqual: true, OverridesInExtension.a(4), .b("foo"))
+  expectEqual(OverridesInExtension.a(4).hashValue, 2)
+  expectEqual(
+    hashEncode { $0.combine(OverridesInExtension.a(4)) },
+    hashEncode { $0.combine(2) })
+}
+
+// Try an indirect enum.
+enum BinaryTree<Element: Hashable>: Hashable {
+  indirect case tree(BinaryTree, BinaryTree)
+  case leaf(Element)
+}
+
+EnumSynthesisTests.test("IndirectEquatability/Hashability") {
+  let one = BinaryTree<Int>.tree(.leaf(10), .leaf(20))
+  let two = BinaryTree<Int>.tree(.leaf(10), .leaf(30))
+  let three = BinaryTree<Int>.tree(.leaf(15), .leaf(20))
+  let four = BinaryTree<Int>.tree(.leaf(15), .leaf(30))
+  checkHashable([one, two, three, four], equalityOracle: { $0 == $1 })
+}
+
+runAllTests()

--- a/test/Prototypes/Result_future.swift
+++ b/test/Prototypes/Result_future.swift
@@ -1,0 +1,158 @@
+//===--- Result.swift -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-stdlib-swift-target-future
+// REQUIRES: executable_test
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+// Executing on the simulator within __abort_with_payload with "No ABI plugin located for triple x86_64h-apple-ios -- shared libraries will not be registered!"
+// UNSUPPORTED: CPU=x86_64 && OS=ios
+// UNSUPPORTED: CPU=i386 && OS=watchos
+
+public enum Result<Value> {
+case Success(Value)
+case Error(Error)
+
+  init(success x: Value) {
+    self = .Success(x)
+  }
+  
+  init(error: Error) {
+    self = .Error(error)
+  }
+  
+  func map<U>(_ transform: (Value) -> U) -> Result<U> {
+    switch self {
+    case .Success(let x): return .Success(transform(x))
+    case .Error(let e): return .Error(e)
+    }
+  }
+
+  func flatMap<U>(_ transform: (Value) -> Result<U>) -> Result<U> {
+    switch self {
+    case .Success(let x): return transform(x)
+    case .Error(let e): return .Error(e)
+    }
+  }
+
+  func get() throws -> Value {
+    switch self {
+    case .Success(let x): return x
+    case .Error(let e): throw e
+    }
+  }
+
+  var success: Value? {
+    switch self {
+    case .Success(let x): return x
+    case .Error: return nil
+    }
+  }
+
+  var error: Error? {
+    switch self {
+    case .Success: return nil
+    case .Error(let x): return x
+    }
+  }
+}
+
+public func ?? <T> (
+  result: Result<T>, defaultValue: @autoclosure () -> T
+) -> T {
+  switch result {
+  case .Success(let x): return x
+  case .Error: return defaultValue()
+  }
+}
+
+// We aren't actually proposing this overload; we think there should
+// be a compiler warning that catches the promotion that you probably
+// don't want.
+public func ?? <T> (
+  result: Result<T>?, defaultValue: @autoclosure () -> T
+) -> T {
+  fatalError("We should warn about Result<T> being promoted to Result<T>?")
+}
+
+/// Translate the execution of a throwing closure into a Result
+func catchResult<Success>(
+  invoking body: () throws -> Success
+) -> Result<Success> {
+  do {
+    return try .Success(body())
+  }
+  catch {
+    return .Error(error)
+  }
+}
+
+// A couple of error types
+enum Nasty : Error {
+case Bad, Awful, Terrible
+}
+
+enum Icky : Error {
+case Sad, Bad, Poor
+}
+
+// Some Results to work with
+let three = Result(success: 3)
+let four = Result(success: 4)
+let nasty = Result<Int>(error: Nasty.Bad)
+let icky = Result<String>(error: Icky.Sad)
+
+print(three)
+print(nasty)
+print(icky)
+
+print(three ?? 4)
+print(nasty ?? 4)
+
+print(three.map { String($0) })
+print(nasty.map { String($0) })
+
+
+print(three.flatMap { .Success(String($0)) })
+print(nasty.flatMap { .Success(String($0)) })
+
+print(three.flatMap { _ in icky })
+print(nasty.flatMap { _ in icky })
+
+try print(three.get())
+do {
+  try print(nasty.get())
+}
+catch {
+  print(error)
+}
+
+func mayFail(_ fail: Bool) throws -> Int {
+  if fail { throw Icky.Poor }
+  return 0
+}
+
+print(catchResult { try mayFail(true) })
+print(catchResult { try mayFail(false) })
+
+print(catchResult { 1 }.flatMap { _ in Result(success: 4) }.flatMap { _ in Result<String>(error: Icky.Poor) })
+print(catchResult { 1 }.map { _ in three }.flatMap {$0} )
+
+let results = [three, nasty, four]
+print(results.flatMap { $0.success })
+print(results.flatMap { $0.error })
+print(results.contains { $0.success != nil })
+
+// Mistaken usage; causes Result<T> to be promoted to Result<T>?
+// print(three ?? nasty)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -738,7 +738,7 @@ else:
 swift_reflection_test_name = 'swift-reflection-test' + variant_suffix
 
 def use_interpreter_for_simple_runs():
-    def make_simple_target_run(gyb=False, stdlib=False, parameterized=False):
+    def make_simple_target_run(gyb=False, stdlib=False, parameterized=False, future=False):
         result = ''
         if gyb:
             result += ('%empty-directory(%t) && '
@@ -752,6 +752,8 @@ def use_interpreter_for_simple_runs():
                config.swift_test_options,
                config.swift_driver_test_options,
                swift_execution_tests_extra_flags))
+        if future:
+            result += '-target %s ' % target_future
         if stdlib:
             result += '-Xfrontend -disable-access-control '
         if parameterized:
@@ -764,6 +766,7 @@ def use_interpreter_for_simple_runs():
     config.target_run_stdlib_swiftgyb = make_simple_target_run(gyb=True)
     config.target_run_simple_swiftgyb = make_simple_target_run(gyb=True)
     config.target_run_stdlib_swift = make_simple_target_run(stdlib=True)
+    config.target_run_stdlib_swift_target_future = make_simple_target_run(stdlib=True, future=True)
     config.target_run_simple_swift = make_simple_target_run()
     config.target_run_simple_swift_parameterized = make_simple_target_run(parameterized=True)
     config.available_features.add('interpret')
@@ -1619,6 +1622,13 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out && '
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_stdlib_swift_target_future = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -o %%t/a.out -module-name main '
+        '-target %s -Xfrontend -disable-access-control  && '
+        '%s %%t/a.out && '
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, target_future, config.target_codesign, config.target_run))
     config.target_run_simple_swiftgyb = (
         '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
@@ -1666,6 +1676,7 @@ config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_si
 config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)', config.target_run_simple_swift_parameterized))
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb', config.target_run_stdlib_swiftgyb))
+config.substitutions.append(('%target-run-stdlib-swift-target-future', config.target_run_stdlib_swift_target_future))
 config.substitutions.append(('%target-run-stdlib-swift', config.target_run_stdlib_swift))
 config.substitutions.append(('%target-repl-run-simple-swift', subst_target_repl_run_simple_swift))
 config.substitutions.append(('%target-run', config.target_run))


### PR DESCRIPTION
Continuing the work started in https://github.com/apple/swift/pull/28610 , prespecializes generic metadata for enums under limited circumstances. Specifically, prespecialization only occurs for usages within the same module where the type itself is defined and for specializations all of whose type arguments are themselves concrete types.