### PR TITLE
Driver: add a flag that compatibility header should only contain public symbols

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -85,6 +85,9 @@ public:
   /// The module for which we should verify all of the generic signatures.
   std::string VerifyGenericSignaturesInModule;
 
+  /// We should only include public symbols in the objc compatibility header.
+  bool ObjcCompatibilityHeaderIsPublic = false;
+
   enum class ActionType {
     NoneAction,        ///< No specific action
     Parse,             ///< Parse only

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -443,6 +443,9 @@ def emit_parseable_module_interface_path :
 def emit_objc_header : Flag<["-"], "emit-objc-header">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit an Objective-C header file">;
+def objc_header_is_public : Flag<["-"], "objc-header-is-public">,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Objective-C header file will be used as public APIs">;
 def emit_objc_header_path : Separate<["-"], "emit-objc-header-path">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
          ArgumentIsPath]>,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -254,6 +254,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_disable_parser_lookup);
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_concise_pound_file);
+  inputArgs.AddLastArg(arguments, options::OPT_objc_header_is_public);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -82,7 +82,7 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.SerializeModuleInterfaceDependencyHashes |=
     Args.hasArg(OPT_serialize_module_interface_dependency_hashes);
-
+  Opts.ObjcCompatibilityHeaderIsPublic |= Args.hasArg(OPT_objc_header_is_public);
   Opts.RemarkOnRebuildFromModuleInterface |=
     Args.hasArg(OPT_Rmodule_interface_rebuild);
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1308,10 +1308,10 @@ static bool performCompile(CompilerInstance &Instance,
 
   // FIXME: This is still a lousy approximation of whether the module file will
   // be externally consumed.
-  bool moduleIsPublic =
-      !Instance.getMainModule()->hasEntryPoint() &&
+  bool moduleIsPublic = opts.ObjcCompatibilityHeaderIsPublic ||
+      (!Instance.getMainModule()->hasEntryPoint() &&
       opts.ImplicitObjCHeaderPath.empty() &&
-      !Context.LangOpts.EnableAppExtensionRestrictions;
+      !Context.LangOpts.EnableAppExtensionRestrictions);
 
   // We've just been told to perform a typecheck, so we can return now.
   if (Action == FrontendOptions::ActionType::Typecheck) {

--- a/test/PrintAsObjC/public-symbols-only.swift
+++ b/test/PrintAsObjC/public-symbols-only.swift
@@ -1,0 +1,14 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %s -module-name PublicSymbols
+// RUN: %target-swift-frontend -parse-as-library %t/PublicSymbols.swiftmodule -typecheck -emit-objc-header-path %t/result.h -import-objc-header %S/../Inputs/empty.h -objc-header-is-public
+// RUN: %FileCheck %s < %t/result.h
+
+import Foundation
+
+// CHECK: @protocol A
+@objc public protocol A {}
+
+// CHECK-NOT: @protocol B
+@objc protocol B {}


### PR DESCRIPTION
The build system should specify this flag if the ObjC compatibility
header is a part of the public API, so the Swift compiler doesn't print
internal symbols in it.

rdar://59166862