### PR TITLE
[Test] Mark Reflection/existentials.swift as unsupported when testing against the OS stdlib.

### DIFF
--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
 
 /*
    This file pokes at the swift_reflection_projectExistential API


### PR DESCRIPTION
The test looks for a recent Remote Mirror addition to print the mangled name of a typeref.

rdar://problem/58939662