### PR TITLE
[Incremental] Try setting mod times explicitly to fix unreproducible ci failure.

### DIFF
--- a/test/Frontend/type-fingerprint.swift
+++ b/test/Frontend/type-fingerprint.swift
@@ -12,16 +12,27 @@
 // RUN: cp %S/Inputs/type-fingerprint/{main,a}.swift %t
 // RUN: cp %S/Inputs/type-fingerprint/ofm.json %t
 // RUN: cp %S/Inputs/type-fingerprint/b0.swift %t/b.swift
+
+// Seeing weird failure on CI, so set the mod times
+// RUN: touch -t 200101010101 %t/*.swift
+
 // RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental ./main.swift ./a.swift ./b.swift -module-name main -output-file-map ofm.json >&output1
 
-// RUN: cp %t/b.swiftdeps %t/b1.swiftdeps
+// only-run-for-debugging: cp %t/b.swiftdeps %t/b1.swiftdeps
 
 // Change one type, but uses of all types get recompiled
 
 // RUN: cp %S/Inputs/type-fingerprint/b1.swift %t/b.swift
+
+// Seeing weird failure on CI, so ensure that b.swift is newer
+// RUN: touch -t 200201010101 %t/*
+// RUN: touch -t 200101010101 %t/*.swift
+// RUN: touch -t 200301010101 %t/b.swift
+
 // RUN: cd %t && %swiftc_driver  -disable-type-fingerprints -enable-batch-mode -j2 -incremental -driver-show-incremental ./main.swift ./a.swift ./b.swift -module-name main -output-file-map ofm.json >&output2
 
-// RUN: cp %t/b.swiftdeps %t/b2.swiftdeps
+// Save for debugging:
+// only-run-for-debugging: cp %t/b.swiftdeps %t/b2.swiftdeps
 
 // RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output2
 
@@ -40,16 +51,26 @@
 // RUN: cp %S/Inputs/type-fingerprint/{main,a}.swift %t
 // RUN: cp %S/Inputs/type-fingerprint/ofm.json %t
 // RUN: cp %S/Inputs/type-fingerprint/b0.swift %t/b.swift
+
+// Seeing weird failure on CI, so set the mod times
+// RUN: touch -t 200101010101 %t/*.swift
+
 // RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental ./main.swift ./a.swift ./b.swift -module-name main -output-file-map ofm.json >&output3
 
-// RUN: cp %t/b.swiftdeps %t/b3.swiftdeps
+// only-run-for-debugging: cp %t/b.swiftdeps %t/b3.swiftdeps
 
 // Change one type, only uses of that type get recompiled
 
 // RUN: cp %S/Inputs/type-fingerprint/b1.swift %t/b.swift
+
+// Seeing weird failure on CI, so ensure that b.swift is newer
+// RUN: touch -t 200201010101 %t/*
+// RUN: touch -t 200101010101 %t/*.swift
+// RUN: touch -t 200301010101 %t/b.swift
+
 // RUN: cd %t && %swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental ./main.swift ./a.swift ./b.swift -module-name main -output-file-map ofm.json >&output4
 
-// RUN: cp %t/b.swiftdeps %t/b4.swiftdeps
+// only-run-for-debugging: cp %t/b.swiftdeps %t/b4.swiftdeps
 
 // RUN: %FileCheck -check-prefix=CHECK-MAINB-RECOMPILED %s < %t/output4
 


### PR DESCRIPTION
`test/Frontend/type-fingerprint.swift` failed on a ci server. It runs fine locally. Try explicitly setting the mod times of the files.
May fix rdar://58959395