### PR TITLE
ClangImporter: Fix mirroring of instance properties as static methods on NSObject

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3787,6 +3787,17 @@ ClangImporter::Implementation::loadNamedMembers(
           Members.push_back(V);
         }
       }
+
+      // If the property's accessors have alternate decls, we might have
+      // to import those too.
+      if (auto *ASD = dyn_cast<AbstractStorageDecl>(TD)) {
+        for (auto *AD : ASD->getAllAccessors()) {
+          for (auto *D : getAlternateDecls(AD)) {
+            if (D->getBaseName() == N)
+              Members.push_back(D);
+          }
+        }
+      }
     }
   }
 

--- a/test/ClangImporter/mirror_instance_property_static_method.swift
+++ b/test/ClangImporter/mirror_instance_property_static_method.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify
+// REQUIRES: objc_interop
+
+import Foundation
+
+func mirrorInstancePropertyAsStaticMethod() {
+  // Instance properties are mirrored as static _methods_. Make sure this works.
+  let _: AnyClass = NSObject.classForCoder()
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/objc/NSObject.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc/NSObject.h
@@ -27,6 +27,10 @@
 @property (readonly) NSInteger hash;
 @end
 
+@interface NSObject (Coding)
+- (Class)classForCoder;
+@end
+
 @interface A : NSObject
 - (int)method:(int)arg withDouble:(double)d;
 + (int)classMethod;


### PR DESCRIPTION
Because all metaclasses ultimately inherit from NSObject, instance
members of NSObject are also visible as static members of NSObject.

If the instance member is a property, we import the getter as an
ordinary static method, and not a static property.

The lazy loading path normally checks for the presence of alternate
decls with the same name, but it was failing to do this check if the
imported decl was a property and the alternate decl was attached to
the accessor and not the property itself.

Fixes <rdar://problem/59170514>.