### PR TITLE
[docs] Update AnyHashable documentation

### DIFF
--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -198,7 +198,7 @@ public struct AnyHashable {
 
 extension AnyHashable: Equatable {
   /// Returns a Boolean value indicating whether two type-erased hashable
-  /// instances wrap the same value of equivalent type.
+  /// instances wrap the same underlying value.
   ///
   /// `AnyHashable` considers bridged counterparts (such as a `String` and an
   /// `NSString`) of the same value to be equivalent when type-erased. Where

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -110,8 +110,8 @@ internal struct _ConcreteHashableBox<Base: Hashable>: _AnyHashableBox {
 /// to an underlying hashable value, hiding the type of the wrapped value.
 ///
 /// For types that support conversions between each other using `as` or `as?`
-/// (such as `Int` and `NSNumber`), `AnyHashable` treats their values as
-/// equivalent when type-erased by forwarding operations to canonical
+/// (such as `Int` and `NSNumber`), `AnyHashable` treats their values
+/// equivalently when type-erased by forwarding operations to canonical
 /// representations of the wrapped values.
 ///
 /// You can store mixed-type keys in dictionaries and other collections that


### PR DESCRIPTION
<!-- What's in this pull request? -->
Certain `AnyHashable` edge cases were addressed in #17396, which defined custom boxes for some types to satisfy `Equatable` and `Hashable` semantic requirements; however, the corresponding documentation has not been updated.

As [demonstrated](https://forums.swift.org/t/why-isn-t-anyhashable-implemented-in-pure-swift/33124/6) on the Swift forums, this has been the cause of some confusion as to the intended behavior, which no longer aligns with the documentation. That the actual behavior is intended was confirmed by @jckarter in #21550:

> `AnyHashable` should behave this way for any types that are transitively `as?`-castable, so you can get a `String` out as an `NSString` and v.v., an `Array<T>` as an `NSArray`, and so on. The standard library integer and floating-point types as well as `CGFloat` and `Decimal` all bridge to `NSNumber`, and `NSNumber` bridges back to any of those types if the value is exactly representable.

This is a stab at updating the documentation accordingly. I've tried to make it succinct but sufficiently understandable, but the result I've arrived at thus far doesn't exactly roll off the tongue.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12091 and SR-12092.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
