### PR TITLE
[5.2]Fix propagation of guaranteed phi args during DiagnoseUnreachable.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -185,12 +185,9 @@ static void propagateBasicBlockArgs(SILBasicBlock &BB) {
     // this to CCP and trigger another round of copy propagation.
     SILArgument *Arg = *AI;
 
-    // If this argument is guaranteed and Args[Idx] is a SILFunctionArgument,
-    // delete the end_borrow.
-    if (Arg->getOwnershipKind() == ValueOwnershipKind::Guaranteed &&
-        isa<SILFunctionArgument>(Args[Idx])) {
+    // If this argument is guaranteed and Args[Idx], delete the end_borrow.
+    if (Arg->getOwnershipKind() == ValueOwnershipKind::Guaranteed)
       deleteEndBorrows(Arg);
-    }
 
     // We were able to fold, so all users should use the new folded value.
     Arg->replaceAllUsesWith(Args[Idx]);

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -760,3 +760,33 @@ bb2:
   %9999 = tuple()
   return %9999 : $()
 }
+
+// Test propagation of guaranteed phi arguments. The nested end_borrow
+// must be removed, even with the outer borrow is *not* a function
+// argument.
+
+enum EnumWithB {
+  case A(B)
+  func testit() -> Int
+}
+
+// CHECK-LABEL: sil hidden [ossa] @testPropagateGuaranteedPhi : $@convention(method) (@guaranteed EnumWithB) -> () {
+// CHECK: bb1([[PHI:%.*]] : @guaranteed $B):
+// CHECK:   br bb2
+// CHECK: bb2:
+// CHECK:   end_borrow [[PHI]] : $B
+// CHECK-NOT: end_borrow
+// CHECK-LABEL: } // end sil function 'testPropagateGuaranteedPhi'
+sil hidden [ossa] @testPropagateGuaranteedPhi : $@convention(method) (@guaranteed EnumWithB) -> () {
+bb0(%0 : @guaranteed $EnumWithB):
+  switch_enum %0 : $EnumWithB, case #EnumWithB.A!enumelt.1: bb1
+
+bb1(%2 : @guaranteed $B):
+  br bb3(%2 : $B)
+
+bb3(%4 : @guaranteed $B):
+  end_borrow %4 : $B
+  end_borrow %2 : $B
+  %99 = tuple ()
+  return %99 : $()
+}


### PR DESCRIPTION
Fixes <rdar://58929109> assertion failure - UNREACHABLE executed at
swift/include/swift/SIL/OwnershipUtils.h:127!

(cherry picked from commit b0786e7e06230a3d1f59271389b56222ea74aca3)

