### PR TITLE
[WebAssembly] enable shims and stubs for WASI

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -43,6 +43,8 @@ typedef __swift_uint32_t __swift_mode_t;
 typedef __swift_uint16_t __swift_mode_t;
 #elif defined(_WIN32)
 typedef __swift_int32_t __swift_mode_t;
+#elif defined(__wasi__)
+typedef __swift_uint32_t __swift_mode_t;
 #else  // just guessing
 typedef __swift_uint16_t __swift_mode_t;
 #endif
@@ -105,7 +107,7 @@ static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
   return malloc_size(ptr);
 }
 #elif defined(__linux__) || defined(__CYGWIN__) || defined(__ANDROID__) \
-   || defined(__HAIKU__) || defined(__FreeBSD__)
+   || defined(__HAIKU__) || defined(__FreeBSD__) || defined(__wasi__)
 static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
 #if defined(__ANDROID__)
 #if !defined(__ANDROID_API__) || __ANDROID_API__ >= 17

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -23,7 +23,7 @@
 
 #include <stdio.h>
 #include <sys/types.h>
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__wasi__)
 #include <unistd.h>
 #endif
 

--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -42,9 +42,7 @@
 #include "swift/Runtime/Mutex.h"
 #include "../SwiftShims/Random.h"
 
-#if defined(__wasi__)
 #include <algorithm> // required for std::min
-#endif
 
 #if defined(__APPLE__)
 

--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -42,6 +42,10 @@
 #include "swift/Runtime/Mutex.h"
 #include "../SwiftShims/Random.h"
 
+#if defined(__wasi__)
+#include <algorithm> // required for std::min
+#endif
+
 #if defined(__APPLE__)
 
 SWIFT_RUNTIME_STDLIB_API
@@ -88,7 +92,7 @@ void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
     if (getrandom_available) {
       actual_nbytes = WHILE_EINTR(syscall(__NR_getrandom, buf, nbytes, 0));
     }
-#elif __has_include(<sys/random.h>) && (defined(__CYGWIN__) || defined(__Fuchsia__))
+#elif __has_include(<sys/random.h>) && (defined(__CYGWIN__) || defined(__Fuchsia__) || defined(__wasi__))
     __swift_size_t getentropy_nbytes = std::min(nbytes, __swift_size_t{256});
     
     if (0 == getentropy(buf, getentropy_nbytes)) {

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -504,7 +504,7 @@ void swift::_swift_stdlib_flockfile_stdout() {
 #if defined(_WIN32)
   _lock_file(stdout);
 #elif defined(__wasi__)
-  // WebAssembly/WASI doesn't support file locking yet
+  // WebAssembly/WASI doesn't support file locking yet https://bugs.swift.org/browse/SR-12097
 #else
   flockfile(stdout);
 #endif
@@ -514,7 +514,7 @@ void swift::_swift_stdlib_funlockfile_stdout() {
 #if defined(_WIN32)
   _unlock_file(stdout);
 #elif defined(__wasi__)
-  // WebAssembly/WASI doesn't support file locking yet
+  // WebAssembly/WASI doesn't support file locking yet https://bugs.swift.org/browse/SR-12097
 #else
   funlockfile(stdout);
 #endif

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -26,7 +26,7 @@
 #define NOMINMAX
 #include <windows.h>
 #else
-#if !defined(__HAIKU__)
+#if !defined(__HAIKU__) && !defined(__wasi__)
 #include <sys/errno.h>
 #else
 #include <errno.h>
@@ -67,7 +67,7 @@ static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
 #define strtod_l swift_strtod_l
 #define strtof_l swift_strtof_l
 #endif
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__wasi__)
 #include <locale.h>
 #else
 #include <xlocale.h>
@@ -503,6 +503,8 @@ const char *swift::_swift_stdlib_strtof_clocale(
 void swift::_swift_stdlib_flockfile_stdout() {
 #if defined(_WIN32)
   _lock_file(stdout);
+#elif defined(__wasi__)
+  // WebAssembly/WASI doesn't support file locking yet
 #else
   flockfile(stdout);
 #endif
@@ -511,6 +513,8 @@ void swift::_swift_stdlib_flockfile_stdout() {
 void swift::_swift_stdlib_funlockfile_stdout() {
 #if defined(_WIN32)
   _unlock_file(stdout);
+#elif defined(__wasi__)
+  // WebAssembly/WASI doesn't support file locking yet
 #else
   funlockfile(stdout);
 #endif


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds `#if defined(__wasi__)` in `stdlib/public/stubs` and implements `_swift_stdlib_getUnsafeArgvArgc` to fix corresponding code when compiling for WASI.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This is a part of [SR-9307](https://bugs.swift.org/browse/SR-9307) and #24684.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

(cc @kateinoigakukun)