### PR TITLE
[CodeCompletion] Introduce 'NotApplicable' and 'Unknown' type relation

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -530,6 +530,9 @@ public:
     /// The result does not have a type (e.g. keyword).
     NotApplicable,
 
+    /// The type relation have not been calculated.
+    Unknown,
+
     /// The relationship of the result's type to the expected type is not
     /// invalid, not convertible, and not identical.
     Unrelated,

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -527,6 +527,8 @@ public:
   /// Describes the relationship between the type of the completion results and
   /// the expected type at the code completion position.
   enum ExpectedTypeRelation {
+    /// The result does not have a type (e.g. keyword).
+    NotApplicable,
 
     /// The relationship of the result's type to the expected type is not
     /// invalid, not convertible, and not identical.

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -585,7 +585,7 @@ public:
   CodeCompletionResult(ResultKind Kind, SemanticContextKind SemanticContext,
                        unsigned NumBytesToErase,
                        CodeCompletionString *CompletionString,
-                       ExpectedTypeRelation TypeDistance = Unrelated,
+                       ExpectedTypeRelation TypeDistance,
                        CodeCompletionOperatorKind KnownOperatorKind =
                            CodeCompletionOperatorKind::None)
       : Kind(Kind), KnownOperatorKind(unsigned(KnownOperatorKind)),
@@ -610,7 +610,7 @@ public:
                        SemanticContextKind SemanticContext,
                        unsigned NumBytesToErase,
                        CodeCompletionString *CompletionString,
-                       ExpectedTypeRelation TypeDistance = Unrelated)
+                       ExpectedTypeRelation TypeDistance)
       : Kind(Keyword), KnownOperatorKind(0),
         SemanticContext(unsigned(SemanticContext)), NotRecommended(false),
         NotRecReason(NotRecommendedReason::NoReason),
@@ -689,7 +689,7 @@ public:
         AssociatedUSRs(AssociatedUSRs), DocWords(DocWords) {
     AssociatedKind = static_cast<unsigned>(DeclKind);
     assert(CompletionString);
-    TypeDistance = ExpectedTypeRelation::Unrelated;
+    TypeDistance = ExpectedTypeRelation::Unknown;
     assert(!isOperator() ||
            getOperatorKind() != CodeCompletionOperatorKind::None);
   }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -903,6 +903,9 @@ static CodeCompletionResult::ExpectedTypeRelation
 calculateMaxTypeRelationForDecl(
     const Decl *D, const ExpectedTypeContext &typeContext,
     bool IsImplicitlyCurriedInstanceMethod = false) {
+  if (typeContext.empty())
+    return CodeCompletionResult::ExpectedTypeRelation::Unknown;
+
   auto Result = CodeCompletionResult::ExpectedTypeRelation::Unrelated;
   for (auto Type : typeContext.possibleTypes) {
     // Do not use Void type context for a single-expression body, since the
@@ -1034,7 +1037,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
     }
 
     auto typeRelation = ExpectedTypeRelation;
-    if (typeRelation == CodeCompletionResult::Unrelated)
+    if (typeRelation == CodeCompletionResult::Unknown)
       typeRelation =
           calculateMaxTypeRelationForDecl(AssociatedDecl, declTypeContext);
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -695,7 +695,7 @@ void CodeCompletionResult::print(raw_ostream &OS) const {
     Prefix.append(Twine(NumBytesToErase).str());
     Prefix.append("]");
   }
-  switch (ExpectedTypeRelation(TypeDistance)) {
+  switch (getExpectedTypeRelation()) {
     case ExpectedTypeRelation::Invalid:
       Prefix.append("/TypeRelation[Invalid]");
       break;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4308,6 +4308,8 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::Super, {});
+    Builder.setExpectedTypeRelation(
+        CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
     Builder.setAssociatedDecl(FD);
     addValueOverride(FD, Reason, dynamicLookupInfo, Builder, hasFuncIntroducer);
     Builder.addBraceStmtWithCursor();
@@ -4335,6 +4337,8 @@ public:
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::Super, {});
+    Builder.setExpectedTypeRelation(
+        CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
     Builder.setAssociatedDecl(SD);
     addValueOverride(SD, Reason, dynamicLookupInfo, Builder, false);
     Builder.addBraceStmtWithCursor();
@@ -4345,6 +4349,8 @@ public:
     CodeCompletionResultBuilder Builder(Sink,
       CodeCompletionResult::ResultKind::Declaration,
       SemanticContextKind::Super, {});
+    Builder.setExpectedTypeRelation(
+        CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
     Builder.setAssociatedDecl(ATD);
     if (!hasTypealiasIntroducer && !hasAccessModifier)
       addAccessControl(ATD, Builder);
@@ -4361,6 +4367,8 @@ public:
         Sink,
         CodeCompletionResult::ResultKind::Declaration,
         SemanticContextKind::Super, {});
+    Builder.setExpectedTypeRelation(
+        CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
     Builder.setAssociatedDecl(CD);
 
     if (!hasAccessModifier)
@@ -4845,16 +4853,19 @@ static bool isClangSubModule(ModuleDecl *TheModule) {
   return false;
 }
 
-static void addKeyword(CodeCompletionResultSink &Sink, StringRef Name,
-                       CodeCompletionKeywordKind Kind,
-                       StringRef TypeAnnotation = "") {
-    CodeCompletionResultBuilder Builder(
-        Sink, CodeCompletionResult::ResultKind::Keyword,
-        SemanticContextKind::None, {});
-    Builder.setKeywordKind(Kind);
-    Builder.addTextChunk(Name);
-    if (!TypeAnnotation.empty())
-      Builder.addTypeAnnotation(TypeAnnotation);
+static void
+addKeyword(CodeCompletionResultSink &Sink, StringRef Name,
+           CodeCompletionKeywordKind Kind, StringRef TypeAnnotation = "",
+           CodeCompletionResult::ExpectedTypeRelation TypeRelation =
+               CodeCompletionResult::ExpectedTypeRelation::NotApplicable) {
+  CodeCompletionResultBuilder Builder(Sink,
+                                      CodeCompletionResult::ResultKind::Keyword,
+                                      SemanticContextKind::None, {});
+  Builder.setKeywordKind(Kind);
+  Builder.addTextChunk(Name);
+  if (!TypeAnnotation.empty())
+    Builder.addTypeAnnotation(TypeAnnotation);
+  Builder.setExpectedTypeRelation(TypeRelation);
 }
 
 static void addDeclKeywords(CodeCompletionResultSink &Sink) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -695,7 +695,7 @@ void CodeCompletionResult::print(raw_ostream &OS) const {
     Prefix.append(Twine(NumBytesToErase).str());
     Prefix.append("]");
   }
-  switch (TypeDistance) {
+  switch (ExpectedTypeRelation(TypeDistance)) {
     case ExpectedTypeRelation::Invalid:
       Prefix.append("/TypeRelation[Invalid]");
       break;
@@ -705,6 +705,8 @@ void CodeCompletionResult::print(raw_ostream &OS) const {
     case ExpectedTypeRelation::Convertible:
       Prefix.append("/TypeRelation[Convertible]");
       break;
+    case ExpectedTypeRelation::NotApplicable:
+    case ExpectedTypeRelation::Unknown:
     case ExpectedTypeRelation::Unrelated:
       break;
   }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3613,8 +3613,13 @@ public:
     }
 
     // Fallback to showing the default type.
-    if (!defaultTypeName.empty())
+    if (!defaultTypeName.empty()) {
       builder.addTypeAnnotation(defaultTypeName);
+      builder.setExpectedTypeRelation(
+          expectedTypeContext.possibleTypes.empty()
+              ? CodeCompletionResult::ExpectedTypeRelation::Unknown
+              : CodeCompletionResult::ExpectedTypeRelation::Unrelated);
+    }
   }
 
   /// Add '#file', '#line', et at.

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -255,7 +255,7 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     } else {
       result = new (*V.Sink.Allocator)
           CodeCompletionResult(kind, context, numBytesToErase, string,
-                               CodeCompletionResult::Unrelated, opKind);
+                               CodeCompletionResult::NotApplicable, opKind);
     }
 
     V.Sink.Results.push_back(result);

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -65,7 +65,7 @@ class CodeCompletionResultBuilder {
       CurrentModule;
   ExpectedTypeContext declTypeContext;
   CodeCompletionResult::ExpectedTypeRelation ExpectedTypeRelation =
-      CodeCompletionResult::Unrelated;
+      CodeCompletionResult::Unknown;
   bool Cancelled = false;
   ArrayRef<std::pair<StringRef, StringRef>> CommentWords;
   bool IsNotRecommended = false;

--- a/test/SourceKit/CodeComplete/complete_constructor.swift.response
+++ b/test/SourceKit/CodeComplete/complete_constructor.swift.response
@@ -7,7 +7,7 @@
       key.description: "(arg1: Int, arg2: Int)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:20complete_constructor3FooC4arg14arg2ACSi_Sitcfc",
       key.modulename: "complete_constructor"

--- a/test/SourceKit/CodeComplete/complete_from_clang_module.swift
+++ b/test/SourceKit/CodeComplete/complete_from_clang_module.swift
@@ -9,7 +9,7 @@ import Foo
 // CHECK-NEXT:       key.typename: "Int32",
 // CHECK-NEXT:       key.doc.brief: "Aaa.  fooIntVar.  Bbb.",
 // CHECK-NEXT:       key.context: source.codecompletion.context.othermodule,
-// CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+// CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // CHECK-NEXT:       key.num_bytes_to_erase: 0,
 // CHECK-NEXT:       key.associated_usrs: "c:@fooIntVar",
 // CHECK-NEXT:       key.modulename: "Foo"

--- a/test/SourceKit/CodeComplete/complete_member.swift.response
+++ b/test/SourceKit/CodeComplete/complete_member.swift.response
@@ -44,7 +44,7 @@
       key.description: "self",
       key.typename: "FooProtocol",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0
     }
   ]

--- a/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
+++ b/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
@@ -19,7 +19,7 @@
       key.description: "self",
       key.typename: "T",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0
     }
   ]

--- a/test/SourceKit/CodeComplete/complete_override.swift.response
+++ b/test/SourceKit/CodeComplete/complete_override.swift.response
@@ -7,7 +7,7 @@
       key.description: "associatedtype",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -17,7 +17,7 @@
       key.description: "class",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -27,7 +27,7 @@
       key.description: "convenience",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -37,7 +37,7 @@
       key.description: "deinit",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -47,7 +47,7 @@
       key.description: "dynamic",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -57,7 +57,7 @@
       key.description: "enum",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -67,7 +67,7 @@
       key.description: "extension",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -77,7 +77,7 @@
       key.description: "f(getMe a: Int, b: Double)",
       key.typename: "",
       key.context: source.codecompletion.context.superclass,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:17complete_override4BaseC1f5getMe1bySi_SdtF",
       key.modulename: "complete_override"
@@ -89,7 +89,7 @@
       key.description: "fileprivate",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -99,7 +99,7 @@
       key.description: "final",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -109,7 +109,7 @@
       key.description: "func",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -119,7 +119,7 @@
       key.description: "import",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -129,7 +129,7 @@
       key.description: "indirect",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -139,7 +139,7 @@
       key.description: "infix",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -149,7 +149,7 @@
       key.description: "init",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -159,7 +159,7 @@
       key.description: "init()",
       key.typename: "",
       key.context: source.codecompletion.context.superclass,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:17complete_override4BaseCACycfc",
       key.modulename: "complete_override"
@@ -171,7 +171,7 @@
       key.description: "inout",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -181,7 +181,7 @@
       key.description: "internal",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -191,7 +191,7 @@
       key.description: "lazy",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -201,7 +201,7 @@
       key.description: "let",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -211,7 +211,7 @@
       key.description: "mutating",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -221,7 +221,7 @@
       key.description: "nonmutating",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -231,7 +231,7 @@
       key.description: "open",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -241,7 +241,7 @@
       key.description: "operator",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -251,7 +251,7 @@
       key.description: "optional",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -261,7 +261,7 @@
       key.description: "override",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -271,7 +271,7 @@
       key.description: "postfix",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -281,7 +281,7 @@
       key.description: "precedencegroup",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -291,7 +291,7 @@
       key.description: "prefix",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -301,7 +301,7 @@
       key.description: "private",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -311,7 +311,7 @@
       key.description: "protocol",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -321,7 +321,7 @@
       key.description: "public",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -331,7 +331,7 @@
       key.description: "required",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -341,7 +341,7 @@
       key.description: "static",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -351,7 +351,7 @@
       key.description: "struct",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -361,7 +361,7 @@
       key.description: "subscript",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -371,7 +371,7 @@
       key.description: "typealias",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -381,7 +381,7 @@
       key.description: "unowned",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -391,7 +391,7 @@
       key.description: "var",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     },
     {
@@ -401,7 +401,7 @@
       key.description: "weak",
       key.typename: "",
       key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
       key.num_bytes_to_erase: 0
     }
   ]

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift
@@ -36,15 +36,20 @@ func testUnknown() {
 // RUN: %sourcekitd-test -req=complete -pos=17:17 %s -- %s > %t.convertible.response
 // RUN: diff -u %s.convertible.response %t.convertible.response
 
-// RUN:  %sourcekitd-test -req=complete -pos=21:10 %s -- %s | %FileCheck %s --check-prefix=BOOLCONTEXT
-// RUN:  %sourcekitd-test -req=complete -pos=24:10 %s -- %s | %FileCheck %s --check-prefix=OPTIONALCONTEXT
-// RUN:  %sourcekitd-test -req=complete -pos=27:10 %s -- %s | %FileCheck %s --check-prefix=VOIDCONTEXT
-// RUN:  %sourcekitd-test -req=complete -pos=27:10 %s -- %s | %FileCheck %s --check-prefix=UNKNOWNCONTEXT
+// RUN: %empty-directory(%t/cache)
+// RUN: %sourcekitd-test -req=complete.cache.ondisk -cache-path %t/cache == -req=complete -pos=21:10 %s -- %s | %FileCheck %s --check-prefix=BOOLCONTEXT
+// RUN: %sourcekitd-test -req=complete.cache.ondisk -cache-path %t/cache == -req=complete -pos=24:10 %s -- %s | %FileCheck %s --check-prefix=OPTIONALCONTEXT
+// RUN: %sourcekitd-test -req=complete.cache.ondisk -cache-path %t/cache == -req=complete -pos=27:10 %s -- %s | %FileCheck %s --check-prefix=VOIDCONTEXT
+// RUN: %sourcekitd-test -req=complete.cache.ondisk -cache-path %t/cache == -req=complete -pos=27:10 %s -- %s | %FileCheck %s --check-prefix=UNKNOWNCONTEXT
 
 // BOOLCONTEXT-LABEL: key.name: "false",
 // BOOLCONTEXT-NOT:   key.name:
 // BOOLCONTEXT:       key.typename: "Bool",
 // BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.identical,
+// BOOLCONTEXT-LABEL: key.name: "Int",
+// BOOLCONTEXT-NOT:   key.name:
+// BOOLCONTEXT:       key.typename: "Int",
+// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // BOOLCONTEXT-LABEL: key.name: "nil",
 // BOOLCONTEXT-NOT:   key.name:
 // BOOLCONTEXT:       key.typename: "",
@@ -58,6 +63,10 @@ func testUnknown() {
 // OPTIONALCONTEXT-NOT:   key.name:
 // OPTIONALCONTEXT:       key.typename: "Bool",
 // OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+// OPTIONALCONTEXT-LABEL: key.name: "Int",
+// OPTIONALCONTEXT-NOT:   key.name:
+// OPTIONALCONTEXT:       key.typename: "Int",
+// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // OPTIONALCONTEXT-LABEL: key.name: "nil",
 // OPTIONALCONTEXT-NOT:   key.name:
 // OPTIONALCONTEXT:       key.typename: "Int?",
@@ -71,6 +80,10 @@ func testUnknown() {
 // VOIDCONTEXT-NOT:   key.name:
 // VOIDCONTEXT:       key.typename: "Bool",
 // VOIDCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+// VOIDCONTEXT-LABEL: key.name: "Int",
+// VOIDCONTEXT-NOT:   key.name:
+// VOIDCONTEXT:       key.typename: "Int",
+// VOIDCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // VOIDCONTEXT-LABEL: key.name: "nil",
 // VOIDCONTEXT-NOT:   key.name:
 // VOIDCONTEXT:       key.typename: "",
@@ -83,6 +96,10 @@ func testUnknown() {
 // UNKNOWNCONTEXT-LABEL: key.name: "false",
 // UNKNOWNCONTEXT-NOT:   key.name:
 // UNKNOWNCONTEXT:       key.typename: "Bool",
+// UNKNOWNCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+// UNKNOWNCONTEXT-LABEL: key.name: "Int",
+// UNKNOWNCONTEXT-NOT:   key.name:
+// UNKNOWNCONTEXT:       key.typename: "Int",
 // UNKNOWNCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // UNKNOWNCONTEXT-LABEL: key.name: "nil",
 // UNKNOWNCONTEXT-NOT:   key.name:

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift
@@ -17,8 +17,78 @@ func testConvertibleContext() -> MyProto {
   return MyEnum.
 }
 
+func testBool() -> Bool {
+  return 
+}
+func testOptionalInt() -> Int? {
+  return 
+}
+func testVoid() -> Void {
+  return 
+}
+func testUnknown() {
+
+}
+
 // RUN: %sourcekitd-test -req=complete -pos=13:17 %s -- %s > %t.identical.response
 // RUN: diff -u %s.identical.response %t.identical.response
 
 // RUN: %sourcekitd-test -req=complete -pos=17:17 %s -- %s > %t.convertible.response
 // RUN: diff -u %s.convertible.response %t.convertible.response
+
+// RUN:  %sourcekitd-test -req=complete -pos=21:10 %s -- %s | %FileCheck %s --check-prefix=BOOLCONTEXT
+// RUN:  %sourcekitd-test -req=complete -pos=24:10 %s -- %s | %FileCheck %s --check-prefix=OPTIONALCONTEXT
+// RUN:  %sourcekitd-test -req=complete -pos=27:10 %s -- %s | %FileCheck %s --check-prefix=VOIDCONTEXT
+// RUN:  %sourcekitd-test -req=complete -pos=27:10 %s -- %s | %FileCheck %s --check-prefix=UNKNOWNCONTEXT
+
+// BOOLCONTEXT-LABEL: key.name: "false",
+// BOOLCONTEXT-NOT:   key.name:
+// BOOLCONTEXT:       key.typename: "Bool",
+// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.identical,
+// BOOLCONTEXT-LABEL: key.name: "nil",
+// BOOLCONTEXT-NOT:   key.name:
+// BOOLCONTEXT:       key.typename: "",
+// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+// BOOLCONTEXT-LABEL: key.name: "true",
+// BOOLCONTEXT-NOT:   key.name:
+// BOOLCONTEXT:       key.typename: "Bool",
+// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.identical,
+
+// OPTIONALCONTEXT-LABEL: key.name: "false",
+// OPTIONALCONTEXT-NOT:   key.name:
+// OPTIONALCONTEXT:       key.typename: "Bool",
+// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+// OPTIONALCONTEXT-LABEL: key.name: "nil",
+// OPTIONALCONTEXT-NOT:   key.name:
+// OPTIONALCONTEXT:       key.typename: "Int?",
+// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.identical,
+// OPTIONALCONTEXT-LABEL: key.name: "true",
+// OPTIONALCONTEXT-NOT:   key.name:
+// OPTIONALCONTEXT:       key.typename: "Bool",
+// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+
+// VOIDCONTEXT-LABEL: key.name: "false",
+// VOIDCONTEXT-NOT:   key.name:
+// VOIDCONTEXT:       key.typename: "Bool",
+// VOIDCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+// VOIDCONTEXT-LABEL: key.name: "nil",
+// VOIDCONTEXT-NOT:   key.name:
+// VOIDCONTEXT:       key.typename: "",
+// VOIDCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+// VOIDCONTEXT-LABEL: key.name: "true",
+// VOIDCONTEXT-NOT:   key.name:
+// VOIDCONTEXT:       key.typename: "Bool",
+// VOIDCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+
+// UNKNOWNCONTEXT-LABEL: key.name: "false",
+// UNKNOWNCONTEXT-NOT:   key.name:
+// UNKNOWNCONTEXT:       key.typename: "Bool",
+// UNKNOWNCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+// UNKNOWNCONTEXT-LABEL: key.name: "nil",
+// UNKNOWNCONTEXT-NOT:   key.name:
+// UNKNOWNCONTEXT:       key.typename: "",
+// UNKNOWNCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+// UNKNOWNCONTEXT-LABEL: key.name: "true",
+// UNKNOWNCONTEXT-NOT:   key.name:
+// UNKNOWNCONTEXT:       key.typename: "Bool",
+// UNKNOWNCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift.convertible.response
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift.convertible.response
@@ -56,7 +56,7 @@
       key.description: "self",
       key.typename: "MyEnum.Type",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0
     },
     {
@@ -91,7 +91,7 @@
       key.description: "Type",
       key.typename: "MyEnum.Type",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0
     }
   ]

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift.identical.response
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift.identical.response
@@ -56,7 +56,7 @@
       key.description: "self",
       key.typename: "MyEnum.Type",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0
     },
     {
@@ -91,7 +91,7 @@
       key.description: "Type",
       key.typename: "MyEnum.Type",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.unrelated,
+      key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0
     }
   ]

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -158,7 +158,8 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
     CodeCompletion::SwiftResult swiftResult(
         CodeCompletion::SwiftResult::ResultKind::Pattern,
         SemanticContextKind::ExpressionSpecific,
-        /*NumBytesToErase=*/0, completionString);
+        /*NumBytesToErase=*/0, completionString,
+        CodeCompletionResult::ExpectedTypeRelation::Unknown);
 
     CompletionBuilder builder(sink, swiftResult);
     builder.setCustomKind(customCompletion.Kind);

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -502,12 +502,15 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
     Info.SemanticContext = CCCtxOtherModule; break;
   }
 
+  static UIdent CCTypeRelNotApplicable("source.codecompletion.typerelation.notapplicable");
   static UIdent CCTypeRelUnrelated("source.codecompletion.typerelation.unrelated");
   static UIdent CCTypeRelInvalid("source.codecompletion.typerelation.invalid");
   static UIdent CCTypeRelConvertible("source.codecompletion.typerelation.convertible");
   static UIdent CCTypeRelIdentical("source.codecompletion.typerelation.identical");
 
   switch (Result->getExpectedTypeRelation()) {
+  case CodeCompletionResult::NotApplicable:
+    Info.TypeRelation = CCTypeRelNotApplicable; break;
   case CodeCompletionResult::Unrelated:
     Info.TypeRelation = CCTypeRelUnrelated; break;
   case CodeCompletionResult::Invalid:

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -503,6 +503,7 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
   }
 
   static UIdent CCTypeRelNotApplicable("source.codecompletion.typerelation.notapplicable");
+  static UIdent CCTypeRelUnknown("source.codecompletion.typerelation.unknown");
   static UIdent CCTypeRelUnrelated("source.codecompletion.typerelation.unrelated");
   static UIdent CCTypeRelInvalid("source.codecompletion.typerelation.invalid");
   static UIdent CCTypeRelConvertible("source.codecompletion.typerelation.convertible");
@@ -511,6 +512,8 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
   switch (Result->getExpectedTypeRelation()) {
   case CodeCompletionResult::NotApplicable:
     Info.TypeRelation = CCTypeRelNotApplicable; break;
+  case CodeCompletionResult::Unknown:
+    Info.TypeRelation = CCTypeRelUnknown; break;
   case CodeCompletionResult::Unrelated:
     Info.TypeRelation = CCTypeRelUnrelated; break;
   case CodeCompletionResult::Invalid:

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -992,7 +992,8 @@ static void transformAndForwardResults(
     CodeCompletion::SwiftResult paren(
         CodeCompletion::SwiftResult::ResultKind::BuiltinOperator,
         SemanticContextKind::ExpressionSpecific,
-        exactMatch ? exactMatch->getNumBytesToErase() : 0, completionString);
+        exactMatch ? exactMatch->getNumBytesToErase() : 0, completionString,
+        CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
 
     SwiftCompletionInfo info;
     std::vector<Completion *> extended =


### PR DESCRIPTION
Now, kinds of type relations are:

* `NotApplicable`: The result is not relevant for type relation (e.g. keywords, and overloads)
* `Unknown`: The relation was not calculated (e.g. cached results), or the context type is unknown
* `Invalid`: The result type is invalid for this context (i.e. 'Void' for non-'Void' context)
* `Unrelated`: The result type has no relation to the context type
* `Convertible`: The result type is convertible to the context type
* `Identical`: The result type is identical to the context type

rdar://problem/59201827