### PR TITLE
[AST/ASTDumper] Fix linker error for `SWIFT_BUILD_ONLY_SYNTAXPARSERLIB` build

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3762,6 +3762,10 @@ void Type::dump() const {
 }
 
 void Type::dump(raw_ostream &os, unsigned indent) const {
+  #if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+    return; // not needed for the parser library.
+  #endif
+
   PrintType(os, indent).visit(*this, "");
   os << "\n";
 }


### PR DESCRIPTION
With such a build we avoid linking the `clangAST` library.
