### PR TITLE
Remove legacy TensorFlow graph program extraction code.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1077,10 +1077,6 @@ public:
   void viewCFG() const;
   /// Like ViewCFG, but the graph does not show the contents of basic blocks.
   void viewCFGOnly() const;
-
-  // SWIFT_ENABLE_TENSORFLOW
-  /// Get estimated code size, for debugging only.
-  unsigned codeSize() const;
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,

--- a/include/swift/SIL/SILFunctionBuilder.h
+++ b/include/swift/SIL/SILFunctionBuilder.h
@@ -69,8 +69,6 @@ class SILFunctionBuilder {
                                          IsThunk_t isThunk,
                                          IsDynamicallyReplaceable_t isDynamic);
 
-
-
   /// Return the declaration of a function, or create it if it doesn't exist.
   SILFunction *getOrCreateFunction(
       SILLocation loc, StringRef name, SILLinkage linkage,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -172,9 +172,6 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   Int32Ty = llvm::Type::getInt32Ty(getLLVMContext());
   Int32PtrTy = Int32Ty->getPointerTo();
   Int64Ty = llvm::Type::getInt64Ty(getLLVMContext());
-  // SWIFT_ENABLE_TENSORFLOW
-  DoubleTy = llvm::Type::getDoubleTy(getLLVMContext());
-  FloatTy = llvm::Type::getFloatTy(getLLVMContext());
 
   Int8PtrTy = llvm::Type::getInt8PtrTy(getLLVMContext());
   Int8PtrPtrTy = Int8PtrTy->getPointerTo(0);
@@ -607,12 +604,6 @@ static bool isReturnAttribute(llvm::Attribute::AttrKind Attr) {
 static bool isReturnedAttribute(llvm::Attribute::AttrKind Attr) {
   return Attr == llvm::Attribute::Returned;
 }
-// SWIFT_ENABLE_TENSORFLOW
-// Similar to the 'return' attribute we assume that the 'sret' attributed is
-// associated with the first function parameter.
-static bool isStructRetAttribute(llvm::Attribute::AttrKind Attr) {
-  return Attr == llvm::Attribute::StructRet;
-}
 
 namespace {
 bool isStandardLibrary(const llvm::Module &M) {
@@ -711,8 +702,7 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
     for (auto Attr : attrs) {
       if (isReturnAttribute(Attr))
         buildRetAttr.addAttribute(Attr);
-      // SWIFT_ENABLE_TENSORFLOW
-      else if (isReturnedAttribute(Attr) || isStructRetAttribute(Attr))
+      else if (isReturnedAttribute(Attr))
         buildFirstParamAttr.addAttribute(Attr);
       else
         buildFnAttr.addAttribute(Attr);

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -68,9 +68,6 @@ SILFunction::create(SILModule &M, SILLinkage linkage, StringRef name,
   if (!name.empty()) {
     entry = &*M.FunctionTable.insert(std::make_pair(name, nullptr)).first;
     PrettyStackTraceSILFunction trace("creating", entry->getValue());
-    if (entry->getValue()) {
-      entry->getValue()->dump();
-    }
     assert(!entry->getValue() && "function already exists");
     name = entry->getKey();
   }
@@ -611,14 +608,6 @@ SubstitutionMap SILFunction::getForwardingSubstitutionMap() {
 
 bool SILFunction::shouldVerifyOwnership() const {
   return !hasSemanticsAttr("verify.ownership.sil.never");
-}
-
-// SWIFT_ENABLE_TENSORFLOW
-unsigned SILFunction::codeSize() const {
-  unsigned size = 0;
-  for (auto &BB : *this)
-    size += BB.codeSize();
-  return size;
 }
 
 static Identifier getIdentifierForObjCSelector(ObjCSelector selector, ASTContext &Ctxt) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -62,16 +62,9 @@ static llvm::cl::opt<bool> AbortOnFailure(
                               "verify-abort-on-failure",
                               llvm::cl::init(true));
 
-// SWIFT_ENABLE_TENSORFLOW
-// This flag is temporarily set to false because debug scope verification does
-// not handle inlined call sites. This is problematic for deabstraction, which
-// does performance inlining at -Onone.
-// When debug scope verification handles inlined call sites, set this flag to
-// true.
-// Documented at SR-8114.
 static llvm::cl::opt<bool> VerifyDIHoles(
                               "verify-di-holes",
-                              llvm::cl::init(false));
+                              llvm::cl::init(true));
 
 static llvm::cl::opt<bool> SkipConvertEscapeToNoescapeAttributes(
     "verify-skip-convert-escape-to-noescape-attributes", llvm::cl::init(false));
@@ -1563,7 +1556,7 @@ public:
                       "Transpose type does not match expected transpose type");
     }
   }
-  
+
   void checkDifferentiableFunctionExtractInst(
       DifferentiableFunctionExtractInst *dfei) {
     auto fnTy = dfei->getFunctionOperand()->getType().getAs<SILFunctionType>();

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -353,17 +353,6 @@ void SILPassManager::dumpPassInfo(const char *Title, unsigned TransIdx,
   llvm::dbgs() << '\n';
 }
 
-// SWIFT_ENABLE_TENSORFLOW
-static void logS4TFPassEvent(long long Delta, llvm::sys::TimePoint<> StartTime,
-                             StringRef passName, bool isFunctionPass,
-                             StringRef funcName) {
-  auto tt = llvm::sys::toTimeT(StartTime);
-  auto strTime = ctime(&tt);
-  strTime[strlen(strTime) - 1] = '\0';
-  llvm::dbgs() << "S4TF," << Delta << "," << strTime << "," << passName << ","
-               << (isFunctionPass ? "F" : "M") << "," << funcName << "\n";
-}
-
 void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
 
   assert(analysesUnlocked() && "Expected all analyses to be unlocked!");
@@ -429,13 +418,6 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
   if (SILPrintPassTime) {
     llvm::dbgs() << Delta << " (" << SFT->getID() << "," << F->getName()
                  << ")\n";
-
-    // SWIFT_ENABLE_TENSORFLOW
-    // Write CSV-formatted events, so that we can do aggregate analysis. Format:
-    // [S4TF] Delta,StartTime,PassName,PassType,FuncName
-    // Here PassType is F since it's a function pass.
-    logS4TFPassEvent(Delta, StartTime, SFT->getID(), /*isFunctionPass*/ true,
-                     F->getName());
   }
 
   // If this pass invalidated anything, print and verify.
@@ -582,13 +564,6 @@ void SILPassManager::runModulePass(unsigned TransIdx) {
   auto Delta = (std::chrono::system_clock::now() - StartTime).count();
   if (SILPrintPassTime) {
     llvm::dbgs() << Delta << " (" << SMT->getID() << ",Module)\n";
-
-    // SWIFT_ENABLE_TENSORFLOW
-    // Write CSV-formatted events, so that we can do aggregate analysis. Format:
-    // [S4TF] Delta,StartTime,PassName,PassType
-    // Here PassType is M since it's a module pass.
-    logS4TFPassEvent(Delta, StartTime, SMT->getID(), /*isFunctionPass*/ false,
-                     /*funcName*/ "");
   }
 
   // If this pass invalidated anything, print and verify.


### PR DESCRIPTION
Graph program extraction is no longer used.
Most of the code was deleted months ago. This deletes more remaining code.

Follow-up to https://github.com/apple/swift/pull/24418.