### PR TITLE
[TypeChecker] Fix a couple of relatively common crashers

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -336,8 +336,9 @@ bool RequirementFailure::diagnoseAsError() {
     return true;
   }
 
-  if (genericCtx != reqDC && (genericCtx->isChildContextOf(reqDC) ||
-                              isStaticOrInstanceMember(AffectedDecl))) {
+  if (reqDC->isTypeContext() && genericCtx != reqDC &&
+      (genericCtx->isChildContextOf(reqDC) ||
+       isStaticOrInstanceMember(AffectedDecl))) {
     auto *NTD = reqDC->getSelfNominalTypeDecl();
     emitDiagnostic(anchor->getLoc(), getDiagnosticInRereference(),
                    AffectedDecl->getDescriptiveKind(),

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -799,6 +799,21 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     if (sameOverloadChoice(choice1, choice2))
       continue;
 
+    // If choices are not of the same kind it means that we can't really
+    // compare the solutions e.g.
+    //
+    // func foo(_: Int) -> (count: Int) {}
+    // func foo(_: String) -> [Int] {}
+    //
+    // _ = foo(#^placeholder^#).count
+    //
+    // Here (for the same locator) one choice would be an array `[Int]`,
+    // and another one would be a tuple `(count: Int)`, both have `.count`
+    // which is referenced completely differently - a property in case of
+    // an array and `element with label 'count:'` in case of a tuple.
+    if (choice1.getKind() != choice2.getKind())
+      return SolutionCompareResult::Incomparable;
+
     auto decl1 = choice1.getDecl();
     auto dc1 = decl1->getDeclContext();
     auto decl2 = choice2.getDecl();

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -203,3 +203,9 @@ func test_generic_subscript_requirements_mismatch_diagnostics() {
 
   s[number: ["hello"]] // expected-error {{subscript 'subscript(number:)' requires that 'String' conform to 'BinaryInteger'}}
 }
+
+// rdar://problem/49712598 - cannot compare solutions with different overload choice kinds
+func rdar49712598(pairs: [(rank: Int, count: Int)]) -> Bool {
+  return pairs[<#test#>].count == 2 // expected-error {{ambiguous use of 'subscript(_:)'}}
+  // expected-error@-1 {{editor placeholder in source file}}
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar49712364.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar49712364.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+protocol A {}
+
+class C<T> where T: A {}
+
+extension C {
+  func foo() {
+    extension C where T: Undefined {
+      class Inner: Encodable {
+        var foo: Int
+      }
+    }
+  }
+}


### PR DESCRIPTION
* [Diagnostics] Unsatisfied requirement `in reference` diagnostics expect type context
* [CSRanking] Consider solutions with different kinds of overloads as incomparable

   If choices are not of the same kind it means that we can't really
    compare the solutions e.g.

    ```swift
    func foo(_: Int) -> (count: Int) {}
    func foo(_: String) -> [Int] {}

    _ = foo(#^placeholder^#).count
    ```

    Here (for the same locator) one choice would be an array `[Int]`,
    and another one would be a tuple `(count: Int)`, both have `.count`
    with is referenced completely differently - a property in case of
    an array and `element with label 'count:'` in case of a tuple.

Resolves: rdar://problem/49712598
Resolves: rdar://problem/50666427

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
