### PR TITLE
[CodeCompletion] Ignore implicit decl when finding equivalent decl

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -56,6 +56,8 @@ template <typename Range>
 unsigned findIndexInRange(Decl *D, const Range &Decls) {
   unsigned N = 0;
   for (auto I = Decls.begin(), E = Decls.end(); I != E; ++I) {
+    if ((*I)->isImplicit())
+      continue;
     if (*I == D)
       return N;
     ++N;
@@ -66,6 +68,8 @@ unsigned findIndexInRange(Decl *D, const Range &Decls) {
 /// Return the element at \p N in \p Decls .
 template <typename Range> Decl *getElementAt(const Range &Decls, unsigned N) {
   for (auto I = Decls.begin(), E = Decls.end(); I != E; ++I) {
+    if ((*I)->isImplicit())
+      continue;
     if (N == 0)
       return *I;
     --N;
@@ -140,6 +144,8 @@ static DeclContext *getEquivalentDeclContextFromSourceFile(DeclContext *DC,
       llvm_unreachable("invalid DC kind for finding equivalent DC (query)");
 
     if (auto storage = dyn_cast<AbstractStorageDecl>(D)) {
+      if (IndexStack.empty())
+        return nullptr;
       auto accessorN = IndexStack.pop_back_val();
       D = getElementAt(storage->getAllAccessors(), accessorN);
     }

--- a/test/SourceKit/CodeComplete/complete_sequence_property_wrapper.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_property_wrapper.swift
@@ -1,0 +1,36 @@
+@propertyWrapper
+struct TwelveOrLess {
+  private var number = 0
+  var wrappedValue: Int {
+    get { return number }
+    set { number = min(newValue, 12) }
+  }
+}
+
+struct MyStruct {
+  @TwelveOrLess var value = 12
+
+  func foo() {}
+
+  func bar(barParam: Int) {
+
+  }
+}
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=track-compiles == \
+// RUN:   -req=complete -req-opts=reuseastcontext=1 -pos=16:1 -repeat-request=2 %s -- %s > %t.response
+// RUN: %FileCheck --check-prefix=RESULT  %s < %t.response
+// RUN: %FileCheck --check-prefix=TRACE  %s < %t.response
+
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "barParam"
+// RESULT: ]
+// RESULT-LABEL: key.results: [
+// RESULT-DAG: key.description: "barParam"
+// RESULT: ]
+
+// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE-NOT: key.description: "completion reusing previous ASTContext (benign diagnostic)"
+// TRACE-LABEL: key.notification: source.notification.compile-did-finish,
+// TRACE: key.description: "completion reusing previous ASTContext (benign diagnostic)"


### PR DESCRIPTION
TypeChecker sometimes (e.g property wrappers) inserts implicit decls (e.g. `PatternBindingDecl`s and `VarDecl`s) between the decl in the AST. This used to confuse `getEquivalentDeclContextFromSourceFile()`. It canceled fast-completion, caused crashes, or completed in a wrong context.

Ignore implicit decls in the AST so that we can find the correct decl context.

rdar://problem/58665268