### PR TITLE
Presets add missing preset default for build_swift test.

### DIFF
--- a/utils/build_swift/tests/build_swift/test_presets.py
+++ b/utils/build_swift/tests/build_swift/test_presets.py
@@ -39,6 +39,7 @@ PRESET_DEFAULTS = {
     'install_destdir': '/tmp/install',
     'install_symroot': '/tmp/install/symroot',
     'install_toolchain_dir': '/tmp/install/toolchain',
+    'install_prefix': '/usr',
     'installable_package': '/tmp/install/pkg',
     'swift_install_destdir': '/tmp/install/swift',
     'symbols_package': '/path/to/symbols/package',


### PR DESCRIPTION
Just missing the default. Adding so the tests pass.