### PR TITLE
Disallow trailing commas when collection type sugar is parsed as exprs.

### DIFF
--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1478,6 +1478,11 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     return new (getASTContext()) TypeExpr(NewTypeRepr);
   }
   
+  auto diagnoseCollectionTrailingComma =
+      [](ASTContext &ctx, CollectionExpr *expr, Diag<> rbracketDiag) {
+        ctx.Diags.diagnose(expr->getCommaLocs()[0], rbracketDiag);
+        ctx.Diags.diagnose(expr->getLBracketLoc(), diag::opening_bracket);
+      };
 
   // Fold [T] into an array type.
   if (auto *AE = dyn_cast<ArrayExpr>(E)) {
@@ -1487,6 +1492,15 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     auto *TyExpr = dyn_cast<TypeExpr>(AE->getElement(0));
     if (!TyExpr)
       return nullptr;
+
+    if (AE->getNumCommas() != 0) {
+      // Once we know the element is a type, if there is a trailing comma, emit
+      // the same error that the parser would emit if this occurred in a type
+      // parsing context. Continue type-checking, however, to avoid spurious
+      // errors later on.
+      diagnoseCollectionTrailingComma(getASTContext(), AE,
+                                      diag::expected_rbracket_array_type);
+    }
 
     auto *NewTypeRepr = new (getASTContext())
         ArrayTypeRepr(TyExpr->getTypeRepr(),
@@ -1526,6 +1540,15 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       assert(TRE->getElements().size() == 2);
       keyTypeRepr = TRE->getElementType(0);
       valueTypeRepr = TRE->getElementType(1);
+    }
+
+    if (DE->getNumCommas() != 0) {
+      // Once we know the elements are types, if there is a trailing comma, emit
+      // the same error that the parser would emit if this occurred in a type
+      // parsing context. Continue type-checking, however, to avoid spurious
+      // errors later on.
+      diagnoseCollectionTrailingComma(getASTContext(), DE,
+                                      diag::expected_rbracket_dictionary_type);
     }
 
     auto *NewTypeRepr = new (getASTContext()) DictionaryTypeRepr(

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -125,3 +125,8 @@ let sr_11134_3 = [
 // expected-note@-1 {{add a separator between the elements}}{{12-12=,}}
 // expected-note@-2 {{remove the space between the elements to silence this warning}}{{12-13=}}
 ]
+
+// Disallow trailing commas when types are parsed in expression contexts.
+let _ = [Int,]() // expected-error {{expected ']' in array type}}
+                 // expected-note@-1 {{to match this opening '['}}
+let _ = [1,] // ok

--- a/test/type/dictionary.swift
+++ b/test/type/dictionary.swift
@@ -43,3 +43,8 @@ struct Y<T> : Hashable {
 let _ = [Y<Int>: Int]()
 let _ = [Y<Int> : Int]()
 let _ = [Y<Int> :Int]()
+
+// Disallow trailing commas when types are parsed in expression contexts.
+let _ = [Int: String,]() // expected-error {{expected ']' in dictionary type}}
+                         // expected-note@-1 {{to match this opening '['}}
+let _ = [1: "foo",] // ok


### PR DESCRIPTION
When the type checker simplifies an `ArrayExpr` or `DictionaryExpr` to the
equivalent `TypeRepr`, it doesn't check whether a trailing comma is present.
Since a trailing comma is allowed for normal expressions, this permits a
strange syntactic inconsistency:

```swift
let x = [Int,]()  // ok
let x: [Int,]     // error

let y = [String: Int,]()  // ok
let y: [String: Int,]     // error
```

This change makes it consistently an error when collection type sugar
parsed as an expression has a trailing comma.
