### PR TITLE
build: delegate rpath handling to CMake

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2583,12 +2583,6 @@ function(_add_swift_executable_single name)
     LINK_LIBRARIES_VAR_NAME link_libraries
     LIBRARY_SEARCH_DIRECTORIES_VAR_NAME library_search_directories)
 
-  if(${SWIFTEXE_SINGLE_SDK} IN_LIST SWIFT_APPLE_PLATFORMS)
-    list(APPEND link_flags
-        "-Xlinker" "-rpath"
-        "-Xlinker" "@executable_path/../lib/swift/${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}")
-  endif()
-
   _list_add_string_suffix(
       "${SWIFTEXE_SINGLE_LINK_LIBRARIES}"
       "-${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTEXE_SINGLE_ARCHITECTURE}"
@@ -2636,6 +2630,11 @@ function(_add_swift_executable_single name)
   set_property(TARGET ${name} APPEND PROPERTY LINK_LIBRARIES ${link_libraries})
   if (SWIFT_PARALLEL_LINK_JOBS)
     set_property(TARGET ${name} PROPERTY JOB_POOL_LINK swift_link_job_pool)
+  endif()
+  if(${SWIFTEXE_SINGLE_SDK} IN_LIST SWIFT_APPLE_PLATFORMS)
+    set_target_properties(${name} PROPERTIES
+      BUILD_WITH_INSTALL_RPATH YES
+      INSTALL_RPATH "@executable_path/../lib/swift/${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}")
   endif()
   set_output_directory(${name}
       BINARY_DIR ${SWIFT_RUNTIME_OUTPUT_INTDIR}

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -40,8 +40,8 @@ function(add_swift_unittest test_dirname)
   endif()
 
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
-      LINK_FLAGS " -Xlinker -rpath -Xlinker ${SWIFT_LIBRARY_OUTPUT_INTDIR}/swift/macosx")
+    set_target_properties(${test_dirname} PROPERTIES
+      BUILD_RPATH ${SWIFT_LIBRARY_OUTPUT_INTDIR}/swift/macosx)
   elseif("${SWIFT_HOST_VARIANT}" STREQUAL "android")
     swift_android_lib_for_arch(${SWIFT_HOST_VARIANT_ARCH} android_system_libs)
     set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_DIRECTORIES

--- a/tools/swift-syntax-parser-test/CMakeLists.txt
+++ b/tools/swift-syntax-parser-test/CMakeLists.txt
@@ -15,14 +15,10 @@ target_link_libraries(swift-syntax-parser-test
     libSwiftSyntaxParser
 )
 
-if(APPLE)
-  # Prioritize finding the parser library from the build/lib directory.
-  # Otherwise it may find it from the 'lib/swift/macosx' directory which could
-  # be out-of-date.
-  get_target_property(link_flags swift-syntax-parser-test LINK_FLAGS)
-  set(link_flags "-Xlinker -rpath -Xlinker @executable_path/../lib ${link_flags}")
-  set_property(TARGET swift-syntax-parser-test PROPERTY
-      LINK_FLAGS "${link_flags}")
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set_target_properties(swift-syntax-parser-test PROPERTIES
+    BUILD_WITH_INSTALL_RPATH YES
+    INSTALL_RPATH @executable_path/../lib)
 endif()
 
 set_property(TARGET swift-syntax-parser-test APPEND_STRING PROPERTY

--- a/unittests/SyntaxParser/CMakeLists.txt
+++ b/unittests/SyntaxParser/CMakeLists.txt
@@ -12,14 +12,9 @@ target_link_libraries(SwiftSyntaxParserTests
   PRIVATE
   libSwiftSyntaxParser)
 
-if(APPLE)
-  # Prioritize finding the parser library from the build/lib directory.
-  # Otherwise it may find it from the 'lib/swift/macosx' directory which could
-  # be out-of-date.
-  get_target_property(link_flags SwiftSyntaxParserTests LINK_FLAGS)
-  set(link_flags "-Xlinker -rpath -Xlinker ${SWIFT_LIBRARY_OUTPUT_INTDIR} ${link_flags}")
-  set_property(TARGET SwiftSyntaxParserTests PROPERTY
-      LINK_FLAGS "${link_flags}")
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set_target_properties(SwiftSyntaxParserTests PROPERTIES
+    BUILD_RPATH ${SWIFT_LIBRARY_OUTPUT_INTDIR})
 endif()
 
 set_property(TARGET SwiftSyntaxParserTests APPEND_STRING PROPERTY


### PR DESCRIPTION
This moves the rpath handling to the build system rather than trying to
figure out the correct flags to pass to the driver.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
