### PR TITLE
build: begin rooting out `EXCLUDE_FROM_ALL`

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2546,9 +2546,9 @@ function(_add_swift_executable_single name)
 
   set(SWIFTEXE_SINGLE_SOURCES ${SWIFTEXE_SINGLE_UNPARSED_ARGUMENTS})
 
-  translate_flag(${SWIFTEXE_SINGLE_EXCLUDE_FROM_ALL}
-      "EXCLUDE_FROM_ALL"
-      SWIFTEXE_SINGLE_EXCLUDE_FROM_ALL_FLAG)
+  if(SWIFTEXE_SINGLE_EXCLUDE_FROM_ALL)
+    message(SEND_ERROR "${name} is using EXCLUDE_FROM_ALL option which is deprecated.")
+  endif()
 
   # Check arguments.
   precondition(SWIFTEXE_SINGLE_SDK MESSAGE "Should specify an SDK")
@@ -2612,7 +2612,6 @@ function(_add_swift_executable_single name)
   add_swift_source_group("${SWIFTEXE_SINGLE_EXTERNAL_SOURCES}")
 
   add_executable(${name}
-      ${SWIFTEXE_SINGLE_EXCLUDE_FROM_ALL_FLAG}
       ${SWIFTEXE_SINGLE_SOURCES}
       ${SWIFTEXE_SINGLE_EXTERNAL_SOURCES})
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -15,9 +15,9 @@ function(add_swift_target_executable name)
 
   set(SWIFTEXE_TARGET_SOURCES ${SWIFTEXE_TARGET_UNPARSED_ARGUMENTS})
 
-  translate_flag(${SWIFTEXE_TARGET_EXCLUDE_FROM_ALL}
-      "EXCLUDE_FROM_ALL"
-      SWIFTEXE_TARGET_EXCLUDE_FROM_ALL_FLAG)
+  if(SWIFTEXE_TARGET_EXCLUDE_FROM_ALL)
+    message(SEND_ERROR "${name} is using EXCLUDE_FROM_ALL which is deprecated.")
+  endif()
 
   # All Swift executables depend on the standard library.
   list(APPEND SWIFTEXE_TARGET_LINK_LIBRARIES swiftCore)
@@ -28,14 +28,6 @@ function(add_swift_target_executable name)
     foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
       set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
       set(VARIANT_NAME "${name}${VARIANT_SUFFIX}")
-
-      set(SWIFTEXE_TARGET_EXCLUDE_FROM_ALL_FLAG_CURRENT
-          ${SWIFTEXE_TARGET_EXCLUDE_FROM_ALL_FLAG})
-      if(NOT "${VARIANT_SUFFIX}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SUFFIX}")
-        # By default, don't build executables for target SDKs to avoid building
-        # target stdlibs.
-        set(SWIFTEXE_TARGET_EXCLUDE_FROM_ALL_FLAG_CURRENT "EXCLUDE_FROM_ALL")
-      endif()
 
       if(SWIFTEXE_TARGET_BUILD_WITH_STDLIB)
         add_dependencies("swift-test-stdlib${VARIANT_SUFFIX}" ${VARIANT_NAME})
@@ -54,8 +46,14 @@ function(add_swift_target_executable name)
           LLVM_LINK_COMPONENTS ${SWIFTEXE_TARGET_LLVM_LINK_COMPONENTS}
           SDK "${sdk}"
           ARCHITECTURE "${arch}"
-          LINK_LIBRARIES ${SWIFTEXE_TARGET_LINK_LIBRARIES}
-          ${SWIFTEXE_TARGET_EXCLUDE_FROM_ALL_FLAG_CURRENT})
+          LINK_LIBRARIES ${SWIFTEXE_TARGET_LINK_LIBRARIES})
+
+      if(NOT "${VARIANT_SUFFIX}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SUFFIX}")
+        # By default, don't build executables for target SDKs to avoid building
+        # target stdlibs.
+        set_target_properties(${VARIANT_NAME} PROPERTIES
+          EXCLUDE_FROM_ALL TRUE)
+      endif()
 
       if(${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
         add_custom_command_target(unused_var2


### PR DESCRIPTION
`EXCLUDE_FROM_ALL` should be discouraged.  `ALL` should build *all*
targets.  If a subset of targets are desired to be built, we should
provide targets which make sense.  Sink the single use of this flag
into the standard library setup.  The custom cross-compilation was
the reason that the flag was plumbed all the way through.  Cleaning
up the macros that have been built up is needed to migrate towards
proper cross-compilation support.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
