### PR TITLE
TBDGen: also using target variant to decide whether @_originallyDefinedIn is active

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1360,8 +1360,17 @@ OriginallyDefinedInAttr::isActivePlatform(const ASTContext &ctx) const {
   Result.Platform = Platform;
   Result.Version = MovedVersion;
   Result.ModuleName = OriginalModuleName;
-  if (isPlatformActive(Platform, ctx.LangOpts)) {
+  if (isPlatformActive(Platform, ctx.LangOpts, /*TargetVariant*/false)) {
     Result.IsSimulator = ctx.LangOpts.Target.isSimulatorEnvironment();
+    return Result;
+  }
+
+  // Also check if the platform is active by using target variant. This ensures
+  // we emit linker directives for multiple platforms when building zippered
+  // libraries.
+  if (ctx.LangOpts.TargetVariant.hasValue() &&
+      isPlatformActive(Platform, ctx.LangOpts, /*TargetVariant*/true)) {
+    Result.IsSimulator = ctx.LangOpts.TargetVariant->isSimulatorEnvironment();
     return Result;
   }
   return None;

--- a/test/TBD/linker-directives-ld-previous-macos.swift
+++ b/test/TBD/linker-directives-ld-previous-macos.swift
@@ -7,8 +7,14 @@
 // RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
 // RUN: %FileCheck %s < %t/linker_directives.tbd
 
+// RUN: %target-swift-frontend -target-variant x86_64-apple-ios13.0-macabi -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
+// RUN: %FileCheck -check-prefix=CHECK-ZIPPERED %s < %t/linker_directives.tbd
+
 // CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit5toastyyF$
 // CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleV4moveyyF$
 // CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMa$
 // CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMn$
 // CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVN$
+
+// CHECK-ZIPPERED: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit5toastyyF$
+// CHECK-ZIPPERED: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit5toastyyF$


### PR DESCRIPTION
This ensures we could emit linker directives for multiple platforms when building
zippered libraries.