### PR TITLE
Revert "Propagate Clang types through SIL"

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -582,10 +582,6 @@ public:
   Type getBridgedToObjC(const DeclContext *dc, Type type,
                         Type *bridgedValueType = nullptr) const;
 
-private:
-  void initializeClangTypeConverter();
-
-public:
   /// Get the Clang type corresponding to a Swift function type.
   ///
   /// \param params The function parameters.
@@ -598,15 +594,6 @@ public:
   getClangFunctionType(ArrayRef<AnyFunctionType::Param> params, Type resultTy,
                        const FunctionType::ExtInfo incompleteExtInfo,
                        FunctionTypeRepresentation trueRep);
-
-  /// Get the canonical Clang type corresponding to a SIL function type.
-  ///
-  /// SIL analog of \c ASTContext::getClangFunctionType .
-  const clang::Type *
-  getCanonicalClangFunctionType(
-    ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
-    const SILFunctionType::ExtInfo incompleteExtInfo,
-    SILFunctionType::Representation trueRep);
 
   /// Determine whether the given Swift type is representable in a
   /// given foreign language.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -564,7 +564,7 @@ struct PrintOptions {
   static PrintOptions printDocInterface();
 
   /// Retrieve the set of options suitable for printing SIL functions.
-  static PrintOptions printSIL(bool printFullConvention = false) {
+  static PrintOptions printSIL() {
     PrintOptions result;
     result.PrintLongAttrsOnSeparateLines = true;
     result.PrintStorageRepresentationAttrs = true;
@@ -575,9 +575,6 @@ struct PrintOptions {
     result.PrintIfConfig = false;
     result.OpaqueReturnTypePrinting =
         OpaqueReturnTypePrintingMode::StableReference;
-    if (printFullConvention)
-      result.PrintFunctionRepresentationAttrs =
-        PrintOptions::FunctionRepresentationMode::Full;
     return result;
   }
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -78,9 +78,6 @@ public:
   /// variables by name when we print it out. This eases diffing of SIL files.
   bool EmitSortedSIL = false;
 
-  /// See \ref FrontendOptions.PrintFullConvention
-  bool PrintFullConvention = false;
-
   /// Whether to stop the optimization pipeline after serializing SIL.
   bool StopOptimizationAfterSerialization = false;
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -253,9 +253,6 @@ public:
   /// See the \ref SILOptions.EmitSortedSIL flag.
   bool EmitSortedSIL = false;
 
-  /// Should we emit the cType when printing @convention(c) or no?
-  bool PrintFullConvention = false;
-
   /// Indicates whether the dependency tracker should track system
   /// dependencies as well.
   bool TrackSystemDeps = false;

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -31,8 +31,8 @@ struct ModuleInterfaceOptions {
   /// interface, or should we fully-qualify them?
   bool PreserveTypesAsWritten = false;
 
-  /// See \ref FrontendOptions.PrintFullConvention.
-  /// FIXME: [clang-function-type-serialization] This flag should go away.
+  /// Should we emit the cType when printing @convention(c) or no?
+  /// FIXME: [clang-function-type-serialization] This check should go away.
   bool PrintFullConvention = false;
 
   /// Copy of all the command-line flags passed at .swiftinterface

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -608,12 +608,10 @@ def module_interface_preserve_types_as_written :
   HelpText<"When emitting a module interface, preserve types as they were "
            "written in the source">;
 
-// FIXME: [clang-function-type-serialization] Make this a SIL-only option once we
-// start unconditionally emitting non-canonical Clang types in swiftinterfaces.
 def experimental_print_full_convention :
  Flag<["-"], "experimental-print-full-convention">,
- HelpText<"When emitting a module interface or SIL, emit additional @convention"
-          " arguments, regardless of whether they were written in the source">;
+ HelpText<"When emitting a module interface, emit additional @convention "
+          "arguments, regardless of whether they were written in the source">;
 
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -647,11 +647,10 @@ public:
   /// \param ShouldSort If set to true sorts functions, vtables, sil global
   ///        variables, and witness tables by name to ease diffing.
   /// \param PrintASTDecls If set to true print AST decls.
-  void print(raw_ostream &OS,
-             ModuleDecl *M = nullptr,
-             const SILOptions &Opts = SILOptions(),
+  void print(raw_ostream &OS, bool Verbose = false,
+             ModuleDecl *M = nullptr, bool ShouldSort = false,
              bool PrintASTDecls = true) const {
-    SILPrintContext PrintCtx(OS, Opts);
+    SILPrintContext PrintCtx(OS, Verbose, ShouldSort);
     print(PrintCtx, M, PrintASTDecls);
   }
 

--- a/include/swift/SIL/SILPrintContext.h
+++ b/include/swift/SIL/SILPrintContext.h
@@ -13,7 +13,6 @@
 #ifndef SWIFT_SIL_PRINTCONTEXT_H
 #define SWIFT_SIL_PRINTCONTEXT_H
 
-#include "swift/AST/SILOptions.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/DenseMap.h"
@@ -66,20 +65,12 @@ protected:
   /// Print debug locations and scopes.
   bool DebugInfo;
 
-  /// See \ref FrontendOptions.PrintFullConvention.
-  bool PrintFullConvention;
-
 public:
   /// Constructor with default values for options.
   ///
   /// DebugInfo will be set according to the -sil-print-debuginfo option.
   SILPrintContext(llvm::raw_ostream &OS, bool Verbose = false,
                   bool SortedSIL = false);
-
-  /// Constructor based on SILOptions.
-  ///
-  /// DebugInfo will be set according to the -sil-print-debuginfo option.
-  SILPrintContext(llvm::raw_ostream &OS, const SILOptions &Opts);
 
   SILPrintContext(llvm::raw_ostream &OS, bool Verbose,
                   bool SortedSIL, bool DebugInfo);
@@ -102,9 +93,6 @@ public:
 
   /// Returns true if debug locations and scopes should be printed.
   bool printDebugInfo() const { return DebugInfo; }
-
-  /// Returns true if the entire @convention(c, cType: ..) should be printed.
-  bool printFullConvention() const { return PrintFullConvention; }
 
   SILPrintContext::ID getID(const SILBasicBlock *Block);
 

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -581,8 +581,7 @@ public:
 
   std::string getAsString() const;
   void dump() const;
-  void print(raw_ostream &OS,
-             const PrintOptions &PO = PrintOptions::printSIL()) const;
+  void print(raw_ostream &OS) const;
 };
 
 // Statically prevent SILTypes from being directly cast to a type

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -488,6 +488,12 @@ Type ASTBuilder::createImplFunctionType(
     break;
   }
 
+  // TODO: [store-sil-clang-function-type]
+  auto einfo = SILFunctionType::ExtInfo(
+      representation, flags.isPseudogeneric(), !flags.isEscaping(),
+      DifferentiabilityKind::NonDifferentiable,
+      /*clangFunctionType*/ nullptr);
+
   llvm::SmallVector<SILParameterInfo, 8> funcParams;
   llvm::SmallVector<SILYieldInfo, 8> funcYields;
   llvm::SmallVector<SILResultInfo, 8> funcResults;
@@ -510,26 +516,6 @@ Type ASTBuilder::createImplFunctionType(
     auto conv = getResultConvention(errorResult->getConvention());
     funcErrorResult.emplace(type, conv);
   }
-
-  const clang::Type *clangFnType = nullptr;
-  auto incompleteExtInfo = SILFunctionType::ExtInfo(
-      SILFunctionType::Representation::Thick, flags.isPseudogeneric(),
-      !flags.isEscaping(), DifferentiabilityKind::NonDifferentiable,
-      clangFnType);
-
-  if (representation == SILFunctionType::Representation::CFunctionPointer) {
-    assert(funcResults.size() <= 1 && funcYields.size() == 0
-           && "@convention(c) functions have at most 1 result and 0 yields.");
-    auto result = funcResults.empty() ? Optional<SILResultInfo>()
-                                      : funcResults[0];
-    auto &Context = getASTContext();
-    clangFnType = Context.getCanonicalClangFunctionType(funcParams, result,
-                                                        incompleteExtInfo,
-                                                        representation);
-  }
-  auto einfo = incompleteExtInfo.withRepresentation(representation)
-                                .withClangFunctionType(clangFnType);
-
   return SILFunctionType::get(genericSig, einfo, funcCoroutineKind,
                               funcCalleeConvention, funcParams, funcYields,
                               funcResults, funcErrorResult,

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -156,57 +156,6 @@ const clang::Type *ClangTypeConverter::getFunctionType(
   }
 }
 
-const clang::Type *ClangTypeConverter::getFunctionType(
-    ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
-    SILFunctionType::Representation repr) {
-
-  // Using the interface type is sufficient as Swift does not allow abstracting
-  // over @convention(c) functions, hence we don't need any substitutions.
-  auto resultClangTy = result.hasValue()
-                     ? convert(result.getValue().getInterfaceType())
-                     : ClangASTContext.VoidTy;
-
-  if (resultClangTy.isNull())
-    return nullptr;
-
-  SmallVector<clang::FunctionProtoType::ExtParameterInfo, 4> extParamInfos;
-  SmallVector<clang::QualType, 4> paramsClangTy;
-  bool someParamIsConsumed = false;
-  for (auto &p : params) {
-    auto pc = convert(p.getInterfaceType());
-    if (pc.isNull())
-      return nullptr;
-    clang::FunctionProtoType::ExtParameterInfo extParamInfo;
-    if (p.isConsumed()) {
-      someParamIsConsumed = true;
-      extParamInfo = extParamInfo.withIsConsumed(true);
-    }
-    extParamInfos.push_back(extParamInfo);
-    paramsClangTy.push_back(pc);
-  }
-
-  clang::FunctionProtoType::ExtProtoInfo info(clang::CallingConv::CC_C);
-  if (someParamIsConsumed)
-    info.ExtParameterInfos = extParamInfos.begin();
-  auto fn = ClangASTContext.getFunctionType(resultClangTy, paramsClangTy, info);
-  if (fn.isNull())
-    return nullptr;
-
-  switch (repr) {
-  case SILFunctionType::Representation::CFunctionPointer:
-    return ClangASTContext.getPointerType(fn).getTypePtr();
-  case SILFunctionType::Representation::Block:
-    return ClangASTContext.getBlockPointerType(fn).getTypePtr();
-  case SILFunctionType::Representation::Thick:
-  case SILFunctionType::Representation::Thin:
-  case SILFunctionType::Representation::Method:
-  case SILFunctionType::Representation::ObjCMethod:
-  case SILFunctionType::Representation::WitnessMethod:
-  case SILFunctionType::Representation::Closure:
-    llvm_unreachable("Expected a C-compatible representation.");
-  }
-}
-
 clang::QualType ClangTypeConverter::convertMemberType(NominalTypeDecl *DC,
                                                       StringRef memberName) {
   auto memberTypeDecl = cast<TypeDecl>(
@@ -621,19 +570,12 @@ clang::QualType ClangTypeConverter::visitFunctionType(FunctionType *type) {
 }
 
 clang::QualType ClangTypeConverter::visitSILFunctionType(SILFunctionType *type) {
-  // We must've already computed it before if applicable.
-  return clang::QualType(type->getClangFunctionType(), 0);
+  llvm::report_fatal_error("Expected only AST types but found a SIL function.");
 }
 
 clang::QualType
 ClangTypeConverter::visitSILBlockStorageType(SILBlockStorageType *type) {
-  // We'll select (void)(^)(). This isn't correct for all blocks, but block
-  // storage type should only be converted for function signature lowering,
-  // where the parameter types do not matter.
-  auto &clangCtx = ClangASTContext;
-  auto fnTy = clangCtx.getFunctionNoProtoType(clangCtx.VoidTy);
-  auto blockTy = clangCtx.getBlockPointerType(fnTy);
-  return clangCtx.getCanonicalType(blockTy);
+  llvm::report_fatal_error("Expected only AST types but found a SIL block.");
 }
 
 clang::QualType

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -73,10 +73,6 @@ public:
     ArrayRef<AnyFunctionType::Param> params, Type resultTy,
     AnyFunctionType::Representation repr);
 
-  const clang::Type *getFunctionType(
-    ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
-    SILFunctionType::Representation repr);
-
 private:
   clang::QualType convert(Type type);
   clang::QualType convertMemberType(NominalTypeDecl *DC,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3229,7 +3229,8 @@ void AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType(
   cml->printClangType(ClangFunctionType, os);
 }
 
-static void assertIsFunctionType(const clang::Type *type) {
+void
+AnyFunctionType::ExtInfo::assertIsFunctionType(const clang::Type *type) {
 #ifndef NDEBUG
   if (!(type->isFunctionPointerType() || type->isBlockPointerType())) {
     SmallString<256> buf;
@@ -3241,10 +3242,6 @@ static void assertIsFunctionType(const clang::Type *type) {
   }
 #endif
   return;
-}
-
-void AnyFunctionType::ExtInfo::assertIsFunctionType(const clang::Type *type) {
-  ::assertIsFunctionType(type);
 }
 
 const clang::Type *AnyFunctionType::getClangFunctionType() const {
@@ -3264,16 +3261,9 @@ const clang::Type *AnyFunctionType::getCanonicalClangFunctionType() const {
   return ty ? ty->getCanonicalTypeInternal().getTypePtr() : nullptr;
 }
 
-void SILFunctionType::ExtInfo::assertIsFunctionType(const clang::Type *type) {
-  ::assertIsFunctionType(type);
-}
-
-const clang::Type *SILFunctionType::getClangFunctionType() const {
-  if (!Bits.SILFunctionType.HasUncommonInfo)
-    return nullptr;
-  auto *type = getTrailingObjects<ExtInfo::Uncommon>()->ClangFunctionType;
-  assert(type && "If the pointer was null, we shouldn't have stored it.");
-  return type;
+// TODO: [store-sil-clang-function-type]
+const clang::FunctionType *SILFunctionType::getClangFunctionType() const {
+  return nullptr;
 }
 
 FunctionType *

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -416,11 +416,12 @@ namespace {
       
       if (pointeeQualType->isFunctionType()) {
         auto funcTy = pointeeType->castTo<FunctionType>();
-        auto extInfo = funcTy->getExtInfo().withRepresentation(
-                AnyFunctionType::Representation::CFunctionPointer)
-                                           .withClangFunctionType(type);
         return {
-          FunctionType::get(funcTy->getParams(), funcTy->getResult(), extInfo),
+          FunctionType::get(funcTy->getParams(), funcTy->getResult(),
+            funcTy->getExtInfo()
+              .withRepresentation(
+                AnyFunctionType::Representation::CFunctionPointer)
+              .withClangFunctionType(type)),
           ImportHint::CFunctionPointer
         };
       }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -68,8 +68,6 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);
-  Opts.PrintFullConvention |=
-    Args.hasArg(OPT_experimental_print_full_convention);
 
   Opts.EnableTesting |= Args.hasArg(OPT_enable_testing);
   Opts.EnablePrivateImports |= Args.hasArg(OPT_enable_private_imports);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -964,8 +964,6 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.DebugSerialization |= Args.hasArg(OPT_sil_debug_serialization);
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);
-  Opts.PrintFullConvention |=
-    Args.hasArg(OPT_experimental_print_full_convention);
   Opts.PrintInstCounts |= Args.hasArg(OPT_print_inst_counts);
   if (const Arg *A = Args.getLastArg(OPT_external_pass_pipeline_filename))
     Opts.ExternalPassPipelineFilename = A->getValue();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -499,19 +499,20 @@ static bool emitSyntax(SourceFile *SF, StringRef OutputFilename) {
 }
 
 /// Writes SIL out to the given file.
-static bool writeSIL(SILModule &SM, ModuleDecl *M, const SILOptions &Opts,
-                     StringRef OutputFilename) {
+static bool writeSIL(SILModule &SM, ModuleDecl *M, bool EmitVerboseSIL,
+                     StringRef OutputFilename, bool SortSIL) {
   auto OS = getFileOutputStream(OutputFilename, M->getASTContext());
   if (!OS) return true;
-  SM.print(*OS, M, Opts);
+  SM.print(*OS, EmitVerboseSIL, M, SortSIL);
 
   return M->getASTContext().hadError();
 }
 
 static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
                      const CompilerInstance &Instance,
-                     const SILOptions &Opts) {
-  return writeSIL(SM, Instance.getMainModule(), Opts, PSPs.OutputFilename);
+                     const SILOptions &opts) {
+  return writeSIL(SM, Instance.getMainModule(), opts.EmitVerboseSIL,
+                  PSPs.OutputFilename, opts.EmitSortedSIL);
 }
 
 /// Prints the Objective-C "generated header" interface for \p M to \p

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1266,7 +1266,10 @@ static CanSILFunctionType getSILFunctionType(
 
   // NOTE: SILFunctionType::ExtInfo doesn't track everything that
   // AnyFunctionType::ExtInfo tracks. For example: 'throws' or 'auto-closure'
-  SILFunctionType::ExtInfo silExtInfo(extInfo, pseudogeneric);
+  auto silExtInfo = SILFunctionType::ExtInfo()
+    .withRepresentation(extInfo.getSILRepresentation())
+    .withIsPseudogeneric(pseudogeneric)
+    .withNoEscape(extInfo.isNoEscape());
   
   // Build the substituted generic signature we extracted.
   bool impliedSignature = false;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -452,6 +452,8 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
 
 SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
   ASTContext &C = getASTContext();
+  auto extInfo = SILFunctionType::ExtInfo()
+    .withRepresentation(SILFunctionType::Representation::CFunctionPointer);
 
   // Use standard library types if we have them; otherwise, fall back to
   // builtins.
@@ -482,19 +484,13 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
     SILParameterInfo(PtrPtrInt8Ty, ParameterConvention::Direct_Unowned),
   };
 
-  SILResultInfo results[] = {SILResultInfo(Int32Ty, ResultConvention::Unowned)};
-
-  auto rep = SILFunctionType::Representation::CFunctionPointer;
-  auto incompleteExtInfo = SILFunctionType::ExtInfo();
-  auto *clangTy = C.getCanonicalClangFunctionType(params, results[0],
-                                                  incompleteExtInfo, rep);
-  auto extInfo = incompleteExtInfo.withRepresentation(rep)
-                                  .withClangFunctionType(clangTy);
-
   CanSILFunctionType topLevelType = SILFunctionType::get(nullptr, extInfo,
                                    SILCoroutineKind::None,
                                    ParameterConvention::Direct_Unowned,
-                                   params, /*yields*/ {}, results, None,
+                                   params, /*yields*/ {},
+                                   SILResultInfo(Int32Ty,
+                                                 ResultConvention::Unowned),
+                                   None,
                                    SubstitutionMap(), false,
                                    C);
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -541,16 +541,9 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
             blockInterfaceTy->getParameters().end(),
             std::back_inserter(params));
 
-  auto results = blockInterfaceTy->getResults();
-  auto incompleteExtInfo = SILFunctionType::ExtInfo();
-  auto *clangFnType = getASTContext().getCanonicalClangFunctionType(
-        params, results.empty() ? Optional<SILResultInfo>() : results[0],
-        incompleteExtInfo,
-        SILFunctionType::Representation::CFunctionPointer);
-
-  auto extInfo = incompleteExtInfo
-        .withRepresentation(SILFunctionType::Representation::CFunctionPointer)
-        .withClangFunctionType(clangFnType);
+  auto extInfo =
+      SILFunctionType::ExtInfo()
+        .withRepresentation(SILFunctionType::Representation::CFunctionPointer);
 
   CanGenericSignature genericSig;
   GenericEnvironment *genericEnv = nullptr;
@@ -575,7 +568,8 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
 
   auto invokeTy = SILFunctionType::get(
       genericSig, extInfo, SILCoroutineKind::None,
-      ParameterConvention::Direct_Unowned, params, /*yields*/ {}, results,
+      ParameterConvention::Direct_Unowned, params, 
+      /*yields*/ {}, blockInterfaceTy->getResults(),
       blockInterfaceTy->getOptionalErrorResult(), SubstitutionMap(), false,
       getASTContext());
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -577,21 +577,20 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     CanType anyObjectMetaTy = CanExistentialMetatypeType::get(anyObjectTy,
                                                   MetatypeRepresentation::ObjC);
 
-    auto paramConvention = ParameterConvention::Direct_Unowned;
-    auto params = {SILParameterInfo(anyObjectMetaTy, paramConvention)};
-    ArrayRef<SILResultInfo> resultInfos =
-        {SILResultInfo(OptNSStringTy, ResultConvention::Autoreleased)};
-    auto incompleteExtInfo = SILFunctionType::ExtInfo();
-    auto repr = SILFunctionType::Representation::CFunctionPointer;
-    auto *clangFnType = ctx.getCanonicalClangFunctionType(params,
-        resultInfos[0], incompleteExtInfo, repr);
-    auto extInfo = incompleteExtInfo.withRepresentation(repr)
-                                    .withClangFunctionType(clangFnType);
-
-    auto NSStringFromClassType = SILFunctionType::get(
-        nullptr, extInfo, SILCoroutineKind::None, paramConvention, params,
-        /*yields*/ {}, resultInfos, /*error result*/ None, SubstitutionMap(),
-        false, ctx);
+    auto NSStringFromClassType = SILFunctionType::get(nullptr,
+                  SILFunctionType::ExtInfo()
+                    .withRepresentation(SILFunctionType::Representation::
+                                        CFunctionPointer),
+                  SILCoroutineKind::None,
+                  ParameterConvention::Direct_Unowned,
+                  SILParameterInfo(anyObjectMetaTy,
+                                   ParameterConvention::Direct_Unowned),
+                  /*yields*/ {},
+                  SILResultInfo(OptNSStringTy,
+                                ResultConvention::Autoreleased),
+                  /*error result*/ None,
+                  SubstitutionMap(), false,
+                  ctx);
     auto NSStringFromClassFn = builder.getOrCreateFunction(
         mainClass, "NSStringFromClass", SILLinkage::PublicExternal,
         NSStringFromClassType, IsBare, IsTransparent, IsNotSerialized,

--- a/test/SIL/clang-function-types.swift
+++ b/test/SIL/clang-function-types.swift
@@ -1,8 +1,0 @@
-// RUN: %target-swift-frontend %s -emit-sil -swift-version 5 -use-clang-function-types -experimental-print-full-convention -o - | %FileCheck %s
-
-public func f(g: @convention(c) () -> ()) { g() }
-
-// CHECK: sil @$s4main1f1gyyyXC_tF : $@convention(thin) (@convention(c, cType: "void (*)(void)") @noescape () -> ()) -> () {
-// CHECK: bb0(%0 : $@convention(c, cType: "void (*)(void)") @noescape () -> ()):
-// CHECK:   debug_value %0 : $@convention(c, cType: "void (*)(void)") @noescape () -> (), let, name "g", argno 1 // id: %1
-// CHECK:   %2 = apply %0() : $@convention(c, cType: "void (*)(void)") @noescape () -> ()

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -101,10 +101,10 @@ static llvm::cl::opt<std::string> Triple("target",
                                          llvm::cl::desc("target triple"));
 
 static llvm::cl::opt<bool>
-EmitSortedSIL("emit-sorted-sil", llvm::cl::Hidden,
-              llvm::cl::init(false),
-              llvm::cl::desc("Sort Functions, VTables, Globals, "
-                             "WitnessTables by name to ease diffing."));
+EnableSILSortOutput("emit-sorted-sil", llvm::cl::Hidden,
+                    llvm::cl::init(false),
+                    llvm::cl::desc("Sort Functions, VTables, Globals, "
+                                   "WitnessTables by name to ease diffing."));
 
 static llvm::cl::opt<bool>
 DisableASTDump("sil-disable-ast-dump", llvm::cl::Hidden,
@@ -250,10 +250,6 @@ int main(int argc, char **argv) {
   Invocation.getLangOptions().EnableAccessControl = false;
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
 
-  SILOptions &Opts = Invocation.getSILOptions();
-  Opts.EmitVerboseSIL = EmitVerboseSIL;
-  Opts.EmitSortedSIL = EmitSortedSIL;
-
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
       Invocation.setUpInputForSILTool(InputFilename, ModuleName,
@@ -360,8 +356,8 @@ int main(int argc, char **argv) {
         OutputFilename.size() ? StringRef(OutputFilename) : "-";
 
     if (OutputFile == "-") {
-      CI.getSILModule()->print(llvm::outs(), CI.getMainModule(),
-                               Invocation.getSILOptions(), !DisableASTDump);
+      CI.getSILModule()->print(llvm::outs(), EmitVerboseSIL, CI.getMainModule(),
+                               EnableSILSortOutput, !DisableASTDump);
     } else {
       std::error_code EC;
       llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
@@ -370,8 +366,8 @@ int main(int argc, char **argv) {
                      << '\n';
         return 1;
       }
-      CI.getSILModule()->print(OS, CI.getMainModule(),
-                               Invocation.getSILOptions(), !DisableASTDump);
+      CI.getSILModule()->print(OS, EmitVerboseSIL, CI.getMainModule(),
+                               EnableSILSortOutput, !DisableASTDump);
     }
   }
 }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -196,10 +196,10 @@ static llvm::cl::opt<std::string>
 ModuleCachePath("module-cache-path", llvm::cl::desc("Clang module cache path"));
 
 static llvm::cl::opt<bool>
-EmitSortedSIL("emit-sorted-sil", llvm::cl::Hidden,
-              llvm::cl::init(false),
-              llvm::cl::desc("Sort Functions, VTables, Globals, "
-                             "WitnessTables by name to ease diffing."));
+EnableSILSortOutput("emit-sorted-sil", llvm::cl::Hidden,
+                    llvm::cl::init(false),
+                    llvm::cl::desc("Sort Functions, VTables, Globals, "
+                                   "WitnessTables by name to ease diffing."));
 
 static llvm::cl::opt<bool>
 DisableASTDump("sil-disable-ast-dump", llvm::cl::Hidden,
@@ -375,8 +375,6 @@ int main(int argc, char **argv) {
       break;
     }
   }
-  SILOpts.EmitVerboseSIL |= EmitVerboseSIL;
-  SILOpts.EmitSortedSIL |= EmitSortedSIL;
 
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
@@ -483,8 +481,8 @@ int main(int argc, char **argv) {
                                    StringRef(OutputFilename) : "-";
 
     if (OutputFile == "-") {
-      CI.getSILModule()->print(llvm::outs(), CI.getMainModule(),
-                               Invocation.getSILOptions(), !DisableASTDump);
+      CI.getSILModule()->print(llvm::outs(), EmitVerboseSIL, CI.getMainModule(),
+                               EnableSILSortOutput, !DisableASTDump);
     } else {
       std::error_code EC;
       llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
@@ -493,8 +491,8 @@ int main(int argc, char **argv) {
                      << EC.message() << '\n';
         return 1;
       }
-      CI.getSILModule()->print(OS, CI.getMainModule(),
-                               Invocation.getSILOptions(), !DisableASTDump);
+      CI.getSILModule()->print(OS, EmitVerboseSIL, CI.getMainModule(),
+                               EnableSILSortOutput, !DisableASTDump);
     }
   }
 


### PR DESCRIPTION
Reverts apple/swift#29239

It causes compiler crashes in a no-assert build:  https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/4327/consoleFull#12977431903122a513-f36a-4c87-8ed7-cbc36a1ec144