### PR TITLE
[stdlib] Backport withContiguousStorageIfAvailable to SubString.UTF8View to 5.2

### DIFF
--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -389,6 +389,13 @@ extension Substring.UTF8View: BidirectionalCollection {
     return _slice.distance(from: start, to: end)
   }
 
+  @_alwaysEmitIntoClient
+  public func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    return try _slice.withContiguousStorageIfAvailable(body)
+  }
+
   @inlinable
   public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
     _slice._failEarlyRangeCheck(index, bounds: bounds)


### PR DESCRIPTION
This is a back port of #29146 to the 5.2 branch. I don't see any particular reason for this wart to persist in Swift 5.2, and the patch is straightforward enough that I think its risk is low, so I'd like to propose we take this back port.
