### PR TITLE
[Incremental] Use the initial value of EnableFineGrainedDependencies as the default.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -298,6 +298,7 @@ namespace swift {
 
     /// Emit the newer, finer-grained swiftdeps file. Eventually will support
     /// faster rebuilds.
+    /// The initializer here sets the default for the frontend and driver.
     bool EnableFineGrainedDependencies = false;
 
     /// When using fine-grained dependencies, emit dot files for every swiftdeps

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -19,6 +19,7 @@
 
 #include "swift/Basic/ArrayRefView.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/LangOptions.h"
 #include "swift/Basic/NullablePtr.h"
 #include "swift/Basic/OutputFileMap.h"
 #include "swift/Basic/Statistic.h"
@@ -327,7 +328,8 @@ public:
               bool ShowDriverTimeCompilation = false,
               std::unique_ptr<UnifiedStatsReporter> Stats = nullptr,
               bool OnlyOneDependencyFile = false,
-              bool EnableFineGrainedDependencies = false,
+              bool EnableFineGrainedDependencies =
+                LangOptions().EnableFineGrainedDependencies,
               bool VerifyFineGrainedDependencyGraphAfterEveryImport = false,
               bool EmitFineGrainedDependencyDotFileAfterEveryImport = false,
               bool FineGrainedDependenciesIncludeIntrafileOnes = false,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/DiagnosticsDriver.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/LangOptions.h"
 #include "swift/Basic/OutputFileMap.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/Range.h"
@@ -964,9 +965,11 @@ Driver::buildCompilation(const ToolChain &TC,
                          options::OPT_disable_only_one_dependency_file, true);
 
     // relies on the new dependency graph
+    // Get the default from the initializer in LangOptions.
     const bool EnableFineGrainedDependencies =
         ArgList->hasFlag(options::OPT_enable_fine_grained_dependencies,
-                         options::OPT_disable_fine_grained_dependencies, false);
+                         options::OPT_disable_fine_grained_dependencies,
+                         LangOptions().EnableFineGrainedDependencies);
 
     const bool VerifyFineGrainedDependencyGraphAfterEveryImport = ArgList->hasArg(
         options::

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -428,7 +428,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableFineGrainedDependencies =
       Args.hasFlag(options::OPT_enable_fine_grained_dependencies,
-                   options::OPT_disable_fine_grained_dependencies, false);
+                   options::OPT_disable_fine_grained_dependencies,
+                   Opts.EnableFineGrainedDependencies);
 
   if (Args.hasArg(OPT_emit_fine_grained_dependency_sourcefile_dot_files))
     Opts.EmitFineGrainedDependencySourcefileDotFiles = true;


### PR DESCRIPTION
Following up on a thought by @varungandhi-apple , centralize the default for enabling fine-grained-dependencies.