### PR TITLE
[Diagnostics] Add a special case diagnostic for call to init on `Void…

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1296,21 +1296,6 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
     }
   }
 
-  // Let's check whether this is a situation when callee expects
-  // no arguments but N are given. Otherwise, just below
-  // `typeCheckArgumentChild*` is going to use `()` is a contextual type which
-  // is incorrect.
-  if (argType && argType->isVoid()) {
-    auto *argExpr = callExpr->getArg();
-    if (isa<ParenExpr>(argExpr) ||
-        (isa<TupleExpr>(argExpr) &&
-         cast<TupleExpr>(argExpr)->getNumElements() > 0)) {
-      diagnose(callExpr->getLoc(), diag::extra_argument_to_nullary_call)
-          .highlight(argExpr->getSourceRange());
-      return true;
-    }
-  }
-
   // Get the expression result of type checking the arguments to the call
   // independently, so we have some idea of what we're working with.
   //


### PR DESCRIPTION
…` with arguments

Expressions like `Void(...)` have a special locator which ends at
`FunctionArgument` instead of `ApplyArgument` which makes it possible
to type-check `Void()` call successfully. "extraneous arguments" diagnostic
needs to handle such situations specifically e.g. `Void(0)`.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
