### PR TITLE
build: hoist `LINK_LIBRARIES` out of `_add_swift_executable_single`

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2506,6 +2506,9 @@ function(_add_swift_executable_single name)
   if(SWIFTEXE_SINGLE_EXCLUDE_FROM_ALL)
     message(SEND_ERROR "${name} is using EXCLUDE_FROM_ALL option which is deprecated.")
   endif()
+  if(SWIFTEXE_SINGLE_LINK_LIBRARIES)
+    message(SEND_ERROR "${name} is using LINK_LIBRARIES parameter which is deprecated.  Please use target_link_libraries instead")
+  endif()
 
   # Check arguments.
   precondition(SWIFTEXE_SINGLE_SDK MESSAGE "Should specify an SDK")
@@ -2539,12 +2542,6 @@ function(_add_swift_executable_single name)
     RESULT_VAR_NAME link_flags
     LINK_LIBRARIES_VAR_NAME link_libraries
     LIBRARY_SEARCH_DIRECTORIES_VAR_NAME library_search_directories)
-
-  _list_add_string_suffix(
-      "${SWIFTEXE_SINGLE_LINK_LIBRARIES}"
-      "-${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTEXE_SINGLE_ARCHITECTURE}"
-      SWIFTEXE_SINGLE_LINK_LIBRARIES_TARGETS)
-  set(SWIFTEXE_SINGLE_LINK_LIBRARIES ${SWIFTEXE_SINGLE_LINK_LIBRARIES_TARGETS})
 
   handle_swift_sources(
       dependency_target
@@ -2609,7 +2606,6 @@ function(_add_swift_executable_single name)
       BINARY_DIR ${SWIFT_RUNTIME_OUTPUT_INTDIR}
       LIBRARY_DIR ${SWIFT_LIBRARY_OUTPUT_INTDIR})
 
-  target_link_libraries("${name}" PRIVATE ${SWIFTEXE_SINGLE_LINK_LIBRARIES})
   swift_common_llvm_config("${name}" ${SWIFTEXE_SINGLE_LLVM_LINK_COMPONENTS})
 
   # NOTE(compnerd) use the C linker language to invoke `clang` rather than

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -45,8 +45,14 @@ function(add_swift_target_executable name)
           DEPENDS ${SWIFTEXE_TARGET_DEPENDS_with_suffix}
           LLVM_LINK_COMPONENTS ${SWIFTEXE_TARGET_LLVM_LINK_COMPONENTS}
           SDK "${sdk}"
-          ARCHITECTURE "${arch}"
-          LINK_LIBRARIES ${SWIFTEXE_TARGET_LINK_LIBRARIES})
+          ARCHITECTURE "${arch}")
+
+      _list_add_string_suffix(
+          "${SWIFTEXE_TARGET_LINK_LIBRARIES}"
+          "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}"
+          SWIFTEXE_TARGET_LINK_LIBRARIES_TARGETS)
+      target_link_libraries(${VARIANT_NAME} PRIVATE
+          ${SWIFTEXE_TARGET_LINK_LIBRARIES_TARGETS})
 
       if(NOT "${VARIANT_SUFFIX}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SUFFIX}")
         # By default, don't build executables for target SDKs to avoid building


### PR DESCRIPTION
Hoist the responsibility for adding the linked libraries out of
`_add_swift_executable_single` to the invoker.  This impacts only
`swift_add_target_executable`.  This continues to bring the computation
of the properties nearer the site of definition.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
