### PR TITLE
Add -no-wmo to mirror -no-whole-module-optimization

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -882,6 +882,9 @@ def disable_batch_mode : Flag<["-"], "disable-batch-mode">,
 def wmo : Flag<["-"], "wmo">, Alias<whole_module_optimization>,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>;
 
+def no_wmo : Flag<["-"], "no-wmo">, Alias<no_whole_module_optimization>,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>;
+
 def force_single_frontend_invocation :
   Flag<["-"], "force-single-frontend-invocation">,
   Alias<whole_module_optimization>,

--- a/test/Driver/negating_WMO.swift
+++ b/test/Driver/negating_WMO.swift
@@ -4,6 +4,8 @@
 // WMO-NOT: -primary-file
 // RUN: %swiftc_driver -whole-module-optimization -no-whole-module-optimization %S/../Inputs/empty.swift -### 2>&1 | %FileCheck -check-prefix NO-WMO %s
 // NO-WMO: -primary-file
+// RUN: %swiftc_driver -wmo -no-wmo %S/../Inputs/empty.swift -### 2>&1 | %FileCheck -check-prefix NO-WMO-SHORT %s
+// NO-WMO-SHORT: -primary-file
 
 // RUN: %swiftc_driver -enable-batch-mode -whole-module-optimization -no-whole-module-optimization %S/../Inputs/empty.swift -### 2>&1 | %FileCheck -check-prefix BATCH %s
 // BATCH: -primary-file


### PR DESCRIPTION
Since we have both `-whole-module-optimization` and `-wmo` this mirrors
`-no-whole-module-optimization` with the shorter version `-no-wmo`