### PR TITLE
[SourceKit] Fix cursorinfo key.modulename with sourceinfo

### DIFF
--- a/test/SourceKit/CursorInfo/use-swift-source-info.swift
+++ b/test/SourceKit/CursorInfo/use-swift-source-info.swift
@@ -23,7 +23,7 @@ func bar() {
 // WITH: source.lang.swift.ref.function.free ({{.*}}/Foo.swift:2:13-2:16)
 // WITHOUT: source.lang.swift.ref.function.free ()
 // BOTH: foo()
-// BOTH: s:3Foo3fooyyF
-// BOTH: () -> ()
-// BOTH: $syycD
-// BOTH: Foo
+// BOTH-NEXT: s:3Foo3fooyyF
+// BOTH-NEXT: () -> ()
+// BOTH-NEXT: $syycD
+// BOTH-NEXT: Foo

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -915,7 +915,7 @@ static bool passCursorInfoForDecl(SourceFile* SF,
     auto ClangMod = Importer->getClangOwningModule(ClangNode);
     if (ClangMod)
       ModuleName = ClangMod->getFullModuleName();
-  } else if (VD->getLoc().isInvalid() && VD->getModuleContext() != MainModule) {
+  } else if (VD->getModuleContext() != MainModule) {
     ModuleName = VD->getModuleContext()->getName().str();
   }
   StringRef ModuleInterfaceName;


### PR DESCRIPTION
In Swift 5.2, the CursorInfo `key.modulename` is broken when swift-source-info is enabled in SourceKit.

Turns out the test written for this scenario had a typo making it accidentally pass.  Quick fix to both here; fixed test fails without the code-change, all tests pass with it.

@nathawes could you take a look please?