### PR TITLE
[build] avoid use generator expression to add linker parameter

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1405,8 +1405,16 @@ function(_add_swift_library_single target name)
       if(${SWIFTLIB_SINGLE_SDK} MATCHES "(I|TV|WATCH)OS")
         target_link_options(${target} PRIVATE
           "LINKER:-bitcode_bundle"
-          $<$<BOOL:SWIFT_EMBED_BITCODE_SECTION_HIDE_SYMBOLS>:"LINKER:-bitcode_hide_symbols">
           "LINKER:-lto_library,${LLVM_LIBRARY_DIR}/libLTO.dylib")
+
+          # Please note that using a generator expression to fit
+          # this in a single target_link_options does not work,
+          # since that seems not to allow the LINKER: prefix to be
+          # evaluated (i.e. it will be added as-is to the linker parameters)
+          if(SWIFT_EMBED_BITCODE_SECTION_HIDE_SYMBOLS)
+            target_link_options(${target} PRIVATE
+              "LINKER:-bitcode_hide_symbols")
+          endif()
       endif()
     endif()
   endif()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1403,18 +1403,27 @@ function(_add_swift_library_single target name)
     # Include LLVM Bitcode slices for iOS, Watch OS, and Apple TV OS device libraries.
     if(SWIFT_EMBED_BITCODE_SECTION AND NOT SWIFTLIB_SINGLE_DONT_EMBED_BITCODE)
       if(${SWIFTLIB_SINGLE_SDK} MATCHES "(I|TV|WATCH)OS")
-        target_link_options(${target} PRIVATE
-          "LINKER:-bitcode_bundle"
-          "LINKER:-lto_library,${LLVM_LIBRARY_DIR}/libLTO.dylib")
+        # The two branches of this if statement accomplish the same end result
+        # We are simply accounting for the fact that on CMake < 3.16
+        # using a generator expression to
+        # specify a LINKER: argument does not work,
+        # since that seems not to allow the LINKER: prefix to be
+        # evaluated (i.e. it will be added as-is to the linker parameters)
+        if(CMAKE_VERSION VERSION_LESS 3.16)
+          target_link_options(${target} PRIVATE
+            "LINKER:-bitcode_bundle"
+            "LINKER:-lto_library,${LLVM_LIBRARY_DIR}/libLTO.dylib")
 
-          # Please note that using a generator expression to fit
-          # this in a single target_link_options does not work,
-          # since that seems not to allow the LINKER: prefix to be
-          # evaluated (i.e. it will be added as-is to the linker parameters)
           if(SWIFT_EMBED_BITCODE_SECTION_HIDE_SYMBOLS)
             target_link_options(${target} PRIVATE
               "LINKER:-bitcode_hide_symbols")
           endif()
+        else()
+          target_link_options(${target} PRIVATE
+            "LINKER:-bitcode_bundle"
+            $<$<BOOL:SWIFT_EMBED_BITCODE_SECTION_HIDE_SYMBOLS>:"LINKER:-bitcode_hide_symbols">
+            "LINKER:-lto_library,${LLVM_LIBRARY_DIR}/libLTO.dylib")
+        endif()
       endif()
     endif()
   endif()


### PR DESCRIPTION
Generator expressions seem not to allow the `LINKER:` prefix to be
expanded correctly when used in `target_link_options`.

To solve this, undo the change from #29451 and instead
use an `if` statement to add the flag when needed.

Addresses rdar://problem/59117166