### PR TITLE
Sema: Only diagnose 'throws' in 'defer' as part of TypeCheckError

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -855,7 +855,6 @@ private:
 
   Kind TheKind;
   bool DiagnoseErrorOnTry = false;
-  bool isInDefer = false;
   DeclContext *RethrowsDC = nullptr;
   InterpolatedStringLiteralExpr *InterpolatedString = nullptr;
 
@@ -899,9 +898,7 @@ public:
   }
 
   static Context forDeferBody() {
-    Context result(Kind::DeferBody);
-    result.isInDefer = true;
-    return result;
+    return Context(Kind::DeferBody);
   }
 
   static Context forInitializer(Initializer *init) {
@@ -979,18 +976,13 @@ public:
 
   static void diagnoseThrowInIllegalContext(DiagnosticEngine &Diags,
                                             ASTNode node,
-                                            StringRef description,
-                                            bool throwInDefer = false) {
-    if (auto *e = node.dyn_cast<Expr*>())
+                                            StringRef description) {
+    if (auto *e = node.dyn_cast<Expr*>()) {
       if (isa<ApplyExpr>(e)) {
         Diags.diagnose(e->getLoc(), diag::throwing_call_in_illegal_context,
                        description);
         return;
       }
-
-    if (throwInDefer) {
-      // Return because this would've already been diagnosed in TypeCheckStmt.
-      return;
     }
 
     Diags.diagnose(node.getStartLoc(), diag::throw_in_illegal_context,
@@ -1156,7 +1148,7 @@ public:
       diagnoseThrowInIllegalContext(Diags, E, "a catch guard expression");
       return;
     case Kind::DeferBody:
-      diagnoseThrowInIllegalContext(Diags, E, "a defer body", isInDefer);
+      diagnoseThrowInIllegalContext(Diags, E, "a defer body");
       return;
     }
     llvm_unreachable("bad context kind");

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -610,13 +610,6 @@ public:
   }
   
   Stmt *visitThrowStmt(ThrowStmt *TS) {
-    // If the throw is in a defer, then it isn't valid.
-    if (isInDefer()) {
-      getASTContext().Diags.diagnose(TS->getThrowLoc(),
-                                     diag::jump_out_of_defer, "throw");
-      return nullptr;
-    }
-
     // Coerce the operand to the exception type.
     auto E = TS->getSubExpr();
 

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -388,12 +388,39 @@ enum DeferThrowError: Error {
 }
 
 func throwInDefer() {
-  defer { throw DeferThrowError.someError } // expected-error {{'throw' cannot transfer control out of a defer statement}}
+  defer { throw DeferThrowError.someError } // expected-error {{errors cannot be thrown out of a defer body}}
   print("Foo")
+}
+
+func throwInDeferOK1() {
+  defer {
+    do {
+      throw DeferThrowError.someError
+    } catch {}
+  }
+  print("Bar")
+}
+
+func throwInDeferOK2() throws {
+  defer {
+    do {
+      throw DeferThrowError.someError
+    } catch {}
+  }
+  print("Bar")
 }
 
 func throwingFuncInDefer1() throws {
   defer { try throwingFunctionCalledInDefer() } // expected-error {{errors cannot be thrown out of a defer body}}
+  print("Bar")
+}
+
+func throwingFuncInDefer1a() throws {
+  defer {
+    do {
+      try throwingFunctionCalledInDefer()
+    } catch {}
+  }
   print("Bar")
 }
 
@@ -402,13 +429,48 @@ func throwingFuncInDefer2() throws {
   print("Bar")
 }
 
+func throwingFuncInDefer2a() throws {
+  defer {
+    do {
+      throwingFunctionCalledInDefer()
+      // expected-error@-1 {{call can throw but is not marked with 'try'}}
+      // expected-note@-2 {{did you mean to use 'try'?}}
+      // expected-note@-3 {{did you mean to handle error as optional value?}}
+      // expected-note@-4 {{did you mean to disable error propagation?}}
+    } catch {}
+  }
+  print("Bar")
+}
+
 func throwingFuncInDefer3() {
   defer { try throwingFunctionCalledInDefer() } // expected-error {{errors cannot be thrown out of a defer body}}
   print("Bar")
 }
 
+func throwingFuncInDefer3a() {
+  defer {
+    do {
+      try throwingFunctionCalledInDefer()
+    } catch {}
+  }
+  print("Bar")
+}
+
 func throwingFuncInDefer4() {
   defer { throwingFunctionCalledInDefer() } // expected-error {{errors cannot be thrown out of a defer body}}
+  print("Bar")
+}
+
+func throwingFuncInDefer4a() {
+  defer {
+    do {
+      throwingFunctionCalledInDefer()
+      // expected-error@-1 {{call can throw but is not marked with 'try'}}
+      // expected-note@-2 {{did you mean to use 'try'?}}
+      // expected-note@-3 {{did you mean to handle error as optional value?}}
+      // expected-note@-4 {{did you mean to disable error propagation?}}
+    } catch {}
+  }
   print("Bar")
 }
 


### PR DESCRIPTION
We had a similar check in TypeCheckStmt but it did not account for the
possibility of the 'throw' being contained inside a 'do'/'catch' inside
a 'defer'. Remove it and just diagnose everything in one place.

Fixes <rdar://problem/57360567>.