### PR TITLE
[TypeChecker/BuilderTransform] Make sure implicit load expression upd…

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -694,8 +694,8 @@ private:
 
       // Load the right-hand side if needed.
       if (finalCapturedExpr->getType()->is<LValueType>()) {
-        auto &cs = solution.getConstraintSystem();
-        finalCapturedExpr = cs.addImplicitLoadExpr(finalCapturedExpr);
+        finalCapturedExpr =
+            TypeChecker::addImplicitLoadExpr(ctx, finalCapturedExpr);
       }
 
       auto assign = new (ctx) AssignExpr(
@@ -840,8 +840,7 @@ public:
 
         // Load the condition if needed.
         if (finalCondExpr->getType()->is<LValueType>()) {
-          auto &cs = solution.getConstraintSystem();
-          finalCondExpr = cs.addImplicitLoadExpr(finalCondExpr);
+          finalCondExpr = TypeChecker::addImplicitLoadExpr(ctx, finalCondExpr);
         }
 
         condElement.setBoolean(finalCondExpr);

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -693,7 +693,7 @@ private:
       declRef->setType(LValueType::get(temporaryVar->getType()));
 
       // Load the right-hand side if needed.
-      if (finalCapturedExpr->getType()->is<LValueType>()) {
+      if (finalCapturedExpr->getType()->hasLValueType()) {
         finalCapturedExpr =
             TypeChecker::addImplicitLoadExpr(ctx, finalCapturedExpr);
       }
@@ -839,7 +839,7 @@ public:
         auto finalCondExpr = rewriteExpr(condExpr);
 
         // Load the condition if needed.
-        if (finalCondExpr->getType()->is<LValueType>()) {
+        if (finalCondExpr->getType()->hasLValueType()) {
           finalCondExpr = TypeChecker::addImplicitLoadExpr(ctx, finalCondExpr);
         }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1094,10 +1094,13 @@ public:
   /// more complicated than simplify wrapping given root in newly created
   /// `LoadExpr`, because `ForceValueExpr` and `ParenExpr` supposed to appear
   /// only at certain positions in AST.
-  static Expr *
-  addImplicitLoadExpr(ASTContext &Context, Expr *expr,
-                      std::function<Type(Expr *)> getType,
-                      std::function<void(Expr *, Type)> setType);
+  static Expr *addImplicitLoadExpr(ASTContext &Context, Expr *expr,
+                                   std::function<Type(Expr *)> getType =
+                                       [](Expr *E) { return E->getType(); },
+                                   std::function<void(Expr *, Type)> setType =
+                                       [](Expr *E, Type type) {
+                                         E->setType(type);
+                                       });
 
   /// Determine whether the given type contains the given protocol.
   ///

--- a/validation-test/Sema/SwiftUI/rdar58972627.swift
+++ b/validation-test/Sema/SwiftUI/rdar58972627.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend %s -target x86_64-apple-macosx10.15 -emit-sil -verify
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+import Combine
+
+struct A: View {
+  var body: some View {
+    Spacer()
+  }
+}
+
+struct B: View {
+  var body: some View {
+    Spacer()
+  }
+}
+
+class Context: ObservableObject {
+  @State var flag: Bool
+
+  init() {
+    self.flag = false
+  }
+}
+
+struct S : View {
+  @EnvironmentObject var context: Context
+
+  var body: some View {
+    VStack {
+      if (context.flag) { // Ok (shouldn't trip SIL Verifier)
+        A()
+      } else {
+        B()
+      }
+    }
+  }
+}


### PR DESCRIPTION
…ates types in AST

Can't use `ConstraintSystem::addImplicitLoadExpr` because that would
only cache types in constraint system and wouldn't propagate them to AST,
since that happens in `ExprRewritter::finalize` during regular solution
application. `TypeChecker::addImplicitLoadExpr` should be used directly
in cases like that.

Resolves: rdar://problem/58972627

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
