### PR TITLE
[Incremental, Frontend, NFC] Redo interface to `ReferencedNameTracker`

### DIFF
--- a/include/swift/AST/ReferencedNameTracker.h
+++ b/include/swift/AST/ReferencedNameTracker.h
@@ -24,34 +24,93 @@ class NominalTypeDecl;
 
 class ReferencedNameTracker {
 
-public:
-  using MemberPair = std::pair<const NominalTypeDecl *, DeclBaseName>;
-private:
-  llvm::DenseMap<DeclBaseName, bool> TopLevelNames;
-  llvm::DenseMap<DeclBaseName, bool> DynamicLookupNames;
-  llvm::DenseMap<MemberPair, bool> UsedMembers;
+  /// Internally, use pairs and tuples for ease of using \c DenseMap
+  /// The second element, if not null, points to the \c Decl that uses the first
+  /// element.
+  using NameAndUse = std::pair<DeclBaseName, const Decl *>;
+
+  /// Also for members, contains the holder, member name, and (if not null) a
+  /// pointer to the use.
+  using HolderMemberAndUse =
+      std::tuple<const NominalTypeDecl *, DeclBaseName, const Decl *>;
+
+  llvm::DenseMap<NameAndUse, bool> TopLevelNames;
+  llvm::DenseMap<NameAndUse, bool> DynamicLookupNames;
+  llvm::DenseMap<HolderMemberAndUse, bool> UsedMembers;
 
 public:
-  const decltype(TopLevelNames) &getTopLevelNames() const {
-    return TopLevelNames;
-  }
-  const decltype(DynamicLookupNames) &getDynamicLookupNames() const {
-    return DynamicLookupNames;
-  }
-  const decltype(UsedMembers) &getUsedMembers() const {
-    return UsedMembers;
-  }
-
-  void addTopLevelName(DeclBaseName name, bool isCascadingUse) {
-    TopLevelNames[name] |= isCascadingUse;
-  }
-  void addDynamicLookupName(DeclBaseName name, bool isCascadingUse) {
-    DynamicLookupNames[name] |= isCascadingUse;
-  }
-  void addUsedMember(MemberPair member, bool isCascadingUse) {
-    UsedMembers[member] |= isCascadingUse;
+  /// Record a top level use.
+  /// \param name The name being used
+  /// \param isCascadingUse Whether the dependency from use to def transitively affects
+  /// uses of the use.
+  /// \param use The declaration using the name, if known.
+  void addTopLevelName(DeclBaseName name, bool isCascadingUse,
+                       NullablePtr<const Decl> use = nullptr) {
+    TopLevelNames[NameAndUse{name, use.getPtrOrNull()}] |= isCascadingUse;
   }
 
+  /// Record a dynamically-looked-up use.
+  /// \param name The name being used
+  /// \param isCascadingUse Whether the dependency from use to def transitively affects
+  /// uses of the use.
+  /// \param use The declaration using the name, if known.
+  void addDynamicLookupName(DeclBaseName name, bool isCascadingUse,
+                            NullablePtr<const Decl> use = nullptr) {
+    DynamicLookupNames[NameAndUse{name, use.getPtrOrNull()}] |= isCascadingUse;
+  }
+
+  /// Record a use of a member.
+  /// \param holder The holder of the member being used.
+  /// \param member The name of the member being used.
+  /// \param isCascadingUse Whether the dependency from use to def transitively affects
+  /// uses of the use.
+  /// \param use The declaration using the name, if known.
+  void addUsedMember(const NominalTypeDecl *holder, DeclBaseName member,
+                     bool isCascadingUse,
+                     NullablePtr<const Decl> use = nullptr) {
+    UsedMembers[HolderMemberAndUse{holder, member, use.getPtrOrNull()}] |=
+        isCascadingUse;
+  }
+
+  /// Invoke  \c fn for each depended-upon top level name, passing in the name,
+  /// whether this use is cascading, and if known, the declaration using the
+  /// name.
+  void forEachTopLevelName(
+      function_ref<void(const DeclBaseName &, bool, NullablePtr<const Decl>)>
+          fn) const {
+    for (auto &entry : TopLevelNames)
+      fn(entry.first.first, entry.second,
+         NullablePtr<const Decl>(entry.first.second));
+  }
+
+  /// Invoke  \c fn for each depended-upon dynamically looked-up name, passing
+  /// in the name, whether this use is cascading, and if known, the declaration
+  /// using the name.
+  void forEachDynamicLookupName(
+      function_ref<void(const DeclBaseName &, bool, NullablePtr<const Decl>)>
+          fn) const {
+    for (auto &entry : DynamicLookupNames)
+      fn(entry.first.first, entry.second,
+         NullablePtr<const Decl>(entry.first.second));
+  }
+
+  /// Invoke  \c fn for each depended-upon member, passing in the holder, the
+  /// member name, whether this use is cascading, and if known, the declaration
+  /// using the name.
+  void forEachUsedMember(
+      function_ref<void(const NominalTypeDecl *, const DeclBaseName &, bool,
+                        NullablePtr<const Decl>)>
+          fn) const {
+    for (auto &entry : UsedMembers)
+      fn(std::get<0>(entry.first), std::get<1>(entry.first), entry.second,
+         NullablePtr<const Decl>(std::get<2>(entry.first)));
+  }
+
+  size_t getNumReferencedTopLevelNames() const { return TopLevelNames.size(); }
+  size_t getNumReferencedDynamicNames() const {
+    return DynamicLookupNames.size();
+  }
+  size_t getNumReferencedMemberNames() const { return UsedMembers.size(); }
 };
 
 } // end namespace swift

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1613,7 +1613,7 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
     stack.pop_back();
 
     if (tracker)
-      tracker->addUsedMember({current, member.getBaseName()},isLookupCascading);
+      tracker->addUsedMember(current, member.getBaseName(), isLookupCascading);
 
     // Look for results within the current nominal type and its extensions.
     bool currentIsProtocol = isa<ProtocolDecl>(current);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -677,9 +677,9 @@ static void countStatsPostSema(UnifiedStatsReporter &Stats,
 
   for (auto SF : Instance.getPrimarySourceFiles()) {
     if (auto *R = SF->getReferencedNameTracker()) {
-      C.NumReferencedTopLevelNames += R->getTopLevelNames().size();
-      C.NumReferencedDynamicNames += R->getDynamicLookupNames().size();
-      C.NumReferencedMemberNames += R->getUsedMembers().size();
+      C.NumReferencedTopLevelNames += R->getNumReferencedTopLevelNames();
+      C.NumReferencedDynamicNames += R->getNumReferencedDynamicNames();
+      C.NumReferencedMemberNames += R->getNumReferencedMemberNames();
     }
   }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -449,7 +449,7 @@ static void checkRedeclaration(ASTContext &ctx, ValueDecl *current) {
       auto found = nominal->lookupDirect(current->getBaseName());
       otherDefinitions.append(found.begin(), found.end());
       if (tracker)
-        tracker->addUsedMember({nominal, current->getBaseName()}, isCascading);
+        tracker->addUsedMember(nominal, current->getBaseName(), isCascading);
     }
   } else {
     // Look within a module context.
@@ -1889,7 +1889,7 @@ public:
         if (auto *tracker = SF->getReferencedNameTracker()) {
           bool isPrivate =
               CD->getFormalAccess() <= AccessLevel::FilePrivate;
-          tracker->addUsedMember({Super, Identifier()}, !isPrivate);
+          tracker->addUsedMember(Super, Identifier(), !isPrivate);
         }
       }
 
@@ -1995,7 +1995,7 @@ public:
       if (auto *tracker = SF->getReferencedNameTracker()) {
         bool isNonPrivate = (PD->getFormalAccess() > AccessLevel::FilePrivate);
         for (auto *parentProto : PD->getInheritedProtocols())
-          tracker->addUsedMember({parentProto, Identifier()}, isNonPrivate);
+          tracker->addUsedMember(parentProto, Identifier(), isNonPrivate);
       }
     }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3798,7 +3798,7 @@ static void recordConformanceDependency(DeclContext *DC,
   // FIXME: 'deinit' is being used as a dummy identifier here. Really we
   // don't care about /any/ of the type's members, only that it conforms to
   // the protocol.
-  tracker->addUsedMember({Adoptee, DeclBaseName::createDestructor()},
+  tracker->addUsedMember(Adoptee, DeclBaseName::createDestructor(),
                          DC->isCascadingContextForLookup(InExpression));
 }
 
@@ -5053,7 +5053,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     }
 
     if (tracker)
-      tracker->addUsedMember({conformance->getProtocol(), Identifier()},
+      tracker->addUsedMember(conformance->getProtocol(), Identifier(),
                              defaultAccess > AccessLevel::FilePrivate);
 
     // Diagnose @NSCoding on file/fileprivate/nested/generic classes, which


### PR DESCRIPTION
Cleans up interface to `ReferencedNameTracker` to allow for use information for cross-type dependencies.