### PR TITLE
[Constraint solver] Sink down initialization pattern handling

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7265,6 +7265,10 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     if (!rewrittenExpr)
       return None;
 
+    if (target.getExprContextualTypePurpose() == CTP_Initialization) {
+
+    }
+
     result.setExpr(rewrittenExpr);
   } else {
     auto fn = *target.getAsFunction();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7265,10 +7265,6 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     if (!rewrittenExpr)
       return None;
 
-    if (target.getExprContextualTypePurpose() == CTP_Initialization) {
-
-    }
-
     result.setExpr(rewrittenExpr);
   } else {
     auto fn = *target.getAsFunction();

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3831,6 +3831,68 @@ static Expr *generateConstraintsFor(ConstraintSystem &cs, Expr *expr,
   return result;
 }
 
+/// Generate constraints to produce the wrapped value type given the property
+/// that has an attached property wrapper.
+///
+/// \param initializerType The type of the adjusted initializer, which
+/// initializes the underlying storage variable.
+/// \param wrappedVar The property that has a property wrapper.
+/// \returns the type of the property.
+static Type generateWrappedPropertyTypeConstraints(
+   ConstraintSystem &cs, Type initializerType,
+   VarDecl *wrappedVar, ConstraintLocator *locator) {
+  Type valueType = LValueType::get(initializerType);
+  auto dc = wrappedVar->getInnermostDeclContext();
+
+  for (unsigned i : indices(wrappedVar->getAttachedPropertyWrappers())) {
+    auto wrapperInfo = wrappedVar->getAttachedPropertyWrapperTypeInfo(i);
+    if (!wrapperInfo)
+      break;
+
+    locator = cs.getConstraintLocator(locator, ConstraintLocator::Member);
+    Type memberType = cs.createTypeVariable(locator, TVO_CanBindToLValue);
+    cs.addValueMemberConstraint(
+        valueType, wrapperInfo.valueVar->createNameRef(),
+        memberType, dc, FunctionRefKind::Unapplied, { }, locator);
+    valueType = memberType;
+  }
+
+  // Set up an equality constraint to drop the lvalue-ness of the value
+  // type we produced.
+  Type propertyType = cs.createTypeVariable(locator, 0);
+  cs.addConstraint(ConstraintKind::Equal, propertyType, valueType, locator);
+  return propertyType;
+}
+
+/// Generate additional constraints for the pattern of an initialization.
+static bool generateInitPatternConstraints(
+    ConstraintSystem &cs, SolutionApplicationTarget target, Expr *initializer) {
+  auto pattern = target.getInitializationPattern();
+  auto locator =
+      cs.getConstraintLocator(initializer, LocatorPathElt::ContextualType());
+  Type patternType = cs.generateConstraints(pattern, locator);
+  if (!patternType)
+    return true;
+
+  // Record the type of this pattern.
+  cs.setType(pattern, patternType);
+
+  if (auto wrappedVar = target.getInitializationWrappedVar()) {
+    // Add an equal constraint between the pattern type and the
+    // property wrapper's "value" type.
+    Type propertyType = generateWrappedPropertyTypeConstraints(
+        cs, cs.getType(target.getAsExpr()), wrappedVar, locator);
+    cs.addConstraint(ConstraintKind::Equal, patternType,
+                     propertyType, locator, /*isFavored*/ true);
+  } else if (!patternType->is<OpaqueTypeArchetypeType>()) {
+    // Add a conversion constraint between the types.
+    cs.addConstraint(ConstraintKind::Conversion, cs.getType(target.getAsExpr()),
+                     patternType, locator, /*isFavored*/true);
+  }
+
+  return false;
+}
+
 bool ConstraintSystem::generateConstraints(
     SolutionApplicationTarget &target,
     FreeTypeVariableBinding allowFreeTypeVariables) {
@@ -3871,6 +3933,12 @@ bool ConstraintSystem::generateConstraints(
 
       addContextualConversionConstraint(expr, convertType, ctp,
                                         isOpaqueReturnType);
+    }
+
+    // For an initialization target, generate constraints for the pattern.
+    if (target.getExprContextualTypePurpose() == CTP_Initialization &&
+        generateInitPatternConstraints(*this, target, expr)) {
+      return true;
     }
 
     return false;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1314,6 +1314,12 @@ public:
     expression.expression = expr;
   }
 
+  void setPattern(Pattern *pattern) {
+    assert(kind == Kind::expression);
+    assert(expression.contextualPurpose == CTP_Initialization);
+    expression.pattern = pattern;
+  }
+
   Optional<AnyFunctionRef> getAsFunction() const {
     switch (kind) {
     case Kind::expression:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1481,6 +1481,7 @@ private:
   llvm::DenseMap<const Expr *, TypeBase *> ExprTypes;
   llvm::DenseMap<const TypeLoc *, TypeBase *> TypeLocTypes;
   llvm::DenseMap<const VarDecl *, TypeBase *> VarTypes;
+  llvm::DenseMap<const Pattern *, TypeBase *> PatternTypes;
   llvm::DenseMap<std::pair<const KeyPathExpr *, unsigned>, TypeBase *>
       KeyPathComponentTypes;
 
@@ -2235,9 +2236,11 @@ public:
       ExprTypes[expr] = type.getPointer();
     } else if (auto typeLoc = node.dyn_cast<const TypeLoc *>()) {
       TypeLocTypes[typeLoc] = type.getPointer();
-    } else {
-      auto var = node.get<const VarDecl *>();
+    } else if (auto var = node.dyn_cast<const VarDecl *>()) {
       VarTypes[var] = type.getPointer();
+    } else {
+      auto pattern = node.get<const Pattern *>();
+      PatternTypes[pattern] = type.getPointer();
     }
 
     // Record the fact that we ascribed a type to this node.
@@ -2258,9 +2261,11 @@ public:
       ExprTypes.erase(expr);
     } else if (auto typeLoc = node.dyn_cast<const TypeLoc *>()) {
       TypeLocTypes.erase(typeLoc);
-    } else {
-      auto var = node.get<const VarDecl *>();
+    } else if (auto var = node.dyn_cast<const VarDecl *>()) {
       VarTypes.erase(var);
+    } else {
+      auto pattern = node.get<const Pattern *>();
+      PatternTypes.erase(pattern);
     }
   }
 
@@ -2287,9 +2292,11 @@ public:
       return ExprTypes.find(expr) != ExprTypes.end();
     } else if (auto typeLoc = node.dyn_cast<const TypeLoc *>()) {
       return TypeLocTypes.find(typeLoc) != TypeLocTypes.end();
-    } else {
-      auto var = node.get<const VarDecl *>();
+    } else if (auto var = node.dyn_cast<const VarDecl *>()) {
       return VarTypes.find(var) != VarTypes.end();
+    } else {
+      auto pattern = node.get<const Pattern *>();
+      return PatternTypes.find(pattern) != PatternTypes.end();
     }
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2153,8 +2153,8 @@ TypeChecker::typeCheckExpression(
     performSyntacticExprDiagnostics(result, dc, isExprStmt);
   }
 
-  target.setExpr(result);
-  return target;
+  resultTarget->setExpr(result);
+  return *resultTarget;
 }
 
 Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
@@ -2422,6 +2422,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
   if (resultTarget) {
     initializer = resultTarget->getAsExpr();
+    pattern = resultTarget->getInitializationPattern();
     return false;
   }
 

--- a/test/Interpreter/repl.swift
+++ b/test/Interpreter/repl.swift
@@ -194,7 +194,7 @@ pr = "foo"
 pr.foo()
 
 var _ : ([Int]).Type = type(of: [4])
-// CHECK: : ([Int]).Type
+// CHECK: : [Int].Type
 var _ : ((Int) -> Int)? = .none
 // CHECK: : ((Int) -> Int)?
 func chained(f f: @escaping (Int) -> ()) -> Int { return 0 }

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -555,7 +555,6 @@ func testThrowNil() throws {
 // condition may have contained a SequenceExpr.
 func r23684220(_ b: Any) {
   if let _ = b ?? b {} // expected-error {{initializer for conditional binding must have Optional type, not 'Any'}}
-  // expected-warning@-1 {{left side of nil coalescing operator '??' has non-optional type 'Any', so the right side is never used}}
 }
 
 


### PR DESCRIPTION
Sink the constraint generation and solution application of initialization patterns, including all
of the logic for property wrappers, from the high-level entry point
`typeCheckBinding` down into the lower-level handling for
solution application targets.