### PR TITLE
Revert "IRGenDebugInfo: Pass Sysroot to DIBuilder::createModule (#29524)"

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -660,8 +660,8 @@ private:
     }
 
     StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
-    llvm::DIModule *M = DBuilder.createModule(Parent, Name, ConfigMacros,
-                                              RemappedIncludePath, Sysroot);
+    llvm::DIModule *M =
+        DBuilder.createModule(Parent, Name, ConfigMacros, RemappedIncludePath);
     DIModuleCache.insert({Key, llvm::TrackingMDNodeRef(M)});
     return M;
   }


### PR DESCRIPTION
This reverts commit 06a829c72e102c827985ee9f2b653f55c5b63b8c.

This breaks building my team's work, and it's not clear what API is expected to consume the sysroot argument; the API in question doesn't (https://github.com/apple/llvm-project/blob/swift/master-next/llvm/include/llvm/IR/DIBuilder.h#L741)