### PR TITLE
TensorFlow: switch to using CTensorFlow from swift-apis

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -41,11 +41,10 @@ if (TENSORFLOW_SWIFT_APIS)
   endforeach()
 endif()
 
-get_filename_component(TensorFlow_LIBRARY_DIR ${TF_LIBRARY} DIRECTORY)
 add_swift_target_library(swiftTensorFlow ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   "${SOURCES}"
 
-  PRIVATE_LINK_LIBRARIES "${TF_LIBRARIES}"
+  PRIVATE_LINK_LIBRARIES ${TF_LIBRARY}
   SWIFT_MODULE_DEPENDS SwiftOnoneSupport
   SWIFT_MODULE_DEPENDS_IOS Darwin
   SWIFT_MODULE_DEPENDS_OSX Darwin
@@ -59,7 +58,7 @@ add_swift_target_library(swiftTensorFlow ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_
   SWIFT_MODULE_DEPENDS Python
   SWIFT_COMPILE_FLAGS
     ${swift_stdlib_compile_flags}
-    -Xcc -I${CMAKE_CURRENT_SOURCE_DIR}
+    -Xcc -I${TENSORFLOW_SWIFT_APIS}/Sources/CTensorFlow
     -Xcc -I${TF_INCLUDE_DIR}
   LINK_FLAGS
     ${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}
@@ -82,6 +81,8 @@ swift_install_in_component(DIRECTORY ${TF_INCLUDE_DIR}/tensorflow/c/
     PATTERN tf_status.h
     PATTERN tf_tensor.h
     PATTERN eager/c_api.h)
-swift_install_in_component(FILES module.modulemap CTensorFlow.h
+swift_install_in_component(FILES
+    ${TENSORFLOW_SWIFT_APIS}/Sources/CTensorFlow/module.modulemap
+    ${TENSORFLOW_SWIFT_APIS}/Sources/CTensorFlow/CTensorFlow.h
   DESTINATION lib/swift/tensorflow
   COMPONENT stdlib)

--- a/stdlib/public/TensorFlow/CTensorFlow.h
+++ b/stdlib/public/TensorFlow/CTensorFlow.h
@@ -1,8 +1,0 @@
-#ifndef CTensorFlow_CTensorFlow_h
-#define CTensorFlow_CTensorFlow_h
-
-#include <tensorflow/c/c_api.h>
-#include <tensorflow/c/c_api_experimental.h>
-#include <tensorflow/c/eager/c_api.h>
-
-#endif

--- a/stdlib/public/TensorFlow/module.modulemap
+++ b/stdlib/public/TensorFlow/module.modulemap
@@ -1,5 +1,0 @@
-module CTensorFlow {
-  header "CTensorFlow.h"
-
-  link "tensorflow"
-}


### PR DESCRIPTION
This adjusts the build to stop replicating the CTensorFlow module
locally and instead using the version in the swift-apis repository.
This more closely mimics the build as if it were out-of-tree enabling a
simpler migration to building this package out-of-tree.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
