### PR TITLE
CI: expand `%ProgramFiles%` manually

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -67,7 +67,7 @@ call :build_lldb %exitOnError%
 
 call :build_libdispatch %exitOnError%
 
-path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%;%ProgramFiles%\Git\usr\bin
+path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%;C:\Program Files\Git\usr\bin
 call :test_swift %exitOnError%
 call :test_libdispatch %exitOnError%
 
@@ -107,7 +107,7 @@ set file_name=icu4c-%icu_version%-Win64-MSVC2017.zip
 curl -L -O "https://github.com/unicode-org/icu/releases/download/release-%icu_version_dashed%/%file_name%" %exitOnError%
 :: unzip warns about the paths in the zip using slashes, which raises the
 :: errorLevel to 1. We cannot use exitOnError, and have to ignore errors.
-"%ProgramFiles%\Git\usr\bin\unzip.exe" -o %file_name% -d "%source_root%\icu-%icu_version%"
+"C:\Program Files\Git\usr\bin\unzip.exe" -o %file_name% -d "%source_root%\icu-%icu_version%"
 exit /b 0
 
 goto :eof
@@ -121,7 +121,7 @@ setlocal enableextensions enabledelayedexpansion
 
 set file_name=sqlite-amalgamation-3270200.zip
 curl -L -O "https://www.sqlite.org/2019/%file_name%" %exitOnError%
-"%ProgramFiles%\Git\usr\bin\unzip.exe" -o %file_name% %exitOnError%
+"C:\Program Files\Git\usr\bin\unzip.exe" -o %file_name% %exitOnError%
 
 goto :eof
 endlocal


### PR DESCRIPTION
This expands `%ProgramFiles%` manually since it is getting expanded to
`C:\Program Files (x86)` rather than `C:\Program Files` as expected.
Although this is less portable, this will at least enable the CI to run
properly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
