### PR TITLE
build: move the RPATH handling to the executables

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -245,17 +245,6 @@ macro(add_sourcekit_executable name)
   target_link_libraries(${name} PRIVATE ${LLVM_COMMON_LIBS})
 
   set_target_properties(${name} PROPERTIES FOLDER "SourceKit executables")
-  if (NOT SWIFT_ASAN_BUILD)
-    if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-      set_target_properties(${name}
-        PROPERTIES
-        LINK_FLAGS "-Wl,-exported_symbol,_main")
-    endif()
-    if(SWIFT_ANALYZE_CODE_COVERAGE)
-      set_property(TARGET "${name}" APPEND_STRING PROPERTY
-        LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
-    endif()
-  endif()
   add_sourcekit_default_compiler_flags("${name}")
 endmacro()
 

--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
@@ -13,12 +13,12 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     BlocksRuntime)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set_target_properties(complete-test
-    PROPERTIES
-    LINK_FLAGS "-Wl,-rpath -Wl,@executable_path/../lib")
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set_target_properties(complete-test PROPERTIES
+    INSTALL_RPATH "@executable_path/../lib")
+  target_link_options(complete-test PRIVATE
+    "LINKER:-exported_symbol,_main")
 endif()
-
 if(SWIFT_ANALYZE_CODE_COVERAGE)
   set_property(TARGET complete-test APPEND_STRING PROPERTY
     LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
@@ -26,6 +26,4 @@ endif()
 
 add_dependencies(tools complete-test)
 swift_install_in_component(TARGETS complete-test
-                           RUNTIME
-                             DESTINATION bin
-                             COMPONENT tools)
+  RUNTIME DESTINATION bin COMPONENT tools)

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -17,10 +17,11 @@ target_include_directories(sourcekitd-repl PRIVATE
 target_link_libraries(sourcekitd-repl PRIVATE
   ${LibEdit_LIBRARIES})
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set_target_properties(sourcekitd-repl
-    PROPERTIES
-    LINK_FLAGS "-Wl,-rpath -Wl,@executable_path/../lib")
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set_target_properties(sourcekitd-repl PROPERTIES
+    INSTALL_RPATH "@executable_path/../lib")
+  target_link_options(sourcekitd-repl PRIVATE
+    "LINKER:-exported_symbol,_main")
 endif()
 if(SWIFT_ANALYZE_CODE_COVERAGE)
   set_property(TARGET sourcekitd-repl APPEND_STRING PROPERTY
@@ -29,6 +30,4 @@ endif()
 
 add_dependencies(tools sourcekitd-repl)
 swift_install_in_component(TARGETS sourcekitd-repl
-                           RUNTIME
-                             DESTINATION bin
-                             COMPONENT tools)
+  RUNTIME DESTINATION bin COMPONENT tools)

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -25,12 +25,12 @@ endif()
 
 add_dependencies(sourcekitd-test sourcekitdTestOptionsTableGen)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set_target_properties(sourcekitd-test
-    PROPERTIES
-    LINK_FLAGS "-Wl,-rpath -Wl,@executable_path/../lib")
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set_target_properties(sourcekitd-test PROPERTIES
+    INSTALL_RPATH "@executable_path/../lib")
+  target_link_options(sourcekitd-test PRIVATE
+    "LINKER:-exported_symbol,_main")
 endif()
-
 if(SWIFT_ANALYZE_CODE_COVERAGE)
   set_property(TARGET sourcekitd-test APPEND_STRING PROPERTY
     LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
@@ -38,6 +38,4 @@ endif()
 
 add_dependencies(tools sourcekitd-test)
 swift_install_in_component(TARGETS sourcekitd-test
-                           RUNTIME
-                             DESTINATION bin
-                             COMPONENT tools)
+  RUNTIME DESTINATION bin COMPONENT tools)


### PR DESCRIPTION
This moves the handling of the RPATH and the exported symbol to the
binary themselves.  The exported symbol is needed due to the use of the
exported symbol list.  This makes the small difference that `_main` is
always exported on Darwin which is not strictly needed in ASAN as ASAN
provides the entry point.

The RPATH is only setup on installation which is sufficient for testing
purposes as CMake ensures that the libraries are fully linked and will
be loaded properly when run from the build tree.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
