### PR TITLE
[ownership] Get rid of old entrypoint for creatingEndBorrow that takes the original value.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -806,12 +806,6 @@ public:
                       EndBorrowInst(getSILDebugLocation(loc), borrowedValue));
   }
 
-  EndBorrowInst *createEndBorrow(SILLocation Loc, SILValue BorrowedValue,
-                                 SILValue OriginalValue) {
-    return insert(new (getModule())
-                      EndBorrowInst(getSILDebugLocation(Loc), BorrowedValue));
-  }
-
   BeginAccessInst *createBeginAccess(SILLocation loc, SILValue address,
                                      SILAccessKind accessKind,
                                      SILAccessEnforcement enforcement,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1177,9 +1177,8 @@ void SILCloner<ImplClass>::visitEndBorrowInst(EndBorrowInst *Inst) {
     return;
 
   recordClonedInstruction(
-      Inst,
-      getBuilder().createEndBorrow(getOpLocation(Inst->getLoc()),
-                                   getOpValue(Inst->getOperand()), SILValue()));
+      Inst, getBuilder().createEndBorrow(getOpLocation(Inst->getLoc()),
+                                         getOpValue(Inst->getOperand())));
 }
 
 template <typename ImplClass>

--- a/lib/SILGen/FormalEvaluation.cpp
+++ b/lib/SILGen/FormalEvaluation.cpp
@@ -48,8 +48,7 @@ void FormalAccess::verify(SILGenFunction &SGF) const {
 //===----------------------------------------------------------------------===//
 
 void SharedBorrowFormalAccess::finishImpl(SILGenFunction &SGF) {
-  SGF.B.createEndBorrow(CleanupLocation::get(loc), borrowedValue,
-                        originalValue);
+  SGF.B.createEndBorrow(CleanupLocation::get(loc), borrowedValue);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3711,7 +3711,7 @@ static SILValue emitLoadOfSemanticRValue(SILGenFunction &SGF,
     if (!isTake) {                                                             \
       SILValue value = SGF.B.createLoadBorrow(loc, src);                       \
       SILValue strongValue = SGF.B.createStrongCopy##Name##Value(loc, value);  \
-      SGF.B.createEndBorrow(loc, value, src);                                  \
+      SGF.B.createEndBorrow(loc, value);                                       \
       return strongValue;                                                      \
     }                                                                          \
     /* Otherwise perform a load take and destroy the stored value. */          \


### PR DESCRIPTION
The original design was to make it so that end_borrow tied at the use level its
original/borrowed value. So we would have:

```
%borrowedVal = begin_borrow %original
...
end_borrow %borrowedVal from %original
```

In the end we decided not to use that design and instead just use:

```
%borrowedVal = begin_borrow %original
...
end_borrow %borrowedVal
```

In order to enable that transition, I left the old API for end_borrow that took
both original and borrowedVal and reimplemented it on top of the new API that
just took the borrowedVal (i.e. the original was just a dead arg).

Now given where we are in the development, it makes sense to get rid of that
transition API and move to just use the new API.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
