### PR TITLE
[ConstraintSystem] Favor resolving closures over any disjunction bind…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -246,7 +246,14 @@ bool ConstraintSystem::PotentialBindings::favoredOverDisjunction(
     // if it's something like a collection (where it has to pick
     // between a conversion and bridging conversion) or concrete
     // type let's prefer the disjunction.
-    return boundType->is<TypeVariableType>();
+    //
+    // We are looking through optionals here because it could be
+    // a situation where disjunction is formed to match optionals
+    // either as deep equality or optional-to-optional conversion.
+    // Such type variables might be connected to closure as well
+    // e.g. when result type is optional, so it makes sense to
+    // open closure before attempting such disjunction.
+    return boundType->lookThroughAllOptionalTypes()->is<TypeVariableType>();
   }
 
   return !InvolvesTypeVariables;

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -953,3 +953,21 @@ class Foo<State: StateType> {
 func test_explicit_variadic_is_interpreted_correctly() {
   _ = { (T: String...) -> String in T[0] + "" } // Ok
 }
+
+// rdar://problem/59208419 - closure result type is incorrectly inferred to be a supertype
+func test_correct_inference_of_closure_result_in_presence_of_optionals() {
+  class A {}
+  class B : A {}
+
+  func foo(_: B) -> Int? { return 42 }
+
+  func bar<T: A>(_: (A) -> T?) -> T? {
+    return .none
+  }
+
+  guard let v = bar({ $0 as? B }),
+        let _ = foo(v) // Ok, v is inferred as `B`
+  else {
+    return;
+  }
+}


### PR DESCRIPTION
…ing type variables

Fix a case where favoring didn't account for "bound" type variable
being wrapped into optional(s) (disjunctions like that are used for
optional conversions). Doing so makes sure that closure result type
is not bound before the body of the closure is "opened", that's
important because body could provide additional context required
to bind result type e.g. `{ $0 as? <Type> }`.

Resolve: rdar://problem/59208419

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
