### PR TITLE
[run-test] Fix --target and --param parsing.

### DIFF
--- a/utils/run-test
+++ b/utils/run-test
@@ -129,7 +129,7 @@ def main():
                         help="build test dependencies before running tests "
                              "(default: true)")
     parser.add_argument("--target",
-                        type=argparse.types.ShellSplitType,
+                        type=argparse.types.ShellSplitType(),
                         action=argparse.actions.AppendAction,
                         dest="targets",
                         help="stdlib deployment targets to test. Accept "
@@ -141,7 +141,7 @@ def main():
                         choices=TEST_SUBSETS, default='primary',
                         help="test subset (default: primary)")
     parser.add_argument("--param",
-                        type=argparse.types.ShellSplitType,
+                        type=argparse.types.ShellSplitType(),
                         action=argparse.actions.AppendAction,
                         default=[],
                         help="key=value parameters they are directly passed "


### PR DESCRIPTION
For argparse, the type value of each argument must be a callable. The previous type was simply pointing to the class that implements the callable, and not to an instance of it.

This should recover the previous functionality for the --target and the --param arguments.

Seems that this is already applied in the build-script, so no changes are necessary there.
