### PR TITLE
[Constraint system] Add a SolutionApplicationTarget-based typeCheckExpression

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7345,6 +7345,13 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     if (!resultExpr)
       return None;
 
+    // For an @autoclosure default parameter type, add the autoclosure
+    // conversion.
+    if (FunctionType *autoclosureParamType =
+            target.getAsAutoclosureParamType()) {
+      resultExpr = buildAutoClosureExpr(resultExpr, autoclosureParamType);
+    }
+
     solution.setExprTypes(resultExpr);
     result.setExpr(resultExpr);
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -834,8 +834,9 @@ public:
                       constraints::ConstraintSystem *baseCS = nullptr);
 
   static Optional<constraints::SolutionApplicationTarget>
-  typeCheckExpression(constraints::SolutionApplicationTarget target,
+  typeCheckExpression(constraints::SolutionApplicationTarget &target,
                       DeclContext *dc,
+                      bool &unresolvedTypeExprs,
                       TypeCheckExprOptions options = TypeCheckExprOptions(),
                       ExprTypeCheckListener *listener = nullptr,
                       constraints::ConstraintSystem *baseCS = nullptr);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -49,6 +49,7 @@ namespace constraints {
   enum class ConstraintKind : char;
   class ConstraintSystem;
   class Solution;
+  class SolutionApplicationTarget;
   class SolutionResult;
 }
 
@@ -828,6 +829,13 @@ public:
   typeCheckExpression(Expr *&expr, DeclContext *dc,
                       TypeLoc convertType = TypeLoc(),
                       ContextualTypePurpose convertTypePurpose = CTP_Unused,
+                      TypeCheckExprOptions options = TypeCheckExprOptions(),
+                      ExprTypeCheckListener *listener = nullptr,
+                      constraints::ConstraintSystem *baseCS = nullptr);
+
+  static Optional<constraints::SolutionApplicationTarget>
+  typeCheckExpression(constraints::SolutionApplicationTarget target,
+                      DeclContext *dc,
                       TypeCheckExprOptions options = TypeCheckExprOptions(),
                       ExprTypeCheckListener *listener = nullptr,
                       constraints::ConstraintSystem *baseCS = nullptr);

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -186,7 +186,7 @@ func testMap() {
 }
 
 // <rdar://problem/22414757> "UnresolvedDot" "in wrong phase" assertion from verifier
-[].reduce { $0 + $1 }  // expected-error {{cannot invoke 'reduce' with an argument list of type '(_)'}}
+[].reduce { $0 + $1 }  // expected-error {{cannot invoke 'reduce' with an argument list of type '(<<error type>>)'}}
 
 
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -186,7 +186,7 @@ func testMap() {
 }
 
 // <rdar://problem/22414757> "UnresolvedDot" "in wrong phase" assertion from verifier
-[].reduce { $0 + $1 }  // expected-error {{cannot invoke 'reduce' with an argument list of type '(<<error type>>)'}}
+[].reduce { $0 + $1 }  // expected-error {{cannot invoke 'reduce' with an argument list of type '(_)'}}
 
 
 


### PR DESCRIPTION
Rework most of typeCheckExpression() to use SolutionApplicationTarget,
folding more information into that data structure and sinking more
expression-checking behavior down into the more general solver and
solution-application code.
