### PR TITLE
CI: force refresh of the working tree

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -82,7 +82,9 @@ setlocal enableextensions enabledelayedexpansion
 
 git -C "%source_root%\swift" config --local core.autocrlf input
 git -C "%source_root%\swift" config --local core.symlink true
-git -C "%source_root%\swift" checkout-index --force --all
+:: refresh the working tree
+git -C "%source_root%\swift" rm --cached -r .
+git -C "%source_root%\swift" reset --hard
 
 git clone --depth 1 --single-branch https://github.com/apple/swift-cmark cmark %exitOnError%
 git clone --depth 1 --single-branch --branch swift/master https://github.com/apple/llvm-project llvm-project %exitOnError%


### PR DESCRIPTION
This attempts to refresh the working tree after the configuration
changes to get the files with the normalized line endings.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
