### PR TITLE
[Python: flake8] Update the utils/python_lint.py script to fail with a non-zero exit code if flake8 and flake8-import-order are not installed (5.2 branch).

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 
 import sys
 from datetime import date
+
 from sphinx.highlighting import lexers
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1133,16 +1133,6 @@ def execute_template(
 
 
 def main():
-    """
-    Lint this file.
-    >>> import sys
-    >>> gyb_path = os.path.realpath(__file__).replace('.pyc', '.py')
-    >>> sys.path.append(os.path.dirname(gyb_path))
-    >>> import python_lint
-    >>> python_lint.lint([gyb_path], verbose=False)
-    0
-    """
-
     import argparse
     import sys
 

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -659,10 +659,6 @@ def run():
     >>> raw_output.close()
     >>> os.remove(raw_output.name)
 
-    Lint this file.
-    >>> import python_lint
-    >>> python_lint.lint([os.path.realpath(__file__)], verbose=False)
-    0
     """
     if len(sys.argv) <= 1:
         import doctest

--- a/utils/python_lint.py
+++ b/utils/python_lint.py
@@ -84,7 +84,7 @@ def lint(args, verbose=False):
         if verbose:
             print(_INSTALL_FLAKE8_MESSAGE)
 
-        return 0
+        return 1
 
     return subprocess.call(
         [sys.executable, '-m', 'flake8'] + args,

--- a/utils/python_lint.py
+++ b/utils/python_lint.py
@@ -1,29 +1,45 @@
 #!/usr/bin/env python
-# python_lint.py - Runs flake8 linting over the repository ------*- python -*-
-#
+
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 
-from __future__ import print_function
+
+"""
+Utility script used to run the flake8 linter over all the project Python
+sources.
+"""
+
+
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import subprocess
 import sys
 
 
-def lint(arguments, verbose=True):
-    flake8_result = subprocess.call(
-        [sys.executable, "-c", "import flake8; import flake8_import_order"]
-    )
-    if flake8_result != 0:
-        if verbose:
-            print("""
+__all__ = [
+    'lint',
+]
+
+
+# -----------------------------------------------------------------------------
+# Constants
+
+_UTILS_DIR = os.path.abspath(os.path.dirname(__file__))
+_PROJECT_DIR = os.path.dirname(_UTILS_DIR)
+
+_REQUIRED_PACKAGES = [
+    'flake8',
+    'flake8-import-order',
+]
+
+_INSTALL_FLAKE8_MESSAGE = """
 The flake8 and flake8-import-order Python packages are required for linting,
 but these were not found on your system.
 
@@ -32,25 +48,49 @@ You can install these using:
     python -m pip install flake8
     python -m pip install flake8-import-order
 
-For more help, see http://flake8.pycqa.org.""")
+For more help, see http://flake8.pycqa.org.
+"""
 
-        # We should be returning `flake8_result` from here.  However,
-        # some Python files lint themselves using embedded doctests,
-        # which causes CI smoke tests to fail because the Linux nodes
-        # do not have these modules installed.
+
+# -----------------------------------------------------------------------------
+# Helpers
+
+def _is_package_installed(name):
+    """Runs the pip command to check if a package is installed.
+    """
+
+    command = [
+        sys.executable,
+        '-m', 'pip',
+        'show', '--quiet',
+        name,
+    ]
+
+    with open(os.devnull, 'w') as devnull:
+        status = subprocess.call(command, stderr=devnull)
+
+    return not status
+
+
+# -----------------------------------------------------------------------------
+
+def lint(args, verbose=False):
+    all_packages_installed = all([
+        _is_package_installed(name)
+        for name in _REQUIRED_PACKAGES
+    ])
+
+    if not all_packages_installed:
+        if verbose:
+            print(_INSTALL_FLAKE8_MESSAGE)
 
         return 0
 
-    utils_directory = os.path.dirname(os.path.abspath(__file__))
-    parent_directory = os.path.dirname(utils_directory)
-    linting_result = subprocess.call(
-        [sys.executable, "-m", "flake8"] + arguments,
-        cwd=parent_directory,
-        universal_newlines=True
-    )
-    return linting_result
+    return subprocess.call(
+        [sys.executable, '-m', 'flake8'] + args,
+        cwd=_PROJECT_DIR,
+        universal_newlines=True)
 
 
 if __name__ == '__main__':
-    linting_result = lint(sys.argv[1:])
-    sys.exit(linting_result)
+    sys.exit(lint(sys.argv[1:], verbose=True))

--- a/validation-test/Python/python-lint.swift
+++ b/validation-test/Python/python-lint.swift
@@ -1,6 +1,0 @@
-// RUN: %{python} %utils/python_lint.py
-// Continuous integration for the OS X Platform also runs the tests in the iPhone, Apple TV and Apple Watch simulators.
-// We only need to run python linting once per OSX Platform test run, rather than once for each supported Apple device.
-// UNSUPPORTED: OS=watchos
-// UNSUPPORTED: OS=ios
-// UNSUPPORTED: OS=tvos

--- a/validation-test/Python/python_lint.swift
+++ b/validation-test/Python/python_lint.swift
@@ -1,0 +1,8 @@
+// Continuous integration for the OS X Platform also runs the tests in the
+// iPhone, Apple TV and Apple Watch simulators. We only need to run the
+// Python lint once per OSX Platform test run, rather than once for each
+// supported Apple device.
+
+// REQUIRES: OS=macosx
+
+// RUN: %{python} %utils/python_lint.py


### PR DESCRIPTION
This PR cherry-picks the changes from #29309 and #29613 to the 5.2 branch, which should fix the now failing `validation-test/Python/line-directive.swift` and `validation-test/Python/gyb.swift` tests that started failing once `flake8` was installed on more nodes.

I also needed to update the `docs/conf.py` script so the Python linter wouldn't fail.