### PR TITLE
[build] Add option to limit number of link jobs

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -64,10 +64,12 @@ KNOWN_SETTINGS=(
     build-stdlib-deployment-targets               "all"             "space-separated list that filters which of the configured targets to build the Swift standard library for, or 'all'"
     build-toolchain-only                          ""                "If set, only build the necessary tools to build an external toolchain"
     cmake-generator                               "Unix Makefiles"  "kind of build system to generate; see output of 'cmake --help' for choices"
-    llvm-num-parallel-lto-link-jobs               ""                "The number of parallel link jobs to use when compiling llvm"
+    llvm-num-parallel-link-jobs                   ""                "The number of parallel link jobs to use when compiling llvm"
+    llvm-num-parallel-lto-link-jobs               ""                "The number of parallel link jobs to use when compiling llvm with LTO enabled"
     reconfigure                                   ""                "force a CMake configuration run even if CMakeCache.txt already exists"
     skip-reconfigure                              ""                "set to skip reconfigure"
-    swift-tools-num-parallel-lto-link-jobs        ""                "The number of parallel link jobs to use when compiling swift tools"
+    swift-tools-num-parallel-link-jobs            ""                "The number of parallel link jobs to use when compiling swift tools"
+    swift-tools-num-parallel-lto-link-jobs        ""                "The number of parallel link jobs to use when compiling swift tools with LTO enabled"
     use-gold-linker                               ""                "Enable using the gold linker"
     workspace                                     "${HOME}/src"     "source directory containing llvm, clang, swift"
 
@@ -639,6 +641,18 @@ function set_build_options_for_host() {
         -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL="$(false_true ${SKIP_BUILD_COMPILER_RT})"
         -DLLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL="$(false_true ${SKIP_BUILD_COMPILER_RT})"
     )
+
+    if [[ "${SWIFT_TOOLS_NUM_PARALLEL_LINK_JOBS}" != "" ]] && [[ $(is_swift_lto_enabled) == "FALSE" ]]; then
+        swift_cmake_options+=(
+            "-DSWIFT_PARALLEL_LINK_JOBS=${SWIFT_TOOLS_NUM_PARALLEL_LINK_JOBS}"
+        )
+    fi
+
+    if [[ "${LLVM_NUM_PARALLEL_LINK_JOBS}" != "" ]] && [[ $(is_llvm_lto_enabled) == "FALSE" ]]; then
+        llvm_cmake_options+=(
+            "-DLLVM_PARALLEL_LINK_JOBS=${LLVM_NUM_PARALLEL_LINK_JOBS}"
+        )
+    fi
 
     # If we are asked to not generate test targets for LLVM and or Swift,
     # disable as many LLVM tools as we can. This improves compile time when

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -490,13 +490,13 @@ def create_argument_parser():
            default=default_max_lto_link_job_counts['llvm'],
            metavar='COUNT',
            help='the maximum number of parallel link jobs to use when '
-                'compiling llvm')
+                'compiling llvm with LTO')
 
     option('--swift-tools-max-parallel-lto-link-jobs', store_int,
            default=default_max_lto_link_job_counts['swift'],
            metavar='COUNT',
            help='the maximum number of parallel link jobs to use when '
-                'compiling swift tools.')
+                'compiling swift tools with LTO')
 
     option('--disable-guaranteed-normal-arguments', store_true,
            help='Disable guaranteed normal arguments')


### PR DESCRIPTION
When building llvm or Swift, linking uses much more memory than compilation, and therefore, it’s useful to limit the number of parallel jobs during linking only, as opposed to all jobs. For example, on a 4 GB RAM linux machine, building fails when two linking tasks are running in parallel, because of shortage of RAM. This is not a problem when two compiling tasks are running in parallel.

This PR enables us to call `build-script` like:

    build-script --swift-tools-num-parallel-link-jobs 1 --llvm-num-parallel-link-jobs 1

to make it run only one link job at a time, while compilations jobs are not restricted.

Work to get parallel link jobs information into CMake / Ninja files has already been done for use with LTO. This PR just exposes that functionality in `build-script` for the case when LTO is not enabled.
