### PR TITLE
utils: change handling of generic specializations in analyze_code_size.py

### DIFF
--- a/utils/analyze_code_size.py
+++ b/utils/analyze_code_size.py
@@ -87,11 +87,12 @@ class Categories(object):
         self.category_matching = [
             ['Objective-C function', re.compile(r'.*[+-]\[')],
             ['C++', re.compile(r'_+swift')],
+            ['Generic specialization of stdlib', re.compile(r'.*generic specialization.* of Swift\.')],
+            ['Generic specialization', re.compile(r'.*generic specialization')],
             ['Merged function', re.compile(r'merged ')],
             ['Key path', re.compile(r'key path')],
             ['Function signature specialization',
                 re.compile(r'function signature specialization')],
-            ['Generic specialization', re.compile(r'generic specialization')],
             ['Reabstraction thunk helper',
                 re.compile(r'reabstraction thunk helper')],
             ['vtable thunk', re.compile(r'vtable thunk for')],


### PR DESCRIPTION
Two changes:

* If a function is a function signature (or any other) specialization of a generic specialization, count it is generic specialization.
  Function signature speializations are just small modifications of the original function, whereas generic specializations are real copies. So it makes more sense to "prioritize" generic specializations.

* Create a separate category of generic specializations of stdlib functions.
