### PR TITLE
[test] Adjust new Substring test

### DIFF
--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -12,22 +12,17 @@ func checkMatch<S: Collection, T: Collection>(_ x: S, _ y: T, _ i: S.Index)
   expectEqual(x[i], y[i])
 }
 
-func checkMatchContiguousStorage<S: Collection, T: Collection>(_ x: S, _ y: T, expected: Bool)
+func checkMatchContiguousStorage<S: Collection, T: Collection>(_ x: S, _ y: T)
   where S.Element == T.Element, S.Element: Equatable
 {
   let xElement = x.withContiguousStorageIfAvailable { $0.first }
   let yElement = y.withContiguousStorageIfAvailable { $0.first }
 
-  if expected {
-    expectEqual(xElement, yElement)
-  } else {
-    expectNotEqual(xElement, yElement)
-  }
+  expectEqual(xElement, yElement)
 }
 
-func checkHasContiguousStorage<S: Collection>(_ x: S, expected: Bool) {
-  let hasStorage = x.withContiguousStorageIfAvailable { _ in true } ?? false
-  expectEqual(hasStorage, expected)
+func checkHasContiguousStorage<S: Collection>(_ x: S) {
+  expectTrue(x.withContiguousStorageIfAvailable { _ in true } ?? false)
 }
 
 func checkHasContiguousStorageSubstring(_ x: Substring.UTF8View) {
@@ -252,21 +247,21 @@ SubstringTests.test("UTF8View") {
     expectEqual("", String(u.dropFirst(100))!)
     expectEqual("", String(u.dropLast(100))!)
 
-    checkHasContiguousStorage(s.utf8, expected: true) // Strings always do
+
+    checkHasContiguousStorage(s.utf8) // Strings always do
     checkHasContiguousStorageSubstring(t)
     checkHasContiguousStorageSubstring(u)
-    checkMatchContiguousStorage(Array(s.utf8), s.utf8, expected: true)
+    checkMatchContiguousStorage(Array(s.utf8), s.utf8)
 
     // The specialization for Substring.withContiguousStorageIfAvailable was
     // added in https://github.com/apple/swift/pull/29146.
     guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
       return
     }
-
-    checkHasContiguousStorage(t, expected: true)
-    checkHasContiguousStorage(u, expected: true)
-    checkMatchContiguousStorage(Array(t), t, expected: true)
-    checkMatchContiguousStorage(Array(u), u, expected: true)
+    checkHasContiguousStorage(t)
+    checkHasContiguousStorage(u)
+    checkMatchContiguousStorage(Array(t), t)
+    checkMatchContiguousStorage(Array(u), u)
   }
 }
 

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -252,23 +252,21 @@ SubstringTests.test("UTF8View") {
     expectEqual("", String(u.dropFirst(100))!)
     expectEqual("", String(u.dropLast(100))!)
 
-    let expectSubstringWCSIA: Bool
-    // This availability guard should refer to a concrete OS version in
-    // future.
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
-      expectSubstringWCSIA = true 
-    } else {
-      expectSubstringWCSIA = false
-    }
-
     checkHasContiguousStorage(s.utf8, expected: true) // Strings always do
-    checkHasContiguousStorage(t, expected: expectSubstringWCSIA)
-    checkHasContiguousStorage(u, expected: expectSubstringWCSIA)
     checkHasContiguousStorageSubstring(t)
     checkHasContiguousStorageSubstring(u)
     checkMatchContiguousStorage(Array(s.utf8), s.utf8, expected: true)
-    checkMatchContiguousStorage(Array(t), t, expected: expectSubstringWCSIA)
-    checkMatchContiguousStorage(Array(u), u, expected: expectSubstringWCSIA)
+
+    // The specialization for Substring.withContiguousStorageIfAvailable was
+    // added in https://github.com/apple/swift/pull/29146.
+    guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+      return
+    }
+
+    checkHasContiguousStorage(t, expected: true)
+    checkHasContiguousStorage(u, expected: true)
+    checkMatchContiguousStorage(Array(t), t, expected: true)
+    checkMatchContiguousStorage(Array(u), u, expected: true)
   }
 }
 


### PR DESCRIPTION
This fixes the new Substring test that checks for the behavioral change introduced in #29094/#29146.

We don't have a good way to test exactly what version of the stdlib we're running on, so it isn't feasible to write two-way tests for behavior that is expected to change between stdlib versions. The `if #available(9999)` checks we have now *will* fail when we run these tests on a future released version of the stdlib that includes these changes. Even worse, the expected behavior on older stdlibs depends on whether the method is called in a Sequence-generic context. (The implementation is marked `@_alwaysEmitIntoClient`, so client code that directly calls it will have the new behavior; however, the Sequence witness table for Substring will still point to the default implementation in old stdlibs.)

Therefore, if the availability test fails, we cannot tell which behavior we need to expect, so we must stop checking for it. 

On the other hand, if the availability check succeeds, then we are guaranteed to have a new stdlib -- so we need to look at the expected behavior in that case, and only that case.

rdar://58868606