### PR TITLE
[5.2][SILProfiler] Do not set up a profiler for a function twice

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -551,7 +551,7 @@ static bool haveProfiledAssociatedFunction(SILDeclRef constant) {
 /// Set up the function for profiling instrumentation.
 static void setUpForProfiling(SILDeclRef constant, SILFunction *F,
                               ForDefinition_t forDefinition) {
-  if (!forDefinition)
+  if (!forDefinition || F->getProfiler())
     return;
 
   ASTNode profiledNode;

--- a/test/Profiler/coverage_struct.swift
+++ b/test/Profiler/coverage_struct.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_struct %s | %FileCheck %s
+
+struct Foo {
+  var a = false
+
+// CHECK: sil_coverage_map {{.*}}// variable initialization expression of coverage_struct.Foo.b : Swift.Bool
+// CHECK-NEXT: [[@LINE+1]]:11 -> [[@LINE+3]]:6 : 0
+  let b = {
+    false
+  }()
+}


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift/pull/29478 which addresses a crash in swift's code coverage logic (https://bugs.swift.org/browse/SR-12045): 'Assertion failed: Function already has a profiler'.

`setUpForProfiling` should always have ignored functions which were already set up, so the issue has been present for a while. However, it's possible that after this function was introduced, SILGen was restructured in a way that makes it more likely to hit this code path.

rdar://58861159