### PR TITLE
DeadFunctionElimination: remove externally available witness tables at the end of the pipeline

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -200,6 +200,8 @@ PASS(LICM, "licm",
      "Loop Invariant Code Motion")
 PASS(LateCodeMotion, "late-codemotion",
      "Late Code Motion with Release Hoisting")
+PASS(LateDeadFunctionElimination, "late-deadfuncelim",
+     "Late Dead Function Elimination")
 PASS(LateInliner, "late-inline",
      "Late Function Inlining")
 PASS(LoopCanonicalizer, "loop-canonicalizer",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -522,7 +522,9 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("LateLoopOpt");
 
   // Delete dead code and drop the bodies of shared functions.
-  P.addDeadFunctionElimination();
+  // Also, remove externally available witness tables. They are not needed
+  // anymore after the last devirtualizer run.
+  P.addLateDeadFunctionElimination();
 
   // Perform the final lowering transformations.
   P.addCodeSinking();

--- a/test/SIL/Serialization/init_existential_inst_deserializes_witness_tables.swift
+++ b/test/SIL/Serialization/init_existential_inst_deserializes_witness_tables.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -sil-inline-threshold 0 %S/Inputs/init_existential_inst_deserializes_witness_tables_input.swift -o %t/Swift.swiftmodule -emit-module -parse-as-library -parse-stdlib -module-link-name swiftCore -module-name Swift -O
-// RUN: %target-swift-frontend -I %t -O %s -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -O %s -Xllvm -sil-disable-pass=late-deadfuncelim -emit-sil -o - | %FileCheck %s
 
 // CHECK: sil_witness_table public_external X: P module Swift {
 

--- a/test/SILOptimizer/devirt_opaque_witness.swift
+++ b/test/SILOptimizer/devirt_opaque_witness.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/opaque_conformance.swiftmodule -primary-file %S/Inputs/opaque_conformance.swift
-// RUN: %target-swift-frontend -O -emit-sil -primary-file %s -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -primary-file %s -I %t -Xllvm -sil-disable-pass=late-deadfuncelim | %FileCheck %s
 
 import opaque_conformance
 

--- a/test/SILOptimizer/sil_witness_tables_external_witnesstable.swift
+++ b/test/SILOptimizer/sil_witness_tables_external_witnesstable.swift
@@ -1,12 +1,18 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/sil_witness_tables_external_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -module-link-name swiftCore
-// RUN: %target-swift-frontend -O -I %t %s -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -O -I %t %s -Xllvm -sil-disable-pass=late-deadfuncelim -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -O -I %t %s -emit-sil | %FileCheck -check-prefix=CHECK-DFE %s
 
 import Swift
 
 // Make sure the specializer produces an external witness table.
 //
 // CHECK: sil_witness_table public_external X: P module Swift {
+
+// Also check that late dead-function-elimination is removing externally
+// available witness tables.
+//
+// CHECK-DFE-NOT: sil_witness_table public_external
 
 func doSomething<T : P>(_ t : T) -> Y {
   return t.doSomething()


### PR DESCRIPTION
... including all SIL functions with are transitively referenced from such witness tables.

After the last devirtualizer run, witness tables are not needed in the optimizer anymore.
We can delete witness tables with an available-externally linkage. IRGen does not emit such witness tables anyway.
This can save a little bit of compile time, because it reduces the amount of SIL at the end of the optimizer pipeline.
It also reduces the size of the SIL output after the optimizer, which makes debugging the SIL output easier.
