### PR TITLE
[5.2][pattern-match] Make sure that when we are extracting a tuple that we fail if we have a non-instruction result.

### DIFF
--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -397,7 +397,12 @@ template <typename LTy> struct tupleextractoperation_ty {
   unsigned index;
   tupleextractoperation_ty(const LTy &Left, unsigned i) : L(Left), index(i) {}
 
-  bool match(SILValue v) { return match(v->getDefiningInstruction()); }
+  bool match(SILValue v) {
+    auto *inst = v->getDefiningInstruction();
+    if (!inst)
+      return false;
+    return match(inst);
+  }
 
   template <typename ITy> bool match(ITy *V) {
     if (auto *TEI = dyn_cast<TupleExtractInst>(V)) {

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2422,6 +2422,16 @@ bb0(%0 : $Builtin.Int64, %1 : $Builtin.RawPointer, %2 : $Builtin.RawPointer):
   return %13 : $()
 }
 
+// Make sure we do not crash here. This ensures that when checking for
+// tuple_extract, we check if we have an argument or not.
+sil @builtin_array_opt_index_raw_pointer_to_index_addr_no_crash : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Builtin.Word {
+bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
+  %2 = index_raw_pointer %0 : $Builtin.RawPointer, %1 : $Builtin.Word
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*Builtin.Word
+  %4 = load %3 : $*Builtin.Word
+  return %4 : $Builtin.Word
+}
+
 // CHECK-LABEL: sil @cmp_zext_peephole
 // CHECK: bb0([[Arg1:%.*]] : $Builtin.Word, [[Arg2:%.*]] : $Builtin.Word):
 // CHECK:   [[ZA1:%.*]] = builtin "zextOrBitCast_Word_Int64"([[Arg1]] : $Builtin.Word) : $Builtin.Int64


### PR DESCRIPTION
The specific problem here is this:

```
sil @builtin_array_opt_index_raw_pointer_to_index_addr_no_crash : $@convention(thin) (Builtin.RawPointer, Builtin.
Word) -> Builtin.Word {
bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
  %2 = index_raw_pointer %0 : $Builtin.RawPointer, %1 : $Builtin.Word
  %3 = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*Builtin.Word
  %4 = load %3 : $*Builtin.Word
  return %4 : $Builtin.Word
}
```

before this commit, we unconditionally called getDefiningInstruction when
looking at %1. This of course returned a null value causing the compiler to
crash in a dyn_cast<TupleExtractInst>().

rdar://59138369
(cherry picked from commit 377b7b131edacf3309fa7095797c8cdec3915857)

----

Explanation: This is a long standing bug from when we implemented multiple result instructions. Specifically, we needed to do a small check whether or not the given value is actually a result of a SILValue. My fix here just does that check.

Scope of issue: Causes the compiler to crash when compiling certain code examples.

Origination: Work to introduce multiple result instructions.

Risk: Low. This has been in the tree a long time and has not been reported. That suggests it is an edge case.

Testing: Added regression test

Reviewers: Andy Trick

Resolves rdar://59138369
