### PR TITLE
[Type checker] Eliminate some unnecessary ExprTypeCheckListener subclasses

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -560,6 +560,7 @@ Optional<Diag<Type, Type>> GenericArgumentsMismatchFailure::getDiagnosticFor(
   case CTP_ReturnSingleExpr:
     return diag::cannot_convert_to_return_type;
   case CTP_DefaultParameter:
+  case CTP_AutoclosureDefaultParameter:
     return diag::cannot_convert_default_arg_value;
   case CTP_YieldByValue:
     return diag::cannot_convert_yield_value;
@@ -2085,6 +2086,7 @@ getContextualNilDiagnostic(ContextualTypePurpose CTP) {
   case CTP_EnumCaseRawValue:
     return diag::cannot_convert_raw_initializer_value_nil;
   case CTP_DefaultParameter:
+  case CTP_AutoclosureDefaultParameter:
     return diag::cannot_convert_default_arg_value_nil;
   case CTP_YieldByValue:
     return diag::cannot_convert_yield_value_nil;
@@ -2863,6 +2865,7 @@ ContextualFailure::getDiagnosticFor(ContextualTypePurpose context,
   case CTP_EnumCaseRawValue:
     return diag::cannot_convert_raw_initializer_value;
   case CTP_DefaultParameter:
+  case CTP_AutoclosureDefaultParameter:
     return forProtocol ? diag::cannot_convert_default_arg_value_protocol
                        : diag::cannot_convert_default_arg_value;
   case CTP_YieldByValue:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9130,6 +9130,7 @@ void ConstraintSystem::addContextualConversionConstraint(
     case CTP_ThrowStmt:
     case CTP_EnumCaseRawValue:
     case CTP_DefaultParameter:
+    case CTP_AutoclosureDefaultParameter:
     case CTP_ClosureResult:
     case CTP_DictionaryKey:
     case CTP_DictionaryValue:

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3209,30 +3209,7 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
                                              /*Implicit=*/true);
 
   // Check the expression as a condition.
-  //
-  // TODO: Type-check of `~=` operator can't (yet) use `typeCheckCondition`
-  // because that utilizes contextual type which interferes with diagnostics.
-  // We don't yet have a full access to pattern-matching context in
-  // constraint system, which is required to enable these situations
-  // to be properly diagnosed.
-  struct ConditionListener : public ExprTypeCheckListener {
-    // Add the appropriate Boolean constraint.
-    bool builtConstraints(ConstraintSystem &cs, Expr *expr) override {
-      // Otherwise, the result must be convertible to Bool.
-      auto boolDecl = cs.getASTContext().getBoolDecl();
-      if (!boolDecl)
-        return true;
-
-      // Condition must convert to Bool.
-      cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
-                       boolDecl->getDeclaredType(),
-                       cs.getConstraintLocator(expr));
-      return false;
-    }
-  };
-
-  ConditionListener listener;
-  bool hadError = !typeCheckExpression(matchCall, DC, &listener);
+  bool hadError = typeCheckCondition(matchCall, DC);
   // Save the type-checked expression in the pattern.
   EP->setMatchExpr(matchCall);
   // Set the type on the pattern.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -133,6 +133,10 @@ enum ContextualTypePurpose {
   CTP_EnumCaseRawValue, ///< Raw value specified for "case X = 42" in enum.
   CTP_DefaultParameter, ///< Default value in parameter 'foo(a : Int = 42)'.
 
+  /// Default value in @autoclosure parameter
+  /// 'foo(a : @autoclosure () -> Int = 42)'.
+  CTP_AutoclosureDefaultParameter,
+
   CTP_CalleeResult,     ///< Constraint is placed on the result of a callee.
   CTP_CallArgument,     ///< Call to function or operator requires type.
   CTP_ClosureResult,    ///< Closure result expects a specific type.


### PR DESCRIPTION
As part of eliminating `ExprTypeCheckListener` so the logic for type-checking expressions is encapsulated within the solver, eliminate two of the remaining four `ExprTypeCheckListener` subclasses:
* Type checking an expression pattern no longer needs special code, because `typeCheckCondition` does all we need
* Type checking an `@autoclosure` default parameter can have its logic sunk into the constraint system