### PR TITLE
[AutoDiff upstream] Add SIL differentiability witnesses.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -1316,6 +1316,66 @@ variable cannot be used as l-value, i.e. the reference to the object cannot be
 modified. As a consequence the variable cannot be accessed with ``global_addr``
 but only with ``global_value``.
 
+Differentiability Witnesses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+  decl ::= sil-differentiability-witness
+  sil-differentiability-witness ::=
+      'sil_differentiability_witness'
+      sil-linkage?
+      '[' 'parameters' sil-differentiability-witness-function-index-list ']'
+      '[' 'results' sil-differentiability-witness-function-index-list ']'
+      generic-parameter-clause?
+      sil-function-name ':' sil-type
+      sil-differentiability-witness-body?
+
+  sil-differentiability-witness-body ::=
+      '{' sil-differentiability-witness-entry?
+          sil-differentiability-witness-entry? '}'
+
+  sil-differentiability-witness-entry ::=
+      sil-differentiability-witness-entry-kind ':'
+      sil-entry-name ':' sil-type
+
+  sil-differentiability-witness-entry-kind ::= 'jvp' | 'vjp'
+
+SIL encodes function differentiability via differentiability witnesses.
+
+Differentiability witnesses map a "key" (including an "original" SIL function)
+to derivative SIL functions.
+
+Differentiability witnesses are keyed by the following:
+
+- An "original" SIL function name.
+- Differentiability parameter indices.
+- Differentiability result indices.
+- A generic parameter clause, representing differentiability generic
+  requirements.
+
+Differentiability witnesses may have a body, specifying derivative functions for
+the key. Verification checks that derivative functions have the expected type
+based on the key.
+
+::
+
+  sil_differentiability_witness hidden [parameters 0] [results 0] <T where T : Differentiable> @id : $@convention(thin) (T) -> T {
+    jvp: @id_jvp : $@convention(thin) (T) -> (T, @owned @callee_guaranteed (T.TangentVector) -> T.TangentVector)
+    vjp: @id_vjp : $@convention(thin) (T) -> (T, @owned @callee_guaranteed (T.TangentVector) -> T.TangentVector)
+  }
+
+During SILGen, differentiability witnesses are emitted for the following:
+
+- `@differentiable` declaration attributes.
+- `@derivative` declaration attributes. Registered derivative functions
+  become differentiability witness entries.
+
+The SIL differentiation transform canonicalizes differentiability witnesses,
+filling in missing entries.
+
+Differentiability witness entries are accessed via the
+`differentiability_witness_function` instruction.
+
 Dataflow Errors
 ---------------
 

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -153,7 +153,15 @@ public:
                                              Type FromType, Type ToType,
                                              Type SelfType,
                                              ModuleDecl *Module);
-  
+
+  /// Mangle a SIL differentiability witness key:
+  /// - Mangled original function name.
+  /// - Parameter indices.
+  /// - Result indices.
+  /// - Derivative generic signature (optional).
+  std::string
+  mangleSILDifferentiabilityWitnessKey(SILDifferentiabilityWitnessKey key);
+
   std::string mangleKeyPathGetterThunkHelper(const AbstractStorageDecl *property,
                                              GenericSignature signature,
                                              CanType baseType,

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -222,6 +222,11 @@ public:
   NominalTypeDecl *getNominal() const;
 };
 
+/// The key type used for uniquing `SILDifferentiabilityWitness` in
+/// `SILModule`: original function name, parameter indices, result indices, and
+/// derivative generic signature.
+using SILDifferentiabilityWitnessKey = std::pair<StringRef, AutoDiffConfig>;
+
 /// Automatic differentiation utility namespace.
 namespace autodiff {
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -678,6 +678,18 @@ ERROR(sil_witness_assoc_conf_not_found,none,
 ERROR(sil_witness_protocol_conformance_not_found,none,
       "sil protocol conformance not found", ())
 
+// SIL differentiability witnesses
+ERROR(sil_diff_witness_expected_token,PointsToFirstBadToken,
+      "expected '%0' in differentiability witness", (StringRef))
+ERROR(sil_diff_witness_serialized_declaration,none,
+      "differentiability witness declaration should not be serialized", ())
+ERROR(sil_diff_witness_undefined,PointsToFirstBadToken,
+      "reference to undefined differentiability witness", ())
+ERROR(sil_diff_witness_invalid_generic_signature,PointsToFirstBadToken,
+      "expected witness generic signature '%0' does not have same generic "
+      "parameters as original function generic signature '%1'",
+      (StringRef, StringRef))
+
 // SIL Coverage Map
 ERROR(sil_coverage_invalid_hash, none,
       "expected coverage hash", ())
@@ -1576,6 +1588,20 @@ ERROR(diff_params_clause_expected_parameter_unnamed,PointsToFirstBadToken,
 // Automatic differentiation attributes
 ERROR(autodiff_attr_expected_original_decl_name,PointsToFirstBadToken,
       "expected an original function name", ())
+
+// SIL autodiff
+ERROR(sil_autodiff_expected_lsquare,PointsToFirstBadToken,
+      "expected '[' to start the %0", (StringRef))
+ERROR(sil_autodiff_expected_rsquare,PointsToFirstBadToken,
+      "expected ']' to complete the %0", (StringRef))
+ERROR(sil_autodiff_expected_index_list,PointsToFirstBadToken,
+      "expected a space-separated list of indices, e.g. '0 1'", ())
+ERROR(sil_autodiff_expected_index_list_label,PointsToFirstBadToken,
+      "expected label '%0' in index list", (StringRef))
+ERROR(sil_autodiff_expected_parameter_index,PointsToFirstBadToken,
+      "expected the index of a parameter to differentiate with respect to", ())
+ERROR(sil_autodiff_expected_result_index,PointsToFirstBadToken,
+      "expected the index of a result to differentiate from", ())
 
 //------------------------------------------------------------------------------
 // MARK: Generics parsing diagnostics

--- a/include/swift/Parse/ParseSILSupport.h
+++ b/include/swift/Parse/ParseSILSupport.h
@@ -32,6 +32,7 @@ namespace swift {
     virtual bool parseSILGlobal(Parser &P) = 0;
     virtual bool parseSILWitnessTable(Parser &P) = 0;
     virtual bool parseSILDefaultWitnessTable(Parser &P) = 0;
+    virtual bool parseSILDifferentiabilityWitness(Parser &P) = 0;
     virtual bool parseSILCoverageMap(Parser &P) = 0;
     virtual bool parseSILProperty(Parser &P) = 0;
     virtual bool parseSILScope(Parser &P) = 0;

--- a/include/swift/SIL/SILDifferentiabilityWitness.h
+++ b/include/swift/SIL/SILDifferentiabilityWitness.h
@@ -1,0 +1,166 @@
+//===--- SILDifferentiabilityWitness.h - Differentiability witnesses ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the SILDifferentiabilityWitness class, which maps an
+// original SILFunction and derivative configuration (parameter indices, result
+// indices, derivative generic signature) to derivative functions (JVP and VJP).
+//
+// SIL differentiability witnesses are generated from the `@differentiable`
+// and `@derivative` AST declaration attributes.
+//
+// Differentiability witnesses are canonicalized by the SIL differentiation
+// transform, which fills in missing derivative functions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILDIFFERENTIABILITYWITNESS_H
+#define SWIFT_SIL_SILDIFFERENTIABILITYWITNESS_H
+
+#include "swift/AST/Attr.h"
+#include "swift/AST/AutoDiff.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/SIL/SILAllocated.h"
+#include "swift/SIL/SILLinkage.h"
+#include "llvm/ADT/ilist.h"
+#include "llvm/ADT/ilist_node.h"
+
+namespace swift {
+
+class SILPrintContext;
+
+class SILDifferentiabilityWitness
+    : public llvm::ilist_node<SILDifferentiabilityWitness>,
+      public SILAllocated<SILDifferentiabilityWitness> {
+private:
+  /// The module which contains the differentiability witness.
+  SILModule &Module;
+  /// The linkage of the differentiability witness.
+  SILLinkage Linkage;
+  /// The original function.
+  SILFunction *OriginalFunction;
+  /// The derivative configuration: parameter indices, result indices, and
+  /// derivative generic signature (optional). The derivative generic signature
+  /// may contain same-type requirements such that all generic parameters are
+  /// bound to concrete types.
+  AutoDiffConfig Config;
+  /// The JVP (Jacobian-vector products) derivative function.
+  SILFunction *JVP;
+  /// The VJP (vector-Jacobian products) derivative function.
+  SILFunction *VJP;
+  /// Whether or not this differentiability witness is a declaration.
+  bool IsDeclaration;
+  /// Whether or not this differentiability witness is serialized, which allows
+  /// devirtualization from another module.
+  bool IsSerialized;
+  /// The AST `@differentiable` or `@derivative` attribute from which the
+  /// differentiability witness is generated. Used for diagnostics.
+  /// Null if the differentiability witness is parsed from SIL or if it is
+  /// deserialized.
+  const DeclAttribute *Attribute = nullptr;
+
+  SILDifferentiabilityWitness(
+      SILModule &module, SILLinkage linkage, SILFunction *originalFunction,
+      IndexSubset *parameterIndices, IndexSubset *resultIndices,
+      GenericSignature derivativeGenSig, SILFunction *jvp, SILFunction *vjp,
+      bool isDeclaration, bool isSerialized, const DeclAttribute *attribute)
+      : Module(module), Linkage(linkage), OriginalFunction(originalFunction),
+        Config(parameterIndices, resultIndices, derivativeGenSig.getPointer()),
+        JVP(jvp), VJP(vjp), IsDeclaration(isDeclaration),
+        IsSerialized(isSerialized), Attribute(attribute) {}
+
+public:
+  static SILDifferentiabilityWitness *
+  createDeclaration(SILModule &module, SILLinkage linkage,
+                    SILFunction *originalFunction,
+                    IndexSubset *parameterIndices, IndexSubset *resultIndices,
+                    GenericSignature derivativeGenSig,
+                    const DeclAttribute *attribute = nullptr);
+
+  static SILDifferentiabilityWitness *createDefinition(
+      SILModule &module, SILLinkage linkage, SILFunction *originalFunction,
+      IndexSubset *parameterIndices, IndexSubset *resultIndices,
+      GenericSignature derivativeGenSig, SILFunction *jvp, SILFunction *vjp,
+      bool isSerialized, const DeclAttribute *attribute = nullptr);
+
+  void convertToDefinition(SILFunction *jvp, SILFunction *vjp,
+                           bool isSerialized);
+
+  SILDifferentiabilityWitnessKey getKey() const;
+  SILModule &getModule() const { return Module; }
+  SILLinkage getLinkage() const { return Linkage; }
+  SILFunction *getOriginalFunction() const { return OriginalFunction; }
+  const AutoDiffConfig &getConfig() const { return Config; }
+  IndexSubset *getParameterIndices() const { return Config.parameterIndices; }
+  IndexSubset *getResultIndices() const { return Config.resultIndices; }
+  GenericSignature getDerivativeGenericSignature() const {
+    return Config.derivativeGenericSignature;
+  }
+  SILFunction *getJVP() const { return JVP; }
+  SILFunction *getVJP() const { return VJP; }
+  SILFunction *getDerivative(AutoDiffDerivativeFunctionKind kind) const {
+    switch (kind) {
+    case AutoDiffDerivativeFunctionKind::JVP:
+      return JVP;
+    case AutoDiffDerivativeFunctionKind::VJP:
+      return VJP;
+    }
+  }
+  void setJVP(SILFunction *jvp) { JVP = jvp; }
+  void setVJP(SILFunction *vjp) { VJP = vjp; }
+  void setDerivative(AutoDiffDerivativeFunctionKind kind,
+                     SILFunction *derivative) {
+    switch (kind) {
+    case AutoDiffDerivativeFunctionKind::JVP:
+      JVP = derivative;
+      break;
+    case AutoDiffDerivativeFunctionKind::VJP:
+      VJP = derivative;
+      break;
+    }
+  }
+  bool isDeclaration() const { return IsDeclaration; }
+  bool isDefinition() const { return !IsDeclaration; }
+  bool isSerialized() const { return IsSerialized; }
+  const DeclAttribute *getAttribute() const { return Attribute; }
+
+  /// Verify that the differentiability witness is well-formed.
+  void verify(const SILModule &module) const;
+
+  void print(llvm::raw_ostream &os, bool verbose = false) const;
+  void dump() const;
+};
+
+} // end namespace swift
+
+namespace llvm {
+
+//===----------------------------------------------------------------------===//
+// ilist_traits for SILDifferentiabilityWitness
+//===----------------------------------------------------------------------===//
+
+template <>
+struct ilist_traits<::swift::SILDifferentiabilityWitness>
+    : public ilist_node_traits<::swift::SILDifferentiabilityWitness> {
+  using SILDifferentiabilityWitness = ::swift::SILDifferentiabilityWitness;
+
+public:
+  static void deleteNode(SILDifferentiabilityWitness *DW) {
+    DW->~SILDifferentiabilityWitness();
+  }
+
+private:
+  void createNode(const SILDifferentiabilityWitness &);
+};
+
+} // namespace llvm
+
+#endif // SWIFT_SIL_SILDIFFERENTIABILITYWITNESS_H

--- a/include/swift/Syntax/TokenKinds.def.gyb
+++ b/include/swift/Syntax/TokenKinds.def.gyb
@@ -165,6 +165,7 @@ SIL_KEYWORD(sil_vtable)
 SIL_KEYWORD(sil_global)
 SIL_KEYWORD(sil_witness_table)
 SIL_KEYWORD(sil_default_witness_table)
+SIL_KEYWORD(sil_differentiability_witness)
 SIL_KEYWORD(sil_coverage_map)
 SIL_KEYWORD(sil_scope)
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -379,6 +379,27 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
   return finalize();
 }
 
+std::string ASTMangler::mangleSILDifferentiabilityWitnessKey(
+    SILDifferentiabilityWitnessKey key) {
+  // TODO(TF-20): Make the mangling scheme robust. Support demangling.
+  beginManglingWithoutPrefix();
+
+  auto originalName = key.first;
+  auto *parameterIndices = key.second.parameterIndices;
+  auto *resultIndices = key.second.resultIndices;
+  auto derivativeGenericSignature = key.second.derivativeGenericSignature;
+
+  Buffer << "AD__" << originalName << '_';
+  Buffer << "P" << parameterIndices->getString();
+  Buffer << "R" << resultIndices->getString();
+  if (derivativeGenericSignature)
+    appendGenericSignature(derivativeGenericSignature);
+
+  auto result = Storage.str().str();
+  Storage.clear();
+  return result;
+}
+
 std::string ASTMangler::mangleTypeForDebugger(Type Ty, const DeclContext *DC) {
   PrettyStackTraceType prettyStackTrace(Ty->getASTContext(),
                                         "mangling type for debugger", Ty);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -226,6 +226,7 @@ void Parser::parseTopLevel() {
     CASE_SIL(sil_global, SILGlobal)
     CASE_SIL(sil_witness_table, SILWitnessTable)
     CASE_SIL(sil_default_witness_table, SILDefaultWitnessTable)
+    CASE_SIL(sil_differentiability_witness, SILDifferentiabilityWitness)
     CASE_SIL(sil_coverage_map, SILCoverageMap)
     CASE_SIL(sil_property, SILProperty)
     CASE_SIL(sil_scope, SILScope)

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -313,6 +313,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
          Tok.isNot(tok::kw_sil_global) &&
          Tok.isNot(tok::kw_sil_witness_table) &&
          Tok.isNot(tok::kw_sil_default_witness_table) &&
+         Tok.isNot(tok::kw_sil_differentiability_witness) &&
          Tok.isNot(tok::kw_sil_property) &&
          (isConditionalBlock ||
           !isTerminatorForBraceItemListKind(Kind, Entries))) {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -76,6 +76,7 @@ public:
   bool parseSILGlobal(Parser &P) override;
   bool parseSILWitnessTable(Parser &P) override;
   bool parseSILDefaultWitnessTable(Parser &P) override;
+  bool parseSILDifferentiabilityWitness(Parser &P) override;
   bool parseSILCoverageMap(Parser &P) override;
   bool parseSILProperty(Parser &P) override;
   bool parseSILScope(Parser &P) override;
@@ -2004,6 +2005,108 @@ static bool parseAssignOwnershipQualifier(AssignOwnershipQualifier &Result,
   // Otherwise, assign Result and return false.
   Result = Tmp;
   return false;
+}
+
+// Parse a list of integer indices, prefaced with the given string label.
+// Returns true on error.
+static bool parseIndexList(Parser &P, StringRef label,
+                           SmallVectorImpl<unsigned> &indices,
+                           const Diagnostic &parseIndexDiag) {
+  SourceLoc loc;
+  // Parse `[<label> <integer_literal>...]`.
+  if (P.parseToken(tok::l_square, diag::sil_autodiff_expected_lsquare,
+                   "index list") ||
+      P.parseSpecificIdentifier(
+          label, diag::sil_autodiff_expected_index_list_label, label))
+    return true;
+  while (P.Tok.is(tok::integer_literal)) {
+    unsigned index;
+    if (P.parseUnsignedInteger(index, loc, parseIndexDiag))
+      return true;
+    indices.push_back(index);
+  }
+  if (P.parseToken(tok::r_square, diag::sil_autodiff_expected_rsquare,
+                   "index list"))
+    return true;
+  return false;
+};
+
+/// sil-differentiability-witness-config-and-function ::=
+///   '[' 'parameters' index-subset ']'
+///   '[' 'results' index-subset ']'
+///   ('<' 'where' derivative-generic-signature-requirements '>')?
+///   sil-function-ref
+///
+/// e.g. parameters 0 1] [results 0] <T where T: Differentiable>
+///      @foo : <T> $(T) -> T
+static Optional<std::pair<AutoDiffConfig, SILFunction *>>
+parseSILDifferentiabilityWitnessConfigAndFunction(Parser &P, SILParser &SP,
+                                                  SILLocation L) {
+  // Parse parameter and result indices.
+  SmallVector<unsigned, 8> parameterIndices;
+  SmallVector<unsigned, 8> resultIndices;
+  if (parseIndexList(P, "parameters", parameterIndices,
+                     diag::sil_autodiff_expected_parameter_index))
+    return {};
+  if (parseIndexList(P, "results", resultIndices,
+                     diag::sil_autodiff_expected_result_index))
+    return {};
+  // Parse witness generic parameter clause.
+  GenericSignature witnessGenSig = GenericSignature();
+  SourceLoc witnessGenSigStartLoc = P.getEndOfPreviousLoc();
+  {
+    // Create a new scope to avoid type redefinition errors.
+    Scope genericsScope(&P, ScopeKind::Generics);
+    auto *genericParams = P.maybeParseGenericParams().getPtrOrNull();
+    if (genericParams) {
+      auto *witnessGenEnv = handleSILGenericParams(genericParams, &P.SF);
+      witnessGenSig = witnessGenEnv->getGenericSignature();
+    }
+  }
+  // Parse original function name and type.
+  SILFunction *originalFunction = nullptr;
+  if (SP.parseSILFunctionRef(L, originalFunction))
+    return {};
+  // Resolve parsed witness generic signature.
+  if (witnessGenSig) {
+    auto origGenSig =
+        originalFunction->getLoweredFunctionType()->getSubstGenericSignature();
+    // Check whether original function generic signature and parsed witness
+    // generic have the same generic parameters.
+    auto areGenericParametersConsistent = [&]() {
+      llvm::SmallDenseSet<GenericParamKey, 4> genericParamKeys;
+      for (auto *origGP : origGenSig->getGenericParams())
+        genericParamKeys.insert(GenericParamKey(origGP));
+      for (auto *witnessGP : witnessGenSig->getGenericParams())
+        if (!genericParamKeys.erase(GenericParamKey(witnessGP)))
+          return false;
+      return genericParamKeys.empty();
+    };
+    if (!areGenericParametersConsistent()) {
+      P.diagnose(witnessGenSigStartLoc,
+                 diag::sil_diff_witness_invalid_generic_signature,
+                 witnessGenSig->getAsString(), origGenSig->getAsString());
+      return {};
+    }
+    // Combine parsed witness requirements with original function generic
+    // signature requirements to form full witness generic signature.
+    SmallVector<Requirement, 4> witnessRequirements(
+        witnessGenSig->getRequirements().begin(),
+        witnessGenSig->getRequirements().end());
+    witnessGenSig = evaluateOrDefault(
+        P.Context.evaluator,
+        AbstractGenericSignatureRequest{origGenSig.getPointer(),
+                                        /*addedGenericParams=*/{},
+                                        std::move(witnessRequirements)},
+        nullptr);
+  }
+  auto origFnType = originalFunction->getLoweredFunctionType();
+  auto *parameterIndexSet = IndexSubset::get(
+      P.Context, origFnType->getNumParameters(), parameterIndices);
+  auto *resultIndexSet =
+      IndexSubset::get(P.Context, origFnType->getNumResults(), resultIndices);
+  AutoDiffConfig config(parameterIndexSet, resultIndexSet, witnessGenSig);
+  return std::make_pair(config, originalFunction);
 }
 
 bool SILParser::parseSILDeclRef(SILDeclRef &Member, bool FnTypeRequired) {
@@ -6415,6 +6518,111 @@ bool SILParserTUState::parseSILDefaultWitnessTable(Parser &P) {
 
   SILDefaultWitnessTable::create(M, *Linkage, protocol, witnessEntries);
   BodyScope.reset();
+  return false;
+}
+
+/// decl-sil-differentiability-witness ::=
+///   'sil_differentiability_witness'
+///   ('[' 'serialized' ']')?
+///   sil-linkage?
+///   sil-differentiability-witness-config-and-function
+///   decl-sil-differentiability-witness-body?
+///
+/// decl-sil-differentiability-witness-body ::=
+///   '{'
+///   ('jvp' sil-function-name ':' sil-type)?
+///   ('vjp' sil-function-name ':' sil-type)?
+///   '}'
+///
+/// index-subset ::=
+///   [0-9]+ (' ' [0-9]+)*
+bool SILParserTUState::parseSILDifferentiabilityWitness(Parser &P) {
+  auto loc = P.consumeToken(tok::kw_sil_differentiability_witness);
+  auto silLoc = RegularLocation(loc);
+  SILParser State(P);
+
+  // Parse the linkage.
+  Optional<SILLinkage> linkage;
+  if (parseSILLinkage(linkage, P))
+    return true;
+
+  // Parse '[serialized]' flag (optional).
+  bool isSerialized = false;
+  SourceLoc serializedTokLoc;
+  if (P.Tok.is(tok::l_square) && P.isIdentifier(P.peekToken(), "serialized")) {
+    isSerialized = true;
+    serializedTokLoc = P.Tok.getLoc();
+    P.consumeToken(tok::l_square);
+    P.consumeToken(tok::identifier);
+    if (P.parseToken(tok::r_square, diag::sil_diff_witness_expected_token, "]"))
+      return true;
+  }
+
+  Scope scope(&P, ScopeKind::TopLevel);
+  Scope body(&P, ScopeKind::FunctionBody);
+
+  // We need to turn on InSILBody to parse the function references.
+  Lexer::SILBodyRAII tmp(*P.L);
+
+  auto configAndFn =
+      parseSILDifferentiabilityWitnessConfigAndFunction(P, State, silLoc);
+  if (!configAndFn) {
+    return true;
+  }
+  auto config = configAndFn->first;
+  auto originalFn = configAndFn->second;
+
+  // If this is just a declaration, create the declaration now and return.
+  if (!P.Tok.is(tok::l_brace)) {
+    if (isSerialized) {
+      P.diagnose(serializedTokLoc,
+                 diag::sil_diff_witness_serialized_declaration);
+      return true;
+    }
+
+    SILDifferentiabilityWitness::createDeclaration(
+        M, linkage ? *linkage : SILLinkage::DefaultForDeclaration, originalFn,
+        config.parameterIndices, config.resultIndices,
+        config.derivativeGenericSignature);
+    return false;
+  }
+
+  // This is a definition, so parse differentiability witness body.
+  SILFunction *jvp = nullptr;
+  SILFunction *vjp = nullptr;
+  if (P.Tok.is(tok::l_brace)) {
+    // Parse '{'.
+    SourceLoc lBraceLoc;
+    P.consumeIf(tok::l_brace, lBraceLoc);
+    // Parse JVP (optional).
+    if (P.isIdentifier(P.Tok, "jvp")) {
+      P.consumeToken(tok::identifier);
+      if (P.parseToken(tok::colon, diag::sil_diff_witness_expected_token, ":"))
+        return true;
+      Scope body(&P, ScopeKind::FunctionBody);
+      if (State.parseSILFunctionRef(silLoc, jvp))
+        return true;
+    }
+    // Parse VJP (optional).
+    if (P.isIdentifier(P.Tok, "vjp")) {
+      P.consumeToken(tok::identifier);
+      if (P.parseToken(tok::colon, diag::sil_diff_witness_expected_token, ":"))
+        return true;
+      Scope body(&P, ScopeKind::FunctionBody);
+      if (State.parseSILFunctionRef(silLoc, vjp))
+        return true;
+    }
+    // Parse '}'.
+    SourceLoc rBraceLoc;
+    if (P.parseMatchingToken(tok::r_brace, rBraceLoc, diag::expected_sil_rbrace,
+                             lBraceLoc))
+      return true;
+  }
+
+  SILDifferentiabilityWitness::createDefinition(
+      M, linkage ? *linkage : SILLinkage::DefaultForDefinition, originalFn,
+      config.parameterIndices, config.resultIndices,
+      config.derivativeGenericSignature, jvp, vjp, isSerialized);
   return false;
 }
 

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -26,6 +26,7 @@ add_swift_host_library(swiftSIL STATIC
   SILDebugScope.cpp
   SILDeclRef.cpp
   SILDefaultWitnessTable.cpp
+  SILDifferentiabilityWitness.cpp
   SILFunction.cpp
   SILFunctionType.cpp
   SILGlobalVariable.cpp

--- a/lib/SIL/SILDifferentiabilityWitness.cpp
+++ b/lib/SIL/SILDifferentiabilityWitness.cpp
@@ -1,0 +1,79 @@
+//===--- SILDifferentiabilityWitness.cpp - Differentiability witnesses ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-differentiability-witness"
+
+// SWIFT_ENABLE_TENSORFLOW
+#include "swift/AST/ASTMangler.h"
+// SWIFT_ENABLE_TENSORFLOW_END
+#include "swift/SIL/SILDifferentiabilityWitness.h"
+#include "swift/SIL/SILModule.h"
+
+using namespace swift;
+
+SILDifferentiabilityWitness *SILDifferentiabilityWitness::createDeclaration(
+    SILModule &module, SILLinkage linkage, SILFunction *originalFunction,
+    IndexSubset *parameterIndices, IndexSubset *resultIndices,
+    GenericSignature derivativeGenSig, const DeclAttribute *attribute) {
+  auto *diffWitness = new (module) SILDifferentiabilityWitness(
+      module, linkage, originalFunction, parameterIndices, resultIndices,
+      derivativeGenSig, /*jvp*/ nullptr, /*vjp*/ nullptr,
+      /*isDeclaration*/ true, /*isSerialized*/ false, attribute);
+  // Register the differentiability witness in the module.
+  Mangle::ASTMangler mangler;
+  auto mangledKey =
+      mangler.mangleSILDifferentiabilityWitnessKey(diffWitness->getKey());
+  assert(!module.DifferentiabilityWitnessMap.count(mangledKey) &&
+         "Cannot create duplicate differentiability witness in a module");
+  module.DifferentiabilityWitnessMap[mangledKey] = diffWitness;
+  module.DifferentiabilityWitnessesByFunction[originalFunction->getName()]
+      .push_back(diffWitness);
+  module.getDifferentiabilityWitnessList().push_back(diffWitness);
+  return diffWitness;
+}
+
+SILDifferentiabilityWitness *SILDifferentiabilityWitness::createDefinition(
+    SILModule &module, SILLinkage linkage, SILFunction *originalFunction,
+    IndexSubset *parameterIndices, IndexSubset *resultIndices,
+    GenericSignature derivativeGenSig, SILFunction *jvp, SILFunction *vjp,
+    bool isSerialized, const DeclAttribute *attribute) {
+  auto *diffWitness = new (module) SILDifferentiabilityWitness(
+      module, linkage, originalFunction, parameterIndices, resultIndices,
+      derivativeGenSig, jvp, vjp, /*isDeclaration*/ false, isSerialized,
+      attribute);
+  // Register the differentiability witness in the module.
+  // Register the differentiability witness in the module.
+  Mangle::ASTMangler mangler;
+  auto mangledKey =
+      mangler.mangleSILDifferentiabilityWitnessKey(diffWitness->getKey());
+  assert(!module.DifferentiabilityWitnessMap.count(mangledKey) &&
+         "Cannot create duplicate differentiability witness in a module");
+  module.DifferentiabilityWitnessMap[mangledKey] = diffWitness;
+  module.DifferentiabilityWitnessesByFunction[originalFunction->getName()]
+      .push_back(diffWitness);
+  module.getDifferentiabilityWitnessList().push_back(diffWitness);
+  return diffWitness;
+}
+
+void SILDifferentiabilityWitness::convertToDefinition(SILFunction *jvp,
+                                                      SILFunction *vjp,
+                                                      bool isSerialized) {
+  assert(IsDeclaration);
+  IsDeclaration = false;
+  JVP = jvp;
+  VJP = vjp;
+  IsSerialized = isSerialized;
+}
+
+SILDifferentiabilityWitnessKey SILDifferentiabilityWitness::getKey() const {
+  return std::make_pair(getOriginalFunction()->getName(), getConfig());
+}

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -13,6 +13,7 @@
 #define DEBUG_TYPE "sil-module"
 #include "swift/SIL/SILModule.h"
 #include "Linker.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/ClangImporter/ClangModule.h"
@@ -574,6 +575,28 @@ lookUpFunctionInVTable(ClassDecl *Class, SILDeclRef Member) {
     return E->Implementation;
 
   return nullptr;
+}
+
+SILDifferentiabilityWitness *
+SILModule::lookUpDifferentiabilityWitness(StringRef name) {
+  auto it = DifferentiabilityWitnessMap.find(name);
+  if (it != DifferentiabilityWitnessMap.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+SILDifferentiabilityWitness *
+SILModule::lookUpDifferentiabilityWitness(SILDifferentiabilityWitnessKey key) {
+  Mangle::ASTMangler mangler;
+  return lookUpDifferentiabilityWitness(
+      mangler.mangleSILDifferentiabilityWitnessKey(key));
+}
+
+/// Look up the differentiability witness corresponding to the given indices.
+llvm::ArrayRef<SILDifferentiabilityWitness *>
+SILModule::lookUpDifferentiabilityWitnessesForFunction(StringRef name) {
+  return DifferentiabilityWitnessesByFunction[name];
 }
 
 void SILModule::registerDeserializationNotificationHandler(

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -436,6 +436,58 @@ void SILType::dump() const {
   llvm::errs() << '\n';
 }
 
+/// Prints the name and type of the given SIL function with the given
+/// `PrintOptions`. Mutates `printOptions`, setting `GenericEnv` and
+/// `AlternativeTypeNames`.
+static void printSILFunctionNameAndType(llvm::raw_ostream &OS,
+                                        const SILFunction *function,
+                                        PrintOptions &printOptions) {
+  function->printName(OS);
+  OS << " : $";
+  llvm::DenseMap<CanType, Identifier> aliases;
+  auto genSig = function->getLoweredFunctionType()->getSubstGenericSignature();
+  auto *genEnv = function->getGenericEnvironment();
+  // If `genSig` and `genEnv` are both defined, get sugared names of generic
+  // parameter types for printing.
+  if (genSig && genEnv) {
+    llvm::DenseSet<Identifier> usedNames;
+    llvm::SmallString<16> disambiguatedNameBuf;
+    unsigned disambiguatedNameCounter = 1;
+    for (auto *paramTy : genSig->getGenericParams()) {
+      // Get a uniqued sugared name for the generic parameter type.
+      auto sugaredTy = genEnv->getSugaredType(paramTy);
+      Identifier name = sugaredTy->getName();
+      while (!usedNames.insert(name).second) {
+        disambiguatedNameBuf.clear();
+        {
+          llvm::raw_svector_ostream names(disambiguatedNameBuf);
+          names << sugaredTy->getName() << disambiguatedNameCounter++;
+        }
+        name = function->getASTContext().getIdentifier(disambiguatedNameBuf);
+      }
+      // If the uniqued sugared name is equal to the sugared name, continue.
+      if (name == sugaredTy->getName())
+        continue;
+      // Otherwise, add sugared name mapping for the type (and its archetype, if
+      // defined).
+      aliases[paramTy->getCanonicalType()] = name;
+      if (auto *archetypeTy =
+              genEnv->mapTypeIntoContext(paramTy)->getAs<ArchetypeType>())
+        aliases[archetypeTy->getCanonicalType()] = name;
+    }
+  }
+  printOptions.GenericEnv = genEnv;
+  printOptions.AlternativeTypeNames = aliases.empty() ? nullptr : &aliases;
+  function->getLoweredFunctionType()->print(OS, printOptions);
+}
+
+/// Prints the name and type of the given SIL function.
+static void printSILFunctionNameAndType(llvm::raw_ostream &OS,
+                                        const SILFunction *function) {
+  auto printOptions = PrintOptions::printSIL();
+  printSILFunctionNameAndType(OS, function, printOptions);
+}
+
 namespace {
   
 class SILPrinter;
@@ -2427,62 +2479,16 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   if (!isExternalDeclaration() && hasOwnership())
     OS << "[ossa] ";
 
-  printName(OS);
-  OS << " : $";
-  
-  // Print the type by substituting our context parameter names for the dependent
-  // parameters. In SIL, we may end up with multiple generic parameters that
-  // have the same name from different contexts, for instance, a generic
-  // protocol requirement with a generic method parameter <T>, which is
-  // witnessed by a generic type that has a generic type parameter also named
-  // <T>, so we may need to introduce disambiguating aliases.
-  llvm::DenseMap<CanType, Identifier> Aliases;
-  llvm::DenseSet<Identifier> UsedNames;
-  
-  auto sig = getLoweredFunctionType()->getSubstGenericSignature();
-  auto *env = getGenericEnvironment();
-  if (sig && env) {
-    llvm::SmallString<16> disambiguatedNameBuf;
-    unsigned disambiguatedNameCounter = 1;
-    for (auto *paramTy : sig->getGenericParams()) {
-      auto sugaredTy = env->getSugaredType(paramTy);
-      Identifier name = sugaredTy->getName();
-      while (!UsedNames.insert(name).second) {
-        disambiguatedNameBuf.clear();
-        {
-          llvm::raw_svector_ostream names(disambiguatedNameBuf);
-          names << sugaredTy->getName() << disambiguatedNameCounter++;
-        }
-        name = getASTContext().getIdentifier(disambiguatedNameBuf);
-      }
-      if (name != sugaredTy->getName()) {
-        Aliases[paramTy->getCanonicalType()] = name;
+  auto printOptions = PrintOptions::printSIL();
+  printSILFunctionNameAndType(OS, this, printOptions);
 
-        // Also for the archetype
-        auto archetypeTy = env->mapTypeIntoContext(paramTy)
-            ->getAs<ArchetypeType>();
-        if (archetypeTy)
-          Aliases[archetypeTy->getCanonicalType()] = name;
-      }
-    }
-  }
-
-  {
-    PrintOptions withGenericEnvironment = PrintOptions::printSIL();
-    withGenericEnvironment.GenericEnv = env;
-    withGenericEnvironment.AlternativeTypeNames =
-      Aliases.empty() ? nullptr : &Aliases;
-    LoweredType->print(OS, withGenericEnvironment);
-  }
-  
   if (!isExternalDeclaration()) {
     if (auto eCount = getEntryCount()) {
       OS << " !function_entry_count(" << eCount.getValue() << ")";
     }
     OS << " {\n";
 
-    SILPrinter(PrintCtx, (Aliases.empty() ? nullptr : &Aliases))
-        .print(this);
+    SILPrinter(PrintCtx, printOptions.AlternativeTypeNames).print(this);
     OS << "} // end sil function '" << getName() << '\'';
   }
 
@@ -2662,6 +2668,31 @@ printSILDefaultWitnessTables(SILPrintContext &Ctx,
     wt->print(Ctx.OS(), Ctx.printVerbose());
 }
 
+static void printSILDifferentiabilityWitnesses(
+    SILPrintContext &Ctx,
+    const SILModule::DifferentiabilityWitnessListType &diffWitnesses) {
+  if (!Ctx.sortSIL()) {
+    for (auto &dw : diffWitnesses)
+      dw.print(Ctx.OS(), Ctx.printVerbose());
+    return;
+  }
+
+  std::vector<const SILDifferentiabilityWitness *> sortedDiffWitnesses;
+  sortedDiffWitnesses.reserve(diffWitnesses.size());
+  for (auto &dw : diffWitnesses)
+    sortedDiffWitnesses.push_back(&dw);
+  std::sort(sortedDiffWitnesses.begin(), sortedDiffWitnesses.end(),
+            [](const SILDifferentiabilityWitness *dw1,
+               const SILDifferentiabilityWitness *dw2) -> bool {
+              // TODO(TF-893): Sort based on more criteria for deterministic
+              // ordering.
+              return dw1->getOriginalFunction()->getName().compare(
+                         dw2->getOriginalFunction()->getName()) == -1;
+            });
+  for (auto *dw : sortedDiffWitnesses)
+    dw->print(Ctx.OS(), Ctx.printVerbose());
+}
+
 static void
 printSILCoverageMaps(SILPrintContext &Ctx,
                      const SILModule::CoverageMapCollectionType &CoverageMaps) {
@@ -2787,6 +2818,8 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
   }
 
   printSILGlobals(PrintCtx, getSILGlobalList());
+  printSILDifferentiabilityWitnesses(PrintCtx,
+                                     getDifferentiabilityWitnessList());
   printSILFunctions(PrintCtx, getFunctionList());
   printSILVTables(PrintCtx, getVTableList());
   printSILWitnessTables(PrintCtx, getWitnessTableList());
@@ -3003,6 +3036,64 @@ void SILDefaultWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
 }
 
 void SILDefaultWitnessTable::dump() const {
+  print(llvm::errs());
+}
+
+void SILDifferentiabilityWitness::print(llvm::raw_ostream &OS,
+                                        bool verbose) const {
+  OS << "// differentiability witness for "
+     << demangleSymbol(getOriginalFunction()->getName()) << '\n';
+  PrintOptions qualifiedSILTypeOptions = PrintOptions::printQualifiedSILType();
+  // sil_differentiability_witness (linkage)?
+  OS << "sil_differentiability_witness ";
+  printLinkage(OS, getLinkage(), /*isDefinition*/ isDefinition());
+  // ([serialized])?
+  if (isSerialized())
+    OS << "[serialized] ";
+  // [parameters ...]
+  OS << "[parameters ";
+  interleave(
+      getParameterIndices()->getIndices(), [&](unsigned index) { OS << index; },
+      [&] { OS << ' '; });
+  // [results ...]
+  OS << "] [results ";
+  interleave(
+      getResultIndices()->getIndices(), [&](unsigned index) { OS << index; },
+      [&] { OS << ' '; });
+  OS << "] ";
+  // (<...>)?
+  if (auto derivativeGenSig = getDerivativeGenericSignature()) {
+    auto subPrinter = PrintOptions::printSIL();
+    derivativeGenSig->print(OS, subPrinter);
+    OS << " ";
+  }
+  // @original-function-name : $original-sil-type
+  printSILFunctionNameAndType(OS, getOriginalFunction());
+
+  if (isDeclaration()) {
+    OS << "\n\n";
+    return;
+  }
+
+  // {
+  //   jvp: @jvp-function-name : $jvp-sil-type
+  //   vjp: @vjp-function-name : $vjp-sil-type
+  // }
+  OS << " {\n";
+  if (auto *jvp = getJVP()) {
+    OS << "  jvp: ";
+    printSILFunctionNameAndType(OS, jvp);
+    OS << '\n';
+  }
+  if (auto *vjp = getVJP()) {
+    OS << "  vjp: ";
+    printSILFunctionNameAndType(OS, vjp);
+    OS << '\n';
+  }
+  OS << "}\n\n";
+}
+
+void SILDifferentiabilityWitness::dump() const {
   print(llvm::errs());
 }
 

--- a/lib/Syntax/SyntaxSerialization.cpp.gyb
+++ b/lib/Syntax/SyntaxSerialization.cpp.gyb
@@ -48,6 +48,7 @@ uint8_t WrapperTypeTraits<tok>::numericValue(const tok &Value) {
     case tok::kw_sil_global:
     case tok::kw_sil_witness_table:
     case tok::kw_sil_default_witness_table:
+    case tok::kw_sil_differentiability_witness:
     case tok::kw_sil_coverage_map:
     case tok::kw_sil_scope:
     case tok::sil_dollar:

--- a/test/AutoDiff/SIL/Parse/sil_differentiability_witness.sil
+++ b/test/AutoDiff/SIL/Parse/sil_differentiability_witness.sil
@@ -1,0 +1,129 @@
+// Round-trip parsing/printing test.
+
+// RUN: %target-sil-opt %s | %target-sil-opt -emit-sorted-sil | %FileCheck --check-prefix=ROUNDTRIP %s
+// REQUIRES: differentiable_programming
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+import _Differentiation
+
+// Test SIL differentiability witness for bodiless original function, with defined jvp/vjp.
+
+sil @externalFn1 : $@convention(thin) (Float) -> Float
+
+sil @AD__externalFn1__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  return undef : $(Float, @callee_guaranteed (Float) -> Float)
+}
+
+sil @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  return undef : $(Float, @callee_guaranteed (Float) -> Float)
+}
+
+sil_differentiability_witness [parameters 0] [results 0] @externalFn1 : $@convention(thin) (Float) -> Float {
+  jvp: @AD__externalFn1__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+  vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+}
+
+// ROUNDTRIP-LABEL: // differentiability witness for externalFn1
+// ROUNDTRIP: sil_differentiability_witness{{( public_external)?}} [parameters 0] [results 0] @externalFn1 : $@convention(thin) (Float) -> Float {
+// ROUNDTRIP:   jvp: @AD__externalFn1__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP:   vjp: @AD__externalFn1__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP: }
+
+// Test SIL differentiability witness for bodiless original function, with bodiless jvp/vjp.
+
+sil @externalFn2 : $@convention(thin) (Float) -> Float
+
+sil @AD__externalFn2__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+
+sil @AD__externalFn2__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+
+sil_differentiability_witness [parameters 0] [results 0] @externalFn2 : $@convention(thin) (Float) -> Float {
+  jvp: @AD__externalFn2__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+  vjp: @AD__externalFn2__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+}
+
+// ROUNDTRIP-LABEL: // differentiability witness for externalFn2
+// ROUNDTRIP: sil_differentiability_witness{{( public_external)?}} [parameters 0] [results 0] @externalFn2 : $@convention(thin) (Float) -> Float {
+// ROUNDTRIP:   jvp: @AD__externalFn2__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP:   vjp: @AD__externalFn2__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP: }
+
+// Test SIL differentiability witness declaration.
+
+sil @externalFn3 : $@convention(thin) (Float) -> Float
+
+sil_differentiability_witness [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float
+
+// ROUNDTRIP-LABEL: // differentiability witness for externalFn3
+// ROUNDTRIP: sil_differentiability_witness{{( public_external)?}} [parameters 0] [results 0] @externalFn3 : $@convention(thin) (Float) -> Float{{[^{]*$}}
+
+// Test public non-generic function.
+// SIL differentiability witness:
+// - Has public linkage (implicit).
+// - Has no `where` clause.
+
+sil [ossa] @foo : $@convention(thin) (Float) -> Float {
+bb0(%0 : $Float):
+  return %0 : $Float
+}
+
+sil @AD__foo__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  return undef : $(Float, @callee_guaranteed (Float) -> Float)
+}
+
+sil @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  return undef : $(Float, @callee_guaranteed (Float) -> Float)
+}
+
+sil_differentiability_witness [parameters 0] [results 0] @foo : $@convention(thin) (Float) -> Float {
+  jvp: @AD__foo__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+  vjp: @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+}
+
+// ROUNDTRIP-LABEL: // differentiability witness for foo
+// ROUNDTRIP: sil_differentiability_witness{{( public_external)?}} [parameters 0] [results 0] @foo : $@convention(thin) (Float) -> Float {
+// ROUNDTRIP:   jvp: @AD__foo__jvp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP:   vjp: @AD__foo__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// ROUNDTRIP: }
+
+// Test internal generic function.
+// SIL differentiability witness:
+// - Has hidden linkage.
+// - Has `where` clause.
+
+sil hidden [ossa] @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
+bb0(%0 : $*T, %1 : $*T, %2 : $Float):
+  copy_addr %1 to [initialization] %0 : $*T
+  %void = tuple ()
+  return %void : $()
+}
+
+sil hidden @AD__generic__jvp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector) {
+bb0(%0 : $*τ_0_0, %1 : $*τ_0_0, %2 : $Float):
+  return undef : $@callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector
+}
+
+sil hidden @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float)) {
+bb0(%0 : $*τ_0_0, %1 : $*τ_0_0, %2 : $Float):
+  return undef : $@callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float)
+}
+
+sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where τ_0_0 : Differentiable> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
+  jvp: @AD__generic__jvp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector)
+  vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
+}
+
+// ROUNDTRIP-LABEL: // differentiability witness for generic
+// ROUNDTRIP: sil_differentiability_witness {{(hidden)|(hidden_external)}} [parameters 0 1] [results 0] <τ_0_0 where τ_0_0 : Differentiable> @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
+// ROUNDTRIP:   jvp: @AD__generic__jvp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector, Float) -> @out τ_0_0.TangentVector)
+// ROUNDTRIP:   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
+// ROUNDTRIP: }


### PR DESCRIPTION
SIL differentiability witnesses are a new top-level SIL construct mapping
"original" SIL functions to derivative SIL functions.

SIL differentiability witnesses have the following components:
- "Original" `SILFunction`.
- SIL linkage.
- Differentiability parameter indices (`IndexSubset`).
- Differentiability result indices (`IndexSubset`).
- Derivative `GenericSignature` representing differentiability generic requirements (optional).
- JVP derivative `SILFunction` (optional).
- VJP derivative `SILFunction` (optional).
- "Is serialized?" bit.

```
sil_differentiability_witness hidden [parameters 0] [results 0] <T where T : Differentiable> @id : $@convention(thin) (T) -> T {
  jvp: @id_jvp : $@convention(thin) (T) -> (T, @owned @callee_guaranteed (T.TangentVector) -> T.TangentVector)
  vjp: @id_vjp : $@convention(thin) (T) -> (T, @owned @callee_guaranteed (T.TangentVector) -> T.TangentVector)
}
```

This patch adds the `SILDifferentiabilityWitness` data structure, with
documentation, parsing, and printing.

Resolves TF-911.

---

Todos:
- TF-1136: upstream `SILDifferentiabilityWitness` serialization.
- TF-1137: upstream `SILDifferentiabilityWitness` verification.
- TF-1138: upstream `SILDifferentiabilityWitness` SILGen from
  `@differentiable` and `@derivative` attributes.
- TF-20: robust mangling for `SILDifferentiabilityWitness` names.