### PR TITLE
[AutoDiff upstream] Add `SILFunctionType` utilities.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4442,7 +4442,7 @@ public:
   /// Given that `this` is a `@differentiable` or `@differentiable(linear)`
   /// function type, returns an `IndexSubset` corresponding to the
   /// differentiability/linearity parameters (e.g. all parameters except the
-  //// `@noDerivative` ones).
+  /// `@noDerivative` ones).
   IndexSubset *getDifferentiabilityParameterIndices();
 
   /// Returns the `@differentiable` or `@differentiable(linear)` function type


### PR DESCRIPTION
Upstream AutoDiff-related `SILFunctionType` utilities:
- `SILFunctionType::getDifferentiabilityParameterIndices`
- `SILFunctionType::getWithDifferentiability`
- `SILFunctionType::getWithoutDifferentiability`

Resolves TF-1125.