### PR TITLE
Move swift runtime failure messages from linkage name to function name

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1847,7 +1847,7 @@ void IRGenDebugInfoImpl::setCurrentLoc(IRBuilder &Builder,
   auto DL = llvm::DebugLoc::get(L.Line, L.Column, Scope, InlinedAt);
   Builder.SetCurrentDebugLocation(DL);
 }
-  
+
 void IRGenDebugInfoImpl::addFailureMessageToCurrentLoc(IRBuilder &Builder,
                                                        StringRef failureMsg) {
   auto TrapLoc = Builder.getCurrentDebugLocation();
@@ -1864,7 +1864,7 @@ void IRGenDebugInfoImpl::addFailureMessageToCurrentLoc(IRBuilder &Builder,
   FuncName += failureMsg;
 
   llvm::DISubprogram *TrapSP = DBuilder.createFunction(
-     MainModule, StringRef(), FuncName, TrapLoc->getFile(), 0, DIFnTy, 0,
+     MainModule, FuncName, StringRef(), TrapLoc->getFile(), 0, DIFnTy, 0,
      llvm::DINode::FlagArtificial, llvm::DISubprogram::SPFlagDefinition,
      nullptr, nullptr, nullptr);
 

--- a/test/DebugInfo/linetable-codeview.swift
+++ b/test/DebugInfo/linetable-codeview.swift
@@ -81,7 +81,7 @@ func foo() {
 // FIXME: The location of ``@llvm.trap`` should be in Integers.swift.gyb
 //        instead of being artificial.
 // CHECK: ![[INLINEDADD]] = !DILocation(line: 0, scope: ![[FAILURE_FUNC:[0-9]+]], inlinedAt: ![[INLINELOC:[0-9]+]]
-// CHECK-DAG: !{{.*}} = distinct !DISubprogram(linkageName: "Swift runtime failure: arithmetic overflow", scope: {{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, {{.*}})
+// CHECK-DAG: !{{.*}} = distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow", scope: {{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, {{.*}})
 // CHECK-DAG: ![[INLINELOC]] = !DILocation(line: 0, scope: !{{[0-9]+}}, inlinedAt: ![[ADD]]
 
 // NOTE: These prologue instructions are given artificial line locations for

--- a/test/IRGen/condfail_message.swift
+++ b/test/IRGen/condfail_message.swift
@@ -11,6 +11,6 @@ func testit(_ a: Int8) -> Int8 {
 
 // CHECK: [[CALLER_LOC:![0-9]+]] = !DILocation(line: 9, column: 12, scope: !{{.*}})
 // CHECK: [[LOC]] = !DILocation(line: 0, scope: [[FAILURE_FUNC:![0-9]+]], inlinedAt: [[CALLER_LOC]])
-// CHECK: [[FAILURE_FUNC]] = distinct !DISubprogram(linkageName: "Swift runtime failure: arithmetic overflow", scope: {{.*}}, file: {{.*}}, type: [[FUNC_TYPE:![0-9]+]], flags: DIFlagArtificial, spFlags: DISPFlagDefinition, {{.*}})
+// CHECK: [[FAILURE_FUNC]] = distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow", scope: {{.*}}, file: {{.*}}, type: [[FUNC_TYPE:![0-9]+]], flags: DIFlagArtificial, spFlags: DISPFlagDefinition, {{.*}})
 // CHECK: [[FUNC_TYPE]] = !DISubroutineType(types: null)
  


### PR DESCRIPTION
This PR moves swift runtimes failure (#25978) messages from the linkage name to the function name.

Since the failure message (i.e. `Swift runtime failure: arithmetic overflow`) don't conform with a proper mangling, when lldb tries to fetch the inlined frame symbol, it gets discarded. Moving it to the function name fixes this issue.

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>