### PR TITLE
[Source Tooling] Refactoring action to convert if statement to switch

### DIFF
--- a/include/swift/IDE/RefactoringKinds.def
+++ b/include/swift/IDE/RefactoringKinds.def
@@ -72,6 +72,8 @@ RANGE_REFACTORING(ConvertGuardExprToIfLetExpr, "Convert To IfLet Expression", co
 
 RANGE_REFACTORING(ConvertToComputedProperty, "Convert To Computed Property", convert.to.computed.property)
 
+RANGE_REFACTORING(ConvertToSwitchStmt, "Convert To Switch Statement", convert.switch.stmt)
+
 // These internal refactorings are designed to be helpful for working on
 // the compiler/standard library, etc., but are likely to be just confusing and
 // noise for general development.

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2243,6 +2243,270 @@ bool RefactoringActionConvertGuardExprToIfLetExpr::performChange() {
   return false;
 }
 
+bool RefactoringActionConvertToSwitchStmt::
+isApplicable(ResolvedRangeInfo Info, DiagnosticEngine &Diag) {
+
+  class ConditionalChecker : public ASTWalker {
+  public:
+    bool ParamsUseSameVars = true;
+    bool ConditionUseOnlyAllowedFunctions = true;
+    StringRef ExpectName;
+
+    Expr *walkToExprPost(Expr *E) {
+      if (E->getKind() != ExprKind::DeclRef)
+        return E;
+      auto D = dyn_cast<DeclRefExpr>(E)->getDecl();
+      if (D->getKind() == DeclKind::Var || D->getKind() == DeclKind::Param)
+        ParamsUseSameVars = checkName(dyn_cast<VarDecl>(D));
+      if (D->getKind() == DeclKind::Func)
+        ConditionUseOnlyAllowedFunctions = checkName(dyn_cast<FuncDecl>(D));
+      if (allCheckPassed())
+        return E;
+      return nullptr;
+    }
+
+    bool allCheckPassed() {
+      return ParamsUseSameVars && ConditionUseOnlyAllowedFunctions;
+    }
+
+  private:
+    bool checkName(VarDecl *VD) {
+      auto Name = VD->getName().str();
+      if (ExpectName.empty())
+        ExpectName = Name;
+      return Name == ExpectName;
+    }
+
+    bool checkName(FuncDecl *FD) {
+      auto Name = FD->getName().str();
+      return Name == "~="
+      || Name == "=="
+      || Name == "__derived_enum_equals"
+      || Name == "__derived_struct_equals"
+      || Name == "||"
+      || Name == "...";
+    }
+  };
+
+  class SwitchConvertable {
+  public:
+    SwitchConvertable(ResolvedRangeInfo Info) {
+      this->Info = Info;
+    }
+
+    bool isApplicable() {
+      if (Info.Kind != RangeKind::SingleStatement)
+        return false;
+      if (!findIfStmt())
+        return false;
+      return checkEachCondition();
+    }
+
+  private:
+    ResolvedRangeInfo Info;
+    IfStmt *If = nullptr;
+    ConditionalChecker checker;
+
+    bool findIfStmt() {
+      if (Info.ContainedNodes.size() != 1)
+        return false;
+      if (auto S = Info.ContainedNodes.front().dyn_cast<Stmt*>())
+        If = dyn_cast<IfStmt>(S);
+      return If != nullptr;
+    }
+
+    bool checkEachCondition() {
+      checker = ConditionalChecker();
+      do {
+        if (!checkEachElement())
+          return false;
+      } while ((If = dyn_cast_or_null<IfStmt>(If->getElseStmt())));
+      return true;
+    }
+
+    bool checkEachElement() {
+      bool result = true;
+      auto ConditionalList = If->getCond();
+      for (auto Element : ConditionalList) {
+        result &= check(Element);
+      }
+      return result;
+    }
+
+    bool check(StmtConditionElement ConditionElement) {
+      if (ConditionElement.getKind() == StmtConditionElement::CK_Availability)
+        return false;
+      ConditionElement.walk(checker);
+      return checker.allCheckPassed();
+    }
+  };
+  return SwitchConvertable(Info).isApplicable();
+}
+
+bool RefactoringActionConvertToSwitchStmt::performChange() {
+
+  class VarNameFinder : public ASTWalker {
+  public:
+    std::string VarName;
+
+    Expr *walkToExprPost(Expr *E) {
+      if (E->getKind() != ExprKind::DeclRef)
+        return E;
+      auto D = dyn_cast<DeclRefExpr>(E)->getDecl();
+      if (D->getKind() != DeclKind::Var && D->getKind() != DeclKind::Param)
+        return E;
+      VarName = dyn_cast<VarDecl>(D)->getName().str().str();
+      return nullptr;
+    }
+  };
+
+  class ConditionalPatternFinder : public ASTWalker {
+  public:
+    ConditionalPatternFinder(SourceManager &SM) : SM(SM) {}
+
+    SmallString<64> ConditionalPattern = SmallString<64>();
+
+    Expr *walkToExprPost(Expr *E) {
+      if (E->getKind() != ExprKind::Binary)
+        return E;
+      auto BE = dyn_cast<BinaryExpr>(E);
+      if (isFunctionNameAllowed(BE))
+        appendPattern(dyn_cast<BinaryExpr>(E)->getArg());
+      return E;
+    }
+
+    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) {
+      ConditionalPattern.append(Lexer::getCharSourceRangeFromSourceRange(SM, P->getSourceRange()).str());
+      if (P->getKind() == PatternKind::OptionalSome)
+        ConditionalPattern.append("?");
+      return { true, nullptr };
+    }
+
+  private:
+
+    SourceManager &SM;
+
+    bool isFunctionNameAllowed(BinaryExpr *E) {
+      auto FunctionBody = dyn_cast<DotSyntaxCallExpr>(E->getFn())->getFn();
+      auto FunctionDeclaration = dyn_cast<DeclRefExpr>(FunctionBody)->getDecl();
+      auto FunctionName = dyn_cast<FuncDecl>(FunctionDeclaration)->getName().str();
+      return FunctionName == "~="
+      || FunctionName == "=="
+      || FunctionName == "__derived_enum_equals"
+      || FunctionName == "__derived_struct_equals";
+    }
+
+    void appendPattern(TupleExpr *Tuple) {
+      auto PatternArgument = Tuple->getElements().back();
+      if (PatternArgument->getKind() == ExprKind::DeclRef)
+        PatternArgument = Tuple->getElements().front();
+      if (ConditionalPattern.size() > 0)
+        ConditionalPattern.append(", ");
+      ConditionalPattern.append(Lexer::getCharSourceRangeFromSourceRange(SM, PatternArgument->getSourceRange()).str());
+    }
+  };
+
+  class ConverterToSwitch {
+  public:
+    ConverterToSwitch(ResolvedRangeInfo Info, SourceManager &SM) : SM(SM) {
+      this->Info = Info;
+    }
+
+    void performConvert(SmallString<64> &Out) {
+      If = findIf();
+      OptionalLabel = If->getLabelInfo().Name.str().str();
+      ControlExpression = findControlExpression();
+      findPatternsAndBodies(PatternsAndBodies);
+      DefaultStatements = findDefaultStatements();
+      makeSwitchStatement(Out);
+    }
+
+  private:
+    ResolvedRangeInfo Info;
+    SourceManager &SM;
+
+    IfStmt *If;
+    IfStmt *PreviousIf;
+
+    std::string OptionalLabel;
+    std::string ControlExpression;
+    SmallVector<std::pair<std::string, std::string>, 16> PatternsAndBodies;
+    std::string DefaultStatements;
+
+    IfStmt *findIf() {
+      auto S = Info.ContainedNodes[0].dyn_cast<Stmt*>();
+      return dyn_cast<IfStmt>(S);
+    }
+
+    std::string findControlExpression() {
+      auto ConditionElement = If->getCond().front();
+      auto Finder = VarNameFinder();
+      ConditionElement.walk(Finder);
+      return Finder.VarName;
+    }
+
+    void findPatternsAndBodies(SmallVectorImpl<std::pair<std::string, std::string>> &Out) {
+      do {
+        auto pattern = findPattern();
+        auto body = findBodyStatements();
+        Out.push_back(std::make_pair(pattern, body));
+        PreviousIf = If;
+      } while ((If = dyn_cast_or_null<IfStmt>(If->getElseStmt())));
+    }
+
+    std::string findPattern() {
+      auto ConditionElement = If->getCond().front();
+      auto Finder = ConditionalPatternFinder(SM);
+      ConditionElement.walk(Finder);
+      return Finder.ConditionalPattern.str().str();
+    }
+
+    std::string findBodyStatements() {
+      return findBodyWithoutBraces(If->getThenStmt());
+    }
+
+    std::string findDefaultStatements() {
+      auto ElseBody = dyn_cast_or_null<BraceStmt>(PreviousIf->getElseStmt());
+      if (!ElseBody)
+        return getTokenText(tok::kw_break);
+      return findBodyWithoutBraces(ElseBody);
+    }
+
+    std::string findBodyWithoutBraces(Stmt *body) {
+      auto BS = dyn_cast<BraceStmt>(body);
+      if (!BS)
+        return Lexer::getCharSourceRangeFromSourceRange(SM, body->getSourceRange()).str().str();
+      if (BS->getElements().empty())
+        return getTokenText(tok::kw_break);
+      SourceRange BodyRange = BS->getElements().front().getSourceRange();
+      BodyRange.widen(BS->getElements().back().getSourceRange());
+      return Lexer::getCharSourceRangeFromSourceRange(SM, BodyRange).str().str();
+    }
+
+    void makeSwitchStatement(SmallString<64> &Out) {
+      StringRef Space = " ";
+      StringRef NewLine = "\n";
+      llvm::raw_svector_ostream OS(Out);
+      if (OptionalLabel.size() > 0)
+        OS << OptionalLabel << ":" << Space;
+      OS << tok::kw_switch << Space << ControlExpression << Space << tok::l_brace << NewLine;
+      for (auto &pair : PatternsAndBodies) {
+        OS << tok::kw_case << Space << pair.first << tok::colon << NewLine;
+        OS << pair.second << NewLine;
+      }
+      OS << tok::kw_default << tok::colon << NewLine;
+      OS << DefaultStatements << NewLine;
+      OS << tok::r_brace;
+    }
+
+  };
+
+  SmallString<64> result;
+  ConverterToSwitch(RangeInfo, SM).performConvert(result);
+  EditConsumer.accept(SM, RangeInfo.ContentRange, result.str());
+  return false;
+}
+
 /// Struct containing info about an IfStmt that can be converted into an IfExpr.
 struct ConvertToTernaryExprInfo {
   ConvertToTernaryExprInfo() {}

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2249,7 +2249,7 @@ isApplicable(ResolvedRangeInfo Info, DiagnosticEngine &Diag) {
   class ConditionalChecker : public ASTWalker {
   public:
     bool ParamsUseSameVars = true;
-    bool ConditionUseOnlyAllowedFunctions = true;
+    bool ConditionUseOnlyAllowedFunctions = false;
     StringRef ExpectName;
 
     Expr *walkToExprPost(Expr *E) {
@@ -2336,6 +2336,8 @@ isApplicable(ResolvedRangeInfo Info, DiagnosticEngine &Diag) {
     bool check(StmtConditionElement ConditionElement) {
       if (ConditionElement.getKind() == StmtConditionElement::CK_Availability)
         return false;
+      if (ConditionElement.getKind() == StmtConditionElement::CK_PatternBinding)
+        checker.ConditionUseOnlyAllowedFunctions = true;
       ConditionElement.walk(checker);
       return checker.allCheckPassed();
     }

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L108-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L108-3.swift.expected
@@ -1,0 +1,148 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  switch x {
+case 5:
+print("5")
+case 4:
+print("4")
+case 1...3:
+print("1...3")
+default:
+print("default")
+}
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L118-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L118-3.swift.expected
@@ -1,0 +1,148 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  switch y {
+case MyType(v: "bye"):
+print("bye")
+case MyType(v: "tchau"):
+print("tchau")
+default:
+print("default")
+}
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L128-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L128-3.swift.expected
@@ -1,0 +1,151 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  switch e {
+case .first:
+break
+case .second:
+print("second")
+default:
+break
+}
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L20-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L20-3.swift.expected
@@ -1,0 +1,148 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  switch e {
+case .first:
+print("first string")
+    print("second string")
+default:
+print("default")
+}
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L29-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L29-3.swift.expected
@@ -1,0 +1,150 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  switch e {
+case .first:
+print("first")
+case .second:
+print("second")
+case .third:
+print("third")
+default:
+break
+}
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L39-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L39-3.swift.expected
@@ -1,0 +1,148 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  switch e {
+case .first:
+print("first")
+case .second:
+print("second")
+default:
+print("default")
+}
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L50-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L50-3.swift.expected
@@ -1,0 +1,150 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  switch someOptional {
+case .some(let x):
+print(x)
+default:
+break
+}
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L54-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L54-3.swift.expected
@@ -1,0 +1,150 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  switch someOptional {
+case let x?:
+print(x)
+default:
+break
+}
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L60-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L60-3.swift.expected
@@ -1,0 +1,150 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  switch optional {
+case let unwraped?:
+print(unwraped)
+default:
+break
+}
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L64-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L64-3.swift.expected
@@ -1,0 +1,150 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  switch optional {
+case var unwraped?:
+unwraped += "!"
+    print(unwraped)
+default:
+break
+}
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L71-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L71-3.swift.expected
@@ -1,0 +1,148 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  switch e {
+case .first, .second, .third:
+print("1-3")
+case .fourth:
+print("4")
+default:
+print(">4")
+}
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L82-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L82-3.swift.expected
@@ -1,0 +1,150 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: switch e {
+case .a:
+innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+default:
+break
+}
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L9-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L9-3.swift.expected
@@ -1,0 +1,147 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  switch e {
+case .first:
+print("first")
+case .second:
+print("second")
+default:
+print("default")
+}
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L99-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L99-3.swift.expected
@@ -1,0 +1,150 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  switch productBarcode {
+case .upc(let numberSystem, let manufacturer, let product, let check):
+print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+case let .qrCode(productCode):
+print("QR code: \(productCode).")
+default:
+break
+}
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/basic.swift
+++ b/test/refactoring/ConvertToSwitchStmt/basic.swift
@@ -134,43 +134,57 @@ func checkEmptyBody(e: E) {
 // RUN: rm -rf %t.result && mkdir -p %t.result
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=9:3 -end-pos=16:4 > %t.result/L9-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L9-3.swift
 // RUN: diff -u %S/Outputs/basic/L9-3.swift.expected %t.result/L9-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=20:3 -end-pos=25:4 > %t.result/L20-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L20-3.swift
 // RUN: diff -u %S/Outputs/basic/L20-3.swift.expected %t.result/L20-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=29:3 -end-pos=35:4 > %t.result/L29-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L29-3.swift
 // RUN: diff -u %S/Outputs/basic/L29-3.swift.expected %t.result/L29-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=39:3 -end-pos=45:4 > %t.result/L39-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L39-3.swift
 // RUN: diff -u %S/Outputs/basic/L39-3.swift.expected %t.result/L39-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=50:3 -end-pos=52:4 > %t.result/L50-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L50-3.swift
 // RUN: diff -u %S/Outputs/basic/L50-3.swift.expected %t.result/L50-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=54:3 -end-pos=56:4 > %t.result/L54-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L54-3.swift
 // RUN: diff -u %S/Outputs/basic/L54-3.swift.expected %t.result/L54-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=60:3 -end-pos=62:4 > %t.result/L60-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L60-3.swift
 // RUN: diff -u %S/Outputs/basic/L60-3.swift.expected %t.result/L60-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=64:3 -end-pos=67:4 > %t.result/L64-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L64-3.swift
 // RUN: diff -u %S/Outputs/basic/L64-3.swift.expected %t.result/L64-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=71:3 -end-pos=77:4 > %t.result/L71-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L71-3.swift
 // RUN: diff -u %S/Outputs/basic/L71-3.swift.expected %t.result/L71-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=82:3 -end-pos=90:4 > %t.result/L82-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L82-3.swift
 // RUN: diff -u %S/Outputs/basic/L82-3.swift.expected %t.result/L82-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=99:3 -end-pos=103:4 > %t.result/L99-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L99-3.swift
 // RUN: diff -u %S/Outputs/basic/L99-3.swift.expected %t.result/L99-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=108:3 -end-pos=116:4 > %t.result/L108-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L108-3.swift
 // RUN: diff -u %S/Outputs/basic/L108-3.swift.expected %t.result/L108-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=118:3 -end-pos=124:4 > %t.result/L118-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L118-3.swift
 // RUN: diff -u %S/Outputs/basic/L118-3.swift.expected %t.result/L118-3.swift
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=128:3 -end-pos=131:4 > %t.result/L128-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L128-3.swift
 // RUN: diff -u %S/Outputs/basic/L128-3.swift.expected %t.result/L128-3.swift

--- a/test/refactoring/ConvertToSwitchStmt/basic.swift
+++ b/test/refactoring/ConvertToSwitchStmt/basic.swift
@@ -1,0 +1,176 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func someFunc(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .first {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  } else if e == .third {
+    print("third")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+enum Foo { case a, b, c }
+func checkLabeledCondition(e: Foo, f: Foo) {
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+enum Barcode {
+  case upc(Int, Int, Int, Int)
+  case qrCode(String)
+}
+func checkEnumWithAssociatedValues(productBarcode: Barcode) {
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+struct MyType: Equatable { let v: String }
+func checkEquatableProtocol(x: Int, y: MyType) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+func checkEmptyBody(e: E) {
+  if e == .first {}
+  else if e == .second {
+    print("second")
+  }
+}
+
+// RUN: rm -rf %t.result && mkdir -p %t.result
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=9:3 -end-pos=16:4 > %t.result/L9-3.swift
+// RUN: diff -u %S/Outputs/basic/L9-3.swift.expected %t.result/L9-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=20:3 -end-pos=25:4 > %t.result/L20-3.swift
+// RUN: diff -u %S/Outputs/basic/L20-3.swift.expected %t.result/L20-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=29:3 -end-pos=35:4 > %t.result/L29-3.swift
+// RUN: diff -u %S/Outputs/basic/L29-3.swift.expected %t.result/L29-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=39:3 -end-pos=45:4 > %t.result/L39-3.swift
+// RUN: diff -u %S/Outputs/basic/L39-3.swift.expected %t.result/L39-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=50:3 -end-pos=52:4 > %t.result/L50-3.swift
+// RUN: diff -u %S/Outputs/basic/L50-3.swift.expected %t.result/L50-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=54:3 -end-pos=56:4 > %t.result/L54-3.swift
+// RUN: diff -u %S/Outputs/basic/L54-3.swift.expected %t.result/L54-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=60:3 -end-pos=62:4 > %t.result/L60-3.swift
+// RUN: diff -u %S/Outputs/basic/L60-3.swift.expected %t.result/L60-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=64:3 -end-pos=67:4 > %t.result/L64-3.swift
+// RUN: diff -u %S/Outputs/basic/L64-3.swift.expected %t.result/L64-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=71:3 -end-pos=77:4 > %t.result/L71-3.swift
+// RUN: diff -u %S/Outputs/basic/L71-3.swift.expected %t.result/L71-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=82:3 -end-pos=90:4 > %t.result/L82-3.swift
+// RUN: diff -u %S/Outputs/basic/L82-3.swift.expected %t.result/L82-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=99:3 -end-pos=103:4 > %t.result/L99-3.swift
+// RUN: diff -u %S/Outputs/basic/L99-3.swift.expected %t.result/L99-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=108:3 -end-pos=116:4 > %t.result/L108-3.swift
+// RUN: diff -u %S/Outputs/basic/L108-3.swift.expected %t.result/L108-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=118:3 -end-pos=124:4 > %t.result/L118-3.swift
+// RUN: diff -u %S/Outputs/basic/L118-3.swift.expected %t.result/L118-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=128:3 -end-pos=131:4 > %t.result/L128-3.swift
+// RUN: diff -u %S/Outputs/basic/L128-3.swift.expected %t.result/L128-3.swift

--- a/test/refactoring/RefactoringKind/basic.swift
+++ b/test/refactoring/RefactoringKind/basic.swift
@@ -392,10 +392,10 @@ struct S {
 // RUN: %refactor -source-filename %s -pos=272:3 -end-pos=275:13 | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-IFLET-EXPRESSION
 
 // RUN: %refactor -source-filename %s -pos=288:3 -end-pos=288:16 | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-COMPUTED-PROPERTY
-// RUN: %refactor -source-filename %s -pos=289:3 -end-pos=289:22 | %FileCheck %s -check-prefix=CHECK-NONE
-// RUN: %refactor -source-filename %s -pos=290:3 -end-pos=290:32 | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-COMPUTED-PROPERTY2
-// RUN: %refactor -source-filename %s -pos=291:3 -end-pos=291:18 | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-COMPUTED-PROPERTY2
-// RUN: %refactor -source-filename %s -pos=292:3 -end-pos=296:4 | %FileCheck %s -check-prefix=CHECK-NONE
+// RUN: %refactor -source-filename %s -pos=289:3 -end-pos=289:22 | %FileCheck %s -check-prefix=CHECK-IS-NOT-CONVERT-TO-COMPUTED-PROPERTY
+// RUN: %refactor -source-filename %s -pos=290:3 -end-pos=290:32 | %FileCheck %s -check-prefix=CHECK-IS-NOT-CONVERT-TO-COMPUTED-PROPERTY
+// RUN: %refactor -source-filename %s -pos=291:3 -end-pos=291:18 | %FileCheck %s -check-prefix=CHECK-IS-NOT-CONVERT-TO-COMPUTED-PROPERTY
+// RUN: %refactor -source-filename %s -pos=292:3 -end-pos=296:4 | %FileCheck %s -check-prefix=CHECK-IS-NOT-CONVERT-TO-COMPUTED-PROPERTY
 
 // CHECK1: Action begins
 // CHECK1-NEXT: Extract Method
@@ -450,6 +450,7 @@ struct S {
 
 // CHECK-CONVERT-TO-COMPUTED-PROPERTY: Convert To Computed Property
 
-// CHECK-CONVERT-TO-COMPUTED-PROPERTY2: Action begins
-// CHECK-CONVERT-TO-COMPUTED-PROPERTY2-NEXT: Move To Extension
-// CHECK-CONVERT-TO-COMPUTED-PROPERTY2-NEXT: Action ends
+// CHECK-IS-NOT-CONVERT-TO-COMPUTED-PROPERTY: Action begins
+// CHECK-IS-NOT-CONVERT-TO-COMPUTED-PROPERTY-NOT: Convert To Computed Property
+// CHECK-IS-NOT-CONVERT-TO-COMPUTED-PROPERTY: Action ends
+

--- a/test/refactoring/RefactoringKind/convert_to_switch_statement.swift
+++ b/test/refactoring/RefactoringKind/convert_to_switch_statement.swift
@@ -1,0 +1,204 @@
+enum E {
+  case first
+  case second
+  case third
+  case fourth
+}
+
+func checkForEnum(e: E) {
+  if e == .first {
+    print("first")
+  } else if e == .second {
+    print("second")
+  }
+  else {
+    print("default")
+  }
+
+  let x = "some other type"
+  if e == .first {
+    print("first")
+  } else if x == "some value" {
+    print("x")
+  }
+}
+
+func checkBiggerOrSmallerSign(integer: Int) {
+  if integer > 0 {
+    print("Positive integer")
+  } else if integer < 0 {
+    print("Negative integer")
+  } else {
+    print("Zero")
+  }
+}
+
+func checkInverseCondition(e: E) {
+  if .first == e {
+    print("first")
+  } else if .second == e {
+    print("second")
+  } else {
+    print("default")
+  }
+}
+
+func checkAvailabilityCondition() {
+  if #available(iOS 13, *) {
+    print("#available may only be used as condition of an 'if', 'guard' or 'while' statement")
+  }
+}
+
+func checkCaseCondition() {
+  let someOptional: Int? = 42
+  // Match using an enumeration case pattern.
+  if case .some(let x) = someOptional {
+    print(x)
+  }
+
+  // Match using an optional pattern.
+  if case let x? = someOptional {
+    print(x)
+  }
+}
+
+func checkOptionalBindingCondition(optional: String?) {
+  if let unwraped = optional {
+    print(unwraped)
+  }
+
+  if var unwraped = optional {
+    unwraped += "!"
+    print(unwraped)
+  }
+}
+
+func checkConditionalList(x: Int, y: Int) -> Bool {
+  if x > 0, y < 0 {
+    return false
+  }
+
+  if x > 0, x < 10 {
+    return true
+  }
+}
+
+func checkFunctionCallExpression() {
+  if checkConditionalList(x: 0, y: 0) {
+    print("false")
+  }
+}
+
+func checkMultipleOrConditions(e: E) {
+  if e == .first || e == .second || e == .third {
+    print("1-3")
+  } else if e == .fourth { 
+    print("4")
+  } else { 
+    print(">4")
+  }
+}
+
+func checkMultipleAndConditions(e: E) {
+  if e == .first && e == .second && e == .third {
+    print("Never executed")
+  } else { 
+    print("Whenever")
+  }
+}
+
+func checkMultipleWithUnrelatedCondition(e: E, x: Int) {
+  if e == .first || x > 0 {
+    print("e is the first or x is positive")
+  } else { 
+    print("Shouldn't convert to switch")
+  }
+}
+
+func checkOperatorIsActuallyBeingUsed(e: E) {
+  if e != .first {
+    print("Can't use at case statement")
+  }
+}
+
+func checkLabeledCondition() {
+  enum Foo { case a, b, c }
+  let e = Foo.a
+  let f = Foo.a
+
+  outerLabel: if e == .a {
+    innerLabel: switch f {
+    case .a:
+      break outerLabel
+    default:
+      break innerLabel
+    }
+    print("outside switch")
+  }
+  print("outside if")
+}
+
+func checkEnumWithAssociatedValues() {
+  enum Barcode {
+    case upc(Int, Int, Int, Int)
+    case qrCode(String)
+  }
+
+  let productBarcode = Barcode.upc(8, 85909, 51226, 3)
+  if case .upc(let numberSystem, let manufacturer, let product, let check) = productBarcode {
+    print("UPC : \(numberSystem), \(manufacturer), \(product), \(check).")
+  } else if case let .qrCode(productCode) = productBarcode {
+    print("QR code: \(productCode).")
+  }
+}
+
+func checkEquatableProtocol(x: Int) {
+  if x == 5 {
+    print("5")
+  } else if x == 4 {
+    print("4")
+  } else if 1...3 ~= x {
+    print("1...3")
+  } else {
+    print("default")
+  }
+
+  struct MyType: Equatable { let v: String }
+  let y = MyType(v: "hello")
+
+  if y == MyType(v: "bye") {
+    print("bye")
+  } else if y == MyType(v: "tchau") {
+    print("tchau")
+  } else {
+    print("default")
+  }
+}
+
+// RUN: %refactor -pos=9:3 -end-pos=16:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=19:3 -end-pos=23:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT2
+// RUN: %refactor -pos=27:3 -end-pos=33:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT2
+// RUN: %refactor -pos=37:3 -end-pos=43:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=47:3 -end-pos=49:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT2
+// RUN: %refactor -pos=55:3 -end-pos=57:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=60:3 -end-pos=62:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=66:3 -end-pos=68:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=70:3 -end-pos=73:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=77:3 -end-pos=79:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT2
+// RUN: %refactor -pos=81:3 -end-pos=83:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT2
+// RUN: %refactor -pos=87:3 -end-pos=89:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT2
+// RUN: %refactor -pos=93:3 -end-pos=99:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=103:3 -end-pos=107:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT2
+// RUN: %refactor -pos=111:3 -end-pos=115:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT2
+// RUN: %refactor -pos=119:3 -end-pos=121:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT2
+// RUN: %refactor -pos=129:3 -end-pos=137:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=148:3 -end-pos=152:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=156:3 -end-pos=164:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=169:3 -end-pos=175:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+
+// CHECK-CONVERT-TO-SWITCH-STATEMENT: Convert To Switch Statement
+
+// CHECK-CONVERT-TO-SWITCH-STATEMENT2: Action begins
+// CHECK-CONVERT-TO-SWITCH-STATEMENT2-NOT: Convert To Switch Statement
+// CHECK-CONVERT-TO-SWITCH-STATEMENT2: Action ends
+

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -73,7 +73,8 @@ Action(llvm::cl::desc("kind:"), llvm::cl::init(RefactoringKind::None),
                       "replace-bodies-with-fatalError", "Perform trailing closure refactoring"),
            clEnumValN(RefactoringKind::MemberwiseInitLocalRefactoring, "memberwise-init", "Generate member wise initializer"),
            clEnumValN(RefactoringKind::ConvertToComputedProperty,
-                   "convert-to-computed-property", "Convert from field initialization to computed property")));
+                   "convert-to-computed-property", "Convert from field initialization to computed property"),
+           clEnumValN(RefactoringKind::ConvertToSwitchStmt, "convert-to-switch-stmt", "Perform convert to switch statement")));
 
 
 static llvm::cl::opt<std::string>


### PR DESCRIPTION
Implement action to convert if statements from:
  ```
var e = E.case1
  if e == .case1 {}
  else if e == .case2 {}
  else {}
```
to
```
  var e = E.case1
  switch e {
  case .case1: break
  case .case2: break
  default: break
  }
```
Resolves [SR-5740](https://bugs.swift.org/browse/SR-5740).

P.S. I can't reopen previous PR](https://github.com/apple/swift/pull/26719) because of force push to branch after rebase. I remade refactoring action to resolve comments from previous PR.

@nathawes please take a look to new implementation.