### PR TITLE
CI: use verbose mode during the CI runs

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -21,7 +21,7 @@
 :: The user will need permission to write files into the Windows SDK and the
 :: VisualC++ folder.
 
-@echo off
+:: @echo off
 
 setlocal enableextensions enabledelayedexpansion
 


### PR DESCRIPTION
Enable verbose mode execution for the build script in the hopes that we
can catch the issue that is preventing the builds on new hosts.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
