### PR TITLE
benchmark: Make building with debug info the default

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -248,6 +248,10 @@ option(SWIFT_BENCHMARK_GENERATE_OPT_VIEW
 set(SWIFT_BENCHMARK_OPT_VIEWER "" CACHE FILEPATH
   "Path to opt-viewer")
 
+option(SWIFT_BENCHMARK_GENERATE_DEBUG_INFO
+  "Produce debug info for benchmarks"
+  TRUE)
+
 if(SWIFT_BENCHMARK_OPT_VIEWER)
   # If the path to the opt-viewer was specified manually and we have no access
   # to the LLVM tree, assume we have the modules for the opt-viewer installed.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -67,6 +67,9 @@ The following build options are available:
     * Enable this option to link the benchmark binaries against the target
       machine's Swift standard library and runtime installed with the OS.
     (default: OFF)
+* `-DSWIFT_BENCHMARK_GENERATE_DEBUG_INFO`
+    * Enable this option to compile benchmark binaries with debug info.
+    (default: ON)
 
 The following build targets are available:
 

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -355,6 +355,10 @@ function (swift_benchmark_compile_archopts)
       "-target" "${target}"
       "-${BENCH_COMPILE_ARCHOPTS_OPT}" ${PAGE_ALIGNMENT_OPTION})
 
+  if(SWIFT_BENCHMARK_GENERATE_DEBUG_INFO)
+    list(APPEND common_options "-g")
+  endif()
+
   if (is_darwin)
     list(APPEND common_options
       "-I" "${srcdir}/utils/ObjectiveCTests"
@@ -383,6 +387,10 @@ function (swift_benchmark_compile_archopts)
       "-c"
       "-target" "${target}"
       "-${driver_opt}")
+
+  if(SWIFT_BENCHMARK_GENERATE_DEBUG_INFO)
+    list(APPEND common_options_driver "-g")
+  endif()
 
   if (is_darwin)
     list(APPEND common_options_driver


### PR DESCRIPTION
Add an on-by-default option to build swift's benchmarks with debug info.

This lets us use the benchmark driver to find lldb bugs, e.g. rdar://59209520.