### PR TITLE
[test] Remove debugging dumps to /tmp

### DIFF
--- a/test/Driver/Dependencies/crash-new-fine.swift
+++ b/test/Driver/Dependencies/crash-new-fine.swift
@@ -62,7 +62,7 @@
 // Touch all files earlier than last compiled date in the build record.
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 -driver-show-incremental |tee /tmp/out1 | %FileCheck -check-prefix=CHECK-CURRENT-WITH-CRASH %s
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 -driver-show-incremental | %FileCheck -check-prefix=CHECK-CURRENT-WITH-CRASH %s
 
 // CHECK-CURRENT-WITH-CRASH: Handled main.swift
 // CHECK-CURRENT-WITH-CRASH: Handled crash.swift

--- a/test/Driver/Dependencies/crash-new.swift
+++ b/test/Driver/Dependencies/crash-new.swift
@@ -62,7 +62,7 @@
 // Touch all files earlier than last compiled date in the build record.
 
 // RUN: touch -t 201401240005 %t/*
-// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 -driver-show-incremental |tee /tmp/out1 | %FileCheck -check-prefix=CHECK-CURRENT-WITH-CRASH %s
+// RUN: cd %t && %swiftc_driver -disable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 -driver-show-incremental | %FileCheck -check-prefix=CHECK-CURRENT-WITH-CRASH %s
 
 // CHECK-CURRENT-WITH-CRASH: Handled main.swift
 // CHECK-CURRENT-WITH-CRASH: Handled crash.swift

--- a/test/Driver/Dependencies/crash-simple-fine.swift
+++ b/test/Driver/Dependencies/crash-simple-fine.swift
@@ -12,7 +12,7 @@
 // CHECK-FIRST: Handled other.swift
 
 // RUN: touch -t 201401240006 %t/crash.swift
-// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | tee /tmp/1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && not %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies-bad.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./crash.swift  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND: Handled crash.swift
 // CHECK-SECOND-NOT: Handled main.swift

--- a/test/Driver/Dependencies/one-way-depends-after-fine.swift
+++ b/test/Driver/Dependencies/one-way-depends-after-fine.swift
@@ -11,7 +11,7 @@
 // ...then reset the .swiftdeps files.
 // RUN: cp -r %S/Inputs/one-way-depends-after-fine/*.swiftdeps %t
 
-// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | tee /tmp/1|%FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -enable-fine-grained-dependencies -c -driver-use-frontend-path "%{python};%S/Inputs/update-dependencies.py" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST-NOT: Handled

--- a/test/Driver/advanced_output_file_map.swift
+++ b/test/Driver/advanced_output_file_map.swift
@@ -88,7 +88,7 @@
 
 
 // RUN: %empty-directory(%t/d)
-// RUN: %swiftc_driver -driver-print-bindings -target x86_64-apple-macosx10.9 -emit-executable -emit-module -serialize-diagnostics -emit-dependencies %/s %/S/Inputs/main.swift %/S/Inputs/lib.swift -g -o ./advanced_output_file_map.out -emit-module-path ./OutputFileMap.swiftmodule -module-name OutputFileMap -output-file-map %t/ofm.json 2>&1 | tee /tmp/out | %FileCheck %/s -check-prefix=BINDINGS-ENA
+// RUN: %swiftc_driver -driver-print-bindings -target x86_64-apple-macosx10.9 -emit-executable -emit-module -serialize-diagnostics -emit-dependencies %/s %/S/Inputs/main.swift %/S/Inputs/lib.swift -g -o ./advanced_output_file_map.out -emit-module-path ./OutputFileMap.swiftmodule -module-name OutputFileMap -output-file-map %t/ofm.json 2>&1 | %FileCheck %/s -check-prefix=BINDINGS-ENA
 // RUN: test ! -e %t/d/advanced_output_file_map.d
 // RUN: test -e %t/d/main.d -a ! -s %t/d/main.d
 // RUN: test -e %t/d/lib.d  -a ! -s %t/d/lib.d


### PR DESCRIPTION
Writing to /tmp will call these tests to fail on Windows and Android. Not all of them run for me on Android, only two do and fail, but I went ahead and cleaned all five up.

@davidungar, presumably you added these just for your own debugging, so they can be taken out.