### PR TITLE
Add -no-whole-module-optimization

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -867,6 +867,10 @@ def whole_module_optimization : Flag<["-"], "whole-module-optimization">,
   HelpText<"Optimize input files together instead of individually">,
   Flags<[FrontendOption, NoInteractiveOption]>;
 
+def no_whole_module_optimization : Flag<["-"], "no-whole-module-optimization">,
+  HelpText<"Disable optimizing input files together instead of individually">,
+  Flags<[FrontendOption, NoInteractiveOption]>;
+
 def enable_batch_mode : Flag<["-"], "enable-batch-mode">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Enable combining frontend jobs into batches">;

--- a/test/Driver/negating_WMO.swift
+++ b/test/Driver/negating_WMO.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %swiftc_driver -whole-module-optimization %S/../Inputs/empty.swift -### 2>&1 | %FileCheck -check-prefix WMO %s
+// WMO-NOT: -primary-file
+// RUN: %swiftc_driver -whole-module-optimization -no-whole-module-optimization %S/../Inputs/empty.swift -### 2>&1 | %FileCheck -check-prefix NO-WMO %s
+// NO-WMO: -primary-file
+
+// RUN: %swiftc_driver -enable-batch-mode -whole-module-optimization -no-whole-module-optimization %S/../Inputs/empty.swift -### 2>&1 | %FileCheck -check-prefix BATCH %s
+// BATCH: -primary-file
+// BATCH-NOT: warning: ignoring '-enable-batch-mode' because '-whole-module-optimization' was also specified


### PR DESCRIPTION
This adds an argument to allow negating `-whole-module-optimization`.
This is useful for cases where it's easier to add an extra flag to your
swiftc invocation rather than removing the original one.