### PR TITLE
[ConstraintSystem] Make variadics work with anonymous closure parameters

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2853,6 +2853,10 @@ public:
     Param getWithoutLabel() const { return Param(Ty, Identifier(), Flags); }
 
     Param withType(Type newType) const { return Param(newType, Label, Flags); }
+
+    Param withFlags(ParameterTypeFlags flags) const {
+      return Param(Ty, Label, flags);
+    }
   };
 
   class CanParam : public Param {

--- a/test/expr/closure/anonymous.swift
+++ b/test/expr/closure/anonymous.swift
@@ -13,38 +13,27 @@ func takesIntArray(_: [Int]) { }
 func takesVariadicInt(_: (Int...) -> ()) { }
 func takesVariadicIntInt(_: (Int, Int...) -> ()) { }
 
-func takesVariadicGeneric<T>(_ f: (T...) -> ()) { }
+func takesVariadicGeneric<T>(_ f: (T...) -> ()) { } // expected-note {{in call to function 'takesVariadicGeneric'}}
 
 func variadic() {
   // These work
 
-  // FIXME: Not anymore: rdar://41416758
   takesVariadicInt({let _ = $0})
-  // expected-error@-1 {{cannot convert value of type '(_) -> ()' to expected argument type '(Int...) -> ()'}}
   takesVariadicInt({let _: [Int] = $0})
-  // expected-error@-1 {{cannot convert value of type '(_) -> ()' to expected argument type '(Int...) -> ()'}}
 
   let _: (Int...) -> () = {let _: [Int] = $0}
-  // expected-error@-1 {{cannot convert value of type '(_) -> ()' to specified type '(Int...) -> ()'}}
 
   takesVariadicInt({takesIntArray($0)})
-  // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
 
   let _: (Int...) -> () = {takesIntArray($0)}
-  // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
 
   takesVariadicGeneric({takesIntArray($0)})
-  // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
 
-  // FIXME(diagnostics): Problems here are related to multi-statement closure bodies not being type-checked together with
-  // enclosing context.
-
+  // FIXME: Problem here is related to multi-statement closure body not being type-checked together with
+  // enclosing context. We could have inferred `$0` to be `[Int]` if `let` was a part of constraint system.
   takesVariadicGeneric({let _: [Int] = $0})
-  // expected-error@-1 {{cannot convert value of type '(_) -> ()' to expected argument type '(_...) -> ()'}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
 
   takesVariadicIntInt({_ = $0; takesIntArray($1)})
-  // expected-error@-1 {{cannot convert value of type '(_, _) -> ()' to expected argument type '(Int, Int...) -> ()'}}
-
   takesVariadicIntInt({_ = $0; let _: [Int] = $1})
-  // expected-error@-1 {{cannot convert value of type '(_, _) -> ()' to expected argument type '(Int, Int...) -> ()'}}
 }


### PR DESCRIPTION
Since opening closure body is now delayed until contextual type becomes
available it's possible to infer anonymous parameters as being variadic
based on context and propagate that information down to the closure body.

Resolves: rdar://problem/41416758

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
