### PR TITLE
[semantic-arc-opts] Convert @owned -> @guaranteed args of transforming terminators when fed by load [copy], copy_value.

### DIFF
--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -113,11 +113,10 @@ LiveRange::LiveRange(SILValue value)
       continue;
     }
 
-    // Otherwise, we have some form of consuming use that either forwards or
-    // that we do not understand. See if we have a forwarding value that has a
-    // single non-trivial operand that can accept a guaranteed value. If not, we
-    // can not recursively process it, so be conservative and assume that we
-    // /may consume/ the value, so the live range must not be eliminated.
+    // Otherwise, see if we have a forwarding value that has a single
+    // non-trivial operand that can accept a guaranteed value. If not, we can
+    // not recursively process it, so be conservative and assume that we /may
+    // consume/ the value, so the live range must not be eliminated.
     //
     // DISCUSSION: For now we do not support forwarding instructions with
     // multiple non-trivial arguments since we would need to optimize all of
@@ -125,7 +124,9 @@ LiveRange::LiveRange(SILValue value)
     //
     // NOTE: Today we do not support TermInsts for simplicity... we /could/
     // support it though if we need to.
-    if (isa<TermInst>(user) || !isGuaranteedForwardingInst(user) ||
+    auto *ti = dyn_cast<TermInst>(user);
+    if ((ti && !ti->isTransformationTerminator()) ||
+        !isGuaranteedForwardingInst(user) ||
         1 != count_if(user->getOperandValues(
                           true /*ignore type dependent operands*/),
                       [&](SILValue v) {
@@ -137,13 +138,39 @@ LiveRange::LiveRange(SILValue value)
     }
 
     // Ok, this is a forwarding instruction whose ownership we can flip from
-    // owned -> guaranteed. Visit its users recursively to see if the the
-    // users force the live range to be alive.
+    // owned -> guaranteed.
     generalForwardingInsts.push_back(user);
-    for (SILValue v : user->getResults()) {
-      if (v.getOwnershipKind() != ValueOwnershipKind::Owned)
+
+    // If we have a non-terminator, just visit its users recursively to see if
+    // the the users force the live range to be alive.
+    if (!ti) {
+      for (SILValue v : user->getResults()) {
+        if (v.getOwnershipKind() != ValueOwnershipKind::Owned)
+          continue;
+        llvm::copy(v->getUses(), std::back_inserter(worklist));
+      }
+      continue;
+    }
+
+    // Otherwise, we know that we have no only a terminator, but a
+    // transformation terminator, so we should add the users of its results to
+    // the worklist.
+    for (auto &succ : ti->getSuccessors()) {
+      auto *succBlock = succ.getBB();
+
+      // If we do not have any arguments, then continue.
+      if (succBlock->args_empty())
         continue;
-      llvm::copy(v->getUses(), std::back_inserter(worklist));
+
+      for (auto *succArg : succBlock->getSILPhiArguments()) {
+        // If we have an any value, just continue.
+        if (succArg->getOwnershipKind() == ValueOwnershipKind::None)
+          continue;
+
+        // Otherwise add all users of this BBArg to the worklist to visit
+        // recursively.
+        llvm::copy(succArg->getUses(), std::back_inserter(worklist));
+      }
     }
   }
 }
@@ -519,8 +546,28 @@ static void convertForwardingInstsFromOwnedToGuaranteed(
   while (!guaranteedForwardingInsts.empty()) {
     auto *i = guaranteedForwardingInsts.back();
     guaranteedForwardingInsts = guaranteedForwardingInsts.drop_back();
-    assert(i->hasResults());
 
+    // If this is a term inst, just convert all of its incoming values that are
+    // owned to be guaranteed.
+    if (auto *ti = dyn_cast<TermInst>(i)) {
+      for (auto &succ : ti->getSuccessors()) {
+        auto *succBlock = succ.getBB();
+
+        // If we do not have any arguments, then continue.
+        if (succBlock->args_empty())
+          continue;
+
+        for (auto *succArg : succBlock->getSILPhiArguments()) {
+          // If we have an any value, just continue.
+          if (succArg->getOwnershipKind() == ValueOwnershipKind::Owned) {
+            succArg->setOwnershipKind(ValueOwnershipKind::Guaranteed);
+          }
+        }
+      }
+      continue;
+    }
+
+    assert(i->hasResults());
     for (SILValue result : i->getResults()) {
       if (auto *svi = dyn_cast<OwnershipForwardingSingleValueInst>(result)) {
         if (svi->getOwnershipKind() == ValueOwnershipKind::Owned) {

--- a/test/SILOptimizer/semantic-arc-opts-canonical.sil
+++ b/test/SILOptimizer/semantic-arc-opts-canonical.sil
@@ -342,10 +342,8 @@ bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObje
   return %9999 : $()
 }
 
-// TODO: We should be able to optimize these switch_enum. Make sure that today
-// we do not do so though.
 // CHECK-LABEL: sil [ossa] @switch_enum_test_no_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
-// CHECK: copy_value
+// CHECK-NOT: copy_value
 // CHECK: } // end sil function 'switch_enum_test_no_default'
 sil [ossa] @switch_enum_test_no_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
 bb0(%0 : @guaranteed $FakeOptional<Builtin.NativeObject>):
@@ -365,7 +363,7 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @switch_enum_test_with_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
-// CHECK: copy_value
+// CHECK-NOT: copy_value
 // CHECK: } // end sil function 'switch_enum_test_with_default'
 sil [ossa] @switch_enum_test_with_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
 bb0(%0 : @guaranteed $FakeOptional<Builtin.NativeObject>):
@@ -431,6 +429,59 @@ bb3(%6 : $*FakeOptional<Klass>):
   dealloc_stack %5 : $*FakeOptional<Klass>
   destroy_addr %4 : $*FakeOptional<Klass>
   dealloc_stack %4 : $*FakeOptional<Klass>
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_test_loadcopy_no_default : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK-NOT: load [copy]
+// CHECK: load_borrow
+// CHECK-NOT: load [copy]
+// CHECK: } // end sil function 'switch_enum_test_loadcopy_no_default'
+sil [ossa] @switch_enum_test_loadcopy_no_default : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @owned $FakeOptional<Builtin.NativeObject>):
+  %0a = alloc_stack $FakeOptional<Builtin.NativeObject>
+  store %0 to [init] %0a : $*FakeOptional<Builtin.NativeObject>
+  %1 = load [copy] %0a : $*FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_addr %0a : $*FakeOptional<Builtin.NativeObject>
+  dealloc_stack %0a : $*FakeOptional<Builtin.NativeObject>
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_test_loadcopy_with_default : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK-NOT: load [copy]
+// CHECK: load_borrow
+// CHECK-NOT: load [copy]
+// CHECK: } // end sil function 'switch_enum_test_loadcopy_with_default'
+sil [ossa] @switch_enum_test_loadcopy_with_default : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @owned $FakeOptional<Builtin.NativeObject>):
+  %0a = alloc_stack $FakeOptional<Builtin.NativeObject>
+  store %0 to [init] %0a : $*FakeOptional<Builtin.NativeObject>
+  %1 = load [copy] %0a : $*FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, default bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2(%3 : @owned $FakeOptional<Builtin.NativeObject>):
+  destroy_value %3 : $FakeOptional<Builtin.NativeObject>
+  br bb3
+
+bb3:
+  destroy_addr %0a : $*FakeOptional<Builtin.NativeObject>
+  dealloc_stack %0a : $*FakeOptional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -360,10 +360,8 @@ bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObje
   return %9999 : $()
 }
 
-// TODO: We should be able to optimize these switch_enum. Make sure that today
-// we do not do so though.
 // CHECK-LABEL: sil [ossa] @switch_enum_test_no_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
-// CHECK: copy_value
+// CHECK-NOT: copy_value
 // CHECK: } // end sil function 'switch_enum_test_no_default'
 sil [ossa] @switch_enum_test_no_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
 bb0(%0 : @guaranteed $FakeOptional<Builtin.NativeObject>):
@@ -383,7 +381,7 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @switch_enum_test_with_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
-// CHECK: copy_value
+// CHECK-NOT: copy_value
 // CHECK: } // end sil function 'switch_enum_test_with_default'
 sil [ossa] @switch_enum_test_with_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
 bb0(%0 : @guaranteed $FakeOptional<Builtin.NativeObject>):
@@ -1137,6 +1135,153 @@ bb0(%0 : $*NativeObjectPair, %1 : @owned $Builtin.NativeObject):
   apply %5(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   destroy_value %3 : $Builtin.NativeObject
   store %1 to [assign] %2 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_test_loadcopy_no_default : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK-NOT: load [copy]
+// CHECK: load_borrow
+// CHECK-NOT: load [copy]
+// CHECK: } // end sil function 'switch_enum_test_loadcopy_no_default'
+sil [ossa] @switch_enum_test_loadcopy_no_default : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @owned $FakeOptional<Builtin.NativeObject>):
+  %0a = alloc_stack $FakeOptional<Builtin.NativeObject>
+  store %0 to [init] %0a : $*FakeOptional<Builtin.NativeObject>
+  %1 = load [copy] %0a : $*FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_addr %0a : $*FakeOptional<Builtin.NativeObject>
+  dealloc_stack %0a : $*FakeOptional<Builtin.NativeObject>
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_test_loadcopy_with_default : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK-NOT: load [copy]
+// CHECK: load_borrow
+// CHECK-NOT: load [copy]
+// CHECK: } // end sil function 'switch_enum_test_loadcopy_with_default'
+sil [ossa] @switch_enum_test_loadcopy_with_default : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @owned $FakeOptional<Builtin.NativeObject>):
+  %0a = alloc_stack $FakeOptional<Builtin.NativeObject>
+  store %0 to [init] %0a : $*FakeOptional<Builtin.NativeObject>
+  %1 = load [copy] %0a : $*FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, default bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2(%3 : @owned $FakeOptional<Builtin.NativeObject>):
+  destroy_value %3 : $FakeOptional<Builtin.NativeObject>
+  br bb3
+
+bb3:
+  destroy_addr %0a : $*FakeOptional<Builtin.NativeObject>
+  dealloc_stack %0a : $*FakeOptional<Builtin.NativeObject>
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_test_copyvalue_no_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'switch_enum_test_copyvalue_no_default'
+sil [ossa] @switch_enum_test_copyvalue_no_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<Builtin.NativeObject>):
+  %1 = copy_value %0 : $FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_test_copyvalue_with_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'switch_enum_test_copyvalue_with_default'
+sil [ossa] @switch_enum_test_copyvalue_with_default : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<Builtin.NativeObject>):
+  %1 = copy_value %0 : $FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, default bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2(%3 : @owned $FakeOptional<Builtin.NativeObject>):
+  destroy_value %3 : $FakeOptional<Builtin.NativeObject>
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_test_copyvalue_with_default_and_extract : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'switch_enum_test_copyvalue_with_default_and_extract'
+sil [ossa] @switch_enum_test_copyvalue_with_default_and_extract : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<Builtin.NativeObject>):
+  %f = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %1 = copy_value %0 : $FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, default bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2(%3 : @owned $FakeOptional<Builtin.NativeObject>):
+  %3a = unchecked_enum_data %3 : $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt.1
+  apply %f(%3a) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3a : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// TODO: We currently are unable to get rid of the begin_borrow. We should be
+// able to with appropriate analysis.
+// CHECK-LABEL: sil [ossa] @switch_enum_test_copyvalue_with_borrow : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'switch_enum_test_copyvalue_with_borrow'
+sil [ossa] @switch_enum_test_copyvalue_with_borrow : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @owned $FakeOptional<Builtin.NativeObject>):
+  %f = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %0a = begin_borrow %0 : $FakeOptional<Builtin.NativeObject>
+  %1 = copy_value %0a : $FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, default bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2(%3 : @owned $FakeOptional<Builtin.NativeObject>):
+  %3a = unchecked_enum_data %3 : $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt.1
+  apply %f(%3a) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  destroy_value %3a : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  end_borrow %0a : $FakeOptional<Builtin.NativeObject>
+  destroy_value %0 : $FakeOptional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
This extends the (copy (guaranteed x)) -> (guaranteed x) optimization to handle
transforming terminator arguments. This will eliminate a ton of ARC traffic
around optionals or casts.

I still need to add support for eliminating copies that forward through br args.
That will be in forthcoming commits after I land some changes to the ownership
model so that we can perform that optimization.

<rdar://problem/56720436>
<rdar://problem/56720519>

----

NOTE: Only the second commit is the actual commit for this. The first commit is from: #29600
