### PR TITLE
SILGen: Fix crash with function conversions involving class-constrained protocols [5.2]

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -569,7 +569,7 @@ ManagedValue Transform::transform(ManagedValue v,
       instanceType = metatypeType.getInstanceType();
 
     auto layout = instanceType.getExistentialLayout();
-    if (layout.explicitSuperclass) {
+    if (layout.getSuperclass()) {
       CanType openedType = OpenedArchetypeType::getAny(inputSubstType);
       SILType loweredOpenedType = SGF.getLoweredType(openedType);
 

--- a/test/SILGen/protocol_with_superclass.swift
+++ b/test/SILGen/protocol_with_superclass.swift
@@ -269,6 +269,25 @@ func passesRefinedProtocol(_ r: RefinedProto) {
 // CHECK-NEXT:  [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT:  return [[RESULT]] : $()
 
+func takesFuncTakingRefinedProto(arg: (RefinedProto) -> ()) {}
+
+func passesFuncTakingBaseClass() {
+  let closure: (BaseClass) -> () = { _ in }
+  takesFuncTakingRefinedProto(arg: closure)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s24protocol_with_superclass25passesFuncTakingBaseClassyyF : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] [ossa] @$s24protocol_with_superclass9BaseClassCIegg_AA12RefinedProto_pIegg_TR : $@convention(thin) (@guaranteed RefinedProto, @guaranteed @callee_guaranteed (@guaranteed BaseClass) -> ()) -> ()
+// CHECK: [[PAYLOAD:%.*]] = open_existential_ref %0 : $RefinedProto to $@opened("{{.*}}") RefinedProto
+// CHECK: [[COPY:%.*]] = copy_value [[PAYLOAD]]
+// CHECK: [[UPCAST:%.*]] = upcast [[COPY]] : $@opened("{{.*}}") RefinedProto to $BaseClass
+// CHECK: [[BORROW:%.*]] = begin_borrow [[UPCAST]]
+// CHECK: apply %1([[BORROW]])
+// CHECK: end_borrow [[BORROW]]
+// CHECK: destroy_value [[UPCAST]]
+// CHECK: return
+
 // CHECK-LABEL: sil_witness_table hidden ConformsToSillyDefault: SillyDefault module protocol_with_superclass {
 // CHECK-NEXT: method #SillyDefault.makeT!1: <Self where Self : SillyDefault> (Self) -> () -> Int : @$s24protocol_with_superclass22ConformsToSillyDefaultCAA0fG0A2aDP5makeTSiyFTW
 // CHECK-NEXT: }

--- a/test/SILGen/protocol_with_superclass_where_clause.swift
+++ b/test/SILGen/protocol_with_superclass_where_clause.swift
@@ -269,6 +269,25 @@ func passesRefinedProtocol(_ r: RefinedProto) {
 // CHECK-NEXT:  [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT:  return [[RESULT]] : $()
 
+func takesFuncTakingRefinedProto(arg: (RefinedProto) -> ()) {}
+
+func passesFuncTakingBaseClass() {
+  let closure: (BaseClass) -> () = { _ in }
+  takesFuncTakingRefinedProto(arg: closure)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s24protocol_with_superclass25passesFuncTakingBaseClassyyF : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] [ossa] @$s24protocol_with_superclass9BaseClassCIegg_AA12RefinedProto_pIegg_TR : $@convention(thin) (@guaranteed RefinedProto, @guaranteed @callee_guaranteed (@guaranteed BaseClass) -> ()) -> ()
+// CHECK: [[PAYLOAD:%.*]] = open_existential_ref %0 : $RefinedProto to $@opened("{{.*}}") RefinedProto
+// CHECK: [[COPY:%.*]] = copy_value [[PAYLOAD]]
+// CHECK: [[UPCAST:%.*]] = upcast [[COPY]] : $@opened("{{.*}}") RefinedProto to $BaseClass
+// CHECK: [[BORROW:%.*]] = begin_borrow [[UPCAST]]
+// CHECK: apply %1([[BORROW]])
+// CHECK: end_borrow [[BORROW]]
+// CHECK: destroy_value [[UPCAST]]
+// CHECK: return
+
 // CHECK-LABEL: sil_witness_table hidden ConformsToSillyDefault: SillyDefault module protocol_with_superclass {
 // CHECK-NEXT: method #SillyDefault.makeT!1: <Self where Self : SillyDefault> (Self) -> () -> Int : @$s24protocol_with_superclass22ConformsToSillyDefaultCAA0fG0A2aDP5makeTSiyFTW
 // CHECK-NEXT: }


### PR DESCRIPTION
If a protocol has a superclass constraint, the existential type can be
upcast to the class type given by the constraint. This wasn't implemented
in the function conversion code path, leading to a crash.

Fixes <https://bugs.swift.org/browse/SR-12018> / <rdar://problem/58861162>.
