### PR TITLE
[Serialization] Recover from a missing conforming type in a protocol conformance

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -581,7 +581,11 @@ ModuleFile::readConformanceChecked(llvm::BitstreamCursor &Cursor,
     ProtocolConformanceXrefLayout::readRecord(scratch, protoID, nominalID,
                                               moduleID);
 
-    auto nominal = cast<NominalTypeDecl>(getDecl(nominalID));
+    auto maybeNominal = getDeclChecked(nominalID);
+    if (!maybeNominal)
+      return maybeNominal.takeError();
+
+    auto nominal = cast<NominalTypeDecl>(maybeNominal.get());
     PrettyStackTraceDecl trace("cross-referencing conformance for", nominal);
     auto proto = cast<ProtocolDecl>(getDecl(protoID));
     PrettyStackTraceDecl traceTo("... to", proto);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3104,6 +3104,16 @@ void SILDeserializer::readWitnessTableEntries(
 
 SILWitnessTable *SILDeserializer::readWitnessTable(DeclID WId,
                                                    SILWitnessTable *existingWt) {
+  auto deserialized = readWitnessTableChecked(WId, existingWt);
+  if (!deserialized) {
+    MF->fatal(deserialized.takeError());
+  }
+  return deserialized.get();
+}
+
+llvm::Expected<SILWitnessTable *>
+  SILDeserializer::readWitnessTableChecked(DeclID WId,
+                                           SILWitnessTable *existingWt) {
   if (WId == 0)
     return nullptr;
   assert(WId <= WitnessTables.size() && "invalid WitnessTable ID");
@@ -3150,8 +3160,12 @@ SILWitnessTable *SILDeserializer::readWitnessTable(DeclID WId,
   }
 
   // Deserialize Conformance.
+  auto maybeConformance = MF->readConformanceChecked(SILCursor);
+  if (!maybeConformance)
+    return maybeConformance.takeError();
+
   auto theConformance = cast<RootProtocolConformance>(
-                          MF->readConformance(SILCursor).getConcrete());
+                          maybeConformance.get().getConcrete());
 
   PrettyStackTraceConformance trace(SILMod.getASTContext(),
                                     "deserializing SIL witness table for",
@@ -3228,8 +3242,18 @@ SILWitnessTable *SILDeserializer::readWitnessTable(DeclID WId,
 void SILDeserializer::getAllWitnessTables() {
   if (!WitnessTableList)
     return;
-  for (unsigned I = 0, E = WitnessTables.size(); I < E; I++)
-    readWitnessTable(I + 1, nullptr);
+  for (unsigned I = 0, E = WitnessTables.size(); I < E; I++) {
+    auto maybeTable = readWitnessTableChecked(I + 1, nullptr);
+    if (!maybeTable) {
+      if (maybeTable.errorIsA<XRefNonLoadedModuleError>()) {
+        // This is most likely caused by decls hidden by an implementation-only
+        // import, it is safe to ignore for this function's purpose.
+        consumeError(maybeTable.takeError());
+      } else {
+        MF->fatal(maybeTable.takeError());
+      }
+    }
+  }
 }
 
 SILWitnessTable *

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -126,8 +126,17 @@ namespace swift {
     SILVTable *readVTable(serialization::DeclID);
     SILGlobalVariable *getGlobalForReference(StringRef Name);
     SILGlobalVariable *readGlobalVar(StringRef Name);
-    SILWitnessTable *readWitnessTable(serialization::DeclID,
+
+    /// Read and return the witness table identified with \p WId.
+    SILWitnessTable *readWitnessTable(serialization::DeclID WId,
                                       SILWitnessTable *existingWt);
+
+    /// Read the witness table identified with \p WId, return the table or
+    /// the first error if any.
+    llvm::Expected<SILWitnessTable *>
+      readWitnessTableChecked(serialization::DeclID WId,
+                              SILWitnessTable *existingWt);
+
     void readWitnessTableEntries(
            llvm::BitstreamEntry &entry,
            std::vector<SILWitnessTable::Entry> &witnessEntries,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -738,9 +738,10 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
     std::copy_if(
         loadedModuleFile->getDependencies().begin(),
         loadedModuleFile->getDependencies().end(), std::back_inserter(missing),
-        [&duplicates](const ModuleFile::Dependency &dependency) -> bool {
+        [&duplicates, &Ctx](const ModuleFile::Dependency &dependency) -> bool {
           if (dependency.isLoaded() || dependency.isHeader() ||
-              dependency.isImplementationOnly()) {
+              (dependency.isImplementationOnly() &&
+               Ctx.LangOpts.DebuggerSupport)) {
             return false;
           }
           return duplicates.insert(dependency.RawPath).second;

--- a/test/Serialization/Recovery/Inputs/custom-modules/Conformance.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Conformance.h
@@ -1,0 +1,4 @@
+enum __attribute__((flag_enum,enum_extensibility(open))) CEnum : int {
+  A = 1 << 0,
+  B = 1 << 1,
+};

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -13,3 +13,4 @@ module SuperclassObjC { header "SuperclassObjC.h" }
 module Typedefs { header "Typedefs.h" }
 module TypeRemovalObjC { header "TypeRemovalObjC.h" }
 module Types { header "Types.h" }
+module Conformance { header "Conformance.h" }

--- a/test/Serialization/Recovery/missing-clang-module-conformance.swift
+++ b/test/Serialization/Recovery/missing-clang-module-conformance.swift
@@ -1,0 +1,18 @@
+/// Recover from reading witness table involving a synthesized conformance
+/// rdar://problem/58924131
+
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/custom-modules %t/
+// RUN: %target-swift-frontend -emit-module %s -module-name MyModule -emit-module-path %t/MyModule.swiftmodule -I %t/custom-modules -swift-version 5
+
+/// Delete the clang module
+// RUN: rm -r %t/custom-modules/
+
+// RUN: not %target-sil-opt %t/MyModule.swiftmodule 2>&1 | %FileCheck %s
+
+@_implementationOnly import Conformance
+// CHECK: missing required module 'Conformance'
+
+public func foo<T: OptionSet>(_ t: T) {}
+
+foo(CEnum.A)


### PR DESCRIPTION
We saw this failure with a Clang module imported @_implementationOnly with synthesized conformances by the ClangImporter. It caused issues only in sil-opt as it reads all the witness tables.

rdar://problem/58924131