### PR TITLE
Sema: Fix module interface printing of inherited generic initializers [5.2]

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -411,10 +411,8 @@ configureGenericDesignatedInitOverride(ASTContext &ctx,
       auto *gp = cast<GenericTypeParamType>(type);
       if (gp->getDepth() < superclassDepth)
         return Type(gp).subst(subMap);
-      return CanGenericTypeParamType::get(
-        gp->getDepth() - superclassDepth + depth,
-          gp->getIndex(),
-          ctx);
+      return genericParams->getParams()[gp->getIndex()]
+                 ->getDeclaredInterfaceType();
     };
 
     auto lookupConformanceFn =

--- a/test/ModuleInterface/inherited-generic-parameters.swift
+++ b/test/ModuleInterface/inherited-generic-parameters.swift
@@ -15,6 +15,10 @@
 public class Base<In, Out> {
 // CHECK-NEXT: public init(x: @escaping (In) -> Out)
   public init(x: @escaping (In) -> Out) {}
+
+// CHECK-NEXT: public init<A>(_: A, _: A)
+  public init<A>(_: A, _: A) {}
+
 // CHECK: }
 }
 
@@ -22,6 +26,7 @@ public class Base<In, Out> {
 public class Derived<T> : Base<T, T> {
 // CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: override public init(x: @escaping (T) -> T)
+// CHECK-NEXT: override public init<A>(_ argument: A, _ argument: A)
 // CHECK-NEXT: }
 }
 


### PR DESCRIPTION
Make sure we use the sugared form of GenericTypeParamType and not
the canonical type.

Fixes <rdar://problem/58578998>.
