### PR TITLE
Search nested types tables in parent modules

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1468,6 +1468,10 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
             if (auto overlayModule = LF->getOverlayModule()) {
               nestedType = findNestedTypeDeclInModule(getFile(), overlayModule,
                                                       memberName, baseType);
+            } else if (LF->getParentModule() != extensionModule) {
+              nestedType = findNestedTypeDeclInModule(getFile(),
+                                                      LF->getParentModule(),
+                                                      memberName, baseType);
             }
           }
         }

--- a/test/Serialization/multi-file-nested-type-extension.swift
+++ b/test/Serialization/multi-file-nested-type-extension.swift
@@ -10,7 +10,7 @@
 // REQUIRES: asserts
 
 // CHECK: Statistics
-// CHECK: 1 Serialization - # of nested types resolved without full lookup
+// CHECK: 2 Serialization - # of nested types resolved without full lookup
 
 // Note the Optional here and below; this was once necessary to produce a crash.
 // Without it, the type of the parameter is initialized "early" enough to not
@@ -20,4 +20,10 @@ extension Outer {
   public typealias Callback = (Outer.InnerFromExtension) -> Void
 
   public func useTypes(_: Outer.Callback?) {}
+}
+
+extension OuterClass.Inner {
+  public static var instance: OuterClass.Inner {
+    return OuterClass.Inner()
+  }
 }


### PR DESCRIPTION
Add another cross-cutting module configuration to the nested types table
search path. A module can have no overlay but also contain a nested
types table suitable for finding a given member name. UIKit is the
sharpest example of this state of affairs. UIKit currently defines an
overlay in Swift where we find some nested types.  But it also defines
an inner module that has some other nested types tables.

Resolves rdar://58940989