### PR TITLE
[TF] Fix `tensorflow_osx_base` build preset.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2263,7 +2263,6 @@ install-lldb
 install-llbuild
 install-swiftpm
 install-swiftsyntax
-skip-install-swiftsyntax-module
 install-skstresstester
 install-swiftevolve
 install-playgroundsupport


### PR DESCRIPTION
Remove deleted `skip-install-swiftsyntax-module` flag from `tensorflow_osx_base` preset.
I didn't spend time to track down when/why exactly the flag was deleted.

`tensorflow_osx_base` is now more in-sync with `mixin_osx_package_base`.

---

Locally verified the fix on macOS.

We haven't run into this issue for a while since we haven't triggered fresh macOS builds using the `tensorflow_osx_base` preset.