### PR TITLE
Sema: Fix crash when property type references type alias with unsatisfied requirements [5.2]

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1461,10 +1461,6 @@ static Type resolveNestedIdentTypeComponent(
                                      inferredAssocType);
     }
 
-    // At this point, we need to have resolved the type of the member.
-    if (memberType->hasError())
-      return memberType;
-
     // If there are generic arguments, apply them now.
     return applyGenericArguments(memberType, resolution, comp, options);
   };

--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -222,3 +222,15 @@ let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{type 'Z2.T' (aka 'Y
 let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl4<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl5<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
+
+// rdar://problem/45271663
+protocol PP { associatedtype V }
+struct SS<PI : PP> {}
+enum EE<A, B> {}
+extension EE : PP where A : PP, B : PP { typealias V = EE<A.V, B.V> }
+
+protocol P2 { associatedtype U }
+func f<PI : PP & P2>(s: SS<PI>) -> SS<EE<PI.U, PI.U>> where PI.U : PP, PI.V : P2 {
+  let t: EE<PI.V.U, PI.V.U>.V
+  // expected-error@-1 {{type 'PI.V.U' does not conform to protocol 'PP'}}
+}


### PR DESCRIPTION
The fix for <https://bugs.swift.org/browse/SR-10466> did not handle
properties because those types are resolved using the archetype
resolver.

We would bail out early because of a bogus early return that can
just be removed.

Fixes <rdar://problem/45271663>.