### PR TITLE
[metadata prespecialization] Future availability.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -625,6 +625,10 @@ public:
   /// compiler for the target platform.
   AvailabilityContext getSwift52Availability();
 
+  /// Get the runtime availability of features that have been introduced in the
+  /// Swift compiler for future versions of the target platform.
+  AvailabilityContext getSwiftFutureAvailability();
+
 
   //===--------------------------------------------------------------------===//
   // Diagnostics Helper functions

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -243,10 +243,27 @@ AvailabilityContext ASTContext::getTypesInAbstractMetadataStateAvailability() {
 }
 
 AvailabilityContext ASTContext::getPrespecializedGenericMetadataAvailability() {
-  return getSwift52Availability();
+  return getSwiftFutureAvailability();
 }
 
 AvailabilityContext ASTContext::getSwift52Availability() {
+  auto target = LangOpts.Target;
+
+  if (target.isMacOSX() ) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(10, 99, 0)));
+  } else if (target.isiOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(99, 0, 0)));
+  } else if (target.isWatchOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(9, 99, 0)));
+  } else {
+    return AvailabilityContext::alwaysAvailable();
+  }
+}
+
+AvailabilityContext ASTContext::getSwiftFutureAvailability() {
   auto target = LangOpts.Target;
 
   if (target.isMacOSX() ) {


### PR DESCRIPTION
Metadata prespecialization will be available after Swift 5.2.