### PR TITLE
[build-script] Add support for building SwiftTSC

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -324,6 +324,7 @@ libcxx
 
 # Build llbuild & swiftpm here
 llbuild
+swifttsc
 swiftpm
 indexstore-db
 sourcekit-lsp
@@ -555,6 +556,7 @@ build-ninja
 
 libcxx
 llbuild
+swifttsc
 swiftpm
 indexstore-db
 sourcekit-lsp
@@ -738,6 +740,7 @@ mixin-preset=
     mixin_linux_install_components_with_clang
 
 llbuild
+swifttsc
 swiftpm
 xctest
 libicu
@@ -979,6 +982,7 @@ lldb
 # Not all tests pass, currently
 #test
 foundation
+swifttsc
 swiftpm
 xctest
 
@@ -1034,6 +1038,7 @@ build-subdir=buildbot_incremental
 libcxx
 libicu
 llbuild
+swifttsc
 swiftpm
 xctest
 foundation
@@ -1148,6 +1153,7 @@ watchos
 
 lldb
 llbuild
+swifttsc
 swiftpm
 swiftsyntax
 skstresstester
@@ -1435,6 +1441,7 @@ libcxx
 
 # Build llbuild & swiftpm here
 llbuild
+swifttsc
 swiftpm
 swiftsyntax
 
@@ -1490,6 +1497,7 @@ build-swift-stdlib-unittest-extra
 
 # Build llbuild & swiftpm here
 llbuild
+swifttsc
 swiftpm
 
 dash-dash
@@ -1509,6 +1517,7 @@ build-subdir=buildbot_incremental
 
 libcxx
 llbuild
+swifttsc
 swiftpm
 
 install-swift

--- a/utils/build-script
+++ b/utils/build-script
@@ -809,6 +809,8 @@ class BuildScriptInvocation(object):
             product_classes.append(products.XCTest)
         if self.args.build_llbuild:
             product_classes.append(products.LLBuild)
+        if self.args.build_swifttsc:
+            product_classes.append(products.SwiftTSC)
         if self.args.build_swiftpm:
             product_classes.append(products.SwiftPM)
         if self.args.build_swiftsyntax:

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -546,6 +546,9 @@ def create_argument_parser():
     option(['--libcxx'], store_true('build_libcxx'),
            help='build libcxx')
 
+    option(['--swifttsc'], toggle_true('build_swifttsc'),
+           help='build SwiftTSC')
+
     option(['-p', '--swiftpm'], toggle_true('build_swiftpm'),
            help='build swiftpm')
 

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -26,6 +26,7 @@ from .skstresstester import SKStressTester
 from .sourcekitlsp import SourceKitLSP
 from .swift import Swift
 from .swiftevolve import SwiftEvolve
+from .swifttsc import SwiftTSC
 from .swiftpm import SwiftPM
 from .swiftsyntax import SwiftSyntax
 from .tsan_libdispatch import TSanLibDispatch
@@ -44,6 +45,7 @@ __all__ = [
     'Ninja',
     'PythonKit',
     'Swift',
+    'SwiftTSC',
     'SwiftPM',
     'XCTest',
     'SwiftSyntax',

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -39,6 +39,8 @@ class SwiftPM(product.Product):
         build_root = os.path.dirname(self.build_dir)
         llbuild_build_dir = os.path.join(
             build_root, '%s-%s' % ("llbuild", host_target))
+        tsc_build_dir = os.path.join(
+            build_root, '%s-%s' % ("swifttsc", host_target))
 
         helper_cmd = [script_path, action]
 
@@ -51,7 +53,8 @@ class SwiftPM(product.Product):
             "--cmake-path", self.toolchain.cmake,
             "--ninja-path", self.toolchain.ninja,
             "--build-dir", self.build_dir,
-            "--llbuild-build-dir", llbuild_build_dir
+            "--llbuild-build-dir", llbuild_build_dir,
+            "--tsc-build-dir", tsc_build_dir,
         ]
         helper_cmd.extend(additional_params)
 

--- a/utils/swift_build_support/swift_build_support/products/swifttsc.py
+++ b/utils/swift_build_support/swift_build_support/products/swifttsc.py
@@ -1,0 +1,59 @@
+# swift_build_support/products/swiftpm.py -----------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+import os
+
+from . import product
+from .. import shell
+
+class SwiftTSC(product.Product):
+    @classmethod
+    def product_source_name(cls):
+        return "swift-tools-support-core"
+
+    @classmethod
+    def is_build_script_impl_product(cls):
+        return False
+
+    def should_build(self, host_target):
+        return True
+
+    def run_build_script(self, host_target):
+        script_path = os.path.join(
+            self.source_dir, 'Utilities', 'build-script-helper.py')
+        toolchain_path = self.install_toolchain_path()
+        swiftc = os.path.join(toolchain_path, "usr", "bin", "swiftc")
+
+        helper_cmd = [script_path, "build"]
+        helper_cmd += [
+            "--swiftc-path", swiftc,
+            "--cmake-path", self.toolchain.cmake,
+            "--ninja-path", self.toolchain.ninja,
+            "--build-dir", self.build_dir,
+        ]
+        shell.call(helper_cmd)
+
+    def build(self, host_target):
+        self.run_build_script(host_target)
+
+    def should_test(self, host_target):
+        # TSC is tested with SwiftPM.
+        return False
+
+    def test(self, host_target):
+        pass
+
+    def should_install(self, host_target):
+        return False
+
+    def install(self, host_target):
+        pass


### PR DESCRIPTION
This adds support for building SwiftTSC as a "product" which can be fed
into SwiftPM for bootstrapping. SwiftTSC's actual test will be run via
SwiftPM.
