### PR TITLE
[build] Fix mismatch use of target_link_options

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1467,7 +1467,7 @@ function(_add_swift_library_single target name)
   endif()
 
   if(target_static)
-    target_link_options(${target_static} PRIVATE
+    target_compile_options(${target_static} PRIVATE
       ${c_compile_flags})
     # FIXME: The fallback paths here are going to be dynamic libraries.
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

This line was changed by https://github.com/apple/swift/pull/29451 and compile flags were passed as link flags

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
