### PR TITLE
[Incremental] Turn type-body-fingerprints on-by-default

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -304,7 +304,7 @@ namespace swift {
     /// the interface hash, hash them into per-iterable-decl-context
     /// fingerprints. Fine-grained dependency types won't dirty every provides
     /// in a file when the user adds a member to, e.g., a struct.
-    bool EnableTypeFingerprints = false;
+    bool EnableTypeFingerprints = true;
 
     /// When using fine-grained dependencies, emit dot files for every swiftdeps
     /// file.


### PR DESCRIPTION
Just the single change, so we can easily revert if need be.
(Keep separate token hashes for each type body.)