### PR TITLE
[Incremental] Tests and bug fixes for per-type fingerprints.

### DIFF
--- a/test/Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh
+++ b/test/Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Fine-grained swiftdeps files use multiple lines for each graph node.
+# Compress such a file so that each entry is one line of the form:
+# <kind> <aspect> <context> <name> <isProvides>
+# Also sort for consistency, since the node order can vary.
+
+awk '/kind:/ {k = $2; f  = "<no fingerprint>"}; /aspect:/ {a = $2}; /context:/ {c = $2}; /name/ {n = $2}; /sequenceNumber/ {s = $2}; /fingerprint:/ {f = $2 }; /isProvides:/ {isP = $2; print k, a, c, n, isP, f}' | sort

--- a/test/InterfaceHash/added_method-type-fingerprints.swift
+++ b/test/InterfaceHash/added_method-type-fingerprints.swift
@@ -1,0 +1,55 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+class C {
+  func f2() -> Int {
+    return 0
+  }
+}
+
+// BEGIN b.swift
+class C {
+  func f2() -> Int {
+    return 0
+  }
+
+  func f3() -> Int {
+    return 1
+  }
+}
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' C true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1C{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1C{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_class_private_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_class_private_property-type-fingerprints.swift
@@ -1,0 +1,53 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+private class C {
+  func f2() -> Int {
+    return 0
+  }
+}
+
+// BEGIN b.swift
+private class C {
+  func f2() -> Int {
+    return 0
+  }
+
+  private var x: Int = 0
+}
+
+// Since C is a type or extension,  the interface hash ought to not get the
+// changed token hash.
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface '' C true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1C{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1C{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_class_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_class_property-type-fingerprints.swift
@@ -1,0 +1,53 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+class C {
+  func f2() -> Int {
+    return 0
+  }
+}
+
+// BEGIN b.swift
+class C {
+  func f2() -> Int {
+    return 0
+  }
+
+  private var x: Int = 0
+}
+
+// Since C is a type or extension,  the interface hash ought to not get the
+// changed token hash.
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface '' C true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1C{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1C{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_enum_private_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_enum_private_property-type-fingerprints.swift
@@ -1,0 +1,56 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+
+// BEGIN a.swift
+private enum A {
+  case x, y
+  func f2() -> Int {
+    return 0
+  }
+}
+
+// BEGIN b.swift
+private enum A {
+  case x, y
+  func f2() -> Int {
+    return 0
+  }
+
+  var foo: Int { return 0 }
+}
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' A true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1A{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1A{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_enum_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_enum_property-type-fingerprints.swift
@@ -1,0 +1,55 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+enum A {
+  case x, y
+  func f2() -> Int {
+    return 0
+  }
+}
+
+// BEGIN b.swift
+enum A {
+  case x, y
+  func f2() -> Int {
+    return 0
+  }
+
+  private var foo: Int { return 0 }
+}
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' A true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1A{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1A{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_method-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_method-type-fingerprints.swift
@@ -1,0 +1,55 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+class C {
+  func f2() -> Int {
+    return 0
+  }
+}
+
+// BEGIN b.swift
+class C {
+  func f2() -> Int {
+    return 0
+  }
+
+  private func f3() -> Int {
+    return 1
+  }
+}
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' C true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1C{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1C{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_method_value_types-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_method_value_types-type-fingerprints.swift
@@ -1,0 +1,88 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+struct A {
+  func f2() -> Int {
+    return 0
+  }
+}
+
+enum B {
+  case x, y
+  func f2() -> Int {
+    return 0
+  }
+}
+
+// BEGIN b.swift
+struct A {
+  func f2() -> Int {
+    return 0
+  }
+
+  private func f3() -> Int {
+    return 1
+  }
+}
+
+enum B {
+  case x, y
+  func f2() -> Int {
+    return 0
+  }
+
+  private func f3() -> Int {
+    return 1
+  }
+}
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' A true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1A{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1A{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' B true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' B true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' B true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' B true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1B{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1B{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_protocol_method-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_protocol_method-type-fingerprints.swift
@@ -1,0 +1,50 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+private protocol P {
+  func f2() -> Int
+  var y: Int { get set }
+}
+
+// BEGIN b.swift
+private protocol P {
+  func f2() -> Int
+  func f3() -> Int
+  var y: Int { get set }
+}
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' P true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1P{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1P{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_protocol_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_protocol_property-type-fingerprints.swift
@@ -1,0 +1,50 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+private protocol P {
+  func f2() -> Int
+  var y: Int { get set }
+}
+
+// BEGIN b.swift
+private protocol P {
+  func f2() -> Int
+  var x: Int { get set }
+  var y: Int { get set }
+}
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' P true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1P{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1P{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_struct_private_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_struct_private_property-type-fingerprints.swift
@@ -1,0 +1,56 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+struct S {
+  func f2() -> Int {
+    return 0
+  }
+
+  var y: Int = 0
+}
+
+// BEGIN b.swift
+struct S {
+  func f2() -> Int {
+    return 0
+  }
+
+  private var x: Int = 0
+  var y: Int = 0
+}
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' S true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1S{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1S{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_struct_property-type-fingerprints.swift
+++ b/test/InterfaceHash/added_private_struct_property-type-fingerprints.swift
@@ -1,0 +1,56 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+
+// BEGIN a.swift
+private struct S {
+  func f2() -> Int {
+    return 0
+  }
+
+  var y: Int = 0
+}
+
+// BEGIN b.swift
+private struct S {
+  func f2() -> Int {
+    return 0
+  }
+
+  var x: Int = 0
+  var y: Int = 0
+}
+
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-SAME-INTERFACE-HASH
+// RUN: %FileCheck %s <%t/diffs -check-prefix=CHECK-DIFFERENT-TYPE-FINGERPRINT
+
+// CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' S true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1S{{[^ ]+}} '' true
+
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1S{{[^ ]+}} '' true

--- a/test/InterfaceHash/edited_method_body-type-fingerprints.swift
+++ b/test/InterfaceHash/edited_method_body-type-fingerprints.swift
@@ -1,0 +1,31 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: cmp %t/{a,b}-processed.swiftdeps 
+
+// BEGIN a.swift
+class C {
+  func f2() -> Int {
+    return 0
+  }
+}
+
+// BEGIN b.swift
+class C {
+  func f2() -> Int {
+    return 1
+  }
+}

--- a/test/InterfaceHash/edited_method_body.swift
+++ b/test/InterfaceHash/edited_method_body.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -disable-type-fingerprints -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -disable-type-fingerprints -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/edited_property_getter-type-fingerprints.swift
+++ b/test/InterfaceHash/edited_property_getter-type-fingerprints.swift
@@ -1,0 +1,33 @@
+// REQUIRES: shell
+// Also uses awk:
+// XFAIL OS=windows
+
+// When adding a private protocol method, the interface hash should stay the same
+// The per-type fingerprint should change
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: cp %t/{a,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/a-processed.swiftdeps
+// RUN: cp %t/{b,x}.swift
+// RUN: %target-swift-frontend -typecheck -enable-type-fingerprints -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh <%t/x.swiftdeps >%t/b-processed.swiftdeps
+
+// RUN: cmp %t/{a,b}-processed.swiftdeps 
+
+// BEGIN a.swift
+class C {
+  var p: Int {
+    return 0
+  }
+}
+
+// BEGIN b.swift
+class C {
+  var p: Int {
+    let x = 1
+    return x
+  }
+}
+

--- a/test/InterfaceHash/edited_property_getter.swift
+++ b/test/InterfaceHash/edited_property_getter.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -disable-type-fingerprints -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -disable-type-fingerprints -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/validation-test/Driver/Dependencies/rdar23148987-type-fingerprints.swift
+++ b/validation-test/Driver/Dependencies/rdar23148987-type-fingerprints.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+
+// RUN: cp %s %t/main.swift
+// RUN: cp %S/Inputs/rdar23148987/helper-1.swift %t/helper.swift
+// RUN: touch -t 201401240005 %t/*.swift
+
+// RUN: cd %t && %target-build-swift -enable-type-fingerprints -c -incremental -output-file-map %S/Inputs/rdar23148987/output.json -parse-as-library ./main.swift ./helper.swift -parseable-output -j1 -module-name main 2>&1 | %FileCheck -check-prefix=CHECK-1 %s
+
+// CHECK-1-NOT: warning
+// CHECK-1: {{^{$}}
+// CHECK-1: "kind": "began"
+// CHECK-1: "name": "compile"
+// CHECK-1: ".\/main.swift"
+// CHECK-1: {{^}$}}
+
+// CHECK-1: {{^{$}}
+// CHECK-1: "kind": "began"
+// CHECK-1: "name": "compile"
+// CHECK-1: ".\/helper.swift"
+// CHECK-1: {{^}$}}
+
+// RUN: ls %t/ | %FileCheck -check-prefix=CHECK-LS %s
+
+// CHECK-LS-DAG: main.o
+// CHECK-LS-DAG: helper.o
+
+// RUN: cd %t && %target-build-swift -enable-type-fingerprints -c -incremental -output-file-map %S/Inputs/rdar23148987/output.json -parse-as-library ./main.swift ./helper.swift -parseable-output -j1 -module-name main 2>&1 | %FileCheck -check-prefix=CHECK-1-SKIPPED %s
+
+// CHECK-1-SKIPPED-NOT: warning
+// CHECK-1-SKIPPED: {{^{$}}
+// CHECK-1-SKIPPED: "kind": "skipped"
+// CHECK-1-SKIPPED: "name": "compile"
+// CHECK-1-SKIPPED: ".\/main.swift"
+// CHECK-1-SKIPPED: {{^}$}}
+
+// CHECK-1-SKIPPED: {{^{$}}
+// CHECK-1-SKIPPED: "kind": "skipped"
+// CHECK-1-SKIPPED: "name": "compile"
+// CHECK-1-SKIPPED: ".\/helper.swift"
+// CHECK-1-SKIPPED: {{^}$}}
+
+// RUN: cp %S/Inputs/rdar23148987/helper-2.swift %t/helper.swift
+// RUN: touch -t 201401240006 %t/helper.swift
+// RUN: cd %t && %target-build-swift -enable-type-fingerprints -c -incremental -output-file-map %S/Inputs/rdar23148987/output.json -parse-as-library ./main.swift ./helper.swift -parseable-output -j1 -module-name main 2>&1 -driver-show-incremental -driver-show-job-lifecycle | %FileCheck -check-prefix=CHECK-2 %s
+
+// CHECK-2-NOT: warning
+// CHECK-2: {{^{$}}
+// CHECK-2: "kind": "began"
+// CHECK-2: "name": "compile"
+// CHECK-2: ".\/helper.swift"
+// CHECK-2: {{^}$}}
+
+// CHECK-2: {{^{$}}
+// CHECK-2: "kind": "began"
+// CHECK-2: "name": "compile"
+// CHECK-2: ".\/main.swift"
+// CHECK-2: {{^}$}}
+
+func test(obj: Test) {
+  obj.foo()
+}

--- a/validation-test/Serialization/rdar40839486.swift
+++ b/validation-test/Serialization/rdar40839486.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -disable-type-fingerprints -emit-module-path %t/main4.swiftmodule -swift-version 4 -Fsystem %sdk/System/Library/PrivateFrameworks/ %s
-// RUN: %target-build-swift -disable-type-fingerprints -emit-module-path %t/main4_2.swiftmodule -swift-version 4.2 -Fsystem %sdk/System/Library/PrivateFrameworks/ %s
+// RUN: %target-build-swift -emit-module-path %t/main4.swiftmodule -swift-version 4 -Fsystem %sdk/System/Library/PrivateFrameworks/ %s
+// RUN: %target-build-swift -emit-module-path %t/main4_2.swiftmodule -swift-version 4.2 -Fsystem %sdk/System/Library/PrivateFrameworks/ %s
 
 // REQUIRES: OS=macosx || OS=ios
 


### PR DESCRIPTION
1. Always add arc from `Decl` interface to whole file, because the fingerprint only captures changes to the body.
2. Ensure that intrafile dependencies are captures in the fine-grained dependency graph whenever type-body fingerprints are enabled. Eases testing.
3. Test with- and without type-body fingerprints.