### PR TITLE
Revert: [SourceKit] Disable module system headers validation

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -362,6 +362,11 @@ bool swift::ide::CompletionInstance::performOperation(
   // source text. That breaks an invariant of syntax tree building.
   Invocation.getLangOptions().BuildSyntaxTree = false;
 
+  // This validation may call stat(2) many times. Disable it to prevent
+  // performance regression.
+  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
+      true;
+
   // Since caching uses the interface hash, and since per type fingerprints
   // weaken that hash, disable them here:
   Invocation.getLangOptions().EnableTypeFingerprints = false;

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -362,11 +362,6 @@ bool swift::ide::CompletionInstance::performOperation(
   // source text. That breaks an invariant of syntax tree building.
   Invocation.getLangOptions().BuildSyntaxTree = false;
 
-  // This validation may call stat(2) many times. Disable it to prevent
-  // performance regression.
-  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
-      true;
-
   // Since caching uses the interface hash, and since per type fingerprints
   // weaken that hash, disable them here:
   Invocation.getLangOptions().EnableTypeFingerprints = false;

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -539,11 +539,6 @@ bool SwiftASTManager::initCompilerInvocation(
   // We don't care about LLVMArgs
   FrontendOpts.LLVMArgs.clear();
 
-  // This validation may call stat(2) many times. Disable it to prevent
-  // performance issues.
-  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
-      true;
-
   // SwiftSourceInfo files provide source location information for decls coming
   // from loaded modules. For most IDE use cases it either has an undesirable
   // impact on performance with no benefit (code completion), results in stale

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3436,8 +3436,6 @@ int main(int argc, char *argv[]) {
     options::DebugForbidTypecheckPrefix;
   InitInvok.getTypeCheckerOptions().DebugConstraintSolver =
       options::DebugConstraintSolver;
-  InitInvok.getSearchPathOptions().DisableModulesValidateSystemDependencies =
-      true;
 
   for (auto ConfigName : options::BuildConfigs)
     InitInvok.getLangOptions().addCustomConditionalCompilationFlag(ConfigName);


### PR DESCRIPTION
Revert #29180 and #29196 

`ClangImporter`'s pcm was messed up if any of the system headers are actually touched.
Revert this for now until we implement a better solution.

rdar://problem/59042838