### PR TITLE
[SIL Optimization] Improve dead-code in OSLogOptimization pass, fix a bug and add helper functions to the new InstructionDeleter utility

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -79,6 +79,13 @@ public:
   /// up.
   void trackIfDead(SILInstruction *inst);
 
+  /// If the instruction \p inst is dead, delete it immediately and record
+  /// its operands so that they can be cleaned up later.
+  void deleteIfDead(
+      SILInstruction *inst,
+      llvm::function_ref<void(SILInstruction *)> callback =
+          [](SILInstruction *) {});
+
   /// Delete the instruction \p inst and record instructions that may become
   /// dead because of the removal of \c inst. This function will add necessary
   /// ownership instructions to fix the lifetimes of the operands of \c inst to
@@ -130,6 +137,14 @@ public:
   void
   cleanUpDeadInstructions(llvm::function_ref<void(SILInstruction *)> callback =
                               [](SILInstruction *) {});
+
+  /// Recursively visit users of \c inst  (including \c inst)and delete
+  /// instructions that are dead (including \c inst). Invoke the \c callback on
+  /// instructions that are deleted.
+  void recursivelyDeleteUsersIfDead(
+      SILInstruction *inst,
+      llvm::function_ref<void(SILInstruction *)> callback =
+                                    [](SILInstruction *) {});
 };
 
 /// If \c inst is dead, delete it and recursively eliminate all code that
@@ -146,6 +161,9 @@ public:
 void eliminateDeadInstruction(
     SILInstruction *inst, llvm::function_ref<void(SILInstruction *)> callback =
                               [](SILInstruction *) {});
+
+/// Return the number of @inout arguments passed to the given apply site.
+unsigned getNumInOutArguments(FullApplySite applySite);
 
 /// For each of the given instructions, if they are dead delete them
 /// along with their dead operands. Note this utility must be phased out and

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.sil
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.sil
@@ -965,3 +965,78 @@ bb0:
     // CHECK-NOT: OSLogMessageDCEStub
     // CHECK: return
 }
+
+// Check dead-code elimination of alloc stack used only as inout parameter of a
+// constant evaluable call (that only writes into that inout parameter).
+sil [ossa] [_semantics "constant_evaluable"] @appendInterpolationStub : $@convention(thin) (@inout OSLogInterpolationDCEStub) -> () {
+bb0(%0 : $*OSLogInterpolationDCEStub):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: @testDCEOfAllocStack
+sil [ossa] @testDCEOfAllocStack : $@convention(thin) () -> () {
+bb0:
+  %0 = string_literal utf8 "some message"
+  %1 = integer_literal $Builtin.Word, 12
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = metatype $@thin String.Type
+  // function_ref String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%0, %1, %2, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = struct $OSLogInterpolationDCEStub(%5 : $String)
+  %7 = alloc_stack $OSLogInterpolationDCEStub
+  store %6 to [init] %7 : $*OSLogInterpolationDCEStub
+  %8 = function_ref @appendInterpolationStub : $@convention(thin) (@inout OSLogInterpolationDCEStub) -> ()
+  %9 = apply %8(%7) : $@convention(thin) (@inout OSLogInterpolationDCEStub) -> ()
+  %10 = load [copy] %7 : $*OSLogInterpolationDCEStub
+  %11 = function_ref @oslogMessageDCEInit : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %12 = apply %11(%10) : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  destroy_value %12 : $OSLogMessageDCEStub
+  destroy_addr %7 : $*OSLogInterpolationDCEStub
+  dealloc_stack %7 : $*OSLogInterpolationDCEStub
+  %13 = tuple ()
+  return %13 : $()
+    // CHECK: bb0
+    // CHECK-NEXT: [[EMPTYTUP:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[EMPTYTUP]]
+}
+
+// Check that dead-code elimination of alloc stack does not happen when there
+// are multiple writable parameters
+sil [ossa] [_semantics "constant_evaluable"] @appendInterpolationStubError : $@convention(thin) (@inout OSLogInterpolationDCEStub, @inout Builtin.Int32) -> () {
+bb0(%0 : $*OSLogInterpolationDCEStub, %1 : $*Builtin.Int32):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: @testNoDCEOfAllocStack
+sil [ossa] @testNoDCEOfAllocStack : $@convention(thin) () -> () {
+bb0:
+  %0 = string_literal utf8 "some message"
+  %1 = integer_literal $Builtin.Word, 12
+  %2 = integer_literal $Builtin.Int1, -1
+  %3 = metatype $@thin String.Type
+  // function_ref String.init(_builtinStringLiteral:utf8CodeUnitCount:isASCII:)
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%0, %1, %2, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = struct $OSLogInterpolationDCEStub(%5 : $String)
+  %7 = alloc_stack $OSLogInterpolationDCEStub
+  store %6 to [init] %7 : $*OSLogInterpolationDCEStub
+  %8 = alloc_stack $Builtin.Int32
+  %lit = integer_literal $Builtin.Int32, -1
+  store %lit to [trivial] %8 : $*Builtin.Int32
+  %9 = function_ref @appendInterpolationStubError : $@convention(thin) (@inout OSLogInterpolationDCEStub, @inout Builtin.Int32) -> ()
+  %10 = apply %9(%7, %8) : $@convention(thin) (@inout OSLogInterpolationDCEStub, @inout Builtin.Int32) -> ()
+  %11 = load [copy] %7 : $*OSLogInterpolationDCEStub
+  %12 = function_ref @oslogMessageDCEInit : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  %13 = apply %12(%11) : $@convention(thin) (@owned OSLogInterpolationDCEStub) -> @owned OSLogMessageDCEStub
+  destroy_value %13 : $OSLogMessageDCEStub
+  destroy_addr %7 : $*OSLogInterpolationDCEStub
+  dealloc_stack %8 : $*Builtin.Int32
+  dealloc_stack %7 : $*OSLogInterpolationDCEStub
+  %14 = tuple ()
+  return %14 : $()
+    // CHECK: bb0
+    // CHECK: alloc_stack $OSLogInterpolationDCEStub
+}

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -487,6 +487,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     let concatString = string + ":" + String(number)
     h.log("\(concatString)")
       // CHECK-NOT: OSLogMessage
+      // CHECK-NOT: OSLogInterpolation
       // CHECK-LABEL: end sil function '$s25OSLogPrototypeCompileTest23testDeadCodeEliminationL_1h6number8num32bit6stringy0aB06LoggerV_Sis5Int32VSStF'
   }
 }


### PR DESCRIPTION
This PR consists of two commits. The first one fixes a bug in the identification of dead constant evaluable calls in the new InstructionDeleter utility. The fix makes the check more conservative and assumes that calls with generic arguments are not dead, as generic functions with arbitrary side-effects can be invoked through them. 

The second commit improves the OSLogOptimization pass so that it can remove alloc_stacks that are dead as a result of the optimization. This change is specific to the pass and exploits the constant-evaluableness of the calls evaluated in that pass. At this point, this cannot be generalized outside of this pass, as it relies on the fact that the constant_evaluable calls "have been" evaluated successfully, which means that they did not have any side-effects (in that calling context) and were only using constants supported by the constant evaluator (all of which have value semantics). 