### PR TITLE
[5.2] [Parse] Suppress unknown platform diagnostics for macCatalyst

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -543,6 +543,11 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   if (AnyArgumentInvalid)
     return nullptr;
   if (!PlatformKind.hasValue()) {
+    if (Platform == "macCatalyst" ||
+        Platform == "macCatalystApplicationExtension") {
+      // Suppress unknown platform diagnostic for macCatalyst.
+      return nullptr;
+    }
     diagnose(AttrLoc, diag::attr_availability_unknown_platform,
            Platform, AttrName);
     return nullptr;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3665,8 +3665,13 @@ Parser::parsePlatformVersionConstraintSpec() {
       platformFromString(PlatformIdentifier.str());
 
   if (!Platform.hasValue() || Platform.getValue() == PlatformKind::none) {
-    diagnose(Tok, diag::avail_query_unrecognized_platform_name,
-             PlatformIdentifier);
+    // Diagnose unrecognized platforms, but suppress if the platform
+    // is macCatalyst.
+    if (!PlatformIdentifier.is("macCatalyst") &&
+        !PlatformIdentifier.is("macCatalystApplicationExtension")) {
+      diagnose(Tok, diag::avail_query_unrecognized_platform_name,
+               PlatformIdentifier);
+    }
     Platform = PlatformKind::none;
   }
 

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+// Don't emit a warning when macatalyst is used in
+// availability markup.
+
+@available(iOS, introduced: 52.0)
+@available(macCatalyst, introduced: 53.0)
+func long_form_availability() {}
+
+@available(macCatalyst, unavailable) // no-warning
+@available(macCatalystApplicationExtension, unavailable) // no-warning
+func unavailable_on_catalyst() {}
+
+@available(macCatalyst 53.0, macCatalystApplicationExtension 54.0, *) // no warning
+func short_form_availability() {}
+
+
+
+


### PR DESCRIPTION
Add explicit suppression of diagnostics complaining that macCatalyst and
macCatalystApplicationExtension are unknown platforms. This enables the
toolchain to consume declarations with macCatalyst availability markup
without emitting an annoying warning.

rdar://problem/59100134