### PR TITLE
Add presets for compiler performance tests

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2217,3 +2217,80 @@ mixin-preset=stdlib_DA_standalone,build
 
 test
 validation-test
+
+#===------------------------------------------------------------------------===#
+# Compiler Performance Test Presets
+#
+# Used by the run_cperf script in apple/swift-source-compat-suite
+#===------------------------------------------------------------------------===#
+
+[preset: mixin_cperf]
+release
+no-assertions
+
+build-ninja
+
+llbuild
+swiftpm
+skip-build-benchmarks
+
+install-llbuild
+install-swift
+install-swiftpm
+
+[preset: cperf,platform=macos]
+mixin-preset=mixin_cperf
+
+ios
+tvos
+watchos
+
+build-subdir=compat_macos
+compiler-vendor=apple
+
+dash-dash
+
+darwin-install-extract-symbols
+darwin-toolchain-alias=swift
+
+darwin-toolchain-bundle-identifier=org.swift.compat-macos
+darwin-toolchain-display-name-short=Swift Development Snapshot
+darwin-toolchain-display-name=Swift Development Snapshot
+darwin-toolchain-name=swift-DEVELOPMENT_SNAPSHOT
+darwin-toolchain-version=3.999.999
+
+install-destdir=%(workspace)s/build/compat_macos/install
+install-prefix=/toolchain/usr
+install-symroot=%(workspace)s/build/compat_macos/symroot
+installable-package=%(workspace)s/build/compat_macos/root.tar.gz
+symbols-package=%(workspace)s/build/compat_macos/root-symbols.tar.gz
+
+llvm-install-components=libclang;libclang-headers
+swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
+
+verbose-build
+reconfigure
+
+[preset: cperf,platform=linux]
+mixin-preset=mixin_cperf
+
+foundation
+libdispatch
+xctest
+
+build-subdir=compat_linux
+
+dash-dash
+
+install-foundation
+install-libdispatch
+install-xctest
+
+install-destdir=%(workspace)s/build/compat_linux/install
+install-prefix=/usr
+installable-package=%(workspace)s/build/compat_linux/root.tar.gz
+
+swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;license
+
+verbose-build
+reconfigure


### PR DESCRIPTION
This PR adds some presets to build-presets.ini which perform fast builds of compile-only toolchains (no editor tools, etc). A separate PR, apple/swift-source-compat-suite#403, will use these presets in the run_cperf tool instead of embedding long build-script invocations in it; this will allow us to do performance tests of different compiler build settings by testing pull requests with different build settings.

(Repurposed from a dummy PR.)