### PR TITLE
ClangImporter: Fix importEnumCaseAlias() when the original is itself an alias

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/AliasCaseErrorEnum/AliasCaseErrorEnum.apinotes
+++ b/test/ClangImporter/Inputs/custom-modules/AliasCaseErrorEnum/AliasCaseErrorEnum.apinotes
@@ -1,0 +1,5 @@
+---
+Name: AliasCaseErrorEnum
+Tags:
+- Name: AliasError
+  NSErrorDomain: AliasErrorDomain

--- a/test/ClangImporter/Inputs/custom-modules/AliasCaseErrorEnum/AliasCaseErrorEnum.h
+++ b/test/ClangImporter/Inputs/custom-modules/AliasCaseErrorEnum/AliasCaseErrorEnum.h
@@ -1,0 +1,10 @@
+@import Foundation;
+
+#define kAliasErrorDomain "com.acme.AliasErrorDomain"
+
+extern NSString *const __nonnull AliasErrorDomain;
+
+typedef NS_ENUM(NSInteger, AliasError) {
+    AliasErrorRealName = 1,
+    AliasErrorFakeName = 1,
+};

--- a/test/ClangImporter/Inputs/custom-modules/AliasCaseErrorEnum/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/AliasCaseErrorEnum/module.map
@@ -1,0 +1,4 @@
+module AliasCaseErrorEnum {
+  umbrella header "AliasCaseErrorEnum.h"
+  export *
+}

--- a/test/ClangImporter/enum-error-case-alias.swift
+++ b/test/ClangImporter/enum-error-case-alias.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -enable-objc-interop -I %S/Inputs/custom-modules/AliasCaseErrorEnum
+
+// REQUIRES: objc_interop
+
+import AliasCaseErrorEnum
+
+// Make sure that we can reference aliases defined in the wrapper type
+// which themselves point at aliases inside the nested 'Code' type.
+
+_ = AliasError.realName
+_ = AliasError.fakeName


### PR DESCRIPTION
This comes up when an imported error enum has duplicate cases.
The FooError.Code enum has an alias for the duplicate case, and
the wrapper type FooError defines aliases for every member of
FooError.Code.

The implementation of importEnumCaseAlias() assumed that 'original'
was an EnumElementDecl, and built AST accordingly; however if it
is a 'VarDecl', we have to build a MemberRefExpr instead.

This regression was introduced in https://github.com/apple/swift/pull/25009.

Fixes rdar://problem/58552618 / https://bugs.swift.org/browse/SR-12136.