### PR TITLE
fix tensorflow headers install location

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -72,7 +72,7 @@ add_swift_target_library(swiftTensorFlow ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_
 
 
 swift_install_in_component(DIRECTORY ${TF_INCLUDE_DIR}/tensorflow/c/
-  DESTINATION lib/swift/tensorflow/tensorflow/c
+  DESTINATION lib/swift/tensorflow/c
   COMPONENT stdlib
   FILES_MATCHING
     PATTERN c_api.h


### PR DESCRIPTION
The compiler and the repl search for headers at `lib/swift`. The tensorflow headers have includes like `#include "tensorflow/c/bla.h"`. This change moves the tensorflow headers so that these includes get found successfully.

I have verified that the toolchain builds and no longer has the header search problem.