### PR TITLE
[Constant Evaluator] Add support for displaying assertion/precondition failure messages and fatalError messages

### DIFF
--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -784,6 +784,13 @@ extractStaticStringValue(SymbolicValue staticString) {
   return staticStringProps[0].getStringValue();
 }
 
+static Optional<StringRef>
+extractStringOrStaticStringValue(SymbolicValue stringValue) {
+  if (stringValue.getKind() == SymbolicValue::String)
+    return stringValue.getStringValue();
+  return extractStaticStringValue(stringValue);
+}
+
 /// If the specified type is a Swift.Array of some element type, then return the
 /// element type.  Otherwise, return a null Type.
 static Type getArrayElementType(Type ty) {
@@ -829,8 +836,8 @@ ConstExprFunctionState::computeWellKnownCallResult(ApplyInst *apply,
     for (unsigned i = 0; i < apply->getNumArguments(); i++) {
       SILValue argument = apply->getArgument(i);
       SymbolicValue argValue = getConstantValue(argument);
-      Optional<StringRef> stringOpt = extractStaticStringValue(argValue);
-
+      Optional<StringRef> stringOpt =
+          extractStringOrStaticStringValue(argValue);
       // The first argument is a prefix that specifies the kind of failure
       // this is.
       if (i == 0) {
@@ -842,7 +849,6 @@ ConstExprFunctionState::computeWellKnownCallResult(ApplyInst *apply,
         }
         continue;
       }
-
       if (stringOpt) {
         message += ": ";
         message += stringOpt.getValue();

--- a/test/SILOptimizer/constant_evaluable_subset_test.swift
+++ b/test/SILOptimizer/constant_evaluable_subset_test.swift
@@ -925,3 +925,35 @@ func interpretBinaryIntegerDescription() -> String {
   str += testBinaryIntegerDescription(UInt(20))
   return str
 }
+
+// CHECK-LABEL: @testPreconditionFailure
+// CHECK: error: not constant evaluable
+@_semantics("constant_evaluable")
+func testPreconditionFailure(_ x: Int) -> Int {
+  precondition(x > 0, "argument must be positive")
+  return x + 1
+    // CHECK: note: operation traps
+    // Note that the message displayed depends on the assert configuration,
+    // therefore it is not checked here. For debug stdlib, the full message
+    // must be displayed.
+}
+
+@_semantics("test_driver")
+func interpretPreconditionFailure() -> Int {
+  return testPreconditionFailure(-10)
+}
+
+// CHECK-LABEL: @testFatalError
+// CHECK: error: not constant evaluable
+@_semantics("constant_evaluable")
+func testFatalError() -> Int {
+  fatalError("invoked an uncallable function")
+  return 0
+    // CHECK: note: Fatal error: invoked an uncallable function
+    // CHECK: note: operation traps
+}
+
+@_semantics("test_driver")
+func interpretFatalError() -> Int {
+  return testFatalError()
+}


### PR DESCRIPTION
when such errors happen during constant evaluation.