### PR TITLE
[ownership] Refactor checked conversion from ArrayRef<SILInstruction *> -> ArrayRef<BranchPropagatedUser> onto BranchPropagatedUser.

### DIFF
--- a/include/swift/SIL/BranchPropagatedUser.h
+++ b/include/swift/SIL/BranchPropagatedUser.h
@@ -108,6 +108,18 @@ public:
         llvm::PointerLikeTypeTraits<InnerTy>::NumLowBitsAvailable
   };
 
+  static ArrayRef<BranchPropagatedUser>
+  convertFromInstArray(ArrayRef<SILInstruction *> instArray) {
+    assert(llvm::all_of(
+               instArray,
+               [](SILInstruction *i) { return !isa<CondBranchInst>(i); }) &&
+           "Passed cond branch to a non-BranchPropagatedUser API");
+    auto *castData =
+        reinterpret_cast<const BranchPropagatedUser *>(instArray.data());
+    ArrayRef<BranchPropagatedUser> castArray(castData, instArray.size());
+    return castArray;
+  }
+
 private:
   BranchPropagatedUser(SILInstruction *inst) : user(inst) {
     assert(!isa<CondBranchInst>(inst));

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -187,24 +187,9 @@ public:
   bool validateLifetime(SILValue value,
                         ArrayRef<SILInstruction *> consumingUses,
                         ArrayRef<SILInstruction *> nonConsumingUses) {
-    assert(llvm::all_of(
-               consumingUses,
-               [](SILInstruction *i) { return !isa<CondBranchInst>(i); }) &&
-           "Passed cond branch to a non-BranchPropagatedUser API");
-    assert(llvm::all_of(
-               nonConsumingUses,
-               [](SILInstruction *i) { return !isa<CondBranchInst>(i); }) &&
-           "Passed cond branch to a non-BranchPropagatedUser API");
-    auto *consumingUsesCast =
-        reinterpret_cast<const BranchPropagatedUser *>(consumingUses.data());
-    auto *nonConsumingUsesCast =
-        reinterpret_cast<const BranchPropagatedUser *>(nonConsumingUses.data());
-    ArrayRef<BranchPropagatedUser> consumingUsesCastArray(consumingUsesCast,
-                                                          consumingUses.size());
-    ArrayRef<BranchPropagatedUser> nonConsumingUsesCastArray(
-        nonConsumingUsesCast, nonConsumingUses.size());
-    return validateLifetime(value, consumingUsesCastArray,
-                            nonConsumingUsesCastArray);
+    return validateLifetime(
+        value, BranchPropagatedUser::convertFromInstArray(consumingUses),
+        BranchPropagatedUser::convertFromInstArray(nonConsumingUses));
   }
 };
 


### PR DESCRIPTION
A branch propagated user that isn't a cond_br is layout compatible with a
SILInstruction *. This helper function converts from ArrayRef<SILInstruction *>
-> ArrayRef<BranchPropagatedUser> but also in asserts builds checks that our
invariant (namely all of the 'SILInstruction *' are not cond_br.
