### PR TITLE
Remove dependency on libatomic on Linux

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -349,6 +349,11 @@ function(_add_variant_c_compile_flags)
     list(APPEND result "-D__ANDROID_API__=${SWIFT_ANDROID_API_LEVEL}")
   endif()
 
+  if("${CFLAGS_SDK}" STREQUAL "LINUX")
+    # this is the minimum architecture that supports 16 byte CAS, which is necessary to avoid a dependency to libatomic
+    list(APPEND result "-march=core2")
+  endif()
+
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)
 endfunction()
 
@@ -466,7 +471,7 @@ function(_add_variant_link_flags)
     RESULT_VAR_NAME result
     MACCATALYST_BUILD_FLAVOR  "${LFLAGS_MACCATALYST_BUILD_FLAVOR}")
   if("${LFLAGS_SDK}" STREQUAL "LINUX")
-    list(APPEND link_libraries "pthread" "atomic" "dl")
+    list(APPEND link_libraries "pthread" "dl")
   elseif("${LFLAGS_SDK}" STREQUAL "FREEBSD")
     list(APPEND link_libraries "pthread")
   elseif("${LFLAGS_SDK}" STREQUAL "CYGWIN")

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -350,8 +350,10 @@ function(_add_variant_c_compile_flags)
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "LINUX")
-    # this is the minimum architecture that supports 16 byte CAS, which is necessary to avoid a dependency to libatomic
-    list(APPEND result "-march=core2")
+    if(${CFLAGS_ARCH} STREQUAL x86_64)
+      # this is the minimum architecture that supports 16 byte CAS, which is necessary to avoid a dependency to libatomic
+      list(APPEND result "-march=core2")
+    endif()
   endif()
 
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -49,8 +49,8 @@ function(add_swift_unittest test_dirname)
     set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_LIBRARIES "log")
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
-      set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY COMPILE_FLAGS
-        " -march=core2")
+      target_compile_options(${test_dirname} PRIVATE
+        -march=core2)
     endif()
   endif()
 

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -48,8 +48,10 @@ function(add_swift_unittest test_dirname)
       "${android_system_libs}")
     set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_LIBRARIES "log")
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-    set_property(TARGET "${test_dirname}" APPEND PROPERTY COMPILE_FLAGS
-      " -march=core2")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+      set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY COMPILE_FLAGS
+        " -march=core2")
+    endif()
   endif()
 
   find_program(LDLLD_PATH "ld.lld")

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -48,8 +48,8 @@ function(add_swift_unittest test_dirname)
       "${android_system_libs}")
     set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_LIBRARIES "log")
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-    set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_LIBRARIES
-      "atomic")
+    set_property(TARGET "${test_dirname}" APPEND PROPERTY COMPILE_FLAGS
+      "-march=core2")
   endif()
 
   find_program(LDLLD_PATH "ld.lld")

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -50,8 +50,6 @@ function(add_swift_unittest test_dirname)
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     set_property(TARGET "${test_dirname}" APPEND PROPERTY COMPILE_FLAGS
       " -march=core2")
-    set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_FLAGS
-      " -march=core2")
   endif()
 
   find_program(LDLLD_PATH "ld.lld")

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -49,7 +49,9 @@ function(add_swift_unittest test_dirname)
     set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_LIBRARIES "log")
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     set_property(TARGET "${test_dirname}" APPEND PROPERTY COMPILE_FLAGS
-      "-Xcc -march=core2")
+      " -march=core2")
+    set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_FLAGS
+      " -march=core2")
   endif()
 
   find_program(LDLLD_PATH "ld.lld")

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -49,7 +49,7 @@ function(add_swift_unittest test_dirname)
     set_property(TARGET "${test_dirname}" APPEND PROPERTY LINK_LIBRARIES "log")
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     set_property(TARGET "${test_dirname}" APPEND PROPERTY COMPILE_FLAGS
-      "-march=core2")
+      "-Xcc -march=core2")
   endif()
 
   find_program(LDLLD_PATH "ld.lld")

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -631,7 +631,7 @@ class RefCountBitsT {
 
 typedef RefCountBitsT<RefCountIsInline> InlineRefCountBits;
 
-class SideTableRefCountBits : public RefCountBitsT<RefCountNotInline>
+class alignas(sizeof(void*) * 2) SideTableRefCountBits : public RefCountBitsT<RefCountNotInline>
 {
   uint32_t weakBits;
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5115,7 +5115,7 @@ void swift::checkMetadataDependencyCycle(const Metadata *startMetadata,
 /***************************************************************************/
 
 namespace {
-  struct PoolRange {
+  struct alignas(sizeof(uintptr_t) * 2) PoolRange {
     static constexpr uintptr_t PageSize = 16 * 1024;
     static constexpr uintptr_t MaxPoolAllocationSize = PageSize / 2;
 


### PR DESCRIPTION
Due to some unfortunate interplay between clang and libstdc++, clang was
not able to correctly identify to alignment of PoolRange and
SideTableRefCountBits, causing it to emit library calls instead of
inlining atomic operations. This was fixed by adding the appropriate
alignment to those types. In addition to that the march for the Linux
target was set to 'core2', which is the earliest architecture to support
cx16, which is necessary for the atomic operations on PoolRange.

