### PR TITLE
[WebAssembly] Add no-op MutexWASI.h implementation

### DIFF
--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -24,6 +24,8 @@
 #include "swift/Runtime/MutexPThread.h"
 #elif defined(_WIN32)
 #include "swift/Runtime/MutexWin32.h"
+#elif defined(__wasi__)
+#include "swift/Runtime/MutexWASI.h"
 #else
 #error "Implement equivalent of MutexPThread.h/cpp for your platform."
 #endif

--- a/include/swift/Runtime/MutexWASI.h
+++ b/include/swift/Runtime/MutexWASI.h
@@ -1,0 +1,67 @@
+//===--- MutexWASI.h - -----------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Stub implementation of Mutex, ConditionVariable, Read/Write lock, and Scoped 
+// lock for WASI. No concrete implementation is provided as WebAssembly doesn't 
+// currently support threading.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_MUTEX_WASI_H
+#define SWIFT_RUNTIME_MUTEX_WASI_H
+
+namespace swift {
+
+typedef void* ConditionHandle;
+typedef void* MutexHandle;
+typedef void* ReadWriteLockHandle;
+
+#define SWIFT_CONDITION_SUPPORTS_CONSTEXPR 1
+#define SWIFT_MUTEX_SUPPORTS_CONSTEXPR 1
+#define SWIFT_READWRITELOCK_SUPPORTS_CONSTEXPR 1
+
+struct ConditionPlatformHelper {
+  static constexpr ConditionHandle staticInit() {
+    return nullptr;
+  };
+  static void init(ConditionHandle &condition) {}
+  static void destroy(ConditionHandle &condition) {}
+  static void notifyOne(ConditionHandle &condition) {}
+  static void notifyAll(ConditionHandle &condition) {}
+  static void wait(ConditionHandle &condition, MutexHandle &mutex);
+};
+
+struct MutexPlatformHelper {
+  static constexpr MutexHandle staticInit() { return nullptr; }
+  static void init(MutexHandle &mutex, bool checked = false) {}
+  static void destroy(MutexHandle &mutex) {}
+  static void lock(MutexHandle &mutex) {}
+  static void unlock(MutexHandle &mutex) {}
+  static bool try_lock(MutexHandle &mutex) { return true; }
+  static void unsafeLock(MutexHandle &mutex) {}
+  static void unsafeUnlock(MutexHandle &mutex) {}
+};
+
+struct ReadWriteLockPlatformHelper {
+  static constexpr ReadWriteLockHandle staticInit() { return nullptr; }
+  static void init(ReadWriteLockHandle &rwlock) {}
+  static void destroy(ReadWriteLockHandle &rwlock) {}
+  static void readLock(ReadWriteLockHandle &rwlock) {}
+  static bool try_readLock(ReadWriteLockHandle &rwlock) { return true; }
+  static void readUnlock(ReadWriteLockHandle &rwlock) {}
+  static void writeLock(ReadWriteLockHandle &rwlock) {}
+  static bool try_writeLock(ReadWriteLockHandle &rwlock) { return true; }
+  static void writeUnlock(ReadWriteLockHandle &rwlock) {}
+};
+}
+
+#endif

--- a/include/swift/Runtime/MutexWASI.h
+++ b/include/swift/Runtime/MutexWASI.h
@@ -10,9 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Stub implementation of Mutex, ConditionVariable, Read/Write lock, and Scoped 
-// lock for WASI. No concrete implementation is provided as WebAssembly doesn't 
-// currently support threading.
+// No-op implementation of locks for the WebAssembly System Interface. The 
+// implementation does not need to perform locking, because as of January 2020 
+// WebAssembly does not support threads.
+// See the current status at https://github.com/WebAssembly/proposals and 
+// https://github.com/webassembly/threads
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Since WebAssembly doesn't support threading, no locking is done in runtime. This PR adds a no-op implementation in `MutexWASI.h` to improve compatibility with [WASI](https://wasi.dev/). 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This is a part of [SR-9307](https://bugs.swift.org/browse/SR-9307) and #24684.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

(cc @kateinoigakukun @zhuowei)
