### PR TITLE
test: loosen the differentiability witness test

### DIFF
--- a/test/AutoDiff/SIL/Serialization/sil_differentiability_witness.sil
+++ b/test/AutoDiff/SIL/Serialization/sil_differentiability_witness.sil
@@ -161,7 +161,7 @@ sil_differentiability_witness hidden [parameters 0 1] [results 0] <τ_0_0 where 
 // ROUNDTRIP:   vjp: @AD__generic__vjp_src_0_wrt_0_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0, Float) -> (@out τ_0_0, @owned @callee_guaranteed (@in_guaranteed τ_0_0.TangentVector) -> (@out τ_0_0.TangentVector, Float))
 // ROUNDTRIP: }
 
-// IRGEN-LABEL: @AD__generic_PSSRS16_Differentiation14DifferentiableRzl = hidden global { i8*, i8* } {
+// IRGEN: @AD__generic_PSSRS{{16_Differentiation|s}}14DifferentiableRzl = hidden global { i8*, i8* } {
 // IRGEN-SAME: @AD__generic__jvp_src_0_wrt_0_1
 // IRGEN-SAME: @AD__generic__vjp_src_0_wrt_0_1
 // IRGEN-SAME: }


### PR DESCRIPTION
There is currently a difference between the tensorflow branch and the
master branch.  On tensorflow, the differentiability support is merged
into the standard library.  This changes the decoration of the witness.
Loosen the test to accept either.

We should change the tensorflow branch to generate the
`_Differentiation` module with the support and then auto-import the
module in the longer term.  This can be gated by the
`-enable-experimental-autodifferentiation` flag to the driver to gain
the same behaviour on both the branches.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
