### PR TITLE
[DNM][AST] Keep track of an "isDerivableFromSwiftType" bit for Clang types.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -594,7 +594,7 @@ public:
   ///                          information, in case it is needed.
   /// \param trueRep The actual calling convention, which must be C-compatible.
   ///                The calling convention in \p incompleteExtInfo is ignored.
-  const clang::Type *
+  ClangTypeWrapper
   getClangFunctionType(ArrayRef<AnyFunctionType::Param> params, Type resultTy,
                        const FunctionType::ExtInfo incompleteExtInfo,
                        FunctionTypeRepresentation trueRep);
@@ -602,7 +602,7 @@ public:
   /// Get the canonical Clang type corresponding to a SIL function type.
   ///
   /// SIL analog of \c ASTContext::getClangFunctionType .
-  const clang::Type *
+  ClangTypeWrapper
   getCanonicalClangFunctionType(
     ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
     const SILFunctionType::ExtInfo incompleteExtInfo,

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -397,7 +397,7 @@ Type ASTBuilder::createFunctionType(
     DifferentiabilityKind::NonDifferentiable,
     /*clangFunctionType*/nullptr);
 
-  const clang::Type *clangFunctionType = nullptr;
+  ClangTypeWrapper clangFunctionType(nullptr);
   if (representation == FunctionTypeRepresentation::CFunctionPointer)
     clangFunctionType = Ctx.getClangFunctionType(funcParams, output,
                                                  incompleteExtInfo,
@@ -511,7 +511,7 @@ Type ASTBuilder::createImplFunctionType(
     funcErrorResult.emplace(type, conv);
   }
 
-  const clang::Type *clangFnType = nullptr;
+  ClangTypeWrapper clangFnType(nullptr);
   auto incompleteExtInfo = SILFunctionType::ExtInfo(
       SILFunctionType::Representation::Thick, flags.isPseudogeneric(),
       !flags.isEscaping(), DifferentiabilityKind::NonDifferentiable,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3633,11 +3633,13 @@ namespace {
 
       OS << "\n";
       Indent += 2;
-      if (auto *cty = T->getClangFunctionType()) {
+      auto cty = T->getClangFunctionType();
+      if (!cty.empty()) {
         std::string s;
         llvm::raw_string_ostream os(s);
-        cty->dump(os);
-        printField("clang_type", os.str());
+        cty.printType(T->getASTContext().getClangModuleLoader(), os);
+        printField("clang_type", QuotedString(os.str()));
+        printFlag(cty.isDerivableFromSwiftType(), "derivable_from_swift_type");
       }
       printAnyFunctionParams(T->getParams(), "input");
       Indent -=2;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3499,7 +3499,7 @@ void printCType(ASTContext &Ctx, ASTPrinter &Printer, ExtInfo &info) {
   auto *cml = Ctx.getClangModuleLoader();
   SmallString<64> buf;
   llvm::raw_svector_ostream os(buf);
-  info.getUncommonInfo().getValue().printClangFunctionType(cml, os);
+  info.getClangTypeWrapper().getValue().printType(cml, os);
   Printer << ", cType: " << QuotedString(os.str());
 }
 
@@ -3907,7 +3907,7 @@ public:
         Printer << "c";
         // FIXME: [clang-function-type-serialization] Once we start serializing
         // Clang function types, we should be able to remove the second check.
-        if (printNameOnly || !info.getUncommonInfo().hasValue())
+        if (printNameOnly || !info.getClangTypeWrapper().hasValue())
           break;
         printCType(Ctx, Printer, info);
         break;
@@ -3974,7 +3974,7 @@ public:
         Printer << "c";
         // FIXME: [clang-function-type-serialization] Once we start serializing
         // Clang function types, we should be able to remove the second check.
-        if (printNameOnly || !info.getUncommonInfo().hasValue())
+        if (printNameOnly || !info.getClangTypeWrapper().hasValue())
           break;
         printCType(Ctx, Printer, info);
         break;

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -617,12 +617,12 @@ clang::QualType ClangTypeConverter::visitEnumType(EnumType *type) {
 
 clang::QualType ClangTypeConverter::visitFunctionType(FunctionType *type) {
   // We must've already computed it before if applicable.
-  return clang::QualType(type->getClangFunctionType(), 0);
+  return clang::QualType(type->getClangFunctionType().getType(), 0);
 }
 
 clang::QualType ClangTypeConverter::visitSILFunctionType(SILFunctionType *type) {
   // We must've already computed it before if applicable.
-  return clang::QualType(type->getClangFunctionType(), 0);
+  return clang::QualType(type->getClangFunctionType().getType(), 0);
 }
 
 clang::QualType

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -416,9 +416,12 @@ namespace {
       
       if (pointeeQualType->isFunctionType()) {
         auto funcTy = pointeeType->castTo<FunctionType>();
-        auto extInfo = funcTy->getExtInfo().withRepresentation(
-                AnyFunctionType::Representation::CFunctionPointer)
-                                           .withClangFunctionType(type);
+        auto rep = AnyFunctionType::Representation::CFunctionPointer;
+        auto computedClangTy = funcTy->getASTContext().getClangFunctionType(
+          funcTy->getParams(), funcTy->getResult(), funcTy->getExtInfo(), rep);
+        auto clangTy = ClangTypeWrapper::pickForExtInfo(type, computedClangTy);
+        auto extInfo = funcTy->getExtInfo().withRepresentation(rep)
+                                           .withClangFunctionType(clangTy);
         return {
           FunctionType::get(funcTy->getParams(), funcTy->getResult(), extInfo),
           ImportHint::CFunctionPointer

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -486,8 +486,8 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
 
   auto rep = SILFunctionType::Representation::CFunctionPointer;
   auto incompleteExtInfo = SILFunctionType::ExtInfo();
-  auto *clangTy = C.getCanonicalClangFunctionType(params, results[0],
-                                                  incompleteExtInfo, rep);
+  auto clangTy = C.getCanonicalClangFunctionType(params, results[0],
+                                                 incompleteExtInfo, rep);
   auto extInfo = incompleteExtInfo.withRepresentation(rep)
                                   .withClangFunctionType(clangTy);
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -543,7 +543,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
 
   auto results = blockInterfaceTy->getResults();
   auto incompleteExtInfo = SILFunctionType::ExtInfo();
-  auto *clangFnType = getASTContext().getCanonicalClangFunctionType(
+  auto clangFnType = getASTContext().getCanonicalClangFunctionType(
         params, results.empty() ? Optional<SILResultInfo>() : results[0],
         incompleteExtInfo,
         SILFunctionType::Representation::CFunctionPointer);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -583,7 +583,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
         {SILResultInfo(OptNSStringTy, ResultConvention::Autoreleased)};
     auto incompleteExtInfo = SILFunctionType::ExtInfo();
     auto repr = SILFunctionType::Representation::CFunctionPointer;
-    auto *clangFnType = ctx.getCanonicalClangFunctionType(params,
+    auto clangFnType = ctx.getCanonicalClangFunctionType(params,
         resultInfos[0], incompleteExtInfo, repr);
     auto extInfo = incompleteExtInfo.withRepresentation(repr)
                                     .withClangFunctionType(clangFnType);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4741,7 +4741,7 @@ public:
     uint8_t rawRepresentation, rawDiffKind;
     bool noescape = false, throws;
     GenericSignature genericSig;
-    clang::Type *clangFunctionType = nullptr;
+    ClangTypeWrapper clangFunctionType(nullptr);
 
     // FIXME: [clang-function-type-serialization] Deserialize a clang::Type out
     // of the record.
@@ -5101,7 +5101,7 @@ public:
     GenericSignatureID rawGenericSig;
     SubstitutionMapID rawSubs;
     ArrayRef<uint64_t> variableData;
-    clang::FunctionType *clangFunctionType = nullptr;
+    ClangTypeWrapper clangFunctionType(nullptr);
 
     // FIXME: [clang-function-type-serialization] Deserialize a
     // clang::FunctionType out of the record.


### PR DESCRIPTION
I wasn't sure what to name the type, so I've named it `ClangTypeWrapper` for now.

Probably clean up the PR a little bit tomorrow but I figured I should put it up sooner rather than later for feedback and testing.