### PR TITLE
SILGen: Relax assertion about missing vtable entries in a class

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -311,8 +311,14 @@ public:
   }
 
   void addPlaceholder(MissingMemberDecl *m) {
-    assert(m->getNumberOfVTableEntries() == 0
-           && "Should not be emitting class with missing members");
+#ifndef NDEBUG
+    auto *classDecl = cast<ClassDecl>(m->getDeclContext());
+    bool isResilient =
+        classDecl->isResilient(SGM.M.getSwiftModule(),
+                               ResilienceExpansion::Maximal);
+    assert(isResilient || m->getNumberOfVTableEntries() == 0 &&
+           "Should not be emitting fragile class with missing members");
+#endif
   }
 };
 

--- a/test/SILGen/vtable_implementation_only.swift
+++ b/test/SILGen/vtable_implementation_only.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+
+// For convenience, this file includes the three different "files" used in this
+// test. It selects one with -DCoreDishwasher, -DDishwasherKit, or neither.
+
+// RUN: %target-swift-frontend -emit-module %s -DCoreDishwasher -module-name CoreDishwasher -o %t/CoreDishwasher -emit-module-path %t/CoreDishwasher.swiftmodule -I %t
+// RUN: %target-swift-frontend -emit-module %s -DDishwasherKit -module-name DishwasherKit -o %t/DishwasherKit -emit-module-path %t/DishwasherKit.swiftmodule -enable-library-evolution -I %t
+// RUN: %target-swift-frontend -emit-silgen -I %t %s
+
+#if CoreDishwasher
+
+  public struct SpimsterWicket {
+    public init() {}
+  }
+
+#elseif DishwasherKit
+
+  @_implementationOnly import CoreDishwasher
+
+  open class Dishwasher {
+    public init() {}
+    
+    var wicket = SpimsterWicket()
+    
+    open var modelName: String { "Dishwasher" }
+  }
+
+#else
+
+  import DishwasherKit
+
+  open class FancyDishwasher: Dishwasher {
+    open override var modelName: String { "Fancy \(super.modelName)" }
+  }
+
+#endif


### PR DESCRIPTION
Since resilient class metadata is built at runtime, we don't actually
care if there are missing vtable entries. The restriction was relaxed
in Sema in 9117c5728a10a829fd492026a62231717d0efe86, but SILGen still
had an assertion here.

Add a test and relax the assertion.

Fixes <rdar://problem/58644615>.