### PR TITLE
[ConstraintSystem] Extend metatype instance type mismatch coverage

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4068,16 +4068,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       auto result =
           matchTypes(instanceType1, instanceType2, subKind, subflags,
                      locator.withPathElement(ConstraintLocator::InstanceType));
-      if (shouldAttemptFixes() && result.isFailure()) {
-        auto *anchor = locator.getAnchor();
-        if (anchor && isa<CoerceExpr>(anchor)) {
-          auto *fix =
-              ContextualMismatch::create(*this, instanceType1, instanceType2,
-                                         getConstraintLocator(locator));
-          conversionsOrFixes.push_back(fix);
-          break;
-        }
-      }
+
+      // If matching of the instance types resulted in the failure make sure
+      // to give `repairFailure` a chance to run to attempt to fix the issue.
+      if (shouldAttemptFixes() && result.isFailure())
+        break;
+
       return result;
     }
 


### PR DESCRIPTION
Originally type mismatches associated with metatypes were only covered
for coercions but fix coverage grew since then and now it makes sense
to remove special case and let `repairFailures` take care of it.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
