### PR TITLE
[partial-apply-combiner] Fix partial_apply combiner implementation for indirect parameters

### DIFF
--- a/test/SILOptimizer/partial_apply_combiner.sil
+++ b/test/SILOptimizer/partial_apply_combiner.sil
@@ -1,0 +1,92 @@
+// RUN: %target-sil-opt -enable-objc-interop -sil-combine-disable-dead-closure-elim=true -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+sil @in_argument_func : $@convention(thin) (@in Builtin.NativeObject) -> ()
+sil @inguaranteed_argument_func : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+
+// CHECK-LABEL: sil @test_in_argument_func : $@convention(thin) (@in Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*Builtin.NativeObject):
+// CHECK:   [[ALLOC:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK:   copy_addr [[ARG]] to [initialization] [[ALLOC]]
+// CHECK-NEXT:   [[PAI:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[ARG]])
+// CHECK-NEXT:   apply {{%.*}}([[ALLOC]])
+// CHECK-NEXT:   strong_release [[PAI]]
+// CHECK-NOT: strong_release
+// CHECK: } // end sil function 'test_in_argument_func'
+sil @test_in_argument_func : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %f = function_ref @in_argument_func : $@convention(thin) (@in Builtin.NativeObject) -> ()
+  %1 = partial_apply [callee_guaranteed] %f(%0) : $@convention(thin) (@in Builtin.NativeObject) -> ()
+  apply %1() : $@callee_guaranteed () -> ()
+  strong_release %1 : $@callee_guaranteed () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @test_in_guaranteed_argument_func : $@convention(thin) (@in Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[ASI:%.*]] = alloc_stack
+// CHECK:   copy_addr [[ARG]] to [initialization] [[ASI]]
+// CHECK:   [[PAI:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[ARG]])
+// CHECK:   apply {{%.*}}([[ASI]])
+// CHECK:   strong_release [[PAI]]
+// CHECK:   [[RELOAD_VALUE:%.*]] = load [[ASI]]
+// CHECK:   strong_release [[RELOAD_VALUE]]
+// CHECK: } // end sil function 'test_in_guaranteed_argument_func'
+sil @test_in_guaranteed_argument_func : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %f = function_ref @inguaranteed_argument_func : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = partial_apply [callee_guaranteed] %f(%0) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %1() : $@callee_guaranteed () -> ()
+  strong_release %1 : $@callee_guaranteed () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @test_in_argument_func_allocstack : $@convention(thin) (@in Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[STACK_1:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK:   [[STACK_2:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK:   copy_addr [take] [[ARG]] to [initialization] [[STACK_2]]
+// CHECK:   copy_addr [[STACK_2]] to [initialization] [[STACK_1]]
+// CHECK-NEXT:   [[PAI:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[STACK_2]])
+// CHECK-NEXT:   apply {{%.*}}([[STACK_1]])
+// CHECK-NEXT:   strong_release [[PAI]]
+// CHECK-NEXT:   dealloc_stack [[STACK_2]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   dealloc_stack [[STACK_1]]
+// CHECK: } // end sil function 'test_in_argument_func_allocstack'
+sil @test_in_argument_func_allocstack : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %alloc = alloc_stack $Builtin.NativeObject
+  copy_addr [take] %0 to [initialization] %alloc : $*Builtin.NativeObject
+
+  %f = function_ref @in_argument_func : $@convention(thin) (@in Builtin.NativeObject) -> ()
+  %1 = partial_apply [callee_guaranteed] %f(%alloc) : $@convention(thin) (@in Builtin.NativeObject) -> ()
+  apply %1() : $@callee_guaranteed () -> ()
+  strong_release %1 : $@callee_guaranteed () -> ()
+  dealloc_stack %alloc : $*Builtin.NativeObject
+
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @test_in_guaranteed_argument_func_allocstack : $@convention(thin) (@in Builtin.NativeObject) -> () {
+sil @test_in_guaranteed_argument_func_allocstack : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %alloc = alloc_stack $Builtin.NativeObject
+  copy_addr [take] %0 to [initialization] %alloc : $*Builtin.NativeObject
+
+  %f = function_ref @inguaranteed_argument_func : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = partial_apply [callee_guaranteed] %f(%alloc) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %1() : $@callee_guaranteed () -> ()
+  strong_release %1 : $@callee_guaranteed () -> ()
+
+  dealloc_stack %alloc : $*Builtin.NativeObject
+
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2955,9 +2955,8 @@ sil @closure_with_in_guaranteed_owned_in_args : $@convention(method) (@in CC2, @
 // CHECK: apply [[CLOSURE]]({{.*}}, [[TMP]])
 // Check that the peephole inserted a release the guaranteed argument
 // CHECK: strong_release %{{[0-9]+}} : $CC1
-// Release the @owned CC4 argument of the function
-// CHECK: load {{%[0-9]+}} : $*CC4
-// CHECK: strong_release {{%[0-9]+}} : $CC4
+// Do not release the @owned CC4 argument of the function
+// CHECK-NOT: load {{%[0-9]+}} : $*CC4
 // CHECK: br bb3
 
 // CHECK: bb2:
@@ -2969,9 +2968,8 @@ sil @closure_with_in_guaranteed_owned_in_args : $@convention(method) (@in CC2, @
 // CHECK: apply [[CLOSURE]]({{.*}}, [[TMP]])
 // Check that the peephole inserted a release the closure's guaranteed argument
 // CHECK: strong_release %{{[0-9]+}} : $CC1
-// Release the @owned CC4 argument of the function
-// CHECK: load {{%[0-9]+}} : $*CC4
-// CHECK: strong_release {{%[0-9]+}} : $CC4
+// Make sure we do not reload/release the @owned CC4 argument of the function
+// CHECK-NOT: load {{%[0-9]+}} : $*CC4
 // CHECK: br bb3
 
 // bb3:
@@ -3089,7 +3087,6 @@ bb2:
 // CHECK-NEXT: copy_addr [[ARG1]] to [initialization] [[TMP]] : $*T
 // CHECK-NEXT: destroy_addr [[ARG1]]
 // CHECK-NEXT: apply [[FN]]<T, T>([[ARG0]], [[TMP]])
-// CHECK-NEXT: destroy_addr [[TMP]]
 // CHECK-NEXT: tuple
 // CHECK-NEXT: dealloc_stack [[TMP]]
 // CHECK-NEXT: return

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -276,7 +276,6 @@ bb0:
 // CHECK-NEXT: copy_addr [take] [[ARG1]] to [initialization] [[PA_TMP]]
 // CHECK-NEXT: apply [[FN]]<T, T>([[ARG0]], [[APPLY_TMP]])
 // CHECK-NEXT: destroy_addr [[PA_TMP]]
-// CHECK-NEXT: destroy_addr [[APPLY_TMP]]
 // CHECK-NEXT: tuple
 // CHECK-NEXT: dealloc_stack [[APPLY_TMP]]
 // CHECK-NEXT: dealloc_stack [[PA_TMP]]


### PR DESCRIPTION
I do not believe that this code was ever correct and we just got lucky since in
the vast majority of cases where this optimization kicks in we also eliminate
the underlying partial apply/allocations.

To make sure that we can properly test this code and make sure that we do not
run into this problem again, I added an option to SILCombinerApplyVisitors that
disables partial apply deletion so we can verify that we do not rely on
eliminating the underlying partial apply for correctness.

<rdar://problem/57855082>

----

To be more specific, partial_apply expects that it will take all of its input
arguments at +1. This includes parameters that are passed @in or @in_guaranteed
to the underlying function. Just to summarize the expected semantics are that:

1. If the underlying function takes the parameter @in then the partial_apply
forwarder allows the underlying function to consume the argument.

2. If the underlying function takes the parameter @in_guaranteed then the
partial_apply forwarder itself will destroy the underlying value.

In terms of the partial_apply combiner this means that unless we can guarantee
that the partial_apply is eliminated as a result of our transformation (which we
can not givne the way this utility is written), we must introduce new copies of
@in, @in_guaranteed partial applied arguments and lifetime extend those copies
to the new direct apply that we are creating. In the case of the parameter being
in_guaranteed we insert a destroy after that call site to ensure that our new
copy is cleaned up. If we have an @in parameter then we allow the underlying
function to clean up the value.

----

NOTE: the 2nd commit here just clarifies the documentation around partial_apply to make it much more explicit what the actual semantics are of partial_apply arguments.