### PR TITLE
build: correct the handling for the static variants

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1416,7 +1416,7 @@ for host in "${ALL_HOSTS[@]}"; do
         module_cache="${build_dir}/module-cache"
 
         # Add any specific cmake options specified by build-script
-        product_cmake_options_name=$(to_varname "${product}")_CMAKE_OPTIONS
+        product_cmake_options_name=$(to_varname "${product/_static}")_CMAKE_OPTIONS
         product_cmake_options=(${!product_cmake_options_name}) # convert to array
         cmake_options+=("${product_cmake_options[@]}")
 


### PR DESCRIPTION
The static variants should use the same flags as the dynamic variants.
We missed the name conversion in the variable computation causing the
static and dynamic builds to diverge.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
