### PR TITLE
Add target variant to -print-target-info

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2176,6 +2176,11 @@ bool Driver::handleImmediateArgs(const ArgList &Args, const ToolChain &TC) {
       commandLine.push_back("-target");
       commandLine.push_back(targetArg->getValue());
     }
+    if (const Arg *targetVariantArg =
+            Args.getLastArg(options::OPT_target_variant)) {
+      commandLine.push_back("-target-variant");
+      commandLine.push_back(targetVariantArg->getValue());
+    }
     if (const Arg *sdkArg = Args.getLastArg(options::OPT_sdk)) {
       commandLine.push_back("-sdk");
       commandLine.push_back(sdkArg->getValue());
@@ -2188,6 +2193,7 @@ bool Driver::handleImmediateArgs(const ArgList &Args, const ToolChain &TC) {
 
     std::string executable = getSwiftProgramPath();
 
+    // FIXME: This bypasses mechanisms like -v and -###. (SR-12119)
     sys::TaskQueue queue;
     queue.addTask(executable.c_str(), commandLine);
     queue.execute(nullptr,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1894,39 +1894,54 @@ createJSONFixItDiagnosticConsumerIfNeeded(
   });
 }
 
-/// Print information about the selected target in JSON.
-static void printTargetInfo(const CompilerInvocation &invocation,
+/// Print information about the target triple in JSON.
+static void printTripleInfo(const llvm::Triple &triple,
                             llvm::raw_ostream &out) {
   out << "{\n";
 
-  // Target information.
-  auto &langOpts = invocation.getLangOptions();
-  out << "  \"target\": {\n";
-
   out << "    \"triple\": \"";
-  out.write_escaped(langOpts.Target.getTriple());
+  out.write_escaped(triple.getTriple());
   out << "\",\n";
 
   out << "    \"unversionedTriple\": \"";
-  out.write_escaped(getUnversionedTriple(langOpts.Target).getTriple());
+  out.write_escaped(getUnversionedTriple(triple).getTriple());
   out << "\",\n";
 
   out << "    \"moduleTriple\": \"";
-  out.write_escaped(getTargetSpecificModuleTriple(langOpts.Target).getTriple());
+  out.write_escaped(getTargetSpecificModuleTriple(triple).getTriple());
   out << "\",\n";
 
   if (auto runtimeVersion = getSwiftRuntimeCompatibilityVersionForTarget(
-          langOpts.Target)) {
+          triple)) {
     out << "    \"swiftRuntimeCompatibilityVersion\": \"";
     out.write_escaped(runtimeVersion->getAsString());
     out << "\",\n";
   }
 
   out << "    \"librariesRequireRPath\": "
-      << (tripleRequiresRPathForSwiftInOS(langOpts.Target) ? "true" : "false")
+      << (tripleRequiresRPathForSwiftInOS(triple) ? "true" : "false")
       << "\n";
 
-  out << "  },\n";
+  out << "  }";
+
+}
+
+/// Print information about the selected target in JSON.
+static void printTargetInfo(const CompilerInvocation &invocation,
+                            llvm::raw_ostream &out) {
+  out << "{\n";
+
+  // Target triple and target variant triple.
+  auto &langOpts = invocation.getLangOptions();
+  out << "  \"target\": ";
+  printTripleInfo(langOpts.Target, out);
+  out << ",\n";
+
+  if (auto &variant = langOpts.TargetVariant) {
+    out << "  \"targetVariant\": ";
+    printTripleInfo(*variant, out);
+    out << ",\n";
+  }
 
   // Various paths.
   auto &searchOpts = invocation.getSearchPathOptions();

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -4,6 +4,9 @@
 // RUN: %swift_driver -print-target-info -target x86_64-unknown-linux | %FileCheck -check-prefix CHECK-LINUX %s
 // RUN: %target-swift-frontend -print-target-info -target x86_64-unknown-linux | %FileCheck -check-prefix CHECK-LINUX %s
 
+// RUN: %swift_driver -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
+// RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
+
 // CHECK-IOS:   "target": {
 // CHECK-IOS:     "triple": "arm64-apple-ios12.0",
 // CHECK-IOS:     "unversionedTriple": "arm64-apple-ios",
@@ -11,6 +14,8 @@
 // CHECK-IOS:     "swiftRuntimeCompatibilityVersion": "5.0",
 // CHECK-IOS:     "librariesRequireRPath": true
 // CHECK-IOS:   }
+
+// CHECK-IOS-NOT: "targetVariant":
 
 // CHECK-IOS:   "paths": {
 // CHECK-IOS:     "runtimeLibraryPaths": [
@@ -26,3 +31,22 @@
 // CHECK-LINUX:     "moduleTriple": "x86_64-unknown-linux",
 // CHECK-LINUX:     "librariesRequireRPath": false
 // CHECK-LINUX:   }
+
+// CHECK-LINUX-NOT: "targetVariant":
+
+
+// CHECK-ZIPPERED: "target": {
+// CHECK-ZIPPERED:   "triple": "x86_64-apple-macosx10.15"
+// CHECK-ZIPPERED:   "unversionedTriple": "x86_64-apple-macosx"
+// CHECK-ZIPPERED:   "moduleTriple": "x86_64-apple-macos"
+// CHECK-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"
+// CHECK-ZIPPERED:   "librariesRequireRPath": false
+// CHECK-ZIPPERED: }
+
+// CHECK-ZIPPERED: "targetVariant": {
+// CHECK-ZIPPERED:   "triple": "x86_64-apple-ios13-macabi"
+// CHECK-ZIPPERED:   "unversionedTriple": "x86_64-apple-ios-macabi"
+// CHECK-ZIPPERED:   "moduleTriple": "x86_64-apple-ios-macabi"
+// CHECK-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"
+// CHECK-ZIPPERED:   "librariesRequireRPath": false
+// CHECK-ZIPPERED: }


### PR DESCRIPTION
Now that the compiler is at least vaguely aware of Mac Catalyst, we should add an object to `-print-target-info` that describes the `-target-variant` option, if passed. This PR does so. The `targetVariant` object has the exact same fields as the `target` object, and is only present when a `-target-variant` option is passed to the compiler.