### PR TITLE
[SE-0274] Update concise #file implementation in response to first round of review

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -139,6 +139,14 @@ ERROR(sdk_node_unrecognized_decl_kind,none,
 ERROR(sdk_node_unrecognized_accessor_kind,none,
       "unrecognized accessor kind '%0' in SDK node", (StringRef))
 
+// Emitted from ModuleDecl::computeMagicFileStringMap()
+WARNING(pound_source_location_creates_pound_file_conflicts,none,
+        "'#sourceLocation' directive produces '#file' string of '%0', which "
+        "conflicts with '#file' strings produced by other paths in the module",
+        (StringRef))
+NOTE(fixit_correct_source_location_file,none,
+     "change file in '#sourceLocation' to '%0'", (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Circular reference diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -305,7 +305,7 @@ public:
   /// Note that this returns an empty StringMap if concise \c #file strings are
   /// disabled. Users should fall back to using the file path in this case.
   llvm::StringMap<std::pair<std::string, /*isWinner=*/bool>>
-  computeMagicFileStringMap() const;
+  computeMagicFileStringMap(bool shouldDiagnose) const;
 
   /// Add a file declaring a cross-import overlay.
   void addCrossImportOverlayFile(StringRef file);

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -109,6 +109,38 @@ enum class SourceFileKind {
   Interface ///< Came from a .swiftinterface file, representing another module.
 };
 
+/// Contains information about where a particular path is used in
+/// \c SourceFiles.
+struct SourceFilePathInfo {
+  struct Comparator {
+    bool operator () (SourceLoc lhs, SourceLoc rhs) const {
+      return lhs.getOpaquePointerValue() <
+             rhs.getOpaquePointerValue();
+    }
+  };
+
+  SourceLoc physicalFileLoc{};
+  std::set<SourceLoc, Comparator> virtualFileLocs{}; // std::set for sorting
+
+  SourceFilePathInfo() = default;
+
+  void merge(const SourceFilePathInfo &other) {
+    if (other.physicalFileLoc.isValid()) {
+      assert(!physicalFileLoc.isValid());
+      physicalFileLoc = other.physicalFileLoc;
+    }
+
+    for (auto &elem : other.virtualFileLocs) {
+      virtualFileLocs.insert(elem);
+    }
+  }
+
+  bool operator == (const SourceFilePathInfo &other) const {
+    return physicalFileLoc == other.physicalFileLoc &&
+           virtualFileLocs == other.virtualFileLocs;
+  }
+};
+
 /// Discriminator for resilience strategy.
 enum class ResilienceStrategy : unsigned {
   /// Public nominal types: fragile
@@ -256,6 +288,24 @@ public:
   bool isClangModule() const;
   void addFile(FileUnit &newFile);
   void removeFile(FileUnit &existingFile);
+
+  /// Creates a map from \c #filePath strings to corresponding \c #file
+  /// strings, diagnosing any conflicts.
+  ///
+  /// A given \c #filePath string always maps to exactly one \c #file string,
+  /// but it is possible for \c #sourceLocation directives to introduce
+  /// duplicates in the opposite direction. If there are such conflicts, this
+  /// method will diagnose the conflict and choose a "winner" among the paths
+  /// in a reproducible way. The \c bool paired with the \c #file string is
+  /// \c true for paths which did not have a conflict or won a conflict, and
+  /// \c false for paths which lost a conflict. Thus, if you want to generate a
+  /// reverse mapping, you should drop or special-case the \c #file strings that
+  /// are paired with \c false.
+  ///
+  /// Note that this returns an empty StringMap if concise \c #file strings are
+  /// disabled. Users should fall back to using the file path in this case.
+  llvm::StringMap<std::pair<std::string, /*isWinner=*/bool>>
+  computeMagicFileStringMap() const;
 
   /// Add a file declaring a cross-import overlay.
   void addCrossImportOverlayFile(StringRef file);

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -321,6 +321,12 @@ public:
   /// forwarded on to IRGen.
   ASTStage_t ASTStage = Unprocessed;
 
+  /// Virtual filenames declared by #sourceLocation(file:) directives in this
+  /// file.
+  llvm::SmallVector<Located<StringRef>, 0> VirtualFilenames;
+
+  llvm::StringMap<SourceFilePathInfo> getInfoForUsedFilePaths() const;
+
   SourceFile(ModuleDecl &M, SourceFileKind K, Optional<unsigned> bufferID,
              ImplicitModuleImportKind ModImpKind, bool KeepParsedTokens = false,
              bool KeepSyntaxTree = false, ParsingOptions parsingOpts = {});

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4822,7 +4822,8 @@ ParserStatus Parser::parseLineDirective(bool isLine) {
           getStringLiteralIfNotInterpolated(Loc, "'#sourceLocation'");
       if (!Filename.hasValue())
         return makeParserError();
-      consumeToken(tok::string_literal);
+      SourceLoc filenameLoc = consumeToken(tok::string_literal);
+      SF.VirtualFilenames.emplace_back(*Filename, filenameLoc);
 
       if (parseToken(tok::comma, diag::sourceLocation_expected, ",") ||
           parseSpecificIdentifier("line", diag::sourceLocation_expected,

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -47,6 +47,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/FileSystem.h"
+#include <set>
 
 
 using namespace swift;
@@ -2750,6 +2751,57 @@ printSILCoverageMaps(SILPrintContext &Ctx,
     M->print(Ctx);
 }
 
+using MagicFileStringMap =
+    llvm::StringMap<std::pair<std::string, /*isWinner=*/bool>>;
+
+static void
+printMagicFileStringMapEntry(SILPrintContext &Ctx,
+                             const MagicFileStringMap::MapEntryTy &entry) {
+  auto &OS = Ctx.OS();
+  OS << "//   '" << std::get<0>(entry.second)
+     << "' => '" << entry.first() << "'";
+
+  if (!std::get<1>(entry.second))
+    OS << " (alternate)";
+
+  OS << "\n";
+}
+
+static void printMagicFileStringMap(SILPrintContext &Ctx,
+                                    const MagicFileStringMap map) {
+  if (map.empty())
+    return;
+
+  Ctx.OS() << "\n\n// Mappings from '#file' to '#filePath':\n";
+
+  if (Ctx.sortSIL()) {
+    llvm::SmallVector<llvm::StringRef, 16> keys;
+    llvm::copy(map.keys(), std::back_inserter(keys));
+
+    llvm::sort(keys, [&](StringRef leftKey, StringRef rightKey) -> bool {
+      const auto &leftValue = map.find(leftKey)->second;
+      const auto &rightValue = map.find(rightKey)->second;
+
+      // Lexicographically earlier #file strings sort earlier.
+      if (std::get<0>(leftValue) != std::get<0>(rightValue))
+        return std::get<0>(leftValue) < std::get<0>(rightValue);
+
+      // Conflict winners sort before losers.
+      if (std::get<1>(leftValue) != std::get<1>(rightValue))
+        return std::get<1>(leftValue);
+
+      // Finally, lexicographically earlier #filePath strings sort earlier.
+      return leftKey < rightKey;
+    });
+
+    for (auto key : keys)
+      printMagicFileStringMapEntry(Ctx, *map.find(key));
+  } else {
+    for (const auto &entry : map)
+      printMagicFileStringMapEntry(Ctx, entry);
+  }
+}
+
 void SILProperty::print(SILPrintContext &Ctx) const {
   PrintOptions Options = PrintOptions::printSIL();
   
@@ -2863,6 +2915,10 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
   printSILCoverageMaps(PrintCtx, getCoverageMaps());
   printSILProperties(PrintCtx, getPropertyList());
   printExternallyVisibleDecls(PrintCtx, externallyVisible.getArrayRef());
+
+  if (M)
+    printMagicFileStringMap(
+        PrintCtx, M->computeMagicFileStringMap());
 
   OS << "\n\n";
 }

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2918,7 +2918,7 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
 
   if (M)
     printMagicFileStringMap(
-        PrintCtx, M->computeMagicFileStringMap());
+        PrintCtx, M->computeMagicFileStringMap(/*shouldDiagnose=*/false));
 
   OS << "\n\n";
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -50,7 +50,8 @@ using namespace Lowering;
 //===----------------------------------------------------------------------===//
 
 SILGenModule::SILGenModule(SILModule &M, ModuleDecl *SM)
-    : M(M), Types(M.Types), SwiftModule(SM), TopLevelSGF(nullptr) {
+    : M(M), Types(M.Types), SwiftModule(SM), TopLevelSGF(nullptr),
+      MagicFileStringsByFilePath(SM->computeMagicFileStringMap()) {
   const SILOptions &Opts = M.getOptions();
   if (!Opts.UseProfile.empty()) {
     auto ReaderOrErr = llvm::IndexedInstrProfReader::create(Opts.UseProfile);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -51,7 +51,8 @@ using namespace Lowering;
 
 SILGenModule::SILGenModule(SILModule &M, ModuleDecl *SM)
     : M(M), Types(M.Types), SwiftModule(SM), TopLevelSGF(nullptr),
-      MagicFileStringsByFilePath(SM->computeMagicFileStringMap()) {
+      MagicFileStringsByFilePath(
+          SM->computeMagicFileStringMap(/*shouldDiagnose=*/true)) {
   const SILOptions &Opts = M.getOptions();
   if (!Opts.UseProfile.empty()) {
     auto ReaderOrErr = llvm::IndexedInstrProfReader::create(Opts.UseProfile);

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -131,6 +131,9 @@ public:
 
   ASTContext &getASTContext() { return M.getASTContext(); }
 
+  llvm::StringMap<std::pair<std::string, /*isWinner=*/bool>>
+  MagicFileStringsByFilePath;
+
   static DeclName getMagicFunctionName(SILDeclRef ref);
   static DeclName getMagicFunctionName(DeclContext *dc);
   

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4892,13 +4892,11 @@ StringRef SILGenFunction::getMagicFilePathString(SourceLoc loc) {
 std::string SILGenFunction::getMagicFileString(SourceLoc loc) {
   auto path = getMagicFilePathString(loc);
 
-  if (!getASTContext().LangOpts.EnableConcisePoundFile)
-    return path;
+  auto result = SGM.MagicFileStringsByFilePath.find(path);
+  if (result != SGM.MagicFileStringsByFilePath.end())
+    return std::get<0>(result->second);
 
-  auto value = getModule().getSwiftModule()->getNameStr().str();
-  value += "/";
-  value += llvm::sys::path::filename(path).str();
-  return value;
+  return path;
 }
 
 /// Emit an application of the given allocating initializer.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4895,10 +4895,9 @@ std::string SILGenFunction::getMagicFileString(SourceLoc loc) {
   if (!getASTContext().LangOpts.EnableConcisePoundFile)
     return path;
 
-  auto value = llvm::sys::path::filename(path).str();
-  value += " (";
-  value += getModule().getSwiftModule()->getNameStr();
-  value += ")";
+  auto value = getModule().getSwiftModule()->getNameStr().str();
+  value += "/";
+  value += llvm::sys::path::filename(path).str();
   return value;
 }
 

--- a/test/SILGen/Inputs/magic_identifier_file_conflicting_other.swift
+++ b/test/SILGen/Inputs/magic_identifier_file_conflicting_other.swift
@@ -1,0 +1,8 @@
+// This file matches test/SILGen/magic_identifier_file_conflicting.swift.
+// It should be compiled with -verify.
+
+// We should diagnose cross-file conflicts.
+// expected-warning@+2 {{'#sourceLocation' directive produces '#file' string of 'Foo/other_file_c.swift', which conflicts with '#file' strings produced by other paths in the module}}
+// expected-note@+1 {{change file in '#sourceLocation' to 'first/other_file_c.swift'}} {{23-50="first/other_file_c.swift"}}
+#sourceLocation(file: "second/other_file_c.swift", line: 1)
+#sourceLocation()

--- a/test/SILGen/magic_identifier_file.swift
+++ b/test/SILGen/magic_identifier_file.swift
@@ -31,3 +31,7 @@ func forceTry(_ fn: () throws -> ()) {
 // ABSOLUTE: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_file.swift"
 // CONCISE: string_literal utf8 "Foo/magic_identifier_file.swift"
 }
+
+// CONCISE-LABEL: // Mappings from '#file' to '#filePath':
+// CONCISE:       //   'Foo/magic_identifier_file.swift' => 'SOURCE_DIR/test/SILGen/magic_identifier_file.swift'
+

--- a/test/SILGen/magic_identifier_file.swift
+++ b/test/SILGen/magic_identifier_file.swift
@@ -8,26 +8,26 @@ func directUse() {
 // BOTH-LABEL: sil {{.*}} @$s3Foo9directUseyyF
   print(#file)
 // ABSOLUTE: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_file.swift"
-// CONCISE: string_literal utf8 "magic_identifier_file.swift (Foo)"
+// CONCISE: string_literal utf8 "Foo/magic_identifier_file.swift"
 }
 
 func indirectUse() {
 // BOTH-LABEL: sil {{.*}} @$s3Foo11indirectUseyyF
   fatalError()
 // ABSOLUTE: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_file.swift"
-// CONCISE: string_literal utf8 "magic_identifier_file.swift (Foo)"
+// CONCISE: string_literal utf8 "Foo/magic_identifier_file.swift"
 }
 
 func forceUnwrap(_ x: ()?) {
 // BOTH-LABEL: sil {{.*}} @$s3Foo11forceUnwrapyyytSgF
   _ = x!
 // ABSOLUTE: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_file.swift"
-// CONCISE: string_literal utf8 "magic_identifier_file.swift (Foo)"
+// CONCISE: string_literal utf8 "Foo/magic_identifier_file.swift"
 }
 
 func forceTry(_ fn: () throws -> ()) {
 // BOTH-LABEL: sil {{.*}} @$s3Foo8forceTryyyyyKXEF
   try! fn()
 // ABSOLUTE: string_literal utf8 "SOURCE_DIR/test/SILGen/magic_identifier_file.swift"
-// CONCISE: string_literal utf8 "magic_identifier_file.swift (Foo)"
+// CONCISE: string_literal utf8 "Foo/magic_identifier_file.swift"
 }

--- a/test/SILGen/magic_identifier_file_conflicting.swift.gyb
+++ b/test/SILGen/magic_identifier_file_conflicting.swift.gyb
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %gyb -D TEMPDIR=%t %s > %t/magic_identifier_file_conflicting.swift
+// RUN: %gyb -D TEMPDIR=%t %s -o %t/magic_identifier_file_conflicting.swift
 
 // We want to check both the diagnostics and the SIL output.
 // RUN: %target-swift-emit-silgen -verify -emit-sorted-sil -enable-experimental-concise-pound-file -module-name Foo %t/magic_identifier_file_conflicting.swift %S/Inputs/magic_identifier_file_conflicting_other.swift | %FileCheck %s

--- a/test/SILGen/magic_identifier_file_conflicting.swift.gyb
+++ b/test/SILGen/magic_identifier_file_conflicting.swift.gyb
@@ -1,0 +1,96 @@
+// RUN: %empty-directory(%t)
+// RUN: %gyb -D TEMPDIR=%t %s > %t/magic_identifier_file_conflicting.swift
+
+// We want to check both the diagnostics and the SIL output.
+// RUN: %target-swift-emit-silgen -verify -emit-sorted-sil -enable-experimental-concise-pound-file -module-name Foo %t/magic_identifier_file_conflicting.swift %S/Inputs/magic_identifier_file_conflicting_other.swift | %FileCheck %s
+
+%{
+TEMPDIR_ESC = TEMPDIR.replace('\\', '\\\\')
+def fixit_loc(start_col, orig_suffix):
+  """
+  Computes a "start-end" string for a fix-it replacing a string literal which
+  starts at start_col and joins orig_suffix to TEMPDIR with a slash.
+  """
+  original = '"{0}/{1}"'.format(TEMPDIR, orig_suffix)
+  end_col = start_col + len(original)
+  return '{0}-{1}'.format(start_col, end_col)
+}%
+
+//
+// Same name as a physical file
+//
+
+// There should be no warning for the exact same path.
+// no-warning
+#sourceLocation(file: "${TEMPDIR_ESC}/magic_identifier_file_conflicting.swift", line: 10)
+#sourceLocation()
+
+// expected-warning@+2 {{'#sourceLocation' directive produces '#file' string of 'Foo/magic_identifier_file_conflicting.swift', which conflicts with '#file' strings produced by other paths in the module}}
+// expected-note@+1 {{change file in '#sourceLocation' to '${TEMPDIR_ESC}/magic_identifier_file_conflicting.swift'}} {{${fixit_loc(23, "other_path_b/magic_identifier_file_conflicting.swift")}="${TEMPDIR_ESC}/magic_identifier_file_conflicting.swift"}}
+#sourceLocation(file: "${TEMPDIR_ESC}/other_path_b/magic_identifier_file_conflicting.swift", line: 20)
+#sourceLocation()
+
+// expected-warning@+2 {{'#sourceLocation' directive produces '#file' string of 'Foo/magic_identifier_file_conflicting.swift', which conflicts with '#file' strings produced by other paths in the module}}
+// expected-note@+1 {{change file in '#sourceLocation' to '${TEMPDIR_ESC}/magic_identifier_file_conflicting.swift'}} {{23-64="${TEMPDIR_ESC}/magic_identifier_file_conflicting.swift"}}
+#sourceLocation(file: "magic_identifier_file_conflicting.swift", line: 30)
+#sourceLocation()
+
+//
+// No physical file with the same name
+//
+
+// There shoud be no warning for a purely virtual file.
+// no-warning
+#sourceLocation(file: "other_file_a.swift", line: 40)
+#sourceLocation()
+
+// Even if you use it twice.
+// no-warning
+#sourceLocation(file: "other_file_a.swift", line: 50)
+#sourceLocation()
+
+// But there should be warnings for different-path, same-name virtual files.
+// The lexicographically first path should be treated as canonical--we diagnose
+// but don't offer a fix-it.
+// expected-warning@+1 {{'#sourceLocation' directive produces '#file' string of 'Foo/other_file_b.swift', which conflicts with '#file' strings produced by other paths in the module}}
+#sourceLocation(file: "first/other_file_b.swift", line: 60)
+#sourceLocation()
+
+// Subsequent paths should fix-it to the first one.
+// expected-warning@+2 {{'#sourceLocation' directive produces '#file' string of 'Foo/other_file_b.swift', which conflicts with '#file' strings produced by other paths in the module}}
+// expected-note@+1 {{change file in '#sourceLocation' to 'first/other_file_b.swift'}} {{23-50="first/other_file_b.swift"}}
+#sourceLocation(file: "second/other_file_b.swift", line: 70)
+#sourceLocation()
+
+// Even if there's more than one.
+// expected-warning@+2 {{'#sourceLocation' directive produces '#file' string of 'Foo/other_file_b.swift', which conflicts with '#file' strings produced by other paths in the module}}
+// expected-note@+1 {{change file in '#sourceLocation' to 'first/other_file_b.swift'}} {{23-49="first/other_file_b.swift"}}
+#sourceLocation(file: "third/other_file_b.swift", line: 80)
+#sourceLocation()
+
+// Even if one is duplicated.
+// expected-warning@+2 {{'#sourceLocation' directive produces '#file' string of 'Foo/other_file_b.swift', which conflicts with '#file' strings produced by other paths in the module}}
+// expected-note@+1 {{change file in '#sourceLocation' to 'first/other_file_b.swift'}} {{23-49="first/other_file_b.swift"}}
+#sourceLocation(file: "third/other_file_b.swift", line: 90)
+#sourceLocation()
+
+// We should diagnose cross-file conflicts.
+// expected-warning@+1 {{'#sourceLocation' directive produces '#file' string of 'Foo/other_file_c.swift', which conflicts with '#file' strings produced by other paths in the module}}
+#sourceLocation(file: "first/other_file_c.swift", line: 100)
+#sourceLocation()
+
+//
+// Check '#file' => '#filePath' mapping table
+//
+
+// CHECK-LABEL: // Mappings from '#file' to '#filePath':
+// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'BUILD_DIR{{[/\\]}}test-{{[^/]+}}{{[/\\]}}SILGen{{[/\\]}}Output{{[/\\]}}magic_identifier_file_conflicting.swift.gyb.tmp{{[/\\]}}magic_identifier_file_conflicting.swift'
+// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'BUILD_DIR{{[/\\]}}test-{{[^/]+}}{{[/\\]}}SILGen{{[/\\]}}Output{{[/\\]}}magic_identifier_file_conflicting.swift.gyb.tmp{{[/\\]}}other_path_b{{[/\\]}}magic_identifier_file_conflicting.swift' (alternate)
+// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting.swift' => 'magic_identifier_file_conflicting.swift' (alternate)
+// CHECK-NEXT:  //   'Foo/magic_identifier_file_conflicting_other.swift' => 'SOURCE_DIR{{[/\\]}}test{{[/\\]}}SILGen{{[/\\]}}Inputs{{[/\\]}}magic_identifier_file_conflicting_other.swift'
+// CHECK-NEXT:  //   'Foo/other_file_a.swift' => 'other_file_a.swift'
+// CHECK-NEXT:  //   'Foo/other_file_b.swift' => 'first/other_file_b.swift'
+// CHECK-NEXT:  //   'Foo/other_file_b.swift' => 'second/other_file_b.swift' (alternate)
+// CHECK-NEXT:  //   'Foo/other_file_b.swift' => 'third/other_file_b.swift' (alternate)
+// CHECK-NEXT:  //   'Foo/other_file_c.swift' => 'first/other_file_c.swift'
+// CHECK-NEXT:  //   'Foo/other_file_c.swift' => 'second/other_file_c.swift' (alternate)

--- a/test/SILGen/magic_identifier_file_conflicting.swift.gyb
+++ b/test/SILGen/magic_identifier_file_conflicting.swift.gyb
@@ -4,6 +4,11 @@
 // We want to check both the diagnostics and the SIL output.
 // RUN: %target-swift-emit-silgen -verify -emit-sorted-sil -enable-experimental-concise-pound-file -module-name Foo %t/magic_identifier_file_conflicting.swift %S/Inputs/magic_identifier_file_conflicting_other.swift | %FileCheck %s
 
+// FIXME: Make this test work on Windows. There's no fundamental reason it
+//        can't; we just need someone with a Windows machine to do it so we
+//        don't have a 30-minute debug cycle.
+// UNSUPPORTED: OS=windows-msvc
+
 %{
 TEMPDIR_ESC = TEMPDIR.replace('\\', '\\\\')
 def fixit_loc(start_col, orig_suffix):

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1208,12 +1208,13 @@ def main():
         help='''Bindings to be set in the template's execution context''')
 
     parser.add_argument(
-        'file', type=argparse.FileType(),
+        'file', type=argparse.FileType('rb'),
         help='Path to GYB template file (defaults to stdin)', nargs='?',
-        default=sys.stdin)
+        default=sys.stdin)    # FIXME: stdin not binary mode on Windows
     parser.add_argument(
-        '-o', dest='target', type=argparse.FileType('w'),
-        help='Output file (defaults to stdout)', default=sys.stdout)
+        '-o', dest='target', type=argparse.FileType('wb'),
+        help='Output file (defaults to stdout)',
+        default=sys.stdout)    # FIXME: stdout not binary mode on Windows
     parser.add_argument(
         '--test', action='store_true',
         default=False, help='Run a self-test')


### PR DESCRIPTION
This PR addresses several issues that came up in the first review of SE-0274:

* The format of the `#file` string is now `<module>/<filename>`. (Technically, the proposal will also allow it to be `<module>/<other-stuff>/<filename>` instead, but that's for future expansion.)

* If a `#sourceLocation(file:line:)` directive maps to the same `#file` string as a real file or another `#sourceLocation` directive, but the paths don't match exactly, the compiler now emits a warning.

* `-emit-sil` and related textual SIL outputs now include a comment with a table mapping `#file` strings to `#filePath` strings. This is a proof-of-concept demonstrating that we can expose this information in e.g. SourceKit later on.

The proposal will be updated to include these changes shortly.