### PR TITLE
Fix missing include

### DIFF
--- a/lib/LLVMPasses/LLVMInlineTree.cpp
+++ b/lib/LLVMPasses/LLVMInlineTree.cpp
@@ -24,6 +24,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Allocator.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"

--- a/tools/SourceKit/lib/Support/UIDRegistry.cpp
+++ b/tools/SourceKit/lib/Support/UIDRegistry.cpp
@@ -13,6 +13,7 @@
 #include "SourceKit/Support/UIdent.h"
 #include "SourceKit/Support/Concurrency.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Allocator.h"
 #include "llvm/Support/raw_ostream.h"
 #include <mutex>
 #include <vector>


### PR DESCRIPTION
https://reviews.llvm.org/D73392 recently landed, which pruned unnecessary includes of Allocator.h. A side effect is that SpecificBumpPtrAllocator is no longer imported in swift when building with master LLVM.

Fix by directly including the header declaring SpecificBumpPtrAllocator.