### PR TITLE
[Constraint system] Sink initialization logic into SolutionApplicationTarget

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -774,8 +774,8 @@ struct Score {
 
 /// An AST node that can gain type information while solving.
 using TypedNode =
-    llvm::PointerUnion3<const Expr *, const TypeLoc *,
-                        const VarDecl *>;
+    llvm::PointerUnion4<const Expr *, const TypeLoc *,
+                        const VarDecl *, const Pattern *>;
 
 /// Display a score.
 llvm::raw_ostream &operator<<(llvm::raw_ostream &out, const Score &score);
@@ -1164,7 +1164,7 @@ class SolutionApplicationTarget {
       Pattern *pattern = nullptr;
 
       /// Whether the expression result will be discarded at the end.
-      bool isDiscarded;
+      bool isDiscarded = false;
     } expression;
 
     struct {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3231,6 +3231,12 @@ public:
     return allocateCopy(vec.begin(), vec.end());
   }
 
+  /// Generate constraints for the given solution target.
+  ///
+  /// \returns true if an error occurred, false otherwise.
+  bool generateConstraints(SolutionApplicationTarget &target,
+                           FreeTypeVariableBinding allowFreeTypeVariables);
+
   /// Generate constraints for the body of the given single-statement closure.
   ///
   /// \returns a possibly-sanitized expression, or null if an error occurred.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1161,10 +1161,14 @@ class SolutionApplicationTarget {
 
       /// When initializing a pattern from the expression, this is the
       /// pattern.
-      Pattern *pattern = nullptr;
+      Pattern *pattern;
+
+      /// The variable to which property wrappers have been applied, if
+      /// this is an initialization involving a property wrapper.
+      VarDecl *wrappedVar;
 
       /// Whether the expression result will be discarded at the end.
-      bool isDiscarded = false;
+      bool isDiscarded;
     } expression;
 
     struct {
@@ -1172,6 +1176,11 @@ class SolutionApplicationTarget {
       BraceStmt *body;
     } function;
   };
+
+  // If the pattern contains a single variable that has an attached
+  // property wrapper, set up the initializer expression to initialize
+  // the backing storage.
+  void maybeApplyPropertyWrapper();
 
 public:
   SolutionApplicationTarget(Expr *expr, DeclContext *dc,
@@ -1279,6 +1288,14 @@ public:
     return kind == Kind::expression &&
         expression.contextualPurpose == CTP_Initialization &&
         isa<OptionalSomePattern>(expression.pattern);
+  }
+
+  /// Retrieve the wrapped variable when initializing a pattern with a
+  /// property wrapper.
+  VarDecl *getInitializationWrappedVar() const {
+    assert(kind == Kind::expression);
+    assert(expression.contextualPurpose == CTP_Initialization);
+    return expression.wrappedVar;
   }
 
   /// Whether this context infers an opaque return type.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2474,8 +2474,8 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
   /// Type checking listener for pattern binding initializers.
   class BindingListener : public ExprTypeCheckListener {
     ASTContext &context;
-    Pattern *&pattern;
-    Expr *&initializer;
+
+    SolutionApplicationTarget target;
 
     /// The locator we're using.
     ConstraintLocator *Locator;
@@ -2487,11 +2487,9 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
     VarDecl *wrappedVar = nullptr;
 
   public:
-    explicit BindingListener(ASTContext &ctx, Pattern *&pattern,
-                             Expr *&initializer)
-        : context(ctx), pattern(pattern), initializer(initializer),
-          Locator(nullptr) {
-      maybeApplyPropertyWrapper();
+    explicit BindingListener(ASTContext &ctx, SolutionApplicationTarget target)
+        : context(ctx), target(target), Locator(nullptr) {
+      wrappedVar = target.getInitializationWrappedVar();
     }
 
     /// Retrieve the type to which the pattern should be coerced.
@@ -2505,7 +2503,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       if (cs) {
         Type valueType = LValueType::get(initType);
         auto dc = wrappedVar->getInnermostDeclContext();
-        auto *loc = cs->getConstraintLocator(initializer);
+        auto *loc = cs->getConstraintLocator(target.getAsExpr());
 
         for (unsigned i : indices(wrappedVar->getAttachedPropertyWrappers())) {
           auto wrapperInfo = wrappedVar->getAttachedPropertyWrapperTypeInfo(i);
@@ -2538,7 +2536,8 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       Locator = cs.getConstraintLocator(expr, LocatorPathElt::ContextualType());
 
       // Collect constraints from the pattern.
-      Type patternType = cs.generateConstraints(pattern, Locator);
+      Type patternType =
+          cs.generateConstraints(target.getInitializationPattern(), Locator);
       if (!patternType)
         return true;
 
@@ -2563,7 +2562,6 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       }
 
       // The expression has been pre-checked; save it in case we fail later.
-      initializer = expr;
       return false;
     }
 
@@ -2593,70 +2591,20 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
             ->setSemanticInit(expr);
       }
 
-      initializer = expr;
       return expr;
-    }
-
-  private:
-    // If the pattern contains a single variable that has an attached
-    // property wrapper, set up the initializer expression to initialize
-    // the backing storage.
-    void maybeApplyPropertyWrapper() {
-      auto singleVar = pattern->getSingleVar();
-      if (!singleVar)
-        return;
-
-      auto wrapperAttrs = singleVar->getAttachedPropertyWrappers();
-      if (wrapperAttrs.empty())
-        return;
-
-      // If the outermost property wrapper is directly initialized, form the
-      // call.
-      auto &ctx = singleVar->getASTContext();
-      auto outermostWrapperAttr = wrapperAttrs.front();
-      if (initializer) {
-        // Form init(wrappedValue:) call(s).
-        Expr *wrappedInitializer =
-            buildPropertyWrapperInitialValueCall(
-                singleVar, Type(), initializer, /*ignoreAttributeArgs=*/false);
-        if (!wrappedInitializer)
-          return;
-
-        initializer = wrappedInitializer;
-      } else if (auto outermostArg = outermostWrapperAttr->getArg()) {
-        Type outermostWrapperType =
-            singleVar->getAttachedPropertyWrapperType(0);
-        if (!outermostWrapperType)
-          return;
-        
-        auto typeExpr = TypeExpr::createImplicitHack(
-            outermostWrapperAttr->getTypeLoc().getLoc(),
-            outermostWrapperType, ctx);
-        initializer = CallExpr::create(
-            ctx, typeExpr, outermostArg,
-            outermostWrapperAttr->getArgumentLabels(),
-            outermostWrapperAttr->getArgumentLabelLocs(),
-            /*hasTrailingClosure=*/false,
-            /*implicit=*/false);
-      } else {
-        llvm_unreachable("No initializer anywhere?");
-      }
-      wrapperAttrs[0]->setSemanticInit(initializer);
-
-      // Note that we have applied to property wrapper, so we can adjust
-      // the initializer type later.
-      wrappedVar = singleVar;
     }
   };
 
   auto &Context = DC->getASTContext();
-  BindingListener listener(Context, pattern, initializer);
+  auto target = SolutionApplicationTarget::forInitialization(
+      initializer, DC, patternType, pattern);
+  initializer = target.getAsExpr();
+  
+  BindingListener listener(Context, target);
   if (!initializer)
     return true;
 
   // Type-check the initializer.
-  auto target = SolutionApplicationTarget::forInitialization(
-      initializer, DC, patternType, pattern);
   bool unresolvedTypeExprs = false;
   auto resultTarget = typeCheckExpression(target, unresolvedTypeExprs,
                                           None, &listener);


### PR DESCRIPTION
Sink more of the logic for handling type checking of initializations into `SolutionApplicationTarget`:
* Handle constraint generation on `SolutionApplicationTarget`
* Handle the property-wrapper transformations needed for initialization on `SolutionApplicationTarget` itself

