### PR TITLE
[Constraint solver] Remove yet more of TypeCheckExprFlags

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3970,7 +3970,7 @@ ValueDecl *ConstraintSystem::findResolvedMemberRef(ConstraintLocator *locator) {
 }
 
 SolutionApplicationTarget::SolutionApplicationTarget(
-    Expr *expr, ContextualTypePurpose contextualPurpose,
+    Expr *expr, DeclContext *dc, ContextualTypePurpose contextualPurpose,
     TypeLoc convertType, bool isDiscarded) {
   // Verify that a purpose was specified if a convertType was.  Note that it is
   // ok to have a purpose without a convertType (which is used for call
@@ -3991,13 +3991,14 @@ SolutionApplicationTarget::SolutionApplicationTarget(
 
   kind = Kind::expression;
   expression.expression = expr;
+  expression.dc = dc;
   expression.contextualPurpose = contextualPurpose;
   expression.convertType = convertType;
   expression.isDiscarded = isDiscarded;
 }
 
 SolutionApplicationTarget SolutionApplicationTarget::forInitialization(
-    Expr *initializer, Type patternType, Pattern *pattern) {
+    Expr *initializer, DeclContext *dc, Type patternType, Pattern *pattern) {
   // Determine the contextual type for the initialization.
   TypeLoc contextualType;
   if (!isa<OptionalSomePattern>(pattern) &&
@@ -4016,18 +4017,43 @@ SolutionApplicationTarget SolutionApplicationTarget::forInitialization(
   }
 
   SolutionApplicationTarget target(
-      initializer, CTP_Initialization, contextualType,
+      initializer, dc, CTP_Initialization, contextualType,
       /*isDiscarded=*/false);
   target.expression.pattern = pattern;
   return target;
 }
 
-bool SolutionApplicationTarget::contextualTypeIsOnlyAHint(
-    bool isOpaqueReturnType) const {
+bool SolutionApplicationTarget::infersOpaqueReturnType() const {
   assert(kind == Kind::expression);
   switch (expression.contextualPurpose) {
   case CTP_Initialization:
-    return !isOpaqueReturnType;
+    if (Type convertType = expression.convertType.getType()) {
+      return convertType->is<OpaqueTypeArchetypeType>();
+    }
+    return false;
+
+  case CTP_ReturnStmt:
+  case CTP_ReturnSingleExpr:
+    if (Type convertType = expression.convertType.getType()) {
+      if (auto opaqueType = convertType->getAs<OpaqueTypeArchetypeType>()) {
+        auto dc = getDeclContext();
+        if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
+          return opaqueType->getDecl()->isOpaqueReturnTypeOfFunction(func);
+        }
+      }
+    }
+    return false;
+
+  default:
+    return false;
+  }
+}
+
+bool SolutionApplicationTarget::contextualTypeIsOnlyAHint() const {
+  assert(kind == Kind::expression);
+  switch (expression.contextualPurpose) {
+  case CTP_Initialization:
+    return !infersOpaqueReturnType();
   case CTP_ForEachStmt:
     return true;
   case CTP_Unused:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1147,6 +1147,7 @@ class SolutionApplicationTarget {
 
   union {
     struct {
+      /// The expression being type-checked.
       Expr *expression;
 
       /// The purpose of the contextual type.
@@ -1154,6 +1155,10 @@ class SolutionApplicationTarget {
 
       /// The type to which the expression should be converted.
       TypeLoc convertType;
+
+      /// When initializing a pattern from the expression, this is the
+      /// pattern.
+      Pattern *pattern = nullptr;
 
       /// Whether the expression result will be discarded at the end.
       bool isDiscarded;
@@ -1184,6 +1189,10 @@ public:
     function.function = fn;
     function.body = body;
   }
+
+  /// Form a target for the initialization of a pattern from an expression.
+  static SolutionApplicationTarget forInitialization(
+      Expr *initializer, Type patternType, Pattern *pattern);
 
   Expr *getAsExpr() const {
     switch (kind) {
@@ -1234,6 +1243,13 @@ public:
   void setExprConversionTypeLoc(TypeLoc type) {
     assert(kind == Kind::expression);
     expression.convertType = type;
+  }
+
+  /// For a pattern initialization target, retrieve the pattern.
+  Pattern *getInitializationPattern() const {
+    assert(kind == Kind::expression);
+    assert(expression.contextualPurpose == CTP_Initialization);
+    return expression.pattern;
   }
 
   /// Whether the contextual type is only a hint, rather than a type

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1150,6 +1150,10 @@ class SolutionApplicationTarget {
       /// The expression being type-checked.
       Expr *expression;
 
+      /// The declaration context in which the expression is being
+      /// type-checked.
+      DeclContext *dc;
+
       /// The purpose of the contextual type.
       ContextualTypePurpose contextualPurpose;
 
@@ -1171,14 +1175,15 @@ class SolutionApplicationTarget {
   };
 
 public:
-  SolutionApplicationTarget(Expr *expr,
+  SolutionApplicationTarget(Expr *expr, DeclContext *dc,
                             ContextualTypePurpose contextualPurpose,
                             Type convertType, bool isDiscarded)
-      : SolutionApplicationTarget(expr, contextualPurpose,
+      : SolutionApplicationTarget(expr, dc, contextualPurpose,
                                   TypeLoc::withoutLoc(convertType),
                                   isDiscarded) { }
 
-  SolutionApplicationTarget(Expr *expr, ContextualTypePurpose contextualPurpose,
+  SolutionApplicationTarget(Expr *expr, DeclContext *dc,
+                            ContextualTypePurpose contextualPurpose,
                             TypeLoc convertType, bool isDiscarded);
 
   SolutionApplicationTarget(AnyFunctionRef fn)
@@ -1192,7 +1197,7 @@ public:
 
   /// Form a target for the initialization of a pattern from an expression.
   static SolutionApplicationTarget forInitialization(
-      Expr *initializer, Type patternType, Pattern *pattern);
+      Expr *initializer, DeclContext *dc, Type patternType, Pattern *pattern);
 
   Expr *getAsExpr() const {
     switch (kind) {
@@ -1201,6 +1206,16 @@ public:
 
     case Kind::function:
       return nullptr;
+    }
+  }
+
+  DeclContext *getDeclContext() const {
+    switch (kind) {
+    case Kind::expression:
+      return expression.dc;
+
+    case Kind::function:
+      return function.function.getAsDeclContext();
     }
   }
 
@@ -1258,9 +1273,12 @@ public:
         expression.contextualPurpose == CTP_Initialization &&
         isa<OptionalSomePattern>(expression.pattern);
   }
-  
+
+  /// Whether this context infers an opaque return type.
+  bool infersOpaqueReturnType() const;
+
   /// Whether the contextual type is only a hint, rather than a type
-  bool contextualTypeIsOnlyAHint(bool isOpaqueReturnType) const;
+  bool contextualTypeIsOnlyAHint() const;
 
   bool isDiscardedExpr() const {
     assert(kind == Kind::expression);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1252,6 +1252,13 @@ public:
     return expression.pattern;
   }
 
+  /// Whether this is an initialization for an Optional.Some pattern.
+  bool isOptionalSomePatternInit() const {
+    return kind == Kind::expression &&
+        expression.contextualPurpose == CTP_Initialization &&
+        isa<OptionalSomePattern>(expression.pattern);
+  }
+  
   /// Whether the contextual type is only a hint, rather than a type
   bool contextualTypeIsOnlyAHint(bool isOpaqueReturnType) const;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2150,7 +2150,7 @@ TypeChecker::typeCheckExpression(
 
   Type convertTo = convertType.getType();
 
-  if (options.contains(TypeCheckExprFlags::ExpressionTypeMustBeOptional)) {
+  if (target.isOptionalSomePatternInit()) {
     assert(!convertTo && "convertType and type check options conflict");
     auto *convertTypeLocator =
         cs.getConstraintLocator(expr, LocatorPathElt::ContextualType());
@@ -2669,24 +2669,12 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
   if (!initializer)
     return true;
 
-  TypeLoc contextualType;
-  auto contextualPurpose = CTP_Unused;
-  TypeCheckExprOptions flags = None;
-
-  // Set the contextual purpose even if the pattern doesn't have a type so
-  // if there's an error we can use that information to inform diagnostics.
-  contextualPurpose = CTP_Initialization;
-
-  if (isa<OptionalSomePattern>(pattern)) {
-    flags |= TypeCheckExprFlags::ExpressionTypeMustBeOptional;
-  }
-    
   // Type-check the initializer.
   auto target = SolutionApplicationTarget::forInitialization(
       initializer, patternType, pattern);
   bool unresolvedTypeExprs = false;
   auto resultTarget = typeCheckExpression(target, DC, unresolvedTypeExprs,
-                                          flags, &listener);
+                                          None, &listener);
 
   if (resultTarget) {
     initializer = resultTarget->getAsExpr();

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -517,23 +517,6 @@ public:
     
     TypeCheckExprOptions options = {};
     
-    // If the result type is an opaque type, this is an opportunity to resolve
-    // the underlying type.
-    auto isOpaqueReturnTypeOfCurrentFunc = [&](OpaqueTypeDecl *opaque) -> bool {
-      // Closures currently don't support having opaque types.
-      auto funcDecl = TheFunc->getAbstractFunctionDecl();
-      if (!funcDecl)
-        return false;
-
-      return opaque->isOpaqueReturnTypeOfFunction(funcDecl);
-    };
-    
-    if (auto opaque = ResultTy->getAs<OpaqueTypeArchetypeType>()) {
-      if (isOpaqueReturnTypeOfCurrentFunc(opaque->getDecl())) {
-        options |= TypeCheckExprFlags::ConvertTypeIsOpaqueReturnType;
-      }
-    }
-
     if (EndTypeCheckLoc.isValid()) {
       assert(DiagnosticSuppression::isEnabled(getASTContext().Diags) &&
              "Diagnosing and AllowUnresolvedTypeVariables don't seem to mix");

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -183,13 +183,6 @@ enum class TypeCheckExprFlags {
   /// as part of the expression diagnostics, which is attempting to narrow
   /// down failure location.
   SubExpressionDiagnostics = 0x400,
-  
-  /// If set, the 'convertType' specified to typeCheckExpression is the opaque
-  /// return type of the declaration being checked. The archetype should be
-  /// opened into a type variable to provide context to the expression, and
-  /// the resulting type will be a candidate for binding the underlying
-  /// type.
-  ConvertTypeIsOpaqueReturnType = 0x800,
 };
 
 using TypeCheckExprOptions = OptionSet<TypeCheckExprFlags>;
@@ -831,7 +824,6 @@ public:
 
   static Optional<constraints::SolutionApplicationTarget>
   typeCheckExpression(constraints::SolutionApplicationTarget &target,
-                      DeclContext *dc,
                       bool &unresolvedTypeExprs,
                       TypeCheckExprOptions options = TypeCheckExprOptions(),
                       ExprTypeCheckListener *listener = nullptr,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -176,10 +176,6 @@ enum class TypeCheckExprFlags {
   /// not affect type checking itself.
   IsExprStmt = 0x20,
 
-  /// If set, a conversion constraint should be specified so that the result of
-  /// the expression is an optional type.
-  ExpressionTypeMustBeOptional = 0x200,
-
   /// FIXME(diagnostics): Once diagnostics are completely switched to new
   /// framework, this flag could be removed as obsolete.
   ///


### PR DESCRIPTION
Sink more information down into `SolutionApplicationTarget` so we can compute per-target two more bits of information that were previously flags passed down:

* `ExpressionTypeMustBeOptional`: used to indicate when we want an optional type (e.g., for an `if let`). This can be recovered by storing the pattern in `SolutionApplicationTarget` (we need it anyway)
* `ConvertTypeIsOpaqueReturnType`: used to note that the expression produces the concrete type for an opaque return type.