### PR TITLE
[SR-11421][Diagnostics] Tailored diagnostic for checked downcast with literals

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1015,6 +1015,11 @@ WARNING(conditional_downcast_coercion,none,
       "conditional cast from %0 to %1 always succeeds",
       (Type, Type))
 
+WARNING(literal_conditional_downcast_to_coercion,none,
+        "conditional downcast from literal to %0 always fails; "
+        "consider using 'as' coercion",
+        (Type))
+
 WARNING(forced_downcast_noop,none,
         "forced cast of %0 to same type has no effect", (Type))
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3648,9 +3648,9 @@ namespace {
       auto sub = cs.coerceToRValue(expr->getSubExpr());
       expr->setSubExpr(sub);
 
-
+      bool isSubExprLiteral = isa<LiteralExpr>(sub);
       auto castContextKind =
-          (SuppressDiagnostics || isInsideIsExpr)
+          (SuppressDiagnostics || isInsideIsExpr || isSubExprLiteral)
             ? CheckedCastContextKind::None
             : CheckedCastContextKind::ConditionalCast;
 
@@ -3661,13 +3661,35 @@ namespace {
       switch (castKind) {
       // Invalid cast.
       case CheckedCastKind::Unresolved:
+        // FIXME: This literal diagnostics needs to be revisited by a proposal
+        // to unify casting semantics for literals.
+        // https://bugs.swift.org/browse/SR-12093
+        if (isSubExprLiteral) {
+          auto protocol = TypeChecker::getLiteralProtocol(ctx, sub);
+          // Special handle for literals conditional checked cast when they can
+          // be statically coerced to the cast type.
+          if (protocol && TypeChecker::conformsToProtocol(
+                              toType, protocol, cs.DC,
+                              ConformanceCheckFlags::InExpression)) {
+            ctx.Diags
+                .diagnose(expr->getLoc(),
+                          diag::literal_conditional_downcast_to_coercion,
+                          toType);
+          } else {
+            ctx.Diags
+                .diagnose(expr->getLoc(), diag::downcast_to_unrelated, fromType,
+                          toType)
+                .highlight(sub->getSourceRange())
+                .highlight(expr->getCastTypeLoc().getSourceRange());
+          }
+        }
         expr->setCastKind(CheckedCastKind::ValueCast);
         break;
 
       case CheckedCastKind::Coercion:
       case CheckedCastKind::BridgingCoercion: {
         ctx.Diags.diagnose(expr->getLoc(), diag::conditional_downcast_coercion,
-                           cs.getType(sub), toType);
+                           fromType, toType);
         expr->setCastKind(castKind);
         cs.setType(expr, OptionalType::get(toType));
         return expr;
@@ -3681,7 +3703,7 @@ namespace {
         expr->setCastKind(castKind);
         break;
       }
-      
+
       return handleOptionalBindingsForCast(expr, simplifyType(cs.getType(expr)),
                                          OptionalBindingsCastKind::Conditional);
     }

--- a/test/expr/cast/literals_downcast.swift
+++ b/test/expr/cast/literals_downcast.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -enable-objc-interop
+
+import Foundation
+
+let ok = "A" as Character // OK
+let succeed = "A" as? String // expected-warning {{always succeeds}}
+let bad = "A" as? Character // expected-warning {{conditional downcast from literal to 'Character' always fails; consider using 'as' coercion}} {{none}}
+let bad2 = "Aa" as? Character // expected-warning {{cast from 'String' to unrelated type 'Character' always fails}}
+let bad1 = 1 as? Character // expected-warning {{cast from 'Int' to unrelated type 'Character' always fails}}
+
+let okInt = 1 as Int // OK
+let badInt = 1 as? Int // expected-warning {{always succeeds}}
+let badInt1 = 1.0 as? Int // expected-warning {{cast from 'Double' to unrelated type 'Int' always fails}}
+let badInt2 = 1 as? Double // expected-warning {{conditional downcast from literal to 'Double' always fails; consider using 'as' coercion}} {{none}}
+
+let okUInt = 1 as UInt // OK
+let badUInt = 1 as? UInt // expected-warning {{conditional downcast from literal to 'UInt' always fails; consider using 'as' coercion}} {{none}}
+let badUInt1 = 1.0 as? UInt // expected-warning {{cast from 'Double' to unrelated type 'UInt' always fails}}
+
+// Can downcast by bridging
+let bridge = "A" as? NSString // expected-warning {{always succeeds}}
+let bridge1 = 1 as? NSNumber // expected-warning {{always succeeds}}
+
+// Custom protocol adoption
+struct S: ExpressibleByStringLiteral {
+  typealias StringLiteralType = String
+  init(stringLiteral value: Self.StringLiteralType) {}
+}
+
+let a = "A" as? S // expected-warning {{conditional downcast from literal to 'S' always fails; consider using 'as' coercion}} {{none}}

--- a/test/expr/cast/literals_downcast.swift
+++ b/test/expr/cast/literals_downcast.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-objc-interop
+// REQUIRES: objc_interop
 
 import Foundation
 

--- a/test/expr/cast/literals_downcast.swift
+++ b/test/expr/cast/literals_downcast.swift
@@ -1,7 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-objc-interop
-// REQUIRES: objc_interop
-
-import Foundation
+// RUN: %target-typecheck-verify-swift
 
 let ok = "A" as Character // OK
 let succeed = "A" as? String // expected-warning {{always succeeds}}
@@ -17,10 +14,6 @@ let badInt2 = 1 as? Double // expected-warning {{conditional downcast from liter
 let okUInt = 1 as UInt // OK
 let badUInt = 1 as? UInt // expected-warning {{conditional downcast from literal to 'UInt' always fails; consider using 'as' coercion}} {{none}}
 let badUInt1 = 1.0 as? UInt // expected-warning {{cast from 'Double' to unrelated type 'UInt' always fails}}
-
-// Can downcast by bridging
-let bridge = "A" as? NSString // expected-warning {{always succeeds}}
-let bridge1 = 1 as? NSNumber // expected-warning {{always succeeds}}
 
 // Custom protocol adoption
 struct S: ExpressibleByStringLiteral {

--- a/test/expr/cast/literals_downcast_bridge.swift
+++ b/test/expr/cast/literals_downcast_bridge.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -enable-objc-interop
+// REQUIRES: OS=macosx
+
+import Foundation
+
+// Can downcast by bridging
+let bridge = "A" as? NSString // expected-warning {{always succeeds}}
+let bridge1 = 1 as? NSNumber // expected-warning {{always succeeds}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Tailored diagnostic when `ConditionalCheckedCastExpr` involves a literal subexpr that can be statically coerced. 
cc @CodaFi 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-11421.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
