### PR TITLE
Fixes for FixedWidthInteger.random(in: ClosedRange<Self>, using:)

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -2733,11 +2733,6 @@ extension FixedWidthInteger {
     in range: ClosedRange<Self>,
     using generator: inout T
   ) -> Self {
-    _precondition(
-      !range.isEmpty,
-      "Can't get random value with an empty range"
-    )
-
     // Compute delta, the distance between the lower and upper bounds. This
     // value may not representable by the type Bound if Bound is signed, but
     // is always representable as Bound.Magnitude.
@@ -2747,7 +2742,7 @@ extension FixedWidthInteger {
     // If we used &+ instead, the result would be zero, which isn't helpful,
     // so we actually need to handle this case separately.
     if delta == Magnitude.max {
-      return Self(truncatingIfNeeded: generator.next())
+      return Self(truncatingIfNeeded: generator.next() as Magnitude)
     }
     // Need to widen delta to account for the right-endpoint of a closed range.
     delta += 1


### PR DESCRIPTION
Allow the closed-range version of `FixedWidthInteger.random(in:using:)` to work for types larger than 64 bits when the entire valid range (`.min ... .max`) is passed in.

Also, closed ranges are never empty, so the unnecessary `!isEmpty` precondition has been removed.