### PR TITLE
[AutoDiff] Improve `getConstrainedDerivativeGenericSignature` helper.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -31,7 +31,7 @@ namespace swift {
 class AnyFunctionType;
 class TupleType;
 struct SILAutoDiffIndices;
-
+class SILFunctionType;
 
 /// A function type differentiability kind.
 enum class DifferentiabilityKind : uint8_t {
@@ -240,6 +240,18 @@ void getSubsetParameterTypes(IndexSubset *indices, AnyFunctionType *type,
                              SmallVectorImpl<Type> &results,
                              bool reverseCurryLevels = false);
 
+/// "Constrained" derivative generic signatures require all differentiability
+/// parameters to conform to the `Differentiable` protocol.
+///
+/// Returns the "constrained" derivative generic signature given:
+/// - An original SIL function type.
+/// - Differentiability parameter indices.
+/// - A possibly "unconstrained" derivative generic signature.
+GenericSignature
+getConstrainedDerivativeGenericSignature(SILFunctionType *originalFnTy,
+                                         IndexSubset *diffParamIndices,
+                                         GenericSignature derivativeGenSig);
+
 } // end namespace autodiff
 
 } // end namespace swift
@@ -342,7 +354,6 @@ namespace swift {
 
 class ASTContext;
 class AnyFunctionType;
-class SILFunctionType;
 typedef CanTypeWrapper<SILFunctionType> CanSILFunctionType;
 enum class SILLinkage : uint8_t;
 

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/AutoDiff.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 
 using namespace swift;
@@ -65,6 +67,31 @@ void autodiff::getSubsetParameterTypes(IndexSubset *subset,
       if (subset->contains(parameterIndexOffset + paramIndex))
         results.push_back(curryLevel->getParams()[paramIndex].getOldType());
   }
+}
+
+GenericSignature autodiff::getConstrainedDerivativeGenericSignature(
+    SILFunctionType *originalFnTy, IndexSubset *diffParamIndices,
+    GenericSignature derivativeGenSig) {
+  if (!derivativeGenSig)
+    derivativeGenSig = originalFnTy->getSubstGenericSignature();
+  if (!derivativeGenSig)
+    return nullptr;
+  // Constrain all differentiability parameters to `Differentiable`.
+  auto &ctx = originalFnTy->getASTContext();
+  auto *diffableProto = ctx.getProtocol(KnownProtocolKind::Differentiable);
+  SmallVector<Requirement, 4> requirements;
+  for (unsigned paramIdx : diffParamIndices->getIndices()) {
+    auto paramType = originalFnTy->getParameters()[paramIdx].getInterfaceType();
+    Requirement req(RequirementKind::Conformance, paramType,
+                    diffableProto->getDeclaredType());
+    requirements.push_back(req);
+  }
+  return evaluateOrDefault(
+      ctx.evaluator,
+      AbstractGenericSignatureRequest{derivativeGenSig.getPointer(),
+                                      /*addedGenericParams*/ {},
+                                      std::move(requirements)},
+      nullptr);
 }
 
 // SWIFT_ENABLE_TENSORFLOW


### PR DESCRIPTION
Move `getConstrainedDerivativeGenericSignature` under `autodiff` namespace.
Improve naming and documentation.

`master` mirror: https://github.com/apple/swift/pull/29620