### PR TITLE
Add python-six as required on Ubuntu to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Instructions for installing CMake and Ninja directly can be found [below](#build
 
 For Ubuntu, you'll need the following development dependencies:
 
-    sudo apt-get install git cmake ninja-build clang python uuid-dev libicu-dev icu-devtools libedit-dev libxml2-dev libsqlite3-dev swig libpython-dev libncurses5-dev pkg-config libcurl4-openssl-dev systemtap-sdt-dev tzdata rsync
+    sudo apt-get install git cmake ninja-build clang python uuid-dev libicu-dev icu-devtools libedit-dev libxml2-dev libsqlite3-dev swig libpython-dev libncurses5-dev pkg-config libcurl4-openssl-dev systemtap-sdt-dev tzdata rsync python-six
 
 **Note:** LLDB currently requires at least `swig-1.3.40` but will successfully build
 with version 2 shipped with Ubuntu.


### PR DESCRIPTION
<!-- What's in this pull request? -->
The current `master` doesn't build on Ubuntu 18.04 Docker image without installing `python-six` package with this error:

```
./utils/build-script --release-debuginfo --test
Traceback (most recent call last):
File "./utils/build-script", line 26, in <module>
from build_swift.build_swift import argparse
File "/swiftwasm/swift/utils/build_swift/build_swift/argparse/_init_.py", line 25, in <module>
from .actions import Action, Nargs
File "/swiftwasm/swift/utils/build_swift/build_swift/argparse/actions.py", line 21, in <module>
import six
ImportError: No module named six
```

This should be reflected in README to make the build process on Ubuntu easier.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link:  -->
Resolves SR-12164.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
