### PR TITLE
cherry-pick tf-1144 fix from master PR

### DIFF
--- a/test/IDE/complete_repl_pattern_binding_with_closure.swift
+++ b/test/IDE/complete_repl_pattern_binding_with_closure.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename %s | %FileCheck %s
+// CHECK: Begin completions
+// CHECK: print
+// CHECK: End completions
+let (a, b) = ({ _ in (1, 2) })(0)
+p

--- a/test/Interpreter/repl.swift
+++ b/test/Interpreter/repl.swift
@@ -252,3 +252,9 @@ let _ = b.bar()
 // CHECK: = "instance ok"
 let _ = b[42]
 // CHECK: = "subscript ok"
+
+let (pbd1, pbd2) = ({ _ in (1, 2)})(0)
+// CHECK: (pbd1, pbd2) : (Int, Int) = (1, 2)
+
+let (pbd3, pbd4) = ({ _ in ({ _ in (3, 4) })(0) })(0)
+// CHECK: (pbd3, pbd4) : (Int, Int) = (3, 4)


### PR DESCRIPTION
This fixes a S4TF v0.7 release blocker, TF-1144. There is a corresponding master PR (https://github.com/apple/swift/pull/29654), but I don't want to wait for that to go in because I don't know how long it will take to find someone to review it.

Original commit description follows.

**Problem**
When you have a pattern binding expression in the REPL that binds a tuple to an expression involving a closure (see tests in this PR for examples), you get this assertion failure:
```
swift-ide-test: /usr/local/google/home/marcrasi/swift-base-master/swift/lib/Sema/TypeCheckConstraints.cpp:1342: bool (anonymous namespace)::PreCheckExpression::walkToClosureExprPre(swift::ClosureExpr *): Assertion `(closure->getParent() == DC || closure->getParent()->isChildContextOf(DC)) && "Decl context isn't correct"' failed.
```

**Explanation**
The [REPL rewrites the pattern binding](https://github.com/apple/swift/blob/37655db07af36d46913ace2feea4b9f36ac090cc/lib/Sema/TypeCheckREPL.cpp#L390). The rewrite introduces a new PatternBindingInitializer DeclContext that contains the initializer expression, but the rewrite does not update the closures in the initializer expression to set their parents to the new DeclContext.

**This PR's solution**
Update the closures in the initializer expression to set their parents to the new DeclContext.