### PR TITLE
Explicit llvm::StringRef -> std::string

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -363,7 +363,7 @@ namespace swift {
     /// compiler flag.
     void addCustomConditionalCompilationFlag(StringRef Name) {
       assert(!Name.empty());
-      CustomConditionalCompilationFlags.push_back(Name);
+      CustomConditionalCompilationFlags.push_back(std::string(Name));
     }
 
     /// Determines if a given conditional compilation flag has been set.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -678,7 +678,7 @@ public:
   void addSemanticsAttr(StringRef Ref) {
     if (hasSemanticsAttr(Ref))
       return;
-    SemanticsAttrSet.push_back(Ref);
+    SemanticsAttrSet.push_back(std::string(Ref));
     std::sort(SemanticsAttrSet.begin(), SemanticsAttrSet.end());
   }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1434,7 +1434,7 @@ void ASTContext::addSearchPath(StringRef searchPath, bool isFramework,
   if (isFramework)
     SearchPathOpts.FrameworkSearchPaths.push_back({searchPath, isSystem});
   else
-    SearchPathOpts.ImportSearchPaths.push_back(searchPath);
+    SearchPathOpts.ImportSearchPaths.push_back(std::string(searchPath));
 
   if (auto *clangLoader = getClangModuleLoader())
     clangLoader->addSearchPath(searchPath, isFramework, isSystem);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -265,7 +265,7 @@ std::string ASTPrinter::sanitizeUtf8(StringRef Text) {
     }
     Data += Step;
   }
-  return Builder.str();
+  return std::string(Builder);
 }
 
 void ASTPrinter::anchor() {}
@@ -4491,7 +4491,7 @@ AnyFunctionType::getParamListAsString(ArrayRef<AnyFunctionType::Param> Params,
   SmallString<16> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
   AnyFunctionType::printParams(Params, OS);
-  return OS.str();
+  return std::string(OS.str());
 }
 
 void LayoutConstraintInfo::print(raw_ostream &OS,

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -989,7 +989,7 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
       while (associatedNotes && *associatedNotes) {
         SmallString<128> notePath(getDiagnosticDocumentationPath());
         llvm::sys::path::append(notePath, *associatedNotes);
-        educationalNotePaths.push_back(notePath.str());
+        educationalNotePaths.push_back(std::string(notePath));
         associatedNotes++;
       }
       info->EducationalNotePaths = educationalNotePaths;

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -201,7 +201,7 @@ std::string DependencyKey::humanReadableName() const {
     return demangleTypeAsContext(context) + "." + name;
   case NodeKind::externalDepend:
   case NodeKind::sourceFileProvide:
-    return llvm::sys::path::filename(name);
+    return std::string(llvm::sys::path::filename(name));
   case NodeKind::potentialMember:
     return demangleTypeAsContext(context) + ".*";
   case NodeKind::nominal:

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1914,7 +1914,7 @@ StringRef ModuleEntity::getName() const {
 std::string ModuleEntity::getFullName() const {
   assert(!Mod.isNull());
   if (auto SwiftMod = Mod.dyn_cast<const ModuleDecl*>())
-    return SwiftMod->getName().str();
+    return std::string(SwiftMod->getName().str());
   return getClangModule(Mod)->getFullModuleName();
 }
 

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -71,7 +71,7 @@ getErrorDomainStringForObjC(const EnumDecl *ED) {
     outerTypes.push_back(D);
   }
 
-  std::string buffer = ED->getParentModule()->getNameStr();
+  std::string buffer(ED->getParentModule()->getNameStr());
   for (auto D : llvm::reverse(outerTypes)) {
     buffer += ".";
     buffer += D->getNameStr();

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -214,7 +214,7 @@ swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
     if (auto ClangD = ClangN.getAsDecl()) {
       bool Ignore = clang::index::generateUSRForDecl(ClangD, Buffer);
       if (!Ignore) {
-        return Buffer.str();
+        return std::string(Buffer);
       } else {
         return std::string();
       }
@@ -228,7 +228,7 @@ swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
         ClangMacroInfo->getDefinitionLoc(),
         Importer.getClangASTContext().getSourceManager(), Buffer);
     if (!Ignore)
-      return Buffer.str();
+      return std::string(Buffer);
     else
       return std::string();
   }
@@ -237,7 +237,7 @@ swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
     if (printObjCUSR(D, OS)) {
       return std::string();
     } else {
-      return OS.str();
+      return std::string(OS.str());
     }
   }
 

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -105,7 +105,7 @@ bool SourceManager::openVirtualFile(SourceLoc loc, StringRef name,
   }
 
   CharSourceRange range = CharSourceRange(*this, loc, end);
-  VirtualFiles[end.Value.getPointer()] = { range, name, lineOffset };
+  VirtualFiles[end.Value.getPointer()] = {range, std::string(name), lineOffset};
   CachedVFile = {nullptr, nullptr};
   return true;
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -481,9 +481,8 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
   if (!llvm::sys::fs::exists(shimsPath)) {
     shimsPath = searchPathOpts.SDKPath;
     llvm::sys::path::append(shimsPath, "usr", "lib", "swift", "shims");
-    invocationArgStrs.insert(invocationArgStrs.end(), {
-      "-isystem", shimsPath.str()
-    });
+    invocationArgStrs.insert(invocationArgStrs.end(),
+                             {"-isystem", std::string(shimsPath)});
   }
 
   // Construct the invocation arguments for the current target.
@@ -638,7 +637,7 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       llvm::sys::path::native(path);
 
       invocationArgStrs.push_back("-isystem");
-      invocationArgStrs.push_back(path.str());
+      invocationArgStrs.push_back(std::string(path));
     } else {
       // On Darwin, Clang uses -isysroot to specify the include
       // system root. On other targets, it seems to use --sysroot.
@@ -747,7 +746,7 @@ addCommonInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
     // Set the Clang resource directory to the path we computed.
     invocationArgStrs.push_back("-resource-dir");
-    invocationArgStrs.push_back(resourceDir.str());
+    invocationArgStrs.push_back(std::string(resourceDir));
   } else {
     invocationArgStrs.push_back("-resource-dir");
     invocationArgStrs.push_back(overrideResourceDir);
@@ -1532,7 +1531,7 @@ ClangImporter::emitBridgingPCH(StringRef headerPath,
 
   auto &FrontendOpts = invocation.getFrontendOpts();
   FrontendOpts.Inputs = {inputFile};
-  FrontendOpts.OutputFile = outputPCHPath;
+  FrontendOpts.OutputFile = std::string(outputPCHPath);
   FrontendOpts.ProgramAction = clang::frontend::GeneratePCH;
 
   auto action = wrapActionForIndexingIfEnabled(
@@ -1556,7 +1555,7 @@ bool ClangImporter::emitPrecompiledModule(StringRef moduleMapPath,
 
   auto LangOpts = invocation.getLangOpts();
   LangOpts->setCompilingModule(clang::LangOptions::CMK_ModuleMap);
-  LangOpts->ModuleName = moduleName;
+  LangOpts->ModuleName = std::string(moduleName);
   LangOpts->CurrentModule = LangOpts->ModuleName;
 
   auto language = getLanguageFromOptions(LangOpts);
@@ -1566,8 +1565,8 @@ bool ClangImporter::emitPrecompiledModule(StringRef moduleMapPath,
 
   auto &FrontendOpts = invocation.getFrontendOpts();
   FrontendOpts.Inputs = {inputFile};
-  FrontendOpts.OriginalModuleMap = moduleMapPath;
-  FrontendOpts.OutputFile = outputPath;
+  FrontendOpts.OriginalModuleMap = std::string(moduleMapPath);
+  FrontendOpts.OutputFile = std::string(outputPath);
   FrontendOpts.ProgramAction = clang::frontend::GenerateModule;
 
   auto action = wrapActionForIndexingIfEnabled(
@@ -1595,7 +1594,7 @@ bool ClangImporter::dumpPrecompiledModule(StringRef modulePath,
 
   auto &FrontendOpts = invocation.getFrontendOpts();
   FrontendOpts.Inputs = {inputFile};
-  FrontendOpts.OutputFile = outputPath;
+  FrontendOpts.OutputFile = std::string(outputPath);
 
   auto action = std::make_unique<clang::DumpModuleInfoAction>();
   dumpInstance->ExecuteAction(*action);

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -691,7 +691,7 @@ private:
       auto Label = LabelList->getChild(Index);
       assert(Label && (Label->getKind() == Node::Kind::Identifier ||
                        Label->getKind() == Node::Kind::FirstElementMarker));
-      return Label->getKind() == Node::Kind::Identifier ? Label->getText()
+      return Label->getKind() == Node::Kind::Identifier ? Label->getText().str()
                                                         : "_";
     };
 
@@ -1121,7 +1121,8 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     return nullptr;
   case Node::Kind::Suffix:
     if (Options.DisplayUnmangledSuffix) {
-      Printer << " with unmangled suffix " << QuotedString(Node->getText());
+      Printer << " with unmangled suffix "
+              << QuotedString(std::string(Node->getText()));
     }
     return nullptr;
   case Node::Kind::Initializer:

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -48,7 +48,7 @@ namespace {
       }
       
       void setAnonymousContextDiscriminator(StringRef discriminator) {
-        AnonymousContextDiscriminator = discriminator;
+        AnonymousContextDiscriminator = discriminator.str();
       }
       
       std::string takeAnonymousContextDiscriminator() {

--- a/lib/Driver/CoarseGrainedDependencyGraph.cpp
+++ b/lib/Driver/CoarseGrainedDependencyGraph.cpp
@@ -268,7 +268,7 @@ CoarseGrainedDependencyGraphImpl::loadFromBuffer(const void *node,
     });
 
     if (iter == provides.end())
-      provides.push_back({name, kind});
+      provides.push_back({std::string(name), kind});
     else
       iter->kindMask |= kind;
 
@@ -276,7 +276,8 @@ CoarseGrainedDependencyGraphImpl::loadFromBuffer(const void *node,
   };
 
   auto interfaceHashCallback = [this, node](StringRef hash) -> LoadResult {
-    auto insertResult = InterfaceHashes.insert(std::make_pair(node, hash));
+    auto insertResult =
+        InterfaceHashes.insert(std::make_pair(node, std::string(hash)));
 
     if (insertResult.second) {
       // Treat a newly-added hash as up-to-date. This includes the initial
@@ -286,7 +287,7 @@ CoarseGrainedDependencyGraphImpl::loadFromBuffer(const void *node,
 
     auto iter = insertResult.first;
     if (hash != iter->second) {
-      iter->second = hash;
+      iter->second = std::string(hash);
       return LoadResult::AffectsDownstream;
     }
 

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -67,9 +67,9 @@ void CommandOutput::ensureEntry(StringRef PrimaryInputFile,
   assert(Type != file_types::TY_Nothing);
   auto &M = DerivedOutputMap.getOrCreateOutputMapForInput(PrimaryInputFile);
   if (Overwrite) {
-    M[Type] = OutputFile;
+    M[Type] = std::string(OutputFile);
   } else {
-    auto res = M.insert(std::make_pair(Type, OutputFile));
+    auto res = M.insert(std::make_pair(Type, std::string(OutputFile)));
     if (res.second) {
       // New entry, no need to compare.
     } else {
@@ -408,20 +408,18 @@ void Job::printSummary(raw_ostream &os) const {
   }
 
   os << "{" << getSource().getClassName() << ": ";
-  interleave(Outputs,
-             [&](const std::string &Arg) {
-               os << llvm::sys::path::filename(Arg);
-             },
-             [&] { os << ' '; });
+  interleave(
+      Outputs,
+      [&](const StringRef &Arg) { os << llvm::sys::path::filename(Arg); },
+      [&] { os << ' '; });
   if (actual_out > limit) {
     os << " ... " << (actual_out-limit) << " more";
   }
   os << " <= ";
-  interleave(Inputs,
-             [&](const std::string &Arg) {
-               os << llvm::sys::path::filename(Arg);
-             },
-             [&] { os << ' '; });
+  interleave(
+      Inputs,
+      [&](const StringRef &Arg) { os << llvm::sys::path::filename(Arg); },
+      [&] { os << ' '; });
   if (actual_in > limit) {
     os << " ... " << (actual_in-limit) << " more";
   }

--- a/lib/Driver/ParseableOutput.cpp
+++ b/lib/Driver/ParseableOutput.cpp
@@ -48,7 +48,7 @@ namespace json {
   template <> struct ScalarEnumerationTraits<file_types::ID> {
     static void enumeration(Output &out, file_types::ID &value) {
       file_types::forAllTypes([&](file_types::ID ty) {
-        std::string typeName = file_types::getTypeName(ty);
+        std::string typeName(file_types::getTypeName(ty));
         out.enumCase(value, typeName.c_str(), ty);
       });
     }
@@ -125,7 +125,7 @@ public:
       if (const auto *BJAction = dyn_cast<BackendJobAction>(&Cmd.getSource())) {
         Inputs.push_back(CommandInput(OutFiles[BJAction->getInputIndex()]));
       } else {
-        for (const std::string FileName : OutFiles) {
+        for (const auto FileName : OutFiles) {
           Inputs.push_back(CommandInput(FileName));
         }
       }
@@ -134,9 +134,10 @@ public:
     // TODO: set up Outputs appropriately.
     file_types::ID PrimaryOutputType = Cmd.getOutput().getPrimaryOutputType();
     if (PrimaryOutputType != file_types::TY_Nothing) {
-      for (const std::string OutputFileName : Cmd.getOutput().
-                                                 getPrimaryOutputFilenames()) {
-        Outputs.push_back(OutputPair(PrimaryOutputType, OutputFileName));
+      for (const auto OutputFileName :
+           Cmd.getOutput().getPrimaryOutputFilenames()) {
+        Outputs.push_back(
+            OutputPair(PrimaryOutputType, std::string(OutputFileName)));
       }
     }
     file_types::forAllTypes([&](file_types::ID Ty) {

--- a/lib/Driver/SourceComparator.cpp
+++ b/lib/Driver/SourceComparator.cpp
@@ -70,7 +70,7 @@ SourceComparator::buildEquivalenceClasses() {
   std::unordered_map<std::string, std::vector<size_t>> rhsMap;
   for (auto index = regionsToCompare.start.rhs();
        index < regionsToCompare.end.rhs(); ++index)
-    rhsMap[linesToCompare.rhs()[index]].push_back(index);
+    rhsMap[std::string(linesToCompare.rhs()[index])].push_back(index);
   return rhsMap;
 }
 
@@ -86,7 +86,7 @@ SourceComparator::buildDAGOfSubsequences(
   for (auto i = regionsToCompare.start.lhs(); i < regionsToCompare.end.lhs();
        ++i) {
     // What lines in rhs does the ith line in lhs match?
-    auto iter = rhsMap.find(linesToCompare.lhs()[i]);
+    auto iter = rhsMap.find(std::string(linesToCompare.lhs()[i]));
     if (iter == rhsMap.end())
       continue; // no match in rhs
     auto &res = iter->second;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1256,13 +1256,13 @@ void ToolChain::getRuntimeLibraryPaths(SmallVectorImpl<std::string> &runtimeLibP
                                        StringRef SDKPath, bool shared) const {
   SmallString<128> scratchPath;
   getResourceDirPath(scratchPath, args, shared);
-  runtimeLibPaths.push_back(scratchPath.str());
+  runtimeLibPaths.push_back(std::string(scratchPath));
 
   // If there's a secondary resource dir, add it too.
   scratchPath.clear();
   getSecondaryResourceDirPath(scratchPath, runtimeLibPaths[0]);
   if (!scratchPath.empty())
-    runtimeLibPaths.push_back(scratchPath.str());
+    runtimeLibPaths.push_back(std::string(scratchPath));
 
   if (!SDKPath.empty()) {
     if (!scratchPath.empty()) {
@@ -1271,12 +1271,12 @@ void ToolChain::getRuntimeLibraryPaths(SmallVectorImpl<std::string> &runtimeLibP
       scratchPath = SDKPath;
       llvm::sys::path::append(scratchPath, "System", "iOSSupport");
       llvm::sys::path::append(scratchPath, "usr", "lib", "swift");
-      runtimeLibPaths.push_back(scratchPath.str());
+      runtimeLibPaths.push_back(std::string(scratchPath));
     }
 
     scratchPath = SDKPath;
     llvm::sys::path::append(scratchPath, "usr", "lib", "swift");
-    runtimeLibPaths.push_back(scratchPath.str());
+    runtimeLibPaths.push_back(std::string(scratchPath));
   }
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -457,7 +457,7 @@ bool ArgsToFrontendOptionsConverter::computeFallbackModuleName() {
   }
   // In order to pass some tests, must leave ModuleName empty.
   if (!Opts.InputsAndOutputs.hasInputs()) {
-    Opts.ModuleName = StringRef();
+    Opts.ModuleName = std::string();
     // FIXME: This is a bug that should not happen, but does in tests.
     // The compiler should bail out earlier, where "no frontend action was
     // selected".
@@ -474,7 +474,7 @@ bool ArgsToFrontendOptionsConverter::computeFallbackModuleName() {
           ? outputFilenames->front()
           : Opts.InputsAndOutputs.getFilenameOfFirstInput();
 
-  Opts.ModuleName = llvm::sys::path::stem(nameToStem);
+  Opts.ModuleName = std::string(llvm::sys::path::stem(nameToStem));
   return false;
 }
 

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -222,7 +222,7 @@ OutputFilesComputer::deriveOutputFileFromParts(StringRef dir,
   llvm::SmallString<128> path(dir);
   llvm::sys::path::append(path, base);
   llvm::sys::path::replace_extension(path, Suffix);
-  return path.str();
+  return std::string(path);
 }
 
 SupplementaryOutputPathsComputer::SupplementaryOutputPathsComputer(
@@ -502,11 +502,12 @@ void SupplementaryOutputPathsComputer::deriveModulePathParameters(
       RequestedAction == FrontendOptions::ActionType::MergeModules ||
       RequestedAction == FrontendOptions::ActionType::EmitModuleOnly || isSIB;
 
-  extension = file_types::getExtension(
-      isSIB ? file_types::TY_SIB : file_types::TY_SwiftModuleFile);
+  extension = std::string(file_types::getExtension(
+      isSIB ? file_types::TY_SIB : file_types::TY_SwiftModuleFile));
 
-  mainOutputIfUsable =
-      canUseMainOutputForModule && !OutputFiles.empty() ? mainOutputFile : "";
+  mainOutputIfUsable = canUseMainOutputForModule && !OutputFiles.empty()
+                           ? std::string(mainOutputFile)
+                           : "";
 }
 
 static SupplementaryOutputPaths

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -56,7 +56,7 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
   llvm::sys::path::remove_filename(DiagnosticDocsPath); // Remove /bin
   llvm::sys::path::append(DiagnosticDocsPath, "share", "doc", "swift",
                           "diagnostics");
-  DiagnosticOpts.DiagnosticDocumentationPath = DiagnosticDocsPath.str();
+  DiagnosticOpts.DiagnosticDocumentationPath = std::string(DiagnosticDocsPath);
 }
 
 /// If we haven't explicitly passed -prebuilt-module-cache-path, set it to
@@ -82,7 +82,7 @@ static void setDefaultPrebuiltCacheIfNecessary(
     platform = getPlatformNameForTriple(triple);
   }
   llvm::sys::path::append(defaultPrebuiltPath, platform, "prebuilt-modules");
-  frontendOpts.PrebuiltModuleCachePath = defaultPrebuiltPath.str();
+  frontendOpts.PrebuiltModuleCachePath = std::string(defaultPrebuiltPath);
 }
 
 static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
@@ -95,7 +95,7 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
 
   llvm::sys::path::append(LibPath, LibSubDir);
   SearchPathOpts.RuntimeLibraryPaths.clear();
-  SearchPathOpts.RuntimeLibraryPaths.push_back(LibPath.str());
+  SearchPathOpts.RuntimeLibraryPaths.push_back(std::string(LibPath));
   if (Triple.isOSDarwin())
     SearchPathOpts.RuntimeLibraryPaths.push_back(DARWIN_OS_LIBRARY_PATH);
 
@@ -109,14 +109,14 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
 
   if (!Triple.isOSDarwin())
     llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
-  SearchPathOpts.RuntimeLibraryImportPaths.push_back(LibPath.str());
+  SearchPathOpts.RuntimeLibraryImportPaths.push_back(std::string(LibPath));
 
   if (!SearchPathOpts.SDKPath.empty()) {
     if (tripleIsMacCatalystEnvironment(Triple)) {
       LibPath = SearchPathOpts.SDKPath;
       llvm::sys::path::append(LibPath, "System", "iOSSupport");
       llvm::sys::path::append(LibPath, "usr", "lib", "swift");
-      SearchPathOpts.RuntimeLibraryImportPaths.push_back(LibPath.str());
+      SearchPathOpts.RuntimeLibraryImportPaths.push_back(std::string(LibPath));
     }
 
     LibPath = SearchPathOpts.SDKPath;
@@ -125,7 +125,8 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
       llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
       llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
     }
-    SearchPathOpts.RuntimeLibraryImportPaths.push_back(LibPath.str());
+    SearchPathOpts.RuntimeLibraryImportPaths.push_back(
+        std::string(LibPath.str()));
   }
 }
 
@@ -178,7 +179,7 @@ setBridgingHeaderFromFrontendOptions(ClangImporterOptions &ImporterOpts,
 }
 
 void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {
-  SearchPathOpts.RuntimeResourcePath = Path;
+  SearchPathOpts.RuntimeResourcePath = std::string(Path);
   updateRuntimeLibraryPaths(SearchPathOpts, LangOpts.Target);
 }
 
@@ -703,9 +704,9 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
     // Provide a working directory to Clang as well if there are any -Xcc
     // options, in case some of them are search-related. But do it at the
     // beginning, so that an explicit -Xcc -working-directory will win.
-    Opts.ExtraArgs.insert(Opts.ExtraArgs.begin(), {
-      "-working-directory", workingDirectory
-    });
+    Opts.ExtraArgs.insert(
+        Opts.ExtraArgs.begin(),
+        {"-working-directory", std::string(workingDirectory)});
   }
 
   Opts.InferImportAsMember |= Args.hasArg(OPT_enable_infer_import_as_member);
@@ -748,10 +749,10 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   auto resolveSearchPath =
       [workingDirectory](StringRef searchPath) -> std::string {
     if (workingDirectory.empty() || path::is_absolute(searchPath))
-      return searchPath;
+      return std::string(searchPath);
     SmallString<64> fullPath{workingDirectory};
     path::append(fullPath, searchPath);
-    return fullPath.str();
+    return std::string(fullPath);
   };
 
   for (const Arg *A : Args.filtered(OPT_I)) {
@@ -1142,7 +1143,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     // TODO: Should we support -fdebug-compilation-dir?
     llvm::SmallString<256> cwd;
     llvm::sys::fs::current_path(cwd);
-    Opts.DebugCompilationDir = cwd.str();
+    Opts.DebugCompilationDir = std::string(cwd);
   }
 
   if (const Arg *A = Args.getLastArg(options::OPT_debug_info_format)) {
@@ -1182,7 +1183,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   for (const Arg *A : Args.filtered(OPT_Xcc)) {
     StringRef Opt = A->getValue();
     if (Opt.startswith("-D") || Opt.startswith("-U"))
-      Opts.ClangDefines.push_back(Opt);
+      Opts.ClangDefines.push_back(std::string(Opt));
   }
 
   for (const Arg *A : Args.filtered(OPT_l, OPT_framework)) {
@@ -1226,7 +1227,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   Opts.FunctionSections = Args.hasArg(OPT_function_sections);
 
   if (Args.hasArg(OPT_autolink_force_load))
-    Opts.ForceLoadSymbolName = Args.getLastArgValue(OPT_module_link_name);
+    Opts.ForceLoadSymbolName =
+        std::string(Args.getLastArgValue(OPT_module_link_name));
 
   Opts.ModuleName = FrontendOpts.ModuleName;
 
@@ -1459,8 +1461,8 @@ static bool ParseMigratorArgs(MigratorOptions &Opts,
       llvm::SmallString<128> authoredDataPath(basePath);
       llvm::sys::path::append(authoredDataPath, getScriptFileName("overlay", langVer));
       // Add authored list first to take higher priority.
-      Opts.APIDigesterDataStorePaths.push_back(authoredDataPath.str());
-      Opts.APIDigesterDataStorePaths.push_back(dataPath.str());
+      Opts.APIDigesterDataStorePaths.push_back(std::string(authoredDataPath));
+      Opts.APIDigesterDataStorePaths.push_back(std::string(dataPath));
     }
   }
 
@@ -1589,12 +1591,13 @@ CompilerInvocation::loadFromSerializedAST(StringRef data) {
   LangOpts.EffectiveLanguageVersion = info.compatibilityVersion;
   setTargetTriple(info.targetTriple);
   if (!extendedInfo.getSDKPath().empty())
-    setSDKPath(extendedInfo.getSDKPath());
+    setSDKPath(std::string(extendedInfo.getSDKPath()));
 
   auto &extraClangArgs = getClangImporterOptions().ExtraArgs;
-  extraClangArgs.insert(extraClangArgs.end(),
-                        extendedInfo.getExtraClangImporterOptions().begin(),
-                        extendedInfo.getExtraClangImporterOptions().end());
+  auto extraClangImporterOptions = extendedInfo.getExtraClangImporterOptions();
+  for (const StringRef &option : extraClangImporterOptions) {
+    extraClangArgs.push_back(std::string(option));
+  }
   return info.status;
 }
 

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -350,7 +350,7 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
     llvm::SmallString<256> Buf;
     Expected.MessageRange = MatchStart.slice(2, End);
     Expected.MessageStr =
-      Lexer::getEncodedStringSegment(Expected.MessageRange, Buf);
+        std::string(Lexer::getEncodedStringSegment(Expected.MessageRange, Buf));
     if (PrevExpectedContinuationLine)
       Expected.LineNo = PrevExpectedContinuationLine;
     else
@@ -787,4 +787,3 @@ bool swift::verifyDiagnostics(SourceManager &SM, ArrayRef<unsigned> BufferIDs,
 
   return HadError;
 }
-

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -721,7 +721,7 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
   }
   if (shouldImplicityImportSwiftOnoneSupportModule(Invocation)) {
     Invocation.getFrontendOptions().ImplicitImportModuleNames.push_back(
-        SWIFT_ONONE_SUPPORT);
+        std::string(SWIFT_ONONE_SUPPORT));
   }
 
   const ImplicitImports implicitImports(*this);

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -77,7 +77,7 @@ void ModuleInterfaceBuilder::configureSubInvocationInputsAndOutputs(
   SOPs.ModuleOutputPath = OutPath.str();
 
   // Pick a primary output path that will cause problems to use.
-  StringRef MainOut = "/<unused>";
+  std::string MainOut = "/<unused>";
   SubFEOpts.InputsAndOutputs
   .setMainAndSupplementaryOutputs({MainOut}, {SOPs});
 }
@@ -98,7 +98,7 @@ void ModuleInterfaceBuilder::configureSubInvocation(
   subInvocation.setModuleName(moduleName);
   subInvocation.setClangModuleCachePath(moduleCachePath);
   subInvocation.getFrontendOptions().PrebuiltModuleCachePath =
-  prebuiltCachePath;
+      std::string(prebuiltCachePath);
   subInvocation.getFrontendOptions().TrackSystemDeps = trackSystemDependencies;
 
   // Respect the detailed-record preprocessor setting of the parent context.
@@ -346,7 +346,7 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     // Setup the callbacks for serialization, which can occur during the
     // optimization pipeline.
     SerializationOptions SerializationOpts;
-    std::string OutPathStr = OutPath;
+    std::string OutPathStr(OutPath);
     SerializationOpts.OutputPath = OutPathStr.c_str();
     SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
     SerializationOpts.AutolinkForceLoad =

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -46,14 +46,13 @@ std::string
 swift::getModuleCachePathFromClang(const clang::CompilerInstance &Clang) {
   if (!Clang.hasPreprocessor())
     return "";
-  std::string SpecificModuleCachePath = Clang.getPreprocessor()
-    .getHeaderSearchInfo()
-    .getModuleCachePath();
+  auto SpecificModuleCachePath =
+      Clang.getPreprocessor().getHeaderSearchInfo().getModuleCachePath();
 
   // The returned-from-clang module cache path includes a suffix directory
   // that is specific to the clang version and invocation; we want the
   // directory above that.
-  return llvm::sys::path::parent_path(SpecificModuleCachePath);
+  return std::string(llvm::sys::path::parent_path(SpecificModuleCachePath));
 }
 
 #pragma mark - Forwarding Modules
@@ -241,7 +240,8 @@ struct ModuleRebuildInfo {
     for (auto &mod : outOfDateModules) {
       if (mod.path == path) return mod;
     }
-    outOfDateModules.push_back({path, None, ModuleKind::Normal, {}, {}});
+    outOfDateModules.push_back(
+        {std::string(path), None, ModuleKind::Normal, {}, {}});
     return outOfDateModules.back();
   }
 
@@ -261,14 +261,14 @@ struct ModuleRebuildInfo {
   /// at \c modulePath.
   void addOutOfDateDependency(StringRef modulePath, StringRef depPath) {
     getOrInsertOutOfDateModule(modulePath)
-      .outOfDateDependencies.push_back(depPath);
+        .outOfDateDependencies.push_back(std::string(depPath));
   }
 
   /// Registers a missing dependency at \c depPath for the module
   /// at \c modulePath.
   void addMissingDependency(StringRef modulePath, StringRef depPath) {
     getOrInsertOutOfDateModule(modulePath)
-      .missingDependencies.push_back(depPath);
+        .missingDependencies.push_back(std::string(depPath));
   }
 
   /// Determines if we saw the given module path and registered is as out of

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -96,7 +96,7 @@
 using namespace swift;
 
 static std::string displayName(StringRef MainExecutablePath) {
-  std::string Name = llvm::sys::path::stem(MainExecutablePath);
+  std::string Name(llvm::sys::path::stem(MainExecutablePath));
   Name += " -frontend";
   return Name;
 }
@@ -307,11 +307,11 @@ static void computeSwiftModuleTraceInfo(
       }
 
       // FIXME: Better error handling
-      StringRef realDepPath
-        = fs::real_path(depPath, buffer, /*expand_tile*/true)
-        ? StringRef(depPath) // Couldn't find the canonical path, assume
-                             // this is good enough.
-        : buffer.str();
+      std::string realDepPath(
+          fs::real_path(depPath, buffer, /*expand_tile*/ true)
+              ? StringRef(depPath) // Couldn't find the canonical path, assume
+                                   // this is good enough.
+              : buffer.str());
 
       traceInfo.push_back({
         /*Name=*/
@@ -434,9 +434,7 @@ static bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
   LoadedModuleTraceFormat trace = {
       /*version=*/LoadedModuleTraceFormat::CurrentVersion,
       /*name=*/mainModule->getName(),
-      /*arch=*/ctxt.LangOpts.Target.getArchName(),
-      swiftModules
-  };
+      /*arch=*/std::string(ctxt.LangOpts.Target.getArchName()), swiftModules};
 
   // raw_fd_ostream is unbuffered, and we may have multiple processes writing,
   // so first write to memory and then dump the buffer to the trace file.
@@ -590,7 +588,7 @@ private:
     if (!(FixitAll || shouldTakeFixit(Info)))
       return;
     for (const auto &Fix : Info.FixIts) {
-      AllEdits.push_back({SM, Fix.getRange(), Fix.getText()});
+      AllEdits.push_back({SM, Fix.getRange(), std::string(Fix.getText())});
     }
   }
 
@@ -1703,7 +1701,7 @@ static bool dumpAPI(ModuleDecl *Mod, StringRef OutDir) {
     SmallString<256> Path = OutDir;
     StringRef Filename = SF->getFilename();
     path::append(Path, path::filename(Filename));
-    return Path.str();
+    return std::string(Path);
   };
 
   std::unordered_set<std::string> Filenames;

--- a/lib/IDE/APIDigesterData.cpp
+++ b/lib/IDE/APIDigesterData.cpp
@@ -87,7 +87,7 @@ CommonDiffItem(SDKNodeKind NodeKind, NodeAnnotation DiffKind,
   ChildIndex.split(Pieces, ":");
   std::transform(Pieces.begin(), Pieces.end(),
                  std::back_inserter(ChildIndexPieces),
-                 [](StringRef Piece) { return std::stoi(Piece); });
+                 [](StringRef Piece) { return std::stoi(std::string(Piece)); });
 }
 
 StringRef swift::ide::api::CommonDiffItem::head() {
@@ -319,7 +319,7 @@ static StringRef getScalarString(llvm::yaml::Node *N) {
 };
 
 static int getScalarInt(llvm::yaml::Node *N) {
-  return std::stoi(cast<llvm::yaml::ScalarNode>(N)->getRawValue());
+  return std::stoi(std::string(cast<llvm::yaml::ScalarNode>(N)->getRawValue()));
 };
 
 static APIDiffItem*

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5565,24 +5565,26 @@ void CodeCompletionCallbacksImpl::doneParsing() {
 
       std::vector<std::string> AccessPath;
       for (auto Piece : Path) {
-        AccessPath.push_back(Piece.Item.str());
+        AccessPath.push_back(std::string(Piece.Item.str()));
       }
 
-      StringRef ModuleFilename = TheModule->getModuleFilename();
+      std::string ModuleFilename(TheModule->getModuleFilename());
       // ModuleFilename can be empty if something strange happened during
       // module loading, for example, the module file is corrupted.
       if (!ModuleFilename.empty()) {
         auto &Ctx = TheModule->getASTContext();
         CodeCompletionCache::Key K{
-          ModuleFilename, TheModule->getName().str(), AccessPath,
-              Request.NeedLeadingDot,
-              SF.hasTestableOrPrivateImport(
-                  AccessLevel::Internal, TheModule,
-                  SourceFile::ImportQueryKind::TestableOnly),
-              SF.hasTestableOrPrivateImport(
-                  AccessLevel::Internal, TheModule,
-                  SourceFile::ImportQueryKind::PrivateOnly),
-          Ctx.LangOpts.CodeCompleteInitsInPostfixExpr};
+            ModuleFilename,
+            std::string(TheModule->getName().str()),
+            AccessPath,
+            Request.NeedLeadingDot,
+            SF.hasTestableOrPrivateImport(
+                AccessLevel::Internal, TheModule,
+                SourceFile::ImportQueryKind::TestableOnly),
+            SF.hasTestableOrPrivateImport(
+                AccessLevel::Internal, TheModule,
+                SourceFile::ImportQueryKind::PrivateOnly),
+            Ctx.LangOpts.CodeCompleteInitsInPostfixExpr};
 
         using PairType = llvm::DenseSet<swift::ide::CodeCompletionCache::Key,
             llvm::DenseMapInfo<CodeCompletionCache::Key>>::iterator;

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -437,7 +437,7 @@ static std::string getName(StringRef cacheDirectory,
   llvm::APInt(64, uint64_t(hash)).toStringUnsigned(hashStr, /*Radix*/ 36);
   OSS << "-" << hashStr << ".completions";
 
-  return name.str();
+  return std::string(name);
 }
 
 Optional<CodeCompletionCache::ValueRefCntPtr>
@@ -490,8 +490,8 @@ OnDiskCodeCompletionCache::getFromFile(StringRef filename) {
     return None;
 
   // Make up a key for readCachedModule.
-  CodeCompletionCache::Key K{filename, "<module-name>", {},   false,
-                             false,    false,           false};
+  CodeCompletionCache::Key K{
+      std::string(filename), "<module-name>", {}, false, false, false, false};
 
   // Read the cached results.
   auto V = CodeCompletionCache::createValue();

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -902,7 +902,8 @@ public:
 
     if (FC.IsInStringLiteral()) {
       return std::make_pair(LineRange(LineIndex, 1),
-        swift::ide::getTextForLine(LineIndex, Text, /*Trim*/false));
+                            std::string(swift::ide::getTextForLine(
+                                LineIndex, Text, /*Trim*/ false)));
     }
 
     // Take the current indent position of the outer context, then add another
@@ -944,7 +945,8 @@ public:
     }
 
     // Reformat the specified line with the calculated indent.
-    StringRef Line = swift::ide::getTextForLine(LineIndex, Text, /*Trim*/true);
+    std::string Line(
+        swift::ide::getTextForLine(LineIndex, Text, /*Trim*/ true));
     std::string IndentedLine;
     if (FmtOptions.UseTabs)
       IndentedLine.assign(ExpandedIndent / FmtOptions.TabWidth, '\t');
@@ -1082,4 +1084,3 @@ std::pair<LineRange, std::string> swift::ide::reformat(LineRange Range,
                                                       walker.getTokens(),
                                                       Line).collect());
 }
-

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -159,7 +159,7 @@ static void printTypeNameToString(Type Ty, std::string &Text) {
   SmallString<128> Buffer;
   llvm::raw_svector_ostream OS(Buffer);
   Ty->print(OS);
-  Text = OS.str();
+  Text = std::string(OS.str());
 }
 
 bool swift::ide::

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -248,7 +248,7 @@ void REPLCompletions::populate(SourceFile &SF, StringRef EnteredCode) {
   if (!Tokens.empty()) {
     Token &LastToken = Tokens.back();
     if (LastToken.is(tok::identifier) || LastToken.isKeyword()) {
-      Prefix = LastToken.getText();
+      Prefix = std::string(LastToken.getText());
 
       unsigned Offset = Ctx.SourceMgr.getLocOffsetInBuffer(LastToken.getLoc(),
                                                            BufferID);
@@ -275,7 +275,7 @@ StringRef REPLCompletions::getRoot() const {
     return Root.getValue();
   }
 
-  std::string RootStr = CookedResults[0].InsertableString;
+  std::string RootStr(CookedResults[0].InsertableString);
   for (auto R : CookedResults) {
     if (R.NumBytesToErase != 0) {
       RootStr.resize(0);
@@ -312,4 +312,3 @@ REPLCompletions::CookedResult REPLCompletions::getNextStem() {
 }
 
 void REPLCompletions::reset() { State = CompletionState::Invalid; }
-

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2986,8 +2986,9 @@ static std::string insertUnderscore(StringRef Text) {
 
 static void insertUnderscoreInDigits(StringRef Digits,
                                      llvm::raw_ostream &OS) {
-  std::string BeforePoint, AfterPoint;
-  std::tie(BeforePoint, AfterPoint) = Digits.split('.');
+  StringRef BeforePointRef, AfterPointRef;
+  std::tie(BeforePointRef, AfterPointRef) = Digits.split('.');
+  std::string BeforePoint(BeforePointRef), AfterPoint(AfterPointRef);
 
   // Insert '_' for the part before the decimal point.
   std::reverse(BeforePoint.begin(), BeforePoint.end());
@@ -3486,7 +3487,7 @@ refactorSwiftModule(ModuleDecl *M, RefactoringOptions Opts,
 
   // Use the default name if not specified.
   if (Opts.PreferredName.empty()) {
-    Opts.PreferredName = getDefaultPreferredName(Opts.Kind);
+    Opts.PreferredName = std::string(getDefaultPreferredName(Opts.Kind));
   }
 
   switch (Opts.Kind) {

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -345,7 +345,7 @@ bool ide::initInvocationByClangArguments(ArrayRef<const char *> ArgList,
     llvm::SmallString<64> Str;
     Str += "-fmodule-name=";
     Str += ClangInvok->getLangOpts()->CurrentModule;
-    CCArgs.push_back(Str.str());
+    CCArgs.push_back(std::string(Str.str()));
   }
 
   if (PPOpts.DetailedRecord) {
@@ -354,7 +354,7 @@ bool ide::initInvocationByClangArguments(ArrayRef<const char *> ArgList,
 
   if (!ClangInvok->getFrontendOpts().Inputs.empty()) {
     Invok.getFrontendOptions().ImplicitObjCHeaderPath =
-      ClangInvok->getFrontendOpts().Inputs[0].getFile();
+        std::string(ClangInvok->getFrontendOpts().Inputs[0].getFile());
   }
 
   return false;
@@ -497,7 +497,7 @@ static std::string getPlistEntry(const llvm::Twine &Path, StringRef KeyName) {
       std::tie(CurLine, Lines) = Lines.split('\n');
       unsigned Begin = CurLine.find("<string>") + strlen("<string>");
       unsigned End = CurLine.find("</string>");
-      return CurLine.substr(Begin, End-Begin);
+      return std::string(CurLine.substr(Begin, End - Begin));
     }
   }
 
@@ -508,7 +508,8 @@ std::string ide::getSDKName(StringRef Path) {
   std::string Name = getPlistEntry(llvm::Twine(Path)+"/SDKSettings.plist",
                                    "CanonicalName");
   if (Name.empty() && Path.endswith(".sdk")) {
-    Name = llvm::sys::path::filename(Path).drop_back(strlen(".sdk"));
+    Name =
+        std::string(llvm::sys::path::filename(Path).drop_back(strlen(".sdk")));
   }
   return Name;
 }
@@ -850,7 +851,7 @@ struct swift::ide::SourceEditJsonConsumer::Implementation {
   }
   void accept(SourceManager &SM, CharSourceRange Range,
               llvm::StringRef Text) {
-    AllEdits.push_back({SM, Range, Text});
+    AllEdits.push_back({SM, Range, std::string(Text)});
   }
 };
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -992,10 +992,10 @@ namespace {
         abiName = synthesizedTypeAttr->originalTypeName;
 
         getMutableImportInfo().RelatedEntityName =
-          synthesizedTypeAttr->getManglingName();
+            std::string(synthesizedTypeAttr->getManglingName());
 
-      // Otherwise, if this was imported from a Clang declaration, use that
-      // declaration's name as the ABI name.
+        // Otherwise, if this was imported from a Clang declaration, use that
+        // declaration's name as the ABI name.
       } else if (auto clangDecl =
                             Mangle::ASTMangler::getClangDeclForMangling(Type)) {
         abiName = clangDecl->getName();
@@ -1012,7 +1012,7 @@ namespace {
       // If the ABI name differs from the user-facing name, add it as
       // an override.
       if (!abiName.empty() && abiName != UserFacingName) {
-        getMutableImportInfo().ABIName = abiName;
+        getMutableImportInfo().ABIName = std::string(abiName);
       }
     }
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -511,7 +511,7 @@ llvm::Constant *IRGenModule::getAddrOfObjCSelectorRef(SILDeclRef method) {
 
 std::string IRGenModule::getObjCSelectorName(SILDeclRef method) {
   assert(method.isForeign);
-  return Selector(method).str();
+  return std::string(Selector(method).str());
 }
 
 static llvm::Value *emitSuperArgument(IRGenFunction &IGF,

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1193,7 +1193,7 @@ static std::string getReflectionSectionName(IRGenModule &IGM,
     OS << "__TEXT,__swift5_" << LongName << ", regular, no_dead_strip";
     break;
   }
-  return OS.str();
+  return std::string(OS.str());
 }
 
 const char *IRGenModule::getFieldTypeMetadataSectionName() {

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -405,7 +405,7 @@ std::string LinkEntity::mangleAsString() const {
   }
 
   case Kind::SILGlobalVariable:
-    return getSILGlobalVariable()->getName();
+    return std::string(getSILGlobalVariable()->getName());
 
   case Kind::ReflectionBuiltinDescriptor:
     return mangler.mangleReflectionBuiltinDescriptor(getType());

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -300,7 +300,8 @@ llvm::Constant *IRGenModule::getAddrOfStringForMetadataRef(
 
 llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(StringRef str,
                                                        MangledTypeRefRole role){
-  return getAddrOfStringForTypeRef(SymbolicMangling{str, {}}, role);
+  return getAddrOfStringForTypeRef(SymbolicMangling{std::string(str), {}},
+                                   role);
 }
 
 llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -337,8 +337,9 @@ recordSourceFile(SourceFile *SF, StringRef indexStorePath,
                  llvm::function_ref<void(StringRef, StringRef)> callback) {
   std::string recordFile;
   bool failed = false;
-  auto consumer = makeRecordingConsumer(SF->getFilename(), indexStorePath,
-                                        &diags, &recordFile, &failed);
+  auto consumer = makeRecordingConsumer(std::string(SF->getFilename()),
+                                        std::string(indexStorePath), &diags,
+                                        &recordFile, &failed);
   indexSourceFile(SF, *consumer);
 
   if (!failed && !recordFile.empty())
@@ -407,13 +408,13 @@ static void addModuleDependencies(ArrayRef<ModuleDecl::ImportedModule> imports,
       case FileUnitKind::ClangModule: {
         auto *LFU = cast<LoadedFile>(FU);
         if (auto F = fileMgr.getFile(LFU->getFilename())) {
-          std::string moduleName = mod->getNameStr();
+          std::string moduleName(mod->getNameStr());
           bool withoutUnitName = true;
           if (FU->getKind() == FileUnitKind::ClangModule) {
             withoutUnitName = false;
             auto clangModUnit = cast<ClangModuleUnit>(LFU);
             if (auto clangMod = clangModUnit->getUnderlyingClangModule()) {
-              moduleName = clangMod->getTopLevelModuleName();
+              moduleName = std::string(clangMod->getTopLevelModuleName());
               // FIXME: clang's -Rremarks do not seem to go through Swift's
               // diagnostic emitter.
               clang::index::emitIndexDataForModuleFile(clangMod,
@@ -455,7 +456,7 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
                                  DiagnosticEngine &diags,
                                  IndexUnitWriter &parentUnitWriter) {
   StringRef filename = module->getModuleFilename();
-  std::string moduleName = module->getNameStr();
+  std::string moduleName(module->getNameStr());
 
   std::string error;
   auto isUptodateOpt = parentUnitWriter.isUnitUpToDateForOutputFile(/*FilePath=*/filename,
@@ -477,8 +478,9 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
   if (!module->isStdlibModule()) {
     std::string recordFile;
     bool failed = false;
-    auto consumer = makeRecordingConsumer(filename, indexStorePath,
-                                          &diags, &recordFile, &failed);
+    auto consumer = makeRecordingConsumer(std::string(filename),
+                                          std::string(indexStorePath), &diags,
+                                          &recordFile, &failed);
     indexModule(module, *consumer);
 
     if (failed)
@@ -522,7 +524,9 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
       appendGroupNameForFilename(groupName, fileNameWithGroup);
 
       std::string outRecordFile;
-      failed = failed || writeRecord(tracker, fileNameWithGroup.str(), indexStorePath, &diags, outRecordFile);
+      failed = failed ||
+               writeRecord(tracker, std::string(fileNameWithGroup),
+                           std::string(indexStorePath), &diags, outRecordFile);
       if (failed)
         return false;
       records.emplace_back(outRecordFile, moduleName.str());
@@ -538,7 +542,7 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
   // FIXME: Get real values for the following.
   StringRef swiftVersion;
   StringRef sysrootPath = clangCI.getHeaderSearchOpts().Sysroot;
-  std::string indexUnitToken = module->getModuleFilename();
+  std::string indexUnitToken(module->getModuleFilename());
   // For indexing serialized modules 'debug compilation' is irrelevant, so
   // set it to true by default.
   bool isDebugCompilation = true;

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -340,7 +340,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     if (auto CI = dyn_cast<CommonDiffItem>(Item)) {
       if (CI->isRename() && (CI->NodeKind == SDKNodeKind::DeclVar ||
                              CI->NodeKind == SDKNodeKind::DeclType)) {
-        Text = CI->getNewName();
+        Text = std::string(CI->getNewName());
         return true;
       }
     }
@@ -385,7 +385,8 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     SF->getTopLevelDecls(TopDecls);
     for (auto *D: TopDecls) {
       if (auto *FD = dyn_cast<FuncDecl>(D)) {
-        InsertedFunctions.insert(FD->getBaseName().getIdentifier().str());
+        InsertedFunctions.insert(
+            std::string(FD->getBaseName().getIdentifier().str()));
       }
     }
 
@@ -393,7 +394,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     for (auto &Cur: HelperFuncInfo) {
       if (Cur.ExpressionToWrap)
         continue;
-      auto FuncName = Cur.getFuncName();
+      std::string FuncName(Cur.getFuncName());
       // Avoid inserting the helper function if it's already present.
       if (!InsertedFunctions.count(FuncName)) {
         Editor.insert(FileEndLoc, Cur.getFuncDef());
@@ -427,7 +428,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       // from type alias to raw-value representable.
       if (isRecognizedTypeAliasChange(Cur.ExpressionToWrap))
         continue;
-      auto FuncName = Cur.getFuncName();
+      std::string FuncName(Cur.getFuncName());
 
       // Avoid inserting the helper function if it's already present.
       if (!InsertedFunctions.count(FuncName)) {
@@ -937,8 +938,8 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
                      " {key, value in (key.rawValue, value)})");
       break;
     case NodeAnnotation::SimpleStringRepresentableUpdate:
-      Segs = {"", "", RawType};
-      Segs.push_back(NewType);
+      Segs = {"", "", std::string(RawType)};
+      Segs.push_back(std::string(NewType));
       Segs.push_back((Twine("\treturn ") + NewType + "(rawValue: input)").str());
       Segs.push_back("\treturn input.rawValue");
       break;

--- a/lib/Migrator/EditorAdapter.cpp
+++ b/lib/Migrator/EditorAdapter.cpp
@@ -33,7 +33,7 @@ EditorAdapter::cacheReplacement(CharSourceRange Range, StringRef Text) const {
     return false;
   unsigned SwiftBufferID, Offset;
   std::tie(SwiftBufferID, Offset) = getLocInfo(Range.getStart());
-  Replacement R { Offset, Range.getByteLength(), Text };
+  Replacement R{Offset, Range.getByteLength(), std::string(Text)};
   if (Replacements.count(R)) {
     return true;
   } else {

--- a/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
+++ b/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
@@ -58,7 +58,7 @@ void FixitApplyDiagnosticConsumer::handleDiagnostic(
       continue;
 
     // Ignore pre-applied equivalents.
-    Replacement R { Offset, Length, Text };
+    Replacement R{Offset, Length, std::string(Text)};
     if (Replacements.count(R)) {
       continue;
     } else {

--- a/lib/Migrator/MigrationState.cpp
+++ b/lib/Migrator/MigrationState.cpp
@@ -25,11 +25,11 @@ using namespace swift::migrator;
 #pragma mark - MigrationState
 
 std::string MigrationState::getInputText() const {
-  return SrcMgr.getEntireTextForBuffer(InputBufferID);
+  return std::string(SrcMgr.getEntireTextForBuffer(InputBufferID));
 }
 
 std::string MigrationState::getOutputText() const {
-  return SrcMgr.getEntireTextForBuffer(OutputBufferID);
+  return std::string(SrcMgr.getEntireTextForBuffer(OutputBufferID));
 }
 
 static bool quickDumpText(StringRef OutFilename, StringRef Text) {

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -279,7 +279,8 @@ void printRemap(const StringRef OriginalFilename,
   assert(!OriginalFilename.empty());
 
   diff_match_patch<std::string> DMP;
-  const auto Diffs = DMP.diff_main(InputText, OutputText, /*checkLines=*/false);
+  const auto Diffs = DMP.diff_main(
+      std::string(InputText), std::string(OutputText), /*checkLines=*/false);
 
   OS << "[";
 
@@ -354,7 +355,7 @@ void printRemap(const StringRef OriginalFilename,
       continue;
     Current.Offset -= 1;
     Current.Remove += 1;
-    Current.Text = InputText.substr(Current.Offset, 1);
+    Current.Text = std::string(InputText.substr(Current.Offset, 1));
   }
 
   for (auto Rep = Replacements.begin(); Rep != Replacements.end(); ++Rep) {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1101,7 +1101,7 @@ static bool parseDeclSILOptional(bool *isTransparent,
       }
   
       // Drop the double quotes.
-      StringRef rawString = SP.P.Tok.getText().drop_front().drop_back();
+      std::string rawString(SP.P.Tok.getText().drop_front().drop_back());
       Semantics->push_back(rawString);
       SP.P.consumeToken(tok::string_literal);
 

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -131,7 +131,7 @@ void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
   case RK_Closure: {
     SymbolicClosure *clo = getClosure();
     SILFunction *target = clo->getTarget();
-    std::string targetName = target->getName();
+    std::string targetName(target->getName());
     os << "closure: target: " << targetName;
     ArrayRef<SymbolicClosureArgument> args = clo->getCaptures();
     os << " captures [\n";

--- a/lib/SIL/SILCoverageMap.cpp
+++ b/lib/SIL/SILCoverageMap.cpp
@@ -34,7 +34,7 @@ SILCoverageMap::create(SILModule &M, StringRef Filename, StringRef Name,
   // Store a copy of the names so that we own the lifetime.
   CM->Filename = M.allocateCopy(Filename);
   CM->Name = M.allocateCopy(Name);
-  CM->PGOFuncName = M.allocateCopy(PGOFuncName);
+  CM->PGOFuncName = std::string(M.allocateCopy(PGOFuncName));
 
   // Since we have two arrays, we need to manually tail allocate each of them,
   // rather than relying on the flexible array trick.

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -698,7 +698,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
             mangleClangDecl(SS, namedClangDecl, getDecl()->getASTContext());
             return SS.str();
           }
-          return namedClangDecl->getName();
+          return std::string(namedClangDecl->getName());
         }
       }
     }
@@ -732,13 +732,13 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
       if (!NameA->Name.empty() &&
           !isForeignToNativeThunk() && !isNativeToForeignThunk()
           && !isCurried) {
-        return NameA->Name;
+        return std::string(NameA->Name);
       }
       
     // Use a given cdecl name for native-to-foreign thunks.
     if (auto CDeclA = getDecl()->getAttrs().getAttribute<CDeclAttr>())
       if (isNativeToForeignThunk()) {
-        return CDeclA->Name;
+        return std::string(CDeclA->Name);
       }
 
     // Otherwise, fall through into the 'other decl' case.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4884,7 +4884,7 @@ std::string SILGenFunction::getMagicFileString(SourceLoc loc) {
   auto path = getMagicFilePathString(loc);
 
   if (!getASTContext().LangOpts.EnableConcisePoundFile)
-    return path;
+    return std::string(path);
 
   auto value = llvm::sys::path::filename(path).str();
   value += " (";

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -29,7 +29,7 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
   {
     auto SILGenName = gDecl->getAttrs().getAttribute<SILGenNameAttr>();
     if (SILGenName && !SILGenName->Name.empty()) {
-      mangledName = SILGenName->Name;
+      mangledName = std::string(SILGenName->Name);
     } else {
       Mangle::ASTMangler NewMangler;
       mangledName = NewMangler.mangleGlobalVariableFull(gDecl);
@@ -272,4 +272,3 @@ void SILGenFunction::emitGlobalAccessor(VarDecl *global,
   (void)ret;
   assert(ret->getDebugScope() && "instruction without scope");
 }
-

--- a/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
@@ -509,7 +509,7 @@ static Identifier getBinaryFunction(StringRef Name, SILType IntSILTy,
   auto IntTy = IntSILTy.castTo<BuiltinIntegerType>();
   unsigned NumBits = IntTy->getWidth().getFixedWidth();
   // Name is something like: add_Int64
-  std::string NameStr = Name;
+  std::string NameStr(Name);
   NameStr += "_Int" + llvm::utostr(NumBits);
   return C.getIdentifier(NameStr);
 }

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -351,7 +351,7 @@ DIMemoryObjectInfo::getPathStringToElement(unsigned Element,
     Result = "self";
   else if (ValueDecl *VD =
                dyn_cast_or_null<ValueDecl>(getLoc().getAsASTNode<Decl>()))
-    Result = VD->getBaseName().getIdentifier().str();
+    Result = std::string(VD->getBaseName().getIdentifier().str());
   else
     Result = "<unknown>";
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2111,7 +2111,7 @@ static Identifier getBinaryFunction(StringRef Name, SILType IntSILTy,
   auto IntTy = IntSILTy.castTo<BuiltinIntegerType>();
   unsigned NumBits = IntTy->getWidth().getFixedWidth();
   // Name is something like: add_Int64
-  std::string NameStr = Name;
+  std::string NameStr(Name);
   NameStr += "_Int" + llvm::utostr(NumBits);
 
   return C.getIdentifier(NameStr);

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -738,7 +738,7 @@ void SILPassManager::resetAndRemoveTransformations() {
 }
 
 void SILPassManager::setStageName(llvm::StringRef NextStage) {
-  StageName = NextStage;
+  StageName = std::string(NextStage);
 }
 
 StringRef SILPassManager::getStageName() const {
@@ -940,7 +940,7 @@ namespace llvm {
 
     std::string getNodeLabel(const CallGraph::Node *Node,
                              const CallGraph *Graph) {
-      std::string Label = Node->F->getName();
+      std::string Label = std::string(Node->F->getName());
       wrap(Label, Node->NumCallSites);
       return Label;
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5473,7 +5473,7 @@ bool ArgumentMismatchFailure::diagnoseUseOfReferenceEqualityOperator() const {
   // comparison with nil is illegal, albeit for different reasons spelled
   // out by the diagnosis.
   if (isa<NilLiteralExpr>(lhs) || isa<NilLiteralExpr>(rhs)) {
-    std::string revisedName = name.str();
+    std::string revisedName(name.str());
     revisedName.pop_back();
 
     auto loc = binaryOp->getLoc();
@@ -5600,7 +5600,7 @@ bool ArgumentMismatchFailure::diagnoseArchetypeMismatch() const {
         OS << " '" << decl->getFullName() << "'";
     }
 
-    return OS.str();
+    return std::string(OS.str());
   };
 
   emitDiagnostic(

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -568,7 +568,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
   if (auto declRefExpr = dyn_cast<DeclRefExpr>(fn)) {
     auto decl = declRefExpr->getDecl();
     candidates.push_back({ decl, skipCurriedSelf(decl) });
-    declName = decl->getBaseName().userFacingName();
+    declName = std::string(decl->getBaseName().userFacingName());
     return;
   }
   
@@ -589,7 +589,8 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
     }
     
     if (!candidates.empty())
-      declName = candidates[0].getDecl()->getBaseName().userFacingName();
+      declName =
+          std::string(candidates[0].getDecl()->getBaseName().userFacingName());
     return;
   }
   
@@ -677,7 +678,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
   // base uncurried by one level, and we refer to the name of the member, not to
   // the name of any base.
   if (auto UDE = dyn_cast<UnresolvedDotExpr>(fn)) {
-    declName = UDE->getName().getBaseName().userFacingName();
+    declName = std::string(UDE->getName().getBaseName().userFacingName());
     hasCurriedSelf = true;
 
     // If base is a module or metatype, this is just a simple
@@ -738,7 +739,8 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
     if (candidates.empty()) continue;
     
     if (declName.empty())
-      declName = candidates[0].getDecl()->getBaseName().userFacingName();
+      declName =
+          std::string(candidates[0].getDecl()->getBaseName().userFacingName());
     return;
   }
   
@@ -873,7 +875,8 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
   }
   
   if (!candidates.empty())
-    declName = candidates[0].getDecl()->getBaseName().userFacingName();
+    declName =
+        std::string(candidates[0].getDecl()->getBaseName().userFacingName());
 }
 
 CalleeCandidateInfo &CalleeCandidateInfo::

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -82,7 +82,7 @@ InstrumenterBase::InstrumenterBase(ASTContext &C, DeclContext *DC)
   const std::string filePrefix = "_pg_file_";
 
   // Setup Module identifier
-  std::string moduleName = TypeCheckDC->getParentModule()->getName().str();
+  std::string moduleName(TypeCheckDC->getParentModule()->getName().str());
   Identifier moduleIdentifier =
       Context.getIdentifier(builtinPrefix + modulePrefix + moduleName);
 
@@ -139,4 +139,3 @@ Expr *InstrumenterBase::buildIDArgumentExpr(Optional<DeclNameRef> name,
   return new (Context) UnresolvedDeclRefExpr(*name, DeclRefKind::Ordinary,
                                              DeclNameLoc(SR.End));
 }
-

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1048,7 +1048,7 @@ static std::string getDeclNameFromContext(DeclContext *dc,
     }
     return result;
   } else {
-    return nominal->getName().str();
+    return std::string(nominal->getName().str());
   }
 }
 

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -64,7 +64,7 @@ class YamlGroupInputParser {
       if (!ParentName.empty()) {
         CombinedName = (llvm::Twine(ParentName) + Separator + GroupName).str();
       } else {
-        CombinedName = GroupName;
+        CombinedName = std::string(GroupName);
       }
 
       for (llvm::yaml::Node &Entry : *Value) {
@@ -75,7 +75,7 @@ class YamlGroupInputParser {
           GroupNameAndFileName.append(CombinedName);
           GroupNameAndFileName.append(Separator);
           GroupNameAndFileName.append(llvm::sys::path::stem(FileName));
-          Map[FileName] = GroupNameAndFileName.str();
+          Map[FileName] = std::string(GroupNameAndFileName);
         } else if (Entry.getType() == llvm::yaml::Node::NodeKind::NK_Mapping) {
           if (parseRoot(Map, &Entry, CombinedName))
             return true;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -433,7 +433,7 @@ std::string SerializedModuleBaseName::getName(file_types::ID fileTy) const {
   result += '.';
   result += file_types::getExtension(fileTy);
 
-  return result.str();
+  return std::string(result);
 }
 
 bool

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -282,7 +282,7 @@ void TBDGenVisitor::addLinkerDirectiveSymbolsLdPrevious(StringRef name,
     if (!IntroVer.hasValue())
       continue;
     auto PlatformNumber = getLinkerPlatformId(Ver);
-    auto It = previousInstallNameMap->find(Ver.ModuleName);
+    auto It = previousInstallNameMap->find(std::string(Ver.ModuleName));
     if (It == previousInstallNameMap->end()) {
       Ctx.Diags.diagnose(SourceLoc(), diag::cannot_find_install_name,
                          Ver.ModuleName, getLinkerPlatformName(Ver));

--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -80,7 +80,7 @@ public:
     }
 
     if (ParsedArgs.getLastArg(OPT_help)) {
-      std::string ExecutableName = llvm::sys::path::stem(MainExecutablePath);
+      std::string ExecutableName(llvm::sys::path::stem(MainExecutablePath));
       Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Autolink Extract", options::AutolinkExtractOption,
                        0, /*ShowAllAliases*/false);
@@ -138,7 +138,7 @@ extractLinkerFlagsFromObjectFile(const llvm::object::ObjectFile *ObjectFile,
       SectionData->split(SplitFlags, llvm::StringRef("\0", 1), -1,
                          /*KeepEmpty=*/false);
       for (const auto &Flag : SplitFlags)
-        LinkerFlags.push_back(Flag);
+        LinkerFlags.push_back(std::string(Flag));
     }
   }
   return false;

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -90,7 +90,7 @@ public:
     }
 
     if (ParsedArgs.getLastArg(OPT_help)) {
-      std::string ExecutableName = llvm::sys::path::stem(MainExecutablePath);
+      std::string ExecutableName(llvm::sys::path::stem(MainExecutablePath));
       Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Module Wrapper", options::ModuleWrapOption, 0,
                        /*ShowAllAliases*/false);
@@ -159,7 +159,7 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   SmallString<128> RuntimeResourcePath;
   CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(
     MainExecutablePath, RuntimeResourcePath);
-  SearchPathOpts.RuntimeResourcePath = RuntimeResourcePath.str();
+  SearchPathOpts.RuntimeResourcePath = std::string(RuntimeResourcePath);
 
   SourceManager SrcMgr;
   TypeCheckerOptions TypeCheckOpts;

--- a/tools/driver/swift_indent_main.cpp
+++ b/tools/driver/swift_indent_main.cpp
@@ -147,7 +147,8 @@ public:
     }
 
     if (ParsedArgs.getLastArg(OPT_help)) {
-      std::string ExecutableName = llvm::sys::path::stem(MainExecutablePath);
+      std::string ExecutableName =
+          std::string(llvm::sys::path::stem(MainExecutablePath));
       Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Format Tool", options::SwiftIndentOption, 0,
                        /*ShowAllAliases*/false);
@@ -183,7 +184,7 @@ public:
       LineRanges.push_back("1:" + std::to_string(UINT_MAX));
     }
 
-    std::string Output = Doc.memBuffer().getBuffer();
+    std::string Output = std::string(Doc.memBuffer().getBuffer());
     for (unsigned Range = 0; Range < LineRanges.size(); ++Range) {
       unsigned FromLine;
       unsigned ToLine;

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -125,7 +125,7 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
       // the old mangling scheme.
       // This makes it easier to share the same database between the
       // mangling and demangling tests.
-      remangled = name;
+      remangled = std::string(name);
     } else {
       remangled = swift::Demangle::mangleNode(pointer);
       unsigned prefixLen = swift::Demangle::getManglingPrefixLength(remangled);
@@ -148,7 +148,7 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
     llvm::outs() << remangled;
     return;
   } else if (RemangleRtMode) {
-    std::string remangled = name;
+    std::string remangled = std::string(name);
     if (pointer) {
       remangled = swift::Demangle::mangleNodeOld(pointer);
     }


### PR DESCRIPTION
 https://github.com/llvm/llvm-project/commit/777180a32b61070a10dd330b4f038bf24e916af1 got rid of implicit casting for llvm::StringRef; it's an expensive operation. This change attempts to respect this upcoming work by dumbly migrating StringRef -> std::string sites (as exposed by my local build).