### PR TITLE
TensorFlow: constrict TensorFlow addition further

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -75,7 +75,7 @@ if(SWIFT_BUILD_STDLIB)
 
   # Note: Python should be built before TensorFlow because Python is a
   # dependency for `numpy.ndarray` bridging to `ShapedArray`/`Tensor`.
-  if(SWIFT_ENABLE_TENSORFLOW)
+  if(SWIFT_ENABLE_TENSORFLOW AND TENSORFLOW_SWIFT_APIS)
     # TODO: Add TensorFlow support for iOS/Raspberry Pi.
     add_subdirectory(TensorFlow)
   endif()

--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -16,6 +16,8 @@
 
 find_package(TensorFlow REQUIRED)
 message(STATUS "Building TensorFlow.")
+message(STATUS "Using TensorFlow high-level APIs library.")
+
 
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
@@ -29,17 +31,13 @@ list(APPEND swift_stdlib_compile_flags "-DCOMPILING_TENSORFLOW_STDLIB_MODULE")
 
 set(SOURCES "")
 
-# Copy TensorFlow high-level API sources, if they exist.
-if (TENSORFLOW_SWIFT_APIS)
-  message(STATUS "Using TensorFlow high-level APIs library.")
-
-  file(GLOB_RECURSE TENSORFLOW_SWIFT_API_SOURCES
-    "${TENSORFLOW_SWIFT_APIS}/Sources/*.swift")
-  foreach(_TENSORFLOW_SWIFT_APIS_SOURCE ${TENSORFLOW_SWIFT_API_SOURCES})
-    file(TO_CMAKE_PATH ${_TENSORFLOW_SWIFT_APIS_SOURCE} _TENSORFLOW_SWIFT_APIS_SOURCE)
-    list(APPEND SOURCES ${_TENSORFLOW_SWIFT_APIS_SOURCE})
-  endforeach()
-endif()
+# Copy TensorFlow high-level API sources.
+file(GLOB_RECURSE TENSORFLOW_SWIFT_API_SOURCES
+  "${TENSORFLOW_SWIFT_APIS}/Sources/*.swift")
+foreach(_TENSORFLOW_SWIFT_APIS_SOURCE ${TENSORFLOW_SWIFT_API_SOURCES})
+  file(TO_CMAKE_PATH ${_TENSORFLOW_SWIFT_APIS_SOURCE} _TENSORFLOW_SWIFT_APIS_SOURCE)
+  list(APPEND SOURCES ${_TENSORFLOW_SWIFT_APIS_SOURCE})
+endforeach()
 
 add_swift_target_library(swiftTensorFlow ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   "${SOURCES}"


### PR DESCRIPTION
This package only makes sense if the `TENSORFLOW_SWIFT_APIS` is defined.
We would previously attempt to install content from the
tensorflow/swift-apis repository unconditionally.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
