### PR TITLE
CI: attempt to fix the index for swift

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -82,7 +82,7 @@ setlocal enableextensions enabledelayedexpansion
 
 git -C "%source_root%\swift" config --local core.autocrlf input
 git -C "%source_root%\swift" config --local core.symlink true
-git -C "%source_root%\swift" checkout HEAD
+git -C "%source_root%\swift" checkout-index --force --all
 
 git clone --depth 1 --single-branch https://github.com/apple/swift-cmark cmark %exitOnError%
 git clone --depth 1 --single-branch --branch swift/master https://github.com/apple/llvm-project llvm-project %exitOnError%


### PR DESCRIPTION
The file endings matter for some of the tests.  Try a different approach
to refreshing the index.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
