### PR TITLE
[ownership] Add an extra run of the early inliner to expose more code to semantic arc opts.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -395,6 +395,7 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
   // we do not spend time optimizing them.
   P.addDeadFunctionElimination();
 
+  P.addEarlyInliner();
   P.addSemanticARCOpts();
 
   // Strip ownership from non-transparent functions.


### PR DESCRIPTION
Not expecting anything specific from this, but it should strengthen the optimization by allowing me to put some more stuff around load promotion/etc in between this and semantic arc opts.

That being said, who knows, maybe we get some wins? = p.