### PR TITLE
[CSDiag] Start chipping away at FailureDiagnosis::diagnoseAmbiguity

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2827,7 +2827,8 @@ namespace {
 
     Type visitDiscardAssignmentExpr(DiscardAssignmentExpr *expr) {
       auto locator = CS.getConstraintLocator(expr);
-      auto typeVar = CS.createTypeVariable(locator, TVO_CanBindToNoEscape);
+      auto typeVar = CS.createTypeVariable(locator, TVO_CanBindToNoEscape |
+                                                    TVO_CanBindToHole);
       return LValueType::get(typeVar);
     }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1271,7 +1271,7 @@ func badTypes() {
 // rdar://34357545
 func unresolvedTypeExistential() -> Bool {
   return (Int.self==_{})
-  // expected-error@-1 {{expression type 'Bool' is ambiguous without more context}}
+  // expected-error@-1 {{'_' can only appear in a pattern or on the left side of an assignment}}
 }
 
 func rdar43525641(_ a: Int, _ b: Int = 0, c: Int = 0, _ d: Int) {}

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -288,8 +288,7 @@ case (_, var e, 3) +++ (1, 2, 3):
 // expected-error@-2{{'var' binding pattern cannot appear in an expression}}
   ()
 case (let (_, _, _)) + 1:
-// expected-error@-1 2 {{'var' binding pattern cannot appear in an expression}}
-// expected-error@-2 {{expression pattern of type 'Int' cannot match values of type '(Int, Int, Int)'}}
+// expected-error@-1 {{expression pattern of type 'Int' cannot match values of type '(Int, Int, Int)'}}
   ()
 }
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -708,7 +708,7 @@ func test() {
 func unusedExpressionResults() {
   // Unused l-value
   _ // expected-error{{'_' can only appear in a pattern or on the left side of an assignment}}
-
+  // expected-error@-1 {{expression resolves to an unused variable}}
 
   // <rdar://problem/20749592> Conditional Optional binding hides compiler error
   let optionalc:C? = nil


### PR DESCRIPTION
Remove some special cases in `FailureDiagnosis::diagnoseAmbiguity`, including:
* Invalid use of `_`. Find solutions using holes for the type of the invalid underscore.
* Empty collection literals without contextual type
* Nil literal without contextual type