### PR TITLE
build: repair the Windows build

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -264,18 +264,6 @@ function(_add_variant_c_compile_flags)
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "WINDOWS")
-    # MSVC doesn't support -Xclang. We don't need to manually specify
-    # the dependent libraries as `cl` does so.
-    if(NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
-      list(APPEND result -Xclang;--dependent-lib=oldnames)
-      # TODO(compnerd) handle /MT, /MTd
-      if("${CFLAGS_BUILD_TYPE}" STREQUAL "Debug")
-        list(APPEND result -Xclang;--dependent-lib=msvcrtd)
-      else()
-        list(APPEND result -Xclang;--dependent-lib=msvcrt)
-      endif()
-    endif()
-
     # MSVC/clang-cl don't support -fno-pic or -fms-compatibility-version.
     if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
       list(APPEND result -fno-pic)
@@ -366,11 +354,6 @@ function(_add_variant_c_compile_flags)
       list(APPEND result -isystem;${path})
     endforeach()
     list(APPEND result "-D__ANDROID_API__=${SWIFT_ANDROID_API_LEVEL}")
-  elseif(CFLAGS_SDK STREQUAL WINDOWS)
-    swift_windows_include_for_arch(${CFLAGS_ARCH} ${CFLAGS_ARCH}_INCLUDE)
-    foreach(path ${${CFLAGS_ARCH}_INCLUDE})
-      list(APPEND result "\"${CMAKE_INCLUDE_FLAG_C}${path}\"")
-    endforeach()
   endif()
 
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)
@@ -910,11 +893,9 @@ function(_add_swift_library_single target name)
 
   if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "WINDOWS")
     if(NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
-      swift_windows_generate_sdk_vfs_overlay(SWIFTLIB_SINGLE_VFS_OVERLAY_FLAGS)
-      foreach(flag ${SWIFTLIB_SINGLE_VFS_OVERLAY_FLAGS})
-        list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xcc;${flag})
-        list(APPEND SWIFTLIB_SINGLE_C_COMPILE_FLAGS ${flag})
-      endforeach()
+      swift_windows_get_sdk_vfs_overlay(SWIFTLIB_SINGLE_VFS_OVERLAY)
+      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
+        -Xcc;-Xclang;-Xcc;-ivfsoverlay;-Xcc;-Xclang;-Xcc;${SWIFTLIB_SINGLE_VFS_OVERLAY})
     endif()
     swift_windows_include_for_arch(${SWIFTLIB_SINGLE_ARCHITECTURE} SWIFTLIB_INCLUDE)
     foreach(directory ${SWIFTLIB_INCLUDE})
@@ -1390,6 +1371,25 @@ function(_add_swift_library_single target name)
   endif()
 
   # Set compilation and link flags.
+  if(SWIFTLIB_SINGLE_SDK STREQUAL WINDOWS)
+    swift_windows_include_for_arch(${SWIFTLIB_SINGLE_ARCHITECTURE}
+      ${SWIFTLIB_SINGLE_ARCHITECTURE}_INCLUDE)
+    target_include_directories(${target} SYSTEM PRIVATE
+      ${${SWIFTLIB_SINGLE_ARCHITECTURE}_INCLUDE})
+
+    if(NOT ${CMAKE_C_COMPILER_ID} STREQUAL MSVC)
+      swift_windows_get_sdk_vfs_overlay(SWIFTLIB_SINGLE_VFS_OVERLAY)
+      target_compile_options(${target} PRIVATE
+        "SHELL:-Xclang -ivfsoverlay -Xclang ${SWIFTLIB_SINGLE_VFS_OVERLAY}")
+
+      # MSVC doesn't support -Xclang. We don't need to manually specify
+      # the dependent libraries as `cl` does so.
+      target_compile_options(${target} PRIVATE
+        "SHELL:-Xclang --dependent-lib=oldnames"
+        # TODO(compnerd) handle /MT, /MTd
+        "SHELL:-Xclang --dependent-lib=msvcrt$<$<CONFIG:Debug>:d>")
+    endif()
+  endif()
   target_include_directories(${target} SYSTEM PRIVATE
     ${SWIFT_${SWIFTLIB_SINGLE_SDK}_${SWIFTLIB_SINGLE_ARCHITECTURE}_ICU_UC_INCLUDE}
     ${SWIFT_${SWIFTLIB_SINGLE_SDK}_${SWIFTLIB_SINGLE_ARCHITECTURE}_ICU_I18N_INCLUDE})
@@ -2575,6 +2575,21 @@ function(_add_swift_executable_single name)
         ${SWIFTEXE_SINGLE_DEPENDS})
   llvm_update_compile_flags("${name}")
 
+  if(SWIFTEXE_SINGLE_SDK STREQUAL WINDOWS)
+    swift_windows_include_for_arch(${SWIFTEXE_SINGLE_ARCHITECTURE}
+      ${SWIFTEXE_SINGLE_ARCHITECTURE}_INCLUDE)
+    target_include_directories(${name} SYSTEM PRIVATE
+      ${${SWIFTEXE_SINGLE_ARCHITECTURE}_INCLUDE})
+
+    if(NOT ${CMAKE_C_COMPILER_ID} STREQUAL MSVC)
+      # MSVC doesn't support -Xclang. We don't need to manually specify
+      # the dependent libraries as `cl` does so.
+      target_compile_options(${name} PRIVATE
+        "SHELL:-Xclang --dependent-lib=oldnames"
+        # TODO(compnerd) handle /MT, /MTd
+        "SHELL:-Xclang --dependent-lib=msvcrt$<$<CONFIG:Debug>:d>")
+    endif()
+  endif()
   target_compile_options(${name} PRIVATE
     ${c_compile_flags})
   target_link_directories(${name} PRIVATE

--- a/cmake/modules/SwiftWindowsSupport.cmake
+++ b/cmake/modules/SwiftWindowsSupport.cmake
@@ -49,7 +49,7 @@ function(swift_windows_lib_for_arch arch var)
   set(${var} ${paths} PARENT_SCOPE)
 endfunction()
 
-function(swift_windows_generate_sdk_vfs_overlay flags)
+function(swift_windows_get_sdk_vfs_overlay overlay)
   get_filename_component(VCToolsInstallDir ${VCToolsInstallDir} ABSOLUTE)
   get_filename_component(UniversalCRTSdkDir ${UniversalCRTSdkDir} ABSOLUTE)
   set(UCRTVersion ${UCRTVersion})
@@ -58,10 +58,8 @@ function(swift_windows_generate_sdk_vfs_overlay flags)
   configure_file("${SWIFT_SOURCE_DIR}/utils/WindowsSDKVFSOverlay.yaml.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
                  @ONLY)
-
-  set(${flags}
-        -Xclang;-ivfsoverlay;-Xclang;"${CMAKE_CURRENT_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
-      PARENT_SCOPE)
+  set(${overlay} ${CMAKE_CURRENT_BINARY_DIR}/windows-sdk-vfs-overlay.yaml
+    PARENT_SCOPE)
 endfunction()
 
 function(swift_verify_windows_VCVAR var)

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -71,6 +71,12 @@ function(add_sourcekit_default_compiler_flags target)
     LIBRARY_SEARCH_DIRECTORIES_VAR_NAME library_search_directories)
 
   # Set compilation and link flags.
+  if(${SWIFT_HOST_VARIANT_SDK} STREQUAL WINDOWS)
+    swift_windows_include_for_arch(${SWIFT_HOST_VARIANT_ARCH}
+      ${SWIFT_HOST_VARIANT_ARCH}_INCLUDE)
+    target_include_directories(${target} SYSTEM PRIVATE
+      ${${SWIFT_HOST_VARIANT_ARCH}_INCLUDE})
+  endif()
   target_compile_options(${target} PRIVATE
     -fblocks)
   target_link_options(${target} PRIVATE


### PR DESCRIPTION
This should repair the Windows build after #29451.  The quoting
behaviour was incorrect and was constructing an invalid compiler
invocation.  Solve the issue by using `target_include_directories`
instead.  However, since this needs the target, hoist the flag
computation to the local sites.  This replicates more logic because of
the custom build trying to replicate the CMake build logic in CMake.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
