### PR TITLE
Sema: Fix duplicate diagnostic spam with 'Self' in properties

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1336,13 +1336,13 @@ public:
     }
 
     if (VD->getDeclContext()->getSelfClassDecl()) {
-      checkDynamicSelfType(VD, VD->getValueInterfaceType());
-
       if (VD->getValueInterfaceType()->hasDynamicSelfType()) {
         if (VD->hasStorage())
           VD->diagnose(diag::dynamic_self_in_stored_property);
         else if (VD->isSettable(nullptr))
           VD->diagnose(diag::dynamic_self_in_mutable_property);
+        else
+          checkDynamicSelfType(VD, VD->getValueInterfaceType());
       }
     }
     
@@ -2153,8 +2153,11 @@ public:
 
     checkExplicitAvailability(FD);
 
-    if (FD->getDeclContext()->getSelfClassDecl())
-      checkDynamicSelfType(FD, FD->getResultInterfaceType());
+    // Skip this for accessors, since we should have diagnosed the
+    // storage itself.
+    if (!isa<AccessorDecl>(FD))
+      if (FD->getDeclContext()->getSelfClassDecl())
+        checkDynamicSelfType(FD, FD->getResultInterfaceType());
 
     checkDefaultArguments(FD->getParameters());
 

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -270,3 +270,20 @@ class Foo {
     Self.value * 2
   }()
 }
+
+// https://bugs.swift.org/browse/SR-11681 - duplicate diagnostics
+struct Box<T> {
+  let boxed: T
+}
+
+class Boxer {
+  lazy var s = Box<Self>(boxed: self as! Self)
+  // expected-error@-1 {{stored property cannot have covariant 'Self' type}}
+  // expected-error@-2 {{mutable property cannot have covariant 'Self' type}}
+
+  var t = Box<Self>(boxed: Self())
+  // expected-error@-1 {{stored property cannot have covariant 'Self' type}}
+  // expected-error@-2 {{covariant 'Self' type cannot be referenced from a stored property initializer}}
+
+  required init() {}
+}


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-11681> / <rdar://problem/56747659>.
