### PR TITLE
Adjust to upstream changes

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -661,8 +661,7 @@ private:
 
     StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
     llvm::DIModule *M =
-        DBuilder.createModule(Parent, Name, ConfigMacros, RemappedIncludePath,
-                              Sysroot);
+        DBuilder.createModule(Parent, Name, ConfigMacros, RemappedIncludePath);
     DIModuleCache.insert({Key, llvm::TrackingMDNodeRef(M)});
     return M;
   }


### PR DESCRIPTION
Commit 7b30370e5bcf569fcdc15204d4c592163fd78cb3 from llvm-project changed
DIBuilder::createModule. Adjust accordingly.

Note that LLDB is going to fail to build. I'm working on a fix for that as well, but I expect the CI to fail.

cc @compnerd @JDevlieghere 
