### PR TITLE
[AutoDiff] Improve `getConstrainedDerivativeGenericSignature` helper.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -29,6 +29,7 @@
 namespace swift {
 
 class AnyFunctionType;
+class SILFunctionType;
 class TupleType;
 
 /// A function type differentiability kind.
@@ -230,6 +231,18 @@ namespace autodiff {
 void getSubsetParameterTypes(IndexSubset *indices, AnyFunctionType *type,
                              SmallVectorImpl<Type> &results,
                              bool reverseCurryLevels = false);
+
+/// "Constrained" derivative generic signatures require all differentiability
+/// parameters to conform to the `Differentiable` protocol.
+///
+/// Returns the "constrained" derivative generic signature given:
+/// - An original SIL function type.
+/// - Differentiability parameter indices.
+/// - A possibly "unconstrained" derivative generic signature.
+GenericSignature
+getConstrainedDerivativeGenericSignature(SILFunctionType *originalFnTy,
+                                         IndexSubset *diffParamIndices,
+                                         GenericSignature derivativeGenSig);
 
 } // end namespace autodiff
 

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/AutoDiff.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 
 using namespace swift;
@@ -65,6 +67,31 @@ void autodiff::getSubsetParameterTypes(IndexSubset *subset,
       if (subset->contains(parameterIndexOffset + paramIndex))
         results.push_back(curryLevel->getParams()[paramIndex].getOldType());
   }
+}
+
+GenericSignature autodiff::getConstrainedDerivativeGenericSignature(
+    SILFunctionType *originalFnTy, IndexSubset *diffParamIndices,
+    GenericSignature derivativeGenSig) {
+  if (!derivativeGenSig)
+    derivativeGenSig = originalFnTy->getSubstGenericSignature();
+  if (!derivativeGenSig)
+    return nullptr;
+  // Constrain all differentiability parameters to `Differentiable`.
+  auto &ctx = originalFnTy->getASTContext();
+  auto *diffableProto = ctx.getProtocol(KnownProtocolKind::Differentiable);
+  SmallVector<Requirement, 4> requirements;
+  for (unsigned paramIdx : diffParamIndices->getIndices()) {
+    auto paramType = originalFnTy->getParameters()[paramIdx].getInterfaceType();
+    Requirement req(RequirementKind::Conformance, paramType,
+                    diffableProto->getDeclaredType());
+    requirements.push_back(req);
+  }
+  return evaluateOrDefault(
+      ctx.evaluator,
+      AbstractGenericSignatureRequest{derivativeGenSig.getPointer(),
+                                      /*addedGenericParams*/ {},
+                                      std::move(requirements)},
+      nullptr);
 }
 
 Type TangentSpace::getType() const {


### PR DESCRIPTION
Move `getConstrainedDerivativeGenericSignature` under `autodiff` namespace.
Improve naming and documentation.

