### PR TITLE
build-script: reduce duplication of check

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2679,6 +2679,10 @@ for host in "${ALL_HOSTS[@]}"; do
         if ! [[ $(should_execute_action "${host}-${tmp_product}-install") ]]; then
             continue
         fi
+        if [[ -z "${INSTALL_DESTDIR}" ]] ; then
+            echo "--install-destdir is required to install products."
+            exit 1
+        fi
 
         INSTALL_TARGETS="install"
 
@@ -2721,19 +2725,11 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ -z "${INSTALL_LLDB}" ]] ; then
                     continue
                 fi
-                if [[ -z "${INSTALL_DESTDIR}" ]] ; then
-                    echo "--install-destdir is required to install products."
-                    exit 1
-                fi
                 INSTALL_TARGETS="install-distribution"
                 ;;
             xctest)
                 if [[ -z "${INSTALL_XCTEST}" ]] ; then
                     continue
-                fi
-                if [[ -z "${INSTALL_DESTDIR}" ]] ; then
-                    echo "--install-destdir is required to install products."
-                    exit 1
                 fi
 
                 case ${host} in
@@ -2754,11 +2750,6 @@ for host in "${ALL_HOSTS[@]}"; do
 
                 if [[ -z "${INSTALL_FOUNDATION}" ]] ; then
                     continue
-                fi
-
-                if [[ -z "${INSTALL_DESTDIR}" ]] ; then
-                    echo "--install-destdir is required to install products."
-                    exit 1
                 fi
 
                 ;;
@@ -2793,10 +2784,6 @@ for host in "${ALL_HOSTS[@]}"; do
             libicu)
                 if [[ -z "${INSTALL_LIBICU}" ]]; then
                     continue
-                fi
-                if [[ -z "${INSTALL_DESTDIR}" ]] ; then
-                    echo "--install-destdir is required to install products."
-                    exit 1
                 fi
                 echo "--- Installing ${product} ---"
                 ICU_BUILD_DIR=$(build_directory ${host} ${product})
@@ -2835,10 +2822,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ -z "${INSTALL_PLAYGROUNDSUPPORT}" ]] ; then
                     continue
                 fi
-                if [[ -z "${INSTALL_DESTDIR}" ]] ; then
-                    echo "--install-destdir is required to install products."
-                    exit 1
-                fi
 
                 echo "--- Installing ${product} ---"
 
@@ -2873,11 +2856,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 exit 1
                 ;;
         esac
-
-        if [[ -z "${INSTALL_DESTDIR}" ]] ; then
-            echo "--install-destdir is required to install products."
-            exit 1
-        fi
 
         echo "--- Installing ${product} ---"
         build_dir=$(build_directory ${host} ${product})


### PR DESCRIPTION
This hoists the shared check to the beginning of the product
installation phase.  This can be done as a shared phase option.  In
theory it should be possible to hoist this further to a single check at
the beginning of the phase.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
