### PR TITLE
build: simplify the ICU include handling

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -373,30 +373,6 @@ function(_add_variant_c_compile_flags)
     endforeach()
   endif()
 
-  set(ICU_UC_INCLUDE_DIR ${SWIFT_${CFLAGS_SDK}_${CFLAGS_ARCH}_ICU_UC_INCLUDE})
-  if(NOT "${ICU_UC_INCLUDE_DIR}" STREQUAL "" AND
-     NOT "${ICU_UC_INCLUDE_DIR}" STREQUAL "/usr/include" AND
-     NOT "${ICU_UC_INCLUDE_DIR}" STREQUAL "/usr/${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_TRIPLE}/include" AND
-     NOT "${ICU_UC_INCLUDE_DIR}" STREQUAL "/usr/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_TRIPLE}/include")
-   if(SWIFT_COMPILER_IS_MSVC_LIKE)
-     list(APPEND result -I;${ICU_UC_INCLUDE_DIR})
-   else()
-     list(APPEND result -isystem;${ICU_UC_INCLUDE_DIR})
-   endif()
-  endif()
-
-  set(ICU_I18N_INCLUDE_DIR ${SWIFT_${CFLAGS_SDK}_${CFLAGS_ARCH}_ICU_I18N_INCLUDE})
-  if(NOT "${ICU_I18N_INCLUDE_DIR}" STREQUAL "" AND
-     NOT "${ICU_I18N_INCLUDE_DIR}" STREQUAL "/usr/include" AND
-     NOT "${ICU_I18N_INCLUDE_DIR}" STREQUAL "/usr/${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_TRIPLE}/include" AND
-     NOT "${ICU_I18N_INCLUDE_DIR}" STREQUAL "/usr/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_TRIPLE}/include")
-   if(SWIFT_COMPILER_IS_MSVC_LIKE)
-     list(APPEND result -I;${ICU_I18N_INCLUDE_DIR})
-   else()
-     list(APPEND result -isystem;${ICU_I18N_INCLUDE_DIR})
-   endif()
-  endif()
-
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)
 endfunction()
 
@@ -1414,6 +1390,9 @@ function(_add_swift_library_single target name)
   endif()
 
   # Set compilation and link flags.
+  target_include_directories(${target} SYSTEM PRIVATE
+    ${SWIFT_${SWIFTLIB_SINGLE_SDK}_${SWIFTLIB_SINGLE_ARCHITECTURE}_ICU_UC_INCLUDE}
+    ${SWIFT_${SWIFTLIB_SINGLE_SDK}_${SWIFTLIB_SINGLE_ARCHITECTURE}_ICU_I18N_INCLUDE})
   target_compile_options(${target} PRIVATE
     ${c_compile_flags})
   target_link_options(${target} PRIVATE


### PR DESCRIPTION
This simplifies the ICU flags handling.  This inlines the use into just
the library case, as the ICU usage is for the standard library targets
only.  It uses CMake to properly add the include paths as a system
search path.  This should fix the Linux builds as the include flags were
being de-duplicated as we are now using CMake more than we were
previously.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
