### PR TITLE
[Diagnostics] Remove `FailureDiagnosis::diagnoseParameterErrors` from CSDiag

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2811,7 +2811,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
 
     if (fixes.size() == 1) {
       // Attempt to disambiguite in cases where all the solutions
-      // produces the same fixes for diferent generic arguments e.g.
+      // produces the same fixes for different generic arguments e.g.
       //   func f<T>(_: T, _: T) {}
       //   f(Int(1), Float(1))
       //

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2765,6 +2765,9 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     ParameterList,
     /// General ambiguity failure.
     General,
+    /// Argument mismatch ambiguity where each solution has the same
+    /// argument mismatch fixes for the same call.
+    ArgumentMismatch
   };
   auto ambiguityKind = AmbiguityKind::CloseMatch;
 
@@ -2775,16 +2778,52 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
       return false;
 
     if (fixes.size() > 1) {
-      ambiguityKind = (ambiguityKind == AmbiguityKind::CloseMatch ||
-                       ambiguityKind == AmbiguityKind::ParameterList) &&
+      // Attempt to disambiguite in cases where the argument matches
+      // involves tuple mismatches. e.g.
+      // func t<T, U>(_: (T, U), _: (U, T)) {}
+      // func useTuples(_ x: Int, y: Float) {
+      //     t((x, y), (x, y))
+      // }
+      // So fixes are ambiguous in all solutions.
+      if ((ambiguityKind == AmbiguityKind::CloseMatch ||
+           ambiguityKind == AmbiguityKind::ArgumentMismatch) &&
           llvm::all_of(fixes, [](const ConstraintFix *fix) -> bool {
-            auto *locator = fix->getLocator();
-            return locator->findLast<LocatorPathElt::ApplyArgument>().hasValue();
-          }) ? AmbiguityKind::ParameterList
-             : AmbiguityKind::General;
+            return fix->getKind() == FixKind::AllowTupleTypeMismatch;
+          })) {
+        ambiguityKind = AmbiguityKind::ArgumentMismatch;
+      } else {
+        ambiguityKind =
+            (ambiguityKind == AmbiguityKind::CloseMatch ||
+             ambiguityKind == AmbiguityKind::ArgumentMismatch ||
+             ambiguityKind == AmbiguityKind::ParameterList) &&
+                    llvm::all_of(
+                        fixes,
+                        [](const ConstraintFix *fix) -> bool {
+                          auto *locator = fix->getLocator();
+                          return locator
+                              ->findLast<LocatorPathElt::ApplyArgument>()
+                              .hasValue();
+                        })
+                ? AmbiguityKind::ParameterList
+                : AmbiguityKind::General;
+      }
     }
 
-    for (const auto *fix: fixes) {
+    if (fixes.size() == 1) {
+      // Attempt to disambiguite in cases where all the solutions
+      // produces the same fixes for diferent generic arguments e.g.
+      //   func f<T>(_: T, _: T) {}
+      //   f(Int(1), Float(1))
+      //
+      ambiguityKind =
+          ((ambiguityKind == AmbiguityKind::CloseMatch ||
+            ambiguityKind == AmbiguityKind::ArgumentMismatch) &&
+           fixes.front()->getKind() == FixKind::AllowArgumentTypeMismatch)
+              ? AmbiguityKind::ArgumentMismatch
+              : AmbiguityKind::CloseMatch;
+    }
+
+    for (const auto *fix : fixes) {
       auto *locator = fix->getLocator();
       // Assignment failures are all about the source expression,
       // because they treat destination as a contextual type.
@@ -2815,6 +2854,15 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
       viableSolutions.push_back(&solution);
     return true;
   });
+
+  if (ambiguityKind == AmbiguityKind::ArgumentMismatch &&
+      viableSolutions.size() == 1) {
+    // Let's apply the solution so the contextual generic types
+    // are available in the system for diagnostics.
+    applySolution(*viableSolutions[0]);
+    solutions.front().Fixes.front()->diagnose(/*asNote*/ false);
+    return true;
+  }
 
   if (!diagnosable || viableSolutions.size() < 2)
     return false;
@@ -2860,6 +2908,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     };
 
     switch (ambiguityKind) {
+    case AmbiguityKind::ArgumentMismatch:
     case AmbiguityKind::CloseMatch:
       // Handled below
       break;

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -270,10 +270,10 @@ func associatedTypeIdentity() {
 
   sameType(cr, c.r_out())
   sameType(dr, d.r_out())
-  sameType(cr, dr) // expected-error{{}} expected-note {{}}
+  sameType(cr, dr) // expected-error {{cannot convert value of type '(some opaque.R).S' (associated type of protocol 'R') to expected argument type '(some opaque.R).S' (associated type of protocol 'R')}}
   sameType(gary(candace()).r_out(), gary(candace()).r_out())
   sameType(gary(doug()).r_out(), gary(doug()).r_out())
-  sameType(gary(doug()).r_out(), gary(candace()).r_out()) // expected-error{{}} expected-note {{}}
+  sameType(gary(doug()).r_out(), gary(candace()).r_out()) // expected-error {{cannot convert value of type 'some R' (result of 'candace()') to expected argument type 'some R' (result of 'doug()')}}
 }
 
 func redeclaration() -> some P { return 0 } // expected-note 2{{previously declared}}


### PR DESCRIPTION
This removes some obsolete code involving argument-to-param from `repairFailures`.
Removing `FailureDiagnosis::diagnoseParameterErrors` from CSDiag and fixing the remaining edge cases that were still being diagnosed by that. All of them related to ambiguity and generic types.
e.g. 
```swift
func f<T>(_ i: T, _ j: T) {}
let _ = f(Int(3), Float(2.5)) 
```

cc @xedin @hborla 