### PR TITLE
Revert "IRGenDebugInfo: Pass Sysroot to DIBuilder::createModule"

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -660,8 +660,8 @@ private:
     }
 
     StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
-    llvm::DIModule *M = DBuilder.createModule(Parent, Name, ConfigMacros,
-                                              RemappedIncludePath, Sysroot);
+    llvm::DIModule *M =
+        DBuilder.createModule(Parent, Name, ConfigMacros, RemappedIncludePath);
     DIModuleCache.insert({Key, llvm::TrackingMDNodeRef(M)});
     return M;
   }


### PR DESCRIPTION
Reverts apple/swift#29524, as DIBuilder::createModule no longer accepts a sysroot argument.