### PR TITLE
[NFC] Improve Nested Types Table Test

### DIFF
--- a/test/Serialization/Inputs/nested-type-with-overlay/overlay.swift
+++ b/test/Serialization/Inputs/nested-type-with-overlay/overlay.swift
@@ -8,3 +8,13 @@ extension Base {
 }
 
 public var shadowedFromSwift = Base.NestedAndShadowed(dummy: ())
+
+public struct CustomError {
+  public struct Code : RawRepresentable {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+  }
+}

--- a/test/Serialization/nested-type-with-overlay.swift
+++ b/test/Serialization/nested-type-with-overlay.swift
@@ -8,8 +8,8 @@
 
 // REQUIRES: asserts
 
-// CHECK: 3 Serialization - # of nested types resolved without full lookup
-// Unfortunately this isn't 4 because of the shadowed nested type from Clang.
+// CHECK: 4 Serialization - # of nested types resolved without full lookup
+// Unfortunately this isn't 5 because of the shadowed nested type from Clang.
 
 import HasOverlay
 
@@ -20,3 +20,9 @@ public func resolveNestedTypes(
 
 public var shadowedFromClang = getShadowedFromClang()
 public var shadowedFromSwift = HasOverlay.shadowedFromSwift
+
+extension CustomError.Code {
+  public static var failedSuccessfully: CustomError.Code {
+    return CustomError.Code(rawValue: -9999)
+  }
+}


### PR DESCRIPTION
To guard against the kind of complex failures seen in rdar://58690068,
improve this regression test with a copy of a shrunken version of
CocoaError.Code.

In that radar, CocoaError.Code was defined in one overlay and extended
in another translation unit.  When deserialization encountered this, it
failed to search the overlay's nested type tables and fell through to
re-enter lookupDirect.
