### PR TITLE
[AutoDiff] NFC: add `SILFunctionType` method assertion.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -179,7 +179,7 @@ CanType SILFunctionType::getSelfInstanceType(SILModule &M) const {
 // SWIFT_ENABLE_TENSORFLOW
 IndexSubset *
 SILFunctionType::getDifferentiationParameterIndices() {
-  assert(isDifferentiable());
+  assert(isDifferentiable() && "Must be a differentiable function");
   SmallVector<unsigned, 8> result;
   for (auto valueAndIndex : enumerate(getParameters()))
     if (valueAndIndex.value().getDifferentiability() !=
@@ -190,6 +190,8 @@ SILFunctionType::getDifferentiationParameterIndices() {
 
 CanSILFunctionType SILFunctionType::getWithDifferentiability(
     DifferentiabilityKind kind, IndexSubset *parameterIndices) {
+  assert(kind != DifferentiabilityKind::NonDifferentiable &&
+         "Differentiability kind must be normal or linear");
   SmallVector<SILParameterInfo, 8> newParameters;
   for (auto paramAndIndex : enumerate(getParameters())) {
     auto &param = paramAndIndex.value();


### PR DESCRIPTION
Assert that `SILFunctionType::getWithDifferentiability` is called only
with `DifferentiabilityKind::Normal` or `DifferentiabilityKind::Linear`.
`DifferentiabilityKind::NonDifferentiable` is invalid.

A `isDifferentiable()` assertion already exists in
`SILFunctionType::getDifferentiationParameterIndices`.

No assertion is needed for `SILFunctionType::getWithoutDifferentiability`
because it works for both differentiable and non-differentiable function types.

Note: a `!isDifferentiable()` assertion cannot be added to
`SILFunctionType::getAutoDiffDerivativeFunctionType` because it fails during
stdlib compilation. More investigation required.

---

Minor changes in preparation for upstreaming to `master`.