### PR TITLE
[Constraint system] Eliminate global flag UnderlyingTypeForOpaqueReturnType

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1041,7 +1041,6 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
   ConstraintKind resultConstraintKind = ConstraintKind::Conversion;
   if (auto opaque = resultContextType->getAs<OpaqueTypeArchetypeType>()) {
     if (opaque->getDecl()->isOpaqueReturnTypeOfFunction(func)) {
-      options |= ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType;
       resultConstraintKind = ConstraintKind::OpaqueUnderlyingType;
     }
   }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7507,6 +7507,11 @@ ArrayRef<Solution> SolutionResult::getAmbiguousSolutions() const {
   return makeArrayRef(solutions, numSolutions);
 }
 
+MutableArrayRef<Solution> SolutionResult::takeAmbiguousSolutions() && {
+  assert(getKind() == Ambiguous);
+  return MutableArrayRef<Solution>(solutions, numSolutions);
+}
+
 llvm::PointerUnion<Expr *, Stmt *> SolutionApplicationTarget::walk(
     ASTWalker &walker) {
   switch (kind) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3831,7 +3831,8 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
 
     case StmtConditionElement::CK_Boolean: {
       Expr *condExpr = condElement.getBoolean();
-      setContextualType(condExpr, TypeLoc::withoutLoc(boolTy), CTP_Condition);
+      setContextualType(condExpr, TypeLoc::withoutLoc(boolTy), CTP_Condition,
+                        /*isOpaqueReturnType=*/false);
 
       condExpr = generateConstraints(condExpr, dc);
       if (!condExpr) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9076,8 +9076,9 @@ void ConstraintSystem::addContextualConversionConstraint(
     case CTP_ReturnStmt:
     case CTP_ReturnSingleExpr:
     case CTP_Initialization:
+      // FIXME: This option should not be global!
       if (Options.contains(
-          ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType))
+            ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType))
         constraintKind = ConstraintKind::OpaqueUnderlyingType;
       break;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9076,9 +9076,7 @@ void ConstraintSystem::addContextualConversionConstraint(
     case CTP_ReturnStmt:
     case CTP_ReturnSingleExpr:
     case CTP_Initialization:
-      // FIXME: This option should not be global!
-      if (Options.contains(
-            ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType))
+      if (contextualType.isOpaqueReturnType)
         constraintKind = ConstraintKind::OpaqueUnderlyingType;
       break;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9064,6 +9064,60 @@ void ConstraintSystem::addConstraint(ConstraintKind kind, Type first,
   }
 }
 
+void ConstraintSystem::addContextualConversionConstraint(
+    Expr *expr, ContextualTypeInfo contextualType) {
+  Type convertType = contextualType.getType();
+  if (convertType.isNull())
+    return;
+
+  // Determine the type of the constraint.
+  auto constraintKind = ConstraintKind::Conversion;
+  switch (contextualType.purpose) {
+    case CTP_ReturnStmt:
+    case CTP_ReturnSingleExpr:
+    case CTP_Initialization:
+      if (Options.contains(
+          ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType))
+        constraintKind = ConstraintKind::OpaqueUnderlyingType;
+      break;
+
+    case CTP_CallArgument:
+      constraintKind = ConstraintKind::ArgumentConversion;
+      break;
+
+    case CTP_YieldByReference:
+      // In a by-reference yield, we expect the contextual type to be an
+      // l-value type, so the result must be bound to that.
+      constraintKind = ConstraintKind::Bind;
+      break;
+
+    case CTP_ArrayElement:
+    case CTP_AssignSource:
+    case CTP_CalleeResult:
+    case CTP_CannotFail:
+    case CTP_Condition:
+    case CTP_Unused:
+    case CTP_YieldByValue:
+    case CTP_ThrowStmt:
+    case CTP_EnumCaseRawValue:
+    case CTP_DefaultParameter:
+    case CTP_ClosureResult:
+    case CTP_DictionaryKey:
+    case CTP_DictionaryValue:
+    case CTP_CoerceOperand:
+    case CTP_SubscriptAssignSource:
+    case CTP_ForEachStmt:
+      break;
+  }
+
+  // Add the constraint.
+  bool isForSingleExprFunction = (contextualType.purpose == CTP_ReturnSingleExpr);
+  auto *convertTypeLocator = getConstraintLocator(
+      expr, LocatorPathElt::ContextualType(isForSingleExprFunction));
+  addConstraint(constraintKind, getType(expr), convertType,
+               convertTypeLocator, /*isFavored*/ true);
+}
+
 Type ConstraintSystem::addJoinConstraint(
     ConstraintLocator *locator,
     ArrayRef<std::pair<Type, ConstraintLocator *>> inputs) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -591,7 +591,7 @@ bool ConstraintSystem::Candidate::solve(
   cs.Timer.emplace(E, cs);
 
   // Generate constraints for the new system.
-  if (auto generatedExpr = cs.generateConstraints(E)) {
+  if (auto generatedExpr = cs.generateConstraints(E, DC)) {
     E = generatedExpr;
   } else {
     // Failure to generate constraint system for sub-expression
@@ -1215,7 +1215,7 @@ ConstraintSystem::solveImpl(Expr *&expr,
   shrink(expr);
 
   // Generate constraints for the main system.
-  if (auto generatedExpr = generateConstraints(expr))
+  if (auto generatedExpr = generateConstraints(expr, DC))
     expr = generatedExpr;
   else {
     if (listener)

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4040,18 +4040,13 @@ private:
   /// \param expr The expression to generate constraints from.
   /// \param convertType The expected type of the expression.
   /// \param listener The callback to check solving progress.
-  /// \param solutions The set of solutions to the system of constraints.
   /// \param allowFreeTypeVariables How to bind free type variables in
   /// the solution.
-  ///
-  /// \returns Error is an error occurred, Solved is system is consistent
-  /// and solutions were found, Unsolved otherwise.
-  SolutionKind solveImpl(Expr *&expr,
-                         Type convertType,
-                         ExprTypeCheckListener *listener,
-                         SmallVectorImpl<Solution> &solutions,
-                         FreeTypeVariableBinding allowFreeTypeVariables
-                          = FreeTypeVariableBinding::Disallow);
+  SolutionResult solveImpl(Expr *&expr,
+                           Type convertType,
+                           ExprTypeCheckListener *listener,
+                           FreeTypeVariableBinding allowFreeTypeVariables
+                             = FreeTypeVariableBinding::Disallow);
 
 public:
   /// Pre-check the expression, validating any types that occur in the

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -792,6 +792,7 @@ using OpenedTypeMap =
 struct ContextualTypeInfo  {
   TypeLoc typeLoc;
   ContextualTypePurpose purpose;
+  bool isOpaqueReturnType = false;
 
   Type getType() const { return typeLoc.getType(); }
 };
@@ -1012,10 +1013,6 @@ enum class ConstraintSystemFlags {
   /// expression, and doesn't dig into its subexpressions.
   ReusePrecheckedType = 0x20,
   
-  /// If set, the top-level expression may be able to provide an underlying
-  /// type for the contextual opaque archetype.
-  UnderlyingTypeForOpaqueReturnType = 0x40,
-
   /// FIXME(diagnostics): Once diagnostics are completely switched to new
   /// framework, this flag could be removed as obsolete.
   ///
@@ -2180,11 +2177,12 @@ public:
   }
 
   void setContextualType(
-      const Expr *expr, TypeLoc T, ContextualTypePurpose purpose) {
+      const Expr *expr, TypeLoc T, ContextualTypePurpose purpose,
+       bool isOpaqueReturnType) {
     assert(expr != nullptr && "Expected non-null expression!");
     assert(contextualTypes.count(expr) == 0 &&
            "Already set this contextual type");
-    contextualTypes[expr] = { T, purpose };
+    contextualTypes[expr] = { T, purpose, isOpaqueReturnType };
   }
 
   Optional<ContextualTypeInfo> getContextualTypeInfo(const Expr *expr) const {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2413,6 +2413,10 @@ public:
   void addConstraint(Requirement req, ConstraintLocatorBuilder locator,
                      bool isFavored = false);
 
+  /// Add the appropriate constraint for a contextual conversion.
+  void addContextualConversionConstraint(
+      Expr *expr, ContextualTypeInfo contextualType);
+
   /// Add a "join" constraint between a set of types, producing the common
   /// supertype.
   ///

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3078,7 +3078,7 @@ public:
   /// Generate constraints for the given (unchecked) expression.
   ///
   /// \returns a possibly-sanitized expression, or null if an error occurred.
-  Expr *generateConstraints(Expr *E, DeclContext *dc = nullptr);
+  Expr *generateConstraints(Expr *E, DeclContext *dc);
 
   /// Generate constraints for binding the given pattern to the
   /// value of the given expression.

--- a/lib/Sema/SolutionResult.h
+++ b/lib/Sema/SolutionResult.h
@@ -120,6 +120,9 @@ public:
   /// Retrieve the set of solutions when there is an ambiguity.
   ArrayRef<Solution> getAmbiguousSolutions() const;
 
+  /// Take the set of solutions when there is an ambiguity.
+  MutableArrayRef<Solution> takeAmbiguousSolutions() &&;
+
   /// Whether this solution requires the client to produce a diagnostic.
   bool requiresDiagnostic() const {
     switch (kind) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2466,7 +2466,7 @@ getTypeOfCompletionOperatorImpl(DeclContext *DC, Expr *expr,
 
   // Construct a constraint system from this expression.
   ConstraintSystem CS(DC, options);
-  expr = CS.generateConstraints(expr);
+  expr = CS.generateConstraints(expr, DC);
   if (!expr)
     return nullptr;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2189,9 +2189,6 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   if (options.contains(TypeCheckExprFlags::AllowUnresolvedTypeVariables))
     csOptions |= ConstraintSystemFlags::AllowUnresolvedTypeVariables;
 
-  if (options.contains(TypeCheckExprFlags::ConvertTypeIsOpaqueReturnType))
-    csOptions |= ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType;
-
   if (options.contains(TypeCheckExprFlags::SubExpressionDiagnostics))
     csOptions |= ConstraintSystemFlags::SubExpressionDiagnostics;
 
@@ -2222,7 +2219,9 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   Expr *contextualTypeExpr = expr;
   if (auto loadExpr = dyn_cast_or_null<LoadExpr>(contextualTypeExpr))
     contextualTypeExpr = loadExpr->getSubExpr();
-  cs.setContextualType(contextualTypeExpr, convertType, convertTypePurpose);
+  cs.setContextualType(
+      contextualTypeExpr, convertType, convertTypePurpose,
+      options.contains(TypeCheckExprFlags::ConvertTypeIsOpaqueReturnType));
 
   // If the convertType is *only* provided for that hint, then null it out so
   // that we don't later treat it as an actual conversion constraint.
@@ -2666,8 +2665,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
         initType = patternType;
 
         // Add a conversion constraint between the types.
-        if (!cs.Options.contains(
-                   ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType)) {
+        if (!initType->is<OpaqueTypeArchetypeType>()) {
           cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
                            patternType, Locator, /*isFavored*/true);
         }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -153,7 +153,7 @@ enum ContextualTypePurpose {
 
 
 
-/// Flags that can be used to control name lookup.
+/// Flags that can be used to control type checking.
 enum class TypeCheckExprFlags {
   /// Whether we know that the result of the expression is discarded.  This
   /// disables constraints forcing an lvalue result to be loadable.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -47,7 +47,6 @@ enum class TypeResolutionStage : uint8_t;
 
 namespace constraints {
   enum class ConstraintKind : char;
-  enum class SolutionKind : char;
   class ConstraintSystem;
   class Solution;
   class SolutionResult;

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -41,10 +41,9 @@ func testFunc() {
   let _: (S) -> Int = \.i
   _ = ([S]()).map(\.i)
 
-  // FIXME: A terrible error, but the same as the pre-existing key path
-  // error in the similar situation: 'let _ = \S.init'.
   _ = ([S]()).map(\.init)
-  // expected-error@-1 {{type of expression is ambiguous without more context}}
+  // expected-error@-1 {{key path cannot refer to static member 'init()'}}
+  // expected-error@-2 {{key path value type '() -> S' cannot be converted to contextual type '_'}}
 
   let kp = \S.i
   let _: KeyPath<S, Int> = kp // works, because type defaults to KeyPath nominal

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -41,9 +41,10 @@ func testFunc() {
   let _: (S) -> Int = \.i
   _ = ([S]()).map(\.i)
 
+  // FIXME: A terrible error, but the same as the pre-existing key path
+  // error in the similar situation: 'let _ = \S.init'.
   _ = ([S]()).map(\.init)
-  // expected-error@-1 {{key path cannot refer to static member 'init()'}}
-  // expected-error@-2 {{key path value type '() -> S' cannot be converted to contextual type '_'}}
+  // expected-error@-1 {{type of expression is ambiguous without more context}}
 
   let kp = \S.i
   let _: KeyPath<S, Int> = kp // works, because type defaults to KeyPath nominal


### PR DESCRIPTION
Make this information contextual (per type) rather than global (per
constraint system) so we don’t misapply it.