### PR TITLE
Sema: Fix performance regression by only checking for selector conflicts in primary files

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -938,9 +938,16 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
                  : diag::objc_name_deinit);
       const_cast<ObjCAttr *>(attr)->clearName();
     } else {
+      auto func = cast<AbstractFunctionDecl>(D);
+
+      // Trigger lazy loading of any imported members with the same selector.
+      // This ensures we correctly diagnose selector conflicts.
+      if (auto *CD = D->getDeclContext()->getSelfClassDecl()) {
+        (void) CD->lookupDirect(*objcName, !func->isStatic());
+      }
+
       // We have a function. Make sure that the number of parameters
       // matches the "number of colons" in the name.
-      auto func = cast<AbstractFunctionDecl>(D);
       auto params = func->getParameters();
       unsigned numParameters = params->size();
       if (auto CD = dyn_cast<ConstructorDecl>(func))

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1619,9 +1619,6 @@ void markAsObjC(ValueDecl *D, ObjCReason reason,
 
     // Record the method in the class, if it's a member of one.
     if (auto classDecl = D->getDeclContext()->getSelfClassDecl()) {
-      // Trigger lazy loading of any imported members with the same selector.
-      (void) classDecl->lookupDirect(selector, !method->isStatic());
-
       classDecl->recordObjCMethod(method, selector);
     }
 


### PR DESCRIPTION
Should fix the regression from https://github.com/apple/swift/pull/26975.