### PR TITLE
[AutoDiff] Support non-active `switch_enum_addr` differentiation.

### DIFF
--- a/include/swift/SILOptimizer/Utils/Differentiation/VJPEmitter.h
+++ b/include/swift/SILOptimizer/Utils/Differentiation/VJPEmitter.h
@@ -135,7 +135,11 @@ public:
 
   void visitCondBranchInst(CondBranchInst *cbi);
 
+  void visitSwitchEnumInstBase(SwitchEnumInstBase *inst);
+
   void visitSwitchEnumInst(SwitchEnumInst *sei);
+
+  void visitSwitchEnumAddrInst(SwitchEnumAddrInst *seai);
 
   // If an `apply` has active results or active inout arguments, replace it
   // with an `apply` of its VJP.

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -162,9 +162,10 @@ static bool diagnoseUnsupportedControlFlow(ADContext &context,
   // Diagnose unsupported branching terminators.
   for (auto &bb : *original) {
     auto *term = bb.getTerminator();
-    // Supported terminators are: `br`, `cond_br`, `switch_enum`.
+    // Supported terminators are: `br`, `cond_br`, `switch_enum`,
+    // `switch_enum_addr`.
     if (isa<BranchInst>(term) || isa<CondBranchInst>(term) ||
-        isa<SwitchEnumInst>(term))
+        isa<SwitchEnumInst>(term) || isa<SwitchEnumAddrInst>(term))
       continue;
     // If terminator is an unsupported branching terminator, emit an error.
     if (term->isBranch()) {

--- a/test/AutoDiff/downstream/activity_analysis.swift
+++ b/test/AutoDiff/downstream/activity_analysis.swift
@@ -568,3 +568,100 @@ func testBeginApplyActiveButInitiallyNonactiveInoutArgument(x: Float) -> Float {
 // CHECK: [NONE]   // function_ref Array.subscript.getter
 // CHECK: [NONE]   %34 = apply %33<Float>(%32, %29, %31) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
 // CHECK: [ACTIVE]   %35 = load [trivial] %32 : $*Float
+
+//===----------------------------------------------------------------------===//
+// Enum differentiation
+//===----------------------------------------------------------------------===//
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable
+// expected-note @+1 {{when differentiating this function definition}}
+func testActiveOptional(_ x: Float) -> Float {
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
+  var maybe: Float? = 10
+  maybe = x
+  return maybe!
+}
+
+// CHECK-LABEL: [AD] Activity info for $s17activity_analysis12testOptionalyS2fF at (source=0 parameters=(0))
+// CHECK: bb0:
+// CHECK: [ACTIVE] %0 = argument of bb0 : $Float
+// CHECK: [ACTIVE]   %2 = alloc_stack $Optional<Float>, var, name "maybe"
+// CHECK: [USEFUL]   %3 = integer_literal $Builtin.IntLiteral, 10
+// CHECK: [USEFUL]   %4 = metatype $@thin Float.Type
+// CHECK: [NONE]   // function_ref Float.init(_builtinIntegerLiteral:)
+// CHECK: [USEFUL]   %6 = apply %5(%3, %4) : $@convention(method) (Builtin.IntLiteral, @thin Float.Type) -> Float
+// CHECK: [USEFUL]   %7 = enum $Optional<Float>, #Optional.some!enumelt.1, %6 : $Float
+// CHECK: [ACTIVE]   %9 = enum $Optional<Float>, #Optional.some!enumelt.1, %0 : $Float
+// CHECK: [ACTIVE]   %10 = begin_access [modify] [static] %2 : $*Optional<Float>
+// CHECK: [ACTIVE]   %13 = begin_access [read] [static] %2 : $*Optional<Float>
+// CHECK: [ACTIVE]   %14 = load [trivial] %13 : $*Optional<Float>
+// CHECK: bb1:
+// CHECK: [NONE]   %18 = integer_literal $Builtin.Word, 85
+// CHECK: [NONE]   %19 = integer_literal $Builtin.Int1, -1
+// CHECK: [NONE]   %20 = integer_literal $Builtin.Word, 537
+// CHECK: [NONE]   %21 = integer_literal $Builtin.Word, 15
+// CHECK: [NONE]   %22 = integer_literal $Builtin.Int1, 0
+// CHECK: [NONE]   // function_ref _diagnoseUnexpectedNilOptional(_filenameStart:_filenameLength:_filenameIsASCII:_line:_isImplicitUnwrap:)
+// CHECK: [NONE]   %24 = apply %23(%17, %18, %19, %20, %22) : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Int1) -> ()
+// CHECK: bb2:
+// CHECK: [ACTIVE] %26 = argument of bb2 : $Float
+
+enum DirectEnum: Differentiable & AdditiveArithmetic {
+  case leaf(Float)
+
+  typealias TangentVector = Self
+
+  static var zero: Self { fatalError() }
+  static func +(_ lhs: Self, _ rhs: Self) -> Self { fatalError() }
+  static func -(_ lhs: Self, _ rhs: Self) -> Self { fatalError() }
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: e)
+// expected-note @+2 {{when differentiating this function definition}}
+// expected-note @+1 {{differentiating enum values is not yet supported}}
+func testActiveEnumValue(_ e: DirectEnum, _ x: Float) -> Float {
+  switch e {
+  case let .leaf(y): return y
+  }
+}
+
+// CHECK-LABEL: [AD] Activity info for ${{.*}}testActiveEnumValue{{.*}} at (source=0 parameters=(0))
+// CHECK: bb0:
+// CHECK: [ACTIVE] %0 = argument of bb0 : $DirectEnum
+// CHECK: [NONE] %1 = argument of bb0 : $Float
+// CHECK: bb1:
+// CHECK: [ACTIVE] %5 = argument of bb1 : $Float
+
+enum IndirectEnum<T: Differentiable>: Differentiable & AdditiveArithmetic {
+  case leaf(T)
+
+  typealias TangentVector = Self
+
+  static func ==(_ lhs: Self, _ rhs: Self) -> Bool { fatalError() }
+  static var zero: Self { fatalError() }
+  static func +(_ lhs: Self, _ rhs: Self) -> Self { fatalError() }
+  static func -(_ lhs: Self, _ rhs: Self) -> Self { fatalError() }
+}
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(wrt: e)
+// expected-note @+2 {{when differentiating this function definition}}
+// expected-note @+1 {{differentiating enum values is not yet supported}}
+func testActiveEnumAddr<T>(_ e: IndirectEnum<T>, _ x: Float) -> T {
+  switch e {
+  case let .leaf(y): return y
+  }
+}
+
+// CHECK-LABEL: [AD] Activity info for ${{.*}}testActiveEnumAddr{{.*}} at (source=0 parameters=(0))
+// CHECK: bb0:
+// CHECK: [ACTIVE] %0 = argument of bb0 : $*T
+// CHECK: [ACTIVE] %1 = argument of bb0 : $*IndirectEnum<T>
+// CHECK: [NONE] %2 = argument of bb0 : $Float
+// CHECK: [ACTIVE]   %5 = alloc_stack $IndirectEnum<T>
+// CHECK: bb1:
+// CHECK: [ACTIVE]   %8 = unchecked_take_enum_data_addr %5 : $*IndirectEnum<T>, #IndirectEnum.leaf!enumelt.1
+// CHECK: [ACTIVE]   %9 = alloc_stack $T, let, name "y"
+// CHECK: [NONE]   %15 = tuple ()

--- a/test/AutoDiff/downstream/control_flow_sil.swift
+++ b/test/AutoDiff/downstream/control_flow_sil.swift
@@ -43,7 +43,6 @@ func cond(_ x: Float) -> Float {
 // CHECK-DATA-STRUCTURES:   case bb1(_AD__cond_bb1__PB__src_0_wrt_0)
 // CHECK-DATA-STRUCTURES: }
 
-
 // CHECK-SIL-LABEL: sil hidden [ossa] @AD__cond__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK-SIL: bb0([[INPUT_ARG:%.*]] : $Float):
 // CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__cond_bb0__PB__src_0_wrt_0 ()
@@ -154,43 +153,19 @@ func enum_notactive(_ e: Enum, _ x: Float) -> Float {
   }
 }
 
-// ECK-SIL-LABEL: sil hidden [ossa] @AD__cond__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
-// ECK-SIL: bb0([[INPUT_ARG:%.*]] : $Float):
-// ECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__cond_bb0__PB__src_0_wrt_0 ()
-// ECK-SIL:   cond_br {{%.*}}, bb1, bb2
-
-// ECK-SIL: bb1:
-// ECK-SIL:   [[BB1_PRED:%.*]] = enum $_AD__cond_bb1__Pred__src_0_wrt_0, #_AD__cond_bb1__Pred__src_0_wrt_0.bb0!enumelt.1, [[BB0_PB_STRUCT]]
-// ECK-SIL:   [[BB1_PB_STRUCT:%.*]] = struct $_AD__cond_bb1__PB__src_0_wrt_0
-// ECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__cond_bb3__Pred__src_0_wrt_0, #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt.1, [[BB1_PB_STRUCT]]
-// ECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED1]] : $_AD__cond_bb3__Pred__src_0_wrt_0)
-
-// ECK-SIL: bb2:
-// ECK-SIL:   [[BB2_PRED:%.*]] = enum $_AD__cond_bb2__Pred__src_0_wrt_0, #_AD__cond_bb2__Pred__src_0_wrt_0.bb0!enumelt.1, [[BB0_PB_STRUCT]]
-// ECK-SIL:   [[BB2_PB_STRUCT:%.*]] = struct $_AD__cond_bb2__PB__src_0_wrt_0
-// ECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__cond_bb3__Pred__src_0_wrt_0, #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt.1, [[BB2_PB_STRUCT]]
-// ECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED2]] : $_AD__cond_bb3__Pred__src_0_wrt_0)
-
-// ECK-SIL: bb3([[ORIG_RES:%.*]] : $Float, [[BB3_PRED_ARG:%.*]] : @owned $_AD__cond_bb3__Pred__src_0_wrt_0)
-// ECK-SIL:   [[BB3_PB_STRUCT:%.*]] = struct $_AD__cond_bb3__PB__src_0_wrt_0
-// ECK-SIL:   [[PULLBACK_REF:%.*]] = function_ref @AD__cond__pullback_src_0_wrt_0
-// ECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PULLBACK_REF]]([[BB3_PB_STRUCT]])
-// ECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
-// ECK-SIL:   return [[VJP_RESULT]]
-
 // CHECK-SIL-LABEL: sil hidden [ossa] @AD__enum_notactive__vjp_src_0_wrt_1 : $@convention(thin) (Enum, Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK-SIL: bb0([[ENUM_ARG:%.*]] : $Enum, [[X_ARG:%.*]] : $Float):
 // CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb0__PB__src_0_wrt_1 ()
 // CHECK-SIL:   switch_enum [[ENUM_ARG]] : $Enum, case #Enum.a!enumelt.1: bb1, case #Enum.b!enumelt.1: bb2
 
 // CHECK-SIL: bb1([[ENUM_A:%.*]] : $Float):
-// CHECK-SIL:   [[BB1_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb1__Pred__src_0_wrt_1, #_AD__enum_notactive_bb1__Pred__src_0_wrt_1.bb0!enumelt.1, %4 : $_AD__enum_notactive_bb0__PB__src_0_wrt_1
+// CHECK-SIL:   [[BB1_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb1__Pred__src_0_wrt_1, #_AD__enum_notactive_bb1__Pred__src_0_wrt_1.bb0!enumelt.1, [[BB0_PB_STRUCT]] : $_AD__enum_notactive_bb0__PB__src_0_wrt_1
 // CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb1__PB__src_0_wrt_1 ({{.*}})
 // CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__enum_notactive_bb3__Pred__src_0_wrt_1, #_AD__enum_notactive_bb3__Pred__src_0_wrt_1.bb1!enumelt.1, [[BB1_PB_STRUCT]] : $_AD__enum_notactive_bb1__PB__src_0_wrt_1
 // CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED1]] : $_AD__enum_notactive_bb3__Pred__src_0_wrt_1)
 
 // CHECK-SIL: bb2([[ENUM_B:%.*]] : $(Float, Float)):
-// CHECK-SIL:   [[BB2_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb2__Pred__src_0_wrt_1, #_AD__enum_notactive_bb2__Pred__src_0_wrt_1.bb0!enumelt.1, %4 : $_AD__enum_notactive_bb0__PB__src_0_wrt_1
+// CHECK-SIL:   [[BB2_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb2__Pred__src_0_wrt_1, #_AD__enum_notactive_bb2__Pred__src_0_wrt_1.bb0!enumelt.1, [[BB0_PB_STRUCT]] : $_AD__enum_notactive_bb0__PB__src_0_wrt_1
 // CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb2__PB__src_0_wrt_1 ({{.*}})
 // CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__enum_notactive_bb3__Pred__src_0_wrt_1, #_AD__enum_notactive_bb3__Pred__src_0_wrt_1.bb2!enumelt.1, [[BB2_PB_STRUCT]] : $_AD__enum_notactive_bb2__PB__src_0_wrt_1
 // CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED2]] : $_AD__enum_notactive_bb3__Pred__src_0_wrt_1)
@@ -201,6 +176,55 @@ func enum_notactive(_ e: Enum, _ x: Float) -> Float {
 // CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PULLBACK_REF]]([[BB3_PB_STRUCT]])
 // CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   return [[VJP_RESULT]]
+// CHECK-SIL: }
+
+// Test `switch_enum_addr`.
+
+// Clone of `enum Optional<Wrapped>`.
+enum AddressOnlyEnum<T> {
+  case some(T)
+  case none
+}
+@differentiable
+@_silgen_name("enum_addr_notactive")
+func enum_addr_notactive<T>(_ e: AddressOnlyEnum<T>, _ x: Float) -> Float {
+  switch e {
+  case .none: break
+  case .some: break
+  }
+  return x
+}
+
+// CHECK-SIL-LABEL: sil hidden [ossa] @AD__enum_addr_notactive__vjp_src_0_wrt_1_l : $@convention(thin) <τ_0_0> (@in_guaranteed AddressOnlyEnum<τ_0_0>, Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK-SIL: bb0([[ENUM_ARG:%.*]] : $*AddressOnlyEnum<τ_0_0>, [[X_ARG:%.*]] : $Float):
+// CHECK-SIL:   [[ENUM_ADDR:%.*]] = alloc_stack $AddressOnlyEnum<τ_0_0>
+// CHECK-SIL:   copy_addr [[ENUM_ARG]] to [initialization] [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
+// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1<τ_0_0> ()
+// CHECK-SIL:   switch_enum_addr [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>, case #AddressOnlyEnum.none!enumelt: bb1, case #AddressOnlyEnum.some!enumelt.1: bb2
+
+// CHECK-SIL: bb1:
+// CHECK-SIL:   [[BB1_PRED_PRED0:%.*]] = enum $_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1<τ_0_0>, #_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1.bb0!enumelt.1, [[BB0_PB_STRUCT]] : $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1<τ_0_0>
+// CHECK-SIL:   dealloc_stack [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
+// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb1__PB__src_0_wrt_1<τ_0_0> ([[BB1_PRED_PRED0]] : $_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1<τ_0_0>)
+// CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1<τ_0_0>, #_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1.bb1!enumelt.1, [[BB1_PB_STRUCT]] : $_AD__enum_addr_notactive_bb1__PB__src_0_wrt_1<τ_0_0>
+// CHECK-SIL:   br bb3([[BB3_PRED_PRED1]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1<τ_0_0>)
+
+// CHECK-SIL: bb2:
+// CHECK-SIL:   [[BB2_PRED_PRED0:%.*]] = enum $_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1<τ_0_0>, #_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1.bb0!enumelt.1, [[BB0_PB_STRUCT]] : $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1<τ_0_0>
+// CHECK-SIL:   [[ENUM_DATA:%.*]] = unchecked_take_enum_data_addr [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>, #AddressOnlyEnum.some!enumelt.1
+// CHECK-SIL:   destroy_addr [[ENUM_DATA]] : $*τ_0_0
+// CHECK-SIL:   dealloc_stack [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
+// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb2__PB__src_0_wrt_1<τ_0_0> ([[BB2_PRED_PRED0]] : $_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1<τ_0_0>)
+// CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1<τ_0_0>, #_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1.bb2!enumelt.1, [[BB2_PB_STRUCT]] : $_AD__enum_addr_notactive_bb2__PB__src_0_wrt_1<τ_0_0>
+// CHECK-SIL:   br bb3([[BB3_PRED_PRED2]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1<τ_0_0>)
+
+// CHECK-SIL: bb3([[BB3_PRED_ARG:%.*]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1<τ_0_0>):
+// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb3__PB__src_0_wrt_1<τ_0_0> ([[BB3_PRED_ARG]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1<τ_0_0>)
+
+// CHECK-SIL:   [[PB_FNREF:%.*]] = function_ref @AD__enum_addr_notactive__pullback_src_0_wrt_1_l : $@convention(thin) <τ_0_0> (Float, @owned _AD__enum_addr_notactive_bb3__PB__src_0_wrt_1<τ_0_0>) -> Float
+// CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PB_FNREF]]<τ_0_0>([[BB3_PB_STRUCT]]) : $@convention(thin) <τ_0_0> (Float, @owned _AD__enum_addr_notactive_bb3__PB__src_0_wrt_1<τ_0_0>) -> Float
+// CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[X_ARG]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
+// CHECK-SIL:   return [[VJP_RESULT]] : $(Float, @callee_guaranteed (Float) -> Float)
 // CHECK-SIL: }
 
 // Test control flow + tuple buffer.


### PR DESCRIPTION
Support differentiation of `switch_enum_addr` with a non-active argument.

- VJP generation: transform `switch_enum_addr` just like `switch_enum`.
- Pullback generation: no special support currently necessary.
  Generic code handles all terminators.

Resolves TF-1132.

---

```swift
enum Indirect<T> {
  case some(T)
}

@differentiable
func foo<T>(_ x: Float, _ e: Indirect<T>) -> Float {
  switch e {
  case .some: return x * x
  }
}

let e = Indirect.some(true)
print(valueWithGradient(at: 3, in: { foo($0, e) }))
```

Before:
```console
$ swift tf-1132.swift
enum.swift:5:2: error: function is not differentiable
@differentiable
~^~~~~~~~~~~~~~
enum.swift:6:6: note: when differentiating this function definition
func foo<T>(_ x: Float, _ e: Indirect<T>) -> Float {
     ^
enum.swift:7:3: note: cannot differentiate unsupported control flow
  switch e {
  ^
```

After:
```console
$ swift tf-1132.swift
(value: 9.0, gradient: 6.0)
```