### PR TITLE
[sourcekitd-test] Remove LLVM Core static library that is getting linked twice

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -5,7 +5,7 @@ swift_add_public_tablegen_target(sourcekitdTestOptionsTableGen)
 add_sourcekit_executable(sourcekitd-test
   sourcekitd-test.cpp
   TestOptions.cpp
-  LLVM_LINK_COMPONENTS core option coverage lto
+  LLVM_LINK_COMPONENTS option coverage lto
 )
 target_link_libraries(sourcekitd-test PRIVATE
   SourceKitSupport


### PR DESCRIPTION
On Linux and Android, this Core library is presumably already supplied by the LLVM CMake config, so adding it here causes the CommandLine option parser to fail as it registers the same option twice.

I have not dug into exactly where the previous dependency's coming from or why it changed, but I can consistently reproduce since late last year on an Android host and in the one time I tried it on Arch Linux x86_64. What happens is that any invocation of sourcekitd-test fails with this error, after building with this command on Linux x86_64:
```
> ./swift/utils/build-script -R --no-assertions --llvm-targets-to-build="X86;ARM;AArch64" -j9 -T

> ./build/Ninja-Release/swift-linux-x86_64/bin/sourcekitd-test --help
: CommandLine Error: Option 'non-global-value-max-name-size' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
```
[@drodriguez says he's seen this intermittently in Linux too](https://github.com/apple/swift/pull/29296#discussion_r370954987), "Yes, I have seen this in one my setups (a chrooted Ubuntu in a CentOS), but I think only from time to time. I couldn't find a reason why this is not happening in CI."

@compnerd, [you last modified this line to remove another LLVM library](https://github.com/apple/swift/commit/717c4d3ebf9#diff-9d9699eccfb258b91e8fd3bda245ab61L16), so maybe you know what's going on.