### PR TITLE
[sil] Add SILArgument::getSingleTerminator() helper.

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -173,6 +173,10 @@ public:
   /// is the enum itself (the operand of the switch_enum).
   SILValue getSingleTerminatorOperand() const;
 
+  /// If this SILArgument's parent block has a single predecessor whose
+  /// terminator has a single operand, return that terminator.
+  TermInst *getSingleTerminator() const;
+
   /// Return the SILArgumentKind of this argument.
   SILArgumentKind getKind() const {
     return SILArgumentKind(ValueBase::getKind());
@@ -263,6 +267,10 @@ public:
   /// argument value. E.g. the incoming value for a switch_enum payload argument
   /// is the enum itself (the operand of the switch_enum).
   SILValue getSingleTerminatorOperand() const;
+
+  /// If this SILArgument's parent block has a single predecessor whose
+  /// terminator has a single operand, return that terminator.
+  TermInst *getSingleTerminator() const;
 
   static bool classof(const SILInstruction *) = delete;
   static bool classof(const SILUndef *) = delete;
@@ -399,6 +407,16 @@ inline bool SILArgument::getSingleTerminatorOperands(
         returnedSingleTermOperands);
   case SILArgumentKind::SILFunctionArgument:
     return false;
+  }
+  llvm_unreachable("Covered switch is not covered?!");
+}
+
+inline TermInst *SILArgument::getSingleTerminator() const {
+  switch (getKind()) {
+  case SILArgumentKind::SILPhiArgument:
+    return cast<SILPhiArgument>(this)->getSingleTerminator();
+  case SILArgumentKind::SILFunctionArgument:
+    return nullptr;
   }
   llvm_unreachable("Covered switch is not covered?!");
 }

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -235,6 +235,14 @@ SILValue SILPhiArgument::getSingleTerminatorOperand() const {
   return getSingleTerminatorOperandForPred(parentBlock, predBlock, getIndex());
 }
 
+TermInst *SILPhiArgument::getSingleTerminator() const {
+  auto *parentBlock = getParent();
+  auto *predBlock = parentBlock->getSinglePredecessorBlock();
+  if (!predBlock)
+    return nullptr;
+  return const_cast<SILBasicBlock *>(predBlock)->getTerminator();
+}
+
 const SILPhiArgument *BranchInst::getArgForOperand(const Operand *oper) const {
   assert(oper->getUser() == this);
   return cast<SILPhiArgument>(


### PR DESCRIPTION
This is just like SILArgument::getSingleTerminatorOperand() except that it
returns the actual Terminator rather than the terminator's argument.
