### PR TITLE
[Function builders] Support multiple Boolean conditions in 'if' statements

### DIFF
--- a/stdlib/public/Darwin/CMakeLists.txt
+++ b/stdlib/public/Darwin/CMakeLists.txt
@@ -44,7 +44,7 @@ set(all_overlays
   MetalKit
   ModelIO
   NaturalLanguage
-  Network
+#  Network
   ObjectiveC
   OpenCL
   os

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -461,3 +461,18 @@ func testNestedClosuresWithDependencies(cond: Bool) {
     }
   }
 }
+
+// Check that we can handle multiple conditions in an 'if' statement.
+func testIfConditions(cond: Bool, c1: Bool, i1: Int, i2: Int) {
+  tuplify(cond) { x in
+    "testIfConditions"
+    if i1 == i2, c1, x {
+      1
+      "hello"
+    }
+    3.14159
+  }
+}
+testIfConditions(cond: true, c1: true, i1: 1, i2: 1)
+// CHECK: testIfConditions
+// CHECK-SAME: hello


### PR DESCRIPTION
Generalize support for function builders to allow 'if' statements that
include multiple Boolean conditions, e.g., "if a, b, c, { ... }".
