### PR TITLE
[SourceKit] Expose 'ExpectedTypeRelation' for the completion results

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -886,6 +886,11 @@ calculateTypeRelationForDecl(const Decl *D, Type ExpectedType,
       return relation;
     }
   }
+  if (auto EED = dyn_cast<EnumElementDecl>(VD)) {
+    return calculateTypeRelation(
+        EED->getParentEnum()->TypeDecl::getDeclaredInterfaceType(),
+        ExpectedType, DC);
+  }
   if (auto NTD = dyn_cast<NominalTypeDecl>(VD)) {
     return std::max(
         calculateTypeRelation(NTD->getInterfaceType(), ExpectedType, DC),

--- a/test/IDE/complete_assignment.swift
+++ b/test/IDE/complete_assignment.swift
@@ -128,16 +128,16 @@ func f2() {
 	}
 
 // ASSIGN_5: Begin completions, 2 items
-// ASSIGN_5-DAG: Decl[EnumElement]/ExprSpecific:     case2[#D1#]; name=case2
-// ASSIGN_5-DAG: Decl[EnumElement]/ExprSpecific:     case1[#D1#]; name=case1
+// ASSIGN_5-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     case2[#D1#]; name=case2
+// ASSIGN_5-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     case1[#D1#]; name=case1
 
 	func f6() {
 	  var d : D2
 	  d = .#^ASSIGN_6^#
 	}
 // ASSIGN_6: Begin completions, 2 items
-// ASSIGN_6-DAG: Decl[EnumElement]/ExprSpecific:     case3[#D2#]; name=case3
-// ASSIGN_6-DAG:Decl[EnumElement]/ExprSpecific:     case4[#D2#]; name=case4
+// ASSIGN_6-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     case3[#D2#]; name=case3
+// ASSIGN_6-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     case4[#D2#]; name=case4
 
   func f7 (C : C2) {
     var i : Int

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -555,9 +555,9 @@ func testTupleShuffle() {
 // SHUFFLE_2-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s2[#String#]; name=s2
 
 // SHUFFLE_3: Begin completions, 3 items
-// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific:     foo[#SimpleEnum#]; name=foo
-// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific:     bar[#SimpleEnum#]; name=bar
-// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific:     baz[#SimpleEnum#]; name=baz
+// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
+// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
+// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
 
 class HasSubscript {
   subscript(idx: Int) -> String {}

--- a/test/IDE/complete_constrained.swift
+++ b/test/IDE/complete_constrained.swift
@@ -118,8 +118,8 @@ struct Vegetarian: EatsFruit, EatsVegetables { }
 func testVegetarian(chef: Chef<Vegetarian>) {
   chef.cook(.#^CONDITIONAL_OVERLOAD_ARG^#)
 // CONDITIONAL_OVERLOAD_ARG: Begin completions, 2 items
-// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/ExprSpecific:     apple[#Fruit#]; name=apple
-// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/ExprSpecific:     broccoli[#Vegetable#]; name=broccoli
+// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     apple[#Fruit#]; name=apple
+// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     broccoli[#Vegetable#]; name=broccoli
 // CONDITIONAL_OVERLOAD_ARG: End completions
 
   var chefMeta: Chef<Vegetarian>.Type = Chef<Vegetarian>.self

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -89,8 +89,8 @@ enum FooEnum: CaseIterable {
 }
 
 // FOO_ENUM_TYPE_CONTEXT: Begin completions
-// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Foo1[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Foo2[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Foo1[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Foo2[#FooEnum#]{{; name=.+$}}
 // FOO_ENUM_TYPE_CONTEXT-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: .alias1[#FooEnum#]; name=alias1
 // FOO_ENUM_TYPE_CONTEXT: End completions
 
@@ -128,8 +128,8 @@ enum FooEnum: CaseIterable {
 // FOO_ENUM_DOT_INVALID-NEXT: End completions
 
 // FOO_ENUM_DOT_ELEMENTS: Begin completions, 3 items
-// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/ExprSpecific: Foo1[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/ExprSpecific: Foo2[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: Foo1[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: Foo2[#FooEnum#]{{; name=.+$}}
 // FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: alias1[#FooEnum#]; name=alias1
 // FOO_ENUM_DOT_ELEMENTS-NEXT: End completions
 
@@ -154,18 +154,18 @@ enum BarEnum {
 }
 
 // BAR_ENUM_TYPE_CONTEXT: Begin completions
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar1[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar2()[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar3({#Int#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar4({#a: Int#}, {#b: Float#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar5({#a: Int#}, {#(Float)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar6({#a: Int#}, {#b: (Float)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar7({#a: Int#}, {#(b: Float, c: Double)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar8({#a: Int#}, {#b: (c: Float, d: Double)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar9({#Int#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar10({#Int#}, {#Float#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar11({#Int#}, {#(Float)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Bar12({#Int#}, {#(Float, Double)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar1[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar2()[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar3({#Int#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar4({#a: Int#}, {#b: Float#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar5({#a: Int#}, {#(Float)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar6({#a: Int#}, {#b: (Float)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar7({#a: Int#}, {#(b: Float, c: Double)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar8({#a: Int#}, {#b: (c: Float, d: Double)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar9({#Int#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar10({#Int#}, {#Float#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar11({#Int#}, {#(Float)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Bar12({#Int#}, {#(Float, Double)#})[#BarEnum#]{{; name=.+$}}
 // BAR_ENUM_TYPE_CONTEXT: End completions
 
 // BAR_ENUM_NO_DOT: Begin completions
@@ -274,8 +274,8 @@ enum QuxEnum : Int {
 }
 
 // QUX_ENUM_TYPE_CONTEXT: Begin completions
-// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Qux1[#QuxEnum#]{{; name=.+$}}
-// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific: .Qux2[#QuxEnum#]{{; name=.+$}}
+// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Qux1[#QuxEnum#]{{; name=.+$}}
+// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Qux2[#QuxEnum#]{{; name=.+$}}
 // QUX_ENUM_TYPE_CONTEXT: End completions
 
 // QUX_ENUM_NO_DOT: Begin completions, 7 items
@@ -436,16 +436,16 @@ func testWithInvalid1() {
 // UNRESOLVED_1:  Begin completions
 // UNRESOLVED_1-NOT:  Baz
 // UNRESOLVED_1-NOT:  Bar
-// UNRESOLVED_1-DAG:  Decl[EnumElement]/ExprSpecific:     Qux1[#QuxEnum#]; name=Qux1
-// UNRESOLVED_1-DAG:  Decl[EnumElement]/ExprSpecific:     Qux2[#QuxEnum#]; name=Qux2
+// UNRESOLVED_1-DAG:  Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     Qux1[#QuxEnum#]; name=Qux1
+// UNRESOLVED_1-DAG:  Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     Qux2[#QuxEnum#]; name=Qux2
 // UNRESOLVED_1-NOT:  Okay
 }
 
 func testUnqualified1(x: QuxEnum) {
   _ = x == .Qux1 || x == .#^UNRESOLVED_2^#Qux2
   // UNRESOLVED_2: Begin completions, 2 items
-  // UNRESOLVED_2-DAG: Decl[EnumElement]/ExprSpecific:     Qux1[#QuxEnum#]; name=Qux1
-  // UNRESOLVED_2-DAG: Decl[EnumElement]/ExprSpecific:     Qux2[#QuxEnum#]; name=Qux2
+  // UNRESOLVED_2-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     Qux1[#QuxEnum#]; name=Qux1
+  // UNRESOLVED_2-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     Qux2[#QuxEnum#]; name=Qux2
   // UNRESOLVED_2: End completions
 
   _ = (x == .Qux1#^UNRESOLVED_3^#)

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -372,8 +372,8 @@ func testIIFE() {
   }()
 }
 // IN_IIFE_1: Begin completions
-// IN_IIFE_1-DAG: Decl[EnumElement]/ExprSpecific: north[#SomeEnum#]
-// IN_IIFE_1-DAG: Decl[EnumElement]/ExprSpecific: south[#SomeEnum#]
+// IN_IIFE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: north[#SomeEnum#]
+// IN_IIFE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: south[#SomeEnum#]
 
 extension Error {
   var myErrorNumber: Int { return 0 }

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -35,11 +35,11 @@ struct TestStruct {
   @MyStruct(arg1: .#^ARG_MyEnum_DOT^#
   var test3
 // ARG_MyEnum_DOT: Begin completions, 2 items
-// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/ExprSpecific:     east[#MyEnum#]; name=east
-// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/ExprSpecific:     west[#MyEnum#]; name=west
+// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     east[#MyEnum#]; name=east
+// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     west[#MyEnum#]; name=west
 // ARG_MyEnum_DOT: End completions
 
- @MyStruct(arg1: MyEnum.#^ARG_MyEnum_NOBINDING^#)
+  @MyStruct(arg1: MyEnum.#^ARG_MyEnum_NOBINDING^#)
 // ARG_MyEnum_NOBINDING: Begin completions
 // ARG_MyEnum_NOBINDING-DAG: Decl[EnumElement]/CurrNominal: east[#MyEnum#];
 // ARG_MyEnum_NOBINDING-DAG: Decl[EnumElement]/CurrNominal: west[#MyEnum#];

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -98,7 +98,7 @@ struct TestSingleExprClosureRetUnresolved {
 
 // TestSingleExprClosureRetUnresolved: Begin completions
 // TestSingleExprClosureRetUnresolved-NOT: notMine
-// TestSingleExprClosureRetUnresolved: Decl[EnumElement]/ExprSpecific: myEnum[#MyEnum#];
+// TestSingleExprClosureRetUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprClosureRetUnresolved-NOT: notMine
 // TestSingleExprClosureRetUnresolved: End completions
 }
@@ -263,7 +263,7 @@ struct TestSingleExprFuncUnresolved {
 
 // TestSingleExprFuncUnresolved: Begin completions
 // TestSingleExprFuncUnresolved-NOT: notMine
-// TestSingleExprFuncUnresolved: Decl[EnumElement]/ExprSpecific: myEnum[#MyEnum#];
+// TestSingleExprFuncUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprFuncUnresolved-NOT: notMine
 // TestSingleExprFuncUnresolved: End completions
 }
@@ -373,7 +373,7 @@ struct TestSingleExprAccessorUnresolved {
 
 // TestSingleExprAccessorUnresolved: Begin completions
 // TestSingleExprAccessorUnresolved-NOT: notMine
-// TestSingleExprAccessorUnresolved: Decl[EnumElement]/ExprSpecific: myEnum[#MyEnum#];
+// TestSingleExprAccessorUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprAccessorUnresolved-NOT: notMine
 // TestSingleExprAccessorUnresolved: End completions
 }
@@ -525,7 +525,7 @@ struct TestSingleExprSubscriptUnresolved {
 
 // TestSingleExprSubscriptUnresolved: Begin completions
 // TestSingleExprSubscriptUnresolved-NOT: notMine
-// TestSingleExprSubscriptUnresolved: Decl[EnumElement]/ExprSpecific: myEnum[#MyEnum#];
+// TestSingleExprSubscriptUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprSubscriptUnresolved-NOT: notMine
 // TestSingleExprSubscriptUnresolved: End completions
 }
@@ -630,7 +630,7 @@ enum TopLevelEnum {
   case foo
 }
 
-// TopLevelEnum: Decl[EnumElement]/ExprSpecific:     foo[#TopLevelEnum#];
+// TopLevelEnum: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: foo[#TopLevelEnum#];
 
 var testAccessorUnresolvedTopLevel: TopLevelEnum {
   .#^testAccessorUnresolvedTopLevel^#

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -519,7 +519,7 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
 enum A { case aaa }
 enum B { case bbb }
 // UNRESOLVED_B-NOT: aaa
-// UNRESOLVED_B: Decl[EnumElement]/ExprSpecific:     bbb[#B#]; name=bbb
+// UNRESOLVED_B: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     bbb[#B#]; name=bbb
 // UNRESOLVED_B-NOT: aaa
 
 struct AA {

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -262,25 +262,25 @@ class C4 {
   }
 }
 // UNRESOLVED_3: Begin completions, 2 items
-// UNRESOLVED_3-DAG: Decl[EnumElement]/ExprSpecific:     North[#SomeEnum1#]; name=North
-// UNRESOLVED_3-DAG: Decl[EnumElement]/ExprSpecific:     South[#SomeEnum1#]; name=South
+// UNRESOLVED_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
+// UNRESOLVED_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
 // UNRESOLVED_3-NOT: SomeOptions1
 // UNRESOLVED_3-NOT: SomeOptions2
 // UNRESOLVED_3-NOT: none
 // UNRESOLVED_3-NOT: some(
 
 // UNRESOLVED_3_OPT: Begin completions, 5 items
-// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific:     North[#SomeEnum1#];
-// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific:     South[#SomeEnum1#];
+// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: North[#SomeEnum1#];
+// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: South[#SomeEnum1#];
 // UNRESOLVED_3_OPT-DAG: Keyword[nil]/ExprSpecific/Erase[1]: nil[#SomeEnum1?#]; name=nil
-// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific:     none[#Optional<SomeEnum1>#]; name=none
-// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific:     some({#SomeEnum1#})[#Optional<SomeEnum1>#];
+// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific: none[#Optional<SomeEnum1>#]; name=none
+// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific: some({#SomeEnum1#})[#Optional<SomeEnum1>#];
 // UNRESOLVED_3_OPT-NOT: init({#(some):
 // UNRESOLVED_3_OPT-NOT: init({#nilLiteral:
 
 // UNRESOLVED_3_OPTOPTOPT: Begin completions, 5 items
-// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific:     North[#SomeEnum1#];
-// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific:     South[#SomeEnum1#];
+// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: North[#SomeEnum1#];
+// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: South[#SomeEnum1#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Keyword[nil]/ExprSpecific/Erase[1]: nil[#SomeEnum1???#]; name=nil
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific:     none[#Optional<SomeEnum1??>#]; name=none
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific:     some({#SomeEnum1??#})[#Optional<SomeEnum1??>#];
@@ -297,8 +297,8 @@ extension Optional where Wrapped == Somewhere {
 func testOptionalWithCustomExtension() {
   var _: Somewhere? = .#^UNRESOLVED_OPT_4^#
 // UNRESOLVED_OPT_4: Begin completions, 7 items
-// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific:     earth[#Somewhere#];
-// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific:     mars[#Somewhere#];
+// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]:     earth[#Somewhere#];
+// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]:     mars[#Somewhere#];
 // UNRESOLVED_OPT_4-DAG: Keyword[nil]/ExprSpecific/Erase[1]: nil[#Somewhere?#]; name=nil
 // UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific:     none[#Optional<Somewhere>#]; name=none
 // UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific:     some({#Somewhere#})[#Optional<Somewhere>#];
@@ -414,8 +414,8 @@ func testAvail1(_ x: EnumAvail1) {
 }
 // ENUM_AVAIL_1: Begin completions, 2 items
 // ENUM_AVAIL_1-NOT: AAA
-// ENUM_AVAIL_1-DAG: Decl[EnumElement]/ExprSpecific:     aaa[#EnumAvail1#];
-// ENUM_AVAIL_1-DAG: Decl[EnumElement]/ExprSpecific/NotRecommended: BBB[#EnumAvail1#];
+// ENUM_AVAIL_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: aaa[#EnumAvail1#];
+// ENUM_AVAIL_1-DAG: Decl[EnumElement]/ExprSpecific/NotRecommended/TypeRelation[Identical]: BBB[#EnumAvail1#];
 // ENUM_AVAIL_1-NOT: AAA
 // ENUM_AVAIL_1: End completions
 
@@ -440,7 +440,7 @@ func testWithLiteral1() {
   let s: S
   _ = s.takeEnum(thing: .#^WITH_LITERAL_1^#, other: 1.0)
 // WITH_LITERAL_1: Begin completions, 1 items
-// WITH_LITERAL_1-NEXT: Decl[EnumElement]/ExprSpecific:     myCase[#S.MyEnum#];
+// WITH_LITERAL_1-NEXT: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myCase[#S.MyEnum#];
 // WITH_LITERAL_1-NEXT: End completions
 }
 func testWithLiteral2() {
@@ -464,7 +464,7 @@ func testWithLiteral3() {
     func test(s: S) {
       _ = s.takeEnum(thing: .#^WITH_LITERAL_3^#, other: 1.0)
 // WITH_LITERAL_3: Begin completions, 1 items
-// WITH_LITERAL_3-NEXT: Decl[EnumElement]/ExprSpecific:     myCase[#MyEnum#];
+// WITH_LITERAL_3-NEXT: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myCase[#MyEnum#];
 // WITH_LITERAL_3-NEXT: End completions
     }
   }
@@ -480,9 +480,9 @@ func enumFromOtherFile() -> EnumFromOtherFile {
   return .#^OTHER_FILE_1^# // Don't crash.
 }
 // OTHER_FILE_1: Begin completions
-// OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific:     b({#String#})[#EnumFromOtherFile#];
-// OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific:     a({#Int#})[#EnumFromOtherFile#];
-// OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific:     c[#EnumFromOtherFile#];
+// OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: b({#String#})[#EnumFromOtherFile#];
+// OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: a({#Int#})[#EnumFromOtherFile#];
+// OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: c[#EnumFromOtherFile#];
 // OTHER_FILE_1: End completions
 
 struct NonOptSet {
@@ -522,8 +522,8 @@ func testInStringInterpolation() {
   let y = "enum: \(.#^STRING_INTERPOLATION_INVALID^#)" // Dont'crash.
 }
 // STRING_INTERPOLATION_1: Begin completions
-// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/ExprSpecific:     foo[#MyEnum#];
-// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/ExprSpecific:     bar[#MyEnum#];
+// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: foo[#MyEnum#];
+// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#MyEnum#];
 // STRING_INTERPOLATION_1: End completions
 
 class BaseClass {
@@ -607,10 +607,10 @@ struct HasOverloaded {
 func testOverload(val: HasOverloaded) {
   let _ = val.takeEnum(.#^OVERLOADED_METHOD_1^#)
 // OVERLOADED_METHOD_1: Begin completions, 4 items
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific:     South[#SomeEnum1#]; name=South
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific:     North[#SomeEnum1#]; name=North
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific:     East[#SomeEnum2#]; name=East
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific:     West[#SomeEnum2#]; name=West
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: East[#SomeEnum2#]; name=East
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: West[#SomeEnum2#]; name=West
 // OVERLOADED_METHOD_1: End completions
 
   let _ = HasOverloaded.init(e: .#^OVERLOADED_INIT_1^#)

--- a/test/SourceKit/CodeComplete/complete_constructor.swift.response
+++ b/test/SourceKit/CodeComplete/complete_constructor.swift.response
@@ -7,6 +7,7 @@
       key.description: "(arg1: Int, arg2: Int)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:20complete_constructor3FooC4arg14arg2ACSi_Sitcfc",
       key.modulename: "complete_constructor"

--- a/test/SourceKit/CodeComplete/complete_docbrief_1.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_1.swift
@@ -35,6 +35,7 @@ func test() {
 // CHECK-NEXT:       key.typename: "Void",
 // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.bar",
 // CHECK-NEXT:       key.context: source.codecompletion.context.superclass,
+// CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
 // CHECK-NEXT:       key.num_bytes_to_erase: 0,
 // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1PPAAE3baryyF",
 // CHECK-NEXT:       key.modulename: "DocBriefTest"
@@ -47,6 +48,7 @@ func test() {
 // CHECK-NEXT:       key.typename: "Void",
 // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
 // CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
+// CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
 // CHECK-NEXT:       key.num_bytes_to_erase: 0,
 // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
 // CHECK-NEXT:       key.modulename: "DocBriefTest"

--- a/test/SourceKit/CodeComplete/complete_docbrief_2.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_2.swift
@@ -39,6 +39,7 @@ func test() {
 // CHECK-NEXT:       key.typename: "Void",
 // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
 // CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
+// CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
 // CHECK-NEXT:       key.num_bytes_to_erase: 0,
 // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefUser1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
 // CHECK-NEXT:       key.modulename: "DocBriefUser"

--- a/test/SourceKit/CodeComplete/complete_docbrief_3.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_3.swift
@@ -40,6 +40,7 @@ func test() {
 // CHECK-NEXT:       key.typename: "Void",
 // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
 // CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
+// CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
 // CHECK-NEXT:       key.num_bytes_to_erase: 0,
 // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
 // CHECK-NEXT:       key.modulename: "DocBriefTest"

--- a/test/SourceKit/CodeComplete/complete_from_clang_module.swift
+++ b/test/SourceKit/CodeComplete/complete_from_clang_module.swift
@@ -9,6 +9,7 @@ import Foo
 // CHECK-NEXT:       key.typename: "Int32",
 // CHECK-NEXT:       key.doc.brief: "Aaa.  fooIntVar.  Bbb.",
 // CHECK-NEXT:       key.context: source.codecompletion.context.othermodule,
+// CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
 // CHECK-NEXT:       key.num_bytes_to_erase: 0,
 // CHECK-NEXT:       key.associated_usrs: "c:@fooIntVar",
 // CHECK-NEXT:       key.modulename: "Foo"

--- a/test/SourceKit/CodeComplete/complete_member.swift
+++ b/test/SourceKit/CodeComplete/complete_member.swift
@@ -51,6 +51,7 @@ func testOverrideUSR() {
 // CHECK-OPTIONAL-NEXT:       key.description: "fooInstanceFunc1(a: Int)",
 // CHECK-OPTIONAL-NEXT:       key.typename: "Double",
 // CHECK-OPTIONAL-NEXT:       key.context: source.codecompletion.context.thisclass,
+// CHECK-OPTIONAL-NEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
 // CHECK-OPTIONAL-NEXT:       key.num_bytes_to_erase: 1,
 // CHECK-OPTIONAL-NEXT:       key.associated_usrs: "s:15complete_member11FooProtocolP16fooInstanceFunc1ySdSiF",
 // CHECK-OPTIONAL-NEXT:       key.modulename: "complete_member"
@@ -72,6 +73,7 @@ func testOverrideUSR() {
 // CHECK-OVERRIDE_USR-NEXT:     key.description: "foo()",
 // CHECK-OVERRIDE_USR-NEXT:     key.typename: "Void",
 // CHECK-OVERRIDE_USR-NEXT:     key.context: source.codecompletion.context.thisclass,
+// CHECK-OVERRIDE_USR-NEXT:     key.typerelation: source.codecompletion.typerelation.unrelated,
 // CHECK-OVERRIDE_USR-NEXT:     key.num_bytes_to_erase: 0,
 // CHECK-OVERRIDE_USR-NEXT:     key.associated_usrs: "s:15complete_member7DerivedC3fooyyF s:15complete_member4BaseC3fooyyF",
 // CHECK-OVERRIDE_USR-NEXT:     key.modulename: "complete_member"

--- a/test/SourceKit/CodeComplete/complete_member.swift.response
+++ b/test/SourceKit/CodeComplete/complete_member.swift.response
@@ -7,6 +7,7 @@
       key.description: "fooInstanceFunc0()",
       key.typename: "Double",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:15complete_member11FooProtocolP16fooInstanceFunc0SdyF",
       key.modulename: "complete_member"
@@ -18,6 +19,7 @@
       key.description: "fooInstanceFunc1(a: Int)",
       key.typename: "Double",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:15complete_member11FooProtocolP16fooInstanceFunc1ySdSiF",
       key.modulename: "complete_member"
@@ -30,6 +32,7 @@
       key.typename: "Int",
       key.doc.brief: "fooInstanceVar Aaa. Bbb.",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:15complete_member11FooProtocolP14fooInstanceVarSivp",
       key.modulename: "complete_member"
@@ -41,6 +44,7 @@
       key.description: "self",
       key.typename: "FooProtocol",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     }
   ]

--- a/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
+++ b/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
@@ -7,6 +7,7 @@
       key.description: "optionalMethod?()",
       key.typename: "Int",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "c:@M@complete_optionalmethod@objc(pl)Proto(im)optionalMethod",
       key.modulename: "complete_optionalmethod"
@@ -18,6 +19,7 @@
       key.description: "self",
       key.typename: "T",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     }
   ]

--- a/test/SourceKit/CodeComplete/complete_override.swift.response
+++ b/test/SourceKit/CodeComplete/complete_override.swift.response
@@ -7,6 +7,7 @@
       key.description: "associatedtype",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -16,6 +17,7 @@
       key.description: "class",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -25,6 +27,7 @@
       key.description: "convenience",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -34,6 +37,7 @@
       key.description: "deinit",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -43,6 +47,7 @@
       key.description: "dynamic",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -52,6 +57,7 @@
       key.description: "enum",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -61,6 +67,7 @@
       key.description: "extension",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -70,6 +77,7 @@
       key.description: "f(getMe a: Int, b: Double)",
       key.typename: "",
       key.context: source.codecompletion.context.superclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:17complete_override4BaseC1f5getMe1bySi_SdtF",
       key.modulename: "complete_override"
@@ -81,6 +89,7 @@
       key.description: "fileprivate",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -90,6 +99,7 @@
       key.description: "final",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -99,6 +109,7 @@
       key.description: "func",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -108,6 +119,7 @@
       key.description: "import",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -117,6 +129,7 @@
       key.description: "indirect",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -126,6 +139,7 @@
       key.description: "infix",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -135,6 +149,7 @@
       key.description: "init",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -144,6 +159,7 @@
       key.description: "init()",
       key.typename: "",
       key.context: source.codecompletion.context.superclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:17complete_override4BaseCACycfc",
       key.modulename: "complete_override"
@@ -155,6 +171,7 @@
       key.description: "inout",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -164,6 +181,7 @@
       key.description: "internal",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -173,6 +191,7 @@
       key.description: "lazy",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -182,6 +201,7 @@
       key.description: "let",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -191,6 +211,7 @@
       key.description: "mutating",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -200,6 +221,7 @@
       key.description: "nonmutating",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -209,6 +231,7 @@
       key.description: "open",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -218,6 +241,7 @@
       key.description: "operator",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -227,6 +251,7 @@
       key.description: "optional",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -236,6 +261,7 @@
       key.description: "override",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -245,6 +271,7 @@
       key.description: "postfix",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -254,6 +281,7 @@
       key.description: "precedencegroup",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -263,6 +291,7 @@
       key.description: "prefix",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -272,6 +301,7 @@
       key.description: "private",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -281,6 +311,7 @@
       key.description: "protocol",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -290,6 +321,7 @@
       key.description: "public",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -299,6 +331,7 @@
       key.description: "required",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -308,6 +341,7 @@
       key.description: "static",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -317,6 +351,7 @@
       key.description: "struct",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -326,6 +361,7 @@
       key.description: "subscript",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -335,6 +371,7 @@
       key.description: "typealias",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -344,6 +381,7 @@
       key.description: "unowned",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -353,6 +391,7 @@
       key.description: "var",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     },
     {
@@ -362,6 +401,7 @@
       key.description: "weak",
       key.typename: "",
       key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0
     }
   ]

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift
@@ -1,0 +1,24 @@
+protocol MyProto {}
+enum MyEnum : MyProto {
+    case foo
+    case bar(Int)
+
+    static func staticReturnVoid() {}
+    static func staticReturnMyEnum() -> MyEnum { return .foo }
+    func intanceReturnVoid() {}
+    func intanceReturnMyEnum() -> MyEnum { return .foo }
+}
+
+func testIdenticalContext() -> MyEnum {
+  return MyEnum.
+}
+
+func testConvertibleContext() -> MyProto {
+  return MyEnum.
+}
+
+// RUN: %sourcekitd-test -req=complete -pos=13:17 %s -- %s > %t.identical.response
+// RUN: diff -u %s.identical.response %t.identical.response
+
+// RUN: %sourcekitd-test -req=complete -pos=17:17 %s -- %s > %t.convertible.response
+// RUN: diff -u %s.convertible.response %t.convertible.response

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift.convertible.response
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift.convertible.response
@@ -1,0 +1,98 @@
+{
+  key.results: [
+    {
+      key.kind: source.lang.swift.decl.enumelement,
+      key.name: "bar()",
+      key.sourcetext: "bar(<#T##Int#>)",
+      key.description: "bar(Int)",
+      key.typename: "MyEnum",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.convertible,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO3baryACSicACmF",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.decl.enumelement,
+      key.name: "foo",
+      key.sourcetext: "foo",
+      key.description: "foo",
+      key.typename: "MyEnum",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.convertible,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO3fooyA2CmF",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "intanceReturnMyEnum(:)",
+      key.sourcetext: "intanceReturnMyEnum(<#T##self: MyEnum##MyEnum#>)",
+      key.description: "intanceReturnMyEnum(self: MyEnum)",
+      key.typename: "() -> MyEnum",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.convertible,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO013intanceReturncD0ACyF",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "intanceReturnVoid(:)",
+      key.sourcetext: "intanceReturnVoid(<#T##self: MyEnum##MyEnum#>)",
+      key.description: "intanceReturnVoid(self: MyEnum)",
+      key.typename: "() -> Void",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.invalid,
+      key.num_bytes_to_erase: 0,
+      key.not_recommended: 1,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO17intanceReturnVoidyyF",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.keyword,
+      key.name: "self",
+      key.sourcetext: "self",
+      key.description: "self",
+      key.typename: "MyEnum.Type",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.num_bytes_to_erase: 0
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.class,
+      key.name: "staticReturnMyEnum()",
+      key.sourcetext: "staticReturnMyEnum()",
+      key.description: "staticReturnMyEnum()",
+      key.typename: "MyEnum",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.convertible,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO012staticReturncD0ACyFZ",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.class,
+      key.name: "staticReturnVoid()",
+      key.sourcetext: "staticReturnVoid()",
+      key.description: "staticReturnVoid()",
+      key.typename: "Void",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.invalid,
+      key.num_bytes_to_erase: 0,
+      key.not_recommended: 1,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO16staticReturnVoidyyFZ",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.keyword,
+      key.name: "Type",
+      key.sourcetext: "Type",
+      key.description: "Type",
+      key.typename: "MyEnum.Type",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.num_bytes_to_erase: 0
+    }
+  ]
+}

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift.identical.response
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift.identical.response
@@ -1,0 +1,98 @@
+{
+  key.results: [
+    {
+      key.kind: source.lang.swift.decl.enumelement,
+      key.name: "bar()",
+      key.sourcetext: "bar(<#T##Int#>)",
+      key.description: "bar(Int)",
+      key.typename: "MyEnum",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.identical,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO3baryACSicACmF",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.decl.enumelement,
+      key.name: "foo",
+      key.sourcetext: "foo",
+      key.description: "foo",
+      key.typename: "MyEnum",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.identical,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO3fooyA2CmF",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "intanceReturnMyEnum(:)",
+      key.sourcetext: "intanceReturnMyEnum(<#T##self: MyEnum##MyEnum#>)",
+      key.description: "intanceReturnMyEnum(self: MyEnum)",
+      key.typename: "() -> MyEnum",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.identical,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO013intanceReturncD0ACyF",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "intanceReturnVoid(:)",
+      key.sourcetext: "intanceReturnVoid(<#T##self: MyEnum##MyEnum#>)",
+      key.description: "intanceReturnVoid(self: MyEnum)",
+      key.typename: "() -> Void",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.invalid,
+      key.num_bytes_to_erase: 0,
+      key.not_recommended: 1,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO17intanceReturnVoidyyF",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.keyword,
+      key.name: "self",
+      key.sourcetext: "self",
+      key.description: "self",
+      key.typename: "MyEnum.Type",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.num_bytes_to_erase: 0
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.class,
+      key.name: "staticReturnMyEnum()",
+      key.sourcetext: "staticReturnMyEnum()",
+      key.description: "staticReturnMyEnum()",
+      key.typename: "MyEnum",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.identical,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO012staticReturncD0ACyFZ",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.class,
+      key.name: "staticReturnVoid()",
+      key.sourcetext: "staticReturnVoid()",
+      key.description: "staticReturnVoid()",
+      key.typename: "Void",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.invalid,
+      key.num_bytes_to_erase: 0,
+      key.not_recommended: 1,
+      key.associated_usrs: "s:21complete_typerelation6MyEnumO16staticReturnVoidyyFZ",
+      key.modulename: "complete_typerelation"
+    },
+    {
+      key.kind: source.lang.swift.keyword,
+      key.name: "Type",
+      key.sourcetext: "Type",
+      key.description: "Type",
+      key.typename: "MyEnum.Type",
+      key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.num_bytes_to_erase: 0
+    }
+  ]
+}

--- a/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
+++ b/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
@@ -19,7 +19,7 @@
       key.description: "east",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.identical,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO4eastyA2CmF",
       key.modulename: "complete_unresolvedmember"
@@ -67,7 +67,7 @@
       key.description: "other(String)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.identical,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO5otheryACSScACmF",
       key.modulename: "complete_unresolvedmember"
@@ -79,7 +79,7 @@
       key.description: "west",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.identical,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO4westyA2CmF",
       key.modulename: "complete_unresolvedmember"

--- a/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
+++ b/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
@@ -7,6 +7,7 @@
       key.description: "create()",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.identical,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO6createACyFZ",
       key.modulename: "complete_unresolvedmember"
@@ -18,6 +19,7 @@
       key.description: "east",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO4eastyA2CmF",
       key.modulename: "complete_unresolvedmember"
@@ -29,6 +31,7 @@
       key.description: "init(i: Int)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.identical,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO1iACSi_tcfc",
       key.modulename: "complete_unresolvedmember"
@@ -40,6 +43,7 @@
       key.description: "init(s: String)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.identical,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO1sACSS_tcfc",
       key.modulename: "complete_unresolvedmember"
@@ -51,6 +55,7 @@
       key.description: "instance",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
+      key.typerelation: source.codecompletion.typerelation.identical,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO8instanceACvpZ",
       key.modulename: "complete_unresolvedmember"
@@ -62,6 +67,7 @@
       key.description: "other(String)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO5otheryACSScACmF",
       key.modulename: "complete_unresolvedmember"
@@ -73,6 +79,7 @@
       key.description: "west",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
+      key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO4westyA2CmF",
       key.modulename: "complete_unresolvedmember"

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -89,6 +89,7 @@ struct CodeCompletionInfo {
   StringRef DocBrief;
   StringRef AssocUSRs;
   UIdent SemanticContext;
+  UIdent TypeRelation;
   Optional<uint8_t> ModuleImportDepth;
   bool NotRecommended;
   unsigned NumBytesToErase;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -502,6 +502,22 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
     Info.SemanticContext = CCCtxOtherModule; break;
   }
 
+  static UIdent CCTypeRelUnrelated("source.codecompletion.typerelation.unrelated");
+  static UIdent CCTypeRelInvalid("source.codecompletion.typerelation.invalid");
+  static UIdent CCTypeRelConvertible("source.codecompletion.typerelation.convertible");
+  static UIdent CCTypeRelIdentical("source.codecompletion.typerelation.identical");
+
+  switch (Result->getExpectedTypeRelation()) {
+  case CodeCompletionResult::Unrelated:
+    Info.TypeRelation = CCTypeRelUnrelated; break;
+  case CodeCompletionResult::Invalid:
+    Info.TypeRelation = CCTypeRelInvalid; break;
+  case CodeCompletionResult::Convertible:
+    Info.TypeRelation = CCTypeRelConvertible; break;
+  case  CodeCompletionResult::Identical:
+    Info.TypeRelation = CCTypeRelIdentical; break;
+  }
+
   Info.ModuleName = Result->getModuleName();
   Info.DocBrief = Result->getBriefDocComment();
   Info.NotRecommended = Result->isNotRecommended();

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CodeCompletionResultsArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CodeCompletionResultsArray.h
@@ -33,6 +33,7 @@ public:
            Optional<llvm::StringRef> DocBrief,
            Optional<llvm::StringRef> AssocUSRs,
            SourceKit::UIdent SemanticContext,
+           SourceKit::UIdent TypeRelation,
            bool NotRecommended,
            unsigned NumBytesToErase);
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CodeCompletionResultsArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CodeCompletionResultsArray.cpp
@@ -31,6 +31,7 @@ struct CodeCompletionResultsArrayBuilder::Implementation {
                       Optional<StringRef>,
                       Optional<StringRef>,
                       UIdent,
+                      UIdent,
                       uint8_t> Builder;
 };
 
@@ -53,6 +54,7 @@ void CodeCompletionResultsArrayBuilder::add(
     Optional<StringRef> DocBrief,
     Optional<StringRef> AssocUSRs,
     UIdent SemanticContext,
+    UIdent TypeRelation,
     bool NotRecommended,
     unsigned NumBytesToErase) {
 
@@ -67,6 +69,7 @@ void CodeCompletionResultsArrayBuilder::add(
                         DocBrief,
                         AssocUSRs,
                         SemanticContext,
+                        TypeRelation,
                         BytesAndNotRecommended);
 }
 
@@ -88,6 +91,7 @@ public:
                              const char *,
                              const char *,
                              sourcekitd_uid_t,
+                             sourcekitd_uid_t,
                              uint8_t> CompactArrayReaderTy;
 
   static bool
@@ -105,6 +109,7 @@ public:
     const char *DocBrief;
     const char *AssocUSRs;
     sourcekitd_uid_t SemanticContext;
+    sourcekitd_uid_t TypeRelation;
     uint8_t BytesAndNotRecommended;
 
     Reader.readEntries(Index,
@@ -117,6 +122,7 @@ public:
                   DocBrief,
                   AssocUSRs,
                   SemanticContext,
+                  TypeRelation,
                   BytesAndNotRecommended);
 
     unsigned NumBytesToErase = BytesAndNotRecommended >> 1;
@@ -144,6 +150,7 @@ public:
       APPLY(KeyAssociatedUSRs, String, AssocUSRs);
     }
     APPLY(KeyContext, UID, SemanticContext);
+    APPLY(KeyTypeRelation, UID, TypeRelation);
     APPLY(KeyNumBytesToErase, Int, NumBytesToErase);
     if (NotRecommended) {
       APPLY(KeyNotRecommended, Bool, NotRecommended);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1982,6 +1982,7 @@ bool SKCodeCompletionConsumer::handleResult(const CodeCompletionInfo &R) {
                      DocBriefOpt,
                      AssocUSRsOpt,
                      R.SemanticContext,
+                     R.TypeRelation,
                      R.NotRecommended,
                      R.NumBytesToErase);
   return true;

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -65,6 +65,7 @@ UID_KEYS = [
         'key.fully_annotated_generic_signature'),
     KEY('DocBrief', 'key.doc.brief'),
     KEY('Context', 'key.context'),
+    KEY('TypeRelation', 'key.typerelation'),
     KEY('ModuleImportDepth', 'key.moduleimportdepth'),
     KEY('NumBytesToErase', 'key.num_bytes_to_erase'),
     KEY('NotRecommended', 'key.not_recommended'),


### PR DESCRIPTION
So that clients can sort the results using the value.
Also, report the type relation of `EnumElementDecl` using the type of the `EnumDecl`.

rdar://problem/59066560