### PR TITLE
Cherry pick autocomplete fixes to tensorflow

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -470,6 +470,8 @@ ERROR(expected_precedencegroup_relation,none,
       (StringRef))
 
 // SIL
+ERROR(expected_sil_keyword,none,
+      "expected SIL keyword", ())
 ERROR(inout_not_attribute, none,
       "@inout is no longer an attribute", ())
 ERROR(only_allowed_in_sil,none,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1959,8 +1959,7 @@ public:
 
 class TypeCheckSourceFileRequest :
     public SimpleRequest<TypeCheckSourceFileRequest,
-                         bool (SourceFile *, unsigned),
-                         CacheKind::SeparatelyCached> {
+                         bool (SourceFile *), CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -1968,8 +1967,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  llvm::Expected<bool> evaluate(Evaluator &evaluator,
-                                SourceFile *SF, unsigned StartElem) const;
+  llvm::Expected<bool> evaluate(Evaluator &evaluator, SourceFile *SF) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -211,7 +211,7 @@ SWIFT_REQUEST(TypeChecker, HasDefaultInitRequest,
 SWIFT_REQUEST(TypeChecker, SynthesizeDefaultInitRequest,
               ConstructorDecl *(NominalTypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckSourceFileRequest,
-              bool(SouceFile *, unsigned), SeparatelyCached, NoLocationInfo)
+              bool(SouceFile *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeWitnessRequest,
               TypeWitnessAndDecl(NormalProtocolConformance *,
                                  AssociatedTypeDecl *),

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -653,8 +653,6 @@ public: // for static functions in Frontend.cpp
   };
 
 private:
-  void createREPLFile(const ImplicitImports &implicitImports);
-
   void addMainFileToModule(const ImplicitImports &implicitImports);
 
   void performSemaUpTo(SourceFile::ASTStage_t LimitStage);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -413,7 +413,8 @@ public:
          bool DelayBodyParsing = true);
   ~Parser();
 
-  bool isInSILMode() const { return SIL != nullptr; }
+  /// Returns true if the buffer being parsed is allowed to contain SIL.
+  bool isInSILMode() const;
 
   /// Calling this function to finalize libSyntax tree creation without destroying
   /// the parser instance.
@@ -430,9 +431,8 @@ public:
                           PreviousLoc);
   }
 
-  ParserPosition getParserPosition(const PersistentParserState::ParserPos &Pos){
-    return ParserPosition(L->getStateForBeginningOfTokenLoc(Pos.Loc),
-                          Pos.PrevLoc);
+  ParserPosition getParserPosition(SourceLoc loc, SourceLoc previousLoc) {
+    return ParserPosition(L->getStateForBeginningOfTokenLoc(loc), previousLoc);
   }
 
   void restoreParserPosition(ParserPosition PP, bool enableDiagnostics = false) {
@@ -661,6 +661,9 @@ public:
   /// Returns \c true if the parser hit the eof before finding matched '}'.
   bool skipBracedBlock();
 
+  /// Skip over SIL decls until we encounter the start of a Swift decl or eof.
+  void skipSILUntilSwiftDecl();
+
   /// If the parser is generating only a syntax tree, try loading the current
   /// node from a previously generated syntax tree.
   /// Returns \c true if the node has been loaded and inserted into the current
@@ -880,10 +883,17 @@ public:
   //===--------------------------------------------------------------------===//
   // Decl Parsing
 
-  /// Return true if parser is at the start of a decl or decl-import.
-  bool isStartOfDecl();
+  /// Returns true if parser is at the start of a Swift decl or decl-import.
+  bool isStartOfSwiftDecl();
 
+  /// Returns true if the parser is at the start of a SIL decl.
+  bool isStartOfSILDecl();
+
+  /// Parse the top-level Swift decls into the source file.
   void parseTopLevel();
+
+  /// Parse the top-level SIL decls into the SIL module.
+  void parseTopLevelSIL();
 
   /// Flags that control the parsing of declarations.
   enum ParseDeclFlags {

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -59,22 +59,11 @@ public:
 /// Parser state persistent across multiple parses.
 class PersistentParserState {
 public:
-  struct ParserPos {
-    SourceLoc Loc;
-    SourceLoc PrevLoc;
-
-    bool isValid() const { return Loc.isValid(); }
-  };
-
-  bool InPoundLineEnvironment = false;
   // FIXME: When condition evaluation moves to a later phase, remove this bit
   // and adjust the client call 'performParseOnly'.
   bool PerformConditionEvaluation = true;
 private:
   swift::ScopeInfo ScopeInfo;
-
-  /// Parser sets this if it stopped parsing before the buffer ended.
-  ParserPosition MarkedPos;
 
   std::unique_ptr<CodeCompletionDelayedDeclState> CodeCompletionDelayedDeclStat;
 
@@ -112,19 +101,6 @@ public:
 
   TopLevelContext &getTopLevelContext() {
     return TopLevelCode;
-  }
-
-  void markParserPosition(ParserPosition Pos,
-                          bool InPoundLineEnvironment) {
-    MarkedPos = Pos;
-    this->InPoundLineEnvironment = InPoundLineEnvironment;
-  }
-
-  /// Returns the marked parser position and resets it.
-  ParserPosition takeParserPosition() {
-    ParserPosition Pos = MarkedPos;
-    MarkedPos = ParserPosition();
-    return Pos;
   }
 };
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -137,10 +137,7 @@ namespace swift {
 
   /// Once parsing is complete, this walks the AST to resolve imports, record
   /// operators, and do other top-level validation.
-  ///
-  /// \param StartElem Where to start for incremental name binding in the main
-  ///                  source file.
-  void performNameBinding(SourceFile &SF, unsigned StartElem = 0);
+  void performNameBinding(SourceFile &SF);
 
   /// Once type-checking is complete, this instruments code with calls to an
   /// intrinsic that record the expected values of local variables so they can
@@ -171,10 +168,7 @@ namespace swift {
 
   /// Once parsing and name-binding are complete, this walks the AST to resolve
   /// types and diagnose problems therein.
-  ///
-  /// \param StartElem Where to start for incremental type-checking in the main
-  /// source file.
-  void performTypeChecking(SourceFile &SF, unsigned StartElem = 0);
+  void performTypeChecking(SourceFile &SF);
 
   /// Now that we have type-checked an entire module, perform any type
   /// checking that requires the full module, e.g., Objective-C method

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -106,29 +106,21 @@ namespace swift {
 
   /// Parse a single buffer into the given source file.
   ///
-  /// If the source file is the main file, stop parsing after the next
-  /// stmt-brace-item with side-effects.
+  /// \param SF The file within the module being parsed.
   ///
-  /// \param SF the file within the module being parsed.
+  /// \param BufferID The buffer to parse from.
   ///
-  /// \param BufferID the buffer to parse from.
+  /// \param PersistentState If non-null the same PersistentState object can be
+  /// used to save parser state for code completion.
   ///
-  /// \param[out] Done set to \c true if end of the buffer was reached.
-  ///
-  /// \param SIL if non-null, we're parsing a SIL file.
-  ///
-  /// \param PersistentState if non-null the same PersistentState object can
-  /// be used to resume parsing or parse delayed function bodies.
-  void parseIntoSourceFile(SourceFile &SF, unsigned BufferID, bool *Done,
-                           SILParserState *SIL = nullptr,
+  /// \param DelayBodyParsing Whether parsing of type and function bodies can be
+  /// delayed.
+  void parseIntoSourceFile(SourceFile &SF, unsigned BufferID,
                            PersistentParserState *PersistentState = nullptr,
                            bool DelayBodyParsing = true);
 
-  /// Parse a single buffer into the given source file, until the full source
-  /// contents are parsed.
-  void parseIntoSourceFileFull(SourceFile &SF, unsigned BufferID,
-                               PersistentParserState *PersistentState = nullptr,
-                               bool DelayBodyParsing = true);
+  /// Parse a source file's SIL declarations into a given SIL module.
+  void parseSourceFileSIL(SourceFile &SF, SILParserState *sil);
 
   /// Finish the code completion.
   void performCodeCompletionSecondPass(PersistentParserState &PersistentState,

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -217,7 +217,7 @@ bool CompletionInstance::performCachedOperaitonIfPossible(
   newSF->enableInterfaceHash();
   // Ensure all non-function-body tokens are hashed into the interface hash
   Ctx->LangOpts.EnableTypeFingerprints = false;
-  parseIntoSourceFileFull(*newSF, tmpBufferID, &newState);
+  parseIntoSourceFile(*newSF, tmpBufferID, &newState);
   // Couldn't find any completion token?
   if (!newState.hasCodeCompletionDelayedDeclState())
     return false;

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -208,10 +208,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   const unsigned OriginalDeclCount = SF.getTopLevelDecls().size();
 
   PersistentParserState PersistentState;
-  bool Done;
-  do {
-    parseIntoSourceFile(SF, *BufferID, &Done, nullptr, &PersistentState);
-  } while (!Done);
+  parseIntoSourceFile(SF, *BufferID, &PersistentState);
   performTypeChecking(SF, OriginalDeclCount);
 
   performCodeCompletionSecondPass(PersistentState, *CompletionCallbacksFactory);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -187,11 +187,7 @@ typeCheckREPLInput(ModuleDecl *MostRecentModule, StringRef Name,
     REPLInputFile.addImports(ImportsWithOptions);
   }
 
-  bool Done;
-  do {
-    parseIntoSourceFile(REPLInputFile, BufferID, &Done, nullptr,
-                        &PersistentState);
-  } while (!Done);
+  parseIntoSourceFile(REPLInputFile, BufferID, &PersistentState);
   performTypeChecking(REPLInputFile);
   return REPLModule;
 }

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -997,10 +997,6 @@ public:
     IRGenOpts.DebugInfoLevel = IRGenDebugInfoLevel::None;
     IRGenOpts.DebugInfoFormat = IRGenDebugInfoFormat::None;
 
-    // The very first module is a dummy.
-    CI.getMainModule()->getMainSourceFile(SourceFileKind::REPL).ASTStage =
-        SourceFile::TypeChecked;
-
     if (!ParseStdlib) {
       // Force standard library to be loaded immediately.  This forces any
       // errors to appear upfront, and helps eliminate some nasty lag after the

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3463,7 +3463,7 @@ ParserResult<Expr> Parser::parseExprCollection() {
       // If The next token is at the beginning of a new line and can never start
       // an element, break.
       if (Tok.isAtStartOfLine() && (Tok.isAny(tok::r_brace, tok::pound_endif) ||
-                                    isStartOfDecl() || isStartOfStmt()))
+                                    isStartOfSwiftDecl() || isStartOfStmt()))
         break;
 
       diagnose(Tok, diag::expected_separator, ",")

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -306,17 +306,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
          Tok.isNot(tok::pound_elseif) &&
          Tok.isNot(tok::pound_else) &&
          Tok.isNot(tok::eof) &&
-         Tok.isNot(tok::kw_sil) &&
-         Tok.isNot(tok::kw_sil_scope) &&
-         Tok.isNot(tok::kw_sil_stage) &&
-         Tok.isNot(tok::kw_sil_vtable) &&
-         Tok.isNot(tok::kw_sil_global) &&
-         Tok.isNot(tok::kw_sil_witness_table) &&
-         Tok.isNot(tok::kw_sil_default_witness_table) &&
-         // SWIFT_ENABLE_TENSORFLOW
-         Tok.isNot(tok::kw_sil_differentiability_witness) &&
-         // SWIFT_ENABLE_TENSORFLOW_END
-         Tok.isNot(tok::kw_sil_property) &&
+         !isStartOfSILDecl() &&
          (isConditionalBlock ||
           !isTerminatorForBraceItemListKind(Kind, Entries))) {
 
@@ -403,7 +393,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       ParserStatus Status = parseLineDirective(false);
       BraceItemsStatus |= Status;
       NeedParseErrorRecovery = Status.isError();
-    } else if (isStartOfDecl()) {
+    } else if (isStartOfSwiftDecl()) {
       SmallVector<Decl*, 8> TmpDecls;
       ParserResult<Decl> DeclResult = 
           parseDecl(IsTopLevel ? PD_AllowTopLevel : PD_Default,
@@ -705,7 +695,7 @@ ParserResult<Stmt> Parser::parseStmtBreak() {
   // since the expression after the break is dead, we don't feel bad eagerly
   // parsing this.
   if (Tok.is(tok::identifier) && !Tok.isAtStartOfLine() &&
-      !isStartOfStmt() && !isStartOfDecl())
+      !isStartOfStmt() && !isStartOfSwiftDecl())
     TargetLoc = consumeIdentifier(&Target);
 
   return makeParserResult(new (Context) BreakStmt(Loc, Target, TargetLoc));
@@ -728,7 +718,7 @@ ParserResult<Stmt> Parser::parseStmtContinue() {
   // since the expression after the continue is dead, we don't feel bad eagerly
   // parsing this.
   if (Tok.is(tok::identifier) && !Tok.isAtStartOfLine() &&
-      !isStartOfStmt() && !isStartOfDecl())
+      !isStartOfStmt() && !isStartOfSwiftDecl())
     TargetLoc = consumeIdentifier(&Target);
 
   return makeParserResult(new (Context) ContinueStmt(Loc, Target, TargetLoc));
@@ -761,7 +751,7 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
   if (Tok.isNot(tok::r_brace, tok::semi, tok::eof, tok::pound_if, 
                 tok::pound_error, tok::pound_warning, tok::pound_endif,
                 tok::pound_else, tok::pound_elseif) &&
-      !isStartOfStmt() && !isStartOfDecl()) {
+      !isStartOfStmt() && !isStartOfSwiftDecl()) {
     SourceLoc ExprLoc = Tok.getLoc();
 
     // Issue a warning when the returned expression is on a different line than

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1636,7 +1636,7 @@ bool Parser::canParseOldStyleProtocolComposition() {
 
 bool Parser::canParseTypeTupleBody() {
   if (Tok.isNot(tok::r_paren) && Tok.isNot(tok::r_brace) &&
-      Tok.isNotEllipsis() && !isStartOfDecl()) {
+      Tok.isNotEllipsis() && !isStartOfSwiftDecl()) {
     do {
       // The contextual inout marker is part of argument lists.
       consumeIf(tok::kw_inout);
@@ -1661,8 +1661,7 @@ bool Parser::canParseTypeTupleBody() {
         if (consumeIf(tok::equal)) {
           while (Tok.isNot(tok::eof) && Tok.isNot(tok::r_paren) &&
                  Tok.isNot(tok::r_brace) && Tok.isNotEllipsis() &&
-                 Tok.isNot(tok::comma) &&
-                 !isStartOfDecl()) {
+                 Tok.isNot(tok::comma) && !isStartOfSwiftDecl()) {
             skipSingle();
           }
         }

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -397,7 +397,7 @@ static void insertPrecedenceGroupDecl(NameBinder &binder, SourceFile &SF,
 /// UnresolvedDeclRefExpr nodes for unresolved value names, and we may have
 /// unresolved type names as well. This handles import directives and forward
 /// references.
-void swift::performNameBinding(SourceFile &SF, unsigned StartElem) {
+void swift::performNameBinding(SourceFile &SF) {
   FrontendStatsTracer tracer(SF.getASTContext().Stats, "Name binding");
 
   // Make sure we skip adding the standard library imports if the
@@ -417,7 +417,7 @@ void swift::performNameBinding(SourceFile &SF, unsigned StartElem) {
 
   // Do a prepass over the declarations to find and load the imported modules
   // and map operator decls.
-  for (auto D : SF.getTopLevelDecls().slice(StartElem)) {
+  for (auto D : SF.getTopLevelDecls()) {
     if (auto *ID = dyn_cast<ImportDecl>(D)) {
       Binder.addImport(ImportedModules, ID);
     } else if (auto *OD = dyn_cast<PrefixOperatorDecl>(D)) {

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -130,11 +130,7 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
                                           Ctx.LangOpts.BuildSyntaxTree);
   importMod->addFile(*importFile);
 
-  bool done;
-  parseIntoSourceFile(*importFile, bufferID, &done, nullptr, nullptr);
-  assert(done && "Parser returned early?");
-  (void)done;
-
+  parseIntoSourceFile(*importFile, bufferID);
   performNameBinding(*importFile);
   importMod->setHasResolvedImports();
   return importMod;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -614,14 +614,8 @@ private:
   
 } // end anonymous namespace
 
-void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF,
-                                                      unsigned StartElem) {
+void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF) {
   TypeRefinementContext *RootTRC = SF.getTypeRefinementContext();
-
-  // If we are not starting at the beginning of the source file, we had better
-  // already have a root type refinement context.
-  assert(StartElem == 0 || RootTRC);
-
   ASTContext &Context = SF.getASTContext();
 
   if (!RootTRC) {
@@ -636,7 +630,7 @@ void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF,
   // Build refinement contexts, if necessary, for all declarations starting
   // with StartElem.
   TypeRefinementContextBuilder Builder(RootTRC, Context);
-  for (auto D : SF.getTopLevelDecls().slice(StartElem)) {
+  for (auto D : SF.getTopLevelDecls()) {
     Builder.build(D);
   }
 }
@@ -645,7 +639,7 @@ TypeRefinementContext *
 TypeChecker::getOrBuildTypeRefinementContext(SourceFile *SF) {
   TypeRefinementContext *TRC = SF->getTypeRefinementContext();
   if (!TRC) {
-    buildTypeRefinementContextHierarchy(*SF, 0);
+    buildTypeRefinementContextHierarchy(*SF);
     TRC = SF->getTypeRefinementContext();
   }
 

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -462,17 +462,17 @@ Identifier REPLChecker::getNextResponseVariableName(DeclContext *DC) {
 /// processREPLTopLevel - This is called after we've parsed and typechecked some
 /// new decls at the top level.  We inject code to print out expressions and
 /// pattern bindings the are evaluated.
-void TypeChecker::processREPLTopLevel(SourceFile &SF, unsigned FirstDecl) {
+void TypeChecker::processREPLTopLevel(SourceFile &SF) {
   // Walk over all decls in the file to find the next available closure
   // discriminator.
   DiscriminatorFinder DF;
   for (Decl *D : SF.getTopLevelDecls())
     D->walk(DF);
 
-  // Move new declarations out.
-  std::vector<Decl *> NewDecls(SF.getTopLevelDecls().begin()+FirstDecl,
+  // Move the new declarations out of the source file.
+  std::vector<Decl *> NewDecls(SF.getTopLevelDecls().begin(),
                                SF.getTopLevelDecls().end());
-  SF.truncateTopLevelDecls(FirstDecl);
+  SF.truncateTopLevelDecls(0);
 
   REPLChecker RC(SF, DF);
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -331,15 +331,13 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
   TC.definedFunctions.clear();
 }
 
-void swift::performTypeChecking(SourceFile &SF, unsigned StartElem) {
+void swift::performTypeChecking(SourceFile &SF) {
   return (void)evaluateOrDefault(SF.getASTContext().evaluator,
-                                 TypeCheckSourceFileRequest{&SF, StartElem},
-                                 false);
+                                 TypeCheckSourceFileRequest{&SF}, false);
 }
 
 llvm::Expected<bool>
-TypeCheckSourceFileRequest::evaluate(Evaluator &eval,
-                                     SourceFile *SF, unsigned StartElem) const {
+TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
   assert(SF && "Source file cannot be null!");
   assert(SF->ASTStage != SourceFile::TypeChecked &&
          "Should not be re-typechecking this file!");
@@ -360,7 +358,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval,
 
   // Make sure that name binding has been completed before doing any type
   // checking.
-  performNameBinding(*SF, StartElem);
+  performNameBinding(*SF);
                                   
   // Could build scope maps here because the AST is stable now.
 
@@ -377,7 +375,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval,
     if (!Ctx.LangOpts.DisableAvailabilityChecking) {
       // Build the type refinement hierarchy for the primary
       // file before type checking.
-      TypeChecker::buildTypeRefinementContextHierarchy(*SF, StartElem);
+      TypeChecker::buildTypeRefinementContextHierarchy(*SF);
     }
 
     // Resolve extensions. This has to occur first during type checking,
@@ -386,7 +384,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval,
     ::bindExtensions(*SF);
 
     // Type check the top-level elements of the source file.
-    for (auto D : SF->getTopLevelDecls().slice(StartElem)) {
+    for (auto D : SF->getTopLevelDecls()) {
       if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
         // Immediately perform global name-binding etc.
         TypeChecker::typeCheckTopLevelCodeDecl(TLCD);
@@ -399,7 +397,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval,
     // If we're in REPL mode, inject temporary result variables and other stuff
     // that the REPL needs to synthesize.
     if (SF->Kind == SourceFileKind::REPL && !Ctx.hadError())
-      TypeChecker::processREPLTopLevel(*SF, StartElem);
+      TypeChecker::processREPLTopLevel(*SF);
 
     typeCheckFunctionsAndExternalDecls(*SF, TC);
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -718,7 +718,7 @@ public:
 
   static void typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD);
 
-  static void processREPLTopLevel(SourceFile &SF, unsigned StartElem);
+  static void processREPLTopLevel(SourceFile &SF);
 
   static void typeCheckDecl(Decl *D);
 
@@ -1491,11 +1491,7 @@ public:
                                         const TypeRefinementContext **MostRefined=nullptr);
 
   /// Walk the AST to build the hierarchy of TypeRefinementContexts
-  ///
-  /// \param StartElem Where to start for incremental building of refinement
-  /// contexts
-  static void buildTypeRefinementContextHierarchy(SourceFile &SF,
-                                                  unsigned StartElem);
+  static void buildTypeRefinementContextHierarchy(SourceFile &SF);
 
   /// Build the hierarchy of TypeRefinementContexts for the entire
   /// source file, if it has not already been built. Returns the root

--- a/test/Parse/identifiers.swift
+++ b/test/Parse/identifiers.swift
@@ -32,9 +32,9 @@ func <#some name#>() {} // expected-error {{editor placeholder in source file}}
 class switch {} // expected-error {{keyword 'switch' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{7-13=`switch`}}
 struct Self {} // expected-error {{keyword 'Self' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Self`}}
 protocol enum {} // expected-error {{keyword 'enum' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{10-14=`enum`}}
-protocol test { // expected-note{{in declaration of 'test'}}
-  associatedtype public // expected-error {{keyword 'public' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{18-24=`public`}} expected-error {{consecutive declarations on a line must be separated by ';'}}
-} // expected-error{{expected declaration}}
+protocol test {
+  associatedtype public // expected-error {{keyword 'public' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{18-24=`public`}}
+}
 func _(_ x: Int) {} // expected-error {{keyword '_' cannot be used as an identifier here}} // expected-note {{if this name is unavoidable, use backticks to escape it}} {{6-7=`_`}}
 
 // SIL keywords are tokenized as normal identifiers in non-SIL mode.

--- a/test/SIL/Parser/attributes.sil
+++ b/test/SIL/Parser/attributes.sil
@@ -5,3 +5,7 @@ sil [_semantics "123"] [_semantics "456"] @foo : $@convention(thin) () -> () {
 bb0:
   return undef : $()
 }
+
+// Make sure we don't try to parse the Swift decl as '@owned() func baz()'.
+sil @bar : $@convention(thin) () -> @owned ()
+func baz()

--- a/test/SIL/Parser/errors.sil
+++ b/test/SIL/Parser/errors.sil
@@ -24,7 +24,7 @@ bb0:
 sil [ossa] @local_value_errors2 : $() -> () {
 bb0:
   %0 = builtin "cmp_eq_Int1"(%0 : $() // expected-error @+1 {{expected ')' or ',' in SIL instruction}}
-} // expected-error {{extraneous '}' at top level}}
+}
 
 sil [ossa] @global_value_errors : $() -> () {
 bb0:
@@ -49,5 +49,4 @@ sil_stage nonsense // expected-error {{expected 'raw' or 'canonical' after 'sil_
 sil [ossa] @missing_type : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   br bb3(%0) // expected-error {{expected ':' before type in SIL value reference}}
-  // FIXME: The next error is unexpected.
-} // expected-error {{extraneous '}' at top level}} {{1-3=}}
+}

--- a/unittests/Parse/TokenizerTests.cpp
+++ b/unittests/Parse/TokenizerTests.cpp
@@ -84,13 +84,7 @@ public:
   std::vector<Token> parseAndGetSplitTokens(unsigned BufID) {
     swift::ParserUnit PU(SM, SourceFileKind::Main, BufID,
                          LangOpts, TypeCheckerOptions(), "unknown");
-
-    bool Done = false;
-    while (!Done) {
-      PU.getParser().parseTopLevel();
-      Done = PU.getParser().Tok.is(tok::eof);
-    }
-    
+    PU.getParser().parseTopLevel();
     return PU.getParser().getSplitTokens();
   }
   

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -308,7 +308,7 @@
        "tensorflow": {
             "aliases": ["tensorflow"],
             "repos": {
-                "llvm-project": "8d389494ae739c7c14dfed9b554ebe0993014568",
+                "llvm-project": "9a06f783600d362278270b9203e32ed604b218db",
                 "swift": "tensorflow",
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2020-01-31-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2020-01-31-a",

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -308,7 +308,7 @@
        "tensorflow": {
             "aliases": ["tensorflow"],
             "repos": {
-                "llvm-project": "13c814f63ed68657fb480dfa428c94cbe82fc064",
+                "llvm-project": "8d389494ae739c7c14dfed9b554ebe0993014568",
                 "swift": "tensorflow",
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2020-01-31-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2020-01-31-a",

--- a/validation-test/IDE/crashers_2/complete_repl_decl_conformance.swift
+++ b/validation-test/IDE/crashers_2/complete_repl_decl_conformance.swift
@@ -1,5 +1,0 @@
-// TODO(SR-12076): Make this not crash.
-// RUN: not --crash %target-swift-ide-test -repl-code-completion -source-filename %s
-// REQUIRES: asserts
-
-struct Bar:

--- a/validation-test/IDE/crashers_2_fixed/0024-complete_repl_decl_conformance.swift
+++ b/validation-test/IDE/crashers_2_fixed/0024-complete_repl_decl_conformance.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename %s
+
+struct Bar:

--- a/validation-test/IDE/crashers_2_fixed/0025-complete_repl_extension_where.swift
+++ b/validation-test/IDE/crashers_2_fixed/0025-complete_repl_extension_where.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -repl-code-completion -source-filename %s
+
+struct Foo<T> {}
+
+extension Foo whe

--- a/validation-test/SIL/crashers/042-swift-parser-parsetoplevel.sil
+++ b/validation-test/SIL/crashers/042-swift-parser-parsetoplevel.sil
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
-class a 4{sil_vtable a

--- a/validation-test/SIL/crashers_fixed/042-swift-parser-parsetoplevel.sil
+++ b/validation-test/SIL/crashers_fixed/042-swift-parser-parsetoplevel.sil
@@ -1,0 +1,2 @@
+// RUN: not %target-sil-opt %s
+class a 4{sil_vtable a


### PR DESCRIPTION
Cherry-picks some PRs necessary for https://bugs.swift.org/browse/SR-12076 into `tensorflow`.

This PR is only cherry-picks and llvm-project commit hash update, no additional changes.

Full explanation of the fix is in the PR description of the corresponding llvm-project PR: https://github.com/apple/llvm-project/pull/751.