### PR TITLE
[SIL Optimization] Make ArraySemantics.cpp aware of "array.uninitialized_intrinsic"

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -41,7 +41,8 @@ enum class ArrayCallKind {
   // a function, and it has a self parameter, make sure that it is defined
   // before this comment.
   kArrayInit,
-  kArrayUninitialized
+  kArrayUninitialized,
+  kArrayUninitializedIntrinsic
 };
 
 /// Wrapper around array semantic calls.
@@ -182,6 +183,21 @@ public:
   
   /// Can this function be inlined by the early inliner.
   bool canInlineEarly() const;
+
+  /// If this is a call to  ArrayUninitialized (or
+  /// ArrayUninitializedInstrinsic), identify the instructions that store
+  /// elements into the array indices. For every index, add the store
+  /// instruction that stores to that index to \p ElementStoreMap.
+  ///
+  /// \returns true iff this is an "array.uninitialized" semantic call, and the
+  /// stores into the array indices are identified and the \p ElementStoreMap is
+  /// populated.
+  ///
+  /// Note that this function does not support array initializations that use
+  /// copy_addr, which implies that arrays with address-only types would not
+  /// be recognized by this function as yet.
+  bool mapInitializationStores(
+      llvm::DenseMap<uint64_t, StoreInst *> &ElementStoreMap);
 
 protected:
   /// Validate the signature of this call.

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -314,6 +314,7 @@ static bool isNonMutatingArraySemanticCall(SILInstruction *Inst) {
   case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
   case ArrayCallKind::kArrayUninitialized:
+  case ArrayCallKind::kArrayUninitializedIntrinsic:
   case ArrayCallKind::kAppendContentsOf:
   case ArrayCallKind::kAppendElement:
     return false;
@@ -662,7 +663,8 @@ bool COWArrayOpt::hasLoopOnlyDestructorSafeArrayOperations() {
         auto Kind = Sem.getKind();
         // Safe because they create new arrays.
         if (Kind == ArrayCallKind::kArrayInit ||
-            Kind == ArrayCallKind::kArrayUninitialized)
+            Kind == ArrayCallKind::kArrayUninitialized ||
+            Kind == ArrayCallKind::kArrayUninitializedIntrinsic)
           continue;
         // All array types must be the same. This is a stronger guaranteed than
         // we actually need. The requirement is that we can't create another

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -641,7 +641,8 @@ static bool removeAndReleaseArray(SingleValueInstruction *NewArrayValue,
 /// side effect?
 static bool isAllocatingApply(SILInstruction *Inst) {
   ArraySemanticsCall ArrayAlloc(Inst);
-  return ArrayAlloc.getKind() == ArrayCallKind::kArrayUninitialized;
+  return ArrayAlloc.getKind() == ArrayCallKind::kArrayUninitialized ||
+         ArrayAlloc.getKind() == ArrayCallKind::kArrayUninitializedIntrinsic;
 }
 
 namespace {
@@ -832,7 +833,9 @@ static bool getDeadInstsAfterInitializerRemoved(
 bool DeadObjectElimination::processAllocApply(ApplyInst *AI,
                                               DeadEndBlocks &DEBlocks) {
   // Currently only handle array.uninitialized
-  if (ArraySemanticsCall(AI).getKind() != ArrayCallKind::kArrayUninitialized)
+  if (ArraySemanticsCall(AI).getKind() != ArrayCallKind::kArrayUninitialized &&
+      ArraySemanticsCall(AI).getKind() !=
+          ArrayCallKind::kArrayUninitializedIntrinsic)
     return false;
 
   llvm::SmallVector<SILInstruction *, 8> instsDeadAfterInitializerRemoved;

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -21,7 +21,7 @@ class TrivialDestructor {
 // Remove a dead array.
 // rdar://20980377 Add dead array elimination to DeadObjectElimination
 // Swift._allocateUninitializedArray <A> (Builtin.Word) -> (Swift.Array<A>, Builtin.RawPointer)
-sil [_semantics "array.uninitialized"] @allocArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> @owned (Array<τ_0_0>, Builtin.RawPointer)
+sil [_semantics "array.uninitialized_intrinsic"] @allocArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> @owned (Array<τ_0_0>, Builtin.RawPointer)
 
 sil [_semantics "array.uninitialized"] @adoptStorageSpecialiedForInt : $@convention(method) (@guaranteed _ContiguousArrayStorage<Int>, Builtin.Word, @thin Array<Int>.Type) -> (@owned Array<Int>, UnsafeMutablePointer<Int>)
 

--- a/test/SILOptimizer/dead_array_elim.swift
+++ b/test/SILOptimizer/dead_array_elim.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -O -emit-sil -primary-file %s | %FileCheck %s
+
+// These tests check whether DeadObjectElimination pass runs as a part of the
+// optimization pipeline and eliminates dead array literals in Swift code.
+// Note that DeadObjectElimination pass relies on @_semantics annotations on
+// the array initializer that is used by the compiler to create array literals.
+// This test would fail if in case the initializer used by the compiler to
+// initialize array literals doesn't match the one expected by the pass.
+
+// CHECK-LABEL: sil hidden @$s15dead_array_elim24testDeadArrayEliminationyyF
+func testDeadArrayElimination() {
+  _ = [1, 2, 3]
+    // CHECK: bb0:
+    // CHECK-NEXT: %{{.*}} = tuple ()
+    // CHECK-NEXT: return %{{.*}} : $()
+}
+
+// CHECK-LABEL: sil hidden @$s15dead_array_elim29testEmptyDeadArrayEliminationyyF
+func testEmptyDeadArrayElimination() {
+  _ = []
+    // CHECK: bb0:
+    // CHECK-NEXT: %{{.*}} = tuple ()
+    // CHECK-NEXT: return %{{.*}} : $()
+}
+
+// The use case tested by the following test, where a _fixLifetime call is
+// invoked on an array, appears when new os log APIs are  used.
+// CHECK-LABEL: sil hidden @$s15dead_array_elim35testDeadArrayElimWithFixLifetimeUseyyF
+func testDeadArrayElimWithFixLifetimeUse() {
+  let a: [Int] = []
+  _fixLifetime(a)
+    // CHECK: bb0:
+    // CHECK-NEXT: %{{.*}} = tuple ()
+    // CHECK-NEXT: return %{{.*}} : $()
+}
+
+// FIXME: DeadObjectElimination doesn't optimize this yet.
+func testDeadArrayElimWithAddressOnlyValues<T>(x: T, y: T) {
+  _ = [x, y]
+}


### PR DESCRIPTION
This semantics attribute is used by the top-level array initializer (in ArrayShared.swift),
which is the entry point used by the compiler to initialize array from array literals.
This initializer is "early inlined" so that other optimizations can work on its body.

This PR also updates DeadObjectElimination and ArrayCOWOpts optimization passes to work with this semantics attribute in addition to "array.uninitialized", which they already use. (But this will not make them more effective as they are also applied after early inlining.)

It also refactors `mapInitializationStores` function from ArrayElementValuePropagation.cpp to
ArraySemantic.cpp so that the array-initialization pattern matching functionality
implemented by the function can be reused by other optimizations.

The purpose of this PR is to reuse the functionality implemented in ArraySemantics such as `getArrayValue`, `getStoragePointer` etc. in a new "mandatory" pass that will unroll forEach loops over array literals, which itself is aimed at optimizing the new os log calls (see https://github.com/apple/swift/pull/29651).