### PR TITLE
[Constraint system] Make solver less expression-centric, part N/M

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1107,8 +1107,14 @@ Optional<BraceStmt *> TypeChecker::applyFunctionBuilderBodyTransform(
   }
 
   // Apply the solution to the function body.
-  return cast_or_null<BraceStmt>(
-     cs.applySolutionToBody(solutions.front(), func));
+  if (auto result = cs.applySolution(
+          solutions.front(),
+          SolutionApplicationTarget(func),
+          /*performingDiagnostics=*/false)) {
+    return result->getFunctionBody();
+  }
+
+  return nullptr;
 }
 
 ConstraintSystem::TypeMatchResult ConstraintSystem::matchFunctionBuilder(

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7231,14 +7231,14 @@ bool ConstraintSystem::applySolutionFixes(const Solution &solution) {
 
 /// Apply a given solution to the expression, producing a fully
 /// type-checked expression.
-llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
+Optional<SolutionApplicationTarget> ConstraintSystem::applySolutionImpl(
     Solution &solution, SolutionApplicationTarget target, Type convertType,
     bool discardedExpr, bool performingDiagnostics) {
   // If any fixes needed to be applied to arrive at this solution, resolve
   // them to specific expressions.
   if (!solution.Fixes.empty()) {
     if (shouldSuppressDiagnostics())
-      return nullptr;
+      return None;
 
     bool diagnosedErrorsViaFixes = applySolutionFixes(solution);
     // If all of the available fixes would result in a warning,
@@ -7248,12 +7248,12 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
         })) {
       // If we already diagnosed any errors via fixes, that's it.
       if (diagnosedErrorsViaFixes)
-        return nullptr;
+        return None;
 
       // If we didn't manage to diagnose anything well, so fall back to
       // diagnosing mining the system to construct a reasonable error message.
       diagnoseFailureFor(target);
-      return nullptr;
+      return None;
     }
   }
 
@@ -7261,9 +7261,13 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
   ExprWalker walker(rewriter);
 
   // Apply the solution to the target.
-  llvm::PointerUnion<Expr *, Stmt *> result;
+  SolutionApplicationTarget result = target;
   if (auto expr = target.getAsExpr()) {
-    result = expr->walk(walker);
+    Expr *rewrittenExpr = expr->walk(walker);
+    if (!rewrittenExpr)
+      return None;
+
+    result.setExpr(rewrittenExpr);
   } else {
     auto fn = *target.getAsFunction();
 
@@ -7284,13 +7288,10 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
         });
 
     if (!newBody)
-      return result;
+      return None;
 
-    result = newBody;
+    result.setFunctionBody(newBody);
   }
-
-  if (result.isNull())
-    return result;
 
   // If we're re-typechecking an expression for diagnostics, don't
   // visit closures that have non-single expression bodies.
@@ -7309,10 +7310,10 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
 
     // If any of them failed to type check, bail.
     if (hadError)
-      return nullptr;
+      return None;
   }
 
-  if (auto resultExpr = result.dyn_cast<Expr *>()) {
+  if (auto resultExpr = result.getAsExpr()) {
     Expr *expr = target.getAsExpr();
     assert(expr && "Can't have expression result without expression target");
     // We are supposed to use contextual type only if it is present and
@@ -7328,19 +7329,20 @@ llvm::PointerUnion<Expr *, Stmt *> ConstraintSystem::applySolutionImpl(
     // If we're supposed to convert the expression to some particular type,
     // do so now.
     if (shouldCoerceToContextualType()) {
-      result = rewriter.coerceToType(resultExpr, convertType,
-                                     getConstraintLocator(expr));
-      if (!result)
-        return nullptr;
+      resultExpr = rewriter.coerceToType(resultExpr, convertType,
+                                         getConstraintLocator(expr));
     } else if (getType(resultExpr)->hasLValueType() && !discardedExpr) {
       // We referenced an lvalue. Load it.
-      result = rewriter.coerceToType(resultExpr,
-                                     getType(resultExpr)->getRValueType(),
-                                     getConstraintLocator(expr));
+      resultExpr = rewriter.coerceToType(resultExpr,
+                                         getType(resultExpr)->getRValueType(),
+                                         getConstraintLocator(expr));
     }
 
-    if (resultExpr)
-      solution.setExprTypes(resultExpr);
+    if (!resultExpr)
+      return None;
+
+    solution.setExprTypes(resultExpr);
+    result.setExpr(resultExpr);
   }
 
   rewriter.finalize();
@@ -7512,13 +7514,14 @@ MutableArrayRef<Solution> SolutionResult::takeAmbiguousSolutions() && {
   return MutableArrayRef<Solution>(solutions, numSolutions);
 }
 
-llvm::PointerUnion<Expr *, Stmt *> SolutionApplicationTarget::walk(
-    ASTWalker &walker) {
+SolutionApplicationTarget SolutionApplicationTarget::walk(ASTWalker &walker) {
   switch (kind) {
   case Kind::expression:
     return getAsExpr()->walk(walker);
 
   case Kind::function:
-    return getAsFunction()->getBody()->walk(walker);
+    return SolutionApplicationTarget(
+        *getAsFunction(),
+        cast_or_null<BraceStmt>(getFunctionBody()->walk(walker)));
   }
 }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7511,6 +7511,7 @@ ArrayRef<Solution> SolutionResult::getAmbiguousSolutions() const {
 
 MutableArrayRef<Solution> SolutionResult::takeAmbiguousSolutions() && {
   assert(getKind() == Ambiguous);
+  markAsDiagnosed();
   return MutableArrayRef<Solution>(solutions, numSolutions);
 }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7231,7 +7231,7 @@ bool ConstraintSystem::applySolutionFixes(const Solution &solution) {
 
 /// Apply a given solution to the expression, producing a fully
 /// type-checked expression.
-Optional<SolutionApplicationTarget> ConstraintSystem::applySolutionImpl(
+Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     Solution &solution, SolutionApplicationTarget target,
     bool performingDiagnostics) {
   // If any fixes needed to be applied to arrive at this solution, resolve

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7331,7 +7331,8 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     // If we're supposed to convert the expression to some particular type,
     // do so now.
     if (shouldCoerceToContextualType()) {
-      resultExpr = rewriter.coerceToType(resultExpr, convertType,
+      resultExpr = rewriter.coerceToType(resultExpr,
+                                         simplifyType(convertType),
                                          getConstraintLocator(expr));
     } else if (getType(resultExpr)->hasLValueType() &&
                !target.isDiscardedExpr()) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1184,7 +1184,9 @@ bool ConstraintSystem::solve(Expr *&expr,
       }
 
       if (stage == 1) {
-        diagnoseFailureFor(expr);
+        diagnoseFailureFor(
+            SolutionApplicationTarget(expr, convertType,
+                                      /*isDiscarded=*/false));
         solution.markAsDiagnosed();
         return true;
       }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1234,8 +1234,6 @@ ConstraintSystem::solveImpl(SolutionApplicationTarget &target,
   if (auto generatedExpr = generateConstraints(expr, DC))
     expr = generatedExpr;
   else {
-    if (listener)
-      listener->constraintGenerationFailed(expr);
     return SolutionResult::forError();
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1172,7 +1172,6 @@ bool ConstraintSystem::solve(Expr *&expr,
         solutions.assign(std::make_move_iterator(ambiguousSolutions.begin()),
                          std::make_move_iterator(ambiguousSolutions.end()));
         dumpSolutions();
-        solution.markAsDiagnosed();
         return false;
       }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1107,6 +1107,24 @@ static bool debugConstraintSolverForTarget(
   return startBound != endBound;
 }
 
+/// If we aren't certain that we've emitted a diagnostic, emit a fallback
+/// diagnostic.
+static void maybeProduceFallbackDiagnostic(
+    ConstraintSystem &cs, SolutionApplicationTarget target) {
+  if (cs.Options.contains(ConstraintSystemFlags::SubExpressionDiagnostics) ||
+      cs.Options.contains(ConstraintSystemFlags::SuppressDiagnostics))
+    return;
+
+  // Before producing fatal error here, let's check if there are any "error"
+  // diagnostics already emitted or waiting to be emitted. Because they are
+  // a better indication of the problem.
+  ASTContext &ctx = cs.getASTContext();
+  if (ctx.Diags.hadAnyError() || ctx.hasDelayedConformanceErrors())
+    return;
+
+  ctx.Diags.diagnose(target.getLoc(), diag::failed_to_produce_diagnostic);
+}
+
 Optional<std::vector<Solution>> ConstraintSystem::solve(
     SolutionApplicationTarget &target,
     ExprTypeCheckListener *listener,
@@ -1152,6 +1170,7 @@ Optional<std::vector<Solution>> ConstraintSystem::solve(
     }
 
     case SolutionResult::Error:
+      maybeProduceFallbackDiagnostic(*this, target);
       return None;
 
     case SolutionResult::TooComplex:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -4188,40 +4188,16 @@ public:
   findBestSolution(SmallVectorImpl<Solution> &solutions,
                    bool minimize);
 
-private:
-  Optional<SolutionApplicationTarget> applySolutionImpl(
-      Solution &solution, SolutionApplicationTarget target,
-      bool performingDiagnostics);
-
 public:
-  /// Apply a given solution to the expression, producing a fully
-  /// type-checked expression.
+  /// Apply a given solution to the target, producing a fully
+  /// type-checked target or \c None if an error occurred.
   ///
-  /// \param convertType the contextual type to which the
-  /// expression should be converted, if any.
-  /// \param discardedExpr if true, the result of the expression
-  /// is contextually ignored.
+  /// \param target the target to which the solution will be applied.
   /// \param performingDiagnostics if true, don't descend into bodies of
   /// non-single expression closures, or build curry thunks.
-  Expr *applySolution(Solution &solution, Expr *expr,
-                      Type convertType,
-                      bool discardedExpr,
-                      bool performingDiagnostics) {
-    auto result = applySolutionImpl(
-        solution, SolutionApplicationTarget(expr, convertType, discardedExpr),
-        performingDiagnostics);
-    if (result)
-      return result->getAsExpr();
-    return nullptr;
-  }
-
-  /// Apply a given solution to the body of the given function.
-  BraceStmt *applySolutionToBody(Solution &solution, AnyFunctionRef fn) {
-    auto result = applySolutionImpl(solution, fn, false);
-    if (result)
-      return result->getFunctionBody();
-    return nullptr;
-  }
+  Optional<SolutionApplicationTarget> applySolution(
+      Solution &solution, SolutionApplicationTarget target,
+      bool performingDiagnostics);
 
   /// Reorder the disjunctive clauses for a given expression to
   /// increase the likelihood that a favored constraint will be successfully

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1223,6 +1223,17 @@ public:
     assert(kind == Kind::function);
     function.body = stmt;
   }
+
+  /// Retrieve the source range of the target.
+  SourceRange getSourceRange() const {
+    switch (kind) {
+    case Kind::expression:
+      return expression.expression->getSourceRange();
+
+    case Kind::function:
+      return function.body->getSourceRange();
+    }
+  }
   /// Walk the contents of the application target.
   SolutionApplicationTarget walk(ASTWalker &walker);
 };
@@ -4078,13 +4089,11 @@ private:
 
   /// Solve the system of constraints generated from provided expression.
   ///
-  /// \param expr The expression to generate constraints from.
-  /// \param convertType The expected type of the expression.
+  /// \param target The target to generate constraints from.
   /// \param listener The callback to check solving progress.
   /// \param allowFreeTypeVariables How to bind free type variables in
   /// the solution.
-  SolutionResult solveImpl(Expr *&expr,
-                           Type convertType,
+  SolutionResult solveImpl(SolutionApplicationTarget &target,
                            ExprTypeCheckListener *listener,
                            FreeTypeVariableBinding allowFreeTypeVariables
                              = FreeTypeVariableBinding::Disallow);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2035,7 +2035,6 @@ Expr *ExprTypeCheckListener::appliedSolution(Solution &solution, Expr *expr) {
   return expr;
 }
 
-void ExprTypeCheckListener::preCheckFailed(Expr *expr) {}
 void ExprTypeCheckListener::applySolutionFailed(Solution &solution,
                                                 Expr *expr) {}
 
@@ -2095,12 +2094,6 @@ public:
 
   Expr *appliedSolution(Solution &solution, Expr *expr) override {
     return BaseListener ? BaseListener->appliedSolution(solution, expr) : expr;
-  }
-
-  void preCheckFailed(Expr *expr) override {
-    if (BaseListener)
-      BaseListener->preCheckFailed(expr);
-    maybeProduceFallbackDiagnostic(expr);
   }
 
   void applySolutionFailed(Solution &solution, Expr *expr) override {
@@ -2169,7 +2162,6 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   // First, pre-check the expression, validating any types that occur in the
   // expression and folding sequence expressions.
   if (ConstraintSystem::preCheckExpression(expr, dc, baseCS)) {
-    listener.preCheckFailed(expr);
     return Type();
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2036,7 +2036,6 @@ Expr *ExprTypeCheckListener::appliedSolution(Solution &solution, Expr *expr) {
 }
 
 void ExprTypeCheckListener::preCheckFailed(Expr *expr) {}
-void ExprTypeCheckListener::constraintGenerationFailed(Expr *expr) {}
 void ExprTypeCheckListener::applySolutionFailed(Solution &solution,
                                                 Expr *expr) {}
 
@@ -2101,12 +2100,6 @@ public:
   void preCheckFailed(Expr *expr) override {
     if (BaseListener)
       BaseListener->preCheckFailed(expr);
-    maybeProduceFallbackDiagnostic(expr);
-  }
-
-  void constraintGenerationFailed(Expr *expr) override {
-    if (BaseListener)
-      BaseListener->constraintGenerationFailed(expr);
     maybeProduceFallbackDiagnostic(expr);
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -856,15 +856,6 @@ public:
                                             TypeCheckExprOptions(), listener);
   }
 
-private:
-  static Type typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
-                                      TypeLoc convertType,
-                                      ContextualTypePurpose convertTypePurpose,
-                                      TypeCheckExprOptions options,
-                                      ExprTypeCheckListener &listener,
-                                      constraints::ConstraintSystem *baseCS);
-
-public:
   /// Type check the given expression and return its type without
   /// applying the solution.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -320,10 +320,6 @@ public:
   /// failure.
   virtual Expr *appliedSolution(constraints::Solution &solution,
                                 Expr *expr);
-
-  /// Callback invoked if application of chosen solution to
-  /// expression has failed.
-  virtual void applySolutionFailed(constraints::Solution &solution, Expr *expr);
 };
 
 /// A conditional conformance that implied some other requirements. That is, \c

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -305,13 +305,6 @@ public:
   /// constraint system, or false otherwise.
   virtual bool builtConstraints(constraints::ConstraintSystem &cs, Expr *expr);
 
-  /// Callback invoked once a solution has been found.
-  ///
-  /// The callback may further alter the expression, returning either a
-  /// new expression (to replace the result) or a null pointer to indicate
-  /// failure.
-  virtual Expr *foundSolution(constraints::Solution &solution, Expr *expr);
-
   /// Callback invokes once the chosen solution has been applied to the
   /// expression.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -321,10 +321,6 @@ public:
   virtual Expr *appliedSolution(constraints::Solution &solution,
                                 Expr *expr);
 
-  /// Callback invoked if expression is structurally unsound and can't
-  /// be correctly processed by the constraint solver.
-  virtual void preCheckFailed(Expr *expr);
-
   /// Callback invoked if application of chosen solution to
   /// expression has failed.
   virtual void applySolutionFailed(constraints::Solution &solution, Expr *expr);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -325,10 +325,6 @@ public:
   /// be correctly processed by the constraint solver.
   virtual void preCheckFailed(Expr *expr);
 
-  /// Callback invoked if constraint system failed to generate
-  /// constraints for a given expression.
-  virtual void constraintGenerationFailed(Expr *expr);
-
   /// Callback invoked if application of chosen solution to
   /// expression has failed.
   virtual void applySolutionFailed(constraints::Solution &solution, Expr *expr);


### PR DESCRIPTION
Further generalize the constraint solver's entry points to make it less tied to a single expression, which involves a number of steps:
* Expand `SolutionApplicationTarget` so it can hold contextual type information, transformed function bodies, etc. This will capture all of the "top-level" things that we can solve in one shot
* Generalize the expression-centric `solve` to work with a `SolutionApplicationTarget` and make the interface less stateful. We're not yet at the point where we can switch other clients over, but it's closer
* Start hollowing out `ExprTypeCheckListener`, which is tied to the notion of a top-level expression. Focus on the easy parts of it to remove.