### PR TITLE
[DON'T MERGE] Indirect availability declarations

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -147,7 +147,12 @@ SIMPLE_DECL_ATTR(dynamicCallable, DynamicCallable,
   OnNominalType |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   6)
-// NOTE: 7 is unused
+DECL_ATTR(_availableRef, AvailableRef,
+  OnAbstractFunction | OnGenericType | OnVar | OnSubscript | OnEnumElement |
+  OnExtension | OnGenericTypeParam |
+  AllowMultipleAttributes | LongAttribute |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove |
+  NotSerialized, 7)
 SIMPLE_DECL_ATTR(_exported, Exported,
   OnImport |
   UserInaccessible |

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -837,6 +837,10 @@ public:
   /// platform).
   AvailableVersionComparison getVersionAvailability(const ASTContext &ctx) const;
 
+  /// Clone this attribute, overriding source location and implicitness.
+  AvailableAttr *clone(ASTContext &context, SourceLoc atLoc, SourceRange range,
+                       bool implicit) const;
+
   /// Create an AvailableAttr that indicates specific availability
   /// for all platforms.
   static AvailableAttr *
@@ -848,6 +852,23 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Available;
+  }
+};
+
+/// Copies availability information from another declaration.
+class AvailableRefAttr : public DeclAttribute {
+public:
+    AvailableRefAttr(SourceLoc AtLoc, SourceRange Range,
+                     TypeLoc TargetType,
+                     bool Implicit = false)
+    : DeclAttribute(DAK_AvailableRef, AtLoc, Range, Implicit),
+      TargetType(TargetType)
+  {}
+
+  TypeLoc TargetType;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_AvailableRef;
   }
 };
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1414,6 +1414,13 @@ WARNING(attr_availability_nonspecific_platform_unexpected_version,none,
       "unexpected version number in '%0' attribute for non-specific platform "
       "'*'", (StringRef))
 
+// _availableRef
+
+ERROR(attr_availableRef_expected_rparen,none,
+      "expected ')' after target name for '_availableRef'", ())
+ERROR(attr_availableRef_expected_target_name,PointsToFirstBadToken,
+      "expected a target name in '_availableRef' attribute", ())
+
 // originallyDefinedIn
 ERROR(originally_defined_in_missing_rparen,none,
       "expected ')' in @_originallyDefinedIn argument list", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4517,6 +4517,15 @@ ERROR(availabilty_string_subscript_migration, none,
       "construct a String from subscripted result", ())
 
 //------------------------------------------------------------------------------
+// MARK: @_availableRef
+//------------------------------------------------------------------------------
+
+ERROR(availableRef_conflicting_available_attribute, none,
+      "@available and @_availableRef cannot appear on the same declaration", ())
+NOTE(availableRef_here, none,
+     "@_availableRef here", ())
+
+//------------------------------------------------------------------------------
 // MARK: @discardableResult
 //------------------------------------------------------------------------------
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -609,6 +609,7 @@ struct PrintOptions {
       PrintOptions::FunctionRepresentationMode::None;
     PO.PrintDocumentationComments = false;
     PO.ExcludeAttrList.push_back(DAK_Available);
+    PO.ExcludeAttrList.push_back(DAK_AvailableRef);
     PO.SkipPrivateStdlibDecls = true;
     PO.ExplodeEnumCaseDecls = true;
     PO.ShouldQualifyNestedDeclarations = QualifyNestedDeclarations::TypesOnly;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -855,6 +855,14 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_AvailableRef: {
+    Printer << "@_availableRef(";
+    auto *attr = cast<AvailableRefAttr>(this);
+    attr->TargetType.getType().print(Printer, Options);
+    Printer << ")";
+    break;
+  }
+
   case DAK_CDecl:
     Printer << "@_cdecl(\"" << cast<CDeclAttr>(this)->Name << "\")";
     break;
@@ -1089,6 +1097,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_semantics";
   case DAK_Available:
     return "availability";
+  case DAK_AvailableRef:
+    return "_availableRef";
   case DAK_ObjC:
   case DAK_ObjCRuntimeName:
     return "objc";
@@ -1482,6 +1492,18 @@ const AvailableAttr *AvailableAttr::isUnavailable(const Decl *D) {
         return AvailableAttr::isUnavailable(ext);
 
   return nullptr;
+}
+
+AvailableAttr *AvailableAttr::clone(ASTContext &context, SourceLoc atLoc,
+                                    SourceRange range, bool implicit) const {
+  auto attr = new (context) AvailableAttr(
+    atLoc, range, Platform, Message, Rename,
+    Introduced.hasValue() ? Introduced.getValue() : llvm::VersionTuple(), range,
+    Deprecated.hasValue() ? Deprecated.getValue() : llvm::VersionTuple(), range,
+    Obsoleted.hasValue() ? Obsoleted.getValue() : llvm::VersionTuple(), range,
+    PlatformAgnostic,
+    implicit);
+  return attr;
 }
 
 SpecializeAttr::SpecializeAttr(SourceLoc atLoc, SourceRange range,

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1158,7 +1158,7 @@ bool ModelASTWalker::handleSpecialDeclAttribute(const DeclAttribute *D,
                                                 ArrayRef<Token> Toks) {
   if (!D)
     return false;
-  if (isa<CustomAttr>(D) || isa<AvailableAttr>(D)) {
+  if (isa<CustomAttr>(D) || isa<AvailableAttr>(D) || isa<AvailableRefAttr>(D)) {
     if (!passTokenNodesUntil(D->getRangeWithAt().Start,
                              ExcludeNodeAtLocation).shouldContinue)
       return false;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1992,6 +1992,36 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     }
     break;
   }
+  case DAK_AvailableRef: {
+    // @_availableRef(SomeDecl.reference)
+
+    // Parse the leading '('.
+    if (Tok.isNot(tok::l_paren)) {
+      diagnose(Loc, diag::attr_expected_lparen, AttrName,
+               DeclAttribute::isDeclModifier(DK));
+      return false;
+    }
+    SourceLoc LParenLoc = consumeToken(tok::l_paren);
+
+    auto TargetType = parseType();
+    if (TargetType.isNull()) {
+      diagnose(Loc, diag::attr_availableRef_expected_target_name);
+      return false;
+    }
+               
+    // Parse the matching ')'.
+    SourceLoc RParenLoc;
+    if (parseMatchingToken(tok::r_paren, RParenLoc,
+                           diag::attr_availableRef_expected_rparen,
+                           LParenLoc))
+      return false;
+
+    auto Attr = new (Context)
+      AvailableRefAttr(AtLoc, SourceRange(AtLoc, Tok.getLoc()),
+                       TargetType.get());
+    Attributes.add(Attr);
+    break;
+  }
   case DAK_PrivateImport: {
     // Parse the leading '('.
     if (Tok.isNot(tok::l_paren)) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1401,76 +1401,7 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
 }
 
 void AttributeChecker::visitAvailableRefAttr(AvailableRefAttr *attr) {
-  DeclContext *DC = D->getDeclContext();
-  TypeLoc &targetLoc = attr->TargetType;
-
-  if (auto avAttr = D->getAttrs().getAttribute<AvailableAttr>()) {
-    diagnose(avAttr->getLocation(),
-             diag::availableRef_conflicting_available_attribute);
-    diagnose(attr->getLocation(),
-             diag::availableRef_here);
-    return;
-  }
-
-  Type target = targetLoc.getType();
-  if (!target && targetLoc.getTypeRepr()) {
-    TypeResolutionOptions options = None;
-    options |= TypeResolutionFlags::AllowUnavailable;
-    options |= TypeResolutionFlags::AllowUnavailableProtocol;
-    options |= TypeResolutionFlags::AllowUnboundGenerics;
-
-    auto resolution = TypeResolution::forContextual(DC);
-    target = resolution.resolveType(targetLoc.getTypeRepr(), options);
-    targetLoc.setType(target);
-  }
-
-  // Definite error-types were already diagnosed in resolveType.
-  if (target->hasError())
-    return;
-
-  TypeDecl *decl;
-  if (auto aliasType = dyn_cast<TypeAliasType>(target.getPointer())) {
-    decl = aliasType->getDecl();
-  } else if (auto nominal = target->getAnyNominal()) {
-    decl = nominal;
-  } else {
-    // FIXME: Diagnose
-    return;
-  }
-
-  const DeclAttributes &targetAttrs = decl->getAttrs();
-  if (targetAttrs.hasAttribute<AvailableRefAttr>()) {
-    // FIXME: Diagnose
-    return;
-  }
-  if (!targetAttrs.hasAttribute<AvailableAttr>()) {
-    // FIXME: Diagnose
-    return;
-  }
-
-  llvm::SmallVector<AvailableAttr*, 4> newAttrs;
-
-  for (auto targetAttr : targetAttrs) {
-    auto *avAttr = dyn_cast<AvailableAttr>(targetAttr);
-    if (!avAttr)
-      continue;
-    auto clone = avAttr->clone(D->getASTContext(),
-                               attr->AtLoc, targetLoc.getSourceRange(),
-                               /*implicit*/true);
-    newAttrs.push_back(clone);
-  }
-  for (auto it = newAttrs.rbegin(); it != newAttrs.rend(); ++it) {
-    D->getAttrs().add(*it);
-  }
-  // for (auto newAttr : newAttrs) {
-  //   visitAvailableAttr(newAttr);
-  //   if (newAttr->isInvalid()) {
-  //     diagnose(attr->getLocation(),
-  //              diag::availableRef_hello);
-  //   }
-  // }
-  diagnose(attr->getLocation(),
-           diag::availableRef_here);
+  // All the work is done by TypeRefinementContextBuilder.
 }
 
 void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1392,6 +1392,7 @@ namespace  {
     UNINTERESTING_ATTR(AccessControl)
     UNINTERESTING_ATTR(Alignment)
     UNINTERESTING_ATTR(AlwaysEmitIntoClient)
+    UNINTERESTING_ATTR(AvailableRef)
     UNINTERESTING_ATTR(Borrowed)
     UNINTERESTING_ATTR(CDecl)
     UNINTERESTING_ATTR(Consuming)

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -1754,6 +1754,12 @@ namespace decls_block {
     BCBlob      // platform, followed by message
   >;
 
+  using AvailableRefDeclAttrLayout = BCRecordLayout<
+    AvailableRef_DECL_ATTR,
+    BCFixed<1>,     // implicit flag
+    BCBlob          // target name
+  >;
+
   using OriginallyDefinedInDeclAttrLayout = BCRecordLayout<
     OriginallyDefinedIn_DECL_ATTR,
     BCFixed<1>,     // implicit flag

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2236,6 +2236,12 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_AvailableRef: {
+      auto *theAttr = cast<AvailableRefAttr>(DA);
+      // FIXME: Do we want to serialize this?
+      return;      
+    }
+
     case DAK_ObjC: {
       auto *theAttr = cast<ObjCAttr>(DA);
       SmallVector<IdentifierID, 4> pieces;

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -12,6 +12,15 @@
 
 import SwiftShims
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+internal typealias _Stdlib_5_1 = Void
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+internal typealias _Stdlib_5_2 = Void
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+internal typealias _Stdlib_Dev = Void
+
 /// Returns 1 if the running OS version is greater than or equal to
 /// major.minor.patchVersion and 0 otherwise.
 ///

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -85,7 +85,7 @@ public protocol _ObjectiveCBridgeable {
 
 #if _runtime(_ObjC)
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@_availableRef(_Stdlib_Dev)
 @available(*, deprecated)
 @_cdecl("_SwiftCreateBridgedArray")
 @usableFromInline
@@ -98,7 +98,7 @@ internal func _SwiftCreateBridgedArray(
   return Unmanaged<AnyObject>.passRetained(bridged)
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@_availableRef(_Stdlib_Dev)
 @available(*, deprecated)
 @_cdecl("_SwiftCreateBridgedMutableArray")
 @usableFromInline

--- a/stdlib/public/core/CollectionDifference.swift
+++ b/stdlib/public/core/CollectionDifference.swift
@@ -12,7 +12,7 @@
 
 /// A collection of insertions and removals that describe the difference 
 /// between two ordered collection states.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 public struct CollectionDifference<ChangeElement> {
   /// A single change to a collection.
   @frozen
@@ -233,7 +233,7 @@ public struct CollectionDifference<ChangeElement> {
 ///   }
 /// }
 /// ```
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference: Collection {
   public typealias Element = Change
 
@@ -281,7 +281,7 @@ extension CollectionDifference: Collection {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference.Index: Equatable {
   @inlinable
   public static func == (
@@ -292,7 +292,7 @@ extension CollectionDifference.Index: Equatable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference.Index: Comparable {
   @inlinable
   public static func < (
@@ -303,7 +303,7 @@ extension CollectionDifference.Index: Comparable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference.Index: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
@@ -311,19 +311,19 @@ extension CollectionDifference.Index: Hashable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference.Change: Equatable where ChangeElement: Equatable {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference: Equatable where ChangeElement: Equatable {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference.Change: Hashable where ChangeElement: Hashable {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference: Hashable where ChangeElement: Hashable {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference where ChangeElement: Hashable {
   /// Returns a new collection difference with associations between individual
   /// elements that have been removed and inserted only once.
@@ -380,7 +380,7 @@ extension CollectionDifference where ChangeElement: Hashable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference.Change: Codable where ChangeElement: Codable {
   private enum _CodingKeys: String, CodingKey {
     case offset
@@ -417,5 +417,5 @@ extension CollectionDifference.Change: Codable where ChangeElement: Codable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference: Codable where ChangeElement: Codable {}

--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -12,7 +12,7 @@
 
 // MARK: Diff application to RangeReplaceableCollection
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension CollectionDifference {
   fileprivate func _fastEnumeratedApply(
     _ consume: (Change) throws -> Void
@@ -67,7 +67,7 @@ extension RangeReplaceableCollection {
   ///
   /// - Complexity: O(*n* + *c*), where *n* is `self.count` and *c* is the
   ///   number of changes contained by the parameter.
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @_availableRef(_Stdlib_5_1)
   public func applying(_ difference: CollectionDifference<Element>) -> Self? {
 
     func append(
@@ -142,7 +142,7 @@ extension BidirectionalCollection {
   /// - Complexity: Worst case performance is O(*n* * *m*), where *n* is the
   ///   count of this collection and *m* is `other.count`. You can expect
   ///   faster execution when the collections share many common elements.
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @_availableRef(_Stdlib_5_1)
   public func difference<C: BidirectionalCollection>(
     from other: C,
     by areEquivalent: (C.Element, Element) -> Bool
@@ -169,7 +169,7 @@ extension BidirectionalCollection where Element: Equatable {
   ///   count of this collection and *m* is `other.count`. You can expect
   ///   faster execution when the collections share many common elements, or
   ///   if `Element` conforms to `Hashable`.
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @_availableRef(_Stdlib_5_1)
   public func difference<C: BidirectionalCollection>(
     from other: C
   ) -> CollectionDifference<Element> where C.Element == Self.Element {
@@ -221,7 +221,7 @@ fileprivate struct _V {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 fileprivate func _myers<C,D>(
   from old: C, to new: D,
   using cmp: (C.Element, D.Element) -> Bool

--- a/stdlib/public/core/Identifiable.swift
+++ b/stdlib/public/core/Identifiable.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A class of types whose instances hold the value of an entity with stable identity.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 public protocol Identifiable {
 
   /// A type representing the stable identity of the entity associated with `self`.
@@ -21,7 +21,7 @@ public protocol Identifiable {
   var id: ID { get }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension Identifiable where Self: AnyObject {
   public var id: ObjectIdentifier {
     return ObjectIdentifier(self)

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -482,10 +482,7 @@ extension String {
   }
 }
 
-@available(macOS, introduced: 9999, deprecated)
-@available(iOS, introduced: 9999, deprecated)
-@available(watchOS, introduced: 9999, deprecated)
-@available(tvOS, introduced: 9999, deprecated)
+@_availableRef(_Stdlib_Dev)
 @available(*, deprecated)
 @_cdecl("_SwiftCreateBridgedString")
 @usableFromInline
@@ -528,7 +525,7 @@ public func _getDescription<T>(_ x: T) -> AnyObject {
 
 @_silgen_name("swift_stdlib_NSStringFromUTF8")
 @usableFromInline //this makes the symbol available to the runtime :(
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@_availableRef(_Stdlib_Dev)
 internal func _NSStringFromUTF8(_ s: UnsafePointer<UInt8>, _ len: Int)
   -> AnyObject {
   return String(

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -103,7 +103,7 @@ extension String.Index {
   ///     `sourcePosition` must be a valid index of at least one of the views
   ///     of `target`.
   ///   - target: The string referenced by the resulting index.
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @_availableRef(_Stdlib_5_1)
   public init?<S: StringProtocol>(
     _ sourcePosition: String.Index, within target: S
   ) {

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -435,7 +435,7 @@ extension Unicode.Scalar.UTF16View: RandomAccessCollection {
 }
 
 extension Unicode.Scalar {
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @_availableRef(_Stdlib_5_1)
   @frozen
   public struct UTF8View {
     @inlinable
@@ -446,12 +446,12 @@ extension Unicode.Scalar {
     internal var value: Unicode.Scalar
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @_availableRef(_Stdlib_5_1)
   @inlinable
   public var utf8: UTF8View { return UTF8View(value: self) }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@_availableRef(_Stdlib_5_1)
 extension Unicode.Scalar.UTF8View: RandomAccessCollection {
   public typealias Indices = Range<Int>
 

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -35,6 +35,7 @@ ATTRIBUTE_NODES = [
     #                | specialize-attr-spec-list
     #                | implements-attr-arguments
     #                | named-attribute-string-argument
+    #                | simple-type-identifier
     #              )? ')'?
     Node('Attribute', kind='Syntax',
          description='''
@@ -66,6 +67,7 @@ ATTRIBUTE_NODES = [
                              kind='DerivativeRegistrationAttributeArguments'),
                        Child('NamedAttributeString',
                              kind='NamedAttributeStringArgument'),
+                       Child('AvailableRefAttributeArgument', kind='Type'),
                    ], description='''
                    The arguments of the attribute. In case the attribute
                    takes multiple arguments, they are gather in the


### PR DESCRIPTION
This is a proof of concept for a variant of `@available` that copies availability information from another declaration. This would fix a pain point for us ABI-stable library developers by eliminating redundant availability incantations and simplifying the error-prone and onerously manual task of finalizing them before stable releases.

```swift
@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.1, *)
internal typealias _Stdlib_5_0 = Void

@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
internal typealias _Stdlib_5_1 = Void

@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
internal typealias _Stdlib_Dev = Void


@_availableRef(_Stdlib_5_1)
public struct CollectionDifference<ChangeElement> { ... }

@_availableRef(_Stdlib_Dev)
public struct FancyNewStdlibFeature { ... }
```

`@_availableRef` is an implementation detail that doesn't affect the public interface of the module. (It gets expanded into the actual `@available` list on serialization.)

Notes:
1. I have no idea what I'm doing here. 😅

2. We'll also need some equivalent of this for `if #available`, so that we can use this in tests as well. (Maintaining `#available` tests in unit tests is currently at least tricky as `@available` attributes are in the actual code.)

3. We need to decide how we want to spell this. Perhaps it makes sense to roll this functionality into `@available` itself. (Something like `@available(at: _Stdlib_5_1)`?)

4. `TypeRefinementContextBuilder` resolves/propagates availability information before `@available` attributes are type checked, which seems backward to me. `@_availableRef` needs to resolve its target type -- I'm not sure if it's okay to do name resolution this early in the type checking process.

5. The argument of `@_availableRef` is currently restricted to a type name -- for extra points, it would be nice if it could refer to other kind of decls (enum cases especially).

6. Using dummy type declarations for this seems like a hack. What if we introduced dedicated syntax for declaring aliases for shorthand-style availability declarations?
    ```swift
    #versiondef(stdlib 5.0: macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.1, *)
    #versiondef(stdlib 5.1: macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
    #versiondef(stdlib dev: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
    ```

    This would get rid of the need to resolve decl names, and it would allow us to use nice version tuples instead of ugly identifiers like `_Stdlib_5_1` . It could also simplify deprecations/obsoletions: 

    ```swift
    @available(stdlib 5.1)
    func foo() { ... }
    @available(stdlib, introduced: 5.1, deprecated: 9.4, message: "blah blah")
    func bar() { ... }

    func baz() {
      if #available(stdlib 7.5) { ... }
    }
    ``` 

    Note how this solves point (3) above -- it basically reuses the existing syntax for OS version numbers. (With some weirdness about how this interacts with the shorthand fallback platform `*`.)
