### PR TITLE
build: add imported library for libedit

### DIFF
--- a/cmake/modules/FindLibEdit.cmake
+++ b/cmake/modules/FindLibEdit.cmake
@@ -59,6 +59,12 @@ else()
                                       LibEdit_LIBRARIES
                                     VERSION_VAR
                                       LibEdit_VERSION_STRING)
-  mark_as_advanced(LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES)
 endif()
 
+if(LibEdit_FOUND AND NOT TARGET libedit)
+  add_library(libedit UNKNOWN IMPORTED)
+  set_target_properties(libedit PROPERTIES
+    IMPORTED_LOCATION ${LibEdit_LIBRARIES}
+    INTERFACE_INCLUDE_DIRECTORIES ${LibEdit_INCLUDE_DIRS})
+endif()
+mark_as_advanced(LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES)

--- a/lib/Immediate/CMakeLists.txt
+++ b/lib/Immediate/CMakeLists.txt
@@ -16,5 +16,5 @@ if(LibEdit_FOUND AND LibEdit_HAS_UNICODE)
   target_compile_definitions(swiftImmediate PRIVATE
     HAVE_LIBEDIT)
   target_link_libraries(swiftImmediate PRIVATE
-    ${LibEdit_LIBRARIES})
+    libedit)
 endif()

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -12,10 +12,8 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     dispatch
     BlocksRuntime)
 endif()
-target_include_directories(sourcekitd-repl PRIVATE
-  ${LibEdit_INCLUDE_DIRS})
 target_link_libraries(sourcekitd-repl PRIVATE
-  ${LibEdit_LIBRARIES})
+  libedit)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set_target_properties(sourcekitd-repl


### PR DESCRIPTION
This allows us to use CMake more effectively rather than proliferating
the linking and header search path logic.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
