### PR TITLE
[Incremental] Turn fine-grained-dependencies on-by-default.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -299,7 +299,7 @@ namespace swift {
     /// Emit the newer, finer-grained swiftdeps file. Eventually will support
     /// faster rebuilds.
     /// The initializer here sets the default for the frontend and driver.
-    bool EnableFineGrainedDependencies = false;
+    bool EnableFineGrainedDependencies = true;
 
     /// When using fine-grained dependencies, emit dot files for every swiftdeps
     /// file.


### PR DESCRIPTION
Turn off by passing in `-disable-fine-grained-dependencies`.