### PR TITLE
Enable building of static-libdispatch without Swift

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1086,6 +1086,7 @@ llvm-cmake-options=-DLLVM_INSTALL_UTILS=ON
 llvm-install-components=all
 
 libdispatch-cmake-options=-DENABLE_SWIFT=OFF
+static-libdispatch-cmake-options=-DENABLE_SWIFT=OFF
 libdispatch
 install-libdispatch
 


### PR DESCRIPTION
A previous commit [1] introduced separate cmake options for the dynamic
and static versions of the libdispatch library.  We should now also
specify `static-libdispatch-cmake-options` in addition to
`libdispatch-cmake-options`.

rdar://59048027

[1] 45af79d1a39209ee270d2ab584d62f1aea131a1c
