### PR TITLE
Added an inline keyword to a function defined in a header

### DIFF
--- a/lib/IRGen/SwitchBuilder.h
+++ b/lib/IRGen/SwitchBuilder.h
@@ -165,10 +165,9 @@ public:
   }
 };
 
-std::unique_ptr<SwitchBuilder> SwitchBuilder::create(IRGenFunction &IGF,
-                                                     llvm::Value *Subject,
-                                                     SwitchDefaultDest Default,
-                                                     unsigned NumCases) {
+inline std::unique_ptr<SwitchBuilder>
+SwitchBuilder::create(IRGenFunction &IGF, llvm::Value *Subject,
+                      SwitchDefaultDest Default, unsigned NumCases) {
   // Pick a builder based on how many total reachable destinations we intend
   // to have.
   switch (NumCases + (Default.getInt() == IsNotUnreachable)) {


### PR DESCRIPTION
Otherwise, we could get an ODR violation due to duplicate definitions
coming from multiple translation units that include this header.
