### PR TITLE
[Constraint system] Set the contextual type for condition expressions.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3821,6 +3821,7 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
     return true;
   }
 
+  Type boolTy = boolDecl->getDeclaredType();
   for (const auto &condElement : condition) {
     switch (condElement.getKind()) {
     case StmtConditionElement::CK_Availability:
@@ -3829,6 +3830,8 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
 
     case StmtConditionElement::CK_Boolean: {
       Expr *condExpr = condElement.getBoolean();
+      setContextualType(condExpr, TypeLoc::withoutLoc(boolTy), CTP_Condition);
+
       condExpr = generateConstraints(condExpr, dc);
       if (!condExpr) {
         return true;
@@ -3836,8 +3839,9 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
 
       addConstraint(ConstraintKind::Conversion,
                     getType(condExpr),
-                    boolDecl->getDeclaredType(),
-                    getConstraintLocator(condExpr));
+                    boolTy,
+                    getConstraintLocator(condExpr,
+                                         LocatorPathElt::ContextualType()));
       continue;
     }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -168,6 +168,10 @@ Solution ConstraintSystem::finalize() {
     solution.addedNodeTypes.insert(nodeType);
   }
 
+  // Remember contextual types.
+  solution.contextualTypes.assign(
+      contextualTypes.begin(), contextualTypes.end());
+
   for (auto &e : CheckedConformances)
     solution.Conformances.push_back({e.first, e.second});
 
@@ -230,6 +234,14 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   for (auto &nodeType : solution.addedNodeTypes) {
     if (!hasType(nodeType.first))
       setType(nodeType.first, nodeType.second);
+  }
+
+  // Add the contextual types.
+  for (const auto &contextualType : solution.contextualTypes) {
+    if (!getContextualTypeInfo(contextualType.first)) {
+      setContextualType(contextualType.first, contextualType.second.typeLoc,
+                        contextualType.second.purpose);
+    }
   }
 
   // Register the conformances checked along the way to arrive to solution.

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -257,7 +257,7 @@ struct MyTuplifiedStruct {
   }
 }
 
-// Check that we're performing syntactic use diagnostics/
+// Check that we're performing syntactic use diagnostics.
 func acceptMetatype<T>(_: T.Type) -> Bool { true }
 
 func syntacticUses<T>(_: T) {
@@ -266,6 +266,21 @@ func syntacticUses<T>(_: T) {
       // expected-note@-1{{use '.self' to reference the type object}}
       acceptMetatype(T) // expected-error{{expected member name or constructor call after type name}}
       // expected-note@-1{{use '.self' to reference the type object}}
+    }
+  }
+}
+
+// Check custom diagnostics within "if" conditions.
+struct HasProperty {
+  var property: Bool = false
+}
+
+func checkConditions(cond: Bool) {
+  var x = HasProperty()
+
+  tuplify(cond) { value in
+    if x.property = value { // expected-error{{use of '=' in a boolean context, did you mean '=='?}}
+      "matched it"
     }
   }
 }


### PR DESCRIPTION
Set the contextual type of conditional expressions (to Bool) with the
"condition" purpose so we get customized diagnostics for mistakes such
as

    if x.property = y { }

Prior to this, we'd get generic "() isn't convertible to Bool"
diagnostic. Now we get

    use of '=' in a boolean context, did you mean '=='?