### PR TITLE
[5.2][Sema/CSApply] Make sure that the member type references created for a `type(of: x).A` expression are visible to the `SourceEntityWalker`

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -778,11 +778,9 @@ namespace {
 
       // If we're referring to a member type, it's just a type
       // reference.
-      if (isa<TypeDecl>(member)) {
+      if (auto *TD = dyn_cast<TypeDecl>(member)) {
         Type refType = simplifyType(openedType);
-        auto ref =
-            TypeExpr::createImplicitHack(memberLoc.getBaseNameLoc(),
-                                         refType, context);
+        auto ref = TypeExpr::createForDecl(memberLoc.getBaseNameLoc(), TD, cs.DC, /*isImplicit=*/false);
         cs.setType(ref, refType);
         auto *result = new (context) DotSyntaxBaseIgnoredExpr(
             base, dotLoc, ref, refType);

--- a/test/Index/expressions.swift
+++ b/test/Index/expressions.swift
@@ -45,3 +45,16 @@ func test1() { // CHECK: [[@LINE]]:6 | function/Swift | test1() | [[test1_USR:.*
     }
   }
 }
+
+protocol AP {
+  // CHECK: [[@LINE+1]]:18 | type-alias/associated-type/Swift | A | [[AP_P_USR:.*]] | Def,RelChild | rel: 1
+  associatedtype A
+}
+// CHECK: [[@LINE+1]]:19 | param/Swift | x | [[TEST2_X_USR:.*]] | Def,RelChild | rel: 1
+func test2<X: AP>(x: X) {
+  // CHECK: [[@LINE+1]]:9 | type-alias/associated-type/Swift | A | [[AP_P_USR]] | Ref,RelCont | rel: 1
+  _ = X.A.self
+  // CHECK: [[@LINE+2]]:16 | param/Swift | x | [[TEST2_X_USR]] | Ref,Read,RelCont | rel: 1
+  // CHECK: [[@LINE+1]]:19 | type-alias/associated-type/Swift | A | [[AP_P_USR]] | Ref,RelCont | rel: 1
+  _ = type(of: x).A.self
+}


### PR DESCRIPTION
For code like

```
  _ = type(of: x).A.self
```

the `A` type reference is written explicitely by the user, but the AST created using `TypeExpr::createImplicitHack` is hiding such a reference,
making the reference invisible to semantic functionality like 'rename'.

rdar://56885871
master: https://github.com/apple/swift/pull/29585