### PR TITLE
SIL optimizer: propagate count and capacity from empty Array/Set/Dictionary singletons.

### DIFF
--- a/test/SILOptimizer/empty_collection_count.swift
+++ b/test/SILOptimizer/empty_collection_count.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Osize %s | %FileCheck %s
+
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+// This is an end-to-end test if the count and/or capacity from empty
+// array/set/dictionary singletons can be propagated.
+
+// CHECK-LABEL: sil @{{.*}}testArray
+// CHECK-NOT: global_addr
+// CHECK: [[Z:%[0-9]+]] = integer_literal $Builtin.Int{{[0-9]*}}, 0 
+// CHECK: [[I:%[0-9]+]] = struct $Int ([[Z]] : $Builtin.Int{{[0-9]*}})
+// CHECK: return [[I]]
+public func testArray() -> Int {
+  let d = Array<Int>()
+  return d.count
+}
+
+// CHECK-LABEL: sil @{{.*}}testDictionary
+// CHECK-NOT: global_addr
+// CHECK: [[Z:%[0-9]+]] = integer_literal $Builtin.Int{{[0-9]*}}, 0 
+// CHECK: [[I:%[0-9]+]] = struct $Int ([[Z]] : $Builtin.Int{{[0-9]*}})
+// CHECK: return [[I]]
+public func testDictionary() -> Int {
+  let d = Dictionary<Int, Int>()
+  return d.count + d.capacity
+}
+
+// CHECK-LABEL: sil @{{.*}}testSet
+// CHECK-NOT: global_addr
+// CHECK: [[Z:%[0-9]+]] = integer_literal $Builtin.Int{{[0-9]*}}, 0 
+// CHECK: [[I:%[0-9]+]] = struct $Int ([[Z]] : $Builtin.Int{{[0-9]*}})
+// CHECK: return [[I]]
+public func testSet() -> Int {
+  let d = Set<Int>()
+  return d.count + d.capacity
+}
+

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -22,6 +22,16 @@ public func returnTestOptions() -> TestOptions {
     return [.first, .second, .third, .fourth]
 }
 
+// CHECK:      sil @{{.*}}returnEmptyTestOptions{{.*}}
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   integer_literal {{.*}}, 0
+// CHECK-NEXT:   struct $Int
+// CHECK-NEXT:   struct $TestOptions
+// CHECK-NEXT:   return
+public func returnEmptyTestOptions() -> TestOptions {
+    return []
+}
+
 // CHECK:        alloc_global @{{.*}}globalTestOptions{{.*}}
 // CHECK-NEXT:   global_addr
 // CHECK-NEXT:   integer_literal {{.*}}, 15


### PR DESCRIPTION
Constant-propagate the 0 value when loading "count" or "capacity" from the empty Array, Set or Dictionary storage.
On high-level SIL this optimization is also done by the ArrayCountPropagation pass, but only for Array.
And even for Array it's sometimes needed to propagate the empty-array count when high-level semantics function are already inlined.

Fixes an optimization deficiency for empty OptionSet literals.

https://bugs.swift.org/browse/SR-12046
rdar://problem/58861171
