### PR TITLE
[sourcekitd-test] When setting -fmodules-cache-path also set -fmodules

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -987,6 +987,13 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     sourcekitd_object_t Args = sourcekitd_request_array_create(nullptr, 0);
     if (!Opts.ModuleCachePath.empty()) {
       if (compilerArgsAreClang) {
+        // We need -fmodules or else the clang argument parsing does not honour
+        // -fmodules-cache-path. In reality, the swift ClangImporter will always
+        // enable modules when importing, so this should only impact the
+        // clang argument parsing. This is needed even if the header doesn't
+        // use modules, since Swift itself will import its shims module, and
+        // that needs to honour the -module-cache-path option when testing.
+        sourcekitd_request_array_set_string(Args, SOURCEKITD_ARRAY_APPEND, "-fmodules");
         std::string opt = "-fmodules-cache-path=" + Opts.ModuleCachePath;
         sourcekitd_request_array_set_string(Args, SOURCEKITD_ARRAY_APPEND, opt.c_str());
       } else {


### PR DESCRIPTION
When doing header interface generation, we interpret clang command-line
arguments in `initInvocationByClangArguments` and attempt to setup a
matching Swift compiler invocation. One important argument is the module
cache, but clang will only interpret `-fmodules-cache-path` if modules
are enabled (typically with `-fmodules`). While the header itself might
not need modules, Swift will import its own shims module and during
testing this needs to honour lit's provided cache. So we add -fmodules
in sourcekitd-test anytime we add -fmodules-cache-path.

rdar://58836540