### PR TITLE
[builtin] Add a new SIL builtin convertStrongToUnsafeUnowned()

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -450,6 +450,25 @@ BUILTIN_SIL_OPERATION(ProjectTailElems, "projectTailElems", Special)
 /// signature is to work around issues with results in SILGen builtin emission.
 BUILTIN_SIL_OPERATION(ConvertStrongToUnownedUnsafe, "convertStrongToUnownedUnsafe", Special)
 
+/// Unsafely convert a value of type @inout @unowned(unsafe) T to a loaded
+/// guaranteed T value that has a lifetime guaranteed by the passed in base
+/// value of type BaseTy.
+///
+/// It has type (@in_guaranteed BaseTy, @in_guaranteed @unowned (unsafe) T) -> @guaranteed T.
+///
+/// NOTE: Saying the result is a guaranteed T is a bit of a misnomer. We aren't
+/// emitting a builtin call, but are just emitting SIL directly.
+///
+/// NOTE: Even though the signature is as mentioned above, we actually tell the
+/// AST we have the signature:
+///
+///   <BaseT, T, U> (BaseT, T) -> U
+///
+/// We then perform the actual type checking in SILGen and assert on
+/// failure. This is an early, unsupported feature so this is sufficient for
+/// now.
+BUILTIN_SIL_OPERATION(ConvertUnownedUnsafeToGuaranteed, "convertUnownedUnsafeToGuaranteed", Special)
+
 #undef BUILTIN_SIL_OPERATION
 
 // BUILTIN_RUNTIME_CALL - A call into a runtime function.

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -634,6 +634,12 @@ BUILTIN_MISC_OPERATION(PoundAssert, "poundAssert", "", Special)
 
 // BUILTIN_MISC_OPERATION_WITH_SILGEN - Miscellaneous operations that are
 // specially emitted during SIL generation.
+//
+// The intention is that this is meant for builtins that need a named
+// builtin representation so one can create a builtin instruction in
+// SIL, but that also need special SILGen behavior. If an operation
+// just emits custom SIL and does not need to be able to form a
+// builtin instruction, please use BUILTIN_SIL_OPERATION.
 #ifndef BUILTIN_MISC_OPERATION_WITH_SILGEN
 #define BUILTIN_MISC_OPERATION_WITH_SILGEN(Id, Name, Attrs, Overload) \
   BUILTIN_MISC_OPERATION(Id, Name, Attrs, Overload)

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -444,6 +444,12 @@ BUILTIN_SIL_OPERATION(AllocWithTailElems, "allocWithTailElems", Special)
 /// Projects the first tail-allocated element of type E from a class C.
 BUILTIN_SIL_OPERATION(ProjectTailElems, "projectTailElems", Special)
 
+/// Unsafely convert a value of type T to an unowned value.
+///
+/// It has type (T, @inout @unowned(unsafe) T) -> (). The reason for the weird
+/// signature is to work around issues with results in SILGen builtin emission.
+BUILTIN_SIL_OPERATION(ConvertStrongToUnownedUnsafe, "convertStrongToUnownedUnsafe", Special)
+
 #undef BUILTIN_SIL_OPERATION
 
 // BUILTIN_RUNTIME_CALL - A call into a runtime function.

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -459,6 +459,24 @@ public:
     return SILType(getASTType().getReferenceStorageReferent(), getCategory());
   }
 
+  /// Return the reference ownership of this type if it is a reference storage
+  /// type. Otherwse, return None.
+  Optional<ReferenceOwnership> getReferenceStorageOwnership() const {
+    auto type = getASTType()->getAs<ReferenceStorageType>();
+    if (!type)
+      return None;
+    return type->getOwnership();
+  }
+
+  /// Attempt to wrap the passed in type as a type with reference ownership \p
+  /// ownership. For simplicity, we always return an address since reference
+  /// storage types may not be loadable (e.x.: weak ownership).
+  SILType getReferenceStorageType(const ASTContext &ctx,
+                                  ReferenceOwnership ownership) const {
+    auto *type = ReferenceStorageType::get(getASTType(), ownership, ctx);
+    return SILType::getPrimitiveAddressType(type->getCanonicalType());
+  }
+
   /// Transform the function type SILType by replacing all of its interface
   /// generic args with the appropriate item from the substitution.
   ///

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -956,6 +956,22 @@ static ValueDecl *getConvertStrongToUnownedUnsafe(ASTContext &ctx,
   return builder.build(id);
 }
 
+static ValueDecl *getConvertUnownedUnsafeToGuaranteed(ASTContext &ctx,
+                                                      Identifier id) {
+  // We actually want this:
+  //
+  ///   <BaseT, T> (BaseT, @inout unowned(unsafe) T) -> T
+  //
+  // But for simplicity, we actually accept three generic params T, U and do the
+  // checking in the emission method that everything works up. This is a
+  // builtin, so we can crash.
+  BuiltinFunctionBuilder builder(ctx, 3);
+  builder.addParameter(makeGenericParam(0));                        // Base
+  builder.addParameter(makeGenericParam(1), ValueOwnership::InOut); // Unmanaged
+  builder.setResult(makeGenericParam(2)); // Guaranteed Result
+  return builder.build(id);
+}
+
 static ValueDecl *getPoundAssert(ASTContext &Context, Identifier Id) {
   auto int1Type = BuiltinIntegerType::get(1, Context);
   auto optionalRawPointerType = BoundGenericEnumType::get(
@@ -2014,6 +2030,9 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   case BuiltinValueKind::ConvertStrongToUnownedUnsafe:
     return getConvertStrongToUnownedUnsafe(Context, Id);
+
+  case BuiltinValueKind::ConvertUnownedUnsafeToGuaranteed:
+    return getConvertUnownedUnsafeToGuaranteed(Context, Id);
 
   case BuiltinValueKind::PoundAssert:
     return getPoundAssert(Context, Id);

--- a/lib/SIL/ValueOwnership.cpp
+++ b/lib/SIL/ValueOwnership.cpp
@@ -547,7 +547,6 @@ UNOWNED_OR_NONE_DEPENDING_ON_RESULT(ZeroInitializer)
       BuiltinInst *BI, StringRef Attr) { \
     llvm_unreachable("builtin should have been lowered in SILGen"); \
   }
-
 #include "swift/AST/Builtins.def"
 
 ValueOwnershipKind

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -405,7 +405,16 @@ public:
     assert(&component == Path.back().get());
     Path.pop_back();
   }
-  
+
+  /// Pop the last component off this LValue unsafely. Validates that the
+  /// component is of kind \p kind as a sanity check.
+  ///
+  /// Please be careful when using this!
+  void unsafelyDropLastComponent(PathComponent::KindTy kind) & {
+    assert(kind == Path.back()->getKind());
+    Path.pop_back();
+  }
+
   /// Add a new component at the end of the access path of this lvalue.
   template <class T, class... As>
   void add(As &&... args) {

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -844,3 +844,12 @@ ManagedValue SILGenBuilder::createProjectBox(SILLocation loc, ManagedValue mv,
   auto *pbi = createProjectBox(loc, mv.getValue(), index);
   return ManagedValue::forUnmanaged(pbi);
 }
+
+ManagedValue SILGenBuilder::createMarkDependence(SILLocation loc,
+                                                 ManagedValue value,
+                                                 ManagedValue base) {
+  CleanupCloner cloner(*this, value);
+  auto *mdi = createMarkDependence(loc, value.forward(getSILGenFunction()),
+                                   base.forward(getSILGenFunction()));
+  return cloner.clone(mdi);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -368,6 +368,10 @@ public:
   using SILBuilder::createProjectBox;
   ManagedValue createProjectBox(SILLocation loc, ManagedValue mv,
                                 unsigned index);
+
+  using SILBuilder::createMarkDependence;
+  ManagedValue createMarkDependence(SILLocation loc, ManagedValue value,
+                                    ManagedValue base);
 };
 
 } // namespace Lowering

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1338,6 +1338,11 @@ public:
                                       const TypeLowering &lowering);
   ManagedValue emitManagedBeginBorrow(SILLocation loc, SILValue v);
 
+  ManagedValue
+  emitManagedBorrowedRValueWithCleanup(SILValue borrowedValue,
+                                       const TypeLowering &lowering);
+  ManagedValue emitManagedBorrowedRValueWithCleanup(SILValue borrowedValue);
+
   ManagedValue emitManagedBorrowedRValueWithCleanup(SILValue original,
                                                     SILValue borrowedValue);
   ManagedValue emitManagedBorrowedRValueWithCleanup(

--- a/test/SILGen/unsafevalue.swift
+++ b/test/SILGen/unsafevalue.swift
@@ -1,0 +1,102 @@
+// RUN: %target-swift-emit-silgen -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil -Onone -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck -check-prefix=CANONICAL %s
+// RUN: %target-swift-emit-sil -O -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck -check-prefix=OPT %s
+
+import Swift
+
+// Eventually element will be unconstrained, but for testing this builtin, we
+// should use it this way.
+@frozen
+public struct UnsafeValue<Element: AnyObject> {
+  @usableFromInline
+  internal unowned(unsafe) var _value: Element?
+
+  @_transparent
+  @inlinable
+  public init() {
+    _value = nil
+  }
+
+  // Create a new unmanaged value that owns the underlying value. This unmanaged
+  // value must after use be deinitialized by calling the function deinitialize()
+  //
+  // This will insert a retain that the optimizer can not remove!
+  @_transparent
+  @inlinable
+  public init(copying newValue: __shared Element) {
+    self.init()
+    _value = newValue
+  }
+
+  // Create a new unmanaged value that unsafely produces a new
+  // unmanaged value without introducing any rr traffic.
+  //
+  // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC : $@convention(method) <Element where Element : AnyObject> (@guaranteed Element, @thin UnsafeValue<Element>.Type) -> UnsafeValue<Element> {
+  // CHECK: bb0([[INPUT_ELEMENT:%.*]] : @guaranteed $Element,
+  // CHECK:   [[BOX:%.*]] = alloc_box
+  // CHECK:   [[UNINIT_BOX:%.*]] = mark_uninitialized [delegatingself] [[BOX]]
+  // CHECK:   [[PROJECT_UNINIT_BOX:%.*]] = project_box [[UNINIT_BOX]]
+  // CHECK:   [[DELEGATING_INIT_RESULT:%.*]] = apply {{%.*}}<Element>(
+  // CHECK:   assign [[DELEGATING_INIT_RESULT]] to [[PROJECT_UNINIT_BOX]]
+  // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT_UNINIT_BOX]]
+  // CHECK:   [[STRUCT_ACCESS:%.*]] = struct_element_addr [[ACCESS]]
+  // CHECK:   [[OPT_INPUT_ELEMENT:%.*]] = enum $Optional<Element>, #Optional.some!enumelt.1, [[INPUT_ELEMENT]]
+  // CHECK:   [[UNMANAGED_OPT_INPUT_ELEMENT:%.*]] = ref_to_unmanaged [[OPT_INPUT_ELEMENT]]
+  // CHECK:   store [[UNMANAGED_OPT_INPUT_ELEMENT]] to [trivial] [[STRUCT_ACCESS]]
+  // CHECK:   end_access [[ACCESS]]
+  // CHECK:   [[RESULT:%.*]] = load [trivial] [[PROJECT_UNINIT_BOX]]
+  // CHECK:   destroy_value [[UNINIT_BOX]]
+  // CHECK:   return [[RESULT]]
+  // CHECK: } // end sil function '$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC'
+  //
+  // CANONICAL-LABEL: sil [transparent] [serialized] @$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC : $@convention(method) <Element where Element : AnyObject> (@guaranteed Element, @thin UnsafeValue<Element>.Type) -> UnsafeValue<Element> {
+  // CANONICAL: bb0([[INPUT_ELEMENT:%.*]] : $Element,
+  // CANONICAL-NEXT: debug_value
+  // TODO(gottesmm): release_value on a .none shouldn't exist.
+  // CANONICAL-NEXT: [[NONE:%.*]] = enum $Optional<Element>, #Optional.none!enumelt
+  // CANONICAL-NEXT: release_value [[NONE]]
+  // CANONICAL-NEXT: [[ENUM:%.*]] = enum $Optional<Element>, #Optional.some!enumelt.1, [[INPUT_ELEMENT]]
+  // CANONICAL-NEXT: [[UNMANAGED_ENUM:%.*]] = ref_to_unmanaged [[ENUM]]
+  // CANONICAL-NEXT: [[RESULT:%.*]] = struct $UnsafeValue<Element> ([[UNMANAGED_ENUM]] : $@sil_unmanaged Optional<Element>)
+  // CANONICAL-NEXT: tuple
+  // CANONICAL-NEXT: return [[RESULT]]
+  // CANONICAL: } // end sil function '$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC'
+  //
+  // OPT-LABEL: sil [transparent] @$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC : $@convention(method) <Element where Element : AnyObject> (@guaranteed Element, @thin UnsafeValue<Element>.Type) -> UnsafeValue<Element> {
+  // OPT: bb0([[INPUT_ELEMENT:%.*]] : $Element,
+  // OPT-NEXT: debug_value
+  // OPT-NEXT: [[ENUM:%.*]] = enum $Optional<Element>, #Optional.some!enumelt.1, [[INPUT_ELEMENT]]
+  // OPT-NEXT: [[UNMANAGED_ENUM:%.*]] = ref_to_unmanaged [[ENUM]]
+  // OPT-NEXT: [[RESULT:%.*]] = struct $UnsafeValue<Element> ([[UNMANAGED_ENUM]] : $@sil_unmanaged Optional<Element>)
+  // OPT-NEXT: return [[RESULT]]
+  // OPT: } // end sil function '$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC'
+  @_transparent
+  @inlinable
+  public init(unsafelyAssign newValue: __shared Element) {
+    self.init()
+    Builtin.convertStrongToUnownedUnsafe(newValue, &_value)
+  }
+
+  // Access the underlying value at +0, guaranteeing its lifetime by base.
+  @_transparent
+  @inlinable
+  func withGuaranteeingBase<Base>(base: Base, f: (Element) -> ()) {
+    // TODO: Once we have a builtin for mark_dependence, fill this in.
+  }
+
+  // If the unmanaged value was initialized with a copy, release the underlying value.
+  //
+  // This will insert a release that can not be removed by the optimizer.
+  @_transparent
+  @inlinable
+  mutating func deinitialize() {
+    _value = nil
+  }
+
+  // Return a new strong reference to the unmanaged value.
+  //
+  // This will insert a retain that can not be removed by the optimizer!
+  @_transparent
+  @inlinable
+  public var strongRef: Element { _value.unsafelyUnwrapped }
+}


### PR DESCRIPTION
The signature is:

(T, @inout @unowned(unsafe) T) -> ()

The reason for the weird signature is that currently the Builtin infrastructure
does not handle guaranteed results well.

The semantics of this builtin is that it enables one to store the first argument
into an unowned unsafe address without any reference counting operations. It
does this just by SILGening the relevant code. The optimizer chews through this
code well, so we get the expected behavior.

I also included a small proof of concept to validate that this builtin works as
expected.
