### PR TITLE
build: remove support for `EXCLUDE_FROM_ALL` (NFC)

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -213,21 +213,16 @@ endmacro()
 #   add_sourcekit_executable(name        # Name of the executable
 #     [LLVM_LINK_COMPONENTS comp1 ...] # LLVM components this executable
 #                                        # depends on
-#     [EXCLUDE_FROM_ALL]              # Whether to exclude this executable from
-#                                     # the ALL_BUILD target
 #     source1 [source2 source3 ...])  # Sources to add into this executable
 macro(add_sourcekit_executable name)
-  cmake_parse_arguments(SOURCEKITEXE
-    "EXCLUDE_FROM_ALL"
-    ""
-    "LLVM_LINK_COMPONENTS"
-    ${ARGN})
+  set(SOURCEKIT_EXECUTABLE_options)
+  set(SOURCEKIT_EXECUTABLE_single_parameter_options)
+  set(SOURCEKIT_EXECUTABLE_multiple_parameter_options LLVM_LINK_COMPONENTS)
+  cmake_parse_arguments(SOURCEKITEXE "${SOURCEKIT_EXECUTABLE_options}"
+    "${SOURCEKIT_EXECUTABLE_single_parameter_options}"
+    "${SOURCEKIT_EXECUTABLE_multiple_parameter_options}" ${ARGN})
 
-  if (${SOURCEKITEXE_EXCLUDE_FROM_ALL})
-    add_executable(${name} EXCLUDE_FROM_ALL ${SOURCEKITEXE_UNPARSED_ARGUMENTS})
-  else()
-    add_executable(${name} ${SOURCEKITEXE_UNPARSED_ARGUMENTS})
-  endif()
+  add_executable(${name} ${SOURCEKITEXE_UNPARSED_ARGUMENTS})
   if(NOT SWIFT_BUILT_STANDALONE AND NOT CMAKE_C_COMPILER_ID MATCHES Clang)
     add_dependencies(${name} clang)
   endif()


### PR DESCRIPTION
This parameter is unused.  Simply remove the option from the
`add_swift_sourcekit_executable`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
