### PR TITLE
[stdlib/private][OSLog] Support expressive, fprintf-style formatting options for integers passed to os log string interpolation.

### DIFF
--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -481,6 +481,9 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
                                      evaluator.getAllocator());
   }
 
+  if (auto *convertEscapeInst = dyn_cast<ConvertEscapeToNoEscapeInst>(value))
+    return getConstantValue(convertEscapeInst->getOperand());
+
   LLVM_DEBUG(llvm::dbgs() << "ConstExpr Unknown simple: " << *value << "\n");
 
   // Otherwise, we don't know how to handle this.

--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -4,6 +4,8 @@ add_swift_target_library(swiftOSLogPrototype
 
   OSLog.swift
   OSLogMessage.swift
+  OSLogIntegerFormatting.swift
+  OSLogStringAlignment.swift
   OSLogIntegerTypes.swift
   OSLogStringTypes.swift
   OSLogNSObjectType.swift

--- a/stdlib/private/OSLog/OSLogIntegerFormatting.swift
+++ b/stdlib/private/OSLog/OSLogIntegerFormatting.swift
@@ -1,0 +1,317 @@
+@frozen
+public struct OSLogIntegerFormatting: Equatable {
+  /// The base to use for the string representation. `radix` must be at least 2
+  /// and at most 36. The default is 10.
+  public var radix: Int
+
+  /// When set, a `+` will be printed for all non-negative integers.
+  public var explicitPositiveSign: Bool
+
+  /// When set, a prefix: 0b or 0o or 0x will be added when the radix is 2, 8 or
+  /// 16 respectively.
+  public var includePrefix: Bool
+
+  /// Whether to use uppercase letters to represent numerals
+  /// greater than 9 (default is to use lowercase).
+  public var uppercase: Bool
+
+  /// Minimum number of digits to display. Numbers having fewer digits than
+  /// minDigits will be displayed with leading zeros.
+  public var minDigits: Int
+
+  /// - Parameters:
+  ///   - radix: The base to use for the string representation. `radix` must be
+  ///     at least 2 and at most 36. The default is 10.
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers. Default is `false`.
+  ///   - includePrefix: Pass `true` to add a prefix: 0b, 0o, 0x to corresponding
+  ///     radices. Default is `false`.
+  ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
+  ///     greater than 9, or `false` to use lowercase letters. The default is
+  ///     `false`.
+  ///   - minDigits: minimum number of digits to display. Numbers will be
+  ///     prefixed with zeros if necessary to meet the minimum. The default is 1.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public init(
+    radix: Int = 10,
+    explicitPositiveSign: Bool = false,
+    includePrefix: Bool = false,
+    uppercase: Bool = false,
+    minDigits: Int = 1
+  ) {
+    precondition(radix >= 2 && radix <= 36)
+
+    self.radix = radix
+    self.explicitPositiveSign = explicitPositiveSign
+    self.includePrefix = includePrefix
+    self.uppercase = uppercase
+    self.minDigits = minDigits
+  }
+
+  /// - Parameters:
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers. Default is `false`.
+  ///   - minDigits: minimum number of digits to display. Numbers will be
+  ///     prefixed with zeros if necessary to meet the minimum. The default is 1.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func decimal(
+    explicitPositiveSign: Bool = false,
+    minDigits: Int = 1
+  ) -> OSLogIntegerFormatting {
+    return OSLogIntegerFormatting(
+      radix: 10,
+      explicitPositiveSign: explicitPositiveSign,
+      minDigits: minDigits)
+  }
+
+  /// Default decimal format.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var decimal: OSLogIntegerFormatting { .decimal() }
+
+  /// - Parameters:
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers. Default is `false`.
+  ///   - includePrefix: Pass `true` to add a prefix: 0b, 0o, 0x to corresponding
+  ///     radices. Default is `false`.
+  ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
+  ///     greater than 9, or `false` to use lowercase letters. The default is
+  ///     `false`.
+  ///   - minDigits: minimum number of digits to display. Numbers will be
+  ///     prefixed with zeros if necessary to meet the minimum. The default is 1.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func hex(
+    explicitPositiveSign: Bool = false,
+    includePrefix: Bool = false,
+    uppercase: Bool = false,
+    minDigits: Int = 1
+  ) -> OSLogIntegerFormatting {
+    return OSLogIntegerFormatting(
+      radix: 16,
+      explicitPositiveSign: explicitPositiveSign,
+      includePrefix: includePrefix,
+      uppercase: uppercase,
+      minDigits: minDigits)
+  }
+
+  /// Default hexadecimal format.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var hex: OSLogIntegerFormatting { .hex() }
+
+  /// - Parameters:
+  ///   - explicitPositiveSign: Pass `true` to add a + sign to non-negative
+  ///     numbers. Default is `false`.
+  ///   - includePrefix: Pass `true` to add a prefix: 0b, 0o, 0x to corresponding
+  ///     radices. Default is `false`.
+  ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
+  ///     greater than 9, or `false` to use lowercase letters. The default is
+  ///     `false`.
+  ///   - minDigits: minimum number of digits to display. Numbers will be
+  ///     prefixed with zeros if necessary to meet the minimum. The default is 1.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func octal(
+    explicitPositiveSign: Bool = false,
+    includePrefix: Bool = false,
+    uppercase: Bool = false,
+    minDigits: Int = 1
+  ) -> OSLogIntegerFormatting {
+    OSLogIntegerFormatting(
+      radix: 8,
+      explicitPositiveSign: explicitPositiveSign,
+      includePrefix: includePrefix,
+      uppercase: uppercase,
+      minDigits: minDigits)
+  }
+
+  /// Default octal format.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var octal: OSLogIntegerFormatting { .octal() }
+}
+
+extension OSLogIntegerFormatting {
+  /// The prefix for the radix in the Swift literal syntax.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  internal var _prefix: String {
+    guard includePrefix else { return "" }
+    switch radix {
+    case 2: return "0b"
+    case 8: return "0o"
+    case 16: return "0x"
+    default: return ""
+    }
+  }
+}
+
+extension OSLogIntegerFormatting {
+
+  /// Returns a fprintf-compatible length modifier for a given argument type.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  internal static func formatSpecifierLengthModifier<I: FixedWidthInteger>(
+    _ type: I.Type
+  ) -> String? {
+    // IEEE Std 1003.1-2017, length modifiers:
+    switch type {
+    //   hh - d, i, o, u, x, or X conversion specifier applies to
+    // (signed|unsigned) char
+    case is CChar.Type: return "hh"
+    case is CUnsignedChar.Type: return "hh"
+
+    //   h  - d, i, o, u, x, or X conversion specifier applies to
+    // (signed|unsigned) short
+    case is CShort.Type: return "h"
+    case is CUnsignedShort.Type: return "h"
+
+    case is CInt.Type: return ""
+    case is CUnsignedInt.Type: return ""
+
+    //   l  - d, i, o, u, x, or X conversion specifier applies to
+    // (signed|unsigned) long
+    case is CLong.Type: return "l"
+    case is CUnsignedLong.Type: return "l"
+
+    //   ll - d, i, o, u, x, or X conversion specifier applies to
+    // (signed|unsigned) long long
+    case is CLongLong.Type: return "ll"
+    case is CUnsignedLongLong.Type: return "ll"
+
+    default: return nil
+    }
+  }
+
+  /// Constructs an os_log format specifier for the given type `type`
+  /// using the specified alignment `align` and privacy qualifier `privacy`.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  @_effects(readonly)
+  internal func formatSpecifier<I: FixedWidthInteger>(
+    for type: I.Type,
+    align: OSLogStringAlignment,
+    privacy: OSLogPrivacy
+  ) -> String {
+    // Based on IEEE Std 1003.1-2017
+    // `d`/`i` is the only signed integral conversions allowed
+    if (type.isSigned && radix != 10) {
+      fatalError("Signed integers must be formatted using .decimal")
+    }
+
+    // IEEE: Each conversion specification is introduced by the '%' character
+    // after which the following appear in sequence:
+    //   1. Zero or more flags (in any order), which modify the meaning of the
+    //      conversion specification.
+    //   2. An optional minimum field width (for alignment). If the converted
+    //      value has fewer bytes than the field width, it shall be padded with
+    //      <space> characters by default on the left; it shall be padded on the
+    //      right if the left-adjustment flag ( '-' ), is given to the
+    //      field width.
+    //   3. An optional precision that gives the minimum number of digits to
+    //      display for the d, i, o, u, x, and X conversion specifiers.
+    //   4. An optional length modifier that specifies the size of the argument.
+    //   5. A conversion specifier character that indicates the type of
+    //      conversion to be applied.
+
+    // Use Swift style prefixes rather than fprintf style prefixes.
+    var specification = _prefix
+    specification += "%"
+
+    // Add privacy qualifier after % sign within curly braces. This is an
+    // os log specific flag.
+    switch privacy {
+    case .private:
+      specification += "{private}"
+    case .public:
+      specification += "{public}"
+    default:
+      break
+    }
+
+    //
+    // 1. Flags
+    //
+    // Use `+` flag if signed, otherwise prefix a literal `+` for unsigned.
+    if explicitPositiveSign {
+      // IEEE: `+` The result of a signed conversion shall always begin with a
+      // sign ( '+' or '-' )
+      if type.isSigned {
+        specification += "+"
+      } else {
+        var newSpecification = "+"
+        newSpecification += specification
+        specification = newSpecification
+      }
+    }
+
+    // IEEE: `-` The result of the conversion shall be left-justified within
+    // the field. The conversion is right-justified if this flag is not
+    // specified.
+    switch align.anchor {
+    case OSLogCollectionBound.start:
+        specification += "-"
+    default:
+        break
+    }
+
+    // 2. Minimumn field width
+    // IEEE: When field width is prefixed by `0`, leading zeros (following any
+    // indication of sign or base) are used to pad to the field width rather
+    // than performing space padding. If the '0' and '-' flags both appear,
+    // the '0' flag is ignored. If a precision is specified, the '0' flag shall
+    // be ignored.
+    //
+    // Commentary: `0` is prefixed to field width when the user doesn't want to
+    // use precision (minDigits). This allows sign and prefix characters to be
+    // counted towards field width (they wouldn't be counted towards precision).
+    // This is more useful for floats, where precision is digits after the radix.
+    // In our case, we're already handling prefix ourselves; we choose not to
+    // support this functionality. In our case, alignment always pads spaces (
+    // to the left or right) until the minimum field width is met.
+    if align.minimumColumnWidth > 0 {
+      specification += align.minimumColumnWidth.description
+    }
+
+    // 3. Precision
+
+    // Default precision for integers is 1, otherwise use the requested precision.
+    if minDigits != 1 {
+      specification += "."
+      specification += minDigits.description
+    }
+
+    // 4. Length modifier
+    guard let lengthModifier =
+      OSLogIntegerFormatting.formatSpecifierLengthModifier(type) else {
+      fatalError("Integer type has unknown byte length")
+    }
+    specification += lengthModifier
+
+    // 5. The conversion specifier
+    switch radix {
+    case 10:
+      specification += type.isSigned ? "d" : "u"
+    case 8:
+      specification += "o"
+    case 16:
+      specification += uppercase ? "X" : "x"
+    default:
+      fatalError("radix must be 10, 8 or 16")
+    }
+    return specification
+  }
+}

--- a/stdlib/private/OSLog/OSLogIntegerTypes.swift
+++ b/stdlib/private/OSLog/OSLogIntegerTypes.swift
@@ -26,7 +26,7 @@ extension OSLogInterpolation {
   /// - Parameters:
   ///  - number: the interpolated expression of type Int, which is autoclosured.
   ///  - format: a formatting option available for integer types, defined by the
-  ///    enum `IntFormat`.
+  ///    enum `OSLogIntegerFormatting`.
   ///  - privacy: a privacy qualifier which is either private or public.
   ///    The default is public.
   @_semantics("constant_evaluable")
@@ -34,17 +34,18 @@ extension OSLogInterpolation {
   @_optimize(none)
   public mutating func appendInterpolation(
     _ number: @autoclosure @escaping () -> Int,
-    format: IntFormat = .decimal,
-    privacy: Privacy = .public
+    format: OSLogIntegerFormatting = .decimal,
+    align: OSLogStringAlignment = .none,
+    privacy: OSLogPrivacy = .public
   ) {
-    appendInteger(number, format: format, privacy: privacy)
+    appendInteger(number, format: format, align: align, privacy: privacy)
   }
 
   /// Define interpolation for expressions of type Int32.
   /// - Parameters:
   ///  - number: the interpolated expression of type Int32, which is autoclosured.
   ///  - format: a formatting option available for integer types, defined by the
-  ///    enum `IntFormat`.
+  ///    enum `OSLogIntegerFormatting`.
   ///  - privacy: a privacy qualifier which is either private or public.
   ///    The default is public.
   @_semantics("constant_evaluable")
@@ -52,21 +53,30 @@ extension OSLogInterpolation {
   @_optimize(none)
   public mutating func appendInterpolation(
     _ number: @autoclosure @escaping () -> Int32,
-    format: IntFormat = .decimal,
-    privacy: Privacy = .public
+    format: OSLogIntegerFormatting = .decimal,
+    align: OSLogStringAlignment = .none,
+    privacy: OSLogPrivacy = .public
   ) {
-    appendInteger(number, format: format, privacy: privacy)
+    appendInteger(number, format: format, align: align, privacy: privacy)
   }
 
+  /// Define interpolation for expressions of type UInt.
+  /// - Parameters:
+  ///  - number: the interpolated expression of type UInt, which is autoclosured.
+  ///  - format: a formatting option available for integer types, defined by the
+  ///    enum `OSLogIntegerFormatting`.
+  ///  - privacy: a privacy qualifier which is either private or public.
+  ///    The default is public.
   @_semantics("constant_evaluable")
   @inlinable
   @_optimize(none)
   public mutating func appendInterpolation(
     _ number: @autoclosure @escaping () -> UInt,
-    format: IntFormat = .decimal,
-    privacy: Privacy = .public
+    format: OSLogIntegerFormatting = .decimal,
+    align: OSLogStringAlignment = .none,
+    privacy: OSLogPrivacy = .public
   ) {
-    appendInteger(number, format: format, privacy: privacy)
+    appendInteger(number, format: format, align: align, privacy: privacy)
   }
 
   /// Given an integer, create and append a format specifier for the integer to the
@@ -77,17 +87,15 @@ extension OSLogInterpolation {
   @_optimize(none)
   internal mutating func appendInteger<T>(
     _ number: @escaping () -> T,
-    format: IntFormat,
-    privacy: Privacy
+    format: OSLogIntegerFormatting,
+    align: OSLogStringAlignment,
+    privacy: OSLogPrivacy
   ) where T: FixedWidthInteger {
     guard argumentCount < maxOSLogArgumentCount else { return }
+    formatString +=
+      format.formatSpecifier(for: T.self, align: align, privacy: privacy)
 
     let isPrivateArgument = isPrivate(privacy)
-    formatString +=
-      getIntegerFormatSpecifier(
-        T.self,
-        format,
-        isPrivateArgument)
     addIntHeaders(isPrivateArgument, sizeForEncoding(T.self))
 
     arguments.append(number)
@@ -113,38 +121,6 @@ extension OSLogInterpolation {
     totalBytesForSerializingArguments += byteCount + 2
 
     preamble = getUpdatedPreamble(isPrivate: isPrivate, isScalar: true)
-  }
-
-  /// Construct an os_log format specifier from the given parameters.
-  /// This function must be constant evaluable and all its arguments
-  /// must be known at compile time.
-  @inlinable
-  @_semantics("constant_evaluable")
-  @_effects(readonly)
-  @_optimize(none)
-  internal func getIntegerFormatSpecifier<T>(
-    _ integerType: T.Type,
-    _ format: IntFormat,
-    _ isPrivate: Bool
-  ) -> String where T : FixedWidthInteger {
-    var formatSpecifier: String = isPrivate ? "%{private}" : "%{public}"
-
-    // Add a length modifier to the specifier.
-    // TODO: more length modifiers will be added.
-    if (integerType.bitWidth == CLongLong.bitWidth) {
-      formatSpecifier += "ll"
-    }
-
-    // TODO: more format specifiers will be added.
-    switch (format) {
-    case .hex:
-      formatSpecifier += "x"
-    case .octal:
-      formatSpecifier += "o"
-    default:
-      formatSpecifier += integerType.isSigned ? "d" : "u"
-    }
-    return formatSpecifier
   }
 }
 

--- a/stdlib/private/OSLog/OSLogMessage.swift
+++ b/stdlib/private/OSLog/OSLogMessage.swift
@@ -14,19 +14,6 @@
 // the new OS log APIs. These are prototype implementations and should not be
 // used outside of tests.
 
-/// Formatting options supported by the logging APIs for logging integers.
-/// These can be specified in the string interpolation passed to the log APIs.
-/// For Example,
-///     log.info("Writing to file with permissions: \(perm, format: .octal)")
-///
-/// See `OSLogInterpolation.appendInterpolation` definitions for default options
-/// for integer types.
-public enum IntFormat {
-  case decimal
-  case hex
-  case octal
-}
-
 /// Privacy qualifiers for indicating the privacy level of the logged data
 /// to the logging system. These can be specified in the string interpolation
 /// passed to the log APIs.
@@ -35,7 +22,7 @@ public enum IntFormat {
 ///
 /// See `OSLogInterpolation.appendInterpolation` definitions for default options
 /// for each supported type.
-public enum Privacy {
+public enum OSLogPrivacy {
   case `private`
   case `public`
 }
@@ -213,7 +200,7 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
   @_semantics("constant_evaluable")
   @_effects(readonly)
   @_optimize(none)
-  internal func isPrivate(_ privacy: Privacy) -> Bool {
+  internal func isPrivate(_ privacy: OSLogPrivacy) -> Bool {
     // Do not use equality comparisons on enums as it is not supported by
     // the constant evaluator.
     if case .private = privacy {

--- a/stdlib/private/OSLog/OSLogNSObjectType.swift
+++ b/stdlib/private/OSLog/OSLogNSObjectType.swift
@@ -34,7 +34,7 @@ extension OSLogInterpolation {
   @_optimize(none)
   public mutating func appendInterpolation(
     _ argumentObject: @autoclosure @escaping () -> NSObject,
-    privacy: Privacy = .private
+    privacy: OSLogPrivacy = .private
   ) {
     guard argumentCount < maxOSLogArgumentCount else { return }
 

--- a/stdlib/private/OSLog/OSLogStringAlignment.swift
+++ b/stdlib/private/OSLog/OSLogStringAlignment.swift
@@ -1,0 +1,69 @@
+@frozen
+public enum OSLogCollectionBound {
+  case start
+  case end
+}
+
+@frozen
+public struct OSLogStringAlignment {
+  /// Minimum number of characters to be displayed. If the value to be printed
+  /// is shorter than this number, the result is padded with spaces. The value
+  /// is not truncated even if the result is larger.
+  public var minimumColumnWidth: Int
+  /// This captures right/left alignment.
+  public var anchor: OSLogCollectionBound
+
+  /// - Parameters:
+  ///   - minimumColumnWidth: Minimum number of characters to be displayed. If the value to be
+  ///    printed is shorter than this number, the result is padded with spaces. The value is not truncated
+  ///    even if the result is larger.
+  ///   - anchor: Use `.end` for right alignment and `.start` for left.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public init(
+    minimumColumnWidth: Int = 0,
+    anchor: OSLogCollectionBound = .end
+  ) {
+    self.minimumColumnWidth = minimumColumnWidth
+    self.anchor = anchor
+  }
+
+  /// Right alignment formatter.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var right: OSLogStringAlignment {
+    OSLogStringAlignment(anchor: .end)
+  }
+
+  /// Left alignment formatter.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var left: OSLogStringAlignment {
+    OSLogStringAlignment(anchor: .start)
+  }
+
+  /// Use default alignment, which is right alignment.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static var none: OSLogStringAlignment { .right  }
+
+  /// Right align and display at least`columns` characters.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func right(columns: Int = 0) -> OSLogStringAlignment {
+    OSLogStringAlignment(minimumColumnWidth: columns, anchor: .end)
+  }
+
+  /// Left align and display at least`columns` characters.
+  @_semantics("constant_evaluable")
+  @inlinable
+  @_optimize(none)
+  public static func left(columns: Int = 0) -> OSLogStringAlignment {
+    OSLogStringAlignment(minimumColumnWidth: columns, anchor: .start)
+  }
+}

--- a/stdlib/private/OSLog/OSLogStringTypes.swift
+++ b/stdlib/private/OSLog/OSLogStringTypes.swift
@@ -37,7 +37,7 @@ extension OSLogInterpolation {
   @_optimize(none)
   public mutating func appendInterpolation(
     _ argumentString: @autoclosure @escaping () -> String,
-    privacy: Privacy = .private
+    privacy: OSLogPrivacy = .private
   ) {
     guard argumentCount < maxOSLogArgumentCount else { return }
 

--- a/test/SILOptimizer/OSLogConstantEvaluableTest.swift
+++ b/test/SILOptimizer/OSLogConstantEvaluableTest.swift
@@ -28,7 +28,7 @@ func osLogMessageStringLiteralInitTest() -> OSLogMessage {
 // CHECK-NOT: error:
 // CHECK-LABEL: @appendLiteral(String) -> ()
 // CHECK-NOT: error:
-// CHECK-LABEL: @appendInterpolation(_: @autoclosure () -> Int, format: IntFormat, privacy: Privacy) -> ()
+// CHECK-LABEL: @appendInterpolation(_: @autoclosure () -> Int, format: OSLogIntegerFormatting, align: OSLogStringAlignment, privacy: OSLogPrivacy) -> ()
 // CHECK-NOT: error:
 // CHECK-LABEL: @appendLiteral(String) -> ()
 // CHECK-NOT: error:
@@ -41,7 +41,7 @@ func intValueInterpolationTest() -> OSLogMessage {
 
 // CHECK-LABEL: @init(literalCapacity: Int, interpolationCount: Int) -> OSLogInterpolation
 // CHECK-NOT: error:
-// CHECK-LABEL: @appendInterpolation(_: @autoclosure () -> String, privacy: Privacy) -> ()
+// CHECK-LABEL: @appendInterpolation(_: @autoclosure () -> String, privacy: OSLogPrivacy) -> ()
 // CHECK-NOT: error:
 @_semantics("test_driver")
 func stringValueInterpolationTest() -> OSLogMessage {

--- a/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
@@ -18,13 +18,13 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
       // expected-error @-1 {{globalStringTablePointer builtin must used only on string literals}}
   }
 
-  func testNonconstantFormatOption(h: Logger, formatOpt: IntFormat) {
+  func testNonconstantFormatOption(h: Logger, formatOpt: OSLogIntegerFormatting) {
     h.log(level: .debug, "Minimum integer value: \(Int.min, format: formatOpt)")
     // expected-error @-1 {{interpolation arguments like format and privacy options must be constants}}
     // expected-error @-2 {{globalStringTablePointer builtin must used only on string literals}}
   }
 
-  func testNonconstantPrivacyOption(h: Logger,  privacyOpt: Privacy) {
+  func testNonconstantPrivacyOption(h: Logger,  privacyOpt: OSLogPrivacy) {
     h.log(level: .debug, "Minimum integer value: \(Int.min, privacy: privacyOpt)")
     // expected-error @-1 {{interpolation arguments like format and privacy options must be constants}}
     // expected-error @-2 {{globalStringTablePointer builtin must used only on string literals}}

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -27,8 +27,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "Minimum integer value: %{public}lld"
-    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "Minimum integer value: %{public}d"
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "Minimum integer value: %{public}ld"
 
     // Check if the size of the argument buffer is a constant.
 
@@ -68,7 +67,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
   // CHECK-LABEL: @${{.*}}testInterpolationWithFormatOptionsL_
   func testInterpolationWithFormatOptions(h: Logger) {
-    h.log(level: .info, "Maximum integer value: \(Int.max, format: .hex)")
+    h.log(level: .info, "Maximum unsigned integer value: \(UInt.max, format: .hex)")
 
     // Check if there is a call to _os_log_impl with a literal format string.
 
@@ -78,8 +77,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "Maximum integer value: %{public}llx"
-    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "Maximum integer value: %{public}x"
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "Maximum unsigned integer value: %{public}lx"
 
     // Check if the size of the argument buffer is a constant.
 
@@ -118,7 +116,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
   // CHECK-LABEL: @${{.*}}testInterpolationWithFormatOptionsAndPrivacyL_
   func testInterpolationWithFormatOptionsAndPrivacy(h: Logger) {
-    let privateID = 0x79abcdef
+    let privateID: UInt = 0x79abcdef
     h.log(
       level: .error,
       "Private Identifier: \(privateID, format: .hex, privacy: .private)")
@@ -131,8 +129,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "Private Identifier: %{private}llx"
-    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "Private Identifier: %{private}x"
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "Private Identifier: %{private}lx"
 
     // Check if the size of the argument buffer is a constant.
 
@@ -172,7 +169,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
   // CHECK-LABEL: @${{.*}}testInterpolationWithMultipleArgumentsL_
   func testInterpolationWithMultipleArguments(h: Logger) {
     let privateID = 0x79abcdef
-    let filePermissions = 0o777
+    let filePermissions: UInt = 0o777
     let pid = 122225
     h.log(
       level: .error,
@@ -190,8 +187,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "Access prevented: process %{public}lld initiated by user: %{private}lld attempted resetting permissions to %{public}llo"
-    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "Access prevented: process %{public}d initiated by user: %{private}d attempted resetting permissions to %{public}o"
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "Access prevented: process %{public}ld initiated by user: %{private}ld attempted resetting permissions to %{public}lo"
 
     // Check if the size of the argument buffer is a constant.
 
@@ -339,8 +335,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[STRING3]] = begin_borrow [[STRING4:%[0-9]+]]
     // CHECK-DAG: [[STRING4]] = apply [[STRING_INIT:%[0-9]+]]([[LIT:%[0-9]+]],
     // CHECK-DAG: [[STRING_INIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "%{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld "
-    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "%{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d "
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "%{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld %{public}ld "
 
     // Check if the size of the argument buffer is a constant.
 

--- a/test/stdlib/OSLogPrototypeExecTest.swift
+++ b/test/stdlib/OSLogPrototypeExecTest.swift
@@ -26,16 +26,16 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     h.log("A message with no data")
 
     // Test logging at specific levels.
-    h.debug("Minimum integer value: \(Int.min, format: .hex)")
-    h.info("Maximum integer value: \(Int.max, format: .hex)")
+    h.debug("Minimum integer value: \(Int.min)")
+    h.info("Maximum unsigned integer value: \(UInt.max, format: .hex)")
 
-    let privateID = 0x79abcdef
+    let privateID: UInt = 0x79abcdef
     h.error("Private Identifier: \(privateID, format: .hex, privacy: .private)")
-    let addr = 0x7afebabe
+    let addr: UInt = 0x7afebabe
     h.fault("Invalid address: 0x\(addr, format: .hex, privacy: .public)")
 
     // Test logging with multiple arguments.
-    let filePermissions = 0o777
+    let filePermissions: UInt = 0o777
     let pid = 122225
     h.error(
       """
@@ -107,7 +107,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
   OSLogTestSuite.test("integer types") {
     let h = Logger()
-    h.log("Smallest 32-bit integer value: \(Int32.min, format: .hex)")
+    h.log("Smallest 32-bit integer value: \(Int32.min)")
   }
 
   OSLogTestSuite.test("dynamic strings") {
@@ -149,7 +149,6 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 // be available.
 
 internal var InterpolationTestSuite = TestSuite("OSLogInterpolationTest")
-internal let intPrefix = Int.bitWidth == CLongLong.bitWidth ? "ll" : ""
 internal let bitsPerByte = 8
 
 /// A struct that exposes methods for checking whether a given byte buffer
@@ -343,7 +342,7 @@ InterpolationTestSuite.test("integer literal") {
     "An integer literal \(10)",
     with: { (formatString, buffer) in
     expectEqual(
-      "An integer literal %{public}\(intPrefix)d",
+      "An integer literal %{public}ld",
       formatString)
 
     let bufferChecker = OSLogBufferChecker(buffer)
@@ -360,10 +359,10 @@ InterpolationTestSuite.test("integer literal") {
 
 InterpolationTestSuite.test("integer with formatting") {
   _checkFormatStringAndBuffer(
-    "Minimum integer value: \(Int.min, format: .hex)",
+    "Minimum integer value: \(UInt.max, format: .hex)",
     with: { (formatString, buffer) in
       expectEqual(
-        "Minimum integer value: %{public}\(intPrefix)x",
+        "Minimum integer value: %{public}lx",
         formatString)
 
       let bufferChecker = OSLogBufferChecker(buffer)
@@ -376,18 +375,18 @@ InterpolationTestSuite.test("integer with formatting") {
         bufferChecker.checkInt(
           startIndex: $0,
           flag: .publicFlag,
-          expectedInt: Int.min)
+          expectedInt: UInt.max)
       })
   })
 }
 
 InterpolationTestSuite.test("integer with privacy and formatting") {
-  let addr = 0x7afebabe
+  let addr: UInt = 0x7afebabe
   _checkFormatStringAndBuffer(
     "Access to invalid address: \(addr, format: .hex, privacy: .private)",
     with: { (formatString, buffer) in
       expectEqual(
-        "Access to invalid address: %{private}\(intPrefix)x",
+        "Access to invalid address: %{private}lx",
         formatString)
 
       let bufferChecker = OSLogBufferChecker(buffer)
@@ -406,7 +405,7 @@ InterpolationTestSuite.test("integer with privacy and formatting") {
 }
 
 InterpolationTestSuite.test("test multiple arguments") {
-  let filePerms = 0o777
+  let filePerms: UInt = 0o777
   let pid = 122225
   let privateID = 0x79abcdef
 
@@ -419,9 +418,9 @@ InterpolationTestSuite.test("test multiple arguments") {
     with: { (formatString, buffer) in
       expectEqual(
         """
-        Access prevented: process %{public}\(intPrefix)d initiated by \
-        user: %{private}\(intPrefix)d attempted resetting permissions \
-        to %{public}\(intPrefix)o
+        Access prevented: process %{public}ld initiated by \
+        user: %{private}ld attempted resetting permissions \
+        to %{public}lo
         """,
         formatString)
 
@@ -466,7 +465,7 @@ InterpolationTestSuite.test("interpolation of too many arguments") {
     with: { (formatString, buffer) in
       expectEqual(
         String(
-          repeating: "%{public}\(intPrefix)d ",
+          repeating: "%{public}ld ",
           count: Int(maxOSLogArgumentCount)),
         formatString)
 
@@ -630,11 +629,65 @@ protocol TestProto {
 InterpolationTestSuite.test("Interpolation of complex expressions") {
   class TestClass<T: TestProto>: NSObject {
     func testFunction() {
-      // The following call should no crash.
+      // The following call should not crash.
       _checkFormatStringAndBuffer("A complex expression \(toString(self))") {
         (formatString, _) in
         expectEqual("A complex expression %s", formatString)
       }
     }
+  }
+}
+
+InterpolationTestSuite.test("Include prefix formatting option") {
+  let unsignedValue: UInt = 0o171
+  _checkFormatStringAndBuffer(
+  "Octal with prefix: \(unsignedValue, format: .octal(includePrefix: true))") {
+    (formatString, buffer) in
+    expectEqual("Octal with prefix: 0o%{public}lo", formatString)
+  }
+}
+
+InterpolationTestSuite.test("Hex with uppercase formatting option") {
+  let unsignedValue: UInt = 0xcafebabe
+  _checkFormatStringAndBuffer(
+  "Hex with uppercase: \(unsignedValue, format: .hex(uppercase: true))") {
+    (formatString, buffer) in
+    expectEqual("Hex with uppercase: %{public}lX", formatString)
+  }
+}
+
+InterpolationTestSuite.test("Integer with explicit positive sign") {
+  let posValue = Int.max
+  _checkFormatStringAndBuffer(
+  "\(posValue, format: .decimal(explicitPositiveSign: true))") {
+    (formatString, buffer) in
+    expectEqual("%{public}+ld", formatString)
+  }
+}
+
+InterpolationTestSuite.test("Unsigned integer with explicit positive sign") {
+  let posValue = UInt.max
+  _checkFormatStringAndBuffer(
+  "\(posValue, format: .decimal(explicitPositiveSign: true))") {
+    (formatString, buffer) in
+    expectEqual("+%{public}lu", formatString)
+  }
+}
+
+InterpolationTestSuite.test("Integer formatting with precision") {
+  let intValue = 10
+  _checkFormatStringAndBuffer(
+  "\(intValue, format: .decimal(minDigits: 10))") {
+    (formatString, buffer) in
+    expectEqual("%{public}.10ld", formatString)
+  }
+}
+
+InterpolationTestSuite.test("Integer formatting with alignment") {
+  let intValue = 10
+  _checkFormatStringAndBuffer(
+  "\(intValue, align: .right(columns: 10)) \(intValue, align: .left(columns: 5))") {
+    (formatString, buffer) in
+    expectEqual("%{public}10ld %{public}-5ld", formatString)
   }
 }


### PR DESCRIPTION
@milseman This PR adds the `IntegerFormatting.swift` and `StringAlignment.swift` features to the new os log overlay, and updates the OSLog test suites to make it compatible with these changes. These files are almost same as what you had made, expect for the following changes: 

1. I have omitted the `separator` option of `IntegerFormatting`. This is because, as of now, os log is not supporting custom separators and therefore I did not want the option to be available to os log users. Similarly, I have also omitted `Fill` character from `String.Alignment` as os log would not be supporting anything but spaces, as of now. 

2. I have updated the implementation of `formatSpecifier` function slightly so that it uses only operations supported by the constant evaluator. This mostly involves replacing all string operations with +=. 

3. The `formatSpecifier` function now takes the privacy specifiers also as a parameter as they also add a flag to the format specifier.

4. I have made the `formatSpecifier` function return a String instead of an optional String?. The conditions under which the function returned nil are now turned into precondition failures. This would enable the constant evaluator to report a reason for failure at compile time when those conditions are reached (without having to return an explicit error message). 

I have not yet added support for formatting strings. I will create a new PR for that. 