### PR TITLE
ClangImporter: Don't force loading of all superclass members in loadNamedMembers()

### DIFF
--- a/test/IRGen/Inputs/usr/include/module.map
+++ b/test/IRGen/Inputs/usr/include/module.map
@@ -9,6 +9,7 @@ module SRoA {
 
 module ObjectiveC {
   header "BridgeTestObjectiveC.h"
+  export *
 }
 
 module CoreCooling {
@@ -17,6 +18,7 @@ module CoreCooling {
 
 module Foundation {
   header "BridgeTestFoundation.h"
+  export *
 }
 
 module CoreFoundation {


### PR DESCRIPTION
I had to fix a fake module.map in IRGen to avoid some breakage.