### PR TITLE
[5.2]Revert: [SourceKit] Disable module system headers validation

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -328,6 +328,11 @@ bool swift::ide::CompletionInstance::performOperation(
   // source text. That breaks an invariant of syntax tree building.
   Invocation.getLangOptions().BuildSyntaxTree = false;
 
+  // This validation may call stat(2) many times. Disable it to prevent
+  // performance regression.
+  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
+      true;
+
   // FIXME: ASTScopeLookup doesn't support code completion yet.
   Invocation.disableASTScopeLookup();
 

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -328,11 +328,6 @@ bool swift::ide::CompletionInstance::performOperation(
   // source text. That breaks an invariant of syntax tree building.
   Invocation.getLangOptions().BuildSyntaxTree = false;
 
-  // This validation may call stat(2) many times. Disable it to prevent
-  // performance regression.
-  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
-      true;
-
   // FIXME: ASTScopeLookup doesn't support code completion yet.
   Invocation.disableASTScopeLookup();
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -539,11 +539,6 @@ bool SwiftASTManager::initCompilerInvocation(
   // We don't care about LLVMArgs
   FrontendOpts.LLVMArgs.clear();
 
-  // This validation may call stat(2) many times. Disable it to prevent
-  // performance issues.
-  Invocation.getSearchPathOptions().DisableModulesValidateSystemDependencies =
-      true;
-
   // SwiftSourceInfo files provide source location information for decls coming
   // from loaded modules. For most IDE use cases it either has an undesirable
   // impact on performance with no benefit (code completion), results in stale

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3302,8 +3302,6 @@ int main(int argc, char *argv[]) {
     options::DebugForbidTypecheckPrefix;
   InitInvok.getTypeCheckerOptions().DebugConstraintSolver =
       options::DebugConstraintSolver;
-  InitInvok.getSearchPathOptions().DisableModulesValidateSystemDependencies =
-      true;
 
   for (auto ConfigName : options::BuildConfigs)
     InitInvok.getLangOptions().addCustomConditionalCompilationFlag(ConfigName);


### PR DESCRIPTION
`swift-5.2-branch` version of #29555. Revert #29202

* **Explanation**: Disabling system headers checking for swift modules does affect `ClangImporter`'s equivalent flag `-fmodules-validate-system-headers` too. We should not disable this.
* **Scode**: All SourceKit Request
* **Risk**: Low. This just revert a change and back to previous behavior
* **Issue**: rdar://problem/59042838
* **Testing**: Passed the current regression tests
* **Reviewer**: Ben Langmuir (@benlangmuir )
