### PR TITLE
[AutoDiff] Fix undiagnosed active `modify` accessor applications.

### DIFF
--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -129,7 +129,7 @@ void DifferentiableActivityInfo::propagateVaried(
   // Handle full apply sites: `apply`, `try_apply`, and `begin_apply`.
   if (FullApplySite::isa(inst)) {
     FullApplySite applySite(inst);
-    // If callee is non-varying, skip.
+    // Skip non-varying callees.
     if (isWithoutDerivative(applySite.getCallee()))
       return;
     // If operand is varied, set all direct/indirect results and inout arguments
@@ -207,8 +207,21 @@ void DifferentiableActivityInfo::propagateVaried(
   }
 }
 
+/// Returns the accessor kind of the given SIL function, if it is a lowered
+/// accessor. Otherwise, return `None`.
+static Optional<AccessorKind> getAccessorKind(SILFunction *fn) {
+  auto *dc = fn->getDeclContext();
+  if (!dc)
+    return None;
+  auto *accessor = dyn_cast_or_null<AccessorDecl>(dc->getAsDecl());
+  if (!accessor)
+    return None;
+  return accessor->getAccessorKind();
+}
+
 void DifferentiableActivityInfo::propagateVariedInwardsThroughProjections(
     SILValue value, unsigned independentVariableIndex) {
+  auto i = independentVariableIndex;
   // Skip `@noDerivative` struct projections.
 #define SKIP_NODERIVATIVE(INST)                                                \
   if (auto *sei = dyn_cast<INST##Inst>(value))                                 \
@@ -218,14 +231,36 @@ void DifferentiableActivityInfo::propagateVariedInwardsThroughProjections(
   SKIP_NODERIVATIVE(StructElementAddr)
 #undef SKIP_NODERIVATIVE
   // Set value as varied and propagate to users.
-  setVariedAndPropagateToUsers(value, independentVariableIndex);
+  setVariedAndPropagateToUsers(value, i);
   auto *inst = value->getDefiningInstruction();
-  if (!inst || ApplySite::isa(inst))
+  if (!inst)
     return;
-  // Standard propagation.
+  if (FullApplySite::isa(inst)) {
+    FullApplySite applySite(inst);
+    // Skip non-varying callees.
+    if (isWithoutDerivative(applySite.getCallee()))
+      return;
+    // If callee is a `modify` accessor, propagate variedness from yielded
+    // addresses to `inout` arguments. Semantically, yielded addresses can be
+    // viewed as a projection into the `inout` argument.
+    // Note: the assumption that yielded addresses are always a projection into
+    // the `inout` argument is a safe over-approximation but not always true.
+    if (auto *bai = dyn_cast<BeginApplyInst>(inst)) {
+      if (auto *calleeFn = bai->getCalleeFunction()) {
+        if (getAccessorKind(calleeFn) == AccessorKind::Modify) {
+          for (auto inoutArg : applySite.getInoutArguments())
+            propagateVariedInwardsThroughProjections(inoutArg, i);
+        }
+      }
+    }
+    return;
+  }
+  // Default: propagate variedness through projections to the operands of their
+  // defining instructions. This handles projections like:
+  // - `struct_element_addr`
+  // - `tuple_element_addr`
   for (auto &op : inst->getAllOperands())
-    propagateVariedInwardsThroughProjections(op.get(),
-                                             independentVariableIndex);
+    propagateVariedInwardsThroughProjections(op.get(), i);
 }
 
 void DifferentiableActivityInfo::setUseful(SILValue value,
@@ -267,9 +302,18 @@ void DifferentiableActivityInfo::propagateUseful(
   // Handle full apply sites: `apply`, `try_apply`, and `begin_apply`.
   if (FullApplySite::isa(inst)) {
     FullApplySite applySite(inst);
-    // If callee is non-varying, skip.
-    if (isWithoutDerivative(applySite.getCallee()))
-      return;
+    // If callee is a `modify` accessor, propagate usefulness through yielded
+    // addresses. Semantically, yielded addresses can be viewed as a projection
+    // into the `inout` argument.
+    // Note: the assumption that yielded addresses are always a projection into
+    // the `inout` argument is a safe over-approximation but not always true.
+    if (auto *bai = dyn_cast<BeginApplyInst>(inst)) {
+      if (auto *calleeFn = bai->getCalleeFunction())
+        if (getAccessorKind(calleeFn) == AccessorKind::Modify)
+          for (auto yield : bai->getYieldedValues())
+            setUsefulAndPropagateToOperands(yield, i);
+    }
+    // Propagate usefulness through apply site arguments.
     for (auto arg : applySite.getArgumentsWithoutIndirectResults())
       setUsefulAndPropagateToOperands(arg, i);
   }

--- a/test/AutoDiff/downstream/activity_analysis.swift
+++ b/test/AutoDiff/downstream/activity_analysis.swift
@@ -471,16 +471,16 @@ func testAccessorCoroutines(_ x: HasCoroutineAccessors) -> HasCoroutineAccessors
 // CHECK: [ACTIVE] %0 = argument of bb0 : $HasCoroutineAccessors
 // CHECK: [ACTIVE]   %2 = alloc_stack $HasCoroutineAccessors, var, name "x"
 // CHECK: [ACTIVE]   %4 = begin_access [read] [static] %2 : $*HasCoroutineAccessors
-// CHECK: [VARIED]   %5 = load [trivial] %4 : $*HasCoroutineAccessors
+// CHECK: [ACTIVE]   %5 = load [trivial] %4 : $*HasCoroutineAccessors
 // CHECK: [NONE]   // function_ref HasCoroutineAccessors.computed.read
-// CHECK: [VARIED] (**%7**, %8) = begin_apply %6(%5) : $@yield_once @convention(method) (HasCoroutineAccessors) -> @yields Float
+// CHECK: [ACTIVE] (**%7**, %8) = begin_apply %6(%5) : $@yield_once @convention(method) (HasCoroutineAccessors) -> @yields Float
 // CHECK: [VARIED] (%7, **%8**) = begin_apply %6(%5) : $@yield_once @convention(method) (HasCoroutineAccessors) -> @yields Float
-// CHECK: [VARIED]   %9 = alloc_stack $Float
-// CHECK: [VARIED]   %11 = load [trivial] %9 : $*Float
+// CHECK: [ACTIVE]   %9 = alloc_stack $Float
+// CHECK: [ACTIVE]   %11 = load [trivial] %9 : $*Float
 // CHECK: [ACTIVE]   %14 = begin_access [modify] [static] %2 : $*HasCoroutineAccessors
 // CHECK: [NONE]   // function_ref HasCoroutineAccessors.computed.modify
 // CHECK:   %15 = function_ref @$s17activity_analysis21HasCoroutineAccessorsV8computedSfvM : $@yield_once @convention(method) (@inout HasCoroutineAccessors) -> @yields @inout Float
-// CHECK: [VARIED] (**%16**, %17) = begin_apply %15(%14) : $@yield_once @convention(method) (@inout HasCoroutineAccessors) -> @yields @inout Float
+// CHECK: [ACTIVE] (**%16**, %17) = begin_apply %15(%14) : $@yield_once @convention(method) (@inout HasCoroutineAccessors) -> @yields @inout Float
 // CHECK: [VARIED] (%16, **%17**) = begin_apply %15(%14) : $@yield_once @convention(method) (@inout HasCoroutineAccessors) -> @yields @inout Float
 // CHECK: [ACTIVE]   %22 = begin_access [read] [static] %2 : $*HasCoroutineAccessors
 // CHECK: [ACTIVE]   %23 = load [trivial] %22 : $*HasCoroutineAccessors
@@ -501,7 +501,7 @@ func testBeginApplyActiveInoutArgument(array: [Float], x: Float) -> Float {
 
 // CHECK-LABEL: [AD] Activity info for ${{.*}}testBeginApplyActiveInoutArgument{{.*}} at (source=0 parameters=(0 1))
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Array<Float>
-// CHECK: [VARIED] %1 = argument of bb0 : $Float
+// CHECK: [ACTIVE] %1 = argument of bb0 : $Float
 // CHECK: [ACTIVE]   %4 = alloc_stack $Array<Float>, var, name "array"
 // CHECK: [ACTIVE]   %5 = copy_value %0 : $Array<Float>
 // CHECK: [USEFUL]   %7 = integer_literal $Builtin.IntLiteral, 0
@@ -510,7 +510,7 @@ func testBeginApplyActiveInoutArgument(array: [Float], x: Float) -> Float {
 // CHECK: [USEFUL]   %10 = apply %9(%7, %8) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [ACTIVE]   %11 = begin_access [modify] [static] %4 : $*Array<Float>
 // CHECK: [NONE]   // function_ref Array.subscript.modify
-// CHECK: [VARIED] (**%13**, %14) = begin_apply %12<Float>(%10, %11) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+// CHECK: [ACTIVE] (**%13**, %14) = begin_apply %12<Float>(%10, %11) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
 // CHECK: [VARIED] (%13, **%14**) = begin_apply %12<Float>(%10, %11) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
 // CHECK: [USEFUL]   %18 = integer_literal $Builtin.IntLiteral, 0
 // CHECK: [USEFUL]   %19 = metatype $@thin Int.Type
@@ -522,3 +522,49 @@ func testBeginApplyActiveInoutArgument(array: [Float], x: Float) -> Float {
 // CHECK: [NONE]   // function_ref Array.subscript.getter
 // CHECK: [NONE]   %26 = apply %25<Float>(%24, %21, %23) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
 // CHECK: [ACTIVE]   %27 = load [trivial] %24 : $*Float
+
+// TF-1115: Test `begin_apply` active `inout` argument with non-active initial result.
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func testBeginApplyActiveButInitiallyNonactiveInoutArgument(x: Float) -> Float {
+  // `var array` is initially non-active.
+  var array: [Float] = [0]
+  // Array subscript assignment below calls `Array.subscript.modify`.
+  // expected-note @+1 {{differentiation of coroutine calls is not yet supported}}
+  array[0] = x
+  return array[0]
+}
+
+// CHECK-LABEL: [AD] Activity info for ${{.*}}testBeginApplyActiveButInitiallyNonactiveInoutArgument{{.*}} at (source=0 parameters=(0))
+// CHECK: [ACTIVE] %0 = argument of bb0 : $Float
+// CHECK: [ACTIVE]   %2 = alloc_stack $Array<Float>, var, name "array"
+// CHECK: [USEFUL]   %3 = integer_literal $Builtin.Word, 1
+// CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
+// CHECK: [USEFUL]   %5 = apply %4<Float>(%3) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: [USEFUL] (**%6**, %7) = destructure_tuple %5 : $(Array<Float>, Builtin.RawPointer)
+// CHECK: [NONE] (%6, **%7**) = destructure_tuple %5 : $(Array<Float>, Builtin.RawPointer)
+// CHECK: [USEFUL]   %8 = pointer_to_address %7 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [USEFUL]   %9 = integer_literal $Builtin.IntLiteral, 0
+// CHECK: [USEFUL]   %10 = metatype $@thin Float.Type
+// CHECK: [NONE]   // function_ref Float.init(_builtinIntegerLiteral:)
+// CHECK: [USEFUL]   %12 = apply %11(%9, %10) : $@convention(method) (Builtin.IntLiteral, @thin Float.Type) -> Float
+// CHECK: [USEFUL]   %15 = integer_literal $Builtin.IntLiteral, 0
+// CHECK: [USEFUL]   %16 = metatype $@thin Int.Type
+// CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
+// CHECK: [USEFUL]   %18 = apply %17(%15, %16) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [ACTIVE]   %19 = begin_access [modify] [static] %2 : $*Array<Float>
+// CHECK: [NONE]   // function_ref Array.subscript.modify
+// CHECK: [ACTIVE] (**%21**, %22) = begin_apply %20<Float>(%18, %19) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+// CHECK: [VARIED] (%21, **%22**) = begin_apply %20<Float>(%18, %19) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+// CHECK: [USEFUL]   %26 = integer_literal $Builtin.IntLiteral, 0
+// CHECK: [USEFUL]   %27 = metatype $@thin Int.Type
+// CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
+// CHECK: [USEFUL]   %29 = apply %28(%26, %27) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [ACTIVE]   %30 = begin_access [read] [static] %2 : $*Array<Float>
+// CHECK: [ACTIVE]   %31 = load_borrow %30 : $*Array<Float>
+// CHECK: [ACTIVE]   %32 = alloc_stack $Float
+// CHECK: [NONE]   // function_ref Array.subscript.getter
+// CHECK: [NONE]   %34 = apply %33<Float>(%32, %29, %31) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
+// CHECK: [ACTIVE]   %35 = load [trivial] %32 : $*Float


### PR DESCRIPTION
Semantically, yielded addresses of `modify` accessor applications can be viewed
as projections into `inout` arguments.

Activity analysis should reflect this assumption: yielded addresses should
propagate variedness and usefulness to `inout` arguments of `modify` accessor
applications.

Now, previously undetected active `modify` accessor applications are diagnosed.

Resolves TF-1115.
TF-1080 tracks `modify` accessor differentiation support.

---

Example `modify` accessor application:

```swift
array[index] = x
```

```sil
// function_ref Array.subscript.modify
%fn = function_ref @$sSayxSiciM :
    $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
(%elt_addr, %token) = begin_apply %fn<Float>(%index, %array) :
    $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
store %x to [trivial] %elt_addr : $*Float
```

If `%array` is active, `%x` should also be active.
Before this patch, active `%array` did not always imply active `%x`.

---

TF-1115 example (undiagnosed active `modify` accessor application):

```swift
@differentiable
func TF_1115(x: Float) -> Float {
    var array: [Float] = [0]
    array[0] = x
    return array[0]
}
print(valueWithGradient(at: 4, in: TF_1115))
```

Before:
```console
$ swift tf-1115.swift
# No error, but incorrect zero derivative.
(value: 4.0, gradient: 0.0)
```

After:
```console
$ swift tf-1115.swift
tf-1115.swift:1:2: error: function is not differentiable
@differentiable
~^~~~~~~~~~~~~~
tf-1115.swift:2:6: note: when differentiating this function definition
func TF_1115(x: Float) -> Float {
     ^
tf-1115.swift:4:14: note: differentiation of coroutine calls is not yet supported
    array[0] = x
             ^
```

---

Note: the assumption that yielded addresses are always a projection into
the `inout` argument is a safe over-approximation but not always true.

In practice, this should be fine for now.

Example:

```swift
var global: Float = 1
extension Float {
  var projection: Float {
    get { self }
    // This `modify` accessor yields a global variable, not a projection from `self`.
    // Diagnosing active applications is nonetheless a safe over-approximation.
    _modify { yield &global }
  }
}
@differentiable
func TF_1115_modifyNonSelfProjection(x: Float) -> Float {
  var result: Float = 0
  // Assignment below calls `Float.projection.modify`.
  result.projection = x
  return result
}
```
```console
$ swift modify.swift
modify.swift:10:2: error: function is not differentiable
@differentiable
~^~~~~~~~~~~~~~
modify.swift:11:6: note: when differentiating this function definition
func TF_1115_modifyNonSelfProjection(x: Float) -> Float {
     ^
modify.swift:14:21: note: differentiation of coroutine calls is not yet supported
  result.projection = x
                    ^
```