### PR TITLE
Revert Clang types in SIL patch

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -582,10 +582,6 @@ public:
   Type getBridgedToObjC(const DeclContext *dc, Type type,
                         Type *bridgedValueType = nullptr) const;
 
-private:
-  void initializeClangTypeConverter();
-
-public:
   /// Get the Clang type corresponding to a Swift function type.
   ///
   /// \param params The function parameters.
@@ -598,15 +594,6 @@ public:
   getClangFunctionType(ArrayRef<AnyFunctionType::Param> params, Type resultTy,
                        const FunctionType::ExtInfo incompleteExtInfo,
                        FunctionTypeRepresentation trueRep);
-
-  /// Get the canonical Clang type corresponding to a SIL function type.
-  ///
-  /// SIL analog of \c ASTContext::getClangFunctionType .
-  const clang::Type *
-  getCanonicalClangFunctionType(
-    ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
-    const SILFunctionType::ExtInfo incompleteExtInfo,
-    SILFunctionType::Representation trueRep);
 
   /// Determine whether the given Swift type is representable in a
   /// given foreign language.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -564,7 +564,7 @@ struct PrintOptions {
   static PrintOptions printDocInterface();
 
   /// Retrieve the set of options suitable for printing SIL functions.
-  static PrintOptions printSIL(bool printFullConvention = false) {
+  static PrintOptions printSIL() {
     PrintOptions result;
     result.PrintLongAttrsOnSeparateLines = true;
     result.PrintStorageRepresentationAttrs = true;
@@ -575,9 +575,6 @@ struct PrintOptions {
     result.PrintIfConfig = false;
     result.OpaqueReturnTypePrinting =
         OpaqueReturnTypePrintingMode::StableReference;
-    if (printFullConvention)
-      result.PrintFunctionRepresentationAttrs =
-        PrintOptions::FunctionRepresentationMode::Full;
     return result;
   }
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -78,9 +78,6 @@ public:
   /// variables by name when we print it out. This eases diffing of SIL files.
   bool EmitSortedSIL = false;
 
-  /// See \ref FrontendOptions.PrintFullConvention
-  bool PrintFullConvention = false;
-
   /// Whether to stop the optimization pipeline after serializing SIL.
   bool StopOptimizationAfterSerialization = false;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -44,6 +44,7 @@
 
 namespace clang {
 class Type;
+class FunctionType;
 } // namespace clang
 
 namespace llvm {
@@ -2946,7 +2947,6 @@ public:
       friend ExtInfo;
       friend class AnyFunctionType;
       friend class FunctionType;
-      friend class SILUncommonInfo;
       // We preserve a full clang::Type *, not a clang::FunctionType * as:
       // 1. We need to keep sugar in case we need to present an error to the user.
       // 2. The actual type being stored is [ignoring sugar] either a
@@ -3917,24 +3917,6 @@ namespace Lowering {
   class TypeConverter;
 };
 
-class SILUncommonInfo {
-  friend class SILFunctionType;
-
-  // Invariant: The FunctionType is canonical.
-  // We store a clang::FunctionType * instead of a clang::CanQualType to
-  // avoid depending on the Clang AST in this header.
-  const clang::Type *ClangFunctionType;
-
-  bool empty() const { return !ClangFunctionType; }
-  SILUncommonInfo(const clang::Type *type) : ClangFunctionType(type) {}
-  SILUncommonInfo(AnyFunctionType::ExtInfo::Uncommon uncommon);
-
-public:
-  /// Analog of AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType.
-  void printClangFunctionType(ClangModuleLoader *cml,
-                              llvm::raw_ostream &os) const;
-};
-
 /// SILFunctionType - The lowered type of a function value, suitable
 /// for use by SIL.
 ///
@@ -3943,8 +3925,7 @@ public:
 /// function parameter and result types.
 class SILFunctionType final : public TypeBase, public llvm::FoldingSetNode,
     private llvm::TrailingObjects<SILFunctionType, SILParameterInfo,
-                                  SILResultInfo, SILYieldInfo, CanType,
-                                  SILUncommonInfo> {
+                                  SILResultInfo, SILYieldInfo, CanType> {
   friend TrailingObjects;
 
   size_t numTrailingObjects(OverloadToken<SILParameterInfo>) const {
@@ -3961,10 +3942,6 @@ class SILFunctionType final : public TypeBase, public llvm::FoldingSetNode,
 
   size_t numTrailingObjects(OverloadToken<CanType>) const {
     return hasResultCache() ? 2 : 0;
-  }
-
-  size_t numTrailingObjects(OverloadToken<SILUncommonInfo>) const {
-    return Bits.SILFunctionType.HasUncommonInfo ? 1 : 0;
   }
 
 public:
@@ -3991,31 +3968,27 @@ public:
 
     unsigned Bits; // Naturally sized for speed.
 
-    // For symmetry with AnyFunctionType::Uncommon
-    using Uncommon = SILUncommonInfo;
+    class Uncommon {
+      friend ExtInfo;
+      friend class SILFunctionType;
+
+      // Invariant: The FunctionType is canonical.
+      // We store a clang::FunctionType * instead of a clang::CanQualType to
+      // avoid depending on the Clang AST in this header.
+      const clang::FunctionType *ClangFunctionType;
+
+      bool empty() const { return !ClangFunctionType; }
+      Uncommon(const clang::FunctionType *type) : ClangFunctionType(type) {}
+
+    public:
+      /// Analog of AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType.
+      void printClangFunctionType(ClangModuleLoader *cml,
+                                  llvm::raw_ostream &os) const;
+    };
 
     Uncommon Other;
 
-    static void assertIsFunctionType(const clang::Type *);
-
-    ExtInfo(unsigned Bits, Uncommon Other) : Bits(Bits), Other(Other) {
-      auto Rep = Representation(Bits & RepresentationMask);
-      // TODO: [clang-function-type-serialization] Once we start serializing
-      // the Clang type, we should also assert that the pointer is non-null.
-      if ((Rep == Representation::CFunctionPointer) && Other.ClangFunctionType)
-        assertIsFunctionType(Other.ClangFunctionType);
-    }
-
-    static constexpr unsigned makeBits(Representation rep,
-                                       bool isPseudogeneric,
-                                       bool isNoEscape,
-                                       DifferentiabilityKind diffKind) {
-      return ((unsigned) rep)
-              | (isPseudogeneric ? PseudogenericMask : 0)
-              | (isNoEscape ? NoEscapeMask : 0)
-              | (((unsigned)diffKind << DifferentiabilityMaskOffset)
-                 & DifferentiabilityMask);
-    }
+    ExtInfo(unsigned Bits, Uncommon Other) : Bits(Bits), Other(Other) {}
 
     friend class SILFunctionType;
   public:
@@ -4025,19 +3998,13 @@ public:
     // Constructor for polymorphic type.
     ExtInfo(Representation rep, bool isPseudogeneric, bool isNoEscape,
             DifferentiabilityKind diffKind,
-            const clang::Type *type)
-      : ExtInfo(makeBits(rep, isPseudogeneric, isNoEscape, diffKind),
+            const clang::FunctionType *type)
+      : ExtInfo(((unsigned) rep)
+                  | (isPseudogeneric ? PseudogenericMask : 0)
+                  | (isNoEscape ? NoEscapeMask : 0)
+                  | (((unsigned)diffKind << DifferentiabilityMaskOffset)
+                     & DifferentiabilityMask),
                 Uncommon(type)) {
-    }
-
-    ExtInfo(AnyFunctionType::ExtInfo info, bool isPseudogeneric)
-      : ExtInfo(makeBits(info.getSILRepresentation(),
-                         isPseudogeneric,
-                         info.isNoEscape(),
-                         info.getDifferentiabilityKind()),
-                info.getUncommonInfo().hasValue()
-                ? Uncommon(info.getUncommonInfo().getValue())
-                : Uncommon(nullptr)) {
     }
 
     static ExtInfo getThin() {
@@ -4125,9 +4092,6 @@ public:
     ExtInfo withNoEscape(bool NoEscape = true) const {
       return ExtInfo(NoEscape ? (Bits | NoEscapeMask) : (Bits & ~NoEscapeMask),
                      Other);
-    }
-    ExtInfo withClangFunctionType(const clang::Type *type) const {
-      return ExtInfo(Bits, Uncommon(type));
     }
 
     std::pair<unsigned, const void *> getFuncAttrKey() const {
@@ -4424,7 +4388,7 @@ public:
     return WitnessMethodConformance;
   }
 
-  const clang::Type *getClangFunctionType() const;
+  const clang::FunctionType *getClangFunctionType() const;
 
   ExtInfo getExtInfo() const {
     return ExtInfo(Bits.SILFunctionType.ExtInfoBits, getClangFunctionType());

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2969,7 +2969,7 @@ public:
     static void assertIsFunctionType(const clang::Type *);
 
     ExtInfo(unsigned Bits, Uncommon Other) : Bits(Bits), Other(Other) {
-      // TODO: [clang-function-type-serialization] Once we start serializing
+      // TODO: [store-sil-clang-function-type] Once we start serializing
       // the Clang type, we should also assert that the pointer is non-null.
       auto Rep = Representation(Bits & RepresentationMask);
       if ((Rep == Representation::CFunctionPointer) && Other.ClangFunctionType)

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -253,9 +253,6 @@ public:
   /// See the \ref SILOptions.EmitSortedSIL flag.
   bool EmitSortedSIL = false;
 
-  /// Should we emit the cType when printing @convention(c) or no?
-  bool PrintFullConvention = false;
-
   /// Indicates whether the dependency tracker should track system
   /// dependencies as well.
   bool TrackSystemDeps = false;

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -31,8 +31,8 @@ struct ModuleInterfaceOptions {
   /// interface, or should we fully-qualify them?
   bool PreserveTypesAsWritten = false;
 
-  /// See \ref FrontendOptions.PrintFullConvention.
-  /// FIXME: [clang-function-type-serialization] This flag should go away.
+  /// Should we emit the cType when printing @convention(c) or no?
+  /// FIXME: [clang-function-type-serialization] This check should go away.
   bool PrintFullConvention = false;
 
   /// Copy of all the command-line flags passed at .swiftinterface

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -608,12 +608,10 @@ def module_interface_preserve_types_as_written :
   HelpText<"When emitting a module interface, preserve types as they were "
            "written in the source">;
 
-// FIXME: [clang-function-type-serialization] Make this a SIL-only option once we
-// start unconditionally emitting non-canonical Clang types in swiftinterfaces.
 def experimental_print_full_convention :
  Flag<["-"], "experimental-print-full-convention">,
- HelpText<"When emitting a module interface or SIL, emit additional @convention"
-          " arguments, regardless of whether they were written in the source">;
+ HelpText<"When emitting a module interface, emit additional @convention "
+          "arguments, regardless of whether they were written in the source">;
 
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -644,11 +644,10 @@ public:
   ///        printed. The module would usually contain the types and Decls that
   ///        the SIL module depends on.
   /// \param PrintASTDecls If set to true print AST decls.
-  void print(raw_ostream &OS,
-             ModuleDecl *M = nullptr,
-             const SILOptions &Opts = SILOptions(),
+  void print(raw_ostream &OS, bool Verbose = false,
+             ModuleDecl *M = nullptr, bool ShouldSort = false,
              bool PrintASTDecls = true) const {
-    SILPrintContext PrintCtx(OS, Opts);
+    SILPrintContext PrintCtx(OS, Verbose, ShouldSort);
     print(PrintCtx, M, PrintASTDecls);
   }
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -166,10 +166,10 @@ private:
   /// Functions, which are dead (and not in the functions list anymore),
   /// but kept alive for debug info generation.
   FunctionListType zombieFunctions;
-  
+
   /// Stores the names of zombie functions.
   llvm::BumpPtrAllocator zombieFunctionNames;
-  
+
   /// Lookup table for SIL vtables from class decls.
   llvm::DenseMap<const ClassDecl *, SILVTable *> VTableMap;
 
@@ -211,7 +211,7 @@ private:
 
   // The map of SILCoverageMaps in the module.
   CoverageMapCollectionType coverageMaps;
-  
+
   // The list of SILProperties in the module.
   PropertyListType properties;
 
@@ -502,7 +502,7 @@ public:
 
   PropertyListType &getPropertyList() { return properties; }
   const PropertyListType &getPropertyList() const { return properties; }
-  
+
   /// Look for a global variable by name.
   ///
   /// \return null if this module has no such global variable
@@ -630,7 +630,7 @@ public:
 
   /// Pretty-print the module.
   void dump(bool Verbose = false) const;
-  
+
   /// Pretty-print the module to a file.
   /// Useful for dumping the module when running in a debugger.
   /// Warning: no error handling is done. Fails with an assert if the file
@@ -643,11 +643,14 @@ public:
   /// \param M If present, the types and declarations from this module will be
   ///        printed. The module would usually contain the types and Decls that
   ///        the SIL module depends on.
+  /// \param Opts The SIL options, used to determine printing verbosity and
+  ///        and sorting.
   /// \param PrintASTDecls If set to true print AST decls.
-  void print(raw_ostream &OS, bool Verbose = false,
-             ModuleDecl *M = nullptr, bool ShouldSort = false,
+  void print(raw_ostream& OS,
+             ModuleDecl *M = nullptr,
+             const SILOptions &Opts = SILOptions(),
              bool PrintASTDecls = true) const {
-    SILPrintContext PrintCtx(OS, Verbose, ShouldSort);
+    SILPrintContext PrintCtx(OS, Opts);
     print(PrintCtx, M, PrintASTDecls);
   }
 

--- a/include/swift/SIL/SILPrintContext.h
+++ b/include/swift/SIL/SILPrintContext.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SIL_PRINTCONTEXT_H
 #define SWIFT_SIL_PRINTCONTEXT_H
 
+#include "swift/AST/SILOptions.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/DenseMap.h"
@@ -71,6 +72,11 @@ public:
   /// DebugInfo will be set according to the -sil-print-debuginfo option.
   SILPrintContext(llvm::raw_ostream &OS, bool Verbose = false,
                   bool SortedSIL = false);
+
+  /// Constructor based on SILOptions.
+  ///
+  /// DebugInfo will be set according to the -sil-print-debuginfo option.
+  SILPrintContext(llvm::raw_ostream &OS, const SILOptions &Opts);
 
   SILPrintContext(llvm::raw_ostream &OS, bool Verbose,
                   bool SortedSIL, bool DebugInfo);

--- a/include/swift/SIL/SILPrintContext.h
+++ b/include/swift/SIL/SILPrintContext.h
@@ -13,7 +13,6 @@
 #ifndef SWIFT_SIL_PRINTCONTEXT_H
 #define SWIFT_SIL_PRINTCONTEXT_H
 
-#include "swift/AST/SILOptions.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/DenseMap.h"
@@ -66,20 +65,12 @@ protected:
   /// Print debug locations and scopes.
   bool DebugInfo;
 
-  /// See \ref FrontendOptions.PrintFullConvention.
-  bool PrintFullConvention;
-
 public:
   /// Constructor with default values for options.
   ///
   /// DebugInfo will be set according to the -sil-print-debuginfo option.
   SILPrintContext(llvm::raw_ostream &OS, bool Verbose = false,
                   bool SortedSIL = false);
-
-  /// Constructor based on SILOptions.
-  ///
-  /// DebugInfo will be set according to the -sil-print-debuginfo option.
-  SILPrintContext(llvm::raw_ostream &OS, const SILOptions &Opts);
 
   SILPrintContext(llvm::raw_ostream &OS, bool Verbose,
                   bool SortedSIL, bool DebugInfo);
@@ -102,9 +93,6 @@ public:
 
   /// Returns true if debug locations and scopes should be printed.
   bool printDebugInfo() const { return DebugInfo; }
-
-  /// Returns true if the entire @convention(c, cType: ..) should be printed.
-  bool printFullConvention() const { return PrintFullConvention; }
 
   SILPrintContext::ID getID(const SILBasicBlock *Block);
 

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -581,8 +581,7 @@ public:
 
   std::string getAsString() const;
   void dump() const;
-  void print(raw_ostream &OS,
-             const PrintOptions &PO = PrintOptions::printSIL()) const;
+  void print(raw_ostream &OS) const;
 };
 
 // Statically prevent SILTypes from being directly cast to a type

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4372,35 +4372,17 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
   return Type();
 }
 
-void
-ASTContext::initializeClangTypeConverter() {
-  auto &impl = getImpl();
-  if (!impl.Converter) {
-    auto *cml = getClangModuleLoader();
-    impl.Converter.emplace(*this, cml->getClangASTContext(), LangOpts.Target);
-  }
-}
-
 const clang::Type *
 ASTContext::getClangFunctionType(ArrayRef<AnyFunctionType::Param> params,
                                  Type resultTy,
                                  FunctionType::ExtInfo incompleteExtInfo,
                                  FunctionTypeRepresentation trueRep) {
-  initializeClangTypeConverter();
-  return getImpl().Converter.getValue().getFunctionType(params, resultTy,
-                                                        trueRep);
-}
-
-const clang::Type *
-ASTContext::getCanonicalClangFunctionType(
-    ArrayRef<SILParameterInfo> params,
-    Optional<SILResultInfo> result,
-    SILFunctionType::ExtInfo incompleteExtInfo,
-    SILFunctionType::Representation trueRep) {
-  initializeClangTypeConverter();
-  auto *ty = getImpl().Converter.getValue().getFunctionType(params, result,
-                                                            trueRep);
-  return ty ? ty->getCanonicalTypeInternal().getTypePtr() : nullptr;
+  auto &impl = getImpl();
+  if (!impl.Converter) {
+    auto *cml = getClangModuleLoader();
+    impl.Converter.emplace(*this, cml->getClangASTContext(), LangOpts.Target);
+  }
+  return impl.Converter.getValue().getFunctionType(params, resultTy, trueRep);
 }
 
 CanGenericSignature ASTContext::getSingleGenericParameterSignature() const {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3158,13 +3158,7 @@ ArrayRef<Requirement> GenericFunctionType::getRequirements() const {
   return Signature->getRequirements();
 }
 
-SILUncommonInfo::SILUncommonInfo(AnyFunctionType::ExtInfo::Uncommon uncommon) {
-  auto *ty = uncommon.ClangFunctionType;
-  ClangFunctionType = ty ? ty->getCanonicalTypeInternal().getTypePtr()
-                         : nullptr;
-}
-
-void SILUncommonInfo::printClangFunctionType(
+void SILFunctionType::ExtInfo::Uncommon::printClangFunctionType(
     ClangModuleLoader *cml, llvm::raw_ostream &os) const {
   cml->printClangType(ClangFunctionType, os);
 }
@@ -3230,11 +3224,11 @@ SILFunctionType::SILFunctionType(
 
   Bits.SILFunctionType.HasErrorResult = errorResult.hasValue();
   Bits.SILFunctionType.ExtInfoBits = ext.Bits;
+  Bits.SILFunctionType.HasUncommonInfo = false;
   // The use of both assert() and static_assert() below is intentional.
   assert(Bits.SILFunctionType.ExtInfoBits == ext.Bits && "Bits were dropped!");
   static_assert(ExtInfo::NumMaskBits == NumSILExtInfoBits,
                 "ExtInfo and SILFunctionTypeBitfields must agree on bit size");
-  Bits.SILFunctionType.HasUncommonInfo = ext.getUncommonInfo().hasValue();
   Bits.SILFunctionType.CoroutineKind = unsigned(coroutineKind);
   NumParameters = params.size();
   if (coroutineKind == SILCoroutineKind::None) {
@@ -3267,9 +3261,6 @@ SILFunctionType::SILFunctionType(
     getMutableFormalResultsCache() = CanType();
     getMutableAllResultsCache() = CanType();
   }
-  if (auto uncommon = ext.getUncommonInfo())
-    *getTrailingObjects<ExtInfo::Uncommon>() = uncommon.getValue();
-
 #ifndef NDEBUG
   if (ext.getRepresentation() == Representation::WitnessMethod)
     assert(!WitnessMethodConformance.isInvalid() &&
@@ -3369,10 +3360,6 @@ CanSILFunctionType SILFunctionType::get(
   assert(coroutineKind != SILCoroutineKind::None || yields.empty());
   assert(!ext.isPseudogeneric() || genericSig);
 
-  // FIXME: [clang-function-type-serialization] Don't drop the Clang type...
-  if (!ctx.LangOpts.UseClangFunctionTypes)
-    ext = ext.withClangFunctionType(nullptr);
-
   llvm::FoldingSetNodeID id;
   SILFunctionType::Profile(id, genericSig, ext, coroutineKind, callee, params,
                            yields, normalResults, errorResult,
@@ -3389,11 +3376,10 @@ CanSILFunctionType SILFunctionType::get(
 
   // See [SILFunctionType-layout]
   bool hasResultCache = normalResults.size() > 1;
-  size_t bytes = totalSizeToAlloc<SILParameterInfo, SILResultInfo, SILYieldInfo,
-                                  CanType, SILFunctionType::ExtInfo::Uncommon>(
+  size_t bytes =
+    totalSizeToAlloc<SILParameterInfo, SILResultInfo, SILYieldInfo, CanType>(
       params.size(), normalResults.size() + (errorResult ? 1 : 0),
-      yields.size(), hasResultCache ? 2 : 0,
-      ext.getUncommonInfo().hasValue() ? 1 : 0);
+      yields.size(), hasResultCache ? 2 : 0);
 
   void *mem = ctx.Allocate(bytes, alignof(SILFunctionType));
 

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -488,6 +488,12 @@ Type ASTBuilder::createImplFunctionType(
     break;
   }
 
+  // TODO: [store-sil-clang-function-type]
+  auto einfo = SILFunctionType::ExtInfo(
+      representation, flags.isPseudogeneric(), !flags.isEscaping(),
+      DifferentiabilityKind::NonDifferentiable,
+      /*clangFunctionType*/ nullptr);
+
   llvm::SmallVector<SILParameterInfo, 8> funcParams;
   llvm::SmallVector<SILYieldInfo, 8> funcYields;
   llvm::SmallVector<SILResultInfo, 8> funcResults;
@@ -510,26 +516,6 @@ Type ASTBuilder::createImplFunctionType(
     auto conv = getResultConvention(errorResult->getConvention());
     funcErrorResult.emplace(type, conv);
   }
-
-  const clang::Type *clangFnType = nullptr;
-  auto incompleteExtInfo = SILFunctionType::ExtInfo(
-      SILFunctionType::Representation::Thick, flags.isPseudogeneric(),
-      !flags.isEscaping(), DifferentiabilityKind::NonDifferentiable,
-      clangFnType);
-
-  if (representation == SILFunctionType::Representation::CFunctionPointer) {
-    assert(funcResults.size() <= 1 && funcYields.size() == 0
-           && "@convention(c) functions have at most 1 result and 0 yields.");
-    auto result = funcResults.empty() ? Optional<SILResultInfo>()
-                                      : funcResults[0];
-    auto &Context = getASTContext();
-    clangFnType = Context.getCanonicalClangFunctionType(funcParams, result,
-                                                        incompleteExtInfo,
-                                                        representation);
-  }
-  auto einfo = incompleteExtInfo.withRepresentation(representation)
-                                .withClangFunctionType(clangFnType);
-
   return SILFunctionType::get(genericSig, einfo, funcCoroutineKind,
                               funcCalleeConvention, funcParams, funcYields,
                               funcResults, funcErrorResult,

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -570,19 +570,12 @@ clang::QualType ClangTypeConverter::visitFunctionType(FunctionType *type) {
 }
 
 clang::QualType ClangTypeConverter::visitSILFunctionType(SILFunctionType *type) {
-  // We must've already computed it before if applicable.
-  return clang::QualType(type->getClangFunctionType(), 0);
+  llvm::report_fatal_error("Expected only AST types but found a SIL function.");
 }
 
 clang::QualType
 ClangTypeConverter::visitSILBlockStorageType(SILBlockStorageType *type) {
-  // We'll select (void)(^)(). This isn't correct for all blocks, but block
-  // storage type should only be converted for function signature lowering,
-  // where the parameter types do not matter.
-  auto &clangCtx = ClangASTContext;
-  auto fnTy = clangCtx.getFunctionNoProtoType(clangCtx.VoidTy);
-  auto blockTy = clangCtx.getBlockPointerType(fnTy);
-  return clangCtx.getCanonicalType(blockTy);
+  llvm::report_fatal_error("Expected only AST types but found a SIL block.");
 }
 
 clang::QualType

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -156,57 +156,6 @@ const clang::Type *ClangTypeConverter::getFunctionType(
   }
 }
 
-const clang::Type *ClangTypeConverter::getFunctionType(
-    ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
-    SILFunctionType::Representation repr) {
-
-  // Using the interface type is sufficient as Swift does not allow abstracting
-  // over @convention(c) functions, hence we don't need any substitutions.
-  auto resultClangTy = result.hasValue()
-                     ? convert(result.getValue().getInterfaceType())
-                     : ClangASTContext.VoidTy;
-
-  if (resultClangTy.isNull())
-    return nullptr;
-
-  SmallVector<clang::FunctionProtoType::ExtParameterInfo, 4> extParamInfos;
-  SmallVector<clang::QualType, 4> paramsClangTy;
-  bool someParamIsConsumed = false;
-  for (auto &p : params) {
-    auto pc = convert(p.getInterfaceType());
-    if (pc.isNull())
-      return nullptr;
-    clang::FunctionProtoType::ExtParameterInfo extParamInfo;
-    if (p.isConsumed()) {
-      someParamIsConsumed = true;
-      extParamInfo = extParamInfo.withIsConsumed(true);
-    }
-    extParamInfos.push_back(extParamInfo);
-    paramsClangTy.push_back(pc);
-  }
-
-  clang::FunctionProtoType::ExtProtoInfo info(clang::CallingConv::CC_C);
-  if (someParamIsConsumed)
-    info.ExtParameterInfos = extParamInfos.begin();
-  auto fn = ClangASTContext.getFunctionType(resultClangTy, paramsClangTy, info);
-  if (fn.isNull())
-    return nullptr;
-
-  switch (repr) {
-  case SILFunctionType::Representation::CFunctionPointer:
-    return ClangASTContext.getPointerType(fn).getTypePtr();
-  case SILFunctionType::Representation::Block:
-    return ClangASTContext.getBlockPointerType(fn).getTypePtr();
-  case SILFunctionType::Representation::Thick:
-  case SILFunctionType::Representation::Thin:
-  case SILFunctionType::Representation::Method:
-  case SILFunctionType::Representation::ObjCMethod:
-  case SILFunctionType::Representation::WitnessMethod:
-  case SILFunctionType::Representation::Closure:
-    llvm_unreachable("Expected a C-compatible representation.");
-  }
-}
-
 clang::QualType ClangTypeConverter::convertMemberType(NominalTypeDecl *DC,
                                                       StringRef memberName) {
   auto memberTypeDecl = cast<TypeDecl>(

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -73,10 +73,6 @@ public:
     ArrayRef<AnyFunctionType::Param> params, Type resultTy,
     AnyFunctionType::Representation repr);
 
-  const clang::Type *getFunctionType(
-    ArrayRef<SILParameterInfo> params, Optional<SILResultInfo> result,
-    SILFunctionType::Representation repr);
-
 private:
   clang::QualType convert(Type type);
   clang::QualType convertMemberType(NominalTypeDecl *DC,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3229,7 +3229,8 @@ void AnyFunctionType::ExtInfo::Uncommon::printClangFunctionType(
   cml->printClangType(ClangFunctionType, os);
 }
 
-static void assertIsFunctionType(const clang::Type *type) {
+void
+AnyFunctionType::ExtInfo::assertIsFunctionType(const clang::Type *type) {
 #ifndef NDEBUG
   if (!(type->isFunctionPointerType() || type->isBlockPointerType())) {
     SmallString<256> buf;
@@ -3241,10 +3242,6 @@ static void assertIsFunctionType(const clang::Type *type) {
   }
 #endif
   return;
-}
-
-void AnyFunctionType::ExtInfo::assertIsFunctionType(const clang::Type *type) {
-  ::assertIsFunctionType(type);
 }
 
 const clang::Type *AnyFunctionType::getClangFunctionType() const {
@@ -3264,16 +3261,9 @@ const clang::Type *AnyFunctionType::getCanonicalClangFunctionType() const {
   return ty ? ty->getCanonicalTypeInternal().getTypePtr() : nullptr;
 }
 
-void SILFunctionType::ExtInfo::assertIsFunctionType(const clang::Type *type) {
-  ::assertIsFunctionType(type);
-}
-
-const clang::Type *SILFunctionType::getClangFunctionType() const {
-  if (!Bits.SILFunctionType.HasUncommonInfo)
-    return nullptr;
-  auto *type = getTrailingObjects<ExtInfo::Uncommon>()->ClangFunctionType;
-  assert(type && "If the pointer was null, we shouldn't have stored it.");
-  return type;
+// TODO: [store-sil-clang-function-type]
+const clang::FunctionType *SILFunctionType::getClangFunctionType() const {
+  return nullptr;
 }
 
 FunctionType *

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -416,11 +416,12 @@ namespace {
       
       if (pointeeQualType->isFunctionType()) {
         auto funcTy = pointeeType->castTo<FunctionType>();
-        auto extInfo = funcTy->getExtInfo().withRepresentation(
-                AnyFunctionType::Representation::CFunctionPointer)
-                                           .withClangFunctionType(type);
         return {
-          FunctionType::get(funcTy->getParams(), funcTy->getResult(), extInfo),
+          FunctionType::get(funcTy->getParams(), funcTy->getResult(),
+            funcTy->getExtInfo()
+              .withRepresentation(
+                AnyFunctionType::Representation::CFunctionPointer)
+              .withClangFunctionType(type)),
           ImportHint::CFunctionPointer
         };
       }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -68,8 +68,6 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);
-  Opts.PrintFullConvention |=
-    Args.hasArg(OPT_experimental_print_full_convention);
 
   Opts.EnableTesting |= Args.hasArg(OPT_enable_testing);
   Opts.EnablePrivateImports |= Args.hasArg(OPT_enable_private_imports);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -964,8 +964,6 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.DebugSerialization |= Args.hasArg(OPT_sil_debug_serialization);
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);
-  Opts.PrintFullConvention |=
-    Args.hasArg(OPT_experimental_print_full_convention);
   Opts.PrintInstCounts |= Args.hasArg(OPT_print_inst_counts);
   if (const Arg *A = Args.getLastArg(OPT_external_pass_pipeline_filename))
     Opts.ExternalPassPipelineFilename = A->getValue();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -499,19 +499,20 @@ static bool emitSyntax(SourceFile *SF, StringRef OutputFilename) {
 }
 
 /// Writes SIL out to the given file.
-static bool writeSIL(SILModule &SM, ModuleDecl *M, const SILOptions &Opts,
-                     StringRef OutputFilename) {
+static bool writeSIL(SILModule &SM, ModuleDecl *M, bool EmitVerboseSIL,
+                     StringRef OutputFilename, bool SortSIL) {
   auto OS = getFileOutputStream(OutputFilename, M->getASTContext());
   if (!OS) return true;
-  SM.print(*OS, M, Opts);
+  SM.print(*OS, EmitVerboseSIL, M, SortSIL);
 
   return M->getASTContext().hadError();
 }
 
 static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
                      const CompilerInstance &Instance,
-                     const SILOptions &Opts) {
-  return writeSIL(SM, Instance.getMainModule(), Opts, PSPs.OutputFilename);
+                     const SILOptions &opts) {
+  return writeSIL(SM, Instance.getMainModule(), opts.EmitVerboseSIL,
+                  PSPs.OutputFilename, opts.EmitSortedSIL);
 }
 
 /// Prints the Objective-C "generated header" interface for \p M to \p

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -499,20 +499,20 @@ static bool emitSyntax(SourceFile *SF, StringRef OutputFilename) {
 }
 
 /// Writes SIL out to the given file.
-static bool writeSIL(SILModule &SM, ModuleDecl *M, bool EmitVerboseSIL,
-                     StringRef OutputFilename, bool SortSIL) {
+static bool writeSIL(SILModule &SM, ModuleDecl *M, const SILOptions &Opts,
+                     StringRef OutputFilename) {
   auto OS = getFileOutputStream(OutputFilename, M->getASTContext());
   if (!OS) return true;
-  SM.print(*OS, EmitVerboseSIL, M, SortSIL);
+  SM.print(*OS, M, Opts);
 
   return M->getASTContext().hadError();
 }
 
 static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
                      const CompilerInstance &Instance,
-                     const SILOptions &opts) {
-  return writeSIL(SM, Instance.getMainModule(), opts.EmitVerboseSIL,
-                  PSPs.OutputFilename, opts.EmitSortedSIL);
+                     const SILOptions &Opts) {
+  return writeSIL(SM, Instance.getMainModule(), Opts,
+                  PSPs.OutputFilename);
 }
 
 /// Prints the Objective-C "generated header" interface for \p M to \p

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1266,7 +1266,10 @@ static CanSILFunctionType getSILFunctionType(
 
   // NOTE: SILFunctionType::ExtInfo doesn't track everything that
   // AnyFunctionType::ExtInfo tracks. For example: 'throws' or 'auto-closure'
-  SILFunctionType::ExtInfo silExtInfo(extInfo, pseudogeneric);
+  auto silExtInfo = SILFunctionType::ExtInfo()
+    .withRepresentation(extInfo.getSILRepresentation())
+    .withIsPseudogeneric(pseudogeneric)
+    .withNoEscape(extInfo.isNoEscape());
   
   // Build the substituted generic signature we extracted.
   bool impliedSignature = false;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3116,6 +3116,11 @@ SILPrintContext::SILPrintContext(llvm::raw_ostream &OS, bool Verbose,
   OutStream(OS), Verbose(Verbose), SortedSIL(SortedSIL),
   DebugInfo(SILPrintDebugInfo) { }
 
+SILPrintContext::SILPrintContext(llvm::raw_ostream &OS,
+                                 const SILOptions &Opts) :
+  OutStream(OS), Verbose(Opts.EmitVerboseSIL), SortedSIL(Opts.EmitSortedSIL),
+  DebugInfo(SILPrintDebugInfo) {}
+
 SILPrintContext::SILPrintContext(llvm::raw_ostream &OS, bool Verbose,
                                  bool SortedSIL, bool DebugInfo) :
   OutStream(OS), Verbose(Verbose), SortedSIL(SortedSIL),

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -452,6 +452,8 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
 
 SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
   ASTContext &C = getASTContext();
+  auto extInfo = SILFunctionType::ExtInfo()
+    .withRepresentation(SILFunctionType::Representation::CFunctionPointer);
 
   // Use standard library types if we have them; otherwise, fall back to
   // builtins.
@@ -482,19 +484,13 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
     SILParameterInfo(PtrPtrInt8Ty, ParameterConvention::Direct_Unowned),
   };
 
-  SILResultInfo results[] = {SILResultInfo(Int32Ty, ResultConvention::Unowned)};
-
-  auto rep = SILFunctionType::Representation::CFunctionPointer;
-  auto incompleteExtInfo = SILFunctionType::ExtInfo();
-  auto *clangTy = C.getCanonicalClangFunctionType(params, results[0],
-                                                  incompleteExtInfo, rep);
-  auto extInfo = incompleteExtInfo.withRepresentation(rep)
-                                  .withClangFunctionType(clangTy);
-
   CanSILFunctionType topLevelType = SILFunctionType::get(nullptr, extInfo,
                                    SILCoroutineKind::None,
                                    ParameterConvention::Direct_Unowned,
-                                   params, /*yields*/ {}, results, None,
+                                   params, /*yields*/ {},
+                                   SILResultInfo(Int32Ty,
+                                                 ResultConvention::Unowned),
+                                   None,
                                    SubstitutionMap(), false,
                                    C);
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -541,16 +541,9 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
             blockInterfaceTy->getParameters().end(),
             std::back_inserter(params));
 
-  auto results = blockInterfaceTy->getResults();
-  auto incompleteExtInfo = SILFunctionType::ExtInfo();
-  auto *clangFnType = getASTContext().getCanonicalClangFunctionType(
-        params, results.empty() ? Optional<SILResultInfo>() : results[0],
-        incompleteExtInfo,
-        SILFunctionType::Representation::CFunctionPointer);
-
-  auto extInfo = incompleteExtInfo
-        .withRepresentation(SILFunctionType::Representation::CFunctionPointer)
-        .withClangFunctionType(clangFnType);
+  auto extInfo =
+      SILFunctionType::ExtInfo()
+        .withRepresentation(SILFunctionType::Representation::CFunctionPointer);
 
   CanGenericSignature genericSig;
   GenericEnvironment *genericEnv = nullptr;
@@ -575,7 +568,8 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
 
   auto invokeTy = SILFunctionType::get(
       genericSig, extInfo, SILCoroutineKind::None,
-      ParameterConvention::Direct_Unowned, params, /*yields*/ {}, results,
+      ParameterConvention::Direct_Unowned, params, 
+      /*yields*/ {}, blockInterfaceTy->getResults(),
       blockInterfaceTy->getOptionalErrorResult(), SubstitutionMap(), false,
       getASTContext());
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -577,21 +577,20 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     CanType anyObjectMetaTy = CanExistentialMetatypeType::get(anyObjectTy,
                                                   MetatypeRepresentation::ObjC);
 
-    auto paramConvention = ParameterConvention::Direct_Unowned;
-    auto params = {SILParameterInfo(anyObjectMetaTy, paramConvention)};
-    ArrayRef<SILResultInfo> resultInfos =
-        {SILResultInfo(OptNSStringTy, ResultConvention::Autoreleased)};
-    auto incompleteExtInfo = SILFunctionType::ExtInfo();
-    auto repr = SILFunctionType::Representation::CFunctionPointer;
-    auto *clangFnType = ctx.getCanonicalClangFunctionType(params,
-        resultInfos[0], incompleteExtInfo, repr);
-    auto extInfo = incompleteExtInfo.withRepresentation(repr)
-                                    .withClangFunctionType(clangFnType);
-
-    auto NSStringFromClassType = SILFunctionType::get(
-        nullptr, extInfo, SILCoroutineKind::None, paramConvention, params,
-        /*yields*/ {}, resultInfos, /*error result*/ None, SubstitutionMap(),
-        false, ctx);
+    auto NSStringFromClassType = SILFunctionType::get(nullptr,
+                  SILFunctionType::ExtInfo()
+                    .withRepresentation(SILFunctionType::Representation::
+                                        CFunctionPointer),
+                  SILCoroutineKind::None,
+                  ParameterConvention::Direct_Unowned,
+                  SILParameterInfo(anyObjectMetaTy,
+                                   ParameterConvention::Direct_Unowned),
+                  /*yields*/ {},
+                  SILResultInfo(OptNSStringTy,
+                                ResultConvention::Autoreleased),
+                  /*error result*/ None,
+                  SubstitutionMap(), false,
+                  ctx);
     auto NSStringFromClassFn = builder.getOrCreateFunction(
         mainClass, "NSStringFromClass", SILLinkage::PublicExternal,
         NSStringFromClassType, IsBare, IsTransparent, IsNotSerialized,

--- a/test/SIL/clang-function-types.swift
+++ b/test/SIL/clang-function-types.swift
@@ -1,8 +1,0 @@
-// RUN: %target-swift-frontend %s -emit-sil -swift-version 5 -use-clang-function-types -experimental-print-full-convention -o - | %FileCheck %s
-
-public func f(g: @convention(c) () -> ()) { g() }
-
-// CHECK: sil @$s4main1f1gyyyXC_tF : $@convention(thin) (@convention(c, cType: "void (*)(void)") @noescape () -> ()) -> () {
-// CHECK: bb0(%0 : $@convention(c, cType: "void (*)(void)") @noescape () -> ()):
-// CHECK:   debug_value %0 : $@convention(c, cType: "void (*)(void)") @noescape () -> (), let, name "g", argno 1 // id: %1
-// CHECK:   %2 = apply %0() : $@convention(c, cType: "void (*)(void)") @noescape () -> ()

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -355,9 +355,13 @@ int main(int argc, char **argv) {
     const StringRef OutputFile =
         OutputFilename.size() ? StringRef(OutputFilename) : "-";
 
+    auto SILOpts = SILOptions();
+    SILOpts.EmitVerboseSIL = EmitVerboseSIL;
+    SILOpts.EmitSortedSIL = EnableSILSortOutput;
+
     if (OutputFile == "-") {
-      CI.getSILModule()->print(llvm::outs(), EmitVerboseSIL, CI.getMainModule(),
-                               EnableSILSortOutput, !DisableASTDump);
+      CI.getSILModule()->print(llvm::outs(), CI.getMainModule(), SILOpts,
+                               !DisableASTDump);
     } else {
       std::error_code EC;
       llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
@@ -366,8 +370,8 @@ int main(int argc, char **argv) {
                      << '\n';
         return 1;
       }
-      CI.getSILModule()->print(OS, EmitVerboseSIL, CI.getMainModule(),
-                               EnableSILSortOutput, !DisableASTDump);
+      CI.getSILModule()->print(OS, CI.getMainModule(), SILOpts,
+                               !DisableASTDump);
     }
   }
 }

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -101,10 +101,10 @@ static llvm::cl::opt<std::string> Triple("target",
                                          llvm::cl::desc("target triple"));
 
 static llvm::cl::opt<bool>
-EmitSortedSIL("emit-sorted-sil", llvm::cl::Hidden,
-              llvm::cl::init(false),
-              llvm::cl::desc("Sort Functions, VTables, Globals, "
-                             "WitnessTables by name to ease diffing."));
+EnableSILSortOutput("emit-sorted-sil", llvm::cl::Hidden,
+                    llvm::cl::init(false),
+                    llvm::cl::desc("Sort Functions, VTables, Globals, "
+                                   "WitnessTables by name to ease diffing."));
 
 static llvm::cl::opt<bool>
 DisableASTDump("sil-disable-ast-dump", llvm::cl::Hidden,
@@ -250,10 +250,6 @@ int main(int argc, char **argv) {
   Invocation.getLangOptions().EnableAccessControl = false;
   Invocation.getLangOptions().EnableObjCAttrRequiresFoundation = false;
 
-  SILOptions &Opts = Invocation.getSILOptions();
-  Opts.EmitVerboseSIL = EmitVerboseSIL;
-  Opts.EmitSortedSIL = EmitSortedSIL;
-
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
       Invocation.setUpInputForSILTool(InputFilename, ModuleName,
@@ -360,8 +356,8 @@ int main(int argc, char **argv) {
         OutputFilename.size() ? StringRef(OutputFilename) : "-";
 
     if (OutputFile == "-") {
-      CI.getSILModule()->print(llvm::outs(), CI.getMainModule(),
-                               Invocation.getSILOptions(), !DisableASTDump);
+      CI.getSILModule()->print(llvm::outs(), EmitVerboseSIL, CI.getMainModule(),
+                               EnableSILSortOutput, !DisableASTDump);
     } else {
       std::error_code EC;
       llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
@@ -370,8 +366,8 @@ int main(int argc, char **argv) {
                      << '\n';
         return 1;
       }
-      CI.getSILModule()->print(OS, CI.getMainModule(),
-                               Invocation.getSILOptions(), !DisableASTDump);
+      CI.getSILModule()->print(OS, EmitVerboseSIL, CI.getMainModule(),
+                               EnableSILSortOutput, !DisableASTDump);
     }
   }
 }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -196,10 +196,10 @@ static llvm::cl::opt<std::string>
 ModuleCachePath("module-cache-path", llvm::cl::desc("Clang module cache path"));
 
 static llvm::cl::opt<bool>
-EmitSortedSIL("emit-sorted-sil", llvm::cl::Hidden,
-              llvm::cl::init(false),
-              llvm::cl::desc("Sort Functions, VTables, Globals, "
-                             "WitnessTables by name to ease diffing."));
+EnableSILSortOutput("emit-sorted-sil", llvm::cl::Hidden,
+                    llvm::cl::init(false),
+                    llvm::cl::desc("Sort Functions, VTables, Globals, "
+                                   "WitnessTables by name to ease diffing."));
 
 static llvm::cl::opt<bool>
 DisableASTDump("sil-disable-ast-dump", llvm::cl::Hidden,
@@ -375,8 +375,6 @@ int main(int argc, char **argv) {
       break;
     }
   }
-  SILOpts.EmitVerboseSIL |= EmitVerboseSIL;
-  SILOpts.EmitSortedSIL |= EmitSortedSIL;
 
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
@@ -483,8 +481,8 @@ int main(int argc, char **argv) {
                                    StringRef(OutputFilename) : "-";
 
     if (OutputFile == "-") {
-      CI.getSILModule()->print(llvm::outs(), CI.getMainModule(),
-                               Invocation.getSILOptions(), !DisableASTDump);
+      CI.getSILModule()->print(llvm::outs(), EmitVerboseSIL, CI.getMainModule(),
+                               EnableSILSortOutput, !DisableASTDump);
     } else {
       std::error_code EC;
       llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
@@ -493,8 +491,8 @@ int main(int argc, char **argv) {
                      << EC.message() << '\n';
         return 1;
       }
-      CI.getSILModule()->print(OS, CI.getMainModule(),
-                               Invocation.getSILOptions(), !DisableASTDump);
+      CI.getSILModule()->print(OS, EmitVerboseSIL, CI.getMainModule(),
+                               EnableSILSortOutput, !DisableASTDump);
     }
   }
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -479,10 +479,12 @@ int main(int argc, char **argv) {
   } else {
     const StringRef OutputFile = OutputFilename.size() ?
                                    StringRef(OutputFilename) : "-";
-
+    auto SILOpts = SILOptions();
+    SILOpts.EmitVerboseSIL = EmitVerboseSIL;
+    SILOpts.EmitSortedSIL = EnableSILSortOutput;
     if (OutputFile == "-") {
-      CI.getSILModule()->print(llvm::outs(), EmitVerboseSIL, CI.getMainModule(),
-                               EnableSILSortOutput, !DisableASTDump);
+      CI.getSILModule()->print(llvm::outs(), CI.getMainModule(),
+                               SILOpts, !DisableASTDump);
     } else {
       std::error_code EC;
       llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
@@ -491,8 +493,8 @@ int main(int argc, char **argv) {
                      << EC.message() << '\n';
         return 1;
       }
-      CI.getSILModule()->print(OS, EmitVerboseSIL, CI.getMainModule(),
-                               EnableSILSortOutput, !DisableASTDump);
+      CI.getSILModule()->print(OS, CI.getMainModule(), SILOpts,
+                               !DisableASTDump);
     }
   }
 


### PR DESCRIPTION
Still keeping some printing changes so that LLDB doesn't break.