### PR TITLE
[Serialization] Bump module format version.

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 534; // add SIL parameter differentiability
+const uint16_t SWIFTMODULE_VERSION_MINOR = 535; // top-level var decls
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///


### PR DESCRIPTION
The change to introduce a "top-level" bit for VarDecls requires a
module format version bump, per https://github.com/apple/swift/pull/29024.
Fixes rdar://problem/59078925
