### PR TITLE
build: treat SourceKit as a host tool

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -1,3 +1,9 @@
+
+project(SourceKit
+  LANGUAGES CXX)
+
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fblocks>)
+
 include(CheckSymbolExists)
 
 # Append our own modules to the module path.


### PR DESCRIPTION
This changes the SourceKit build to use the host configuration.  This is
the appropriate way to handle the build of SourceKit as it is not a
target component.  Doing so simplifies the build, makes it more obvious
how to migrate the SourceKit build to the standard CMake build
techniques.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
