### PR TITLE
Parse Swift decls in one shot

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -470,6 +470,8 @@ ERROR(expected_precedencegroup_relation,none,
       (StringRef))
 
 // SIL
+ERROR(expected_sil_keyword,none,
+      "expected SIL keyword", ())
 ERROR(inout_not_attribute, none,
       "@inout is no longer an attribute", ())
 ERROR(only_allowed_in_sil,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -413,7 +413,8 @@ public:
          bool DelayBodyParsing = true);
   ~Parser();
 
-  bool isInSILMode() const { return SIL != nullptr; }
+  /// Returns true if the buffer being parsed is allowed to contain SIL.
+  bool isInSILMode() const;
 
   /// Calling this function to finalize libSyntax tree creation without destroying
   /// the parser instance.
@@ -661,6 +662,9 @@ public:
   /// Returns \c true if the parser hit the eof before finding matched '}'.
   bool skipBracedBlock();
 
+  /// Skip over SIL decls until we encounter the start of a Swift decl or eof.
+  void skipSILUntilSwiftDecl();
+
   /// If the parser is generating only a syntax tree, try loading the current
   /// node from a previously generated syntax tree.
   /// Returns \c true if the node has been loaded and inserted into the current
@@ -880,10 +884,17 @@ public:
   //===--------------------------------------------------------------------===//
   // Decl Parsing
 
-  /// Return true if parser is at the start of a Swift decl or decl-import.
+  /// Returns true if parser is at the start of a Swift decl or decl-import.
   bool isStartOfSwiftDecl();
 
+  /// Returns true if the parser is at the start of a SIL decl.
+  bool isStartOfSILDecl();
+
+  /// Parse the top-level Swift decls into the source file.
   void parseTopLevel();
+
+  /// Parse the top-level SIL decls into the SIL module.
+  void parseTopLevelSIL();
 
   /// Flags that control the parsing of declarations.
   enum ParseDeclFlags {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -880,8 +880,8 @@ public:
   //===--------------------------------------------------------------------===//
   // Decl Parsing
 
-  /// Return true if parser is at the start of a decl or decl-import.
-  bool isStartOfDecl();
+  /// Return true if parser is at the start of a Swift decl or decl-import.
+  bool isStartOfSwiftDecl();
 
   void parseTopLevel();
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -431,9 +431,8 @@ public:
                           PreviousLoc);
   }
 
-  ParserPosition getParserPosition(const PersistentParserState::ParserPos &Pos){
-    return ParserPosition(L->getStateForBeginningOfTokenLoc(Pos.Loc),
-                          Pos.PrevLoc);
+  ParserPosition getParserPosition(SourceLoc loc, SourceLoc previousLoc) {
+    return ParserPosition(L->getStateForBeginningOfTokenLoc(loc), previousLoc);
   }
 
   void restoreParserPosition(ParserPosition PP, bool enableDiagnostics = false) {

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -59,22 +59,11 @@ public:
 /// Parser state persistent across multiple parses.
 class PersistentParserState {
 public:
-  struct ParserPos {
-    SourceLoc Loc;
-    SourceLoc PrevLoc;
-
-    bool isValid() const { return Loc.isValid(); }
-  };
-
-  bool InPoundLineEnvironment = false;
   // FIXME: When condition evaluation moves to a later phase, remove this bit
   // and adjust the client call 'performParseOnly'.
   bool PerformConditionEvaluation = true;
 private:
   swift::ScopeInfo ScopeInfo;
-
-  /// Parser sets this if it stopped parsing before the buffer ended.
-  ParserPosition MarkedPos;
 
   std::unique_ptr<CodeCompletionDelayedDeclState> CodeCompletionDelayedDeclStat;
 
@@ -112,19 +101,6 @@ public:
 
   TopLevelContext &getTopLevelContext() {
     return TopLevelCode;
-  }
-
-  void markParserPosition(ParserPosition Pos,
-                          bool InPoundLineEnvironment) {
-    MarkedPos = Pos;
-    this->InPoundLineEnvironment = InPoundLineEnvironment;
-  }
-
-  /// Returns the marked parser position and resets it.
-  ParserPosition takeParserPosition() {
-    ParserPosition Pos = MarkedPos;
-    MarkedPos = ParserPosition();
-    return Pos;
   }
 };
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -106,29 +106,21 @@ namespace swift {
 
   /// Parse a single buffer into the given source file.
   ///
-  /// If the source file is the main file, stop parsing after the next
-  /// stmt-brace-item with side-effects.
+  /// \param SF The file within the module being parsed.
   ///
-  /// \param SF the file within the module being parsed.
+  /// \param BufferID The buffer to parse from.
   ///
-  /// \param BufferID the buffer to parse from.
+  /// \param PersistentState If non-null the same PersistentState object can be
+  /// used to save parser state for code completion.
   ///
-  /// \param[out] Done set to \c true if end of the buffer was reached.
-  ///
-  /// \param SIL if non-null, we're parsing a SIL file.
-  ///
-  /// \param PersistentState if non-null the same PersistentState object can
-  /// be used to resume parsing or parse delayed function bodies.
-  void parseIntoSourceFile(SourceFile &SF, unsigned BufferID, bool *Done,
-                           SILParserState *SIL = nullptr,
+  /// \param DelayBodyParsing Whether parsing of type and function bodies can be
+  /// delayed.
+  void parseIntoSourceFile(SourceFile &SF, unsigned BufferID,
                            PersistentParserState *PersistentState = nullptr,
                            bool DelayBodyParsing = true);
 
-  /// Parse a single buffer into the given source file, until the full source
-  /// contents are parsed.
-  void parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
-                               PersistentParserState *PersistentState = nullptr,
-                               bool DelayBodyParsing = true);
+  /// Parse a source file's SIL declarations into a given SIL module.
+  void parseSourceFileSIL(SourceFile &SF, SILParserState *sil);
 
   /// Finish the code completion.
   void performCodeCompletionSecondPass(PersistentParserState &PersistentState,

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -217,7 +217,7 @@ bool CompletionInstance::performCachedOperaitonIfPossible(
   newSF->enableInterfaceHash();
   // Ensure all non-function-body tokens are hashed into the interface hash
   Ctx->LangOpts.EnableTypeFingerprints = false;
-  parseIntoSourceFileFull(*newSF, tmpBufferID, &newState);
+  parseIntoSourceFile(*newSF, tmpBufferID, &newState);
   // Couldn't find any completion token?
   if (!newState.hasCodeCompletionDelayedDeclState())
     return false;

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -208,10 +208,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   const unsigned OriginalDeclCount = SF.getTopLevelDecls().size();
 
   PersistentParserState PersistentState;
-  bool Done;
-  do {
-    parseIntoSourceFile(SF, *BufferID, &Done, nullptr, &PersistentState);
-  } while (!Done);
+  parseIntoSourceFile(SF, *BufferID, &PersistentState);
   performTypeChecking(SF, OriginalDeclCount);
 
   performCodeCompletionSecondPass(PersistentState, *CompletionCallbacksFactory);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -187,11 +187,7 @@ typeCheckREPLInput(ModuleDecl *MostRecentModule, StringRef Name,
     REPLInputFile.addImports(ImportsWithOptions);
   }
 
-  bool Done;
-  do {
-    parseIntoSourceFile(REPLInputFile, BufferID, &Done, nullptr,
-                        &PersistentState);
-  } while (!Done);
+  parseIntoSourceFile(REPLInputFile, BufferID, &PersistentState);
   performTypeChecking(REPLInputFile);
   return REPLModule;
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3047,9 +3047,9 @@ bool Parser::parseDeclModifierList(DeclAttributes &Attributes,
         // treat 'class' as a modifier; in the case of a following CC
         // token, we cannot be sure there is no intention to override
         // or witness something static.
-        if (isStartOfDecl() || (isa<ClassDecl>(CurDeclContext) &&
-                                (Tok.is(tok::code_complete) ||
-                                 Tok.getRawText().equals("override")))) {
+        if (isStartOfSwiftDecl() || (isa<ClassDecl>(CurDeclContext) &&
+                                     (Tok.is(tok::code_complete) ||
+                                      Tok.getRawText().equals("override")))) {
           /* We're OK */
         } else {
           // This 'class' is a real ClassDecl introducer.
@@ -3296,8 +3296,7 @@ static bool isParenthesizedUnowned(Parser &P) {
           (P.Tok.getText() == "safe" || P.Tok.getText() == "unsafe");
 }
 
-  
-bool Parser::isStartOfDecl() {
+bool Parser::isStartOfSwiftDecl() {
   // If this is obviously not the start of a decl, then we're done.
   if (!isKeywordPossibleDeclStart(Tok)) return false;
 
@@ -3348,7 +3347,7 @@ bool Parser::isStartOfDecl() {
     if (Tok.isAny(tok::r_brace, tok::eof, tok::pound_endif))
       return true;
 
-    return isStartOfDecl();
+    return isStartOfSwiftDecl();
   }
 
   // Otherwise, the only hard case left is the identifier case.
@@ -3374,7 +3373,7 @@ bool Parser::isStartOfDecl() {
     consumeToken(tok::l_paren);
     consumeToken(tok::identifier);
     consumeToken(tok::r_paren);
-    return isStartOfDecl();
+    return isStartOfSwiftDecl();
   }
 
   // If the next token is obviously not the start of a decl, bail early.
@@ -3384,7 +3383,7 @@ bool Parser::isStartOfDecl() {
   // Otherwise, do a recursive parse.
   Parser::BacktrackingScope Backtrack(*this);
   consumeToken(tok::identifier);
-  return isStartOfDecl();
+  return isStartOfSwiftDecl();
 }
 
 void Parser::consumeDecl(ParserPosition BeginParserPosition,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -239,11 +239,6 @@ void Parser::parseTopLevel() {
   SF.ASTStage = SourceFile::Parsed;
   verify(SF);
 
-  // Next time start relexing from the beginning of the comment so that we can
-  // attach it to the token.
-  State->markParserPosition(getParserPosition(),
-                            InPoundLineEnvironment);
-
   // Finalize the token receiver.
   SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
   TokReceiver->finalize();
@@ -4012,7 +4007,8 @@ Parser::parseDeclListDelayed(IterableDeclContext *IDC) {
     return {std::vector<Decl *>(), None};
   }
 
-  auto BeginParserPosition = getParserPosition({BodyRange.Start, SourceLoc()});
+  auto BeginParserPosition = getParserPosition(BodyRange.Start,
+                                               /*previousLoc*/ SourceLoc());
   auto EndLexerState = L->getStateForEndOfTokenLoc(BodyRange.End);
 
   // ParserPositionRAII needs a primed parser to restore to.
@@ -6426,7 +6422,8 @@ BraceStmt *Parser::parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD) {
          "function body should be delayed");
 
   auto bodyRange = AFD->getBodySourceRange();
-  auto BeginParserPosition = getParserPosition({bodyRange.Start, SourceLoc()});
+  auto BeginParserPosition = getParserPosition(bodyRange.Start,
+                                               /*previousLoc*/ SourceLoc());
   auto EndLexerState = L->getStateForEndOfTokenLoc(AFD->getEndLoc());
 
   // ParserPositionRAII needs a primed parser to restore to.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3463,7 +3463,7 @@ ParserResult<Expr> Parser::parseExprCollection() {
       // If The next token is at the beginning of a new line and can never start
       // an element, break.
       if (Tok.isAtStartOfLine() && (Tok.isAny(tok::r_brace, tok::pound_endif) ||
-                                    isStartOfDecl() || isStartOfStmt()))
+                                    isStartOfSwiftDecl() || isStartOfStmt()))
         break;
 
       diagnose(Tok, diag::expected_separator, ",")

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -306,15 +306,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
          Tok.isNot(tok::pound_elseif) &&
          Tok.isNot(tok::pound_else) &&
          Tok.isNot(tok::eof) &&
-         Tok.isNot(tok::kw_sil) &&
-         Tok.isNot(tok::kw_sil_scope) &&
-         Tok.isNot(tok::kw_sil_stage) &&
-         Tok.isNot(tok::kw_sil_vtable) &&
-         Tok.isNot(tok::kw_sil_global) &&
-         Tok.isNot(tok::kw_sil_witness_table) &&
-         Tok.isNot(tok::kw_sil_default_witness_table) &&
-         Tok.isNot(tok::kw_sil_differentiability_witness) &&
-         Tok.isNot(tok::kw_sil_property) &&
+         !isStartOfSILDecl() &&
          (isConditionalBlock ||
           !isTerminatorForBraceItemListKind(Kind, Entries))) {
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -401,7 +401,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       ParserStatus Status = parseLineDirective(false);
       BraceItemsStatus |= Status;
       NeedParseErrorRecovery = Status.isError();
-    } else if (isStartOfDecl()) {
+    } else if (isStartOfSwiftDecl()) {
       SmallVector<Decl*, 8> TmpDecls;
       ParserResult<Decl> DeclResult = 
           parseDecl(IsTopLevel ? PD_AllowTopLevel : PD_Default,
@@ -703,7 +703,7 @@ ParserResult<Stmt> Parser::parseStmtBreak() {
   // since the expression after the break is dead, we don't feel bad eagerly
   // parsing this.
   if (Tok.is(tok::identifier) && !Tok.isAtStartOfLine() &&
-      !isStartOfStmt() && !isStartOfDecl())
+      !isStartOfStmt() && !isStartOfSwiftDecl())
     TargetLoc = consumeIdentifier(&Target);
 
   return makeParserResult(new (Context) BreakStmt(Loc, Target, TargetLoc));
@@ -726,7 +726,7 @@ ParserResult<Stmt> Parser::parseStmtContinue() {
   // since the expression after the continue is dead, we don't feel bad eagerly
   // parsing this.
   if (Tok.is(tok::identifier) && !Tok.isAtStartOfLine() &&
-      !isStartOfStmt() && !isStartOfDecl())
+      !isStartOfStmt() && !isStartOfSwiftDecl())
     TargetLoc = consumeIdentifier(&Target);
 
   return makeParserResult(new (Context) ContinueStmt(Loc, Target, TargetLoc));
@@ -759,7 +759,7 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
   if (Tok.isNot(tok::r_brace, tok::semi, tok::eof, tok::pound_if, 
                 tok::pound_error, tok::pound_warning, tok::pound_endif,
                 tok::pound_else, tok::pound_elseif) &&
-      !isStartOfStmt() && !isStartOfDecl()) {
+      !isStartOfStmt() && !isStartOfSwiftDecl()) {
     SourceLoc ExprLoc = Tok.getLoc();
 
     // Issue a warning when the returned expression is on a different line than

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1636,7 +1636,7 @@ bool Parser::canParseOldStyleProtocolComposition() {
 
 bool Parser::canParseTypeTupleBody() {
   if (Tok.isNot(tok::r_paren) && Tok.isNot(tok::r_brace) &&
-      Tok.isNotEllipsis() && !isStartOfDecl()) {
+      Tok.isNotEllipsis() && !isStartOfSwiftDecl()) {
     do {
       // The contextual inout marker is part of argument lists.
       consumeIf(tok::kw_inout);
@@ -1661,8 +1661,7 @@ bool Parser::canParseTypeTupleBody() {
         if (consumeIf(tok::equal)) {
           while (Tok.isNot(tok::eof) && Tok.isNot(tok::r_paren) &&
                  Tok.isNot(tok::r_brace) && Tok.isNotEllipsis() &&
-                 Tok.isNot(tok::comma) &&
-                 !isStartOfDecl()) {
+                 Tok.isNot(tok::comma) && !isStartOfSwiftDecl()) {
             skipSingle();
           }
         }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -558,6 +558,8 @@ Parser::~Parser() {
   delete SyntaxContext;
 }
 
+bool Parser::isInSILMode() const { return SF.Kind == SourceFileKind::SIL; }
+
 bool Parser::allowTopLevelCode() const {
   return SF.isScriptMode();
 }
@@ -1238,11 +1240,7 @@ ParserUnit::~ParserUnit() {
 
 OpaqueSyntaxNode ParserUnit::parse() {
   auto &P = getParser();
-  bool Done = false;
-  while (!Done) {
-    P.parseTopLevel();
-    Done = P.Tok.is(tok::eof);
-  }
+  P.parseTopLevel();
   return P.finalizeSyntaxTree();
 }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -148,7 +148,7 @@ void Parser::performCodeCompletionSecondPassImpl(
   if (info.PrevOffset != ~0U)
     prevLoc = SourceMgr.getLocForOffset(BufferID, info.PrevOffset);
   // Set the parser position to the start of the delayed decl or the body.
-  restoreParserPosition(getParserPosition({startLoc, prevLoc}));
+  restoreParserPosition(getParserPosition(startLoc, prevLoc));
 
   // Do not delay parsing in the second pass.
   llvm::SaveAndRestore<bool> DisableDelayedBody(DelayBodyParsing, false);
@@ -543,13 +543,6 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
   // Set the token to a sentinel so that we know the lexer isn't primed yet.
   // This cannot be tok::unknown, since that is a token the lexer could produce.
   Tok.setKind(tok::NUM_TOKENS);
-
-  auto ParserPos = State->takeParserPosition();
-  if (ParserPos.isValid() &&
-      L->isStateForCurrentBuffer(ParserPos.LS)) {
-    restoreParserPosition(ParserPos);
-    InPoundLineEnvironment = State->InPoundLineEnvironment;
-  }
 }
 
 Parser::~Parser() {

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -713,7 +713,7 @@ SourceLoc Parser::skipUntilGreaterInTypeList(bool protocolComposition) {
     // 'Self' can appear in types, skip it.
     if (Tok.is(tok::kw_Self))
       break;
-    if (isStartOfStmt() || isStartOfDecl() || Tok.is(tok::pound_endif))
+    if (isStartOfStmt() || isStartOfSwiftDecl() || Tok.is(tok::pound_endif))
       return lastLoc;
     break;
 
@@ -742,7 +742,7 @@ void Parser::skipUntilDeclRBrace() {
   while (Tok.isNot(tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif,
                    tok::code_complete) &&
-         !isStartOfDecl())
+         !isStartOfSwiftDecl())
     skipSingle();
 }
 
@@ -750,7 +750,7 @@ void Parser::skipUntilDeclStmtRBrace(tok T1) {
   while (Tok.isNot(T1, tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif,
                    tok::code_complete) &&
-         !isStartOfStmt() && !isStartOfDecl()) {
+         !isStartOfStmt() && !isStartOfSwiftDecl()) {
     skipSingle();
   }
 }
@@ -759,7 +759,7 @@ void Parser::skipUntilDeclStmtRBrace(tok T1, tok T2) {
   while (Tok.isNot(T1, T2, tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif,
                    tok::code_complete) &&
-         !isStartOfStmt() && !isStartOfDecl()) {
+         !isStartOfStmt() && !isStartOfSwiftDecl()) {
     skipSingle();
   }
 }
@@ -770,7 +770,7 @@ void Parser::skipListUntilDeclRBrace(SourceLoc startLoc, tok T1, tok T2) {
     bool hasDelimiter = Tok.getLoc() == startLoc || consumeIf(tok::comma);
     bool possibleDeclStartsLine = Tok.isAtStartOfLine();
     
-    if (isStartOfDecl()) {
+    if (isStartOfSwiftDecl()) {
       
       // Could have encountered something like `_ var:` 
       // or `let foo:` or `var:`
@@ -800,7 +800,7 @@ void Parser::skipListUntilDeclRBrace(SourceLoc startLoc, tok T1, tok T2) {
 void Parser::skipUntilDeclRBrace(tok T1, tok T2) {
   while (Tok.isNot(T1, T2, tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif) &&
-         !isStartOfDecl()) {
+         !isStartOfSwiftDecl()) {
     skipSingle();
   }
 }
@@ -1106,7 +1106,7 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
     // If we're in a comma-separated list, the next token is at the
     // beginning of a new line and can never start an element, break.
     if (Tok.isAtStartOfLine() &&
-        (Tok.is(tok::r_brace) || isStartOfDecl() || isStartOfStmt())) {
+        (Tok.is(tok::r_brace) || isStartOfSwiftDecl() || isStartOfStmt())) {
       break;
     }
     // If we found EOF or such, bailout.

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -113,16 +113,9 @@ void PrettyStackTraceParser::print(llvm::raw_ostream &out) const {
   out << '\n';
 }
 
-static void parseIntoSourceFileImpl(SourceFile &SF,
-                                    unsigned BufferID,
-                                    bool *Done,
-                                    SILParserState *SIL,
-                                    PersistentParserState *PersistentState,
-                                    bool FullParse,
-                                    bool DelayBodyParsing) {
-  assert((!FullParse || (SF.canBeParsedInFull() && !SIL)) &&
-         "cannot parse in full with the given parameters!");
-
+void swift::parseIntoSourceFile(SourceFile &SF, unsigned int BufferID,
+                                PersistentParserState *PersistentState,
+                                bool DelayBodyParsing) {
   std::shared_ptr<SyntaxTreeCreator> STreeCreator;
   if (SF.shouldBuildSyntaxTree()) {
     STreeCreator = std::make_shared<SyntaxTreeCreator>(
@@ -139,21 +132,15 @@ static void parseIntoSourceFileImpl(SourceFile &SF,
     DelayBodyParsing = false;
   if (SF.shouldBuildSyntaxTree())
     DelayBodyParsing = false;
-  if (SIL)
-    DelayBodyParsing = false;
 
   FrontendStatsTracer tracer(SF.getASTContext().Stats, "Parsing");
-  Parser P(BufferID, SF, SIL ? SIL->Impl.get() : nullptr,
-           PersistentState, STreeCreator, DelayBodyParsing);
+  Parser P(BufferID, SF, /*SIL*/ nullptr, PersistentState, STreeCreator,
+           DelayBodyParsing);
   PrettyStackTraceParser StackTrace(P);
 
   llvm::SaveAndRestore<NullablePtr<llvm::MD5>> S(P.CurrentTokenHash,
                                                  SF.getInterfaceHashPtr());
-
-  do {
-    P.parseTopLevel();
-    *Done = P.Tok.is(tok::eof);
-  } while (FullParse && !*Done);
+  P.parseTopLevel();
 
   if (STreeCreator) {
     auto rawNode = P.finalizeSyntaxTree();
@@ -161,27 +148,17 @@ static void parseIntoSourceFileImpl(SourceFile &SF,
   }
 }
 
-void swift::parseIntoSourceFile(SourceFile &SF,
-                                unsigned BufferID,
-                                bool *Done,
-                                SILParserState *SIL,
-                                PersistentParserState *PersistentState,
-                                bool DelayBodyParsing) {
-  parseIntoSourceFileImpl(SF, BufferID, Done, SIL,
-                          PersistentState,
-                          /*FullParse=*/SF.shouldBuildSyntaxTree(),
-                          DelayBodyParsing);
-}
+void swift::parseSourceFileSIL(SourceFile &SF, SILParserState *sil) {
+  auto bufferID = SF.getBufferID();
+  assert(bufferID);
 
-void swift::parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
-                                    PersistentParserState *PersistentState,
-                                    bool DelayBodyParsing) {
-  bool Done = false;
-  parseIntoSourceFileImpl(SF, BufferID, &Done, /*SIL=*/nullptr,
-                          PersistentState, /*FullParse=*/true,
-                          DelayBodyParsing);
+  FrontendStatsTracer tracer(SF.getASTContext().Stats, "Parsing SIL");
+  Parser parser(*bufferID, SF, sil->Impl.get(),
+                /*persistentParserState*/ nullptr,
+                /*syntaxTreeCreator*/ nullptr, /*delayBodyParsing*/ false);
+  PrettyStackTraceParser StackTrace(parser);
+  parser.parseTopLevelSIL();
 }
-
 
 //===----------------------------------------------------------------------===//
 // SILParser
@@ -1157,9 +1134,6 @@ bool SILParser::performTypeLocChecking(TypeLoc &T, bool IsSILType,
                                        GenericEnvironment *GenericEnv,
                                        DeclContext *DC) {
   // Do some type checking / name binding for the parsed type.
-  assert(P.SF.ASTStage == SourceFile::Parsing &&
-         "Unexpected stage during parsing!");
-
   if (GenericEnv == nullptr)
     GenericEnv = ContextGenericEnv;
 
@@ -1177,12 +1151,6 @@ bool SILParser::performTypeLocChecking(TypeLoc &T, bool IsSILType,
 static llvm::PointerUnion<ValueDecl *, ModuleDecl *>
 lookupTopDecl(Parser &P, DeclBaseName Name, bool typeLookup) {
   // Use UnqualifiedLookup to look through all of the imports.
-  // We have to lie and say we're done with parsing to make this happen.
-  assert(P.SF.ASTStage == SourceFile::Parsing &&
-         "Unexpected stage during parsing!");
-  llvm::SaveAndRestore<SourceFile::ASTStage_t> ASTStage(P.SF.ASTStage,
-                                                        SourceFile::Parsed);
-
   UnqualifiedLookupOptions options;
   if (typeLookup)
     options |= UnqualifiedLookupFlags::TypeLookup;

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -130,11 +130,7 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
                                           Ctx.LangOpts.BuildSyntaxTree);
   importMod->addFile(*importFile);
 
-  bool done;
-  parseIntoSourceFile(*importFile, bufferID, &done, nullptr, nullptr);
-  assert(done && "Parser returned early?");
-  (void)done;
-
+  parseIntoSourceFile(*importFile, bufferID);
   performNameBinding(*importFile);
   importMod->setHasResolvedImports();
   return importMod;

--- a/test/Parse/identifiers.swift
+++ b/test/Parse/identifiers.swift
@@ -32,9 +32,9 @@ func <#some name#>() {} // expected-error {{editor placeholder in source file}}
 class switch {} // expected-error {{keyword 'switch' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{7-13=`switch`}}
 struct Self {} // expected-error {{keyword 'Self' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Self`}}
 protocol enum {} // expected-error {{keyword 'enum' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{10-14=`enum`}}
-protocol test { // expected-note{{in declaration of 'test'}}
-  associatedtype public // expected-error {{keyword 'public' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{18-24=`public`}} expected-error {{consecutive declarations on a line must be separated by ';'}}
-} // expected-error{{expected declaration}}
+protocol test {
+  associatedtype public // expected-error {{keyword 'public' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{18-24=`public`}}
+}
 func _(_ x: Int) {} // expected-error {{keyword '_' cannot be used as an identifier here}} // expected-note {{if this name is unavoidable, use backticks to escape it}} {{6-7=`_`}}
 
 // SIL keywords are tokenized as normal identifiers in non-SIL mode.

--- a/test/SIL/Parser/attributes.sil
+++ b/test/SIL/Parser/attributes.sil
@@ -5,3 +5,7 @@ sil [_semantics "123"] [_semantics "456"] @foo : $@convention(thin) () -> () {
 bb0:
   return undef : $()
 }
+
+// Make sure we don't try to parse the Swift decl as '@owned() func baz()'.
+sil @bar : $@convention(thin) () -> @owned ()
+func baz()

--- a/test/SIL/Parser/errors.sil
+++ b/test/SIL/Parser/errors.sil
@@ -24,7 +24,7 @@ bb0:
 sil [ossa] @local_value_errors2 : $() -> () {
 bb0:
   %0 = builtin "cmp_eq_Int1"(%0 : $() // expected-error @+1 {{expected ')' or ',' in SIL instruction}}
-} // expected-error {{extraneous '}' at top level}}
+}
 
 sil [ossa] @global_value_errors : $() -> () {
 bb0:
@@ -49,5 +49,4 @@ sil_stage nonsense // expected-error {{expected 'raw' or 'canonical' after 'sil_
 sil [ossa] @missing_type : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   br bb3(%0) // expected-error {{expected ':' before type in SIL value reference}}
-  // FIXME: The next error is unexpected.
-} // expected-error {{extraneous '}' at top level}} {{1-3=}}
+}

--- a/unittests/Parse/TokenizerTests.cpp
+++ b/unittests/Parse/TokenizerTests.cpp
@@ -84,13 +84,7 @@ public:
   std::vector<Token> parseAndGetSplitTokens(unsigned BufID) {
     swift::ParserUnit PU(SM, SourceFileKind::Main, BufID,
                          LangOpts, TypeCheckerOptions(), "unknown");
-
-    bool Done = false;
-    while (!Done) {
-      PU.getParser().parseTopLevel();
-      Done = PU.getParser().Tok.is(tok::eof);
-    }
-    
+    PU.getParser().parseTopLevel();
     return PU.getParser().getSplitTokens();
   }
   

--- a/validation-test/SIL/crashers/042-swift-parser-parsetoplevel.sil
+++ b/validation-test/SIL/crashers/042-swift-parser-parsetoplevel.sil
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
-class a 4{sil_vtable a

--- a/validation-test/SIL/crashers_fixed/042-swift-parser-parsetoplevel.sil
+++ b/validation-test/SIL/crashers_fixed/042-swift-parser-parsetoplevel.sil
@@ -1,0 +1,2 @@
+// RUN: not %target-sil-opt %s
+class a 4{sil_vtable a


### PR DESCRIPTION
This is an intermediate step to requestifying `SourceFile::getTopLevelDecls`. Instead of interleaving type-checking and parsing for SIL files, first parse the file for Swift decls by skipping over any intermixed SIL decls. Then we can perform type checking, and finally SIL parsing where we now skip over Swift decls.

I decided to go for this approach over requiring Swift decls to precede SIL decls as we have ~500 tests with intermixed Swift and SIL, and they are a bit more readable when the Swift code is next the SIL being tested.