### PR TITLE
Create a new module and SourceFile for REPL completion

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1959,8 +1959,7 @@ public:
 
 class TypeCheckSourceFileRequest :
     public SimpleRequest<TypeCheckSourceFileRequest,
-                         bool (SourceFile *, unsigned),
-                         CacheKind::SeparatelyCached> {
+                         bool (SourceFile *), CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -1968,8 +1967,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
-                                SourceFile *SF, unsigned StartElem) const;
+  llvm::Expected<bool> evaluate(Evaluator &evaluator, SourceFile *SF) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -211,7 +211,7 @@ SWIFT_REQUEST(TypeChecker, HasDefaultInitRequest,
 SWIFT_REQUEST(TypeChecker, SynthesizeDefaultInitRequest,
               ConstructorDecl *(NominalTypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckSourceFileRequest,
-              bool(SouceFile *, unsigned), SeparatelyCached, NoLocationInfo)
+              bool(SouceFile *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeWitnessRequest,
               TypeWitnessAndDecl(NormalProtocolConformance *,
                                  AssociatedTypeDecl *),

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -653,8 +653,6 @@ public: // for static functions in Frontend.cpp
   };
 
 private:
-  void createREPLFile(const ImplicitImports &implicitImports);
-
   void addMainFileToModule(const ImplicitImports &implicitImports);
 
   void performSemaUpTo(SourceFile::ASTStage_t LimitStage);

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -137,10 +137,7 @@ namespace swift {
 
   /// Once parsing is complete, this walks the AST to resolve imports, record
   /// operators, and do other top-level validation.
-  ///
-  /// \param StartElem Where to start for incremental name binding in the main
-  ///                  source file.
-  void performNameBinding(SourceFile &SF, unsigned StartElem = 0);
+  void performNameBinding(SourceFile &SF);
 
   /// Once type-checking is complete, this instruments code with calls to an
   /// intrinsic that record the expected values of local variables so they can
@@ -171,10 +168,7 @@ namespace swift {
 
   /// Once parsing and name-binding are complete, this walks the AST to resolve
   /// types and diagnose problems therein.
-  ///
-  /// \param StartElem Where to start for incremental type-checking in the main
-  /// source file.
-  void performTypeChecking(SourceFile &SF, unsigned StartElem = 0);
+  void performTypeChecking(SourceFile &SF);
 
   /// Now that we have type-checked an entire module, perform any type
   /// checking that requires the full module, e.g., Objective-C method

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -997,10 +997,6 @@ public:
     IRGenOpts.DebugInfoLevel = IRGenDebugInfoLevel::None;
     IRGenOpts.DebugInfoFormat = IRGenDebugInfoFormat::None;
 
-    // The very first module is a dummy.
-    CI.getMainModule()->getMainSourceFile(SourceFileKind::REPL).ASTStage =
-        SourceFile::TypeChecked;
-
     if (!ParseStdlib) {
       // Force standard library to be loaded immediately.  This forces any
       // errors to appear upfront, and helps eliminate some nasty lag after the

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -397,7 +397,7 @@ static void insertPrecedenceGroupDecl(NameBinder &binder, SourceFile &SF,
 /// UnresolvedDeclRefExpr nodes for unresolved value names, and we may have
 /// unresolved type names as well. This handles import directives and forward
 /// references.
-void swift::performNameBinding(SourceFile &SF, unsigned StartElem) {
+void swift::performNameBinding(SourceFile &SF) {
   FrontendStatsTracer tracer(SF.getASTContext().Stats, "Name binding");
 
   // Make sure we skip adding the standard library imports if the
@@ -417,7 +417,7 @@ void swift::performNameBinding(SourceFile &SF, unsigned StartElem) {
 
   // Do a prepass over the declarations to find and load the imported modules
   // and map operator decls.
-  for (auto D : SF.getTopLevelDecls().slice(StartElem)) {
+  for (auto D : SF.getTopLevelDecls()) {
     if (auto *ID = dyn_cast<ImportDecl>(D)) {
       Binder.addImport(ImportedModules, ID);
     } else if (auto *OD = dyn_cast<PrefixOperatorDecl>(D)) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -614,14 +614,8 @@ private:
   
 } // end anonymous namespace
 
-void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF,
-                                                      unsigned StartElem) {
+void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF) {
   TypeRefinementContext *RootTRC = SF.getTypeRefinementContext();
-
-  // If we are not starting at the beginning of the source file, we had better
-  // already have a root type refinement context.
-  assert(StartElem == 0 || RootTRC);
-
   ASTContext &Context = SF.getASTContext();
 
   if (!RootTRC) {
@@ -636,7 +630,7 @@ void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF,
   // Build refinement contexts, if necessary, for all declarations starting
   // with StartElem.
   TypeRefinementContextBuilder Builder(RootTRC, Context);
-  for (auto D : SF.getTopLevelDecls().slice(StartElem)) {
+  for (auto D : SF.getTopLevelDecls()) {
     Builder.build(D);
   }
 }
@@ -645,7 +639,7 @@ TypeRefinementContext *
 TypeChecker::getOrBuildTypeRefinementContext(SourceFile *SF) {
   TypeRefinementContext *TRC = SF->getTypeRefinementContext();
   if (!TRC) {
-    buildTypeRefinementContextHierarchy(*SF, 0);
+    buildTypeRefinementContextHierarchy(*SF);
     TRC = SF->getTypeRefinementContext();
   }
 

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -462,17 +462,17 @@ Identifier REPLChecker::getNextResponseVariableName(DeclContext *DC) {
 /// processREPLTopLevel - This is called after we've parsed and typechecked some
 /// new decls at the top level.  We inject code to print out expressions and
 /// pattern bindings the are evaluated.
-void TypeChecker::processREPLTopLevel(SourceFile &SF, unsigned FirstDecl) {
+void TypeChecker::processREPLTopLevel(SourceFile &SF) {
   // Walk over all decls in the file to find the next available closure
   // discriminator.
   DiscriminatorFinder DF;
   for (Decl *D : SF.getTopLevelDecls())
     D->walk(DF);
 
-  // Move new declarations out.
-  std::vector<Decl *> NewDecls(SF.getTopLevelDecls().begin()+FirstDecl,
+  // Move the new declarations out of the source file.
+  std::vector<Decl *> NewDecls(SF.getTopLevelDecls().begin(),
                                SF.getTopLevelDecls().end());
-  SF.truncateTopLevelDecls(FirstDecl);
+  SF.truncateTopLevelDecls(0);
 
   REPLChecker RC(SF, DF);
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -680,7 +680,7 @@ public:
 
   static void typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD);
 
-  static void processREPLTopLevel(SourceFile &SF, unsigned StartElem);
+  static void processREPLTopLevel(SourceFile &SF);
 
   static void typeCheckDecl(Decl *D);
 
@@ -1376,11 +1376,7 @@ public:
                                         const TypeRefinementContext **MostRefined=nullptr);
 
   /// Walk the AST to build the hierarchy of TypeRefinementContexts
-  ///
-  /// \param StartElem Where to start for incremental building of refinement
-  /// contexts
-  static void buildTypeRefinementContextHierarchy(SourceFile &SF,
-                                                  unsigned StartElem);
+  static void buildTypeRefinementContextHierarchy(SourceFile &SF);
 
   /// Build the hierarchy of TypeRefinementContexts for the entire
   /// source file, if it has not already been built. Returns the root

--- a/validation-test/IDE/crashers_2/complete_repl_decl_conformance.swift
+++ b/validation-test/IDE/crashers_2/complete_repl_decl_conformance.swift
@@ -1,5 +1,0 @@
-// TODO(SR-12076): Make this not crash.
-// RUN: not --crash %target-swift-ide-test -repl-code-completion -source-filename %s
-// REQUIRES: asserts
-
-struct Bar:

--- a/validation-test/IDE/crashers_2_fixed/0024-complete_repl_decl_conformance.swift
+++ b/validation-test/IDE/crashers_2_fixed/0024-complete_repl_decl_conformance.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename %s
+
+struct Bar:

--- a/validation-test/IDE/crashers_2_fixed/0025-complete_repl_extension_where.swift
+++ b/validation-test/IDE/crashers_2_fixed/0025-complete_repl_extension_where.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename %s
+
+struct Foo<T> {}
+
+extension Foo whe


### PR DESCRIPTION
Rather than attempting to temporarily insert decls into the last source file, just create a new module and source file and carry across the imports from the last module. This matches how the REPL deals with new lines of input.

Resolves SR-12076.
Resolves rdar://problem/58860034.