### PR TITLE
swift-symbolgraph-extract: Mark required args

### DIFF
--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -32,10 +32,10 @@ namespace options {
 static llvm::cl::OptionCategory Category("swift-symbolgraph-extract Options");
 
 static llvm::cl::opt<std::string>
-ModuleName("module-name", llvm::cl::desc("Name of the module to extract"), llvm::cl::cat(Category));
+ModuleName("module-name", llvm::cl::desc("Name of the module to extract (Required)"), llvm::cl::cat(Category));
 
 static llvm::cl::list<std::string>
-FrameworkSearchPaths("F", llvm::cl::desc("add a directory to the framework search paths"), llvm::cl::ZeroOrMore,
+FrameworkSearchPaths("F", llvm::cl::desc("Add a directory to the framework search paths"), llvm::cl::ZeroOrMore,
                      llvm::cl::cat(Category));
 
 static llvm::cl::list<std::string>
@@ -54,7 +54,7 @@ SDK("sdk", llvm::cl::desc("Path to the SDK"),
     llvm::cl::cat(Category));
 
 static llvm::cl::opt<std::string>
-Target("target", llvm::cl::desc("Target triple"),
+Target("target", llvm::cl::desc("Target triple (Required)"),
        llvm::cl::cat(Category));
 
 static llvm::cl::opt<std::string>
@@ -67,8 +67,28 @@ static llvm::cl::opt<std::string>
 MinimumAccessLevel("minimum-access-level", llvm::cl::desc("Include symbols with this access level or more"), llvm::cl::cat(Category));
 
 static llvm::cl::opt<std::string>
-OutputPath("o", llvm::cl::desc("Symbol Graph JSON Output Path"), llvm::cl::cat(Category));
+OutputPath("o", llvm::cl::desc("Symbol Graph JSON Output Path (Required)"), llvm::cl::cat(Category));
 } // end namespace options
+
+static bool argumentsAreValid() {
+  bool Valid = true;
+  if (options::Target.empty()) {
+    llvm::errs() << "Required -target option is missing\n";
+    Valid = false;
+  }
+
+  if (options::ModuleName.empty()) {
+    llvm::errs() << "Required -module-name argument is missing\n";
+    Valid = false;
+  }
+
+  if (options::OutputPath.empty()) {
+    llvm::errs() << "Required -o argument is missing\n";
+    Valid = false;
+  }
+
+  return Valid;
+}
 
 int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv0, void *MainAddr) {
   INITIALIZE_LLVM();
@@ -79,8 +99,18 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv
   SmallVector<const char *, 8> ArgsWithArgv0 { Argv0 };
   ArgsWithArgv0.append(Args.begin(), Args.end());
 
+  if (Args.empty()) {
+    ArgsWithArgv0.push_back("-help");
+  }
+
   llvm::cl::ParseCommandLineOptions(ArgsWithArgv0.size(),
-      llvm::makeArrayRef(ArgsWithArgv0).data(), "Swift Symbol Graph Extractor\n");
+      llvm::makeArrayRef(ArgsWithArgv0).data(),
+      "Swift Symbol Graph Extractor\n");
+
+  if (!argumentsAreValid()) {
+    llvm::cl::PrintHelpMessage();
+    return EXIT_FAILURE;
+  }
 
   CompilerInvocation Invocation;
 


### PR DESCRIPTION
- Mark required arguments
- Print help usage on zero args

rdar://problem/58770554