### PR TITLE
[AutoDiff] Speed up compile time by 3.5x by caching derivative function types.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -117,6 +117,7 @@ namespace swift {
   // SWIFT_ENABLE_TENSORFLOW
   struct AutoDiffConfig;
   struct AutoDiffDerivativeFunctionKind;
+  struct SILAutoDiffDerivativeFunctionKey;
   class DerivativeAttr;
   class DifferentiableAttr;
   // SWIFT_ENABLE_TENSORFLOW END
@@ -293,6 +294,10 @@ public:
 
   /// Cached mapping from types to their associated tangent spaces.
   llvm::DenseMap<Type, Optional<TangentSpace>> AutoDiffTangentSpaces;
+  
+  /// A cache of derivative function types per configuration.
+  llvm::DenseMap<SILAutoDiffDerivativeFunctionKey, CanSILFunctionType>
+      SILAutoDiffDerivativeFunctions;
 
   /// Cache of `@differentiable` attributes keyed by parameter indices. Used to
   /// diagnose duplicate `@differentiable` attributes for the same key.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -435,10 +435,6 @@ struct ASTContext::Implementation {
   llvm::FoldingSet<DeclName::CompoundDeclName> CompoundNames;
   llvm::DenseMap<UUID, OpenedArchetypeType *> OpenedExistentialArchetypes;
 
-  // SWIFT_ENABLE_TENSORFLOW
-  /// A cache of tangent spaces per type.
-  llvm::DenseMap<CanType, Optional<TangentSpace>> TangentSpaces;
-
   /// For uniquifying `IndexSubset` allocations.
   llvm::FoldingSet<IndexSubset> IndexSubsets;
 


### PR DESCRIPTION
Compiling packages that use AutoDiff is currently extremely slow. For example, compiling [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis) takes ~5 minutes on a slower machine. This is largely due to calls to `SILFunctionType::getAutoDiffDerivativeFunctionType` in SIL verifier, which spends a long time computing generic signatures with GSB.

This PR improves this situation by caching computed derivative function types in `ASTContext`. This resulted in a 1.6x speedup in running the AutoDiff test suite, and a 3.5x speedup in compiling [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis).

Future investigations:
- Cache generic signatures computed from `getAutoDiffDerivativeFunctionGenericSignature`.
- Cache transpose function types computed from `SILFunctionType::getAutoDiffTransposeFunctionType()`.

----

Here are the results building [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis) with `-j56`.

Before:
```
swift build  411.45s user 31.20s system 334% cpu 2:12.52 total
```

After:
```
swift build  154.03s user 28.26s system 485% cpu 37.519 total
```

Resolves TF-1133.