### PR TITLE
Private method should be for non-Windows only

### DIFF
--- a/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
@@ -82,6 +82,7 @@ public func _stdlib_thread_barrier_init(
   return 0
 }
 
+#if !os(Windows)
 private func _stdlib_thread_barrier_mutex_and_cond_init(_ barrier: UnsafeMutablePointer<_stdlib_thread_barrier_t>) -> CInt {
   guard pthread_mutex_init(barrier.pointee.mutex!, nil) == 0 else {
     return -1
@@ -92,6 +93,7 @@ private func _stdlib_thread_barrier_mutex_and_cond_init(_ barrier: UnsafeMutable
   }
   return 0
 }
+#endif
 
 public func _stdlib_thread_barrier_destroy(
   _ barrier: UnsafeMutablePointer<_stdlib_thread_barrier_t>


### PR DESCRIPTION
Fix build failure on Windows due to #12212
- Wrap private method that is only used on non-Windows