### PR TITLE
[SILOptimizer] Add pipeline execution request

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -110,6 +110,7 @@ namespace swift {
   struct RawComment;
   class DocComment;
   class SILBoxType;
+  class SILTransform;
   class TypeAliasDecl;
   class VarDecl;
   class UnifiedStatsReporter;
@@ -972,6 +973,15 @@ public:
 
   /// Each kind and SourceFile has its own cache for a Type.
   Type &getDefaultTypeRequestCache(SourceFile *, KnownProtocolKind);
+
+  using SILTransformCtors = ArrayRef<SILTransform *(*)(void)>;
+
+  /// Register IRGen specific SIL passes such that the SILOptimizer can access
+  /// and execute them without directly depending on IRGen.
+  void registerIRGenSILTransforms(SILTransformCtors fns);
+
+  /// Retrieve the IRGen specific SIL passes.
+  SILTransformCtors getIRGenSILTransforms() const;
 
 private:
   friend Decl;

--- a/include/swift/AST/SILOptimizerRequests.h
+++ b/include/swift/AST/SILOptimizerRequests.h
@@ -1,0 +1,96 @@
+//===--- SILOptimizerRequests.h - SILOptimizer Requests ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines SILOptimizer requests.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_REQUESTS_H
+#define SWIFT_SILOPTIMIZER_REQUESTS_H
+
+#include "swift/AST/ASTTypeIDs.h"
+#include "swift/AST/SimpleRequest.h"
+
+namespace swift {
+
+namespace irgen {
+class IRGenModule;
+}
+
+class SILModule;
+class SILPassPipelinePlan;
+
+struct SILPipelineExecutionDescriptor {
+  SILModule *SM;
+
+  // Note that we currently store a reference to the pipeline plan on the stack.
+  // If ExecuteSILPipelineRequest ever becomes cached, we will need to adjust
+  // this.
+  const SILPassPipelinePlan &Plan;
+  bool IsMandatory;
+  irgen::IRGenModule *IRMod;
+
+  bool operator==(const SILPipelineExecutionDescriptor &other) const;
+  bool operator!=(const SILPipelineExecutionDescriptor &other) const {
+    return !(*this == other);
+  }
+};
+
+llvm::hash_code hash_value(const SILPipelineExecutionDescriptor &desc);
+
+/// Executes a SIL pipeline plan on a SIL module.
+class ExecuteSILPipelineRequest
+    : public SimpleRequest<ExecuteSILPipelineRequest,
+                           bool(SILPipelineExecutionDescriptor),
+                           CacheKind::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<bool> evaluate(Evaluator &evaluator,
+                                SILPipelineExecutionDescriptor desc) const;
+};
+
+void simple_display(llvm::raw_ostream &out,
+                    const SILPipelineExecutionDescriptor &desc);
+
+SourceLoc extractNearestSourceLoc(const SILPipelineExecutionDescriptor &desc);
+
+/// Report that a request of the given kind is being evaluated, so it
+/// can be recorded by the stats reporter.
+template <typename Request>
+void reportEvaluatedRequest(UnifiedStatsReporter &stats,
+                            const Request &request);
+
+/// The zone number for SILOptimizer.
+#define SWIFT_TYPEID_ZONE SILOptimizer
+#define SWIFT_TYPEID_HEADER "swift/AST/SILOptimizerTypeIDZone.def"
+#include "swift/Basic/DefineTypeIDZone.h"
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER
+
+// Set up reporting of evaluated requests.
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
+template<>                                                                     \
+inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
+                                   const RequestType &request) {               \
+  ++stats.getFrontendCounters().RequestType;                                   \
+}
+#include "swift/AST/SILOptimizerTypeIDZone.def"
+#undef SWIFT_REQUEST
+
+} // end namespace swift
+
+#endif // SWIFT_SILOPTIMIZER_REQUESTS_H

--- a/include/swift/AST/SILOptimizerTypeIDZone.def
+++ b/include/swift/AST/SILOptimizerTypeIDZone.def
@@ -1,0 +1,18 @@
+//===--- SILOptimizerTypeIDZone.def -----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This definition file describes the requests in SILOptimizer's zone.
+//
+//===----------------------------------------------------------------------===//
+
+SWIFT_REQUEST(SILOptimizer, ExecuteSILPipelineRequest,
+              bool(SILPipelineExecutionDescriptor), Uncached, NoLocationInfo)

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -274,6 +274,10 @@ FRONTEND_STATISTIC(SILModule, NumSILGenWitnessTables)
 FRONTEND_STATISTIC(SILModule, NumSILGenDefaultWitnessTables)
 FRONTEND_STATISTIC(SILModule, NumSILGenGlobalVariables)
 
+#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(SILOptimizer, NAME)
+#include "swift/AST/SILOptimizerTypeIDZone.def"
+#undef SWIFT_REQUEST
+
 FRONTEND_STATISTIC(SILModule, NumSILOptFunctions)
 FRONTEND_STATISTIC(SILModule, NumSILOptVtables)
 FRONTEND_STATISTIC(SILModule, NumSILOptWitnessTables)

--- a/include/swift/Basic/TypeID.h
+++ b/include/swift/Basic/TypeID.h
@@ -38,6 +38,7 @@ enum class Zone : uint8_t {
   Parse                   = 8,
   TypeChecker             = 10,
   SILGen                  = 12,
+  SILOptimizer            = 13,
   TBDGen                  = 14,
   // N.B. This is not a formal zone and exists solely to support the unit tests.
   ArithmeticEvaluator     = 255,

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -771,6 +771,13 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){
   return OS;
 }
 
+/// Print a simple description of a SILModule for the request evaluator.
+void simple_display(llvm::raw_ostream &out, const SILModule *M);
+
+/// Retrieve a SourceLoc for a SILModule that the request evaluator can use for
+/// diagnostics.
+SourceLoc extractNearestSourceLoc(const SILModule *SM);
+
 namespace Lowering {
 /// Determine whether the given class will be allocated/deallocated using the
 /// Objective-C runtime, i.e., +alloc and -dealloc.

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -37,8 +37,15 @@ namespace irgen {
 class IRGenModule;
 }
 
+/// The main entrypoint for executing a pipeline pass on a SIL module.
+void executePassPipelinePlan(SILModule *SM, const SILPassPipelinePlan &plan,
+                             bool isMandatory = false,
+                             irgen::IRGenModule *IRMod = nullptr);
+
 /// The SIL pass manager.
 class SILPassManager {
+  friend class ExecuteSILPipelineRequest;
+
   /// The module that the pass manager will transform.
   SILModule *Mod;
 
@@ -107,19 +114,12 @@ class SILPassManager {
   /// pass manager is destroyed.
   DeserializationNotificationHandler *deserializationNotificationHandler;
 
-public:
   /// C'tor. It creates and registers all analysis passes, which are defined
-  /// in Analysis.def.
-  ///
-  /// If \p isMandatory is true, passes are also run for functions
-  /// which have OptimizationMode::NoOptimization.
-  SILPassManager(SILModule *M, bool isMandatory = false);
+  /// in Analysis.def. This is private as it should only be used by
+  /// ExecuteSILPipelineRequest.
+  SILPassManager(SILModule *M, bool isMandatory, irgen::IRGenModule *IRMod);
 
-  /// C'tor. It creates an IRGen pass manager. Passes can query for the
-  /// IRGenModule.
-  SILPassManager(SILModule *M, irgen::IRGenModule *IRMod,
-                 bool isMandatory = false);
-
+public:
   const SILOptions &getOptions() const;
 
   /// Searches for an analysis of type T in the list of registered

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -113,13 +113,12 @@ public:
   ///
   /// If \p isMandatory is true, passes are also run for functions
   /// which have OptimizationMode::NoOptimization.
-  SILPassManager(SILModule *M, llvm::StringRef Stage = "",
-                 bool isMandatory = false);
+  SILPassManager(SILModule *M, bool isMandatory = false);
 
   /// C'tor. It creates an IRGen pass manager. Passes can query for the
   /// IRGenModule.
   SILPassManager(SILModule *M, irgen::IRGenModule *IRMod,
-                 llvm::StringRef Stage = "", bool isMandatory = false);
+                 bool isMandatory = false);
 
   const SILOptions &getOptions() const;
 

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -99,9 +99,6 @@ class SILPassManager {
   /// OptimizationMode::NoOptimization.
   bool isMandatory = false;
 
-  /// The IRGen SIL passes. These have to be dynamically added by IRGen.
-  llvm::DenseMap<unsigned, SILTransform *> IRGenPasses;
-
   /// The notification handler for this specific SILPassManager.
   ///
   /// This is not owned by the pass manager, it is owned by the SILModule which
@@ -267,15 +264,6 @@ public:
       }
       execute();
     }
-  }
-
-  void registerIRGenPass(PassKind Kind, SILTransform *Transform) {
-    assert(IRGenPasses.find(unsigned(Kind)) == IRGenPasses.end() &&
-           "Pass already registered");
-    assert(
-        IRMod &&
-        "Attempting to register an IRGen pass with a non-IRGen pass manager");
-    IRGenPasses[unsigned(Kind)] = Transform;
   }
 
 private:

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -375,6 +375,12 @@ namespace swift {
   /// should call this functions after forming the ASTContext.
   void registerSILGenRequestFunctions(Evaluator &evaluator);
 
+  /// Register SILOptimizer-level request functions with the evaluator.
+  ///
+  /// Clients that form an ASTContext and will perform any SIL optimization
+  /// should call this functions after forming the ASTContext.
+  void registerSILOptimizerRequestFunctions(Evaluator &evaluator);
+
   /// Register TBDGen-level request functions with the evaluator.
   ///
   /// Clients that form an ASTContext and will perform any TBD generation

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -392,6 +392,9 @@ namespace swift {
   /// Calling registerIDERequestFunctions will invoke this function as well.
   void registerIDETypeCheckRequestFunctions(Evaluator &evaluator);
 
+  /// Register SILOptimizer passes necessary for IRGen.
+  void registerIRGenSILTransforms(ASTContext &ctx);
+
 } // end namespace swift
 
 #endif // SWIFT_SUBSYSTEMS_H

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -472,6 +472,9 @@ struct ASTContext::Implementation {
   llvm::DenseMap<OverrideSignatureKey, GenericSignature> overrideSigCache;
 
   Optional<ClangTypeConverter> Converter;
+
+  /// The IRGen specific SIL transforms that have been registered.
+  SILTransformCtors IRGenSILPasses;
 };
 
 ASTContext::Implementation::Implementation()
@@ -4572,6 +4575,17 @@ bool ASTContext::overrideGenericSignatureReqsSatisfied(
     return derivedSig->requirementsNotSatisfiedBy(sig).empty();
   }
   llvm_unreachable("Unhandled OverrideGenericSignatureReqCheck in switch");
+}
+
+void ASTContext::registerIRGenSILTransforms(SILTransformCtors ctors) {
+  assert(getImpl().IRGenSILPasses.empty() && "Already registered");
+  getImpl().IRGenSILPasses = ctors;
+}
+
+ASTContext::SILTransformCtors ASTContext::getIRGenSILTransforms() const {
+  auto passes = getImpl().IRGenSILPasses;
+  assert(!passes.empty() && "Didn't register the necessary passes");
+  return passes;
 }
 
 SILLayout *SILLayout::get(ASTContext &C,

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(swiftFrontend PRIVATE
   swiftParseSIL
   swiftSILGen
   swiftSILOptimizer
+  swiftIRGen
   swiftSema
   swiftSerialization
   swiftTBDGen)

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -222,6 +222,9 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
           FrontendOptions::ActionType::REPL) {
     registerIDERequestFunctions(Context->evaluator);
   }
+
+  registerIRGenSILTransforms(*Context);
+
   if (setUpModuleLoaders())
     return true;
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -211,6 +211,7 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
   registerParseRequestFunctions(Context->evaluator);
   registerTypeCheckerRequestFunctions(Context->evaluator);
   registerSILGenRequestFunctions(Context->evaluator);
+  registerSILOptimizerRequestFunctions(Context->evaluator);
   registerTBDGenRequestFunctions(Context->evaluator);
 
   // Migrator, indexing and typo correction need some IDE requests.

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -40,6 +40,7 @@ add_swift_host_library(swiftIRGen STATIC
   IRGenFunction.cpp
   IRGenMangler.cpp
   IRGenModule.cpp
+  IRGenSILPasses.cpp
   IRGenSIL.cpp
   Linking.cpp
   LoadableByAddress.cpp

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -854,7 +854,7 @@ void swift::irgen::deleteIRGenModule(
 /// IRGenModule.
 static void runIRGenPreparePasses(SILModule &Module,
                                   irgen::IRGenModule &IRModule) {
-  SILPassManager PM(&Module, &IRModule, "irgen", /*isMandatoryPipeline=*/ true);
+  SILPassManager PM(&Module, &IRModule, /*isMandatoryPipeline=*/ true);
   PM.executePassPipelinePlan(
       SILPassPipelinePlan::getIRGenPreparePassPipeline(Module.getOptions()));
 }

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -855,17 +855,6 @@ void swift::irgen::deleteIRGenModule(
 static void runIRGenPreparePasses(SILModule &Module,
                                   irgen::IRGenModule &IRModule) {
   SILPassManager PM(&Module, &IRModule, "irgen", /*isMandatoryPipeline=*/ true);
-  bool largeLoadable = Module.getOptions().EnableLargeLoadableTypes;
-#define PASS(ID, Tag, Name)
-#define IRGEN_PASS(ID, Tag, Name)                                              \
-  if (swift::PassKind::ID == swift::PassKind::LoadableByAddress) {             \
-    if (largeLoadable) {                                                       \
-      PM.registerIRGenPass(swift::PassKind::ID, irgen::create##ID());          \
-    }                                                                          \
-  } else {                                                                     \
-    PM.registerIRGenPass(swift::PassKind::ID, irgen::create##ID());            \
-  }
-#include "swift/SILOptimizer/PassManager/Passes.def"
   PM.executePassPipelinePlan(
       SILPassPipelinePlan::getIRGenPreparePassPipeline(Module.getOptions()));
 }

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -854,9 +854,9 @@ void swift::irgen::deleteIRGenModule(
 /// IRGenModule.
 static void runIRGenPreparePasses(SILModule &Module,
                                   irgen::IRGenModule &IRModule) {
-  SILPassManager PM(&Module, &IRModule, /*isMandatoryPipeline=*/ true);
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getIRGenPreparePassPipeline(Module.getOptions()));
+  auto &opts = Module.getOptions();
+  auto plan = SILPassPipelinePlan::getIRGenPreparePassPipeline(opts);
+  executePassPipelinePlan(&Module, plan, /*isMandatory*/ true, &IRModule);
 }
 
 /// Generates LLVM IR, runs the LLVM passes and produces the output file.

--- a/lib/IRGen/IRGenSILPasses.cpp
+++ b/lib/IRGen/IRGenSILPasses.cpp
@@ -1,0 +1,33 @@
+//===--- IRGenSILPasses.cpp - The IRGen Prepare SIL Passes ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the registration of SILOptimizer passes necessary for
+//  IRGen.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/IRGen/IRGenSILPasses.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/Subsystems.h"
+
+namespace swift {
+using SILTransformCtor = SILTransform *(void);
+static SILTransformCtor *irgenSILPassFns[] = {
+#define PASS(Name, Tag, Desc)
+#define IRGEN_PASS(Name, Tag, Desc) &irgen::create##Name,
+#include "swift/SILOptimizer/PassManager/Passes.def"
+};
+} // end namespace swift
+
+void swift::registerIRGenSILTransforms(ASTContext &ctx) {
+  ctx.registerIRGenSILTransforms(irgenSILPassFns);
+}

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -728,3 +728,18 @@ SILLinkage swift::getDeclSILLinkage(const ValueDecl *decl) {
   }
   return linkage;
 }
+
+void swift::simple_display(llvm::raw_ostream &out, const SILModule *M) {
+  if (!M) {
+    out << "(null)";
+    return;
+  }
+  out << "SIL for ";
+  simple_display(out, M->getSwiftModule());
+}
+
+SourceLoc swift::extractNearestSourceLoc(const SILModule *M) {
+  if (!M)
+    return SourceLoc();
+  return extractNearestSourceLoc(M->getSwiftModule());
+}

--- a/lib/SILOptimizer/CMakeLists.txt
+++ b/lib/SILOptimizer/CMakeLists.txt
@@ -34,6 +34,7 @@ add_subdirectory(UtilityPasses)
 add_subdirectory(Utils)
 
 add_swift_host_library(swiftSILOptimizer STATIC
+  SILOptimizerRequests.cpp
   ${SILOPTIMIZER_SOURCES})
 target_link_libraries(swiftSILOptimizer PRIVATE
   swiftSIL)

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -736,8 +736,8 @@ SILTransform *swift::createLateDeadFunctionElimination() {
 }
 
 void swift::performSILDeadFunctionElimination(SILModule *M) {
-  SILPassManager PM(M);
   llvm::SmallVector<PassKind, 1> Pass = {PassKind::DeadFunctionElimination};
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getPassPipelineForKinds(M->getOptions(), Pass));
+  auto &opts = M->getOptions();
+  auto plan = SILPassPipelinePlan::getPassPipelineForKinds(opts, Pass);
+  executePassPipelinePlan(M, plan);
 }

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -275,9 +275,8 @@ public:
 
 } // end anonymous namespace
 
-SILPassManager::SILPassManager(SILModule *M, llvm::StringRef Stage,
-                               bool isMandatory)
-    : Mod(M), StageName(Stage), isMandatory(isMandatory),
+SILPassManager::SILPassManager(SILModule *M, bool isMandatory)
+    : Mod(M), isMandatory(isMandatory),
       deserializationNotificationHandler(nullptr) {
 #define ANALYSIS(NAME) \
   Analyses.push_back(create##NAME##Analysis(Mod));
@@ -295,8 +294,8 @@ SILPassManager::SILPassManager(SILModule *M, llvm::StringRef Stage,
 }
 
 SILPassManager::SILPassManager(SILModule *M, irgen::IRGenModule *IRMod,
-                               llvm::StringRef Stage, bool isMandatory)
-    : SILPassManager(M, Stage, isMandatory) {
+                               bool isMandatory)
+    : SILPassManager(M, isMandatory) {
   this->IRMod = IRMod;
 }
 

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -51,7 +51,7 @@ bool swift::runSILDiagnosticPasses(SILModule &Module) {
 
   auto &Ctx = Module.getASTContext();
 
-  SILPassManager PM(&Module, "", /*isMandatoryPipeline=*/ true);
+  SILPassManager PM(&Module, /*isMandatoryPipeline=*/ true);
   PM.executePassPipelinePlan(
       SILPassPipelinePlan::getDiagnosticPassPipeline(Module.getOptions()));
 
@@ -99,7 +99,7 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
   if (Module.getOptions().DisableSILPerfOptimizations) {
     // If we are not supposed to run SIL perf optzns, we may still need to
     // serialize. So serialize now.
-    SILPassManager PM(&Module, "" /*stage*/, true /*isMandatory*/);
+    SILPassManager PM(&Module, true /*isMandatory*/);
     PM.executePassPipelinePlan(
         SILPassPipelinePlan::getSerializeSILPassPipeline(Module.getOptions()));
     return;
@@ -113,7 +113,7 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
 
   // Check if we actually serialized our module. If we did not, serialize now.
   if (!Module.isSerialized()) {
-    SILPassManager PM(&Module, "" /*stage*/, true /*isMandatory*/);
+    SILPassManager PM(&Module, true /*isMandatory*/);
     PM.executePassPipelinePlan(
         SILPassPipelinePlan::getSerializeSILPassPipeline(Module.getOptions()));
   }
@@ -137,7 +137,7 @@ void swift::runSILPassesForOnone(SILModule &Module) {
 
   // We want to run the Onone passes also for function which have an explicit
   // Onone attribute.
-  SILPassManager PM(&Module, "Onone", /*isMandatoryPipeline=*/ true);
+  SILPassManager PM(&Module, /*isMandatoryPipeline=*/ true);
   PM.executePassPipelinePlan(
       SILPassPipelinePlan::getOnonePassPipeline(Module.getOptions()));
 
@@ -203,7 +203,7 @@ StringRef swift::PassKindTag(PassKind Kind) {
 // convert it to a module pass to ensure that the SIL input is always at the
 // same stage of lowering.
 void swift::runSILLoweringPasses(SILModule &Module) {
-  SILPassManager PM(&Module, "LoweringPasses", /*isMandatoryPipeline=*/ true);
+  SILPassManager PM(&Module, /*isMandatoryPipeline=*/ true);
   PM.executePassPipelinePlan(
       SILPassPipelinePlan::getLoweringPassPipeline(Module.getOptions()));
 

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -40,8 +40,10 @@
 using namespace swift;
 
 bool swift::runSILDiagnosticPasses(SILModule &Module) {
+  auto &opts = Module.getOptions();
+
   // Verify the module, if required.
-  if (Module.getOptions().VerifyAll)
+  if (opts.VerifyAll)
     Module.verify();
 
   // If we parsed a .sil file that is already in canonical form, don't rerun
@@ -49,21 +51,20 @@ bool swift::runSILDiagnosticPasses(SILModule &Module) {
   if (Module.getStage() != SILStage::Raw)
     return false;
 
-  auto &Ctx = Module.getASTContext();
-
-  SILPassManager PM(&Module, /*isMandatoryPipeline=*/ true);
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getDiagnosticPassPipeline(Module.getOptions()));
+  executePassPipelinePlan(&Module,
+                          SILPassPipelinePlan::getDiagnosticPassPipeline(opts),
+                          /*isMandatory*/ true);
 
   // If we were asked to debug serialization, exit now.
-  if (Module.getOptions().DebugSerialization)
+  auto &Ctx = Module.getASTContext();
+  if (opts.DebugSerialization)
     return Ctx.hadError();
 
   // Generate diagnostics.
   Module.setStage(SILStage::Canonical);
 
   // Verify the module, if required.
-  if (Module.getOptions().VerifyAll)
+  if (opts.VerifyAll)
     Module.verify();
   else {
     LLVM_DEBUG(Module.verify());
@@ -76,54 +77,52 @@ bool swift::runSILDiagnosticPasses(SILModule &Module) {
 bool swift::runSILOwnershipEliminatorPass(SILModule &Module) {
   auto &Ctx = Module.getASTContext();
 
-  SILPassManager PM(&Module);
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getOwnershipEliminatorPassPipeline(
-          Module.getOptions()));
+  auto &opts = Module.getOptions();
+  executePassPipelinePlan(
+      &Module, SILPassPipelinePlan::getOwnershipEliminatorPassPipeline(opts));
 
   return Ctx.hadError();
 }
 
 // Prepare SIL for the -O pipeline.
 void swift::runSILOptPreparePasses(SILModule &Module) {
-  SILPassManager PM(&Module);
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getSILOptPreparePassPipeline(Module.getOptions()));
+  auto &opts = Module.getOptions();
+  auto plan = SILPassPipelinePlan::getSILOptPreparePassPipeline(opts);
+  executePassPipelinePlan(&Module, plan);
 }
 
 void swift::runSILOptimizationPasses(SILModule &Module) {
+  auto &opts = Module.getOptions();
+
   // Verify the module, if required.
-  if (Module.getOptions().VerifyAll)
+  if (opts.VerifyAll)
     Module.verify();
 
-  if (Module.getOptions().DisableSILPerfOptimizations) {
+  if (opts.DisableSILPerfOptimizations) {
     // If we are not supposed to run SIL perf optzns, we may still need to
     // serialize. So serialize now.
-    SILPassManager PM(&Module, true /*isMandatory*/);
-    PM.executePassPipelinePlan(
-        SILPassPipelinePlan::getSerializeSILPassPipeline(Module.getOptions()));
+    executePassPipelinePlan(
+        &Module, SILPassPipelinePlan::getSerializeSILPassPipeline(opts),
+        /*isMandatory*/ true);
     return;
   }
 
-  {
-    SILPassManager PM(&Module);
-    PM.executePassPipelinePlan(
-        SILPassPipelinePlan::getPerformancePassPipeline(Module.getOptions()));
-  }
+  executePassPipelinePlan(
+      &Module, SILPassPipelinePlan::getPerformancePassPipeline(opts));
 
   // Check if we actually serialized our module. If we did not, serialize now.
   if (!Module.isSerialized()) {
-    SILPassManager PM(&Module, true /*isMandatory*/);
-    PM.executePassPipelinePlan(
-        SILPassPipelinePlan::getSerializeSILPassPipeline(Module.getOptions()));
+    executePassPipelinePlan(
+        &Module, SILPassPipelinePlan::getSerializeSILPassPipeline(opts),
+        /*isMandatory*/ true);
   }
 
   // If we were asked to debug serialization, exit now.
-  if (Module.getOptions().DebugSerialization)
+  if (opts.DebugSerialization)
     return;
 
   // Verify the module, if required.
-  if (Module.getOptions().VerifyAll)
+  if (opts.VerifyAll)
     Module.verify();
   else {
     LLVM_DEBUG(Module.verify());
@@ -137,9 +136,9 @@ void swift::runSILPassesForOnone(SILModule &Module) {
 
   // We want to run the Onone passes also for function which have an explicit
   // Onone attribute.
-  SILPassManager PM(&Module, /*isMandatoryPipeline=*/ true);
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getOnonePassPipeline(Module.getOptions()));
+  executePassPipelinePlan(
+      &Module, SILPassPipelinePlan::getOnonePassPipeline(Module.getOptions()),
+      /*isMandatory*/ true);
 
   // Verify the module, if required.
   if (Module.getOptions().VerifyAll)
@@ -151,9 +150,9 @@ void swift::runSILPassesForOnone(SILModule &Module) {
 
 void swift::runSILOptimizationPassesWithFileSpecification(SILModule &M,
                                                           StringRef Filename) {
-  SILPassManager PM(&M);
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getPassPipelineFromFile(M.getOptions(), Filename));
+  auto &opts = M.getOptions();
+  executePassPipelinePlan(
+      &M, SILPassPipelinePlan::getPassPipelineFromFile(opts, Filename));
 }
 
 /// Get the Pass ID enum value from an ID string.
@@ -203,9 +202,10 @@ StringRef swift::PassKindTag(PassKind Kind) {
 // convert it to a module pass to ensure that the SIL input is always at the
 // same stage of lowering.
 void swift::runSILLoweringPasses(SILModule &Module) {
-  SILPassManager PM(&Module, /*isMandatoryPipeline=*/ true);
-  PM.executePassPipelinePlan(
-      SILPassPipelinePlan::getLoweringPassPipeline(Module.getOptions()));
+  auto &opts = Module.getOptions();
+  executePassPipelinePlan(&Module,
+                          SILPassPipelinePlan::getLoweringPassPipeline(opts),
+                          /*isMandatory*/ true);
 
   assert(Module.getStage() == SILStage::Lowered);
 }

--- a/lib/SILOptimizer/SILOptimizerRequests.cpp
+++ b/lib/SILOptimizer/SILOptimizerRequests.cpp
@@ -1,0 +1,71 @@
+//===--- SILOptimizerRequests.cpp - Requests for SIL Optimization  --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/SILOptimizerRequests.h"
+#include "swift/AST/Evaluator.h"
+#include "swift/SILOptimizer/PassManager/PassPipeline.h"
+#include "swift/Subsystems.h"
+#include "llvm/ADT/Hashing.h"
+
+using namespace swift;
+
+namespace swift {
+// Implement the SILOptimizer type zone (zone 13).
+#define SWIFT_TYPEID_ZONE SILOptimizer
+#define SWIFT_TYPEID_HEADER "swift/AST/SILOptimizerTypeIDZone.def"
+#include "swift/Basic/ImplementTypeIDZone.h"
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER
+} // end namespace swift
+
+//----------------------------------------------------------------------------//
+// ExecuteSILPipelineRequest computation.
+//----------------------------------------------------------------------------//
+
+bool SILPipelineExecutionDescriptor::
+operator==(const SILPipelineExecutionDescriptor &other) const {
+  return SM == other.SM && Plan == other.Plan &&
+         IsMandatory == other.IsMandatory && IRMod == other.IRMod;
+}
+
+llvm::hash_code swift::hash_value(const SILPipelineExecutionDescriptor &desc) {
+  return llvm::hash_combine(desc.SM, desc.Plan, desc.IsMandatory, desc.IRMod);
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const SILPipelineExecutionDescriptor &desc) {
+  out << "Run pipelines { ";
+  interleave(
+      desc.Plan.getPipelines(),
+      [&](SILPassPipeline stage) { out << stage.Name; },
+      [&]() { out << ", "; });
+  out << " } on ";
+  simple_display(out, desc.SM);
+}
+
+SourceLoc
+swift::extractNearestSourceLoc(const SILPipelineExecutionDescriptor &desc) {
+  return extractNearestSourceLoc(desc.SM);
+}
+
+// Define request evaluation functions for each of the SILGen requests.
+static AbstractRequestFunction *silOptimizerRequestFunctions[] = {
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \
+  reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
+#include "swift/AST/SILOptimizerTypeIDZone.def"
+#undef SWIFT_REQUEST
+};
+
+void swift::registerSILOptimizerRequestFunctions(Evaluator &evaluator) {
+  evaluator.registerRequestFunctions(Zone::SILOptimizer,
+                                     silOptimizerRequestFunctions);
+}

--- a/lib/SILOptimizer/UtilityPasses/InstCount.cpp
+++ b/lib/SILOptimizer/UtilityPasses/InstCount.cpp
@@ -155,7 +155,6 @@ SILTransform *swift::createInstCount() {
 void swift::performSILInstCountIfNeeded(SILModule *M) {
   if (!M->getOptions().PrintInstCounts)
     return;
-  SILPassManager PrinterPM(M);
-  PrinterPM.executePassPipelinePlan(
-      SILPassPipelinePlan::getInstCountPassPipeline(M->getOptions()));
+  executePassPipelinePlan(
+      M, SILPassPipelinePlan::getInstCountPassPipeline(M->getOptions()));
 }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -258,9 +258,10 @@ static cl::opt<std::string>
 
 static void runCommandLineSelectedPasses(SILModule *Module,
                                          irgen::IRGenModule *IRGenMod) {
-  SILPassManager PM(Module, IRGenMod);
-  PM.executePassPipelinePlan(SILPassPipelinePlan::getPassPipelineForKinds(
-      Module->getOptions(), Passes));
+  auto &opts = Module->getOptions();
+  executePassPipelinePlan(
+      Module, SILPassPipelinePlan::getPassPipelineForKinds(opts, Passes),
+      /*isMandatory*/ false, IRGenMod);
 
   if (Module->getOptions().VerifyAll)
     Module->verify();

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -259,14 +259,6 @@ static cl::opt<std::string>
 static void runCommandLineSelectedPasses(SILModule *Module,
                                          irgen::IRGenModule *IRGenMod) {
   SILPassManager PM(Module, IRGenMod);
-  for (auto P : Passes) {
-#define PASS(ID, Tag, Name)
-#define IRGEN_PASS(ID, Tag, Name)                                              \
-  if (P == PassKind::ID)                                                       \
-    PM.registerIRGenPass(swift::PassKind::ID, irgen::create##ID());
-#include "swift/SILOptimizer/PassManager/Passes.def"
-  }
-
   PM.executePassPipelinePlan(SILPassPipelinePlan::getPassPipelineForKinds(
       Module->getOptions(), Passes));
 


### PR DESCRIPTION
Add `ExecuteSILPipelineRequest` which executes a pipeline plan on a given SIL (and possibly IRGen) module. This serves as a top-level request for the SILOptimizer that we'll be able to hang dependencies off.