### PR TITLE
[Constraint solver] Request contextual type information per expression.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7321,7 +7321,8 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
     auto shouldCoerceToContextualType = [&]() {
       return convertType &&
           !(getType(resultExpr)->isUninhabited() &&
-            getContextualTypePurpose() == CTP_ReturnSingleExpr);
+            getContextualTypePurpose(target.getAsExpr())
+              == CTP_ReturnSingleExpr);
     };
 
     // If we're supposed to convert the expression to some particular type,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -532,8 +532,9 @@ class ContextualFailure : public FailureDiagnostic {
 public:
   ContextualFailure(ConstraintSystem &cs, Type lhs, Type rhs,
                     ConstraintLocator *locator)
-      : ContextualFailure(cs, cs.getContextualTypePurpose(), lhs, rhs,
-                          locator) {}
+      : ContextualFailure(cs,
+                          cs.getContextualTypePurpose(locator->getAnchor()),
+                          lhs, rhs, locator) {}
 
   ContextualFailure(ConstraintSystem &cs, ContextualTypePurpose purpose,
                     Type lhs, Type rhs, ConstraintLocator *locator)

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -191,7 +191,7 @@ bool MissingConformance::diagnose(bool asNote) const {
   auto *locator = getLocator();
 
   if (IsContextual) {
-    auto context = cs.getContextualTypePurpose();
+    auto context = cs.getContextualTypePurpose(locator->getAnchor());
     MissingContextualConformanceFailure failure(
         cs, context, NonConformingType, ProtocolType, locator);
     return failure.diagnose(asNote);
@@ -262,9 +262,9 @@ ContextualMismatch *ContextualMismatch::create(ConstraintSystem &cs, Type lhs,
 /// and the contextual type.
 static Optional<std::tuple<ContextualTypePurpose, Type, Type>>
 getStructuralTypeContext(ConstraintSystem &cs, ConstraintLocator *locator) {
-  if (auto contextualType = cs.getContextualType()) {
+  if (auto contextualType = cs.getContextualType(locator->getAnchor())) {
     if (auto *anchor = simplifyLocatorToAnchor(locator))
-      return std::make_tuple(cs.getContextualTypePurpose(),
+      return std::make_tuple(cs.getContextualTypePurpose(locator->getAnchor()),
                              cs.getType(anchor),
                              contextualType);
   } else if (auto argApplyInfo = cs.getFunctionArgApplyInfo(locator)) {
@@ -304,7 +304,7 @@ bool AllowTupleTypeMismatch::coalesceAndDiagnose(
   Type toType;
 
   if (getFromType()->is<TupleType>() && getToType()->is<TupleType>()) {
-    purpose = cs.getContextualTypePurpose();
+    purpose = cs.getContextualTypePurpose(locator->getAnchor());
     fromType = getFromType();
     toType = getToType();
   } else if (auto contextualTypeInfo = getStructuralTypeContext(cs, locator)) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2995,7 +2995,7 @@ bool ConstraintSystem::repairFailures(
   auto elt = path.back();
   switch (elt.getKind()) {
   case ConstraintLocator::LValueConversion: {
-    auto CTP = getContextualTypePurpose();
+    auto CTP = getContextualTypePurpose(anchor);
     // Special case for `CTP_CallArgument` set by CSDiag
     // while type-checking each argument because we yet
     // to cover argument-to-parameter conversions in the
@@ -3368,7 +3368,7 @@ bool ConstraintSystem::repairFailures(
     if (lhs->isHole() || rhs->isHole())
       return true;
 
-    auto purpose = getContextualTypePurpose();
+    auto purpose = getContextualTypePurpose(anchor);
     if (rhs->isVoid() &&
         (purpose == CTP_ReturnStmt || purpose == CTP_ReturnSingleExpr)) {
       conversionsOrFixes.push_back(

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -747,7 +747,7 @@ void ConstraintSystem::shrink(Expr *expr) {
       // that have overload sets.
       if (auto collectionExpr = dyn_cast<CollectionExpr>(expr)) {
         visitCollectionExpr(collectionExpr, CS.getContextualType(expr),
-                            CS.getContextualTypePurpose());
+                            CS.getContextualTypePurpose(expr));
         // Don't try to walk into the dictionary.
         return {false, expr};
       }
@@ -813,11 +813,11 @@ void ConstraintSystem::shrink(Expr *expr) {
         if (Candidates.empty())
           return expr;
 
-        auto contextualType = CS.getContextualType();
+        auto contextualType = CS.getContextualType(expr);
         // If there is a contextual type set for this expression.
         if (!contextualType.isNull()) {
           Candidates.push_back(Candidate(CS, PrimaryExpr, contextualType,
-                                         CS.getContextualTypePurpose()));
+                                         CS.getContextualTypePurpose(expr)));
           return expr;
         }
 
@@ -1191,6 +1191,8 @@ ConstraintSystem::solveImpl(Expr *&expr,
   // Set up the expression type checker timer.
   Timer.emplace(expr, *this);
 
+  Expr *origExpr = expr;
+
   // Try to shrink the system by reducing disjunction domains. This
   // goes through every sub-expression and generate its own sub-system, to
   // try to reduce the domains of those subexpressions.
@@ -1209,23 +1211,23 @@ ConstraintSystem::solveImpl(Expr *&expr,
   // constraint.
   if (convertType) {
     auto constraintKind = ConstraintKind::Conversion;
-    
-    if ((getContextualTypePurpose() == CTP_ReturnStmt ||
-         getContextualTypePurpose() == CTP_ReturnSingleExpr ||
-         getContextualTypePurpose() == CTP_Initialization)
+
+    auto ctp = getContextualTypePurpose(origExpr);
+    if ((ctp == CTP_ReturnStmt ||
+         ctp == CTP_ReturnSingleExpr ||
+         ctp == CTP_Initialization)
         && Options.contains(ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType))
       constraintKind = ConstraintKind::OpaqueUnderlyingType;
     
-    if (getContextualTypePurpose() == CTP_CallArgument)
+    if (ctp == CTP_CallArgument)
       constraintKind = ConstraintKind::ArgumentConversion;
 
     // In a by-reference yield, we expect the contextual type to be an
     // l-value type, so the result must be bound to that.
-    if (getContextualTypePurpose() == CTP_YieldByReference)
+    if (ctp == CTP_YieldByReference)
       constraintKind = ConstraintKind::Bind;
 
-    bool isForSingleExprFunction =
-        getContextualTypePurpose() == CTP_ReturnSingleExpr;
+    bool isForSingleExprFunction = ctp == CTP_ReturnSingleExpr;
     auto *convertTypeLocator = getConstraintLocator(
         expr, LocatorPathElt::ContextualType(isForSingleExprFunction));
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -441,6 +441,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numFunctionBuilderTransformed = cs.functionBuilderTransformed.size();
   numResolvedOverloads = cs.ResolvedOverloads.size();
   numInferredClosureTypes = cs.ClosureTypes.size();
+  numContextualTypes = cs.contextualTypes.size();
 
   PreviousScore = cs.CurrentScore;
 
@@ -509,6 +510,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any inferred closure types (e.g. used in function builder body).
   truncate(cs.ClosureTypes, numInferredClosureTypes);
+
+  // Remove any contextual types.
+  truncate(cs.contextualTypes, numContextualTypes);
 
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2918,9 +2918,11 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
                      return locator
                          ->isLastElement<LocatorPathElt::ContextualType>();
                    })) {
+      auto anchor =
+          viableSolutions.front()->Fixes.front()->getLocator()->getAnchor();
       auto baseName = name.getBaseName();
       DE.diagnose(commonAnchor->getLoc(), diag::no_candidates_match_result_type,
-                  baseName.userFacingName(), getContextualType());
+                  baseName.userFacingName(), getContextualType(anchor));
     } else {
       emitGeneralAmbiguityFailure();
     }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2178,22 +2178,16 @@ public:
     assert(E != nullptr && "Expected non-null expression!");
     return E == contextualTypeNode ? contextualType.getType() : Type();
   }
-  Type getContextualType() const {
-    return contextualType.getType();
+
+  TypeLoc getContextualTypeLoc(Expr *expr) const {
+    return expr == contextualTypeNode ? contextualType : TypeLoc();
   }
 
-  TypeLoc getContextualTypeLoc() const {
-    return contextualType;
+  ContextualTypePurpose getContextualTypePurpose(Expr *expr) const {
+    return (expr && expr == contextualTypeNode) ? contextualTypePurpose
+                                                : CTP_Unused;
   }
 
-  const Expr *getContextualTypeNode() const {
-    return contextualTypeNode;
-  }
-
-  ContextualTypePurpose getContextualTypePurpose() const {
-    return contextualTypePurpose;
-  }
-  
   /// Retrieve the constraint locator for the given anchor and
   /// path, uniqued.
   ConstraintLocator *

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3770,9 +3770,9 @@ void ConstraintSystem::print(raw_ostream &out) const {
   
   out << "Score: " << CurrentScore << "\n";
 
-  if (auto ty = contextualType.getType()) {
-    out << "Contextual Type: " << ty.getString(PO);
-    if (TypeRepr *TR = contextualType.getTypeRepr()) {
+  for (const auto &contextualType : contextualTypes) {
+    out << "Contextual Type: " << contextualType.second.getType().getString(PO);
+    if (TypeRepr *TR = contextualType.second.typeLoc.getTypeRepr()) {
       out << " at ";
       TR->getSourceRange().print(out, getASTContext().SourceMgr, /*text*/false);
     }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2217,7 +2217,12 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
 
   // Tell the constraint system what the contextual type is.  This informs
   // diagnostics and is a hint for various performance optimizations.
-  cs.setContextualType(expr, convertType, convertTypePurpose);
+  // FIXME: Look through LoadExpr. This is an egregious hack due to the
+  // way typeCheckExprIndependently works.
+  Expr *contextualTypeExpr = expr;
+  if (auto loadExpr = dyn_cast_or_null<LoadExpr>(contextualTypeExpr))
+    contextualTypeExpr = loadExpr->getSubExpr();
+  cs.setContextualType(contextualTypeExpr, convertType, convertTypePurpose);
 
   // If the convertType is *only* provided for that hint, then null it out so
   // that we don't later treat it as an actual conversion constraint.

--- a/test/Constraints/assignment.swift
+++ b/test/Constraints/assignment.swift
@@ -67,6 +67,7 @@ value(_) // expected-error{{'_' can only appear in a pattern or on the left side
 func f23798944() {
   let s = ""
   if s.count = 0 { // expected-error {{use of '=' in a boolean context, did you mean '=='?}}
+    // expected-error@-1{{cannot assign to property: 'count' is a get-only property}}
   }
 }
 


### PR DESCRIPTION
When requesting information about the contextual type of a constraint
system, do so using a given expression rather than treating it like
the global state that it is.
