### PR TITLE
[5.2] SILGen: Lower the type of the return value merge phi in the context of the current function

### DIFF
--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -30,8 +30,8 @@ void SILGenFunction::prepareEpilog(Type resultType, bool isThrowing,
     // emits unreachable if there is no source level return.
     NeedsReturn = (fnConv.funcTy->getNumResults() != 0);
     for (auto directResult : fnConv.getDirectSILResults()) {
-      SILType resultType =
-          F.mapTypeIntoContext(fnConv.getSILType(directResult));
+      SILType resultType = F.getLoweredType(
+          F.mapTypeIntoContext(fnConv.getSILType(directResult)));
       epilogBB->createPhiArgument(resultType, ValueOwnershipKind::Owned);
     }
   }

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -149,3 +149,19 @@ struct S2 : X {
     return foo
   }
 }
+
+class Base {}
+class Sub1 : Base {}
+class Sub2 : Base {}
+
+public class D {
+   var cond = true
+   // CHECK-LABEL: sil private [ossa] @$s18opaque_result_type1DC1c33_C2C55A4BAF30C3244D4A165D48A91142LLQrvg
+   // CHECK: bb3([[RET:%[0-9]+]] : @owned $Base):
+   // CHECH:  return [[RET]]
+   // CHECK: } // end sil function '$s18opaque_result_type1DC1c33_C2C55A4BAF30C3244D4A165D48A91142LLQrvg'
+   private lazy var c: some Base = {
+        let d = cond ? Sub1() : Sub2()
+        return d
+    }()
+}


### PR DESCRIPTION
* Description: The lowering of return block arguments did not lower
opaque result types in the context of the function. This leads to SIL
verification errors in assert builds.
* Scope: Introduced with the automatic lowering of opaque result types
to their underlying types based on the current function context last year.
* Testing: A regression test was added to the Swift test suite.

rdar://58929484