### PR TITLE
fix REPL crash involving pattern bindings to expressions with closures

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1466,7 +1466,7 @@ PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
       class Walker : public ASTWalker {
       public:
         DeclContext *NewParent;
-        Walker(DeclContext *NewParent) : NewParent(NewParent) {}
+        explicit Walker(DeclContext *NewParent) : NewParent(NewParent) {}
         virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
           if (auto *ACE = dyn_cast<AbstractClosureExpr>(E)) {
             ACE->setParent(NewParent);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1456,8 +1456,30 @@ PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
   auto PBE = PatternBindingEntry(Pat, EqualLoc, E, BindingInitContext);
   auto *Result = create(Ctx, StaticLoc, StaticSpelling, VarLoc, PBE, Parent);
 
-  if (BindingInitContext)
+  if (BindingInitContext) {
     cast<PatternBindingInitializer>(BindingInitContext)->setBinding(Result, 0);
+
+    // If the expression contains any closures, then we must change the
+    // closures' parents to `BindingInitContext`, because the closures are now
+    // children of `BindingInitContext`.
+    if (E) {
+      class Walker : public ASTWalker {
+      public:
+        DeclContext *NewParent;
+        Walker(DeclContext *NewParent) : NewParent(NewParent) {}
+        virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+          if (auto *ACE = dyn_cast<AbstractClosureExpr>(E)) {
+            ACE->setParent(NewParent);
+            // Don't set the parents of nested closures.
+            return { false, E };
+          }
+          return { true, E };
+        }
+      };
+      Walker walker(BindingInitContext);
+      E->walk(walker);
+    }
+  }
 
   return Result;
 }

--- a/test/IDE/complete_repl_pattern_binding_with_closure.swift
+++ b/test/IDE/complete_repl_pattern_binding_with_closure.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename %s | %FileCheck %s
+// CHECK: Begin completions
+// CHECK: print
+// CHECK: End completions
+let (a, b) = ({ _ in (1, 2) })()
+p

--- a/test/IDE/complete_repl_pattern_binding_with_closure.swift
+++ b/test/IDE/complete_repl_pattern_binding_with_closure.swift
@@ -2,5 +2,5 @@
 // CHECK: Begin completions
 // CHECK: print
 // CHECK: End completions
-let (a, b) = ({ _ in (1, 2) })()
+let (a, b) = ({ _ in (1, 2) })(0)
 p

--- a/test/Interpreter/repl.swift
+++ b/test/Interpreter/repl.swift
@@ -252,3 +252,11 @@ let _ = b.bar()
 // CHECK: = "instance ok"
 let _ = b[42]
 // CHECK: = "subscript ok"
+
+let (pbd1, pbd2) = ({ _ in (1, 2)})(0)
+// CHECK: pbd1: Int = 1
+// CHECK: pbd2: Int = 2
+
+let (pbd3, pbd4) = ({ _ in ({ _ in (3, 4) })(0) })(0)
+// CHECK: pbd3: Int = 3
+// CHECK: pbd4: Int = 4

--- a/test/Interpreter/repl.swift
+++ b/test/Interpreter/repl.swift
@@ -254,7 +254,7 @@ let _ = b[42]
 // CHECK: = "subscript ok"
 
 let (pbd1, pbd2) = ({ _ in (1, 2)})(0)
-// CHECK (pbd1, pbd2) : (Int, Int) = (1, 2)
+// CHECK: (pbd1, pbd2) : (Int, Int) = (1, 2)
 
 let (pbd3, pbd4) = ({ _ in ({ _ in (3, 4) })(0) })(0)
-// CHECK (pbd3, pbd4) : (Int, Int) = (3, 4)
+// CHECK: (pbd3, pbd4) : (Int, Int) = (3, 4)

--- a/test/Interpreter/repl.swift
+++ b/test/Interpreter/repl.swift
@@ -254,9 +254,7 @@ let _ = b[42]
 // CHECK: = "subscript ok"
 
 let (pbd1, pbd2) = ({ _ in (1, 2)})(0)
-// CHECK: pbd1: Int = 1
-// CHECK: pbd2: Int = 2
+// CHECK (pbd1, pbd2) : (Int, Int) = (1, 2)
 
 let (pbd3, pbd4) = ({ _ in ({ _ in (3, 4) })(0) })(0)
-// CHECK: pbd3: Int = 3
-// CHECK: pbd4: Int = 4
+// CHECK (pbd3, pbd4) : (Int, Int) = (3, 4)


### PR DESCRIPTION
**Problem**
When you have a pattern binding expression in the REPL that binds a tuple to an expression involving a closure (see tests in this PR for examples), you get this assertion failure:
```
swift-ide-test: /usr/local/google/home/marcrasi/swift-base-master/swift/lib/Sema/TypeCheckConstraints.cpp:1342: bool (anonymous namespace)::PreCheckExpression::walkToClosureExprPre(swift::ClosureExpr *): Assertion `(closure->getParent() == DC || closure->getParent()->isChildContextOf(DC)) && "Decl context isn't correct"' failed.
```

**Explanation**
The [REPL rewrites the pattern binding](https://github.com/apple/swift/blob/37655db07af36d46913ace2feea4b9f36ac090cc/lib/Sema/TypeCheckREPL.cpp#L390). The rewrite introduces a new PatternBindingInitializer DeclContext that contains the initializer expression, but the rewrite does not update the closures in the initializer expression to set their parents to the new DeclContext.

**This PR's solution**
Update the closures in the initializer expression to set their parents to the new DeclContext.
