### PR TITLE
Adjust Convenience Initializer Inheritance Predicate

### DIFF
--- a/test/ModuleInterface/forbid-inherits-superclass-initializers-client.swift
+++ b/test/ModuleInterface/forbid-inherits-superclass-initializers-client.swift
@@ -1,0 +1,61 @@
+// Compile the imported module to a .swiftinterface and ensure the convenience
+// init delegates through the subclasses correctly.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/inherits-superclass-initializers.swift -emit-module-path %t/Module.swiftmodule -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution -swift-version 5
+// RUN: rm %t/Module.swiftmodule
+// RUN: %target-typecheck-verify-swift -I %t -L %t
+
+// Make sure the same error is emitted when importing a .swiftmodule
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/inherits-superclass-initializers.swift -emit-module-path %t/Module.swiftmodule -module-name Module -enable-library-evolution -swift-version 5
+// RUN: %target-typecheck-verify-swift -I %t -L %t
+
+import Module
+
+final class StorageBase: Base {
+  var x: Int
+
+  init(suppressesInheritance x: Int) { // expected-note {{declared here}}
+    self.x = x
+  }
+}
+
+_ = StorageBase() // expected-error {{suppressesInheritance}}
+
+extension Base {
+  public convenience init(conveniently: ()) {
+    self.init()
+  }
+}
+
+final class ConvenientClientBase: Base {
+  var x: Int
+}
+
+
+final class ConvenientDefaultStorageBase: Base {
+  // The addition of storage suppresses convenience initializer inheritance
+  // The default does *not* suppress designated initializer inheritance
+  var x: Int = 42
+}
+
+final class ConvenientDesignatedClientBase: Base {
+  var x: Int
+
+  init(designatedly: ()) {
+    self.x = 42
+  }
+}
+
+final class ConvenientDesignatedEmptyClientBase: Base {
+  init(designatedly: ()) {
+    super.init(arg: 42)
+  }
+}
+
+_ = ConvenientClientBase(conveniently: ()) // expected-error {{cannot be constructed}}
+_ = ConvenientDefaultStorageBase(conveniently: ()) // expected-error {{expected 'arg:'}} expected-error {{expected argument type 'Int'}}
+_ = ConvenientDesignatedClientBase(conveniently: ()) // expected-error {{expected 'designatedly:}}
+_ = ConvenientDesignatedEmptyClientBase(arg: 42) // expected-error {{argument passed to call that takes no arguments}}

--- a/test/ModuleInterface/inherits-superclass-initializers-client.swift
+++ b/test/ModuleInterface/inherits-superclass-initializers-client.swift
@@ -4,7 +4,7 @@
 // REQUIRES: executable_test
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/inherits-superclass-initializers.swift -emit-module-path %t/Module.swiftmodule -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/inherits-superclass-initializers.swift -emit-module-path %t/Module.swiftmodule -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution -swift-version 5
 // RUN: rm %t/Module.swiftmodule
 // RUN: %target-build-swift %s -I %t -L %t -lModule -o %t/main %target-rpath(%t)
 // RUN: %target-codesign %t/main %t/%target-library-name(Module)
@@ -13,12 +13,45 @@
 // Make sure the same error is emitted when importing a .swiftmodule
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/inherits-superclass-initializers.swift -emit-module-path %t/Module.swiftmodule -module-name Module -enable-library-evolution
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/inherits-superclass-initializers.swift -emit-module-path %t/Module.swiftmodule -module-name Module -enable-library-evolution -swift-version 5
 // RUN: %target-build-swift %s -I %t -L %t -lModule -o %t/main %target-rpath(%t)
 // RUN: %target-codesign %t/main %t/%target-library-name(Module)
 // RUN: %target-run %t/main %t/%target-library-name(Module) | %FileCheck %s
 
 import Module
+
+// rdar://59171169 Even though Base has missing designated initializers, as long
+// as this client doesn't add more storage that would require additional
+// designated initializers to handle we should still inherit convenience
+// intializers.
+final class ClientSub: Base {}
+
+public class ConvenientClientBase: Base {
+  // does not add storage, does not override any designated inits
+}
+
+final class ConvenientDefaultStorageBase: Base {
+  var x: Int = 42
+}
+
+final class ConvenientStaticClientBase: Base {
+  static var x: Int = 42
+}
+
+final class ConvenientDesignatedEmptyClientBase: Base {
+  // Suppresses designated init inheritance. Convenience initializer inheritance
+  // is not suppressed because there are no stored properties.
+  init(designatedly: ()) {
+    super.init(arg: 42)
+  }
+}
+
+extension Base {
+  public convenience init(conveniently: ()) {
+    self.init()
+  }
+}
+
 
 _ = Base()
 // CHECK: secret init from Base
@@ -30,6 +63,29 @@ _ = Sub()
 _ = SubSub()
 // CHECK: secret init from SubSub
 // CHECK: secret init from Sub
+// CHECK: secret init from Base
+
+_ = ClientSub()
+// CHECK: secret init from Base
+
+_ = ConvenientClientBase()
+// CHECK: secret init from Base
+
+_ = ConvenientClientBase(conveniently: ())
+// CHECK: secret init from Base
+
+let store = ConvenientDefaultStorageBase(arg: 42)
+print(store.x)
+// CHECK: public init from Base
+// CHECK: 42
+
+_ = ConvenientStaticClientBase(conveniently: ())
+// CHECK: secret init from Base
+
+_ = ConvenientDesignatedEmptyClientBase()
+// CHECK: secret init from Base
+
+_ = ConvenientDesignatedEmptyClientBase(conveniently: ())
 // CHECK: secret init from Base
 
 test()

--- a/test/ModuleInterface/inherits-superclass-initializers.swift
+++ b/test/ModuleInterface/inherits-superclass-initializers.swift
@@ -1,4 +1,6 @@
-// Note: this test has a client: inherits-superclass-initializers-client.swift
+// Note: this test has clients:
+// - inherits-superclass-initializers-client.swift
+// - forbid-inherits-superclass-initializers-client.swift
 
 // RUN: %empty-directory(%t)
 


### PR DESCRIPTION
Convenience initializer inheritance must be suppressed if the derived
class cannot see all designated initializers and attempts to add storage
to the base.  The previous predicate instead punted on all superclasses that
had missing designated initializers. This prevented the following
well-behaved code from compiling:

```
// Superclass.framework
open class Superclass {
  internal init(x: ()) { }

  public init() {}
}
```

```
// Subclass.framework
import Superclass

public class Subclass: Superclass {
  // does not add storage, does not override any designated inits
}

extension Superclass {
  public convenience init(y: ()) {
    self.init()
  }
}

_ = Subclass(y: ())
```

Enhance the positive runtime test and add a negative compile-time test that
ensures that we suppress inheritance on the right set of declarations.

Resolves rdar://59171169
