### PR TITLE
[metadata prespecialization] On by default.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -262,7 +262,7 @@ public:
         EnableAnonymousContextMangledNames(false), ForcePublicLinkage(false),
         LazyInitializeClassMetadata(false),
         LazyInitializeProtocolConformances(false), DisableLegacyTypeInfo(false),
-        PrespecializeGenericMetadata(false), UseIncrementalLLVMCodeGen(true),
+        PrespecializeGenericMetadata(true), UseIncrementalLLVMCodeGen(true),
         UseSwiftCall(false), GenerateProfile(false),
         EnableDynamicReplacementChaining(false),
         DisableRoundTripDebugTypes(false), DisableDebuggerShadowCopies(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -651,9 +651,9 @@ def disable_verify_exclusivity : Flag<["-"], "disable-verify-exclusivity">,
 def disable_legacy_type_info : Flag<["-"], "disable-legacy-type-info">,
   HelpText<"Completely disable legacy type layout">;
 
-def prespecialize_generic_metadata : Flag<["-"], "prespecialize-generic-metadata">,
-  HelpText<"Statically specialize metadata for generic types at types that "
-           "are known to be used in source.">;
+def disable_generic_metadata_prespecialization : Flag<["-"], "disable-generic-metadata-prespecialization">,
+  HelpText<"Do not statically specialize metadata for generic types at types "
+           "that are known to be used in source.">;
 
 def read_legacy_type_info_path_EQ : Joined<["-"], "read-legacy-type-info-path=">,
   HelpText<"Read legacy type layout from the given path instead of default path">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1327,8 +1327,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.DisableLegacyTypeInfo = true;
   }
 
-  if (Args.hasArg(OPT_prespecialize_generic_metadata)) {
-    Opts.PrespecializeGenericMetadata = true;
+  if (Args.hasArg(OPT_disable_generic_metadata_prespecialization)) {
+    Opts.PrespecializeGenericMetadata = false;
   }
 
   if (const Arg *A = Args.getLastArg(OPT_read_legacy_type_info_path_EQ)) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1340,7 +1340,8 @@ bool IRGenModule::shouldPrespecializeGenericMetadata() {
       AvailabilityContext::forDeploymentTarget(context);
   return IRGen.Opts.PrespecializeGenericMetadata && 
     deploymentAvailability.isContainedIn(
-      context.getPrespecializedGenericMetadataAvailability());
+      context.getPrespecializedGenericMetadataAvailability()) &&
+    (Triple.isOSDarwin() || Triple.isTvOS() || Triple.isOSLinux());
 }
 
 void IRGenerator::addGenModule(SourceFile *SF, IRGenModule *IGM) {

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -701,36 +701,40 @@ bool irgen::isNominalGenericContextTypeMetadataAccessTrivial(
   auto substitutions =
       type->getContextSubstitutionMap(IGM.getSwiftModule(), &nominal);
 
-  return llvm::all_of(environment->getGenericParams(), [&](auto parameter) {
-    auto conformances =
-        environment->getGenericSignature()->getConformsTo(parameter);
-    auto witnessTablesAreReferenceable =
-        llvm::all_of(conformances, [&](ProtocolDecl *conformance) {
-          return conformance->getModuleContext() == IGM.getSwiftModule() &&
-                 !conformance->isResilient(IGM.getSwiftModule(),
-                                           ResilienceExpansion::Minimal);
-        });
+  auto allWitnessTablesAreReferenceable = llvm::all_of(environment->getGenericParams(), [&](auto parameter) {
+    auto signature = environment->getGenericSignature();
+    auto protocols = signature->getConformsTo(parameter);
     auto argument = ((Type *)parameter)->subst(substitutions);
-    auto genericArgument = argument->getAnyGeneric();
-    // For now, to avoid statically specializing generic protocol witness
-    // tables, don't statically specialize metadata for types any of whose
-    // arguments are generic.
-    //
-    // TODO: This is more pessimistic than necessary.  Specialize even in
-    //       the face of generic arguments so long as those arguments
-    //       aren't required to conform to any protocols.
-    //
+    auto canonicalType = argument->getCanonicalType();
+    auto witnessTablesAreReferenceable = [&]() {
+      return llvm::all_of(protocols, [&](ProtocolDecl *protocol) {
+        auto conformance =
+            signature->lookupConformance(canonicalType, protocol);
+        if (!conformance.isConcrete()) {
+          return false;
+        }
+        auto rootConformance = conformance.getConcrete()->getRootConformance();
+        return !IGM.isDependentConformance(rootConformance) &&
+               !IGM.isResilientConformance(rootConformance);
+      });
+    };
     // TODO: Once witness tables are statically specialized, check whether the
     //       ConformanceInfo returns nullptr from tryGetConstantTable.
-    //       early return.
-    auto isGeneric = genericArgument && genericArgument->isGenericContext();
-    auto isNominal = argument->getNominalOrBoundGenericNominal();
-    auto isExistential = argument->isExistentialType();
-    return isNominal && !isGeneric && !isExistential &&
-           witnessTablesAreReferenceable &&
-           irgen::isTypeMetadataAccessTrivial(IGM,
-                                              argument->getCanonicalType());
-  }) && IGM.getTypeInfoForUnlowered(type).isFixedSize(ResilienceExpansion::Maximal);
+    auto isGenericWithoutPrespecializedConformance = [&]() {
+      auto genericArgument = argument->getAnyGeneric();
+      return genericArgument && genericArgument->isGenericContext() && 
+        (protocols.size() > 0);
+    };
+    auto isExistential = [&]() { return argument->isExistentialType(); };
+    auto metadataAccessIsTrivial = [&]() {
+      return irgen::isTypeMetadataAccessTrivial(IGM,
+                                                argument->getCanonicalType());
+    };
+    return !isGenericWithoutPrespecializedConformance() && !isExistential() && 
+           metadataAccessIsTrivial() && witnessTablesAreReferenceable();
+  });
+  return allWitnessTablesAreReferenceable
+  && IGM.getTypeInfoForUnlowered(type).isFixedSize(ResilienceExpansion::Maximal);
 }
 
 /// Is it basically trivial to access the given metadata?  If so, we don't

--- a/test/IRGen/conditional_conformances.swift
+++ b/test/IRGen/conditional_conformances.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=CHECK --check-prefix=%target-os
-// RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_with_assoc.swift | %FileCheck %S/../Inputs/conditional_conformance_with_assoc.swift --check-prefix=CHECK --check-prefix=%target-os
-// RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_subclass.swift | %FileCheck %S/../Inputs/conditional_conformance_subclass.swift --check-prefix=CHECK --check-prefix=%target-os
-// RUN: %target-swift-frontend -emit-ir %S/../Inputs/conditional_conformance_recursive.swift | %FileCheck %S/../Inputs/conditional_conformance_recursive.swift --check-prefix=CHECK --check-prefix=%target-os
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=CHECK --check-prefix=%target-os
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -emit-ir %S/../Inputs/conditional_conformance_with_assoc.swift | %FileCheck %S/../Inputs/conditional_conformance_with_assoc.swift --check-prefix=CHECK --check-prefix=%target-os
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -emit-ir %S/../Inputs/conditional_conformance_subclass.swift | %FileCheck %S/../Inputs/conditional_conformance_subclass.swift --check-prefix=CHECK --check-prefix=%target-os
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -emit-ir %S/../Inputs/conditional_conformance_recursive.swift | %FileCheck %S/../Inputs/conditional_conformance_recursive.swift --check-prefix=CHECK --check-prefix=%target-os
 
 // Too many pointer-sized integers in the IR
 // REQUIRES: PTRSIZE=64

--- a/test/IRGen/conditional_conformances_future.swift
+++ b/test/IRGen/conditional_conformances_future.swift
@@ -5,4 +5,5 @@
 
 // Too many pointer-sized integers in the IR
 // REQUIRES: PTRSIZE=64
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 

--- a/test/IRGen/conditional_conformances_future.swift
+++ b/test/IRGen/conditional_conformances_future.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances_future.swift -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=%target-os
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir %S/../Inputs/conditional_conformance_with_assoc.swift | %FileCheck %S/../Inputs/conditional_conformance_with_assoc_future.swift -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=%target-os
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir %S/../Inputs/conditional_conformance_subclass.swift | %FileCheck %S/../Inputs/conditional_conformance_subclass_future.swift -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=%target-os
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir %S/../Inputs/conditional_conformance_recursive.swift | %FileCheck %S/../Inputs/conditional_conformance_recursive.swift -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=%target-os
+
+// Too many pointer-sized integers in the IR
+// REQUIRES: PTRSIZE=64
+

--- a/test/IRGen/conditional_conformances_gettypemetdatabyname.swift
+++ b/test/IRGen/conditional_conformances_gettypemetdatabyname.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.99 -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=TYPEBYNAME
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -target x86_64-apple-macosx10.99 -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=TYPEBYNAME
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.99 -emit-ir %S/../Inputs/conditional_conformance_basic_conformances.swift | %FileCheck %S/../Inputs/conditional_conformance_basic_conformances.swift --check-prefix=TYPEBYNAME_PRESPECIALIZED
 
 // Too many pointer-sized integers in the IR
 // REQUIRES: PTRSIZE=64

--- a/test/IRGen/dynamic_self_metadata.swift
+++ b/test/IRGen/dynamic_self_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -parse-as-library | %FileCheck %s
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization %s -emit-ir -parse-as-library | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/dynamic_self_metadata.swift
+++ b/test/IRGen/dynamic_self_metadata.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -disable-generic-metadata-prespecialization %s -emit-ir -parse-as-library | %FileCheck %s
 
+// UNSUPPORTED: OS=windows-msvc
 // REQUIRES: CPU=x86_64
 
 // FIXME: Not a SIL test because we can't parse dynamic Self in SIL.

--- a/test/IRGen/dynamic_self_metadata_future.swift
+++ b/test/IRGen/dynamic_self_metadata_future.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend %s -target %module-target-future -emit-ir -parse-as-library | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // REQUIRES: CPU=x86_64
 
 // FIXME: Not a SIL test because we can't parse dynamic Self in SIL.

--- a/test/IRGen/dynamic_self_metadata_future.swift
+++ b/test/IRGen/dynamic_self_metadata_future.swift
@@ -1,0 +1,78 @@
+// RUN: %target-swift-frontend %s -target %module-target-future -emit-ir -parse-as-library | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+
+// REQUIRES: CPU=x86_64
+
+// FIXME: Not a SIL test because we can't parse dynamic Self in SIL.
+// <rdar://problem/16931299>
+
+// CHECK: [[TYPE:%.+]] = type <{ [8 x i8] }>
+
+@inline(never) func id<T>(_ t: T) -> T {
+  return t
+}
+// CHECK-LABEL: define hidden swiftcc void @"$s28dynamic_self_metadata_future2idyxxlF"
+
+protocol P {
+  associatedtype T
+}
+
+extension P {
+  func f() {}
+}
+
+struct G<T> : P {
+  var t: T
+}
+
+class C {
+  class func fromMetatype() -> Self? { return nil }
+  // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC12fromMetatypeACXDSgyFZ"(%swift.type* swiftself)
+  // CHECK: ret i64 0
+
+  func fromInstance() -> Self? { return nil }
+  // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC12fromInstanceACXDSgyF"(%T28dynamic_self_metadata_future1CC* swiftself)
+  // CHECK: ret i64 0
+
+  func dynamicSelfArgument() -> Self? {
+    return id(nil)
+  }
+  // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC0A12SelfArgumentACXDSgyF"(%T28dynamic_self_metadata_future1CC* swiftself)
+  // CHECK: [[GEP1:%.+]] = getelementptr {{.*}} %0
+  // CHECK: [[TYPE1:%.+]] = load {{.*}} [[GEP1]]
+  // CHECK: [[T0:%.+]] = call swiftcc %swift.metadata_response @"$sSqMa"(i64 0, %swift.type* [[TYPE1]])
+  // CHECK: [[TYPE2:%.+]] = extractvalue %swift.metadata_response [[T0]], 0
+  // CHECK: call swiftcc void @"$s28dynamic_self_metadata_future2idyxxlF"({{.*}}, %swift.type* [[TYPE2]])
+
+  func dynamicSelfConformingType() -> Self? {
+    _ = G(t: self).f()
+    return nil
+  }
+  // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC0A18SelfConformingTypeACXDSgyF"(%T28dynamic_self_metadata_future1CC* swiftself)
+  // CHECK: [[SELF_GEP:%.+]] = getelementptr {{.*}} %0
+  // CHECK: [[SELF_TYPE:%.+]] = load {{.*}} [[SELF_GEP]]
+  // CHECK: call i8** @swift_getWitnessTable(
+  // CHECK-SAME:   %swift.protocol_conformance_descriptor* bitcast (
+  // CHECK-SAME:     {{.*}} @"$s28dynamic_self_metadata_future1GVyxGAA1PAAMc" 
+  // CHECK-SAME:     to %swift.protocol_conformance_descriptor*
+  // CHECK-SAME:   ), 
+  // CHECK-SAME:   %swift.type* getelementptr inbounds (
+  // CHECK-SAME:     %swift.full_type, 
+  // CHECK-SAME:     %swift.full_type* bitcast (
+  // CHECK-SAME:       <{ 
+  // CHECK-SAME:         i8**, 
+  // CHECK-SAME:         [[INT]], 
+  // CHECK-SAME:         %swift.type_descriptor*, 
+  // CHECK-SAME:         %swift.type*, 
+  // CHECK-SAME:         i32, 
+  // CHECK-SAME:         {{(\[4 x i8\])?}}, 
+  // CHECK-SAME:         i64 
+  // CHECK-SAME:       }>* @"$s28dynamic_self_metadata_future1GVyAA1CCXDGMf" 
+  // CHECK-SAME:       to %swift.full_type*
+  // CHECK-SAME:     ), 
+  // CHECK-SAME:     i32 0, 
+  // CHECK-SAME:     i32 1
+  // CHECK-SAME:   ), 
+  // CHECK-SAME:   i8*** undef
+  // CHECK-SAME: )
+}

--- a/test/IRGen/foreign_types_future.sil
+++ b/test/IRGen/foreign_types_future.sil
@@ -1,4 +1,8 @@
-// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -target %module-target-future -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
 
 sil_stage canonical
 import c_layout
@@ -20,7 +24,8 @@ import c_layout
 // CHECK-SAME:  [[INT]] 512,
 // CHECK-SAME:  @"$sSo14HasNestedUnionV18__Unnamed_struct_sVMn"
 // CHECK-SAME:  i32 0,
-// CHECK-SAME:  i32 4 }
+// CHECK-SAME:  i32 4, 
+// CHECK-SAME:  i64 0 }
 
 // CHECK-LABEL: @"\01l_type_metadata_table" = private constant
 // CHECK-SAME: @"$sSo12AmazingColorVMn"

--- a/test/IRGen/foreign_types_future.sil
+++ b/test/IRGen/foreign_types_future.sil
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -target %module-target-future -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/generic_metatypes_future.swift
+++ b/test/IRGen/generic_metatypes_future.swift
@@ -1,15 +1,14 @@
 
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target x86_64-apple-macosx10.9  -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target i386-apple-ios7.0        -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target x86_64-apple-ios7.0      -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target x86_64-apple-tvos9.0     -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target i386-apple-watchos2.0    -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32  %s
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target x86_64-unknown-linux-gnu -disable-objc-interop -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
+// RUN: %swift -module-name generic_metatypes -target x86_64-apple-macosx10.99  -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
+// RUN: %swift -module-name generic_metatypes -target x86_64-apple-ios99.0      -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
+// RUN: %swift -module-name generic_metatypes -target x86_64-apple-tvos99.0     -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64  %s
+// RUN: %swift -module-name generic_metatypes -target i386-apple-watchos9.99    -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32  %s
+// RUN: %swift -module-name generic_metatypes -target x86_64-unknown-linux-gnu -disable-objc-interop -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
 
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target armv7-apple-ios7.0       -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target arm64-apple-ios7.0       -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target arm64-apple-tvos9.0      -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
-// RUN: %swift -disable-generic-metadata-prespecialization -module-name generic_metatypes -target armv7k-apple-watchos2.0  -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
+// RUN: %swift -module-name generic_metatypes -target arm64-apple-ios99.0       -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
+// RUN: %swift -module-name generic_metatypes -target arm64-apple-tvos99.0      -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 -DINT=i64 %s
+// RUN: %swift -module-name generic_metatypes -target armv7k-apple-watchos9.99  -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
+
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM
@@ -101,10 +100,40 @@ func genericMetatype<A>(_ x: A.Type) {}
 
 // CHECK-LABEL: define hidden swiftcc void @"$s17generic_metatypes20makeGenericMetatypesyyF"() {{.*}} {
 func makeGenericMetatypes() {
-  // CHECK: call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$s17generic_metatypes6OneArgVyAA3FooVGMD") [[NOUNWIND_READNONE:#[0-9]+]]
+  // CHECK: call swiftcc void @"$s17generic_metatypes0A8MetatypeyyxmlF"(
+  // CHECK-SAME:   %swift.type* getelementptr inbounds (
+  // CHECK-SAME:     %swift.full_type, %swift.full_type* bitcast (
+  // CHECK-SAME:       <{ 
+  // CHECK-SAME:         i8**, 
+  // CHECK-SAME:         [[INT]], 
+  // CHECK-SAME:         %swift.type_descriptor*, 
+  // CHECK-SAME:         %swift.type*, 
+  // CHECK-SAME:         i64 
+  // CHECK-SAME:       }>* @"$s17generic_metatypes6OneArgVyAA3FooVGMf" 
+  // CHECK-SAME:       to %swift.full_type*
+  // CHECK-SAME:     ), 
+  // CHECK-SAME:     i32 0, 
+  // CHECK-SAME:     i32 1
+  // CHECK-SAME:   ), 
+  // CHECK-SAME:   %swift.type* getelementptr inbounds (
+  // CHECK-SAME:     %swift.full_type, 
+  // CHECK-SAME:     %swift.full_type* bitcast (
+  // CHECK-SAME:       <{ 
+  // CHECK-SAME:         i8**, 
+  // CHECK-SAME:         [[INT]], 
+  // CHECK-SAME:         %swift.type_descriptor*, 
+  // CHECK-SAME:         %swift.type*, 
+  // CHECK-SAME:         i64 
+  // CHECK-SAME:       }>* @"$s17generic_metatypes6OneArgVyAA3FooVGMf" 
+  // CHECK-SAME:       to %swift.full_type*
+  // CHECK-SAME:     ), 
+  // CHECK-SAME:     i32 0, 
+  // CHECK-SAME:     i32 1
+  // CHECK-SAME:   )
+  // CHECK-SAME: )
   genericMetatype(OneArg<Foo>.self)
 
-  // CHECK: call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$s17generic_metatypes7TwoArgsVyAA3FooVAA3BarCGMD") [[NOUNWIND_READNONE]]
+  // CHECK: call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$s17generic_metatypes7TwoArgsVyAA3FooVAA3BarCGMD") [[NOUNWIND_READNONE:#[0-9]+]]
   genericMetatype(TwoArgs<Foo, Bar>.self)
 
   // CHECK: call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$s17generic_metatypes9ThreeArgsVyAA3FooVAA3BarCAEGMD") [[NOUNWIND_READNONE]]

--- a/test/IRGen/generic_metatypes_future.swift
+++ b/test/IRGen/generic_metatypes_future.swift
@@ -10,6 +10,7 @@
 // RUN: %swift -module-name generic_metatypes -target armv7k-apple-watchos9.99  -emit-ir -disable-legacy-type-info -parse-stdlib -primary-file %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 -DINT=i32 %s
 
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM
 

--- a/test/IRGen/generic_structs_future.sil
+++ b/test/IRGen/generic_structs_future.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %{python} %utils/chex.py < %s > %t/generic_structs.sil
-// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization %t/generic_structs.sil -emit-ir | %FileCheck %t/generic_structs.sil
+// RUN: %{python} %utils/chex.py < %s > %t/generic_structs_future.sil
+// RUN: %target-swift-frontend -target %module-target-future %t/generic_structs_future.sil -emit-ir | %FileCheck %t/generic_structs_future.sil
 
 // REQUIRES: CPU=x86_64
 
@@ -9,15 +9,15 @@ import Builtin
 // -- Generic structs with fixed layout should have no completion function
 //    and emit the field offset vector as part of the pattern.
 // CHECK:       [[PATTERN:@.*]] = internal constant [4 x i32] [i32 0, i32 1, i32 8, i32 0]
-// CHECK-LABEL: @"$s15generic_structs18FixedLayoutGenericVMP" = internal constant <{ {{.*}} }> <{
+// CHECK-LABEL: @"$s22generic_structs_future18FixedLayoutGenericVMP" = internal constant <{ {{.*}} }> <{
 // -- instantiation function
-// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s15generic_structs18FixedLayoutGenericVMi"
+// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s22generic_structs_future18FixedLayoutGenericVMi"
 // -- completion function
 // CHECK-SAME:   i32 0,
 // -- pattern flags
-// CHECK-SAME:   <i32 0x4000_0001>,
+// CHECK-SAME:   <i32 0x4000_0003>,
 // -- vwtable pointer
-// CHECK-SAME:   @"$s15generic_structs18FixedLayoutGenericVWV"
+// CHECK-SAME:   @"$s22generic_structs_future18FixedLayoutGenericVWV"
 // -- extra data pattern
 // CHECK-SAME: [4 x i32]* [[PATTERN]]
 // CHECK-SAME: i16 1,
@@ -25,8 +25,8 @@ import Builtin
 
 // -- Generic structs with dynamic layout contain the vwtable pattern as part
 //    of the metadata pattern, and no independent vwtable symbol
-// CHECK: @"$s15generic_structs13SingleDynamicVWV" = internal constant
-// CHECK-SAME:   i8* bitcast (%swift.opaque* ([24 x i8]*, [24 x i8]*, %swift.type*)* @"$s15generic_structs13SingleDynamicVwCP" to i8*),
+// CHECK: @"$s22generic_structs_future13SingleDynamicVWV" = internal constant
+// CHECK-SAME:   i8* bitcast (%swift.opaque* ([24 x i8]*, [24 x i8]*, %swift.type*)* @"$s22generic_structs_future13SingleDynamicVwCP" to i8*),
 // -- ...
 // -- placeholder for size, stride, flags
 // CHECK-SAME:   i64 0,
@@ -36,7 +36,7 @@ import Builtin
 
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
 // CHECK: [[SINGLEDYNAMIC_NAME:@.*]] = private constant [14 x i8] c"SingleDynamic\00"
-// CHECK: @"$s15generic_structs13SingleDynamicVMn" = hidden constant 
+// CHECK: @"$s22generic_structs_future13SingleDynamicVMn" = hidden constant 
 // --       flags: struct, unique, generic
 // CHECK-SAME:   <i32 0x0000_00D1>
 // --       name
@@ -46,23 +46,23 @@ import Builtin
 // --       field offset vector offset
 // CHECK-SAME:   i32 3,
 // --       generic instantiation info
-// CHECK-SAME:   [{{[0-9]+}} x i8*]* @"$s15generic_structs13SingleDynamicVMI"
-// CHECK-SAME:   @"$s15generic_structs13SingleDynamicVMP"
+// CHECK-SAME:   [{{[0-9]+}} x i8*]* @"$s22generic_structs_future13SingleDynamicVMI"
+// CHECK-SAME:   @"$s22generic_structs_future13SingleDynamicVMP"
 // --       generic params, requirements, key args, extra args
 // CHECK-SAME:   i16 1, i16 0, i16 1, i16 0
 // --       generic parameters
 // CHECK-SAME:   <i8 0x80>
 // CHECK-SAME: }>
-// CHECK: @"$s15generic_structs13SingleDynamicVMP" = internal constant <{ {{.*}} }> <{
+// CHECK: @"$s22generic_structs_future13SingleDynamicVMP" = internal constant <{ {{.*}} }> <{
 // -- instantiation function
-// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s15generic_structs13SingleDynamicVMi"
+// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8*)* @"$s22generic_structs_future13SingleDynamicVMi"
 // -- vwtable pointer
-// CHECK-SAME:   @"$s15generic_structs13SingleDynamicVWV"
+// CHECK-SAME:   @"$s22generic_structs_future13SingleDynamicVWV"
 
 // -- Nominal type descriptor for generic struct with protocol requirements
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
 // CHECK: [[DYNAMICWITHREQUIREMENTS_NAME:@.*]] = private constant [24 x i8] c"DynamicWithRequirements\00"
-// CHECK: @"$s15generic_structs23DynamicWithRequirementsVMn" = hidden constant <{ {{.*}} i32 }> <{
+// CHECK: @"$s22generic_structs_future23DynamicWithRequirementsVMn" = hidden constant <{ {{.*}} i32 }> <{
 // --       flags: struct, unique, generic
 // CHECK-SAME:   <i32 0x0000_00D1>
 // --       name
@@ -81,26 +81,26 @@ import Builtin
 //   --       param 0
 // CHECK-SAME: i32 0
 //   --       protocol Req1
-// CHECK-SAME: @"$s15generic_structs4Req1Mp"
+// CHECK-SAME: @"$s22generic_structs_future4Req1Mp"
 
 //   --       protocol requirement with key arg
 // CHECK-SAME: i32 128
 //   --       param 1
 // CHECK-SAME: i32 2
 //   --       protocol Req2
-// CHECK-SAME: @"$s15generic_structs4Req2Mp"
+// CHECK-SAME: @"$s22generic_structs_future4Req2Mp"
 // CHECK-SAME: }>
 
-// CHECK: @"$s15generic_structs23DynamicWithRequirementsVMP" = internal constant <{ {{.*}} }> <{
+// CHECK: @"$s22generic_structs_future23DynamicWithRequirementsVMP" = internal constant <{ {{.*}} }> <{
 
 // -- Fixed-layout struct metadata contains fixed field offsets
-// CHECK: @"$s15generic_structs6IntishVMf" = internal constant <{ {{.*}} i32, [4 x i8] }> <{
+// CHECK: @"$s22generic_structs_future6IntishVMf" = internal constant <{ {{.*}} i32, [4 x i8], i64 }> <{
 // CHECK-SAME:   i32 0
 // CHECK-SAME: }>
-// CHECK: @"$s15generic_structs7CharethVMf" = internal constant <{ {{.*}} i32, [4 x i8] }> <{
+// CHECK: @"$s22generic_structs_future7CharethVMf" = internal constant <{ {{.*}} i32, [4 x i8], i64 }> <{
 // CHECK-SAME:   i32 0
 // CHECK-SAME: }>
-// CHECK: @"$s15generic_structs8StringlyVMf" = internal constant <{ {{.*}} i32, i32, i32, [4 x i8] }> <{
+// CHECK: @"$s22generic_structs_future8StringlyVMf" = internal constant <{ {{.*}} i32, i32, i32, [4 x i8], i64 }> <{
 // CHECK-SAME:   i32 0, i32 8, i32 16, [4 x i8] zeroinitializer
 // CHECK-SAME: }>
 
@@ -162,7 +162,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i32*
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i32, i32* [[METADATA]], i64 10
   // CHECK: [[FIELD_OFFSET:%.*]] = load i32, i32* [[FIELD_OFFSET_ADDR]], align 8
-  // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
+  // CHECK: [[BYTES:%.*]] = bitcast %T22generic_structs_future14ComplexDynamicV* %0 to i8*
   // CHECK: [[BYTE_OFFSET:%.*]] = getelementptr inbounds i8, i8* [[BYTES]], i32 [[FIELD_OFFSET]]
   // CHECK: bitcast i8* [[BYTE_OFFSET]] to %swift.opaque*
   %b = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.b
@@ -170,18 +170,18 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i32*
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i32, i32* [[METADATA]], i64 11
   // CHECK: [[FIELD_OFFSET:%.*]] = load i32, i32* [[FIELD_OFFSET_ADDR]], align 8
-  // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
+  // CHECK: [[BYTES:%.*]] = bitcast %T22generic_structs_future14ComplexDynamicV* %0 to i8*
   // CHECK: [[BYTE_OFFSET:%.*]] = getelementptr inbounds i8, i8* [[BYTES]], i32 [[FIELD_OFFSET]]
-  // CHECK: bitcast i8* [[BYTE_OFFSET]] to %T15generic_structs13SingleDynamicV
+  // CHECK: bitcast i8* [[BYTE_OFFSET]] to %T22generic_structs_future13SingleDynamicV
   %5 = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.c
   %c = struct_element_addr %5 : $*SingleDynamic<B>, #SingleDynamic.x
 
   // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i32*
   // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i32, i32* [[METADATA]], i64 12
   // CHECK: [[FIELD_OFFSET:%.*]] = load i32, i32* [[FIELD_OFFSET_ADDR]], align 8
-  // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
+  // CHECK: [[BYTES:%.*]] = bitcast %T22generic_structs_future14ComplexDynamicV* %0 to i8*
   // CHECK: [[BYTE_OFFSET:%.*]] = getelementptr inbounds i8, i8* [[BYTES]], i32 [[FIELD_OFFSET]]
-  // CHECK: bitcast i8* [[BYTE_OFFSET]] to %T15generic_structs7CharethV
+  // CHECK: bitcast i8* [[BYTE_OFFSET]] to %T22generic_structs_future7CharethV
   %d = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.d
   copy_addr %a to %1 : $*Byteful
   copy_addr %b to %2 : $*A
@@ -191,14 +191,14 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   return %v : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$s15generic_structs13SingleDynamicVMi"(%swift.type_descriptor*, i8**, i8*)
+// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$s22generic_structs_future13SingleDynamicVMi"(%swift.type_descriptor*, i8**, i8*)
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   %T = load %swift.type*, %swift.type** [[T0]], align 8
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2, i64 16)
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** %1, i8* %2, i64 24)
 // CHECK-NEXT:   ret %swift.type* [[METADATA]]
 // CHECK: }
 
-// CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$s15generic_structs13SingleDynamicVMr"
+// CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$s22generic_structs_future13SingleDynamicVMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
 //   Lay out fields.
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i32*
@@ -211,7 +211,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
 // Check that we directly delegate buffer witnesses to a single dynamic field:
 
 //   initializeBufferWithCopyOfBuffer
-// CHECK-LABEL: define internal %swift.opaque* @"$s15generic_structs13SingleDynamicVwCP"([24 x i8]* noalias %dest, [24 x i8]* noalias %src, %swift.type* %"SingleDynamic<T>") {{.*}} {
+// CHECK-LABEL: define internal %swift.opaque* @"$s22generic_structs_future13SingleDynamicVwCP"([24 x i8]* noalias %dest, [24 x i8]* noalias %src, %swift.type* %"SingleDynamic<T>") {{.*}} {
 // CHECK:      %T = load %swift.type*,
 // CHECK:      [[T0:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], i64 -1
@@ -235,7 +235,7 @@ struct GenericLayoutWithAssocType<T: ParentHasAssociatedType> {
   var x: T.Assoc
   var y: T.Assoc.Assoc
 }
-// CHECK-LABEL: define internal %swift.type* @"$s15generic_structs26GenericLayoutWithAssocTypeVMi"(
+// CHECK-LABEL: define internal %swift.type* @"$s22generic_structs_future26GenericLayoutWithAssocTypeVMi"(
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   %T = load %swift.type*, %swift.type** [[T0]], align 8
 // CHECK:   [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i32 1
@@ -244,7 +244,7 @@ struct GenericLayoutWithAssocType<T: ParentHasAssociatedType> {
 
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata
 
-// CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s15generic_structs26GenericLayoutWithAssocTypeVMr"(
+// CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$s22generic_structs_future26GenericLayoutWithAssocTypeVMr"(
 
 // CHECK: [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState(i64 0, %swift.type* %T)
 // CHECK: [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -252,10 +252,10 @@ struct GenericLayoutWithAssocType<T: ParentHasAssociatedType> {
 // CHECK: [[T0_GEP:%.*]] = getelementptr inbounds i8*, i8** %T.ParentHasAssociatedType, i32 1
 // CHECK: [[T0:%.*]] = load i8*, i8** [[T0_GEP]]
 // CHECK: [[T1:%.*]] = bitcast i8* [[T0]] to i8**
-// CHECK: [[T4:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %T.HasAssociatedType, %swift.type* %T, %swift.protocol_requirement* @"$s15generic_structs17HasAssociatedTypeTL", %swift.protocol_requirement* @"$s5Assoc15generic_structs17HasAssociatedTypePTl")
+// CHECK: [[T4:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %T.HasAssociatedType, %swift.type* %T, %swift.protocol_requirement* @"$s22generic_structs_future17HasAssociatedTypeTL", %swift.protocol_requirement* @"$s5Assoc22generic_structs_future17HasAssociatedTypePTl")
 
 // CHECK: %T.Assoc = extractvalue %swift.metadata_response [[T4]], 0
 // CHECK:   %T.Assoc.HasAssociatedType = call swiftcc i8** @swift_getAssociatedConformanceWitness(i8** %T.ParentHasAssociatedType, %swift.type* %T, %swift.type* %T.Assoc,
 
-// CHECK:   [[T2:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %T.Assoc.HasAssociatedType, %swift.type* %T.Assoc, %swift.protocol_requirement* @"$s15generic_structs17HasAssociatedTypeTL", %swift.protocol_requirement* @"$s5Assoc15generic_structs17HasAssociatedTypePTl")
+// CHECK:   [[T2:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness(i64 0, i8** %T.Assoc.HasAssociatedType, %swift.type* %T.Assoc, %swift.protocol_requirement* @"$s22generic_structs_future17HasAssociatedTypeTL", %swift.protocol_requirement* @"$s5Assoc22generic_structs_future17HasAssociatedTypePTl")
 // CHECK:   %T.Assoc.Assoc = extractvalue %swift.metadata_response [[T2]], 0

--- a/test/IRGen/generic_structs_future.sil
+++ b/test/IRGen/generic_structs_future.sil
@@ -2,6 +2,7 @@
 // RUN: %{python} %utils/chex.py < %s > %t/generic_structs_future.sil
 // RUN: %target-swift-frontend -target %module-target-future %t/generic_structs_future.sil -emit-ir | %FileCheck %t/generic_structs_future.sil
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // REQUIRES: CPU=x86_64
 
 import Builtin

--- a/test/IRGen/prespecialized-metadata/class-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/class-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -parse-stdlib -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/class-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/class-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -parse-stdlib -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -parse-stdlib -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-0argument.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-0argument.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-0argument.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-0argument.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-0distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-0distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-0distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-0distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance_stdlib_equatable-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance_stdlib_equatable-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance_stdlib_equatable-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance_stdlib_equatable-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
@@ -22,8 +22,27 @@ func consume<T>(_ t: T) {
 // TODO: Once prespecialization is done for generic arguments which are 
 //       themselves generic (Outer<Inner<Int>>, here), a direct reference to
 //       the prespecialized metadata should be emitted here.
-// CHECK:  [[TYPE:%[0-9]+]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$s4main5OuterVyAA5InnerVySiGGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(%swift.opaque* noalias nocapture %{{[0-9]+}}, %swift.type* [[TYPE]])
+// CHECK: call swiftcc void @"$s4main5OuterV5firstACyxGx_tcfC"(
+// CHECK-SAME:   %T4main5OuterV* noalias nocapture sret %13, 
+// CHECK-SAME:   %swift.opaque* noalias nocapture %14, 
+// CHECK-SAME:   %swift.type* getelementptr inbounds (
+// CHECK-SAME:     %swift.full_type, 
+// CHECK-SAME:     %swift.full_type* bitcast (
+// CHECK-SAME:       <{ 
+// CHECK-SAME:         i8**, 
+// CHECK-SAME:         [[INT]], 
+// CHECK-SAME:         %swift.type_descriptor*, 
+// CHECK-SAME:         %swift.type*, 
+// CHECK-SAME:         i32, 
+// CHECK-SAME:         {{(\[4 x i8\],)?}} 
+// CHECK-SAME:         i64 
+// CHECK-SAME:       }>* @"$s4main5InnerVySiGMf" 
+// CHECK-SAME:       to %swift.full_type*
+// CHECK-SAME:     ), 
+// CHECK-SAME:     i32 0, 
+// CHECK-SAME:     i32 1
+// CHECK-SAME:   )
+// CHECK-SAME: )
 // CHECK: }
 func doit() {
   consume( Outer(first: Inner(first: 13)) )
@@ -34,6 +53,108 @@ doit()
 // CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5OuterVMa"([[INT]], %swift.type*) #{{[0-9]+}} {
 // CHECK: entry:
 // CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
-// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata([[INT]] %0, i8* [[ERASED_TYPE]], i8* undef, i8* undef, %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* @"$s4main5OuterVMn" to %swift.type_descriptor*)) #{{[0-9]+}}
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32, 
+// CHECK-SAME:           {{(\[4 x i8\],)?}} 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5InnerVySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ) 
+// CHECK-SAME:     to i8*
+// CHECK-SAME:   ), 
+// CHECK-SAME:   [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32,
+// CHECK-SAME:           {{(\[4 x i8\],)?}} 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5OuterVyAA5InnerVySiGGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main5OuterVMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main5InnerVMa"([[INT]], %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_LABEL:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_LABEL]]:
+// CHECK:   [[EQUAL_TYPE:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE]]
+// CHECK:   [[EQUAL_TYPES:%[0-9]+]] = and i1 true, [[EQUAL_TYPE]]
+// CHECK:   br i1 [[EQUAL_TYPES]], label %[[EXIT_PRESPECIALIZED:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32,
+// CHECK-SAME:           {{(\[4 x i8\],)?}} 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main5InnerVySiGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8 }>* 
+// CHECK-SAME:       @"$s4main5InnerVMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2conformance-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2conformance-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3conformance-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3conformance-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4conformance-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4conformance-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5conformance-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5conformance-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-clang_node-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-clang_node-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays(mock-sdk-directory: %S/../Inputs)
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs -I %t) -target %module-target-future -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 
 // UNSUPPORTED: CPU=i386 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
@@ -1,0 +1,125 @@
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// CHECK: @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGMf" = internal constant <{ 
+// CHECK-SAME:   i8**, 
+// CHECK-SAME:   [[INT]], 
+// CHECK-SAME:   %swift.type_descriptor*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   %swift.type*, 
+// CHECK-SAME:   i32, 
+// CHECK-SAME:   {{(\[4 x i8\])?}}, 
+// CHECK-SAME:   i64 
+// CHECK-SAME: }> <{ 
+//               i8** getelementptr inbounds (
+//                 %swift.vwtable, 
+//                 %swift.vwtable* @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGWV", 
+//                 i32 0, 
+//                 i32 0
+//               ), 
+// CHECK-SAME:   [[INT]] 512, 
+// CHECK-SAME:   %swift.type_descriptor* bitcast (
+// CHECK-SAME:     <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* 
+// CHECK-SAME:     @"$s4main9NamespaceVAAq_RszrlE5ValueVMn" 
+// CHECK-SAME:     to %swift.type_descriptor*
+// CHECK-SAME:   ), 
+// CHECK-SAME:   %swift.type* @"$sSiN", 
+// CHECK-SAME:   %swift.type* @"$sSSN", 
+// CHECK-SAME:   i32 0, 
+// CHECK-SAME:   {{(\[4 x i8\] zeroinitializer)?}}, 
+// CHECK-SAME:   i64 3 
+// CHECK-SAME: }>, 
+// CHECK-SAME: align [[ALIGNMENT]]
+
+struct Namespace<First, Second> {
+}
+extension Namespace where First == Second {
+  struct Value<Third> {
+    let value: (First, Third)
+  }
+}
+
+@inline(never)
+func consume<T>(_ t: T) {
+  withExtendedLifetime(t) { t in
+  }
+}
+
+// CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
+// CHECK-SAME:     %swift.opaque* noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32,
+// CHECK-SAME:           {{(\[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     )
+// CHECK-SAME:   )
+// CHECK: }
+func doit() {
+  consume( Namespace.Value(value: (1, "two")) )
+}
+doit()
+
+// CHECK: ; Function Attrs: noinline nounwind readnone
+// CHECK: define hidden swiftcc %swift.metadata_response @"$s4main9NamespaceVAAq_RszrlE5ValueVMa"([[INT]], %swift.type*, %swift.type*) #{{[0-9]+}} {
+// CHECK: entry:
+// CHECK:   [[ERASED_TYPE_1:%[0-9]+]] = bitcast %swift.type* %1 to i8*
+// CHECK:   [[ERASED_TYPE_2:%[0-9]+]] = bitcast %swift.type* %2 to i8*
+// CHECK:   br label %[[TYPE_COMPARISON_1:[0-9]+]]
+// CHECK: [[TYPE_COMPARISON_1]]:
+// CHECK:   [[EQUAL_TYPE_1_1:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSiN" to i8*), [[ERASED_TYPE_1]]
+// CHECK:   [[EQUAL_TYPES_1_1:%[0-9]+]] = and i1 true, [[EQUAL_TYPE_1_1]]
+// CHECK:   [[EQUAL_TYPE_1_2:%[0-9]+]] = icmp eq i8* bitcast (%swift.type* @"$sSSN" to i8*), [[ERASED_TYPE_2]]
+// CHECK:   [[EQUAL_TYPES_1_2:%[0-9]+]] = and i1 [[EQUAL_TYPES_1_1]], [[EQUAL_TYPE_1_2]]
+// CHECK:   br i1 [[EQUAL_TYPES_1_2]], label %[[EXIT_PRESPECIALIZED_1:[0-9]+]], label %[[EXIT_NORMAL:[0-9]+]]
+// CHECK: [[EXIT_PRESPECIALIZED_1]]:
+// CHECK:   ret %swift.metadata_response { 
+// CHECK-SAME:     %swift.type* getelementptr inbounds (
+// CHECK-SAME:       %swift.full_type, 
+// CHECK-SAME:       %swift.full_type* bitcast (
+// CHECK-SAME:         <{ 
+// CHECK-SAME:           i8**, 
+// CHECK-SAME:           [[INT]], 
+// CHECK-SAME:           %swift.type_descriptor*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           %swift.type*, 
+// CHECK-SAME:           i32, 
+// CHECK-SAME:           {{(\[4 x i8\])?}}, 
+// CHECK-SAME:           i64 
+// CHECK-SAME:         }>* @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGMf" 
+// CHECK-SAME:         to %swift.full_type*
+// CHECK-SAME:       ), 
+// CHECK-SAME:       i32 0, 
+// CHECK-SAME:       i32 1
+// CHECK-SAME:     ), 
+// CHECK-SAME:     [[INT]] 0 
+// CHECK-SAME:   }
+// CHECK: [[EXIT_NORMAL]]:
+// CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateGenericMetadata(
+// CHECK-SAME:     [[INT]] %0, 
+// CHECK-SAME:     i8* [[ERASED_TYPE_1]], 
+// CHECK-SAME:     i8* [[ERASED_TYPE_2]], 
+// CHECK-SAME:     i8* undef, 
+// CHECK-SAME:     %swift.type_descriptor* bitcast (
+// CHECK-SAME:       <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i16, i16, i8, i8, i8, i8, i32, i32, i32 }>* 
+// CHECK-SAME:       @"$s4main9NamespaceVAAq_RszrlE5ValueVMn" 
+// CHECK-SAME:       to %swift.type_descriptor*
+// CHECK-SAME:     )
+// CHECK-SAME:   ) #{{[0-9]+}}
+// CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+// CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
@@ -11,7 +11,7 @@
 // CHECK-SAME:   %swift.type*, 
 // CHECK-SAME:   %swift.type*, 
 // CHECK-SAME:   i32, 
-// CHECK-SAME:   {{(\[4 x i8\])?}}, 
+// CHECK-SAME:   {{(\[4 x i8\],)?}}
 // CHECK-SAME:   i64 
 // CHECK-SAME: }> <{ 
 //               i8** getelementptr inbounds (
@@ -29,7 +29,7 @@
 // CHECK-SAME:   %swift.type* @"$sSiN", 
 // CHECK-SAME:   %swift.type* @"$sSSN", 
 // CHECK-SAME:   i32 0, 
-// CHECK-SAME:   {{(\[4 x i8\] zeroinitializer)?}}, 
+// CHECK-SAME:   {{(\[4 x i8\] zeroinitializer,)?}}
 // CHECK-SAME:   i64 3 
 // CHECK-SAME: }>, 
 // CHECK-SAME: align [[ALIGNMENT]]
@@ -60,7 +60,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:           %swift.type_descriptor*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           i32,
-// CHECK-SAME:           {{(\[4 x i8\])?}}, 
+// CHECK-SAME:           {{(\[4 x i8\],)?}} 
 // CHECK-SAME:           i64 
 // CHECK-SAME:         }>* @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGMf" 
 // CHECK-SAME:         to %swift.full_type*
@@ -99,7 +99,7 @@ doit()
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           %swift.type*, 
 // CHECK-SAME:           i32, 
-// CHECK-SAME:           {{(\[4 x i8\])?}}, 
+// CHECK-SAME:           {{(\[4 x i8\],)?}}
 // CHECK-SAME:           i64 
 // CHECK-SAME:         }>* @"$s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGMf" 
 // CHECK-SAME:         to %swift.full_type*

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-0distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-0distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-0distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-0distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-2distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-2distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-2distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-2distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-3distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-3distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-3distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-3distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-4distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-4distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-4distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-4distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-5distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-5distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-5distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-5distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-within-class-1argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-within-class-1argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-public-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-public-inmodule-1argument-1distinct_use.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target %module-target-future -emit-ir -prespecialize-generic-metadata %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios

--- a/test/IRGen/prespecialized-metadata/struct-public-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-public-inmodule-1argument-1distinct_use.swift
@@ -1,5 +1,6 @@
 // RUN: %swift -target %module-target-future -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/signature_conformances_multifile.swift
+++ b/test/IRGen/signature_conformances_multifile.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s %S/Inputs/signature_conformances_other.swift | %FileCheck %s
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -emit-ir -primary-file %s %S/Inputs/signature_conformances_other.swift | %FileCheck %s
 
 // Make sure we correctly determine the witness table is dependent, even though
 // it was defined in a different file.

--- a/test/IRGen/signature_conformances_multifile_future.swift
+++ b/test/IRGen/signature_conformances_multifile_future.swift
@@ -1,0 +1,65 @@
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir -primary-file %s %S/Inputs/signature_conformances_other.swift | %FileCheck %s -DINT=i%target-ptrsize
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+// Make sure we correctly determine the witness table is dependent, even though
+// it was defined in a different file.
+
+// CHECK-LABEL: define hidden swiftcc void @"$s39signature_conformances_multifile_future5passQyyF"()
+func passQ() {
+  // CHECK: call swiftcc void @"$s39signature_conformances_multifile_future12AlsoConformsVACyxGycfC"(%swift.type* @"$sSiN")
+  // CHECK: [[WITNESS_TABLE:%[0-9]+]] = call i8** @"$s39signature_conformances_multifile_future12AlsoConformsVySiGACyxGAA1QAAWl"()
+  // CHECK: call swiftcc void @"$s39signature_conformances_multifile_future6takesQyyxAA1QRzlF"(
+  // CHECK-SAME:   %swift.opaque* noalias nocapture undef, 
+  // CHECK-SAME:   %swift.type* getelementptr inbounds (
+  // CHECK-SAME:     %swift.full_type, 
+  // CHECK-SAME:     %swift.full_type* bitcast (
+  // CHECK-SAME:       <{ 
+  // CHECK-SAME:         i8**, 
+  // CHECK-SAME:         [[INT]], 
+  // CHECK-SAME:         %swift.type_descriptor*, 
+  // CHECK-SAME:         %swift.type*, 
+  // CHECK-SAME:         i64 
+  // CHECK-SAME:       }>* @"$s39signature_conformances_multifile_future12AlsoConformsVySiGMf" 
+  // CHECK-SAME:       to %swift.full_type*
+  // CHECK-SAME:     ), 
+  // CHECK-SAME:     i32 0, 
+  // CHECK-SAME:     i32 1
+  // CHECK-SAME:   ), 
+  // CHECK-SAME:   i8** [[WITNESS_TABLE]]
+  // CHECK-SAME: )
+  takesQ(AlsoConforms<Int>())
+
+  // CHECK: ret void
+}
+
+// CHECK-LABEL: define hidden swiftcc void @"$s39signature_conformances_multifile_future5passPyyF"()
+func passP() {
+  // CHECK: call swiftcc void @"$s39signature_conformances_multifile_future8ConformsVACyxq_GycfC"(%swift.type* @"$sSiN", %swift.type* @"$sSSN")
+  // CHECK: [[WITNESS_TABLE:%[0-9]+]] = call i8** @"$s39signature_conformances_multifile_future8ConformsVySiSSGACyxq_GAA1PAAWl"()
+  // CHECK: call swiftcc void @"$s39signature_conformances_multifile_future6takesPyyxAA1PRzlF"(
+  // CHECK-SAME:   %swift.opaque* noalias nocapture undef, 
+  // CHECK-SAME:   %swift.type* getelementptr inbounds (
+  // CHECK-SAME:     %swift.full_type, 
+  // CHECK-SAME:     %swift.full_type* bitcast (
+  // CHECK-SAME:       <{ 
+  // CHECK-SAME:         i8**, 
+  // CHECK-SAME:         [[INT]], 
+  // CHECK-SAME:         %swift.type_descriptor*, 
+  // CHECK-SAME:         %swift.type*, 
+  // CHECK-SAME:         %swift.type*, 
+  // CHECK-SAME:         i64 
+  // CHECK-SAME:       }>* @"$s39signature_conformances_multifile_future8ConformsVySiSSGMf" 
+  // CHECK-SAME:       to %swift.full_type*
+  // CHECK-SAME:     ), 
+  // CHECK-SAME:     i32 0, 
+  // CHECK-SAME:     i32 1
+  // CHECK-SAME:   ), 
+  // CHECK-SAME:   i8** [[WITNESS_TABLE]]
+  // CHECK-SAME: )
+  takesP(Conforms<Int, String>())
+
+  // CHECK: ret void
+}

--- a/test/IRGen/signature_conformances_multifile_future.swift
+++ b/test/IRGen/signature_conformances_multifile_future.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -target %module-target-future -emit-ir -primary-file %s %S/Inputs/signature_conformances_other.swift | %FileCheck %s -DINT=i%target-ptrsize
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/synthesized_conformance.swift
+++ b/test/IRGen/synthesized_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -swift-version 4 | %FileCheck %s
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -emit-ir %s -swift-version 4 | %FileCheck %s
 
 struct Struct<T> {
     var x: T

--- a/test/IRGen/synthesized_conformance_future.swift
+++ b/test/IRGen/synthesized_conformance_future.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -target %module-target-future -emit-ir %s -swift-version 4 | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios

--- a/test/IRGen/synthesized_conformance_future.swift
+++ b/test/IRGen/synthesized_conformance_future.swift
@@ -1,0 +1,100 @@
+// RUN: %target-swift-frontend -target %module-target-future -emit-ir %s -swift-version 4 | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+
+// UNSUPPORTED: CPU=i386 && OS=ios
+// UNSUPPORTED: CPU=armv7 && OS=ios
+// UNSUPPORTED: CPU=armv7s && OS=ios
+
+struct Struct<T> {
+    var x: T
+}
+
+extension Struct: Equatable where T: Equatable {}
+extension Struct: Hashable where T: Hashable {}
+extension Struct: Codable where T: Codable {}
+
+enum Enum<T> {
+    case a(T), b(T)
+}
+
+extension Enum: Equatable where T: Equatable {}
+extension Enum: Hashable where T: Hashable {}
+
+final class Final<T> {
+    var x: T
+    init(x: T) { self.x = x }
+}
+
+extension Final: Encodable where T: Encodable {}
+extension Final: Decodable where T: Decodable {}
+
+class Nonfinal<T> {
+    var x: T
+    init(x: T) { self.x = x }
+}
+extension Nonfinal: Encodable where T: Encodable {}
+
+func doEquality<T: Equatable>(_: T) {}
+// CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s30synthesized_conformance_future8equalityyyF"()
+public func equality() {
+    // CHECK: [[Struct_Equatable:%.*]] = call i8** @"$s30synthesized_conformance_future6StructVySiGACyxGSQAASQRzlWl"()
+
+    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future10doEqualityyyxSQRzlF"(
+    // CHECK-SAME:   %swift.opaque* noalias nocapture {{[^,]*}},
+    // CHECK-SAME:   %swift.type* getelementptr inbounds (
+    // CHECK-SAME:     %swift.full_type,
+    // CHECK-SAME:     %swift.full_type* bitcast (
+    // CHECK-SAME:       <{
+    // CHECK-SAME:         i8**,
+    // CHECK-SAME:         [[INT]],
+    // CHECK-SAME:         %swift.type_descriptor*,
+    // CHECK-SAME:         %swift.type*,
+    // CHECK-SAME:         i32, 
+    // CHECK-SAME:         {{(\[4 x i8\],)?}}
+    // CHECK-SAME:         i64
+    // CHECK-SAME:       }>* @"$s30synthesized_conformance_future6StructVySiGMf"
+    // CHECK-SAME:       to %swift.full_type*
+    // CHECK-SAME:     ),
+    // CHECK-SAME:     i32 0,
+    // CHECK-SAME:     i32 1
+    // CHECK-SAME:   ),
+    // CHECK-SAME:   i8** [[Struct_Equatable]]
+    // CHECK-SAME: )
+    doEquality(Struct(x: 1))
+    // CHECK: [[Enum_Equatable:%.*]] = call i8** @"$s30synthesized_conformance_future4EnumOySiGACyxGSQAASQRzlWl"()
+    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future10doEqualityyyxSQRzlF"(%swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}}, i8** [[Enum_Equatable]])
+    doEquality(Enum.a(1))
+}
+
+func doEncodable<T: Encodable>(_: T) {}
+// CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s30synthesized_conformance_future9encodableyyF"()
+public func encodable() {
+    // CHECK: [[Struct_Encodable:%.*]] = call i8** @"$s30synthesized_conformance_future6StructVySiGACyxGSEAASeRzSERzlWl"()
+    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future11doEncodableyyxSERzlF"(
+    // CHECK-SAME:   %swift.opaque* noalias nocapture {{[^,]*}}, 
+    // CHECK-SAME:   %swift.type* getelementptr inbounds (
+    // CHECK-SAME:     %swift.full_type, 
+    // CHECK-SAME:     %swift.full_type* bitcast (
+    // CHECK-SAME:       <{ 
+    // CHECK-SAME:         i8**, 
+    // CHECK-SAME:         [[INT]], 
+    // CHECK-SAME:         %swift.type_descriptor*, 
+    // CHECK-SAME:         %swift.type*, 
+    // CHECK-SAME:         i32, 
+    // CHECK-SAME:         {{(\[4 x i8\],)?}}
+    // CHECK-SAME:         i64 
+    // CHECK-SAME:       }>* @"$s30synthesized_conformance_future6StructVySiGMf" 
+    // CHECK-SAME:       to %swift.full_type*
+    // CHECK-SAME:     ), 
+    // CHECK-SAME:     i32 0, 
+    // CHECK-SAME:     i32 1
+    // CHECK-SAME:   ), 
+    // CHECK-SAME:   i8** [[Struct_Encodable]]
+    // CHECK-SAME: )
+    doEncodable(Struct(x: 1))
+    // CHECK: [[Final_Encodable:%.*]] = call i8** @"$s30synthesized_conformance_future5FinalCySiGACyxGSEAASERzlWl"()
+    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future11doEncodableyyxSERzlF"(%swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}}, i8** [[Final_Encodable]])
+    doEncodable(Final(x: 1))
+    // CHECK: [[Nonfinal_Encodable:%.*]] = call i8** @"$s30synthesized_conformance_future8NonfinalCySiGACyxGSEAASERzlWl"()
+    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future11doEncodableyyxSERzlF"(%swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}}, i8** [[Nonfinal_Encodable]])
+    doEncodable(Nonfinal(x: 1))
+}

--- a/test/Inputs/conditional_conformance_basic_conformances_future.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances_future.swift
@@ -66,50 +66,42 @@ public func single_concrete() {
 }
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s42conditional_conformance_basic_conformances15single_concreteyyF"()
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[Single_TYPE:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMD")
 // CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGACyxGAA2P1A2A0G0RzlWl"()
-// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Single_TYPE]], %swift.type* [[Single_TYPE]], i8** [[Single_P1]])
+// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(
+// CHECK-SAME:      %swift.type* getelementptr inbounds (
+// CHECK-SAME:        %swift.full_type, 
+// CHECK-SAME:        %swift.full_type* bitcast (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            [[INT]], 
+// CHECK-SAME:            %swift.type_descriptor*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMf" 
+// CHECK-SAME:          to %swift.full_type*
+// CHECK-SAME:        ), 
+// CHECK-SAME:        i32 0, 
+// CHECK-SAME:        i32 1
+// CHECK-SAME:      ), 
+// CHECK-SAME:      %swift.type* getelementptr inbounds (
+// CHECK-SAME:        %swift.full_type, 
+// CHECK-SAME:        %swift.full_type* bitcast (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            [[INT]], 
+// CHECK-SAME:            %swift.type_descriptor*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMf" 
+// CHECK-SAME:          to %swift.full_type*
+// CHECK-SAME:        ), 
+// CHECK-SAME:        i32 0, 
+// CHECK-SAME:        i32 1
+// CHECK-SAME:      ), 
+// CHECK-SAME:      i8** [[Single_P1]]
+// CHECK-SAME:    )
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
-
-// CHECK-PRESPECIALIZED: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s42conditional_conformance_basic_conformances15single_concreteyyF"()
-// CHECK-PRESPECIALIZED-NEXT:  entry:
-// CHECK-PRESPECIALIZED-NEXT:    [[Single_P1:%.*]] = call i8** @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGACyxGAA2P1A2A0G0RzlWl"()
-// CHECK-PRESPECIALIZED-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(
-// CHECK-PRESPECIALIZED-SAME:      %swift.type* getelementptr inbounds (
-// CHECK-PRESPECIALIZED-SAME:        %swift.full_type, 
-// CHECK-PRESPECIALIZED-SAME:        %swift.full_type* bitcast (
-// CHECK-PRESPECIALIZED-SAME:          <{ 
-// CHECK-PRESPECIALIZED-SAME:            i8**, 
-// CHECK-PRESPECIALIZED-SAME:            [[INT]], 
-// CHECK-PRESPECIALIZED-SAME:            %swift.type_descriptor*, 
-// CHECK-PRESPECIALIZED-SAME:            %swift.type*, 
-// CHECK-PRESPECIALIZED-SAME:            i64 
-// CHECK-PRESPECIALIZED-SAME:          }>* @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMf" 
-// CHECK-PRESPECIALIZED-SAME:          to %swift.full_type*
-// CHECK-PRESPECIALIZED-SAME:        ), 
-// CHECK-PRESPECIALIZED-SAME:        i32 0, 
-// CHECK-PRESPECIALIZED-SAME:        i32 1
-// CHECK-PRESPECIALIZED-SAME:      ), 
-// CHECK-PRESPECIALIZED-SAME:      %swift.type* getelementptr inbounds (
-// CHECK-PRESPECIALIZED-SAME:        %swift.full_type, 
-// CHECK-PRESPECIALIZED-SAME:        %swift.full_type* bitcast (
-// CHECK-PRESPECIALIZED-SAME:          <{ 
-// CHECK-PRESPECIALIZED-SAME:            i8**, 
-// CHECK-PRESPECIALIZED-SAME:            [[INT]], 
-// CHECK-PRESPECIALIZED-SAME:            %swift.type_descriptor*, 
-// CHECK-PRESPECIALIZED-SAME:            %swift.type*, 
-// CHECK-PRESPECIALIZED-SAME:            i64 
-// CHECK-PRESPECIALIZED-SAME:          }>* @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMf" 
-// CHECK-PRESPECIALIZED-SAME:          to %swift.full_type*
-// CHECK-PRESPECIALIZED-SAME:        ), 
-// CHECK-PRESPECIALIZED-SAME:        i32 0, 
-// CHECK-PRESPECIALIZED-SAME:        i32 1
-// CHECK-PRESPECIALIZED-SAME:      ), 
-// CHECK-PRESPECIALIZED-SAME:      i8** [[Single_P1]]
-// CHECK-PRESPECIALIZED-SAME:    )
-// CHECK-PRESPECIALIZED-NEXT:    ret void
-// CHECK-PRESPECIALIZED-NEXT:  }
 
 
 // Lazy witness table accessor for the concrete Single<IsP2> : P1.
@@ -122,27 +114,33 @@ public func single_concrete() {
 // CHECK-NEXT:    br i1 [[IS_NULL]], label %cacheIsNull, label %cont
 
 // CHECK:       cacheIsNull:
-// macosx-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMa"(i64 255)
-// macosx-NEXT:    [[Single_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// macosx-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
-// ios-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMa"(i64 255)
-// ios-NEXT:    [[Single_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// ios-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
-// tvos-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMa"(i64 255)
-// tvos-NEXT:    [[Single_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// tvos-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
-// watchos-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMa"(i64 255)
-// watchos-NEXT:    [[Single_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// watchos-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
-// linux-gnu-NEXT:     [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMD")
-// linux-android-NEXT: [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMD")
-// windows-msvc-NEXT: [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMD")
-
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s42conditional_conformance_basic_conformances4IsP2VAA0F0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
 
-// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @swift_getWitnessTable
+// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @swift_getWitnessTable(
+// CHECK-SAME:      %swift.protocol_conformance_descriptor* bitcast (
+// CHECK-SAME:        { i32, i32, i32, i32, i32, i32, i32, i16, i16, i32, i32 }* 
+// CHECK-SAME:        @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlMc" 
+// CHECK-SAME:        to %swift.protocol_conformance_descriptor*
+// CHECK-SAME:      ), 
+// CHECK-SAME:      %swift.type* getelementptr inbounds (
+// CHECK-SAME:        %swift.full_type, 
+// CHECK-SAME:        %swift.full_type* bitcast (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            [[INT]], 
+// CHECK-SAME:            %swift.type_descriptor*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMf" 
+// CHECK-SAME:          to %swift.full_type*
+// CHECK-SAME:        ), 
+// CHECK-SAME:        i32 0, 
+// CHECK-SAME:        i32 1
+// CHECK-SAME:      ), 
+// CHECK-SAME:      i8*** [[CONDITIONAL_REQUIREMENTS]]
+// CHECK-SAME:    )
 // CHECK-NEXT:    store atomic i8** [[Single_P1]], i8*** @"$s42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGACyxGAA2P1A2A0G0RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -277,17 +275,51 @@ public func double_generic_concrete<X: P2>(_: X.Type) {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s42conditional_conformance_basic_conformances23double_generic_concreteyyxmAA2P2RzlF"(%swift.type*, %swift.type* %X, i8** %X.P2)
 // CHECK-NEXT:  entry:
 // CHECK:         %conditional.requirement.buffer = alloca [2 x i8**], align 8
-// CHECK:         [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6DoubleVMa"(i64 0, %swift.type* %X, %swift.type* bitcast (i64* getelementptr inbounds (<{ i8**, i64, <{ {{.*}} }>* }>, <{ {{.*}} }>* @"$s42conditional_conformance_basic_conformances4IsP3VMf", i32 0, i32 1) to %swift.type*))
-// CHECK-NEXT:    [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-
-// CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [2 x i8**], [2 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
+// CHECK:    [[Double_TYPE_Response:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6DoubleVMa"(
+// CHECK-SAME:      i64 0, 
+// CHECK-SAME:      %swift.type* 
+// CHECK-SAME:      %X, 
+// CHECK-SAME:      %swift.type* bitcast (
+// CHECK-SAME:        i64* getelementptr inbounds (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            i64, 
+// CHECK-SAME:            <{ i32, i32, i32, i32, i32, i32, i32 }>*, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>, 
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            i64, 
+// CHECK-SAME:            <{ i32, i32, i32, i32, i32, i32, i32 }>*, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s42conditional_conformance_basic_conformances4IsP3VMf", 
+// CHECK-SAME:          i32 0, 
+// CHECK-SAME:          i32 1
+// CHECK-SAME:        ) to %swift.type*
+// CHECK-SAME:      )
+// CHECK-SAME:    )
+// CHECK:    [[Double_TYPE:%[0-9]+]] = extractvalue %swift.metadata_response [[Double_TYPE_Response]], 0
+// CHECK:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [2 x i8**], [2 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** %X.P2, i8*** [[B_P2_PTR]], align 8
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 1
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s42conditional_conformance_basic_conformances4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[C_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
-// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable(
+// CHECK-SAME:      %swift.protocol_conformance_descriptor* bitcast (
+// CHECK-SAME:        { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i32, i32 }* 
+// CHECK-SAME:        @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlMc" 
+// CHECK-SAME:        to %swift.protocol_conformance_descriptor*
+// CHECK-SAME:      ), 
+// CHECK-SAME:      %swift.type* %2, 
+// CHECK-SAME:      i8*** [[CONDITIONAL_REQUIREMENTS]]
+// CHECK-SAME:    )
+
+// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(
+// CHECK-SAME:      %swift.type* [[Double_TYPE]], 
+// CHECK-SAME:      %swift.type* [[Double_TYPE]], 
+// CHECK-SAME:      i8** [[Double_P1]]
+// CHECK-SAME:    )
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 
@@ -296,9 +328,42 @@ public func double_concrete_concrete() {
 }
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s42conditional_conformance_basic_conformances016double_concrete_F0yyF"()
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[Double_TYPE:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMD")
 // CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGACyxq_GAA2P1A2A0G0RzAA0H0R_rlWl"()
-// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
+// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(
+// CHECK-SAME:      %swift.type* getelementptr inbounds (
+// CHECK-SAME:        %swift.full_type, 
+// CHECK-SAME:        %swift.full_type* bitcast (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            [[INT]], 
+// CHECK-SAME:            %swift.type_descriptor*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMf" 
+// CHECK-SAME:          to %swift.full_type*
+// CHECK-SAME:        ), 
+// CHECK-SAME:        i32 0, 
+// CHECK-SAME:        i32 1
+// CHECK-SAME:      ), 
+// CHECK-SAME:      %swift.type* getelementptr inbounds (
+// CHECK-SAME:        %swift.full_type, 
+// CHECK-SAME:        %swift.full_type* bitcast (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            [[INT]], 
+// CHECK-SAME:            %swift.type_descriptor*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMf" 
+// CHECK-SAME:          to %swift.full_type*
+// CHECK-SAME:        ), 
+// CHECK-SAME:        i32 0, 
+// CHECK-SAME:        i32 1
+// CHECK-SAME:      ), 
+// CHECK-SAME:      i8** [[Double_P1]]
+// CHECK-SAME:    )
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 
@@ -312,29 +377,36 @@ public func double_concrete_concrete() {
 // CHECK-NEXT:    br i1 [[IS_NULL]], label %cacheIsNull, label %cont
 
 // CHECK:       cacheIsNull:
-// macosx-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMa"(i64 255)
-// macosx-NEXT:    [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// macosx-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
-// ios-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMa"(i64 255)
-// ios-NEXT:    [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// ios-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
-// tvos-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMa"(i64 255)
-// tvos-NEXT:    [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// tvos-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
-// watchos-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMa"(i64 255)
-// watchos-NEXT:    [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// watchos-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
-// linux-gnu-NEXT:     [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMD")
-// linux-android-NEXT: [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMD")
-// windows-msvc-NEXT: [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMD")
-
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [2 x i8**], [2 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s42conditional_conformance_basic_conformances4IsP2VAA0F0AAWP", i32 0, i32 0), i8*** [[B_P2_PTR]], align 8
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 1
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s42conditional_conformance_basic_conformances4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[C_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable(
+// CHECK-SAME:      %swift.protocol_conformance_descriptor* bitcast (
+// CHECK-SAME:        { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i32, i32 }* 
+// CHECK-SAME:        @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlMc" 
+// CHECK-SAME:        to %swift.protocol_conformance_descriptor*
+// CHECK-SAME:      ), 
+// CHECK-SAME:      %swift.type* getelementptr inbounds (
+// CHECK-SAME:        %swift.full_type, 
+// CHECK-SAME:        %swift.full_type* bitcast (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            i64, 
+// CHECK-SAME:            %swift.type_descriptor*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMf" 
+// CHECK-SAME:          to %swift.full_type*
+// CHECK-SAME:        ), 
+// CHECK-SAME:        i32 0, 
+// CHECK-SAME:        i32 1
+// CHECK-SAME:      ), 
+// CHECK-SAME:      i8*** [[CONDITIONAL_REQUIREMENTS]]
+// CHECK-SAME:    )
 // CHECK-NEXT:    store atomic i8** [[Double_P1]], i8*** @"$s42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGACyxq_GAA2P1A2A0G0RzAA0H0R_rlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 

--- a/test/Inputs/conditional_conformance_subclass_future.swift
+++ b/test/Inputs/conditional_conformance_subclass_future.swift
@@ -1,0 +1,176 @@
+public func takes_p1<T: P1>(_: T.Type) {}
+public protocol P1 {
+  func normal()
+  func generic<T: P3>(_: T)
+}
+public protocol P2 {}
+public protocol P3 {}
+
+public struct IsP2: P2 {}
+
+public class Base<A> {}
+extension Base: P1 where A: P2 {
+  public func normal() {}
+  public func generic<T: P3>(_: T) {}
+}
+
+// witness method for Base.normal
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP6normalyyFTW"(%T32conditional_conformance_subclass4BaseC.0** noalias nocapture swiftself dereferenceable(8), %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8*, i8** %SelfWitnessTable, i32 -1
+// CHECK-NEXT:    [[A_P2:%.*]] = load i8*, i8** [[A_P2_PTR]], align 8
+// CHECK-NEXT:    %"\CF\84_0_0.P2" = bitcast i8* [[A_P2]] to i8**
+// CHECK-NEXT:    [[SELF:%.]] = load %T32conditional_conformance_subclass4BaseC.0*, %T32conditional_conformance_subclass4BaseC.0** %0
+// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass4BaseCA2A2P2RzlE6normalyyF"(i8** %"\CF\84_0_0.P2", %T32conditional_conformance_subclass4BaseC.0* swiftself [[SELF]])
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+// witness method for Base.generic
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_1_0", i8** %"\CF\84_1_0.P3", %T32conditional_conformance_subclass4BaseC.1** noalias nocapture swiftself dereferenceable(8), %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8*, i8** %SelfWitnessTable, i32 -1
+// CHECK-NEXT:    [[A_P2:%.*]] = load i8*, i8** [[A_P2_PTR]], align 8
+// CHECK-NEXT:    %"\CF\84_0_0.P2" = bitcast i8* [[A_P2]] to i8**
+// CHECK-NEXT:    [[SELF:%.]] = load %T32conditional_conformance_subclass4BaseC.1*, %T32conditional_conformance_subclass4BaseC.1** %1, align 8
+// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass4BaseCA2A2P2RzlE7genericyyqd__AA2P3Rd__lF"(%swift.opaque* noalias nocapture %0, %swift.type* %"\CF\84_1_0", i8** %"\CF\84_0_0.P2", i8** %"\CF\84_1_0.P3", %T32conditional_conformance_subclass4BaseC.1* swiftself [[SELF]])
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+
+public class SubclassGeneric<T>: Base<T> {}
+public class SubclassConcrete: Base<IsP2> {}
+public class SubclassGenericConcrete: SubclassGeneric<IsP2> {}
+
+public func subclassgeneric_generic<T: P2>(_: T.Type) {
+  takes_p1(SubclassGeneric<T>.self)
+}
+
+// CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s32conditional_conformance_subclass23subclassgeneric_genericyyxmAA2P2RzlF"(%swift.type*, %swift.type* %T, i8** %T.P2)
+// CHECK-NEXT:  entry:
+// CHECK:         %conditional.requirement.buffer = alloca [1 x i8**], align 8
+// CHECK:         [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s32conditional_conformance_subclass15SubclassGenericCMa"(i64 0, %swift.type* %T)
+// CHECK-NEXT:    [[SubclassGeneric_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
+// CHECK-NEXT:    [[T_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
+// CHECK-NEXT:    store i8** %T.P2, i8*** [[T_P2_PTR]], align 8
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @swift_getWitnessTable
+// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass8takes_p1yyxmAA2P1RzlF"(%swift.type* [[SubclassGeneric_TYPE]], %swift.type* [[SubclassGeneric_TYPE]], i8** [[Base_P1]])
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+public func subclassgeneric_concrete() {
+  takes_p1(SubclassGeneric<IsP2>.self)
+}
+
+// CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s32conditional_conformance_subclass24subclassgeneric_concreteyyF"()
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[SubclassGeneric_TYPE:%.*]] = call {{.*}}@"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMD"
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGAA4BaseCyxGAA2P1A2A0G0RzlWl"()
+// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass8takes_p1yyxmAA2P1RzlF"(%swift.type* [[SubclassGeneric_TYPE]], %swift.type* [[SubclassGeneric_TYPE]], i8** [[Base_P1]])
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+// Lazy witness table accessor for the concrete SubclassGeneric<IsP2> : Base.
+
+// CHECK-LABEL: define linkonce_odr hidden i8** @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGAA4BaseCyxGAA2P1A2A0G0RzlWl"()
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    %conditional.requirement.buffer = alloca [1 x i8**], align 8
+// CHECK-NEXT:    [[CACHE:%.*]] = load i8**, i8*** @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGAA4BaseCyxGAA2P1A2A0G0RzlWL", align 8
+// CHECK-NEXT:    [[IS_NULL:%.*]] = icmp eq i8** [[CACHE]], null
+// CHECK-NEXT:    br i1 [[IS_NULL]], label %cacheIsNull, label %cont
+
+// CHECK:       cacheIsNull:
+// macosx-NEXT:    [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMD")
+// ios-NEXT:    [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMD")
+// watchos-NEXT:    [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMD")
+// tvos-NEXT:    [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMD")
+// linux-gnu-NEXT:     [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMD")
+// linux-android-NEXT: [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMD")
+// windows-msvc-NEXT: [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGMD")
+
+// CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
+// CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
+// CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s32conditional_conformance_subclass4IsP2VAA0E0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @swift_getWitnessTable
+// CHECK-NEXT:    store atomic i8** [[Base_P1]], i8*** @"$s32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGAA4BaseCyxGAA2P1A2A0G0RzlWL" release, align 8
+// CHECK-NEXT:    br label %cont
+
+// CHECK:       cont:
+// CHECK-NEXT:    [[T0:%.*]] = phi i8** [ [[CACHE]], %entry ], [ [[Base_P1]], %cacheIsNull ]
+// CHECK-NEXT:    ret i8** [[T0]]
+// CHECK-NEXT:  }
+
+public func subclassconcrete() {
+  takes_p1(SubclassConcrete.self)
+}
+
+// CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s32conditional_conformance_subclass16subclassconcreteyyF"()
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s32conditional_conformance_subclass16SubclassConcreteCMa"(i64 0)
+// CHECK-NEXT:    [[SubclassConcrete_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT:    [[SubclassConcrete_P1:%.*]] = call i8** @"$s32conditional_conformance_subclass16SubclassConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWl"()
+// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass8takes_p1yyxmAA2P1RzlF"(%swift.type* [[SubclassConcrete_TYPE]], %swift.type* [[SubclassConcrete_TYPE]], i8** [[SubclassConcrete_P1]])
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: define linkonce_odr hidden i8** @"$s32conditional_conformance_subclass16SubclassConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWl"()
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    %conditional.requirement.buffer = alloca [1 x i8**], align 8
+// CHECK-NEXT:    [[CACHE:%.*]] = load i8**, i8*** @"$s32conditional_conformance_subclass16SubclassConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWL", align 8
+// CHECK-NEXT:    [[IS_NULL:%.*]] = icmp eq i8** [[CACHE]], null
+// CHECK-NEXT:    br i1 [[IS_NULL]], label %cacheIsNull, label %cont
+
+// CHECK:       cacheIsNull:
+// CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s32conditional_conformance_subclass16SubclassConcreteCMa"(i64 255)
+// CHECK-NEXT:    [[SubclassConcrete_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
+
+// CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
+// CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
+// CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s32conditional_conformance_subclass4IsP2VAA0E0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @swift_getWitnessTable
+// CHECK-NEXT:    store atomic i8** [[Base_P1]], i8*** @"$s32conditional_conformance_subclass16SubclassConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWL" release, align 8
+// CHECK-NEXT:    br label %cont
+
+// CHECK:       cont:
+// CHECK-NEXT:    [[T0:%.*]] = phi i8** [ [[CACHE]], %entry ], [ [[Base_P1]], %cacheIsNull ]
+// CHECK-NEXT:    ret i8** [[T0]]
+// CHECK-NEXT:  }
+
+public func subclassgenericconcrete() {
+  takes_p1(SubclassGenericConcrete.self)
+}
+
+// CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s32conditional_conformance_subclass23subclassgenericconcreteyyF"()
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s32conditional_conformance_subclass23SubclassGenericConcreteCMa"(i64 0)
+// CHECK-NEXT:    [[SubclassGenericConcrete_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT:    [[SubclassGenericConcrete_P1:%.*]] = call i8** @"$s32conditional_conformance_subclass23SubclassGenericConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWl"()
+// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass8takes_p1yyxmAA2P1RzlF"(%swift.type* [[SubclassGenericConcrete_TYPE]], %swift.type* [[SubclassGenericConcrete_TYPE]], i8** [[SubclassGenericConcrete_P1]])
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: define linkonce_odr hidden i8** @"$s32conditional_conformance_subclass23SubclassGenericConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWl"()
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    %conditional.requirement.buffer = alloca [1 x i8**], align 8
+// CHECK-NEXT:    [[CACHE:%.*]] = load i8**, i8*** @"$s32conditional_conformance_subclass23SubclassGenericConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWL", align 8
+// CHECK-NEXT:    [[IS_NULL:%.*]] = icmp eq i8** [[CACHE]], null
+// CHECK-NEXT:    br i1 [[IS_NULL]], label %cacheIsNull, label %cont
+
+// CHECK:       cacheIsNull:
+// CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s32conditional_conformance_subclass23SubclassGenericConcreteCMa"(i64 255)
+// CHECK-NEXT:    [[SubclassGenericConcrete_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT:    extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
+// CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
+// CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$s32conditional_conformance_subclass4IsP2VAA0E0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @swift_getWitnessTable
+// CHECK-NEXT:    store atomic i8** [[Base_P1]], i8*** @"$s32conditional_conformance_subclass23SubclassGenericConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWL" release, align 8
+// CHECK-NEXT:    br label %cont
+
+// CHECK:       cont:
+// CHECK-NEXT:    [[T0:%.*]] = phi i8** [ [[CACHE]], %entry ], [ [[Base_P1]], %cacheIsNull ]
+// CHECK-NEXT:    ret i8** [[T0]]
+// CHECK-NEXT:  }

--- a/test/Inputs/conditional_conformance_with_assoc_future.swift
+++ b/test/Inputs/conditional_conformance_with_assoc_future.swift
@@ -200,9 +200,43 @@ public func concrete_concrete() {
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s34conditional_conformance_with_assoc09concrete_E0yyF"()
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[X:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMD")
 // CHECK-NEXT:    [[Z:%.*]] = call i8** @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGACyxq_GAA2P1A2A0I0R_AA0H03AT2RpzAakM_AmaLP3AT3RPzrlWl"()
-// CHECK-NEXT:    call swiftcc void @"$s34conditional_conformance_with_assoc8takes_p1yyxmAA2P1RzlF"(%swift.type* [[X]], %swift.type* [[X]], i8** [[Z]])
+// CHECK-NEXT:    call swiftcc void @"$s34conditional_conformance_with_assoc8takes_p1yyxmAA2P1RzlF"(
+// CHECK-SAME:      %swift.type* getelementptr inbounds (
+// CHECK-SAME:        %swift.full_type, 
+// CHECK-SAME:        %swift.full_type* bitcast (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            [[INT]], 
+// CHECK-SAME:            %swift.type_descriptor*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMf" 
+// CHECK-SAME:          to %swift.full_type*
+// CHECK-SAME:        ), 
+// CHECK-SAME:        i32 0, 
+// CHECK-SAME:        i32 1
+// CHECK-SAME:      ), 
+// CHECK-SAME:      %swift.type* getelementptr inbounds (
+// CHECK-SAME:        %swift.full_type, 
+// CHECK-SAME:        %swift.full_type* bitcast (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            [[INT]], 
+// CHECK-SAME:            %swift.type_descriptor*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMf" 
+// CHECK-SAME:          to %swift.full_type*
+// CHECK-SAME:        ), 
+// CHECK-SAME:        i32 0, 
+// CHECK-SAME:        i32 1
+// CHECK-SAME:      )
+// CHECK-SAME:    )
 // CHECK-NEXT:    ret void
 // CHECK-NEXT: }
 
@@ -216,21 +250,6 @@ public func concrete_concrete() {
 // CHECK-NEXT:    br i1 [[IS_NULL]], label %cacheIsNull, label %cont
 
 // CHECK:       cacheIsNull:
-// macosx-NEXT:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMa"(i64 255)
-// macosx-NEXT:   [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// macosx-NEXT:   extractvalue %swift.metadata_response [[T0]], 1
-// ios-NEXT:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMa"(i64 255)
-// ios-NEXT:   [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// ios-NEXT:   extractvalue %swift.metadata_response [[T0]], 1
-// watchos-NEXT:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMa"(i64 255)
-// watchos-NEXT:   [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// watchos-NEXT:   extractvalue %swift.metadata_response [[T0]], 1
-// tvos-NEXT:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMa"(i64 255)
-// tvos-NEXT:   [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// tvos-NEXT:   extractvalue %swift.metadata_response [[T0]], 1
-// linux-gnu-NEXT:    [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMD")
-// linux-android-NEXT: [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMD")
-// windows-msvc-NEXT: [[T0:%.*]] = call %swift.type* @__swift_instantiateConcreteTypeFromMangledNameAbstract({ i32, i32 }* @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMD")
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [3 x i8**], [3 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"$s34conditional_conformance_with_assoc4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[C_P3_PTR]], align 8
@@ -238,7 +257,31 @@ public func concrete_concrete() {
 // CHECK-NEXT:    store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @"$s34conditional_conformance_with_assoc6IsBothVAA2P2AAWP", i32 0, i32 0), i8*** [[B_AT2_P2_PTR]], align 8
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 2
 // CHECK-NEXT:    store i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"$s34conditional_conformance_with_assoc4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[B_AT2_AT2_AT3_P3_PTR]], align 8
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @swift_getWitnessTable(
+// CHECK-SAME:      %swift.protocol_conformance_descriptor* bitcast (
+// CHECK-SAME:        { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i16, i16, i32, i32 }* 
+// CHECK-SAME:        @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlMc" 
+// CHECK-SAME:        to %swift.protocol_conformance_descriptor*
+// CHECK-SAME:      ), 
+// CHECK-SAME:      %swift.type* getelementptr inbounds (
+// CHECK-SAME:        %swift.full_type, 
+// CHECK-SAME:        %swift.full_type* bitcast (
+// CHECK-SAME:          <{ 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            [[INT]], 
+// CHECK-SAME:            %swift.type_descriptor*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            %swift.type*, 
+// CHECK-SAME:            i8**, 
+// CHECK-SAME:            i64 
+// CHECK-SAME:          }>* @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMf" 
+// CHECK-SAME:          to %swift.full_type*
+// CHECK-SAME:        ), 
+// CHECK-SAME:        i32 0, 
+// CHECK-SAME:        i32 1
+// CHECK-SAME:      ), 
+// CHECK-SAME:      i8*** [[CONDITIONAL_REQUIREMENTS]]
+// CHECK-SAME:    )
 // CHECK-NEXT:    store atomic i8** [[Double_P1]], i8*** @"$s34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGACyxq_GAA2P1A2A0I0R_AA0H03AT2RpzAakM_AmaLP3AT3RPzrlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 


### PR DESCRIPTION
Previously, `-Xfrontend -prespecialize-generic-metadata` had to be passed in order for generic metadata to be prespecialized.  Now it is prespecialized unless `-Xfrontend -disable-generic-metadata-prespecialization` is passed.