### PR TITLE
AST: Fix computeSelfParam() to respect __consuming on class methods [5.2]

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2402,7 +2402,8 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
     if (isInitializingCtor) {
       // initializing constructors of value types always have an implicitly
       // inout self.
-      selfAccess = SelfAccessKind::Mutating;
+      if (!containerTy->hasReferenceSemantics())
+        selfAccess = SelfAccessKind::Mutating;
     } else {
       // allocating constructors have metatype 'self'.
       isStatic = true;
@@ -2429,10 +2430,6 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
   // 'static' functions have 'self' of type metatype<T>.
   if (isStatic)
     return AnyFunctionType::Param(MetatypeType::get(selfTy, Ctx));
-
-  // Reference types have 'self' of type T.
-  if (containerTy->hasReferenceSemantics())
-    return AnyFunctionType::Param(selfTy);
 
   auto flags = ParameterTypeFlags();
   switch (selfAccess) {

--- a/test/SILGen/value_ownership_class.swift
+++ b/test/SILGen/value_ownership_class.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+class ConsumingClass {
+  __consuming func consumingMethod() {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s21value_ownership_class14ConsumingClassC15consumingMethodyyF : $@convention(method) (@owned ConsumingClass) -> () {

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -101,9 +101,10 @@ struct DoesNotConform : Up {
 
 // Circular protocols
 
-protocol CircleMiddle : CircleStart { func circle_middle() } // expected-error 3 {{protocol 'CircleMiddle' refines itself}}
-protocol CircleStart : CircleEnd { func circle_start() }
-// expected-note@-1 3 {{protocol 'CircleStart' declared here}}
+protocol CircleMiddle : CircleStart { func circle_middle() } // expected-error 2 {{protocol 'CircleMiddle' refines itself}}
+// expected-note@-1 {{protocol 'CircleMiddle' declared here}}
+protocol CircleStart : CircleEnd { func circle_start() } // expected-error {{protocol 'CircleStart' refines itself}}
+// expected-note@-1 2 {{protocol 'CircleStart' declared here}}
 protocol CircleEnd : CircleMiddle { func circle_end()} // expected-note 3 {{protocol 'CircleEnd' declared here}}
 
 protocol CircleEntry : CircleTrivial { }


### PR DESCRIPTION
Fixes <rdar://problem/58887618>.