### PR TITLE
[ModuleInterface] Pass Through Flags for Nested Types Tables

### DIFF
--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -347,6 +347,8 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     // optimization pipeline.
     SerializationOptions SerializationOpts;
     std::string OutPathStr = OutPath;
+    SerializationOpts.EnableNestedTypeLookupTable
+        = FEOpts.EnableSerializationNestedTypeLookupTable;
     SerializationOpts.OutputPath = OutPathStr.c_str();
     SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
     SerializationOpts.AutolinkForceLoad =

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 537; // SIL differentiability witnesses
+const uint16_t SWIFTMODULE_VERSION_MINOR = 538; // swiftmodules from swiftinterfaces have nested types tables
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/Serialization/interface-module-nested-types.swift
+++ b/test/Serialization/interface-module-nested-types.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/Build)
+// RUN: %empty-directory(%t/PrebuiltCache)
+
+// 1. Create a module for our nested type
+// RUN: echo 'public protocol Nest { associatedtype Egg }' > %t/TestModule.swift
+
+// 2. Create an interface for it
+// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5
+
+// 3. Build a .swiftmodule from the .swiftinterface and put it in the module cache
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Build/TestModule.swiftinterface -o %t/PrebuiltCache/TestModule.swiftmodule
+
+// 4. Import the module in a different module that extends the nested type.
+// RUN: echo 'import TestModule; extension Nest where Egg == Int { public func robin() -> Egg { return 3 } }' > %t/NestModule.swift
+
+// 5. Create an interface for it
+// RUN: %target-swift-frontend -typecheck %t/NestModule.swift -I %t/PrebuiltCache -sdk %t -prebuilt-module-cache-path %t/PrebuiltCache -module-cache-path %t/ModuleCache -emit-module-interface-path %t/Build/NestModule.swiftinterface -swift-version 5
+
+// 6. Build a .swiftmodule from the .swiftinterface and put it in the module cache
+// RUN: %target-swift-frontend -compile-module-from-interface -I %t/PrebuiltCache -sdk %t %t/Build/NestModule.swiftinterface -o %t/PrebuiltCache/NestModule.swiftmodule
+
+// 7. Ensure we resolve the cross-ref to the nested type properly.
+// RUN: %target-swift-frontend -typecheck %s -I %t/PrebuiltCache -sdk %t -prebuilt-module-cache-path %t/PrebuiltCache -module-cache-path %t/ModuleCache -print-stats 2>&1 | %FileCheck %s
+
+import TestModule
+import NestModule
+
+// CHECK: Statistics
+// CHECK: 1 Serialization - # of nested types resolved without full lookup
+
+func tweet<Location: Nest>(from place: Location) where Location.Egg == Int {
+  _ = place.robin()
+}


### PR DESCRIPTION
When a swift module is generated from a swift interface file, we must
remember to setup the nested types tables. Plumb the flag down from the
frontend options.

In the future, we must remove the ability to turn this off. There's
literally zero reason to have this be a configuration option anymore.

Resolves rdar://59202687 and its many, many dupes.