### PR TITLE
Add a new mandatory optimization pass for unrolling forEach calls over arrays created from array literals.

### DIFF
--- a/include/swift/AST/SemanticAttrs.def
+++ b/include/swift/AST/SemanticAttrs.def
@@ -60,6 +60,8 @@ SEMANTICS_ATTR(ARRAY_COUNT, "array.count")
 SEMANTICS_ATTR(ARRAY_DEALLOC_UNINITIALIZED, "array.dealloc_uninitialized")
 SEMANTICS_ATTR(ARRAY_UNINITIALIZED_INTRINSIC, "array.uninitialized_intrinsic")
 
+SEMANTICS_ATTR(SEQUENCE_FOR_EACH, "sequence.forEach")
+
 SEMANTICS_ATTR(OPTIMIZE_SIL_SPECIALIZE_GENERIC_NEVER, "optimize.sil.specialize.generic.never")
 SEMANTICS_ATTR(OPTIMIZE_SIL_SPECIALIZE_GENERIC_PARTIAL_NEVER,
           "optimize.sil.specialize.generic.partial.never")

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -319,6 +319,8 @@ PASS(NonInlinableFunctionSkippingChecker, "check-non-inlinable-function-skipping
 PASS(YieldOnceCheck, "yield-once-check",
     "Check correct usage of yields in yield-once coroutines")
 PASS(OSLogOptimization, "os-log-optimization", "Optimize os log calls")
+PASS(ForEachLoopUnroll, "for-each-loop-unroll",
+     "Unroll forEach loops over array literals")
 PASS(MandatoryCombine, "mandatory-combine",
     "Perform mandatory peephole combines")
 PASS(BugReducerTester, "bug-reducer-tester",

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -145,6 +145,15 @@ public:
       SILInstruction *inst,
       llvm::function_ref<void(SILInstruction *)> callback =
                                     [](SILInstruction *) {});
+
+  /// Recursively visit users of \c inst  (including \c inst)and force delete
+  /// them. Also, destroy the consumed operands of the deleted instructions
+  /// whenever necessary. Invoke the \c callback on instructions that are
+  /// deleted.
+  void recursivelyForceDeleteUsersAndFixLifetimes(
+      SILInstruction *inst,
+      llvm::function_ref<void(SILInstruction *)> callback =
+          [](SILInstruction *) {});
 };
 
 /// If \c inst is dead, delete it and recursively eliminate all code that

--- a/lib/SILOptimizer/LoopTransforms/CMakeLists.txt
+++ b/lib/SILOptimizer/LoopTransforms/CMakeLists.txt
@@ -5,4 +5,5 @@ silopt_register_sources(
   LoopRotate.cpp
   LoopUnroll.cpp
   LICM.cpp
+  ForEachLoopUnroll.cpp
 )

--- a/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
@@ -1,0 +1,630 @@
+//===--- ForEachLoopUnrolling.cpp - Unroll loops over array literals ----- ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This pass unrolls Sequence.forEach calls invoked on an array created
+// from an array literal. See below for an overview of the algorithm. This is
+// a function-level transformation pass that operates on ownership SIL and
+// so must be applied before ownership is stripped.
+//
+// Algorithm overview:
+//
+// 1. Iterate over the body of the function and analyze calls to the array
+//    initializer annotated "array.uninitialized_intrinsic". This is done in
+//    `run` method.
+//
+// 2. For every "array.uninintialized_intrinsic" initializer call, try
+//    extracting the elements with which the array is initialized, and classify
+//    the uses of the array into incidental uses, forEach calls and uses that
+//    can write into the array. If any of the following conditions hold, give
+//    up and look for the next initializer call:
+//         - The elements stored into the array cannot be extracted.
+//         - The array can be modified after initialization.
+//         - There are no forEach calls on the array.
+//         - The array is too large to unroll forEach calls. This check uses
+//            SILModule::UnrollThreshold parameter.
+//    If none of the above conditions hold, procede to unrolling every forEach
+//    call on the array (Step 3). Step 2 is implemented in the function:
+//    `tryUnrollForEachCallsOverArrayLiteral`.
+//
+// 3. Given a forEach call, unroll it by applying the "body closure" passed to
+//    the call to every element of the array. There are three important
+//    details to this unrolling. Firstly, the SILValue of the element stored
+//    into the array through the store instruction (identified in step 2) may
+//    not be valid at the point where the unrolling must happen (i.e., where the
+//    forEach is called). Therefore, we need to copy_value the elements at the
+//    point where they are stored and ensure that the copies are alive until
+//    they are used by the unrolled code. The implementation actually
+//    makes the copies valid for the entire lifetime of the array.
+//
+//    Secondly, the body closure uses @in_guaranteed convention for the
+//    parameter. Therefore, an alloc_stack is created before the unrolled code
+//    begins to hold the elements, and is destoryed once the unrolled code ends.
+//
+//    Thirdly, the body closure throws. Hence, it has to be try_applied. This
+//    means that we need to chain the try_applies in such a way that when the
+//    try_apply on the element e_i completes normally it jumps to the try_apply
+//    of e_i+1. When the try_apply (of any element) throws, it must go to the
+//    error block of the original forEach call.
+//
+//    All of this is implemented by the function `unrollForEach`.
+//
+// 4. Delete the forEach calls that were unrolled and clean up dead code
+//    resulting due to that.
+//
+// This transformation is illustrated below on a small example:
+//
+// Input:
+//      %initResult = apply %arrayUninitialized(...)
+//      (%array, %storage_ptr) = destructure_tuple %initResult
+//      store %elem1 at array index 1
+//      store %elem2 at array index 2
+//      ..
+//      try_apply %forEach(%body, %array) normal bb1, error bb2
+//    bb1(%res : $()):
+//      ..
+//    bb2(%error : @owned $Error):
+//      ...
+//    bb3:
+//      destroy_value %array
+//
+// Output:
+//
+//      %initResult = apply %arrayUninitialized(...)
+//      (%array, %storage_ptr) = destructure_tuple %initResult
+//      %elem1copy = copy_value %elem1  <--
+//      store %elem1 at array index 1
+//      %elem2copy = copy_value %elem2  <--
+//      store %elem2 at array index 2
+//      ..
+//      alloc_stack %stack
+//      %elem1borrow = begin_borrow %elem1copy
+//      store_borrow %elem1borrow to %stack
+//      end_borrow %elem1borrow
+//      try_apply %body(%stack) normal normalbb1, error errbb1
+//
+//    errbb1(%error : @owned $Error):
+//       br bb2(%error)
+//
+//    normalbb1(%res : $()):
+//      %elem2borrow = begin_borrow %elem2copy
+//      store_borrow %elem2borrow to %stack
+//      end_borrow %elem2borrow
+//      try_apply %body(%stack) normal bb1, error errbb2
+//
+//    errbb2(%error : @owned $Error):
+//       br bb2(%error)
+//
+//    bb1(%res : $()):
+//      dealloc_stack %stack
+//      ...
+//    bb2(%error : @owned $Error):
+//      ...
+//      dealloc_stack %stack
+//    bb3:
+//      destroy_value %elem1copy
+//      destroy_value %elem2copy
+//      destroy_value %array
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/SemanticAttrs.h"
+#include "swift/AST/SubstitutionMap.h"
+#include "swift/Basic/OptimizationMode.h"
+#include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/CFG.h"
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILConstants.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/TypeLowering.h"
+#include "swift/SILOptimizer/Analysis/ArraySemantic.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/ValueLifetime.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace swift;
+
+namespace {
+
+/// A class for processing and storing information about an array
+/// such as the values with which it is initialized and the kind of
+/// users it has.
+class ArrayInfo {
+  /// The array value returned by the _allocateUninitialized call.
+  SILValue arrayValue;
+
+  /// A map from an array index to the store instruction that initializes that
+  /// index.
+  llvm::DenseMap<uint64_t, StoreInst *> elementStoreMap;
+
+  /// List of Sequence.forEach calls invoked on the array.
+  SmallSetVector<TryApplyInst *, 4> forEachCalls;
+
+  /// Indicates whether the array could be modified after initialization. Note
+  /// that this not include modifications to the elements of the array. When
+  /// set, this will prevent the forEach loops from getting unrolled.
+  bool mayBeWritten = false;
+
+  /// Instructions that destroy the array. These must be destroy_value
+  /// instructions either of the \c arrayValue or the copy_values of that.
+  SmallVector<SILInstruction *, 4> destroys;
+
+  /// Classify uses of the array into forEach uses, read-only uses etc. and set
+  /// the fields of this instance appropriately. This function will recursively
+  /// classify the uses of borrows and copy-values of the array as well.
+  void classifyUsesOfArray(SILValue arrayValue);
+
+public:
+  ArrayInfo() {}
+
+  /// Given an apply instruction \c apply, try to initialize this ArrayInfo
+  /// with it. This would succeed iff the apply instruction starts an
+  /// initialization pattern that is auto-generated by the compiler for array
+  /// literals. Return true on success and false on failure.
+  bool tryInitialize(ApplyInst *apply);
+
+  /// Return the SILValue of the array that is initialized.
+  SILValue getArrayValue() {
+    assert(arrayValue);
+    return arrayValue;
+  }
+
+  /// Return true iff the array could be modified after initialization.
+  bool mayBeModified() {
+    assert(arrayValue);
+    return mayBeWritten;
+  }
+
+  /// Return the forEach uses identified for the array.
+  ArrayRef<TryApplyInst *> getForEachUses() {
+    assert(arrayValue);
+    return ArrayRef<TryApplyInst *>(forEachCalls.begin(), forEachCalls.end());
+  }
+
+  /// Return the number of elements in the array.
+  uint64_t getNumElements() {
+    assert(arrayValue);
+    return elementStoreMap.size();
+  }
+
+  /// Return the store instruction that initializes the given \c index
+  /// of the array.
+  StoreInst *getElementStore(uint64_t index) {
+    assert(arrayValue);
+    return elementStoreMap[index];
+  }
+
+  /// Return the SIL type of the elements stored in the array.
+  /// \pre the array must be non-empty.
+  SILType getElementSILType() {
+    assert(getNumElements() > 0 && "cannot call this on empty arrays");
+    return elementStoreMap[0]->getSrc()->getType();
+  }
+
+  /// Add the destroy_value instructions that represents the last use of the
+  /// array to the parameter \c lastDestroys. The \c lastDestroys
+  /// added by this function are guaranteed to come after all uses of the
+  /// \c arrayValue and copy_values of the \c arrayValue (along all
+  /// "non-dead-end" blocks).
+  void getLastDestroys(SmallVectorImpl<DestroyValueInst *> &lastDestroys);
+};
+
+/// Given a Array-typed SIL value \c array and an instruction \c user that uses
+/// the array, check whether this use actually represents a call to _fixLifetime
+/// function. This would be the case if \c user is a store_borrow instruction
+/// that stores into an alloc_stack which is passed to a fixLifetime
+/// instruction. That is, if the following pattern holds:
+///
+///            %stack = alloc_stack
+///      user: store_borrow %array to %stack
+///            fixLifetime %stack
+/// \returns the fixLifetime instruction if this is a fixLifetime use of the
+/// array, nullptr otherwise.
+static FixLifetimeInst *isFixLifetimeUseOfArray(SILInstruction *user,
+                                                SILValue array) {
+  StoreBorrowInst *storeUser = dyn_cast<StoreBorrowInst>(user);
+  if (!storeUser || storeUser->getSrc() != array)
+    return nullptr;
+  AllocStackInst *alloc = dyn_cast<AllocStackInst>(storeUser->getDest());
+  if (!alloc)
+    return nullptr;
+  auto fixLifetimeUsers = alloc->getUsersOfType<FixLifetimeInst>();
+  if (fixLifetimeUsers.empty())
+    return nullptr;
+  auto firstUser = fixLifetimeUsers.begin();
+  FixLifetimeInst *result = *firstUser;
+  // We need to have a unique result.
+  if (++firstUser != fixLifetimeUsers.end())
+    return nullptr;
+  return result;
+}
+
+/// Given an array-typed SIL value \c array and an instruction \c user that uses
+/// the array, check whether this use actually represents a call to the
+/// Sequence.forEach function. This would be case if \c user is a store_borrow
+/// instruction that stores into an alloc_stack which is passed to a try-apply
+/// of the Sequence.forEach function. That is, if the following pattern holds:
+///
+///            %stack = alloc_stack
+///      user: store_borrow %array to %stack
+///            try_apply %forEachCall(%closure, %array)
+/// \returns the try-apply instruction invoking the forEach function if this is
+/// a forEach use of the array, nullptr otherwise.
+static TryApplyInst *isForEachUseOfArray(SILInstruction *user, SILValue array) {
+  StoreBorrowInst *storeUser = dyn_cast<StoreBorrowInst>(user);
+  if (!storeUser || storeUser->getSrc() != array)
+    return nullptr;
+  AllocStackInst *alloc = dyn_cast<AllocStackInst>(storeUser->getDest());
+  if (!alloc)
+    return nullptr;
+  auto applyUsers = alloc->getUsersOfType<TryApplyInst>();
+  if (applyUsers.empty())
+    return nullptr;
+  auto firstUser = applyUsers.begin();
+  TryApplyInst *apply = *firstUser;
+  // We need to have a unique result.
+  if (++firstUser != applyUsers.end())
+    return nullptr;
+  SILFunction *callee = apply->getCalleeFunction();
+  if (!callee || !callee->hasSemanticsAttr(semantics::SEQUENCE_FOR_EACH))
+    return nullptr;
+  return apply;
+}
+
+void ArrayInfo::classifyUsesOfArray(SILValue arrayValue) {
+  for (Operand *operand : arrayValue->getUses()) {
+    auto *user = operand->getUser();
+    if (isIncidentalUse(user))
+      continue;
+    // Ignore this user if it is a call to _fixLifetime. Note that this use
+    // will not be subsumed by InstructionUtils::isIncidentalUse check made
+    // above as the array would be passed indirectly.
+    if (isFixLifetimeUseOfArray(user, arrayValue))
+      continue;
+    // Check if this is a forEach call on the array.
+    if (TryApplyInst *forEachCall = isForEachUseOfArray(user, arrayValue)) {
+      forEachCalls.insert(forEachCall);
+      continue;
+    }
+    // Recursively classify begin_borrow and copy_value uses.
+    if (BeginBorrowInst *beginBorrow = dyn_cast<BeginBorrowInst>(user)) {
+      classifyUsesOfArray(beginBorrow);
+      continue;
+    }
+    if (CopyValueInst *copyValue = dyn_cast<CopyValueInst>(user)) {
+      classifyUsesOfArray(copyValue);
+      continue;
+    }
+    if (DestroyValueInst *destroyValue = dyn_cast<DestroyValueInst>(user)) {
+      destroys.push_back(destroyValue);
+      continue;
+    }
+    // Set mayBeWritten to true if the user could potentially modify the array.
+    // Note that the array elements are allowed to be modified as long
+    // as the array itself is not modified (which is possible with reference
+    // types).
+    ArraySemanticsCall arrayOp(user);
+    if (!arrayOp.doesNotChangeArray())
+      mayBeWritten = true;
+  }
+}
+
+bool ArrayInfo::tryInitialize(ApplyInst *apply) {
+  ArraySemanticsCall arrayAllocateUninitCall(
+      apply, semantics::ARRAY_UNINITIALIZED_INTRINSIC);
+  if (!arrayAllocateUninitCall)
+    return false;
+  arrayValue = arrayAllocateUninitCall.getArrayValue();
+  if (!arrayValue)
+    return false;
+  if (!arrayAllocateUninitCall.mapInitializationStores(elementStoreMap))
+    return false;
+  // Collect information about uses of the array value.
+  classifyUsesOfArray(arrayValue);
+  return true;
+}
+
+void ArrayInfo::getLastDestroys(
+    SmallVectorImpl<DestroyValueInst *> &lastDestroys) {
+  assert(arrayValue);
+  // Collect the frontier instructions of the field \c destroys, which stores
+  // destroy_value instructions of the \c arrayValue as well as of its
+  // copy_values, using ValueLifetimeAnalysis. The frontier is a list of
+  // instructions that mark the exits of the flow of control from the
+  // \c destroys.
+  ValueLifetimeAnalysis lifetimeAnalysis =
+      ValueLifetimeAnalysis(arrayValue->getDefiningInstruction(), destroys);
+  ValueLifetimeAnalysis::Frontier frontier;
+  lifetimeAnalysis.computeFrontier(frontier,
+                                   ValueLifetimeAnalysis::DontModifyCFG);
+  for (SILInstruction *frontierInst : frontier) {
+    // Skip frontier instructions at the start of a basic block as they do not
+    // follow a destroy_value of the array. Note that the goal is to collect
+    // the last destroys, which must always immediately preceed a frontier
+    // instruction as it marks the end of the use of the array.
+    if (frontierInst == &frontierInst->getParent()->front())
+      continue;
+    SILInstruction *inst = &*(--frontierInst->getIterator());
+    // This must be a destroy instruction. Moreover it must also belong to \c
+    // destroys.
+    DestroyValueInst *lastDestroy = dyn_cast<DestroyValueInst>(inst);
+    assert(lastDestroy);
+    lastDestroys.push_back(cast<DestroyValueInst>(lastDestroy));
+  }
+}
+
+/// Delete the forEach calls from the SIL that contains it. This function will
+/// not clean up any resulting dead instructions.
+static void removeForEachCall(TryApplyInst *forEachCall,
+                              InstructionDeleter &deleter) {
+  AllocStackInst *allocStack =
+      dyn_cast<AllocStackInst>(forEachCall->getArgument(1));
+  assert(allocStack);
+  // The allocStack will be used in the forEach call and also in a store
+  // instruction and a dealloc_stack instruction. Force delete all of them.
+  deleter.recursivelyForceDeleteUsersAndFixLifetimes(allocStack);
+}
+
+/// Unroll the \c forEachCall on an array, using the information in
+/// \c ArrayInfo. Once unrolled, \c forEachCall will be deleted
+/// from the containing function.  This function implements the following
+/// transformation.
+///  - If the array stores non-trivial elements, for every element stored
+///   into the array, insert a copy_value of the element just before it
+///   is stored. This is necessary so that an @owned SILValue for the
+///   element is available at the point where the forEach is used.
+///
+///  - Create an alloc_stack A at the point of the forEach call. This is
+///   necessary to indirectly pass the elements of the array.
+///
+///  For every element e_i at the index i of the array, do the following:
+///    - create a new basic block b_i if i > 0. Let b_0 denote the basic block
+///      that contains the forEach call.
+///    - store_borrow the element e_i into the alloc_stack A. Note that we
+///      can use the owned copy of e_i created in the previous step.
+///    - try_apply the forEach's body closure on the the alloc_stack A.
+///      If i is not the last index, jump to b_i+1 in the normal case of the
+///      try_apply. If i is the last index of the array jump to the normal
+///      target of the forEach call. Jump to a new error block: err_i in the
+///      error case. Make err_i jump to the error target of the original
+///      forEach call.
+///
+///  - Dealloc the alloc_stack along the normal and error targets of the
+///   forEach calls.
+///
+///  - Destroy all the copies of the elements (if it is non-trivial) just
+///   before the array's lifetime ends.
+static void unrollForEach(ArrayInfo &arrayInfo, TryApplyInst *forEachCall,
+                          InstructionDeleter &deleter) {
+  if (arrayInfo.getNumElements() == 0) {
+    // If this is an empty array, delete the forEach entirely.
+    removeForEachCall(forEachCall, deleter);
+    return;
+  }
+
+  SILFunction *fun = forEachCall->getFunction();
+  SILLocation forEachLoc = forEachCall->getLoc();
+  SILValue forEachBodyClosure = forEachCall->getArgument(0);
+  SILType arrayElementType = arrayInfo.getElementSILType();
+
+  SILFunctionType *bodyClosureType =
+    forEachBodyClosure->getType().getAs<SILFunctionType>();
+  SILParameterInfo bodyParameterInfo = bodyClosureType->getParameters()[0];
+  // The forEachBodyClosure must use @in_guaranteed convention for passing
+  // arguments.
+  assert(bodyParameterInfo.getConvention() ==
+         ParameterConvention::Indirect_In_Guaranteed &&
+         "forEach body closure is expected to take @in_guaranteed argument");
+
+  // Copy the elements stored into the array. This is necessary as we need to
+  // extend the lifetime of the stored elements at least until the forEach call,
+  // which will now be unrolled. The following code inserts a copy_value of the
+  // elements just before the point where they are stored into the array, and
+  // a corresponding destroy_value at the end of the lifetime of the array. In
+  // other words, the lifetime of the element copies are made to match the
+  // lifetime of the array. Even though copies can be destroyed sooner after
+  // they are used by the unrolled code, doing so may introduce more destroys
+  // than needed as the unrolled code have many branches (due to try applies)
+  // all of which joins later into a single path eventually.
+  SmallVector<SILValue, 4> elementCopies;
+  for (uint64_t i = 0; i < arrayInfo.getNumElements(); i++) {
+    StoreInst *elementStore = arrayInfo.getElementStore(i);
+    // Insert the copy just before the store of the element into the array.
+    SILValue copy = SILBuilderWithScope(elementStore)
+                        .emitCopyValueOperation(elementStore->getLoc(),
+                                                elementStore->getSrc());
+    elementCopies.push_back(copy);
+  }
+
+  // Destroy the copy_value of the elements before the last destroys of the
+  // array. It is important that the copied elements are destroyed before the
+  // array is destroyed. This enables other optimizations.
+  SmallVector<DestroyValueInst *, 4> lastDestroys;
+  arrayInfo.getLastDestroys(lastDestroys);
+  for (DestroyValueInst *destroy : lastDestroys) {
+    SILBuilderWithScope destroyBuilder(destroy);
+    for (SILValue element : elementCopies) {
+      destroyBuilder.emitDestroyValueOperation(destroy->getLoc(), element);
+    }
+  }
+
+  // Create alloc_stack for passing the array elements indirectly.
+  SILValue allocStack = SILBuilderWithScope(forEachCall)
+                            .createAllocStack(forEachLoc, arrayElementType);
+
+  // Extract the Error and normal targets of the forEach call. Both these
+  // targets must be taking a phi argument.
+  SILBasicBlock *normalBB = forEachCall->getNormalBB();
+  SILBasicBlock *errorBB = forEachCall->getErrorBB();
+  assert(errorBB->getSILPhiArguments().size() == 1 &&
+         normalBB->getSILPhiArguments().size() == 1);
+  SILPhiArgument *normalArgument = normalBB->getSILPhiArguments()[0];
+  SILPhiArgument *errorArgument = errorBB->getSILPhiArguments()[0];
+
+  // A generator for creating a basic block for use as the target of the
+  // "normal" branch of a try_apply.
+  auto normalTargetGenerator = [&](SILBasicBlock *insertionBlock) {
+    SILBasicBlock *newBB = fun->createBasicBlockBefore(insertionBlock);
+    newBB->createPhiArgument(normalArgument->getType(),
+                             normalArgument->getOwnershipKind());
+    return newBB;
+  };
+
+  // A generator for creating a basic block for use as the target of the
+  // "error" branch of a try_apply. The error block created here will always
+  // jump to the error target of the original forEach.
+  auto errorTargetGenerator = [&](SILBasicBlock *insertionBlock) {
+    SILBasicBlock *newErrorBB = fun->createBasicBlockBefore(insertionBlock);
+    SILValue argument = newErrorBB->createPhiArgument(
+        errorArgument->getType(), errorArgument->getOwnershipKind());
+    // Make the errorBB jump to the error target of the original forEach.
+    SILBuilderWithScope builder(newErrorBB, forEachCall);
+    builder.createBranch(forEachLoc, errorBB, argument);
+    return newErrorBB;
+  };
+
+  // The basic block to jump to in the normal case of the try_apply in each
+  // unrolling.
+  SILBasicBlock *nextNormalBB = normalBB;
+
+  // Iterate through the array indices in the reverse order and do the
+  // following:
+  //   - create a new basic block b_i if i > 0. Let b_0 denote the basic block
+  //     that contains the forEach call.
+  //   - store_borrow the owned copy of the element e_i into the `allocStack`.
+  //   - try_apply the forEach's body closure on the `allocStack`. The normal
+  //     target of the try_apply is b_i+1 if i is not the last index, otherwise
+  //     it is `normalBB`. (The normal target is captured by `nextNormalBB`.)
+  //     Jump to a new error block: err_i in the error case. Note that all
+  //     error blocks jump to the error target of the original forEach call.
+  for (uint64_t num = arrayInfo.getNumElements(); num > 0; num--) {
+    SILValue elementCopy = elementCopies[num - 1];
+    SILBasicBlock *currentBB = num > 1 ? normalTargetGenerator(nextNormalBB)
+                                       : forEachCall->getParentBlock();
+    SILBuilderWithScope unrollBuilder(currentBB, forEachCall);
+    if (arrayElementType.isTrivial(*fun)) {
+      unrollBuilder.createStore(forEachLoc, elementCopy, allocStack,
+                                StoreOwnershipQualifier::Trivial);
+    } else {
+      // Borrow the elementCopy and store it in the allocStack. Note that the
+      // element's copy is guaranteed to be alive until the array is alive.
+      // Therefore it is okay to use a borrow here.
+      SILValue borrowedElem =
+          unrollBuilder.createBeginBorrow(forEachLoc, elementCopy);
+      unrollBuilder.createStoreBorrow(forEachLoc, borrowedElem, allocStack);
+      unrollBuilder.createEndBorrow(forEachLoc, borrowedElem);
+    }
+    SILBasicBlock *errorTarget = errorTargetGenerator(nextNormalBB);
+    // Note that the substitution map must be empty as we are not supporting
+    // elements of address-only type. All elements in the array are guaranteed
+    // to be loadable. TODO: generalize this to address-only types.
+    unrollBuilder.createTryApply(forEachLoc, forEachBodyClosure,
+                                 SubstitutionMap(), allocStack, nextNormalBB,
+                                 errorTarget);
+    nextNormalBB = currentBB;
+  }
+
+  // Dealloc the stack in the normalBB and also in errorBB. Note that every
+  // try_apply created during the unrolling must pass through these blocks.
+  SILBuilderWithScope(&normalBB->front())
+      .createDeallocStack(forEachLoc, allocStack);
+  SILBuilderWithScope(&errorBB->front())
+      .createDeallocStack(forEachLoc, allocStack);
+
+  // Remove the forEach call as it has now been unrolled.
+  removeForEachCall(forEachCall, deleter);
+}
+
+/// Determine whether the cost of unrolling the forEach is within the
+/// \c unrollThreshold.
+static bool canUnrollForEachOfArray(ArrayInfo arrayInfo, SILModule &module) {
+  const uint64_t unrollThreshold = module.getOptions().UnrollThreshold;
+  // The cost of unrolling a forEach loop is mostly just two instructions per
+  // array element: one to store the element into an alloc_stack and another to
+  // invoke the forEach body closure with the element. Note that the copy_value
+  // of the element and the basic blocks created for the try-applies of the
+  // body closure are not counted, as these should likely get optimized away.
+  const uint64_t cost = 2;
+  return arrayInfo.getNumElements() * cost <= unrollThreshold;
+}
+
+static bool tryUnrollForEachCallsOverArrayLiteral(ApplyInst *apply,
+                                                  InstructionDeleter &deleter) {
+  ArrayInfo arrayInfo;
+  if (!arrayInfo.tryInitialize(apply))
+    return false;
+  // Bail out, if the array could be modified after initialization.
+  if (arrayInfo.mayBeModified())
+    return false;
+  // If there are no forEach loops to unroll, return.
+  ArrayRef<TryApplyInst *> forEachCalls = arrayInfo.getForEachUses();
+  if (forEachCalls.empty())
+    return false;
+  // If the array is too large to unroll, bail out.
+  if (!canUnrollForEachOfArray(arrayInfo, apply->getParent()->getModule()))
+    return false;
+  for (TryApplyInst *forEachCall : forEachCalls)
+    unrollForEach(arrayInfo, forEachCall, deleter);
+  return true;
+}
+
+class ForEachLoopUnroller : public SILFunctionTransform {
+
+  ~ForEachLoopUnroller() override {}
+
+  void run() override {
+    SILFunction &fun = *getFunction();
+    bool changed = false;
+
+    if (!fun.hasOwnership())
+      return;
+
+    InstructionDeleter deleter;
+    for (SILBasicBlock &bb : fun) {
+      for (auto instIter = bb.begin(); instIter != bb.end();) {
+        SILInstruction *inst = &*instIter;
+        ApplyInst *apply = dyn_cast<ApplyInst>(inst);
+        if (!apply) {
+          instIter++;
+          continue;
+        }
+        // Note that the following operation may delete a forEach call but
+        // would not delete this apply instruction, which is an array
+        // initializer. Therefore, the iterator should be valid here.
+        changed |= tryUnrollForEachCallsOverArrayLiteral(apply, deleter);
+        instIter++;
+      }
+    }
+
+    if (changed) {
+      deleter.cleanUpDeadInstructions();
+      PM->invalidateAnalysis(&fun,
+                  SILAnalysis::InvalidationKind::FunctionBody);
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createForEachLoopUnroll() {
+  return new ForEachLoopUnroller();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -614,6 +614,7 @@ SILPassPipelinePlan::getSILOptPreparePassPipeline(const SILOptions &Options) {
   }
 
   P.startPipeline("SILOpt Prepare Passes");
+  P.addForEachLoopUnroll();
   P.addMandatoryCombine();
   P.addAccessMarkerElimination();
 
@@ -673,6 +674,7 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   SILPassPipelinePlan P(Options);
 
   P.startPipeline("Mandatory Combines");
+  P.addForEachLoopUnroll();
   P.addMandatoryCombine();
 
   // First serialize the SIL if we are asked to.

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -710,6 +710,7 @@ extension Sequence {
   ///
   /// - Parameter body: A closure that takes an element of the sequence as a
   ///   parameter.
+  @_semantics("sequence.forEach")
   @inlinable
   public func forEach(
     _ body: (Element) throws -> Void

--- a/test/SILOptimizer/OSLogPrototypeFullOptTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeFullOptTest.swift
@@ -1,0 +1,174 @@
+// RUN: %target-swift-frontend -emit-ir -swift-version 5 -O -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
+
+// This tests the optimality of the IR generated for the new os log APIs. This
+// is not testing the output of a specific optimization pass (which has separate
+// tests) but that all optimizations together result in optimal IR. If this test
+// fails, it implies that some expected optimizations fail to get triggered on
+// os log APIs. TODO: eventually these optimization should also happen in Onone
+// mode.
+
+import OSLogPrototype
+import Foundation
+
+// CHECK-LABEL: define hidden swiftcc void @"${{.*}}testSimpleInterpolation
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+func testSimpleInterpolation(h: Logger) {
+  h.log(level: .debug, "Minimum integer value: \(Int.min)")
+    // CHECK: entry:
+    // CHECK-NEXT: [[LOGLEVEL:%.+]] = tail call swiftcc i8 @"$sSo13os_log_type_ta0A0E5debugABvgZ"()
+    // CHECK-NEXT: tail call swiftcc %TSo9OS_os_logC* @"$s14OSLogPrototype6LoggerV9logObjectSo06OS_os_D0Cvg"
+    // CHECK-NEXT: [[LOGOBJ:%.+]] = bitcast %TSo9OS_os_logC*
+    // CHECK-NEXT: tail call zeroext i1 @os_log_type_enabled
+    // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
+
+    // CHECK: [[ENABLED]]:
+    //
+    // Header bytes.
+    //
+    // CHECK-64-NEXT: [[BUFFER:%.+]] = tail call noalias i8* @swift_slowAlloc(i64 12
+    // CHECK-32-NEXT: [[BUFFER:%.+]] = tail call noalias i8* @swift_slowAlloc(i32 8
+    // CHECK-NEXT: store i8 0, i8* [[BUFFER]], align 1
+    // CHECK-NEXT: [[OFFSET1:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 1
+    // CHECK-NEXT: store i8 1, i8* [[OFFSET1]], align 1
+    //
+    // Argument bytes.
+    //
+    // CHECK-NEXT: [[OFFSET2:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 2
+    // CHECK-NEXT: store i8 2, i8* [[OFFSET2]], align 1
+    // CHECK-NEXT: [[OFFSET3:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 3
+    // CHECK-64-NEXT: store i8 8, i8* [[OFFSET3]], align 1
+    // CHECK-32-NEXT: store i8 4, i8* [[OFFSET3]], align 1
+    // CHECK-NEXT: [[OFFSET4:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 4
+    // CHECK-NEXT: [[BITCASTED:%.+]] = bitcast i8* [[OFFSET4]] to i{{.*}}*
+    // CHECK-64-NEXT: store i64 -9223372036854775808, i64* [[BITCASTED]], align 1
+    // CHECK-32-NEXT: store i32 -2147483648, i32* [[BITCASTED]], align 1
+    // CHECK-64-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([35 x i8], [35 x i8]* @{{.*}}, i64 0, i64 0), i8* [[BUFFER]], i32 12)
+    // CHECK-32-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([35 x i8], [35 x i8]* @{{.*}}, i32 0, i32 0), i8* [[BUFFER]], i32 8)
+    // CHECK-NEXT: tail call void @swift_slowDealloc(i8* [[BUFFER]]
+    // CHECK-NEXT: br label %[[NOT_ENABLED]]
+
+    // CHECK: [[NOT_ENABLED]]:
+    // CHECK-NEXT: bitcast
+    // CHECK-NEXT: tail call void @llvm.objc.release
+    // CHECK-NEXT: ret void
+}
+
+// CHECK-LABEL: define hidden swiftcc void @"${{.*}}testInterpolationWithMultipleArguments
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+func testInterpolationWithMultipleArguments(h: Logger) {
+  let privateID: Int32 = 0x79abcdef
+  let filePermissions: Int32 = 0o777
+  let pid: Int32 = 122225
+  h.log(
+    level: .error,
+    """
+    Access prevented: process \(pid) initiated by \
+    user: \(privateID, privacy: .private) attempted resetting \
+    permissions to \(filePermissions)
+    """)
+    // CHECK: entry:
+    // CHECK-NEXT: [[LOGLEVEL:%.+]] = tail call swiftcc i8 @"$sSo13os_log_type_ta0A0E5errorABvgZ"()
+    // CHECK-NEXT: tail call swiftcc %TSo9OS_os_logC* @"$s14OSLogPrototype6LoggerV9logObjectSo06OS_os_D0Cvg"
+    // CHECK-NEXT: [[LOGOBJ:%.+]] = bitcast %TSo9OS_os_logC*
+    // CHECK-NEXT: tail call zeroext i1 @os_log_type_enabled
+    // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
+
+    // CHECK: [[ENABLED]]:
+    //
+    // Header bytes.
+    //
+    // CHECK-NEXT: [[BUFFER:%.+]] = tail call noalias i8* @swift_slowAlloc(i{{.*}} 20
+    // CHECK-NEXT: store i8 1, i8* [[BUFFER]], align 1
+    // CHECK-NEXT: [[OFFSET1:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 1
+    // CHECK-NEXT: store i8 3, i8* [[OFFSET1]], align 1
+    //
+    // First argument bytes.
+    //
+    // CHECK-NEXT: [[OFFSET2:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 2
+    // CHECK-NEXT: store i8 2, i8* [[OFFSET2]], align 1
+    // CHECK-NEXT: [[OFFSET3:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 3
+    // CHECK-NEXT: store i8 4, i8* [[OFFSET3]], align 1
+    // CHECK-NEXT: [[OFFSET4:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 4
+    // CHECK-NEXT: [[BITCASTED:%.+]] = bitcast i8* [[OFFSET4]] to i32*
+    // CHECK-NEXT: store i32 122225, i32* [[BITCASTED]], align 1
+    //
+    // Second argument
+    //
+    // CHECK-NEXT: [[OFFSET12:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 8
+    // CHECK-NEXT: store i8 1, i8* [[OFFSET12]], align 1
+    // CHECK-NEXT: [[OFFSET13:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 9
+    // CHECK-NEXT: store i8 4, i8* [[OFFSET13]], align 1
+    // CHECK-NEXT: [[OFFSET14:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 10
+    // CHECK-NEXT: [[BITCASTED2:%.+]] = bitcast i8* [[OFFSET14]] to i32*
+    // CHECK-NEXT: store i32 2041302511, i32* [[BITCASTED2]], align 1
+    //
+    // Third argument
+    //
+    // CHECK-NEXT: [[OFFSET22:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 14
+    // CHECK-NEXT: store i8 2, i8* [[OFFSET22]], align 1
+    // CHECK-NEXT: [[OFFSET23:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 15
+    // CHECK-NEXT: store i8 4, i8* [[OFFSET23]], align 1
+    // CHECK-NEXT: [[OFFSET24:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 16
+    // CHECK-NEXT: [[BITCASTED3:%.+]] = bitcast i8* [[OFFSET24]] to i32*
+    // CHECK-NEXT: store i32 511, i32* [[BITCASTED3]], align 1
+    //
+    // os_log_impl call.
+    // CHECK-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([114 x i8], [114 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* [[BUFFER]], i32 20)
+    // CHECK-NEXT: tail call void @swift_slowDealloc(i8* [[BUFFER]]
+    // CHECK-NEXT: br label %[[NOT_ENABLED]]
+
+    // CHECK: [[NOT_ENABLED]]:
+    // CHECK-NEXT: bitcast
+    // CHECK-NEXT: tail call void @llvm.objc.release
+    // CHECK-NEXT: ret void
+}
+
+// CHECK-LABEL: define hidden swiftcc void @"${{.*}}testNSObjectInterpolation
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+func testNSObjectInterpolation(h: Logger, nsArray: NSArray) {
+  h.log("NSArray: \(nsArray, privacy: .public)")
+    // CHECK: entry:
+    // CHECK-NEXT: bitcast %TSo7NSArrayC* %1 to i8*
+    // CHECK-NEXT: [[NSARRAY_ARG:%.+]] = tail call i8* @llvm.objc.retain
+    // CHECK-NEXT: [[LOGLEVEL:%.+]] = tail call swiftcc i8 @"$sSo13os_log_type_ta0A0E7defaultABvgZ"()
+    // CHECK-NEXT: tail call swiftcc %TSo9OS_os_logC* @"$s14OSLogPrototype6LoggerV9logObjectSo06OS_os_D0Cvg"
+    // CHECK-NEXT: [[LOGOBJ:%.+]] = bitcast %TSo9OS_os_logC*
+    // CHECK-NEXT: tail call zeroext i1 @os_log_type_enabled
+    // CHECK-NEXT: br i1 {{%.*}}, label %[[ENABLED:[0-9]+]], label %[[NOT_ENABLED:[0-9]+]]
+
+    // CHECK: [[ENABLED]]:
+    //
+    // Header bytes.
+    //
+    // CHECK-64-NEXT: [[BUFFER:%.+]] = tail call noalias i8* @swift_slowAlloc(i64 12
+    // CHECK-32-NEXT: [[BUFFER:%.+]] = tail call noalias i8* @swift_slowAlloc(i32 8
+    // CHECK-NEXT: store i8 2, i8* [[BUFFER]], align 1
+    // CHECK-NEXT: [[OFFSET1:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 1
+    // CHECK-NEXT: store i8 1, i8* [[OFFSET1]], align 1
+    //
+    // Argument bytes.
+    //
+    // CHECK-NEXT: [[OFFSET2:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 2
+    // CHECK-NEXT: store i8 66, i8* [[OFFSET2]], align 1
+    // CHECK-NEXT: [[OFFSET3:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 3
+    // CHECK-64-NEXT: store i8 8, i8* [[OFFSET3]], align 1
+    // CHECK-32-NEXT: store i8 4, i8* [[OFFSET3]], align 1
+    // CHECK-NEXT: [[OFFSET4:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 4
+    // CHECK-NEXT: [[BITCASTED_DEST:%.+]] = bitcast i8* [[OFFSET4]] to %TSo7NSArrayC**
+    // CHECK-NEXT: [[BITCASTED_SRC:%.+]] = bitcast i8* [[NSARRAY_ARG]] to %TSo7NSArrayC*
+    // CHECK-NEXT: store %TSo7NSArrayC*  [[BITCASTED_SRC]], %TSo7NSArrayC** [[BITCASTED_DEST]], align 1
+    // CHECK-64-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([20 x i8], [20 x i8]* @{{.*}}, i64 0, i64 0), i8* [[BUFFER]], i32 12)
+    // CHECK-32-NEXT: tail call void @_os_log_impl({{.*}}, {{.*}} [[LOGOBJ]], i8 zeroext [[LOGLEVEL]], i8* getelementptr inbounds ([20 x i8], [20 x i8]* @{{.*}}, i32 0, i32 0), i8* [[BUFFER]], i32 8)
+    // CHECK-NEXT: tail call void @swift_slowDealloc(i8* [[BUFFER]]
+    // CHECK-NEXT: br label %[[NOT_ENABLED]]
+
+    // CHECK: [[NOT_ENABLED]]:
+    // CHECK-NEXT: tail call void @llvm.objc.release(i8* [[NSARRAY_ARG]])
+    // CHECK-NEXT: bitcast
+    // CHECK-NEXT: tail call void @llvm.objc.release
+    // CHECK-NEXT: ret void
+}
+
+// TODO: add test for String. It is more complicated due to more complex logic
+// in string serialization.

--- a/test/SILOptimizer/for_each_loop_unroll_test.sil
+++ b/test/SILOptimizer/for_each_loop_unroll_test.sil
@@ -1,0 +1,225 @@
+// RUN: %target-sil-opt -for-each-loop-unroll -enable-sil-verify-all %s 2>&1 | %FileCheck %s
+
+// SIL tests for the ForEachLoopUnroll mandatory optimization pass that unrolls
+// Sequence.forEach calls over array literals.
+
+import Swift
+import Builtin
+
+sil [_semantics "array.uninitialized_intrinsic"] @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+
+sil [_semantics "sequence.forEach"] @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+
+sil @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error Error
+
+sil hidden [ossa] @forEachLoopUnrollTest : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Word, 2
+  %1 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  (%3, %4) = destructure_tuple %2 : $(Array<Builtin.Int64>, Builtin.RawPointer)
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Builtin.Int64
+  %6 = integer_literal $Builtin.Int64, 15
+  store %6 to [trivial] %5 : $*Builtin.Int64
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %5 : $*Builtin.Int64, %12 : $Builtin.Word
+  %14 = integer_literal $Builtin.Int64, 27
+  store %14 to [trivial] %13 : $*Builtin.Int64
+  %21 = begin_borrow %3 : $Array<Builtin.Int64>
+  %22 = alloc_stack $Array<Builtin.Int64>
+  %23 = store_borrow %21 to %22 : $*Array<Builtin.Int64>
+  %24 = function_ref @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error Error to $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error Error to $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error Error
+  // A stub for Sequence.forEach(_:)
+  %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  try_apply %30<[Builtin.Int64]>(%26, %22) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  dealloc_stack %22 : $*Array<Builtin.Int64>
+  end_borrow %21 : $Array<Builtin.Int64>
+  destroy_value %3 : $Array<Builtin.Int64>
+  %37 = tuple ()
+  return %37 : $()
+
+bb2(%39 : @owned $Error):
+  unreachable
+}
+// CHECK-LABEL: forEachLoopUnrollTest
+// CHECK: [[LIT1:%[0-9]+]] = integer_literal $Builtin.Int64, 15
+// CHECK: [[LIT2:%[0-9]+]] = integer_literal $Builtin.Int64, 27
+// CHECK: [[BODYCLOSURE:%[0-9]+]] = thin_to_thick_function
+// CHECK-NOT: forEach
+// CHECK: [[STACK:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK: store [[LIT1]] to [trivial] [[STACK]]
+// CHECK: try_apply [[BODYCLOSURE]]([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error Error, normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+
+// CHECK: [[ERROR]]([[ERRPARAM:%[0-9]+]] : @owned $Error):
+// CHECK: br [[ERROR3:bb[0-9]+]]([[ERRPARAM]] : $Error)
+
+// CHECK: [[NORMAL]](%{{.*}} : $()):
+// CHECK: store [[LIT2]] to [trivial] [[STACK]] : $*Builtin.Int64
+// CHECK: try_apply [[BODYCLOSURE]]([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error Error, normal [[NORMAL2:bb[0-9]+]], error [[ERROR2:bb[0-9]+]]
+
+// CHECK: [[ERROR2]]([[ERRPARAM2:%[0-9]+]] : @owned $Error):
+// CHECK: br [[ERROR3:bb[0-9]+]]([[ERRPARAM2]] : $Error)
+
+// CHECK: [[NORMAL2]](%{{.*}} : $()):
+// CHECK: dealloc_stack [[STACK]]
+// Note that the temporary alloc_stack of the array created for the forEach call
+// will be cleaned up when the forEach call is removed.
+// CHECK: destroy_value
+
+// CHECK: [[ERROR3]]([[ERRPARAM3:%[0-9]+]] : @owned $Error):
+// CHECK: dealloc_stack [[STACK]]
+// CHECK: unreachable
+
+sil @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed () -> @out Int) -> @error Error
+
+sil hidden [ossa] @nonTrivialForEachLoopUnrollTest : $@convention(thin) (@owned @callee_guaranteed () -> @out Int, @owned @callee_guaranteed () -> @out Int) -> () {
+bb0(%0: @owned $@callee_guaranteed () -> @out Int, %1: @owned $@callee_guaranteed () -> @out Int):
+  %2 = integer_literal $Builtin.Word, 2
+  %3 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  %4 = apply %3<() -> Int>(%2) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  (%5, %6) = destructure_tuple %4 : $(Array<()->Int>, Builtin.RawPointer)
+  %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
+  store %0 to [init] %7 : $*@callee_guaranteed () -> @out Int
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %7 : $*@callee_guaranteed () -> @out Int, %12 : $Builtin.Word
+  store %1 to [init] %13 : $*@callee_guaranteed () -> @out Int
+  %21 = begin_borrow %5 : $Array<()->Int>
+  %22 = alloc_stack $Array<()->Int>
+  %23 = store_borrow %21 to %22 : $*Array<()->Int>
+  %24 = function_ref @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed () -> @out Int) -> @error Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed @callee_guaranteed () -> @out Int) -> @error Error to $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed () -> @out Int) -> @error Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed () -> @out Int) -> @error Error to $@noescape @callee_guaranteed (@in_guaranteed @callee_guaranteed () -> @out Int) -> @error Error
+  // A stub for Sequence.forEach(_:)
+  %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  try_apply %30<[() -> Int]>(%26, %22) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  dealloc_stack %22 : $*Array<() -> Int>
+  end_borrow %21 : $Array<() -> Int>
+  destroy_value %5 : $Array<() -> Int>
+  %37 = tuple ()
+  return %37 : $()
+
+bb2(%39 : @owned $Error):
+  unreachable
+}
+// CHECK-LABEL: nonTrivialForEachLoopUnrollTest
+// CHECK: [[ELEM1:%[0-9]+]] = copy_value %0
+// CHECK-NEXT: store %0 to [init] %{{.*}} : $*@callee_guaranteed () -> @out Int
+// CHECK: [[ELEM2:%[0-9]+]] = copy_value %1
+// CHECK-NEXT: store %1 to [init] %{{.*}} : $*@callee_guaranteed () -> @out Int
+// CHECK: [[BODYCLOSURE:%[0-9]+]] = thin_to_thick_function
+// CHECK-NOT: forEach
+// CHECK: [[STACK:%[0-9]+]] = alloc_stack $@callee_guaranteed () -> @out Int
+// CHECK: [[ELEM1BORROW:%[0-9]+]] = begin_borrow [[ELEM1]]
+// CHECK: store_borrow [[ELEM1BORROW]] to [[STACK]]
+// CHECK: end_borrow [[ELEM1BORROW]]
+// CHECK: try_apply [[BODYCLOSURE]]([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed @callee_guaranteed () -> @out Int) -> @error Error, normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+
+// CHECK: [[ERROR]]([[ERRPARAM:%[0-9]+]] : @owned $Error):
+// CHECK: br [[ERROR3:bb[0-9]+]]([[ERRPARAM]] : $Error)
+
+// CHECK: [[NORMAL]](%{{.*}} : $()):
+// CHECK: [[ELEM2BORROW:%[0-9]+]] = begin_borrow [[ELEM2]]
+// CHECK: store_borrow [[ELEM2BORROW]] to [[STACK]]
+// CHECK: end_borrow [[ELEM2BORROW]]
+// CHECK: try_apply [[BODYCLOSURE]]([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed @callee_guaranteed () -> @out Int) -> @error Error, normal [[NORMAL2:bb[0-9]+]], error [[ERROR2:bb[0-9]+]]
+
+// CHECK: [[ERROR2]]([[ERRPARAM2:%[0-9]+]] : @owned $Error):
+// CHECK: br [[ERROR3:bb[0-9]+]]([[ERRPARAM2]] : $Error)
+
+// CHECK: [[NORMAL2]](%{{.*}} : $()):
+// CHECK: dealloc_stack [[STACK]]
+// Note that the temporary alloc_stack of the array created for the forEach call
+// will be cleaned up when the forEach call is removed.
+// CHECK: destroy_value
+
+// CHECK: [[ERROR3]]([[ERRPARAM3:%[0-9]+]] : @owned $Error):
+// CHECK: dealloc_stack [[STACK]]
+// CHECK: unreachable
+
+sil hidden [ossa] @checkIndirectFixLifetimeUsesAreIgnored : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Word, 2
+  %1 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  (%3, %4) = destructure_tuple %2 : $(Array<Builtin.Int64>, Builtin.RawPointer)
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Builtin.Int64
+  %6 = integer_literal $Builtin.Int64, 15
+  store %6 to [trivial] %5 : $*Builtin.Int64
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %5 : $*Builtin.Int64, %12 : $Builtin.Word
+  %14 = integer_literal $Builtin.Int64, 27
+  store %14 to [trivial] %13 : $*Builtin.Int64
+  %21 = begin_borrow %3 : $Array<Builtin.Int64>
+  %22 = alloc_stack $Array<Builtin.Int64>
+  %23 = store_borrow %21 to %22 : $*Array<Builtin.Int64>
+  %24 = function_ref @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error Error to $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error Error to $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error Error
+  // A stub for Sequence.forEach(_:)
+  %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  try_apply %30<[Builtin.Int64]>(%26, %22) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  // An indirect fixLifetime use
+  dealloc_stack %22 : $*Array<Builtin.Int64>
+  %33 = alloc_stack $Array<Builtin.Int64>
+  %34 = store_borrow %21 to %33 : $*Array<Builtin.Int64>
+  fix_lifetime %33 : $*Array<Builtin.Int64>
+  dealloc_stack %33 : $*Array<Builtin.Int64>
+  end_borrow %21 : $Array<Builtin.Int64>
+  destroy_value %3 : $Array<Builtin.Int64>
+  %37 = tuple ()
+  return %37 : $()
+
+bb2(%39 : @owned $Error):
+  unreachable
+}
+// CHECK-LABEL: @checkIndirectFixLifetimeUsesAreIgnored
+// CHECK-NOT: function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+// CHECK: end sil function 'checkIndirectFixLifetimeUsesAreIgnored'
+
+sil hidden [ossa] @testUnrollOfArrayWithPhiArguments : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 57
+  br bb1(%0 : $Builtin.Int64)
+
+bb1(%arg : $Builtin.Int64):
+  %10 = integer_literal $Builtin.Word, 1
+  %11 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  %12 = apply %11<Builtin.Int64>(%10) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  (%13, %14) = destructure_tuple %12 : $(Array<Builtin.Int64>, Builtin.RawPointer)
+  %15 = pointer_to_address %14 : $Builtin.RawPointer to [strict] $*Builtin.Int64
+  store %arg to [trivial] %15 : $*Builtin.Int64
+  br bb2(%arg : $Builtin.Int64)
+
+bb2(%arg2 : $Builtin.Int64):
+  %21 = begin_borrow %13 : $Array<Builtin.Int64>
+  %22 = alloc_stack $Array<Builtin.Int64>
+  %23 = store_borrow %21 to %22 : $*Array<Builtin.Int64>
+  %24 = function_ref @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error Error to $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error Error to $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error Error
+  // A stub for Sequence.forEach(_:)
+  %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  try_apply %30<[Builtin.Int64]>(%26, %22) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb3, error bb4
+
+bb3(%32 : $()):
+  dealloc_stack %22 : $*Array<Builtin.Int64>
+  end_borrow %21 : $Array<Builtin.Int64>
+  destroy_value %13 : $Array<Builtin.Int64>
+  %37 = tuple ()
+  return %37 : $()
+
+bb4(%39 : @owned $Error):
+  unreachable
+}
+// CHECK-LABEL: @testUnrollOfArrayWithPhiArguments
+// CHECK-NOT: function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+// CHECK: end sil function 'testUnrollOfArrayWithPhiArguments'
+

--- a/test/SILOptimizer/for_each_loop_unroll_test.swift
+++ b/test/SILOptimizer/for_each_loop_unroll_test.swift
@@ -1,0 +1,111 @@
+// RUN: %target-swift-frontend -emit-sil -primary-file %s | %FileCheck %s
+
+// Tests for the ForEachLoopUnroll mandatory optimization pass that unrolls
+// Sequence.forEach calls over array literals.
+
+// CHECK-LABEL: sil hidden @$s25for_each_loop_unroll_test0D19LetArrayLiteralTestyyF : $@convention(thin) () -> ()
+func unrollLetArrayLiteralTest() {
+  let a = [Int64(15), Int64(27)]
+  a.forEach { print($0) }
+  // CHECK: [[LIT1:%[0-9]+]] = integer_literal $Builtin.Int64, 15
+  // CHECK: [[INT1:%[0-9]+]] = struct $Int64 ([[LIT1]] : $Builtin.Int64)
+  // CHECK: [[LIT2:%[0-9]+]] = integer_literal $Builtin.Int64, 27
+  // CHECK: [[INT2:%[0-9]+]] = struct $Int64 ([[LIT2]] : $Builtin.Int64)
+  // CHECK-NOT: forEach
+  // CHECK: [[STACK:%[0-9]+]] = alloc_stack $Int64
+  // CHECK: store [[INT1]] to [[STACK]]
+  // CHECK: try_apply %{{.*}}([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed Int64) -> @error Error, normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+
+  // CHECK: [[NORMAL]](%{{.*}} : $()):
+  // CHECK: store [[INT2]] to [[STACK]] : $*Int64
+  // CHECK: try_apply {{.*}}([[STACK]])
+}
+
+// CHECK-LABEL: sil hidden @$s25for_each_loop_unroll_test0D35LetArrayLiteralWithVariableElements1x1yys5Int64V_AFtF
+func unrollLetArrayLiteralWithVariableElements(x: Int64, y: Int64) {
+  let a = [x, y]
+  a.forEach { print($0) }
+  // CHECK-NOT: forEach
+  // CHECK: [[STACK:%[0-9]+]] = alloc_stack $Int64
+  // CHECK: store %0 to [[STACK]]
+  // CHECK: try_apply %{{.*}}([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed Int64) -> @error Error, normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+  
+  // CHECK: [[NORMAL]](%{{.*}} : $()):
+  // CHECK: store %1 to [[STACK]] : $*Int64
+  // CHECK: try_apply {{.*}}([[STACK]])
+}
+
+// CHECK-LABEL: sil hidden @$s25for_each_loop_unroll_test0D37LetArrayLiteralWithNonTrivialElementsyyF
+func unrollLetArrayLiteralWithNonTrivialElements() {
+  let a = ["a", "aa"]
+  a.forEach { print($0) }
+  // CHECK: [[LIT1:%[0-9]+]] = string_literal utf8 "a"
+  // CHECK: [[STRING_INIT:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+  // CHECK: [[STRING1:%[0-9]+]] = apply [[STRING_INIT]]([[LIT1]],
+  
+  // CHECK: [[LIT2:%[0-9]+]] = string_literal utf8 "aa"
+  // CHECK: [[STRING_INIT2:%[0-9]+]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+  // CHECK: [[STRING2:%[0-9]+]] = apply [[STRING_INIT2]]([[LIT2]],
+
+  // CHECK-NOT: forEach
+  // CHECK: [[STACK:%[0-9]+]] = alloc_stack $String
+  // CHECK: store [[STRING1]] to [[STACK]] : $*String
+  // CHECK: try_apply %{{.*}}([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed String) -> @error Error, normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+  
+  // CHECK: [[NORMAL]](%{{.*}} : $()):
+  // CHECK: store [[STRING2]] to [[STACK]] : $*String
+  // CHECK: try_apply {{.*}}([[STACK]])
+}
+
+// This test mimics the array liteal and forEach created by the OSLogOptimization pass.
+// CHECK-LABEL: sil hidden @$s25for_each_loop_unroll_test0D27LetArrayLiteralWithClosures1i1jys5Int32V_AFtF
+func unrollLetArrayLiteralWithClosures(i: Int32, j: Int32) {
+  let a = [{ i } , { j }]
+  a.forEach { print($0()) }
+  // CHECK: [[ALLOCATE:%[0-9]+]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
+  // CHECK: [[ARRAYTUP:%[0-9]+]] = apply [[ALLOCATE]]<() -> Int32>
+  // CHECK: [[STORAGEPTR:%[0-9]+]] =  tuple_extract [[ARRAYTUP]] : $(Array<() -> Int32>, Builtin.RawPointer), 1
+  // CHECK: [[STORAGEADDR:%[0-9]+]] = pointer_to_address [[STORAGEPTR]]
+  // CHECK: store [[CLOSURE1:%[0-9]+]] to [[STORAGEADDR]]
+  // CHECK: [[INDEX1:%[0-9]+]] = index_addr [[STORAGEADDR]]
+  // CHECK: store [[CLOSURE2:%[0-9]+]] to [[INDEX1]]
+  
+  // CHECK-NOT: forEach
+  // CHECK: [[STACK:%[0-9]+]] = alloc_stack
+  // CHECK: store [[CLOSURE1]] to [[STACK]]
+  // CHECK: try_apply %{{.*}}([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed {{.*}}) -> @error Error, normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+  
+  // CHECK: [[NORMAL]](%{{.*}} : $()):
+  // CHECK: store [[CLOSURE2]] to [[STACK]]
+  // CHECK: try_apply {{.*}}([[STACK]])
+}
+
+// CHECK-LABEL: sil hidden @$s25for_each_loop_unroll_test0E16NoUnrollScenarioyyF
+func testNoUnrollScenario() {
+  var a = [Int64(15), Int64(27)]
+  a.append(Int64(7))
+  a.forEach { print($0) }
+  // CHECK: forEach
+}
+
+// FIXME: Currently, array literals with address-only types cannot be unrolled
+// as they are initialied using copy_addr instead of store.
+// CHECK-LABEL: sil hidden @$s25for_each_loop_unroll_test0E27UnrollingOfAddressOnlyTypes1x1yyx_xtlF
+func testUnrollingOfAddressOnlyTypes<T>(x: T, y: T) {
+  let a = [x, y]
+  a.forEach { print($0) }
+  // CHECK: forEach
+}
+
+// Check that when there are multiple forEach loops they are unrolled.
+// CHECK-LABEL: sil hidden @$s25for_each_loop_unroll_test0D13MultipleLoops1x1y1zys5Int64V_AGSbtF
+func unrollMultipleLoops(x: Int64, y: Int64, z: Bool) {
+  let a = [x, y]
+  if z {
+    a.forEach { print($0) }
+  } else {
+    a.forEach{ print($0 + 1) }
+  }
+    // CHECK-NOT: forEach
+    // CHECK-LABEL: end sil function '$s25for_each_loop_unroll_test0D13MultipleLoops1x1y1zys5Int64V_AGSbtF'
+}

--- a/test/stdlib/OSLogPrototypeExecTest.swift
+++ b/test/stdlib/OSLogPrototypeExecTest.swift
@@ -1,6 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -swift-version 5 -DPTR_SIZE_%target-ptrsize -o %t/OSLogPrototypeExecTest
 // RUN: %target-run %t/OSLogPrototypeExecTest
+//
+// RUN: %target-build-swift %s -O -swift-version 5 -DPTR_SIZE_%target-ptrsize -o %t/OSLogPrototypeExecTest
+// RUN: %target-run %t/OSLogPrototypeExecTest
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
 


### PR DESCRIPTION
This enables optimizing further the output of the OSLogOptimization pass, and results in highly-compact and optimized IR for calls to the new os log API. Some examples of the optimized IR that would be generated for the new os log calls is available in the new test suite: `test/SILOptimizer/OSLogPrototypeFullOptTest.swift`. 

This PR has two commits. The latest commit (f40d225) has changes specific to this PR  and the previous commit is a minor extension to the ArraySemantics.h and refactoring of a utility function, which is discussed separately in this PR: https://github.com/apple/swift/pull/29643. 

The new mandatory optimization is implemented in the file: `lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp`. This optimization is added before the MandatoryCombine pass in the pass pipeline.

<rdar://58928427>
