### PR TITLE
[SE-0279][Parser] Add support for multiple trailing closures syntax

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1767,6 +1767,15 @@ ERROR(availability_query_repeated_platform, none,
 ERROR(unknown_syntax_entity, PointsToFirstBadToken,
       "unknown %0 syntax exists in the source", (StringRef))
 
+//------------------------------------------------------------------------------
+// MARK: multiple trailing closures diagnostics
+//------------------------------------------------------------------------------
+ERROR(expected_argument_label_followed_by_closure_literal,none,
+      "expected an argument label followed by a closure literal", ())
+
+ERROR(expected_multiple_closures_block_rbrace,none,
+      "expected '}' at the end of a trailing closures block", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1772,6 +1772,8 @@ ERROR(unknown_syntax_entity, PointsToFirstBadToken,
 //------------------------------------------------------------------------------
 ERROR(expected_argument_label_followed_by_closure_literal,none,
       "expected an argument label followed by a closure literal", ())
+ERROR(expected_closure_literal,none,
+      "expected a closure literal", ())
 
 ERROR(expected_multiple_closures_block_rbrace,none,
       "expected '}' at the end of a trailing closures block", ())

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -2157,6 +2157,12 @@ public:
   }
   
   unsigned getNumElements() const { return Bits.TupleExpr.NumElements; }
+
+  unsigned getNumTrailingElements() const {
+    return FirstTrailingArgumentAt
+               ? getNumElements() - *FirstTrailingArgumentAt
+               : 0;
+  }
   
   Expr *getElement(unsigned i) const {
     return getElements()[i];

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -67,6 +67,18 @@ namespace swift {
   class KeyPathExpr;
   class CaptureListExpr;
 
+struct TrailingClosure {
+  Identifier Label;
+  SourceLoc LabelLoc;
+  Expr *ClosureExpr;
+
+  TrailingClosure(Expr *closure)
+      : TrailingClosure(Identifier(), SourceLoc(), closure) {}
+
+  TrailingClosure(Identifier label, SourceLoc labelLoc, Expr *closure)
+      : Label(label), LabelLoc(labelLoc), ClosureExpr(closure) {}
+};
+
 enum class ExprKind : uint8_t {
 #define EXPR(Id, Parent) Id,
 #define LAST_EXPR(Id) Last_Expr = Id,
@@ -1194,7 +1206,7 @@ public:
                                    ArrayRef<Identifier> argLabels,
                                    ArrayRef<SourceLoc> argLabelLocs,
                                    SourceLoc rParenLoc,
-                                   ArrayRef<Expr *> trailingClosures,
+                                   ArrayRef<TrailingClosure> trailingClosures,
                                    bool implicit);
 
   LiteralKind getLiteralKind() const {
@@ -1822,7 +1834,7 @@ public:
                                       ArrayRef<Identifier> argLabels,
                                       ArrayRef<SourceLoc> argLabelLocs,
                                       SourceLoc rParenLoc,
-                                      ArrayRef<Expr *> trailingClosures,
+                                      ArrayRef<TrailingClosure> trailingClosures,
                                       bool implicit);
 
   DeclNameRef getName() const { return Name; }
@@ -2373,7 +2385,7 @@ public:
                                ArrayRef<Identifier> indexArgLabels,
                                ArrayRef<SourceLoc> indexArgLabelLocs,
                                SourceLoc rSquareLoc,
-                               ArrayRef<Expr *> trailingClosures,
+                               ArrayRef<TrailingClosure> trailingClosures,
                                ConcreteDeclRef decl = ConcreteDeclRef(),
                                bool implicit = false,
                                AccessSemantics semantics
@@ -4252,7 +4264,7 @@ public:
   static CallExpr *
   create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc, ArrayRef<Expr *> args,
          ArrayRef<Identifier> argLabels, ArrayRef<SourceLoc> argLabelLocs,
-         SourceLoc rParenLoc, ArrayRef<Expr *> trailingClosures, bool implicit,
+         SourceLoc rParenLoc, ArrayRef<TrailingClosure> trailingClosures, bool implicit,
          llvm::function_ref<Type(const Expr *)> getType =
              [](const Expr *E) -> Type { return E->getType(); });
 
@@ -5146,7 +5158,7 @@ public:
                                      ArrayRef<Identifier> indexArgLabels,
                                      ArrayRef<SourceLoc> indexArgLabelLocs,
                                      SourceLoc rSquareLoc,
-                                     ArrayRef<Expr *> trailingClosures);
+                                     ArrayRef<TrailingClosure> trailingClosures);
     
     /// Create an unresolved component for a subscript.
     ///
@@ -5198,7 +5210,7 @@ public:
                               ArrayRef<Identifier> indexArgLabels,
                               ArrayRef<SourceLoc> indexArgLabelLocs,
                               SourceLoc rSquareLoc,
-                              Expr *trailingClosure,
+                              ArrayRef<TrailingClosure> trailingClosures,
                               Type elementType,
                               ArrayRef<ProtocolConformanceRef> indexHashables);
 
@@ -5588,7 +5600,8 @@ Expr *packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
                          ArrayRef<Identifier> &argLabels,
                          ArrayRef<SourceLoc> &argLabelLocs,
                          SourceLoc rParenLoc,
-                         ArrayRef<Expr *> trailingClosures, bool implicit,
+                         ArrayRef<TrailingClosure> trailingClosures,
+                         bool implicit,
                          SmallVectorImpl<Identifier> &argLabelsScratch,
                          SmallVectorImpl<SourceLoc> &argLabelLocsScratch,
                          llvm::function_ref<Type(const Expr *)> getType =

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1206,6 +1206,8 @@ public:
                                    ArrayRef<Identifier> argLabels,
                                    ArrayRef<SourceLoc> argLabelLocs,
                                    SourceLoc rParenLoc,
+                                   SourceLoc trailingLBrace,
+                                   SourceLoc trailingRBrace,
                                    ArrayRef<TrailingClosure> trailingClosures,
                                    bool implicit);
 
@@ -1834,6 +1836,8 @@ public:
                                       ArrayRef<Identifier> argLabels,
                                       ArrayRef<SourceLoc> argLabelLocs,
                                       SourceLoc rParenLoc,
+                                      SourceLoc trailingLBrace,
+                                      SourceLoc trailingRBrace,
                                       ArrayRef<TrailingClosure> trailingClosures,
                                       bool implicit);
 
@@ -2055,8 +2059,8 @@ class TupleExpr final : public Expr,
   SourceLoc LParenLoc;
   SourceLoc RParenLoc;
 
-  SourceLoc TrailingBlockLBrace;
-  SourceLoc TrailingBlockRBrace;
+  SourceLoc TrailingLBraceLoc;
+  SourceLoc TrailingRBraceLoc;
 
   Optional<unsigned> FirstTrailingArgumentAt;
 
@@ -2127,6 +2131,9 @@ public:
   SourceLoc getRParenLoc() const { return RParenLoc; }
 
   SourceRange getSourceRange() const;
+
+  SourceLoc getTrailingLBraceLoc() const { return TrailingLBraceLoc; }
+  SourceLoc getTrailingRBraceLoc() const { return TrailingRBraceLoc; }
 
   /// Whether this expression has a trailing closure as its argument.
   bool hasTrailingClosure() const {
@@ -2385,6 +2392,8 @@ public:
                                ArrayRef<Identifier> indexArgLabels,
                                ArrayRef<SourceLoc> indexArgLabelLocs,
                                SourceLoc rSquareLoc,
+                               SourceLoc trailingLBrace,
+                               SourceLoc trailingRBrace,
                                ArrayRef<TrailingClosure> trailingClosures,
                                ConcreteDeclRef decl = ConcreteDeclRef(),
                                bool implicit = false,
@@ -4248,8 +4257,9 @@ public:
                  ArrayRef<Identifier> argLabels,
                  llvm::function_ref<Type(const Expr *)> getType =
                      [](const Expr *E) -> Type { return E->getType(); }) {
-    return create(ctx, fn, SourceLoc(), args, argLabels, { }, SourceLoc(),
-                  /*trailingClosures=*/{}, /*implicit=*/true, getType);
+    return create(ctx, fn, SourceLoc(), args, argLabels, {}, SourceLoc(),
+                  SourceLoc(), SourceLoc(), /*trailingClosures=*/{},
+                  /*implicit=*/true, getType);
   }
 
   /// Create a new call expression.
@@ -4264,7 +4274,8 @@ public:
   static CallExpr *
   create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc, ArrayRef<Expr *> args,
          ArrayRef<Identifier> argLabels, ArrayRef<SourceLoc> argLabelLocs,
-         SourceLoc rParenLoc, ArrayRef<TrailingClosure> trailingClosures, bool implicit,
+         SourceLoc rParenLoc, SourceLoc trailingLBrace, SourceLoc trailingRBrace,
+         ArrayRef<TrailingClosure> trailingClosures, bool implicit,
          llvm::function_ref<Type(const Expr *)> getType =
              [](const Expr *E) -> Type { return E->getType(); });
 
@@ -5158,6 +5169,8 @@ public:
                                      ArrayRef<Identifier> indexArgLabels,
                                      ArrayRef<SourceLoc> indexArgLabelLocs,
                                      SourceLoc rSquareLoc,
+                                     SourceLoc trailingLBrace,
+                                     SourceLoc trailingRBrace,
                                      ArrayRef<TrailingClosure> trailingClosures);
     
     /// Create an unresolved component for a subscript.
@@ -5210,6 +5223,8 @@ public:
                               ArrayRef<Identifier> indexArgLabels,
                               ArrayRef<SourceLoc> indexArgLabelLocs,
                               SourceLoc rSquareLoc,
+                              SourceLoc trailingLBrace,
+                              SourceLoc trailingRBrace,
                               ArrayRef<TrailingClosure> trailingClosures,
                               Type elementType,
                               ArrayRef<ProtocolConformanceRef> indexHashables);
@@ -5600,6 +5615,8 @@ Expr *packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
                          ArrayRef<Identifier> &argLabels,
                          ArrayRef<SourceLoc> &argLabelLocs,
                          SourceLoc rParenLoc,
+                         SourceLoc trailingLBrace,
+                         SourceLoc trailingRBrace,
                          ArrayRef<TrailingClosure> trailingClosures,
                          bool implicit,
                          SmallVectorImpl<Identifier> &argLabelsScratch,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1194,7 +1194,7 @@ public:
                                    ArrayRef<Identifier> argLabels,
                                    ArrayRef<SourceLoc> argLabelLocs,
                                    SourceLoc rParenLoc,
-                                   Expr *trailingClosure,
+                                   ArrayRef<Expr *> trailingClosures,
                                    bool implicit);
 
   LiteralKind getLiteralKind() const {
@@ -1822,7 +1822,7 @@ public:
                                       ArrayRef<Identifier> argLabels,
                                       ArrayRef<SourceLoc> argLabelLocs,
                                       SourceLoc rParenLoc,
-                                      Expr *trailingClosure,
+                                      ArrayRef<Expr *> trailingClosures,
                                       bool implicit);
 
   DeclNameRef getName() const { return Name; }
@@ -2373,7 +2373,7 @@ public:
                                ArrayRef<Identifier> indexArgLabels,
                                ArrayRef<SourceLoc> indexArgLabelLocs,
                                SourceLoc rSquareLoc,
-                               Expr *trailingClosure,
+                               ArrayRef<Expr *> trailingClosures,
                                ConcreteDeclRef decl = ConcreteDeclRef(),
                                bool implicit = false,
                                AccessSemantics semantics
@@ -4237,7 +4237,7 @@ public:
                  llvm::function_ref<Type(const Expr *)> getType =
                      [](const Expr *E) -> Type { return E->getType(); }) {
     return create(ctx, fn, SourceLoc(), args, argLabels, { }, SourceLoc(),
-                  /*trailingClosure=*/nullptr, /*implicit=*/true, getType);
+                  /*trailingClosures=*/{}, /*implicit=*/true, getType);
   }
 
   /// Create a new call expression.
@@ -4248,11 +4248,11 @@ public:
   /// or which must be empty.
   /// \param argLabelLocs The locations of the argument labels, whose size must
   /// equal args.size() or which must be empty.
-  /// \param trailingClosure The trailing closure, if any.
+  /// \param trailingClosures The list of trailing closures, if any.
   static CallExpr *
   create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc, ArrayRef<Expr *> args,
          ArrayRef<Identifier> argLabels, ArrayRef<SourceLoc> argLabelLocs,
-         SourceLoc rParenLoc, Expr *trailingClosure, bool implicit,
+         SourceLoc rParenLoc, ArrayRef<Expr *> trailingClosures, bool implicit,
          llvm::function_ref<Type(const Expr *)> getType =
              [](const Expr *E) -> Type { return E->getType(); });
 
@@ -4273,7 +4273,7 @@ public:
   unsigned getNumArguments() const { return Bits.CallExpr.NumArgLabels; }
   bool hasArgumentLabelLocs() const { return Bits.CallExpr.HasArgLabelLocs; }
 
-  /// Whether this call with written with a trailing closure.
+  /// Whether this call with written with a single trailing closure.
   bool hasTrailingClosure() const { return Bits.CallExpr.HasTrailingClosure; }
 
   using TrailingCallArguments::getArgumentLabels;
@@ -5146,7 +5146,7 @@ public:
                                      ArrayRef<Identifier> indexArgLabels,
                                      ArrayRef<SourceLoc> indexArgLabelLocs,
                                      SourceLoc rSquareLoc,
-                                     Expr *trailingClosure);
+                                     ArrayRef<Expr *> trailingClosures);
     
     /// Create an unresolved component for a subscript.
     ///
@@ -5588,7 +5588,7 @@ Expr *packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
                          ArrayRef<Identifier> &argLabels,
                          ArrayRef<SourceLoc> &argLabelLocs,
                          SourceLoc rParenLoc,
-                         Expr *trailingClosure, bool implicit,
+                         ArrayRef<Expr *> trailingClosures, bool implicit,
                          SmallVectorImpl<Identifier> &argLabelsScratch,
                          SmallVectorImpl<SourceLoc> &argLabelLocsScratch,
                          llvm::function_ref<Type(const Expr *)> getType =

--- a/include/swift/AST/TrailingCallArguments.h
+++ b/include/swift/AST/TrailingCallArguments.h
@@ -82,16 +82,14 @@ class TrailingCallArguments
 protected:
   /// Determine the total size to allocate.
   static size_t totalSizeToAlloc(ArrayRef<Identifier> argLabels,
-                                 ArrayRef<SourceLoc> argLabelLocs,
-                                 bool hasTrailingClosure) {
+                                 ArrayRef<SourceLoc> argLabelLocs) {
     return TrailingObjects::template totalSizeToAlloc<Identifier, SourceLoc>(
         argLabels.size(), argLabelLocs.size());
   }
 
   /// Initialize the actual call arguments.
   void initializeCallArguments(ArrayRef<Identifier> argLabels,
-                               ArrayRef<SourceLoc> argLabelLocs,
-                               bool hasTrailingClosure) {
+                               ArrayRef<SourceLoc> argLabelLocs) {
     if (!argLabels.empty()) {
       std::uninitialized_copy(argLabels.begin(), argLabels.end(),
                               this->template getTrailingObjects<Identifier>());

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1567,7 +1567,7 @@ public:
                              SmallVectorImpl<Identifier> &exprLabels,
                              SmallVectorImpl<SourceLoc> &exprLabelLocs,
                              SourceLoc &rightLoc,
-                             Expr *&trailingClosure,
+                             SmallVectorImpl<Expr *> &trailingClosures,
                              syntax::SyntaxKind Kind);
 
   ParserResult<Expr> parseTrailingClosure(SourceRange calleeRange);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1567,12 +1567,19 @@ public:
                              SmallVectorImpl<Identifier> &exprLabels,
                              SmallVectorImpl<SourceLoc> &exprLabelLocs,
                              SourceLoc &rightLoc,
+                             SourceLoc &trailingLBrace,
+                             SourceLoc &trailingRBrace,
                              SmallVectorImpl<TrailingClosure> &trailingClosures,
                              syntax::SyntaxKind Kind);
 
   ParserStatus
-  parseTrailingClosures(SourceRange calleeRange,
+  parseTrailingClosures(bool isExprBasic, SourceRange calleeRange,
+                        SourceLoc &LBrace, SourceLoc &RBrace,
                         SmallVectorImpl<TrailingClosure> &closures);
+
+  ParserStatus
+  parseMultipleTrailingClosures(SourceLoc &LBrace, SourceLoc &RBrace,
+                                SmallVectorImpl<TrailingClosure> &closures);
 
   /// Parse an object literal.
   ///

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1567,7 +1567,7 @@ public:
                              SmallVectorImpl<Identifier> &exprLabels,
                              SmallVectorImpl<SourceLoc> &exprLabelLocs,
                              SourceLoc &rightLoc,
-                             SmallVectorImpl<Expr *> &trailingClosures,
+                             SmallVectorImpl<TrailingClosure> &trailingClosures,
                              syntax::SyntaxKind Kind);
 
   ParserResult<Expr> parseTrailingClosure(SourceRange calleeRange);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1570,7 +1570,9 @@ public:
                              SmallVectorImpl<TrailingClosure> &trailingClosures,
                              syntax::SyntaxKind Kind);
 
-  ParserResult<Expr> parseTrailingClosure(SourceRange calleeRange);
+  ParserStatus
+  parseTrailingClosures(SourceRange calleeRange,
+                        SmallVectorImpl<TrailingClosure> &closures);
 
   /// Parse an object literal.
   ///

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1850,8 +1850,7 @@ CustomAttr::CustomAttr(SourceLoc atLoc, SourceRange range, TypeLoc type,
       initContext(initContext) {
   hasArgLabelLocs = !argLabelLocs.empty();
   numArgLabels = argLabels.size();
-  initializeCallArguments(argLabels, argLabelLocs,
-                          /*hasTrailingClosure=*/false);
+  initializeCallArguments(argLabels, argLabelLocs);
 }
 
 CustomAttr *CustomAttr::create(ASTContext &ctx, SourceLoc atLoc, TypeLoc type,
@@ -1876,8 +1875,7 @@ CustomAttr *CustomAttr::create(ASTContext &ctx, SourceLoc atLoc, TypeLoc type,
   if (arg)
     range.End = arg->getEndLoc();
 
-  size_t size = totalSizeToAlloc(argLabels, argLabelLocs,
-                                 /*hasTrailingClosure=*/false);
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
   void *mem = ctx.Allocate(size, alignof(CustomAttr));
   return new (mem) CustomAttr(atLoc, range, type, initContext, arg, argLabels,
                               argLabelLocs, implicit);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1867,8 +1867,8 @@ CustomAttr *CustomAttr::create(ASTContext &ctx, SourceLoc atLoc, TypeLoc type,
   Expr *arg = nullptr;
   if (hasInitializer) {
     arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
-                             rParenLoc, nullptr, implicit, argLabelsScratch,
-                             argLabelLocsScratch);
+                             rParenLoc, /*trailingClosures=*/{}, implicit,
+                             argLabelsScratch, argLabelLocsScratch);
   }
 
   SourceRange range(atLoc, type.getSourceRange().End);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1867,7 +1867,8 @@ CustomAttr *CustomAttr::create(ASTContext &ctx, SourceLoc atLoc, TypeLoc type,
   Expr *arg = nullptr;
   if (hasInitializer) {
     arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
-                             rParenLoc, /*trailingClosures=*/{}, implicit,
+                             rParenLoc, SourceLoc(), SourceLoc(),
+                             /*trailingClosures=*/{}, implicit,
                              argLabelsScratch, argLabelLocsScratch);
   }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1259,14 +1259,18 @@ SourceRange TupleExpr::getSourceRange() const {
   }
 }
 
-TupleExpr::TupleExpr(SourceLoc LParenLoc, ArrayRef<Expr *> SubExprs,
+TupleExpr::TupleExpr(SourceLoc LParenLoc, SourceLoc RParenLoc,
+                     ArrayRef<Expr *> SubExprs,
                      ArrayRef<Identifier> ElementNames, 
                      ArrayRef<SourceLoc> ElementNameLocs,
-                     SourceLoc RParenLoc, bool HasTrailingClosure, 
+                     SourceLoc TrailingLBrace,
+                     SourceLoc TrailingRBrace,
+                     Optional<unsigned> FirstTrailingArgumentAt,
                      bool Implicit, Type Ty)
   : Expr(ExprKind::Tuple, Implicit, Ty),
-    LParenLoc(LParenLoc), RParenLoc(RParenLoc) {
-  Bits.TupleExpr.HasTrailingClosure = HasTrailingClosure;
+    LParenLoc(LParenLoc), RParenLoc(RParenLoc),
+    TrailingBlockLBrace(TrailingLBrace), TrailingBlockRBrace(TrailingRBrace),
+    FirstTrailingArgumentAt(FirstTrailingArgumentAt) {
   Bits.TupleExpr.HasElementNames = !ElementNames.empty();
   Bits.TupleExpr.HasElementNameLocations = !ElementNameLocs.empty();
   Bits.TupleExpr.NumElements = SubExprs.size();
@@ -1295,11 +1299,30 @@ TupleExpr::TupleExpr(SourceLoc LParenLoc, ArrayRef<Expr *> SubExprs,
 }
 
 TupleExpr *TupleExpr::create(ASTContext &ctx,
-                             SourceLoc LParenLoc, 
+                             SourceLoc LParenLoc,
                              ArrayRef<Expr *> SubExprs,
-                             ArrayRef<Identifier> ElementNames, 
+                             ArrayRef<Identifier> ElementNames,
                              ArrayRef<SourceLoc> ElementNameLocs,
-                             SourceLoc RParenLoc, bool HasTrailingClosure, 
+                             SourceLoc RParenLoc,
+                             bool HasTrailingClosure,
+                             bool Implicit, Type Ty) {
+  Optional<unsigned> FirstTrailingArgumentAt =
+      HasTrailingClosure ? SubExprs.size() - 1 : Optional<unsigned>();
+
+  return create(ctx, LParenLoc, RParenLoc, SubExprs, ElementNames,
+                ElementNameLocs, SourceLoc(), SourceLoc(),
+                FirstTrailingArgumentAt, Implicit, Ty);
+}
+
+TupleExpr *TupleExpr::create(ASTContext &ctx,
+                             SourceLoc LParenLoc,
+                             SourceLoc RParenLoc,
+                             ArrayRef<Expr *> SubExprs,
+                             ArrayRef<Identifier> ElementNames,
+                             ArrayRef<SourceLoc> ElementNameLocs,
+                             SourceLoc TrailingLBrace,
+                             SourceLoc TrailingRBrace,
+                             Optional<unsigned> FirstTrailingArgumentAt,
                              bool Implicit, Type Ty) {
   assert(!Ty || isa<TupleType>(Ty.getPointer()));
   auto hasNonEmptyIdentifier = [](ArrayRef<Identifier> Ids) -> bool {
@@ -1319,23 +1342,24 @@ TupleExpr *TupleExpr::create(ASTContext &ctx,
                                                       ElementNames.size(),
                                                       ElementNameLocs.size());
   void *mem = ctx.Allocate(size, alignof(TupleExpr));
-  return new (mem) TupleExpr(LParenLoc, SubExprs, ElementNames, ElementNameLocs,
-                             RParenLoc, HasTrailingClosure, Implicit, Ty);
+  return new (mem) TupleExpr(LParenLoc, RParenLoc, SubExprs, ElementNames,
+                             ElementNameLocs, TrailingLBrace, TrailingRBrace,
+                             FirstTrailingArgumentAt, Implicit, Ty);
 }
 
 TupleExpr *TupleExpr::createEmpty(ASTContext &ctx, SourceLoc LParenLoc, 
                                   SourceLoc RParenLoc, bool Implicit) {
-  return create(ctx, LParenLoc, { }, { }, { }, RParenLoc, 
-                /*HasTrailingClosure=*/false, Implicit, 
+  return create(ctx, LParenLoc, RParenLoc, {}, {}, {}, SourceLoc(), SourceLoc(),
+                /*FirstTrailingArgumentAt=*/None, Implicit,
                 TupleType::getEmpty(ctx));
 }
 
 TupleExpr *TupleExpr::createImplicit(ASTContext &ctx, ArrayRef<Expr *> SubExprs,
                                      ArrayRef<Identifier> ElementNames) {
-  return create(ctx, SourceLoc(), SubExprs, ElementNames, { }, SourceLoc(),
-                /*HasTrailingClosure=*/false, /*Implicit=*/true, Type());
+  return create(ctx, SourceLoc(), SourceLoc(), SubExprs, ElementNames, {},
+                SourceLoc(), SourceLoc(), /*FirstTrailingArgumentAt=*/None,
+                /*Implicit=*/true, Type());
 }
-
 
 ArrayExpr *ArrayExpr::create(ASTContext &C, SourceLoc LBracketLoc,
                              ArrayRef<Expr*> Elements,

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -967,7 +967,7 @@ swift::packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
                           ArrayRef<Identifier> &argLabels,
                           ArrayRef<SourceLoc> &argLabelLocs,
                           SourceLoc rParenLoc,
-                          Expr *trailingClosure, bool implicit,
+                          ArrayRef<Expr *> trailingClosures, bool implicit,
                           SmallVectorImpl<Identifier> &argLabelsScratch,
                           SmallVectorImpl<SourceLoc> &argLabelLocsScratch,
                           llvm::function_ref<Type(const Expr *)> getType) {
@@ -976,7 +976,7 @@ swift::packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
   argLabelLocsScratch.clear();
 
   // Construct a TupleExpr or ParenExpr, as appropriate, for the argument.
-  if (!trailingClosure) {
+  if (trailingClosures.empty()) {
     // Do we have a single, unlabeled argument?
     if (args.size() == 1 && (argLabels.empty() || argLabels[0].empty())) {
       auto arg = new (ctx) ParenExpr(lParenLoc, args[0], rParenLoc,
@@ -1007,11 +1007,12 @@ swift::packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
     return arg;
   }
 
-  // If we have no other arguments, represent the trailing closure as a
+  // If we have no other arguments, represent the a single trailing closure as a
   // parenthesized expression.
-  if (args.empty()) {
-    auto arg = new (ctx) ParenExpr(lParenLoc, trailingClosure, rParenLoc,
-                                   /*hasTrailingClosure=*/true);
+  if (args.empty() && trailingClosures.size() == 1) {
+    auto arg =
+        new (ctx) ParenExpr(lParenLoc, trailingClosures.front(), rParenLoc,
+                            /*hasTrailingClosure=*/true);
     computeSingleArgumentType(ctx, arg, implicit, getType);
     argLabelsScratch.push_back(Identifier());
     argLabels = argLabelsScratch;
@@ -1025,7 +1026,7 @@ swift::packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
   SmallVector<Expr *, 4> argsScratch;
   argsScratch.reserve(args.size() + 1);
   argsScratch.append(args.begin(), args.end());
-  argsScratch.push_back(trailingClosure);
+  argsScratch.append(trailingClosures.begin(), trailingClosures.end());
   args = argsScratch;
 
   argLabelsScratch.reserve(args.size());
@@ -1033,23 +1034,24 @@ swift::packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
     argLabelsScratch.assign(args.size(), Identifier());
   } else {
     argLabelsScratch.append(argLabels.begin(), argLabels.end());
-    argLabelsScratch.push_back(Identifier());
+    if (trailingClosures.size() == 1)
+      argLabelsScratch.push_back(Identifier());
   }
   argLabels = argLabelsScratch;
 
   if (!argLabelLocs.empty()) {
     argLabelLocsScratch.reserve(argLabelLocs.size() + 1);
     argLabelLocsScratch.append(argLabelLocs.begin(), argLabelLocs.end());
-    argLabelLocsScratch.push_back(SourceLoc());
+    if (trailingClosures.size() == 1)
+      argLabelLocsScratch.push_back(SourceLoc());
     argLabelLocs = argLabelLocsScratch;
   }
 
-  auto arg = TupleExpr::create(ctx, lParenLoc, args, argLabels,
-                               argLabelLocs, rParenLoc,
-                               /*HasTrailingClosure=*/true,
+  auto arg = TupleExpr::create(ctx, lParenLoc, rParenLoc, args, argLabels,
+                               argLabelLocs, SourceLoc(), SourceLoc(),
+                               args.size() - trailingClosures.size(),
                                /*Implicit=*/false);
   computeSingleArgumentType(ctx, arg, implicit, getType);
-
   return arg;
 }
 
@@ -1099,12 +1101,12 @@ ObjectLiteralExpr *ObjectLiteralExpr::create(ASTContext &ctx,
                                              ArrayRef<Identifier> argLabels,
                                              ArrayRef<SourceLoc> argLabelLocs,
                                              SourceLoc rParenLoc,
-                                             Expr *trailingClosure,
+                                             ArrayRef<Expr *> trailingClosures,
                                              bool implicit) {
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
-                                 rParenLoc, trailingClosure, implicit,
+                                 rParenLoc, trailingClosures, implicit,
                                  argLabelsScratch, argLabelLocsScratch);
 
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
@@ -1112,7 +1114,7 @@ ObjectLiteralExpr *ObjectLiteralExpr::create(ASTContext &ctx,
   void *memory = ctx.Allocate(size, alignof(ObjectLiteralExpr));
   return new (memory) ObjectLiteralExpr(poundLoc, kind, arg, argLabels,
                                         argLabelLocs,
-                                        trailingClosure != nullptr, implicit);
+                                        trailingClosures.size() == 1, implicit);
 }
 
 StringRef ObjectLiteralExpr::getLiteralKindRawName() const {
@@ -1491,7 +1493,7 @@ SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base,
                                      ArrayRef<Identifier> indexArgLabels,
                                      ArrayRef<SourceLoc> indexArgLabelLocs,
                                      SourceLoc rSquareLoc,
-                                     Expr *trailingClosure,
+                                     ArrayRef<Expr *> trailingClosures,
                                      ConcreteDeclRef decl,
                                      bool implicit,
                                      AccessSemantics semantics) {
@@ -1499,7 +1501,7 @@ SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base,
   SmallVector<SourceLoc, 4> indexArgLabelLocsScratch;
   Expr *index = packSingleArgument(ctx, lSquareLoc, indexArgs, indexArgLabels,
                                    indexArgLabelLocs, rSquareLoc,
-                                   trailingClosure, implicit,
+                                   trailingClosures, implicit,
                                    indexArgLabelsScratch,
                                    indexArgLabelLocsScratch);
 
@@ -1508,7 +1510,7 @@ SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base,
   void *memory = ctx.Allocate(size, alignof(SubscriptExpr));
   return new (memory) SubscriptExpr(base, index, indexArgLabels,
                                     indexArgLabelLocs,
-                                    trailingClosure != nullptr,
+                                    trailingClosures.size() == 1,
                                     decl, implicit, semantics);
 }
 
@@ -1586,13 +1588,13 @@ UnresolvedMemberExpr::create(ASTContext &ctx, SourceLoc dotLoc,
                              ArrayRef<Identifier> argLabels,
                              ArrayRef<SourceLoc> argLabelLocs,
                              SourceLoc rParenLoc,
-                             Expr *trailingClosure,
+                             ArrayRef<Expr *> trailingClosures,
                              bool implicit) {
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels,
                                  argLabelLocs, rParenLoc,
-                                 trailingClosure, implicit,
+                                 trailingClosures, implicit,
                                  argLabelsScratch,
                                  argLabelLocsScratch);
 
@@ -1601,7 +1603,7 @@ UnresolvedMemberExpr::create(ASTContext &ctx, SourceLoc dotLoc,
   void *memory = ctx.Allocate(size, alignof(UnresolvedMemberExpr));
   return new (memory) UnresolvedMemberExpr(dotLoc, nameLoc, name, arg,
                                            argLabels, argLabelLocs,
-                                           trailingClosure != nullptr,
+                                           trailingClosures.size() == 1,
                                            implicit);
 }
 
@@ -1639,17 +1641,20 @@ bool ApplyExpr::hasTrailingClosure() const {
 CallExpr::CallExpr(Expr *fn, Expr *arg, bool Implicit,
                    ArrayRef<Identifier> argLabels,
                    ArrayRef<SourceLoc> argLabelLocs,
+                   bool hasTrailingClosure,
                    Type ty)
     : ApplyExpr(ExprKind::Call, fn, arg, Implicit, ty)
 {
   Bits.CallExpr.NumArgLabels = argLabels.size();
   Bits.CallExpr.HasArgLabelLocs = !argLabelLocs.empty();
+  Bits.CallExpr.HasTrailingClosure = hasTrailingClosure;
   initializeCallArguments(argLabels, argLabelLocs);
 }
 
 CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
                            ArrayRef<Identifier> argLabels,
                            ArrayRef<SourceLoc> argLabelLocs,
+                           bool hasTrailingClosure,
                            bool implicit, Type type,
                            llvm::function_ref<Type(const Expr *)> getType) {
   SmallVector<Identifier, 4> argLabelsScratch;
@@ -1657,7 +1662,6 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
   if (argLabels.empty()) {
     // Inspect the argument to dig out the argument labels, their location, and
     // whether there is a trailing closure.
-    bool hasTrailingClosure;
     argLabels = getArgumentLabelsFromArgument(arg, argLabelsScratch,
                                               &argLabelLocsScratch,
                                               &hasTrailingClosure,
@@ -1668,7 +1672,8 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(CallExpr));
-  return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs, type);
+  return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs,
+                               hasTrailingClosure, type);
 }
 
 CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc,
@@ -1689,7 +1694,8 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc,
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(CallExpr));
-  return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs, Type());
+  return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs,
+                               trailingClosures.size() == 1, Type());
 }
 
 Expr *CallExpr::getDirectCallee() const {
@@ -2164,12 +2170,12 @@ KeyPathExpr::Component::forUnresolvedSubscript(ASTContext &ctx,
                                          ArrayRef<Identifier> indexArgLabels,
                                          ArrayRef<SourceLoc> indexArgLabelLocs,
                                          SourceLoc rSquareLoc,
-                                         Expr *trailingClosure) {
+                                         ArrayRef<Expr *> trailingClosures) {
   SmallVector<Identifier, 4> indexArgLabelsScratch;
   SmallVector<SourceLoc, 4> indexArgLabelLocsScratch;
   Expr *index = packSingleArgument(ctx, lSquareLoc, indexArgs, indexArgLabels,
                                    indexArgLabelLocs, rSquareLoc,
-                                   trailingClosure, /*implicit*/ false,
+                                   trailingClosures, /*implicit*/ false,
                                    indexArgLabelsScratch,
                                    indexArgLabelLocsScratch);
   return forUnresolvedSubscriptWithPrebuiltIndexExpr(ctx, index,

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -967,6 +967,8 @@ swift::packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
                           ArrayRef<Identifier> &argLabels,
                           ArrayRef<SourceLoc> &argLabelLocs,
                           SourceLoc rParenLoc,
+                          SourceLoc trailingLBrace,
+                          SourceLoc trailingRBrace,
                           ArrayRef<TrailingClosure> trailingClosures,
                           bool implicit,
                           SmallVectorImpl<Identifier> &argLabelsScratch,
@@ -1024,34 +1026,44 @@ swift::packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
 
   assert(argLabels.empty() || args.size() == argLabels.size());
 
+  unsigned numRegularArgs = args.size();
+
   // Form a tuple, including the trailing closure.
   SmallVector<Expr *, 4> argsScratch;
-  argsScratch.reserve(args.size() + 1);
+  argsScratch.reserve(numRegularArgs + trailingClosures.size());
   argsScratch.append(args.begin(), args.end());
   for (const auto &closure : trailingClosures)
     argsScratch.push_back(closure.ClosureExpr);
   args = argsScratch;
 
-  argLabelsScratch.reserve(args.size());
-  if (argLabels.empty()) {
-    argLabelsScratch.assign(args.size(), Identifier());
-  } else {
-    argLabelsScratch.append(argLabels.begin(), argLabels.end());
+  {
+    if (argLabels.empty()) {
+      argLabelsScratch.resize(numRegularArgs);
+    } else {
+      argLabelsScratch.append(argLabels.begin(), argLabels.end());
+    }
+
     for (const auto &closure : trailingClosures)
       argLabelsScratch.push_back(closure.Label);
-  }
-  argLabels = argLabelsScratch;
 
-  if (!argLabelLocs.empty()) {
-    argLabelLocsScratch.reserve(argLabelLocs.size() + trailingClosures.size());
-    argLabelLocsScratch.append(argLabelLocs.begin(), argLabelLocs.end());
+    argLabels = argLabelsScratch;
+  }
+
+  {
+    if (argLabelLocs.empty()) {
+      argLabelLocsScratch.resize(numRegularArgs);
+    } else {
+      argLabelLocsScratch.append(argLabelLocs.begin(), argLabelLocs.end());
+    }
+
     for (const auto &closure : trailingClosures)
       argLabelLocsScratch.push_back(closure.LabelLoc);
+
     argLabelLocs = argLabelLocsScratch;
   }
 
   auto arg = TupleExpr::create(ctx, lParenLoc, rParenLoc, args, argLabels,
-                               argLabelLocs, SourceLoc(), SourceLoc(),
+                               argLabelLocs, trailingLBrace, trailingRBrace,
                                args.size() - trailingClosures.size(),
                                /*Implicit=*/false);
   computeSingleArgumentType(ctx, arg, implicit, getType);
@@ -1104,13 +1116,16 @@ ObjectLiteralExpr *ObjectLiteralExpr::create(ASTContext &ctx,
                                              ArrayRef<Identifier> argLabels,
                                              ArrayRef<SourceLoc> argLabelLocs,
                                              SourceLoc rParenLoc,
+                                             SourceLoc trailingLBrace,
+                                             SourceLoc trailingRBrace,
                                              ArrayRef<TrailingClosure> trailingClosures,
                                              bool implicit) {
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
-                                 rParenLoc, trailingClosures, implicit,
-                                 argLabelsScratch, argLabelLocsScratch);
+                                 rParenLoc, trailingLBrace, trailingRBrace,
+                                 trailingClosures, implicit, argLabelsScratch,
+                                 argLabelLocsScratch);
 
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
@@ -1230,6 +1245,8 @@ SourceRange TupleExpr::getSourceRange() const {
     start = LParenLoc;
   } else if (getNumElements() == 0) {
     return { SourceLoc(), SourceLoc() };
+  } else if (TrailingLBraceLoc.isValid()) {
+    start = TrailingLBraceLoc;
   } else {
     // Scan forward for the first valid source loc.
     for (Expr *expr : getElements()) {
@@ -1240,9 +1257,12 @@ SourceRange TupleExpr::getSourceRange() const {
     }
   }
   
-  if (hasTrailingClosure() || RParenLoc.isInvalid()) {
+  if (hasTrailingClosure() || hasMultipleTrailingClosures() ||
+      RParenLoc.isInvalid()) {
     if (getNumElements() == 0) {
       return { SourceLoc(), SourceLoc() };
+    } else if (TrailingRBraceLoc.isValid()) {
+      end = TrailingRBraceLoc;
     } else {
       // Scan backwards for a valid source loc.
       for (Expr *expr : llvm::reverse(getElements())) {
@@ -1273,7 +1293,7 @@ TupleExpr::TupleExpr(SourceLoc LParenLoc, SourceLoc RParenLoc,
                      bool Implicit, Type Ty)
   : Expr(ExprKind::Tuple, Implicit, Ty),
     LParenLoc(LParenLoc), RParenLoc(RParenLoc),
-    TrailingBlockLBrace(TrailingLBrace), TrailingBlockRBrace(TrailingRBrace),
+    TrailingLBraceLoc(TrailingLBrace), TrailingRBraceLoc(TrailingRBrace),
     FirstTrailingArgumentAt(FirstTrailingArgumentAt) {
   Bits.TupleExpr.HasElementNames = !ElementNames.empty();
   Bits.TupleExpr.HasElementNameLocations = !ElementNameLocs.empty();
@@ -1496,6 +1516,8 @@ SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base,
                                      ArrayRef<Identifier> indexArgLabels,
                                      ArrayRef<SourceLoc> indexArgLabelLocs,
                                      SourceLoc rSquareLoc,
+                                     SourceLoc trailingLBrace,
+                                     SourceLoc trailingRBrace,
                                      ArrayRef<TrailingClosure> trailingClosures,
                                      ConcreteDeclRef decl,
                                      bool implicit,
@@ -1504,6 +1526,7 @@ SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base,
   SmallVector<SourceLoc, 4> indexArgLabelLocsScratch;
   Expr *index = packSingleArgument(ctx, lSquareLoc, indexArgs, indexArgLabels,
                                    indexArgLabelLocs, rSquareLoc,
+                                   trailingLBrace, trailingRBrace,
                                    trailingClosures, implicit,
                                    indexArgLabelsScratch,
                                    indexArgLabelLocsScratch);
@@ -1591,14 +1614,15 @@ UnresolvedMemberExpr::create(ASTContext &ctx, SourceLoc dotLoc,
                              ArrayRef<Identifier> argLabels,
                              ArrayRef<SourceLoc> argLabelLocs,
                              SourceLoc rParenLoc,
+                             SourceLoc trailingLBrace,
+                             SourceLoc trailingRBrace,
                              ArrayRef<TrailingClosure> trailingClosures,
                              bool implicit) {
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
-  Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels,
-                                 argLabelLocs, rParenLoc,
-                                 trailingClosures, implicit,
-                                 argLabelsScratch,
+  Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
+                                 rParenLoc, trailingLBrace, trailingRBrace,
+                                 trailingClosures, implicit, argLabelsScratch,
                                  argLabelLocsScratch);
 
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
@@ -1684,15 +1708,17 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc,
                            ArrayRef<Identifier> argLabels,
                            ArrayRef<SourceLoc> argLabelLocs,
                            SourceLoc rParenLoc,
+                           SourceLoc trailingLBrace,
+                           SourceLoc trailingRBrace,
                            ArrayRef<TrailingClosure> trailingClosures,
                            bool implicit,
                            llvm::function_ref<Type(const Expr *)> getType) {
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
-                                 rParenLoc, trailingClosures, implicit,
-                                 argLabelsScratch, argLabelLocsScratch,
-                                 getType);
+                                 rParenLoc, trailingLBrace, trailingRBrace,
+                                 trailingClosures, implicit, argLabelsScratch,
+                                 argLabelLocsScratch, getType);
 
   size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
@@ -2149,6 +2175,8 @@ KeyPathExpr::Component::forSubscript(ASTContext &ctx,
                              ArrayRef<Identifier> indexArgLabels,
                              ArrayRef<SourceLoc> indexArgLabelLocs,
                              SourceLoc rSquareLoc,
+                             SourceLoc trailingLBrace,
+                             SourceLoc trailingRBrace,
                              ArrayRef<TrailingClosure> trailingClosures,
                              Type elementType,
                              ArrayRef<ProtocolConformanceRef> indexHashables) {
@@ -2156,6 +2184,7 @@ KeyPathExpr::Component::forSubscript(ASTContext &ctx,
   SmallVector<SourceLoc, 4> indexArgLabelLocsScratch;
   Expr *index = packSingleArgument(ctx, lSquareLoc, indexArgs, indexArgLabels,
                                    indexArgLabelLocs, rSquareLoc,
+                                   trailingLBrace, trailingRBrace,
                                    trailingClosures, /*implicit*/ false,
                                    indexArgLabelsScratch,
                                    indexArgLabelLocsScratch);
@@ -2173,17 +2202,17 @@ KeyPathExpr::Component::forUnresolvedSubscript(ASTContext &ctx,
                                          ArrayRef<Identifier> indexArgLabels,
                                          ArrayRef<SourceLoc> indexArgLabelLocs,
                                          SourceLoc rSquareLoc,
+                                         SourceLoc trailingLBrace,
+                                         SourceLoc trailingRBrace,
                                          ArrayRef<TrailingClosure> trailingClosures) {
   SmallVector<Identifier, 4> indexArgLabelsScratch;
   SmallVector<SourceLoc, 4> indexArgLabelLocsScratch;
-  Expr *index = packSingleArgument(ctx, lSquareLoc, indexArgs, indexArgLabels,
-                                   indexArgLabelLocs, rSquareLoc,
-                                   trailingClosures, /*implicit*/ false,
-                                   indexArgLabelsScratch,
-                                   indexArgLabelLocsScratch);
-  return forUnresolvedSubscriptWithPrebuiltIndexExpr(ctx, index,
-                                               indexArgLabels,
-                                               lSquareLoc);
+  Expr *index = packSingleArgument(
+      ctx, lSquareLoc, indexArgs, indexArgLabels, indexArgLabelLocs, rSquareLoc,
+      trailingLBrace, trailingRBrace, trailingClosures, /*implicit*/ false,
+      indexArgLabelsScratch, indexArgLabelLocsScratch);
+  return forUnresolvedSubscriptWithPrebuiltIndexExpr(ctx, index, indexArgLabels,
+                                                     lSquareLoc);
 }
 
 KeyPathExpr::Component::Component(ASTContext *ctxForCopyingLabels,

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1012,7 +1012,8 @@ swift::packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc,
 
   // If we have no other arguments, represent the a single trailing closure as a
   // parenthesized expression.
-  if (args.empty() && trailingClosures.size() == 1) {
+  if (args.empty() && trailingClosures.size() == 1 &&
+      trailingClosures.front().LabelLoc.isInvalid()) {
     auto &trailingClosure = trailingClosures.front();
     auto arg =
         new (ctx) ParenExpr(lParenLoc, trailingClosure.ClosureExpr, rParenLoc,

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1066,7 +1066,7 @@ ObjectLiteralExpr::ObjectLiteralExpr(SourceLoc PoundLoc, LiteralKind LitKind,
   Bits.ObjectLiteralExpr.NumArgLabels = argLabels.size();
   Bits.ObjectLiteralExpr.HasArgLabelLocs = !argLabelLocs.empty();
   Bits.ObjectLiteralExpr.HasTrailingClosure = hasTrailingClosure;
-  initializeCallArguments(argLabels, argLabelLocs, hasTrailingClosure);  
+  initializeCallArguments(argLabels, argLabelLocs);
 }
 
 ObjectLiteralExpr *
@@ -1083,7 +1083,7 @@ ObjectLiteralExpr::create(ASTContext &ctx, SourceLoc poundLoc, LiteralKind kind,
                                                  &hasTrailingClosure,
                                                  getType);
 
-  size_t size = totalSizeToAlloc(argLabels, argLabelLocs, hasTrailingClosure);
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(ObjectLiteralExpr));
   return new (memory) ObjectLiteralExpr(poundLoc, kind, arg, argLabels,
@@ -1107,8 +1107,7 @@ ObjectLiteralExpr *ObjectLiteralExpr::create(ASTContext &ctx,
                                  rParenLoc, trailingClosure, implicit,
                                  argLabelsScratch, argLabelLocsScratch);
 
-  size_t size = totalSizeToAlloc(argLabels, argLabelLocs,
-                                 trailingClosure != nullptr);
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(ObjectLiteralExpr));
   return new (memory) ObjectLiteralExpr(poundLoc, kind, arg, argLabels,
@@ -1460,7 +1459,7 @@ SubscriptExpr::SubscriptExpr(Expr *base, Expr *index,
   Bits.SubscriptExpr.NumArgLabels = argLabels.size();
   Bits.SubscriptExpr.HasArgLabelLocs = !argLabelLocs.empty();
   Bits.SubscriptExpr.HasTrailingClosure = hasTrailingClosure;
-  initializeCallArguments(argLabels, argLabelLocs, hasTrailingClosure);
+  initializeCallArguments(argLabels, argLabelLocs);
 }
 
 SubscriptExpr *
@@ -1478,7 +1477,7 @@ SubscriptExpr::create(ASTContext &ctx, Expr *base, Expr *index,
                                                  &hasTrailingClosure,
                                                  getType);
 
-  size_t size = totalSizeToAlloc(argLabels, argLabelLocs, hasTrailingClosure);
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(SubscriptExpr));
   return new (memory) SubscriptExpr(base, index, argLabels, argLabelLocs,
@@ -1504,8 +1503,7 @@ SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base,
                                    indexArgLabelsScratch,
                                    indexArgLabelLocsScratch);
 
-  size_t size = totalSizeToAlloc(indexArgLabels, indexArgLabelLocs,
-                                 trailingClosure != nullptr);
+  size_t size = totalSizeToAlloc(indexArgLabels, indexArgLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(SubscriptExpr));
   return new (memory) SubscriptExpr(base, index, indexArgLabels,
@@ -1525,7 +1523,7 @@ DynamicSubscriptExpr::DynamicSubscriptExpr(Expr *base, Expr *index,
   Bits.DynamicSubscriptExpr.NumArgLabels = argLabels.size();
   Bits.DynamicSubscriptExpr.HasArgLabelLocs = !argLabelLocs.empty();
   Bits.DynamicSubscriptExpr.HasTrailingClosure = hasTrailingClosure;
-  initializeCallArguments(argLabels, argLabelLocs, hasTrailingClosure);
+  initializeCallArguments(argLabels, argLabelLocs);
   if (implicit) setImplicit(implicit);
 }
 
@@ -1543,7 +1541,7 @@ DynamicSubscriptExpr::create(ASTContext &ctx, Expr *base, Expr *index,
                                                  &hasTrailingClosure,
                                                  getType);
 
-  size_t size = totalSizeToAlloc(argLabels, argLabelLocs, hasTrailingClosure);
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(DynamicSubscriptExpr));
   return new (memory) DynamicSubscriptExpr(base, index, argLabels, argLabelLocs,
@@ -1563,7 +1561,7 @@ UnresolvedMemberExpr::UnresolvedMemberExpr(SourceLoc dotLoc,
   Bits.UnresolvedMemberExpr.NumArgLabels = argLabels.size();
   Bits.UnresolvedMemberExpr.HasArgLabelLocs = !argLabelLocs.empty();
   Bits.UnresolvedMemberExpr.HasTrailingClosure = hasTrailingClosure;
-  initializeCallArguments(argLabels, argLabelLocs, hasTrailingClosure);
+  initializeCallArguments(argLabels, argLabelLocs);
 }
 
 UnresolvedMemberExpr *UnresolvedMemberExpr::create(ASTContext &ctx,
@@ -1571,7 +1569,7 @@ UnresolvedMemberExpr *UnresolvedMemberExpr::create(ASTContext &ctx,
                                                    DeclNameLoc nameLoc,
                                                    DeclNameRef name,
                                                    bool implicit) {
-  size_t size = totalSizeToAlloc({ }, { }, /*hasTrailingClosure=*/false);
+  size_t size = totalSizeToAlloc({ }, { });
 
   void *memory = ctx.Allocate(size, alignof(UnresolvedMemberExpr));
   return new (memory) UnresolvedMemberExpr(dotLoc, nameLoc, name, nullptr,
@@ -1598,8 +1596,7 @@ UnresolvedMemberExpr::create(ASTContext &ctx, SourceLoc dotLoc,
                                  argLabelsScratch,
                                  argLabelLocsScratch);
 
-  size_t size = totalSizeToAlloc(argLabels, argLabelLocs,
-                                 trailingClosure != nullptr);
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(UnresolvedMemberExpr));
   return new (memory) UnresolvedMemberExpr(dotLoc, nameLoc, name, arg,
@@ -1642,26 +1639,25 @@ bool ApplyExpr::hasTrailingClosure() const {
 CallExpr::CallExpr(Expr *fn, Expr *arg, bool Implicit,
                    ArrayRef<Identifier> argLabels,
                    ArrayRef<SourceLoc> argLabelLocs,
-                   bool hasTrailingClosure,
                    Type ty)
     : ApplyExpr(ExprKind::Call, fn, arg, Implicit, ty)
 {
   Bits.CallExpr.NumArgLabels = argLabels.size();
   Bits.CallExpr.HasArgLabelLocs = !argLabelLocs.empty();
-  Bits.CallExpr.HasTrailingClosure = hasTrailingClosure;
-  initializeCallArguments(argLabels, argLabelLocs, hasTrailingClosure);
+  initializeCallArguments(argLabels, argLabelLocs);
 }
 
 CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
                            ArrayRef<Identifier> argLabels,
                            ArrayRef<SourceLoc> argLabelLocs,
-                           bool hasTrailingClosure, bool implicit, Type type,
+                           bool implicit, Type type,
                            llvm::function_ref<Type(const Expr *)> getType) {
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   if (argLabels.empty()) {
     // Inspect the argument to dig out the argument labels, their location, and
     // whether there is a trailing closure.
+    bool hasTrailingClosure;
     argLabels = getArgumentLabelsFromArgument(arg, argLabelsScratch,
                                               &argLabelLocsScratch,
                                               &hasTrailingClosure,
@@ -1669,33 +1665,31 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
     argLabelLocs = argLabelLocsScratch;
   }
 
-  size_t size = totalSizeToAlloc(argLabels, argLabelLocs, hasTrailingClosure);
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(CallExpr));
-  return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs,
-                               hasTrailingClosure, type);
+  return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs, type);
 }
 
 CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, SourceLoc lParenLoc,
                            ArrayRef<Expr *> args,
                            ArrayRef<Identifier> argLabels,
                            ArrayRef<SourceLoc> argLabelLocs,
-                           SourceLoc rParenLoc, Expr *trailingClosure,
+                           SourceLoc rParenLoc,
+                           ArrayRef<Expr *> trailingClosures,
                            bool implicit,
                            llvm::function_ref<Type(const Expr *)> getType) {
   SmallVector<Identifier, 4> argLabelsScratch;
   SmallVector<SourceLoc, 4> argLabelLocsScratch;
   Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
-                                 rParenLoc, trailingClosure, implicit,
+                                 rParenLoc, trailingClosures, implicit,
                                  argLabelsScratch, argLabelLocsScratch,
                                  getType);
 
-  size_t size = totalSizeToAlloc(argLabels, argLabelLocs,
-                                 trailingClosure != nullptr);
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs);
 
   void *memory = ctx.Allocate(size, alignof(CallExpr));
-  return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs,
-                               trailingClosure != nullptr, Type());
+  return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs, Type());
 }
 
 Expr *CallExpr::getDirectCallee() const {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -869,7 +869,8 @@ void CodeCompletionResultBuilder::addCallParameter(Identifier Name,
                                                    bool IsVarArg,
                                                    bool IsInOut,
                                                    bool IsIUO,
-                                                   bool isAutoClosure) {
+                                                   bool isAutoClosure,
+                                                   bool useUnderscoreLabel) {
   CurrentNestingLevel++;
   using ChunkKind = CodeCompletionString::Chunk::ChunkKind;
 
@@ -908,6 +909,11 @@ void CodeCompletionResultBuilder::addCallParameter(Identifier Name,
       addChunkWithText(
           CodeCompletionString::Chunk::ChunkKind::CallParameterName,
           escapeKeyword(Name.str(), false, EscapedKeyword));
+      addChunkWithTextNoCopy(
+          CodeCompletionString::Chunk::ChunkKind::CallParameterColon, ": ");
+    } else if (useUnderscoreLabel) {
+      addChunkWithTextNoCopy(
+          CodeCompletionString::Chunk::ChunkKind::CallParameterName, "_");
       addChunkWithTextNoCopy(
           CodeCompletionString::Chunk::ChunkKind::CallParameterColon, ": ");
     } else if (!LocalName.empty()) {
@@ -2498,7 +2504,8 @@ public:
         contextTy = typeContext->getDeclaredTypeInContext();
 
       Builder.addCallParameter(argName, bodyName, paramTy, contextTy,
-                               isVariadic, isInOut, isIUO, isAutoclosure);
+                               isVariadic, isInOut, isIUO, isAutoclosure,
+                               /*useUnderscoreLabel=*/false);
 
       modifiedBuilder = true;
       NeedComma = true;
@@ -4136,7 +4143,8 @@ public:
       Builder.addCallParameter(Arg->getLabel(), Identifier(),
                                Arg->getPlainType(), ContextType,
                                Arg->isVariadic(), Arg->isInOut(),
-                               /*isIUO=*/false, Arg->isAutoClosure());
+                               /*isIUO=*/false, Arg->isAutoClosure(),
+                               /*useUnderscoreLabel=*/true);
       auto Ty = Arg->getPlainType();
       if (Arg->isInOut()) {
         Ty = InOutType::get(Ty);

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -371,12 +371,12 @@ public:
 
   void addCallParameter(Identifier Name, Identifier LocalName, Type Ty,
                         Type ContextTy, bool IsVarArg, bool IsInOut, bool IsIUO,
-                        bool isAutoClosure);
+                        bool isAutoClosure, bool useUnderscoreLabel);
 
   void addCallParameter(Identifier Name, Type Ty, Type ContextTy = Type()) {
     addCallParameter(Name, Identifier(), Ty, ContextTy,
                      /*IsVarArg=*/false, /*IsInOut=*/false, /*isIUO=*/false,
-                     /*isAutoClosure=*/false);
+                     /*isAutoClosure=*/false, /*useUnderscoreLabel=*/false);
   }
 
   void addGenericParameter(StringRef Name) {

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -633,10 +633,9 @@ private:
             return Stop;
         }
         if (PE->hasTrailingClosure()) {
-          if (auto *Last = PE->getSubExpr()) {
-            TC = dyn_cast<ClosureExpr>(Last);
-            TCL = dyn_cast<CaptureListExpr>(Last);
-          }
+          auto *LastElem = PE->getSubExpr();
+          TC = dyn_cast_or_null<ClosureExpr>(LastElem);
+          TCL = dyn_cast_or_null<CaptureListExpr>(LastElem);
         }
       } else if (auto *TE = dyn_cast_or_null<TupleExpr>(Arg)) {
         if (isa<SubscriptExpr>(E)) {
@@ -646,10 +645,15 @@ private:
           if (!handleParens(TE->getLParenLoc(), TE->getRParenLoc(), ContextLoc))
             return Stop;
         }
-        if (TE->hasTrailingClosure()) {
-          if (auto *Last = TE->getElements().back()) {
-            TC = dyn_cast<ClosureExpr>(Last);
-            TCL = dyn_cast<CaptureListExpr>(Last);
+        if (TE->hasTrailingClosure() || TE->hasMultipleTrailingClosures()) {
+          if (TE->getTrailingLBraceLoc().isValid()) {
+            if (!handleBraces(TE->getTrailingLBraceLoc(),
+                            TE->getTrailingRBraceLoc(), ContextLoc))
+              return Stop;
+          } else {
+            Expr *LastElem = TE->getElements().back();
+            TC = dyn_cast_or_null<ClosureExpr>(LastElem);
+            TCL = dyn_cast_or_null<CaptureListExpr>(LastElem);
           }
         }
       }
@@ -2176,13 +2180,18 @@ private:
           TCL = dyn_cast_or_null<CaptureListExpr>(Last);
         }
       } else if (auto *TE = dyn_cast_or_null<TupleExpr>(Arg)) {
-        if (auto Ctx = getIndentContextFrom(TE, ContextLoc)) {
+        if (auto Ctx = getIndentContextFrom(TE, ContextLoc))
           return Ctx;
-        }
-        if (TE->hasTrailingClosure()) {
-          Expr *Last = TE->getElements().back();
-          TCE = dyn_cast_or_null<ClosureExpr>(Last);
-          TCL = dyn_cast_or_null<CaptureListExpr>(Last);
+        if (TE->hasTrailingClosure() || TE->hasMultipleTrailingClosures()) {
+          if (TE->getTrailingLBraceLoc().isValid()) {
+            if (auto Ctx = getIndentContextFromTrailingClosureGroup(TE,
+                                                                    ContextLoc))
+            return Ctx;
+          } else {
+            Expr *LastElem = TE->getElements().back();
+            TCE = dyn_cast_or_null<ClosureExpr>(LastElem);
+            TCL = dyn_cast_or_null<CaptureListExpr>(LastElem);
+          }
         }
       }
 
@@ -2334,9 +2343,7 @@ private:
     }
 
     ListAligner Aligner(SM, TargetLocation, ContextLoc, L, R);
-    auto NumElems = TE->getNumElements();
-    if (TE->hasTrailingClosure())
-      --NumElems;
+    auto NumElems = TE->getNumElements() - TE->getNumTrailingElements();
     for (auto I : range(NumElems)) {
       SourceRange ElemRange = TE->getElementNameLoc(I);
       if (Expr *Elem = TE->getElement(I))
@@ -2353,6 +2360,40 @@ private:
       }
     }
     return Aligner.getContextAndSetAlignment(CtxOverride);
+  }
+
+  Optional<IndentContext>
+  getIndentContextFromTrailingClosureGroup(TupleExpr *TE,
+                                           SourceLoc ContextLoc) {
+    SourceLoc L = TE->getTrailingLBraceLoc();
+    SourceLoc R = getLocIfKind(SM, TE->getTrailingRBraceLoc(), tok::r_brace);
+
+    if (L.isInvalid() || !overlapsTarget(L, R))
+      return None;
+
+    ContextLoc = CtxOverride.propagateContext(SM, ContextLoc,
+                                              IndentContext::LineStart,
+                                              L, R);
+    auto NumElems = TE->getNumElements();
+    auto FirstTrailing = NumElems - TE->getNumTrailingElements();
+    for (auto I: range(FirstTrailing, NumElems)) {
+      SourceRange ElemRange = TE->getElementNameLoc(I);
+      if (Expr *Elem = TE->getElement(I))
+        widenOrSet(ElemRange, Elem->getSourceRange());
+      assert(ElemRange.isValid());
+      if (isTargetContext(ElemRange)) {
+        return IndentContext {
+          ElemRange.Start,
+          !OutdentChecker::hasOutdent(SM, ElemRange, TE)
+        };
+      }
+    }
+    SourceRange Range = SourceRange(L, TE->getEndLoc());
+    return IndentContext {
+      ContextLoc,
+      containsTarget(L, R) &&
+        !OutdentChecker::hasOutdent(SM, Range, TE, RangeKind::Open)
+    };
   }
 
   Optional<IndentContext>

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2535,7 +2535,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
     SmallVector<Expr *, 2> args;
     SmallVector<Identifier, 2> argLabels;
     SmallVector<SourceLoc, 2> argLabelLocs;
-    Expr *trailingClosure = nullptr;
+    SmallVector<Expr *, 2> trailingClosures;
     bool hasInitializer = false;
     ParserStatus status;
 
@@ -2573,9 +2573,9 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
         status |= parseExprList(tok::l_paren, tok::r_paren,
                                 /*isPostfix=*/false, /*isExprBasic=*/true,
                                 lParenLoc, args, argLabels, argLabelLocs,
-                                rParenLoc, trailingClosure,
+                                rParenLoc, trailingClosures,
                                 SyntaxKind::TupleExprElementList);
-        assert(!trailingClosure && "Cannot parse a trailing closure here");
+        assert(trailingClosures.empty() && "Cannot parse a trailing closure here");
         hasInitializer = true;
       }
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2535,7 +2535,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
     SmallVector<Expr *, 2> args;
     SmallVector<Identifier, 2> argLabels;
     SmallVector<SourceLoc, 2> argLabelLocs;
-    SmallVector<Expr *, 2> trailingClosures;
+    SmallVector<TrailingClosure, 2> trailingClosures;
     bool hasInitializer = false;
     ParserStatus status;
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2535,6 +2535,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
     SmallVector<Expr *, 2> args;
     SmallVector<Identifier, 2> argLabels;
     SmallVector<SourceLoc, 2> argLabelLocs;
+    SourceLoc trailingLBrace, trailingRBrace;
     SmallVector<TrailingClosure, 2> trailingClosures;
     bool hasInitializer = false;
     ParserStatus status;
@@ -2573,7 +2574,8 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
         status |= parseExprList(tok::l_paren, tok::r_paren,
                                 /*isPostfix=*/false, /*isExprBasic=*/true,
                                 lParenLoc, args, argLabels, argLabelLocs,
-                                rParenLoc, trailingClosures,
+                                rParenLoc, trailingLBrace, trailingRBrace,
+                                trailingClosures,
                                 SyntaxKind::TupleExprElementList);
         assert(trailingClosures.empty() && "Cannot parse a trailing closure here");
         hasInitializer = true;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1187,18 +1187,18 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       SmallVector<Expr *, 2> indexArgs;
       SmallVector<Identifier, 2> indexArgLabels;
       SmallVector<SourceLoc, 2> indexArgLabelLocs;
-      Expr *trailingClosure;
+      SmallVector<Expr *, 2> trailingClosures;
 
       ParserStatus status = parseExprList(
           tok::l_square, tok::r_square,
           /*isPostfix=*/true, isExprBasic, lSquareLoc, indexArgs,
-          indexArgLabels, indexArgLabelLocs, rSquareLoc, trailingClosure,
+          indexArgLabels, indexArgLabelLocs, rSquareLoc, trailingClosures,
           SyntaxKind::TupleExprElementList);
       Result = makeParserResult(
           status | Result,
           SubscriptExpr::create(Context, Result.get(), lSquareLoc, indexArgs,
                                 indexArgLabels, indexArgLabelLocs, rSquareLoc,
-                                trailingClosure, ConcreteDeclRef(),
+                                trailingClosures, ConcreteDeclRef(),
                                 /*implicit=*/false));
       SyntaxContext->createNodeInPlace(SyntaxKind::SubscriptExpr);
       continue;
@@ -1606,14 +1606,14 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       SmallVector<Expr *, 2> args;
       SmallVector<Identifier, 2> argLabels;
       SmallVector<SourceLoc, 2> argLabelLocs;
-      Expr *trailingClosure;
+      SmallVector<Expr *, 2> trailingClosures;
       
       ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
                                           /*isPostfix=*/true, isExprBasic,
                                           lParenLoc, args, argLabels,
                                           argLabelLocs,
                                           rParenLoc,
-                                          trailingClosure,
+                                          trailingClosures,
                                           SyntaxKind::TupleExprElementList);
       SyntaxContext->createNodeInPlace(SyntaxKind::FunctionCallExpr);
       return makeParserResult(
@@ -1621,7 +1621,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                  UnresolvedMemberExpr::create(Context, DotLoc, NameLoc, Name,
                                               lParenLoc, args, argLabels,
                                               argLabelLocs, rParenLoc,
-                                              trailingClosure,
+                                              trailingClosures,
                                               /*implicit=*/false));
     }
 
@@ -3010,7 +3010,7 @@ Parser::parseExprList(tok leftTok, tok rightTok, SyntaxKind Kind) {
   SmallVector<Expr*, 8> subExprs;
   SmallVector<Identifier, 8> subExprNames;
   SmallVector<SourceLoc, 8> subExprNameLocs;
-  Expr *trailingClosure = nullptr;
+  SmallVector<Expr *, 2> trailingClosures;
 
   SourceLoc leftLoc, rightLoc;
   ParserStatus status = parseExprList(leftTok, rightTok, /*isPostfix=*/false,
@@ -3020,7 +3020,7 @@ Parser::parseExprList(tok leftTok, tok rightTok, SyntaxKind Kind) {
                                       subExprNames,
                                       subExprNameLocs,
                                       rightLoc,
-                                      trailingClosure,
+                                      trailingClosures,
                                       Kind);
 
   // A tuple with a single, unlabeled element is just parentheses.
@@ -3056,10 +3056,8 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
                                    SmallVectorImpl<Identifier> &exprLabels,
                                    SmallVectorImpl<SourceLoc> &exprLabelLocs,
                                    SourceLoc &rightLoc,
-                                   Expr *&trailingClosure,
+                                   SmallVectorImpl<Expr *> &trailingClosures,
                                    SyntaxKind Kind) {
-  trailingClosure = nullptr;
-
   StructureMarkerRAII ParsingExprList(*this, Tok);
   
   if (ParsingExprList.isFailed()) {
@@ -3147,7 +3145,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
     return status;
 
   // Record the trailing closure.
-  trailingClosure = closure.get();
+  trailingClosures.push_back(closure.get());
 
   return status;
 }
@@ -3205,14 +3203,14 @@ Parser::parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LitKind,
   SmallVector<Expr *, 2> args;
   SmallVector<Identifier, 2> argLabels;
   SmallVector<SourceLoc, 2> argLabelLocs;
-  Expr *trailingClosure;
+  SmallVector<Expr *, 2> trailingClosures;
 
   ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
                                       /*isPostfix=*/true, isExprBasic,
                                       lParenLoc, args, argLabels,
                                       argLabelLocs,
                                       rParenLoc,
-                                      trailingClosure,
+                                      trailingClosures,
                                       SyntaxKind::TupleExprElementList);
   if (status.hasCodeCompletion())
     return makeParserCodeCompletionResult<Expr>();
@@ -3222,7 +3220,7 @@ Parser::parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LitKind,
   return makeParserResult(
     ObjectLiteralExpr::create(Context, PoundLoc, LitKind, lParenLoc, args,
                               argLabels, argLabelLocs, rParenLoc,
-                              trailingClosure, /*implicit=*/false));
+                              trailingClosures, /*implicit=*/false));
 }
 
 /// Parse and diagnose unknown pound expression
@@ -3247,13 +3245,13 @@ ParserResult<Expr> Parser::parseExprPoundUnknown(SourceLoc LSquareLoc) {
   SmallVector<SourceLoc, 2> argLabelLocs;
   SmallVector<Expr *, 2> args;
   SmallVector<Identifier, 2> argLabels;
-  Expr *trailingClosure;
+  SmallVector<Expr *, 2> trailingClosures;
   if (Tok.isFollowingLParen()) {
     // Parse arguments.
     ParserStatus status =
         parseExprList(tok::l_paren, tok::r_paren,
                       /*isPostfix=*/true, /*isExprBasic*/ true, LParenLoc,
-                      args, argLabels, argLabelLocs, RParenLoc, trailingClosure,
+                      args, argLabels, argLabelLocs, RParenLoc, trailingClosures,
                       SyntaxKind::TupleExprElementList);
     if (status.hasCodeCompletion())
       return makeParserCodeCompletionResult<Expr>();
@@ -3348,7 +3346,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
                        { Identifier() },
                        { },
                        SourceLoc(),
-                       /*trailingClosure=*/nullptr,
+                       /*trailingClosures=*/{},
                        /*implicit=*/false));
     CodeCompletion->completePostfixExprParen(fn.get(), CCE);
     // Eat the code completion token because we handled it.
@@ -3362,21 +3360,22 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
   SmallVector<Expr *, 2> args;
   SmallVector<Identifier, 2> argLabels;
   SmallVector<SourceLoc, 2> argLabelLocs;
-  Expr *trailingClosure;
+  SmallVector<Expr *, 2> trailingClosures;
 
   ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
                                       /*isPostfix=*/true, isExprBasic,
                                       lParenLoc, args, argLabels,
                                       argLabelLocs,
                                       rParenLoc,
-                                      trailingClosure,
+                                      trailingClosures,
                                       SyntaxKind::TupleExprElementList);
 
   // Form the call.
-  return makeParserResult(
-      status | fn, CallExpr::create(Context, fn.get(), lParenLoc, args,
-                                    argLabels, argLabelLocs, rParenLoc,
-                                    trailingClosure, /*implicit=*/false));
+  return makeParserResult(status | fn,
+                          CallExpr::create(Context, fn.get(), lParenLoc, args,
+                                           argLabels, argLabelLocs, rParenLoc,
+                                           trailingClosures,
+                                           /*implicit=*/false));
 }
 
 /// parseExprCollection - Parse a collection literal expression.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1187,7 +1187,7 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       SmallVector<Expr *, 2> indexArgs;
       SmallVector<Identifier, 2> indexArgLabels;
       SmallVector<SourceLoc, 2> indexArgLabelLocs;
-      SmallVector<Expr *, 2> trailingClosures;
+      SmallVector<TrailingClosure, 2> trailingClosures;
 
       ParserStatus status = parseExprList(
           tok::l_square, tok::r_square,
@@ -1230,7 +1230,7 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       Result = makeParserResult(
           ParserStatus(closure) | ParserStatus(Result),
           CallExpr::create(Context, Result.get(), SourceLoc(), {}, {}, {},
-                           SourceLoc(), closure.get(), /*implicit=*/false));
+                           SourceLoc(), {closure.get()}, /*implicit=*/false));
       SyntaxContext->createNodeInPlace(SyntaxKind::FunctionCallExpr);
 
       // We only allow a single trailing closure on a call.  This could be
@@ -1606,7 +1606,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       SmallVector<Expr *, 2> args;
       SmallVector<Identifier, 2> argLabels;
       SmallVector<SourceLoc, 2> argLabelLocs;
-      SmallVector<Expr *, 2> trailingClosures;
+      SmallVector<TrailingClosure, 2> trailingClosures;
       
       ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
                                           /*isPostfix=*/true, isExprBasic,
@@ -1644,7 +1644,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                  ParserStatus(closure),
                  UnresolvedMemberExpr::create(Context, DotLoc, NameLoc, Name,
                                               SourceLoc(), { }, { }, { },
-                                              SourceLoc(), closure.get(),
+                                              SourceLoc(), {closure.get()},
                                               /*implicit=*/false));
     }
 
@@ -3010,7 +3010,7 @@ Parser::parseExprList(tok leftTok, tok rightTok, SyntaxKind Kind) {
   SmallVector<Expr*, 8> subExprs;
   SmallVector<Identifier, 8> subExprNames;
   SmallVector<SourceLoc, 8> subExprNameLocs;
-  SmallVector<Expr *, 2> trailingClosures;
+  SmallVector<TrailingClosure, 2> trailingClosures;
 
   SourceLoc leftLoc, rightLoc;
   ParserStatus status = parseExprList(leftTok, rightTok, /*isPostfix=*/false,
@@ -3056,7 +3056,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
                                    SmallVectorImpl<Identifier> &exprLabels,
                                    SmallVectorImpl<SourceLoc> &exprLabelLocs,
                                    SourceLoc &rightLoc,
-                                   SmallVectorImpl<Expr *> &trailingClosures,
+                                   SmallVectorImpl<TrailingClosure> &trailingClosures,
                                    SyntaxKind Kind) {
   StructureMarkerRAII ParsingExprList(*this, Tok);
   
@@ -3145,7 +3145,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
     return status;
 
   // Record the trailing closure.
-  trailingClosures.push_back(closure.get());
+  trailingClosures.push_back({closure.get()});
 
   return status;
 }
@@ -3203,7 +3203,7 @@ Parser::parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LitKind,
   SmallVector<Expr *, 2> args;
   SmallVector<Identifier, 2> argLabels;
   SmallVector<SourceLoc, 2> argLabelLocs;
-  SmallVector<Expr *, 2> trailingClosures;
+  SmallVector<TrailingClosure, 2> trailingClosures;
 
   ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
                                       /*isPostfix=*/true, isExprBasic,
@@ -3245,7 +3245,7 @@ ParserResult<Expr> Parser::parseExprPoundUnknown(SourceLoc LSquareLoc) {
   SmallVector<SourceLoc, 2> argLabelLocs;
   SmallVector<Expr *, 2> args;
   SmallVector<Identifier, 2> argLabels;
-  SmallVector<Expr *, 2> trailingClosures;
+  SmallVector<TrailingClosure, 2> trailingClosures;
   if (Tok.isFollowingLParen()) {
     // Parse arguments.
     ParserStatus status =
@@ -3360,7 +3360,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
   SmallVector<Expr *, 2> args;
   SmallVector<Identifier, 2> argLabels;
   SmallVector<SourceLoc, 2> argLabelLocs;
-  SmallVector<Expr *, 2> trailingClosures;
+  SmallVector<TrailingClosure, 2> trailingClosures;
 
   ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
                                       /*isPostfix=*/true, isExprBasic,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3199,6 +3199,9 @@ static bool isBlockOfMultipleTrailingClosures(bool isExprBasic, Parser &P) {
 ParserStatus Parser::parseMultipleTrailingClosures(
     SourceLoc &LBrace, SourceLoc &RBrace,
     SmallVectorImpl<TrailingClosure> &closures) {
+  SyntaxParsingContext ClauseCtx(SyntaxContext,
+                                 SyntaxKind::MultipleTrailingClosureClause);
+
   // Consume '{' of the trailing closure
   LBrace = consumeToken(tok::l_brace);
 
@@ -3213,6 +3216,8 @@ ParserStatus Parser::parseMultipleTrailingClosures(
       break;
     }
 
+    SyntaxParsingContext ElementCtx(SyntaxContext,
+                                    SyntaxKind::MultipleTrailingClosureElement);
     Identifier label;
     auto labelLoc = consumeArgumentLabel(label);
     if (!labelLoc.isValid())
@@ -3235,6 +3240,7 @@ ParserStatus Parser::parseMultipleTrailingClosures(
       consumeToken();
     }
   } while (!Tok.is(tok::r_brace));
+  SyntaxContext->collectNodesInPlace(SyntaxKind::MultipleTrailingClosureElementList);
 
   // Consume `}` of the trailing closure.
   if (parseMatchingToken(tok::r_brace, RBrace,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1187,17 +1187,20 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       SmallVector<Expr *, 2> indexArgs;
       SmallVector<Identifier, 2> indexArgLabels;
       SmallVector<SourceLoc, 2> indexArgLabelLocs;
+      SourceLoc trailingLBrace, trailingRBrace;
       SmallVector<TrailingClosure, 2> trailingClosures;
 
       ParserStatus status = parseExprList(
           tok::l_square, tok::r_square,
           /*isPostfix=*/true, isExprBasic, lSquareLoc, indexArgs,
-          indexArgLabels, indexArgLabelLocs, rSquareLoc, trailingClosures,
+          indexArgLabels, indexArgLabelLocs, rSquareLoc,
+          trailingLBrace, trailingRBrace, trailingClosures,
           SyntaxKind::TupleExprElementList);
       Result = makeParserResult(
           status | Result,
           SubscriptExpr::create(Context, Result.get(), lSquareLoc, indexArgs,
                                 indexArgLabels, indexArgLabelLocs, rSquareLoc,
+                                trailingLBrace, trailingRBrace,
                                 trailingClosures, ConcreteDeclRef(),
                                 /*implicit=*/false));
       SyntaxContext->createNodeInPlace(SyntaxKind::SubscriptExpr);
@@ -1221,9 +1224,11 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
                 leadingTriviaLoc(), *SyntaxContext));
       }
 
+      SourceLoc LBrace, RBrace;
       SmallVector<TrailingClosure, 2> trailingClosures;
       auto trailingResult =
-          parseTrailingClosures(callee->getSourceRange(), trailingClosures);
+          parseTrailingClosures(isExprBasic, callee->getSourceRange(), LBrace,
+                                RBrace, trailingClosures);
       if (trailingClosures.empty())
         return nullptr;
 
@@ -1231,7 +1236,8 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       Result = makeParserResult(
           ParserStatus(Result) | trailingResult,
           CallExpr::create(Context, Result.get(), SourceLoc(), {}, {}, {},
-                           SourceLoc(), trailingClosures, /*implicit=*/false));
+                           SourceLoc(), LBrace, RBrace, trailingClosures,
+                           /*implicit=*/false));
       SyntaxContext->createNodeInPlace(SyntaxKind::FunctionCallExpr);
 
       // We only allow a single trailing closure on a call.  This could be
@@ -1607,6 +1613,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       SmallVector<Expr *, 2> args;
       SmallVector<Identifier, 2> argLabels;
       SmallVector<SourceLoc, 2> argLabelLocs;
+      SourceLoc trailingLBrace, trailingRBrace;
       SmallVector<TrailingClosure, 2> trailingClosures;
       
       ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
@@ -1614,6 +1621,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                                           lParenLoc, args, argLabels,
                                           argLabelLocs,
                                           rParenLoc,
+                                          trailingLBrace, trailingRBrace,
                                           trailingClosures,
                                           SyntaxKind::TupleExprElementList);
       SyntaxContext->createNodeInPlace(SyntaxKind::FunctionCallExpr);
@@ -1622,6 +1630,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                  UnresolvedMemberExpr::create(Context, DotLoc, NameLoc, Name,
                                               lParenLoc, args, argLabels,
                                               argLabelLocs, rParenLoc,
+                                              trailingLBrace, trailingRBrace,
                                               trailingClosures,
                                               /*implicit=*/false));
     }
@@ -1635,9 +1644,10 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                 leadingTriviaLoc(), *SyntaxContext));
       }
 
+      SourceLoc LBrace, RBrace;
       SmallVector<TrailingClosure, 2> trailingClosures;
-      auto result =
-          parseTrailingClosures(NameLoc.getSourceRange(), trailingClosures);
+      auto result = parseTrailingClosures(isExprBasic, NameLoc.getSourceRange(),
+                                          LBrace, RBrace, trailingClosures);
       if (trailingClosures.empty())
         return nullptr;
 
@@ -1646,7 +1656,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       return makeParserResult(
           result, UnresolvedMemberExpr::create(Context, DotLoc, NameLoc, Name,
                                                SourceLoc(), {}, {}, {},
-                                               SourceLoc(), trailingClosures,
+                                               SourceLoc(), LBrace, RBrace,
+                                               trailingClosures,
                                                /*implicit=*/false));
     }
 
@@ -3015,6 +3026,7 @@ Parser::parseExprList(tok leftTok, tok rightTok, SyntaxKind Kind) {
   SmallVector<TrailingClosure, 2> trailingClosures;
 
   SourceLoc leftLoc, rightLoc;
+  SourceLoc trailingLBrace, trailingRBrace;
   ParserStatus status = parseExprList(leftTok, rightTok, /*isPostfix=*/false,
                                       /*isExprBasic=*/true,
                                       leftLoc,
@@ -3022,6 +3034,8 @@ Parser::parseExprList(tok leftTok, tok rightTok, SyntaxKind Kind) {
                                       subExprNames,
                                       subExprNameLocs,
                                       rightLoc,
+                                      trailingLBrace,
+                                      trailingRBrace,
                                       trailingClosures,
                                       Kind);
 
@@ -3058,6 +3072,8 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
                                    SmallVectorImpl<Identifier> &exprLabels,
                                    SmallVectorImpl<SourceLoc> &exprLabelLocs,
                                    SourceLoc &rightLoc,
+                                   SourceLoc &trailingLBrace,
+                                   SourceLoc &trailingRBrace,
                                    SmallVectorImpl<TrailingClosure> &trailingClosures,
                                    SyntaxKind Kind) {
   StructureMarkerRAII ParsingExprList(*this, Tok);
@@ -3141,12 +3157,86 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
 
   // Parse the closure.
   status |=
-      parseTrailingClosures(SourceRange(leftLoc, rightLoc), trailingClosures);
+      parseTrailingClosures(isExprBasic, SourceRange(leftLoc, rightLoc),
+                            trailingLBrace, trailingRBrace, trailingClosures);
   return status;
 }
 
+/// Check whether upcoming trailing closure actually represents a block of
+/// labeled trailing closures e.g.
+/// foo() {
+///  <label-1>: { ... }
+///  ...
+/// }
+static bool isBlockOfMultipleTrailingClosures(bool isExprBasic, Parser &P) {
+  assert(isValidTrailingClosure(isExprBasic, P));
+  Parser::BacktrackingScope backtrack(P);
+  P.consumeToken(tok::l_brace);
+
+  if (!P.Tok.canBeArgumentLabel() || P.Tok.is(tok::kw__))
+    return false;
+
+  auto text = P.Tok.getText();
+  if (text[0] == '$')
+    return false;
+
+  P.consumeToken(); // Consume Label text.
+
+  if (!P.Tok.is(tok::colon))
+    return false;
+
+  P.consumeToken(); // Consume `:`
+
+  // If the next token after the label is not a left brace
+  // that means what follows is not a valid closure, which
+  // in turn means it can't be a labeled block.
+  if (!P.Tok.is(tok::l_brace))
+    return false;
+
+  return isValidTrailingClosure(isExprBasic, P);
+}
+
+ParserStatus Parser::parseMultipleTrailingClosures(
+    SourceLoc &LBrace, SourceLoc &RBrace,
+    SmallVectorImpl<TrailingClosure> &closures) {
+  // Consume '{' of the trailing closure
+  LBrace = consumeToken();
+
+  // There could N labeled closures depending on the number of arguments.
+  do {
+    if (!(Tok.canBeArgumentLabel() && peekToken().is(tok::colon)))
+      return makeParserError();
+
+    Identifier label;
+    auto labelLoc = consumeArgumentLabel(label);
+    if (!labelLoc.isValid())
+      return makeParserError();
+
+    consumeToken(); // Consume ':'
+
+    auto closure = parseExprClosure();
+    if (closure.isNull())
+      return makeParserError();
+
+    closures.push_back({label, labelLoc, closure.get()});
+
+    // Recover if blocks are separated by comma instead of newline.
+    if (Tok.is(tok::comma)) {
+      diagnose(Tok.getLoc(), diag::unexpected_separator, ",")
+        .fixItRemove(Tok.getLoc());
+      consumeToken();
+    }
+  } while (!Tok.is(tok::r_brace));
+
+  // Consume `}` of the trailing closure.
+  RBrace = consumeToken();
+
+  return makeParserSuccess();
+}
+
 ParserStatus
-Parser::parseTrailingClosures(SourceRange calleeRange,
+Parser::parseTrailingClosures(bool isExprBasic, SourceRange calleeRange,
+                              SourceLoc &LBrace, SourceLoc &RBrace,
                               SmallVectorImpl<TrailingClosure> &closures) {
   SourceLoc braceLoc = Tok.getLoc();
 
@@ -3156,10 +3246,22 @@ Parser::parseTrailingClosures(SourceRange calleeRange,
   auto origLine = SourceMgr.getLineNumber(calleeRange.End);
   auto braceLine = SourceMgr.getLineNumber(braceLoc);
 
-  // Parse the closure.
-  ParserResult<Expr> closure = parseExprClosure();
-  if (closure.isNull())
-    return makeParserError();
+  ParserStatus result;
+
+  if (isBlockOfMultipleTrailingClosures(isExprBasic, *this)) {
+    result |= parseMultipleTrailingClosures(LBrace, RBrace, closures);
+  } else {
+    // Parse the closure.
+    ParserResult<Expr> closure = parseExprClosure();
+    if (closure.isNull())
+      return makeParserError();
+
+    result |= closure;
+
+    LBrace = braceLoc;
+    RBrace = closure.get()->getEndLoc();
+    closures.push_back({closure.get()});
+  }
 
   // Warn if the trailing closure is separated from its callee by more than
   // one line. A single-line separation is acceptable for a trailing closure
@@ -3167,17 +3269,18 @@ Parser::parseTrailingClosures(SourceRange calleeRange,
   if (braceLine > origLine + 1) {
     diagnose(braceLoc, diag::trailing_closure_after_newlines);
     diagnose(calleeRange.Start, diag::trailing_closure_callee_here);
-    
-    auto *CE = dyn_cast<ClosureExpr>(closure.get());
-    if (CE && CE->hasAnonymousClosureVars() &&
-        CE->getParameters()->size() == 0) {
-      diagnose(braceLoc, diag::brace_stmt_suggest_do)
-        .fixItInsert(braceLoc, "do ");
+
+    if (closures.size() == 1) {
+      auto *CE = dyn_cast<ClosureExpr>(closures[0].ClosureExpr);
+      if (CE && CE->hasAnonymousClosureVars() &&
+          CE->getParameters()->size() == 0) {
+        diagnose(braceLoc, diag::brace_stmt_suggest_do)
+          .fixItInsert(braceLoc, "do ");
+      }
     }
   }
 
-  closures.push_back({closure.get()});
-  return closure;
+  return result;
 }
 
 /// Parse an object literal expression.
@@ -3201,6 +3304,7 @@ Parser::parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LitKind,
   SmallVector<Expr *, 2> args;
   SmallVector<Identifier, 2> argLabels;
   SmallVector<SourceLoc, 2> argLabelLocs;
+  SourceLoc trailingLBrace, trailingRBrace;
   SmallVector<TrailingClosure, 2> trailingClosures;
 
   ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
@@ -3208,6 +3312,8 @@ Parser::parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LitKind,
                                       lParenLoc, args, argLabels,
                                       argLabelLocs,
                                       rParenLoc,
+                                      trailingLBrace,
+                                      trailingRBrace,
                                       trailingClosures,
                                       SyntaxKind::TupleExprElementList);
   if (status.hasCodeCompletion())
@@ -3218,6 +3324,7 @@ Parser::parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LitKind,
   return makeParserResult(
     ObjectLiteralExpr::create(Context, PoundLoc, LitKind, lParenLoc, args,
                               argLabels, argLabelLocs, rParenLoc,
+                              trailingLBrace, trailingRBrace,
                               trailingClosures, /*implicit=*/false));
 }
 
@@ -3243,13 +3350,15 @@ ParserResult<Expr> Parser::parseExprPoundUnknown(SourceLoc LSquareLoc) {
   SmallVector<SourceLoc, 2> argLabelLocs;
   SmallVector<Expr *, 2> args;
   SmallVector<Identifier, 2> argLabels;
+  SourceLoc trailingLBrace, trailingRBrace;
   SmallVector<TrailingClosure, 2> trailingClosures;
   if (Tok.isFollowingLParen()) {
     // Parse arguments.
     ParserStatus status =
         parseExprList(tok::l_paren, tok::r_paren,
                       /*isPostfix=*/true, /*isExprBasic*/ true, LParenLoc,
-                      args, argLabels, argLabelLocs, RParenLoc, trailingClosures,
+                      args, argLabels, argLabelLocs, RParenLoc,
+                      trailingLBrace, trailingRBrace, trailingClosures,
                       SyntaxKind::TupleExprElementList);
     if (status.hasCodeCompletion())
       return makeParserCodeCompletionResult<Expr>();
@@ -3344,6 +3453,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
                        { Identifier() },
                        { },
                        SourceLoc(),
+                       SourceLoc(), SourceLoc(),
                        /*trailingClosures=*/{},
                        /*implicit=*/false));
     CodeCompletion->completePostfixExprParen(fn.get(), CCE);
@@ -3358,6 +3468,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
   SmallVector<Expr *, 2> args;
   SmallVector<Identifier, 2> argLabels;
   SmallVector<SourceLoc, 2> argLabelLocs;
+  SourceLoc trailingLBrace, trailingRBrace;
   SmallVector<TrailingClosure, 2> trailingClosures;
 
   ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
@@ -3365,6 +3476,8 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
                                       lParenLoc, args, argLabels,
                                       argLabelLocs,
                                       rParenLoc,
+                                      trailingLBrace,
+                                      trailingRBrace,
                                       trailingClosures,
                                       SyntaxKind::TupleExprElementList);
 
@@ -3372,6 +3485,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
   return makeParserResult(status | fn,
                           CallExpr::create(Context, fn.get(), lParenLoc, args,
                                            argLabels, argLabelLocs, rParenLoc,
+                                           trailingLBrace, trailingRBrace,
                                            trailingClosures,
                                            /*implicit=*/false));
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3256,6 +3256,9 @@ ParserStatus Parser::parseMultipleTrailingClosures(
                          diag::expected_multiple_closures_block_rbrace,
                          LBrace)) {
     Status.setIsParseError();
+  } else {
+    if (!Status.hasCodeCompletion())
+      Status = makeParserSuccess();
   }
 
   return Status;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3174,9 +3174,8 @@ static bool isBlockOfMultipleTrailingClosures(bool isExprBasic, Parser &P) {
   // If closure doesn't start from a label there is no reason
   // to look any farther.
   {
-    const auto &nextTok = P.peekToken();
-    if (!nextTok.canBeArgumentLabel() || nextTok.is(tok::kw__) ||
-        nextTok.getText()[0] == '$')
+    const auto nextTok = P.peekToken();
+    if (!nextTok.canBeArgumentLabel() || nextTok.getText()[0] == '$')
       return false;
   }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3170,16 +3170,18 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
 /// }
 static bool isBlockOfMultipleTrailingClosures(bool isExprBasic, Parser &P) {
   assert(isValidTrailingClosure(isExprBasic, P));
+
+  // If closure doesn't start from a label there is no reason
+  // to look any farther.
+  {
+    const auto &nextTok = P.peekToken();
+    if (!nextTok.canBeArgumentLabel() || nextTok.is(tok::kw__) ||
+        nextTok.getText()[0] == '$')
+      return false;
+  }
+
   Parser::BacktrackingScope backtrack(P);
   P.consumeToken(tok::l_brace);
-
-  if (!P.Tok.canBeArgumentLabel() || P.Tok.is(tok::kw__))
-    return false;
-
-  auto text = P.Tok.getText();
-  if (text[0] == '$')
-    return false;
-
   P.consumeToken(); // Consume Label text.
 
   if (!P.Tok.is(tok::colon))

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -912,12 +912,14 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
         SmallVector<Expr *, 2> args;
         SmallVector<Identifier, 2> argLabels;
         SmallVector<SourceLoc, 2> argLabelLocs;
+        SourceLoc trailingLBrace, trailingRBrace;
         SmallVector<TrailingClosure, 2> trailingClosures;
         ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
                                             /*isPostfix=*/true,
                                             /*isExprBasic=*/false,
                                             lParenLoc, args, argLabels,
                                             argLabelLocs, rParenLoc,
+                                            trailingLBrace, trailingRBrace,
                                             trailingClosures,
                                             SyntaxKind::Unknown);
         if (status.isSuccess()) {

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -912,7 +912,7 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
         SmallVector<Expr *, 2> args;
         SmallVector<Identifier, 2> argLabels;
         SmallVector<SourceLoc, 2> argLabelLocs;
-        SmallVector<Expr *, 2> trailingClosures;
+        SmallVector<TrailingClosure, 2> trailingClosures;
         ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
                                             /*isPostfix=*/true,
                                             /*isExprBasic=*/false,

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -912,13 +912,13 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
         SmallVector<Expr *, 2> args;
         SmallVector<Identifier, 2> argLabels;
         SmallVector<SourceLoc, 2> argLabelLocs;
-        Expr *trailingClosure;
+        SmallVector<Expr *, 2> trailingClosures;
         ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
                                             /*isPostfix=*/true,
                                             /*isExprBasic=*/false,
                                             lParenLoc, args, argLabels,
                                             argLabelLocs, rParenLoc,
-                                            trailingClosure,
+                                            trailingClosures,
                                             SyntaxKind::Unknown);
         if (status.isSuccess()) {
           backtrack.cancelBacktrack();

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -831,7 +831,7 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
 
     SmallVector<Identifier, 4> yieldLabels;
     SmallVector<SourceLoc, 4> yieldLabelLocs;
-    SmallVector<Expr *, 2> trailingClosures;
+    SmallVector<TrailingClosure, 2> trailingClosures;
 
     status = parseExprList(tok::l_paren, tok::r_paren,
                            /*postfix (allow trailing closure)*/ false,

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -831,7 +831,7 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
 
     SmallVector<Identifier, 4> yieldLabels;
     SmallVector<SourceLoc, 4> yieldLabelLocs;
-    Expr *trailingClosure = nullptr;
+    SmallVector<Expr *, 2> trailingClosures;
 
     status = parseExprList(tok::l_paren, tok::r_paren,
                            /*postfix (allow trailing closure)*/ false,
@@ -839,9 +839,9 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
                            lpLoc,
                            yields, yieldLabels, yieldLabelLocs,
                            rpLoc,
-                           trailingClosure,
+                           trailingClosures,
                            SyntaxKind::ExprList);
-    assert(trailingClosure == nullptr);
+    assert(trailingClosures.empty());
     assert(yieldLabels.empty());
     assert(yieldLabelLocs.empty());
   } else {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -831,6 +831,7 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
 
     SmallVector<Identifier, 4> yieldLabels;
     SmallVector<SourceLoc, 4> yieldLabelLocs;
+    SourceLoc trailingLBrace, trailingRBrace;
     SmallVector<TrailingClosure, 2> trailingClosures;
 
     status = parseExprList(tok::l_paren, tok::r_paren,
@@ -839,6 +840,7 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
                            lpLoc,
                            yields, yieldLabels, yieldLabelLocs,
                            rpLoc,
+                           trailingLBrace, trailingRBrace,
                            trailingClosures,
                            SyntaxKind::ExprList);
     assert(trailingClosures.empty());

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -100,6 +100,8 @@ class BuilderClosureVisitor
     SourceLoc closeLoc = args.empty() ? loc : args.back()->getEndLoc();
     Expr *result = CallExpr::create(ctx, memberRef, openLoc, args,
                                     argLabels, argLabelLocs, closeLoc,
+                                    /*trailingLBrace=*/SourceLoc(),
+                                    /*trailingRBrace=*/SourceLoc(),
                                     /*trailing closures*/{},
                                     /*implicit*/true);
 

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -100,7 +100,7 @@ class BuilderClosureVisitor
     SourceLoc closeLoc = args.empty() ? loc : args.back()->getEndLoc();
     Expr *result = CallExpr::create(ctx, memberRef, openLoc, args,
                                     argLabels, argLabelLocs, closeLoc,
-                                    /*trailing closure*/ nullptr,
+                                    /*trailing closures*/{},
                                     /*implicit*/true);
 
     return result;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2056,14 +2056,14 @@ namespace {
             arguments.push_back(SE->getIndex()->getSemanticsProvidingExpr());
           }
 
-          Expr *trailingClosure = nullptr;
+          SmallVector<Expr *, 2> trailingClosures;
           if (SE->hasTrailingClosure())
-            trailingClosure = arguments.back();
+            trailingClosures.push_back(arguments.back());
 
           componentExpr = SubscriptExpr::create(
               ctx, dotExpr, SE->getStartLoc(), arguments,
               SE->getArgumentLabels(), SE->getArgumentLabelLocs(),
-              SE->getEndLoc(), trailingClosure,
+              SE->getEndLoc(), trailingClosures,
               SE->hasDecl() ? SE->getDecl() : ConcreteDeclRef(),
               /*implicit=*/true, SE->getAccessSemantics());
         }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2056,14 +2056,19 @@ namespace {
             arguments.push_back(SE->getIndex()->getSemanticsProvidingExpr());
           }
 
+          SourceLoc trailingLBrace, trailingRBrace;
           SmallVector<TrailingClosure, 2> trailingClosures;
-          if (SE->hasTrailingClosure())
-            trailingClosures.push_back({arguments.back()});
+          if (SE->hasTrailingClosure()) {
+            auto *closure = arguments.back();
+            trailingLBrace = closure->getStartLoc();
+            trailingRBrace = closure->getEndLoc();
+            trailingClosures.push_back({closure});
+          }
 
           componentExpr = SubscriptExpr::create(
               ctx, dotExpr, SE->getStartLoc(), arguments,
               SE->getArgumentLabels(), SE->getArgumentLabelLocs(),
-              SE->getEndLoc(), trailingClosures,
+              SE->getEndLoc(), trailingLBrace, trailingRBrace, trailingClosures,
               SE->hasDecl() ? SE->getDecl() : ConcreteDeclRef(),
               /*implicit=*/true, SE->getAccessSemantics());
         }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2056,9 +2056,9 @@ namespace {
             arguments.push_back(SE->getIndex()->getSemanticsProvidingExpr());
           }
 
-          SmallVector<Expr *, 2> trailingClosures;
+          SmallVector<TrailingClosure, 2> trailingClosures;
           if (SE->hasTrailingClosure())
-            trailingClosures.push_back(arguments.back());
+            trailingClosures.push_back({arguments.back()});
 
           componentExpr = SubscriptExpr::create(
               ctx, dotExpr, SE->getStartLoc(), arguments,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -988,6 +988,7 @@ namespace {
 
                 E = CallExpr::create(Context, newCallee, lParen, {newArg},
                                      {Identifier()}, {SourceLoc()}, rParen,
+                                     SourceLoc(), SourceLoc(),
                                      /*trailingClosures=*/{},
                                      /*implicit=*/false);
               }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -988,7 +988,7 @@ namespace {
 
                 E = CallExpr::create(Context, newCallee, lParen, {newArg},
                                      {Identifier()}, {SourceLoc()}, rParen,
-                                     /*trailingClosure=*/nullptr,
+                                     /*trailingClosures=*/{},
                                      /*implicit=*/false);
               }
             }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -730,7 +730,7 @@ Expr *swift::buildPropertyWrapperWrappedValueCall(
       initializer = CallExpr::create(
          ctx, typeExpr, startLoc, {initializer}, {argName},
          {initializer->getStartLoc()}, endLoc,
-         nullptr, /*implicit=*/true);
+         /*trailingClosures=*/{}, /*implicit=*/true);
       continue;
     }
 
@@ -761,7 +761,7 @@ Expr *swift::buildPropertyWrapperWrappedValueCall(
 
     initializer = CallExpr::create(
         ctx, typeExpr, startLoc, elements, elementNames, elementLocs,
-        endLoc, nullptr, /*implicit=*/true);
+        endLoc, /*trailingClosures=*/{}, /*implicit=*/true);
   }
   
   return initializer;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -727,10 +727,12 @@ Expr *swift::buildPropertyWrapperWrappedValueCall(
       if (endLoc.isInvalid() && startLoc.isValid())
         endLoc = wrapperAttrs[i]->getTypeLoc().getSourceRange().End;
 
-      initializer = CallExpr::create(
-         ctx, typeExpr, startLoc, {initializer}, {argName},
-         {initializer->getStartLoc()}, endLoc,
-         /*trailingClosures=*/{}, /*implicit=*/true);
+      initializer =
+          CallExpr::create(ctx, typeExpr, startLoc, {initializer}, {argName},
+                           {initializer->getStartLoc()}, endLoc,
+                           /*trailingLBrace=*/SourceLoc(),
+                           /*trailingRBrace=*/SourceLoc(),
+                           /*trailingClosures=*/{}, /*implicit=*/true);
       continue;
     }
 
@@ -759,10 +761,12 @@ Expr *swift::buildPropertyWrapperWrappedValueCall(
     if (endLoc.isInvalid() && startLoc.isValid())
       endLoc = wrapperAttrs[i]->getTypeLoc().getSourceRange().End;
 
-    initializer = CallExpr::create(
-        ctx, typeExpr, startLoc, elements, elementNames, elementLocs,
-        endLoc, /*trailingClosures=*/{}, /*implicit=*/true);
+    initializer = CallExpr::create(ctx, typeExpr, startLoc, elements,
+                                   elementNames, elementLocs, endLoc,
+                                   /*trailingLBrace=*/SourceLoc(),
+                                   /*trailingRBrace=*/SourceLoc(),
+                                   /*trailingClosures=*/{}, /*implicit=*/true);
   }
-  
+
   return initializer;
 }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -831,7 +831,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
     lookupExpr = SubscriptExpr::create(
         ctx, wrapperMetatype, SourceLoc(), args,
         subscriptDecl->getFullName().getArgumentNames(), { }, SourceLoc(),
-        nullptr, subscriptDecl, /*Implicit=*/true);
+        /*trailingClosures=*/{}, subscriptDecl, /*Implicit=*/true);
 
     // FIXME: Since we're not resolving overloads or anything, we should be
     // building fully type-checked AST above; we already have all the

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -831,6 +831,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
     lookupExpr = SubscriptExpr::create(
         ctx, wrapperMetatype, SourceLoc(), args,
         subscriptDecl->getFullName().getArgumentNames(), { }, SourceLoc(),
+        /*trailingLBrace=*/SourceLoc(), /*trailingRBrace=*/SourceLoc(),
         /*trailingClosures=*/{}, subscriptDecl, /*Implicit=*/true);
 
     // FIXME: Since we're not resolving overloads or anything, we should be

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -972,6 +972,7 @@ func test_correct_inference_of_closure_result_in_presence_of_optionals() {
   }
 }
 
+
 // rdar://problem/59741308 - inference fails with tuple element has to joined to supertype
 func rdar_59741308() {
   class Base {

--- a/test/IDE/complete_multiple_trailingclosure.swift
+++ b/test/IDE/complete_multiple_trailingclosure.swift
@@ -1,0 +1,85 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GLOBAL_FUNC_1 | %FileCheck %s -check-prefix=GLOBAL_FUNC_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GLOBAL_FUNC_2 | %FileCheck %s -check-prefix=GLOBAL_FUNC_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GLOBAL_FUNC_3 | %FileCheck %s -check-prefix=GLOBAL_FUNC_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GLOBAL_FUNC_4 | %FileCheck %s -check-prefix=GLOBAL_FUNC_4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GLOBAL_FUNC_5 | %FileCheck %s -check-prefix=GLOBAL_FUNC_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=METHOD_1 | %FileCheck %s -check-prefix=METHOD_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=METHOD_2 | %FileCheck %s -check-prefix=METHOD_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=METHOD_3 | %FileCheck %s -check-prefix=METHOD_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=METHOD_4 | %FileCheck %s -check-prefix=METHOD_4
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=METHOD_5 | %FileCheck %s -check-prefix=METHOD_1
+
+
+func globalFunc1(fn1: () -> Int, fn2: () -> String) {}
+func testGlobalFunc() {
+  globalFunc1 {
+    #^GLOBAL_FUNC_1^#
+// GLOBAL_FUNC_1: Begin completions, 1 items
+// GLOBAL_FUNC_1-DAG: Pattern/ExprSpecific: {#fn1: () -> Int##() -> Int#}[#() -> Int#];
+// GLOBAL_FUNC_1: End completions
+  }
+  globalFunc1() {
+    #^GLOBAL_FUNC_2^#
+// Same as GLOBAL_FUNC_1
+  }
+  globalFunc1() {
+    fn1: { 1 }
+    #^GLOBAL_FUNC_3^#
+// GLOBAL_FUNC_3: Begin completions, 1 items
+// GLOBAL_FUNC_3-DAG: Pattern/ExprSpecific:               {#fn2: () -> String##() -> String#}[#() -> String#]; name=fn2: () -> String
+// GLOBAL_FUNC_3: End completions
+  }
+
+  globalFunc1(fn1: { 1 }) {
+    #^GLOBAL_FUNC_4^#
+// GLOBAL_FUNC_4: Begin completions
+// GLOBAL_FUNC_4-NOT: Decl[Struct]/OtherModule[Swift]/TypeRelation[Identical]: Int[#Int#];
+// GLOBAL_FUNC_4-DAG: Pattern/ExprSpecific: {#fn2: () -> String##() -> String#}[#() -> String#];
+// GLOBAL_FUNC_4-DAG: Decl[Struct]/OtherModule[Swift]/TypeRelation[Identical]: String[#String#];
+// GLOBAL_FUNC_4: End completions
+  }
+
+  globalFunc1() {
+    #^GLOBAL_FUNC_5^#
+// Same as GLOBAL_FUNC_1
+    fn2: { "" }
+  }
+}
+
+struct MyStruct {
+  func method1(fn1: () -> Int, fn2: () -> String) {}
+}
+func testMethod(value: MyStruct) {
+  value.method1 {
+    #^METHOD_1^#
+// METHOD_1: Begin completions, 1 items
+// METHOD_1-DAG: Pattern/ExprSpecific: {#fn1: () -> Int##() -> Int#}[#() -> Int#];
+// METHOD_1: End completions
+  }
+  value.method1() {
+    #^METHOD_2^#
+// Same as METHOD_1
+  }
+  value.method1() {
+    fn1: { 1 }
+    #^METHOD_3^#
+// METHOD_3: Begin completions, 1 items
+// METHOD_3-DAG: Pattern/ExprSpecific:               {#fn2: () -> String##() -> String#}[#() -> String#]; name=fn2: () -> String
+// METHOD_3: End completions
+  }
+
+  value.method1(fn1: { 1 }) {
+    #^METHOD_4^#
+// METHOD_4: Begin completions
+// METHOD_4-NOT: Decl[Struct]/OtherModule[Swift]/TypeRelation[Identical]: Int[#Int#];
+// METHOD_4-DAG: Pattern/ExprSpecific: {#fn2: () -> String##() -> String#}[#() -> String#];
+// METHOD_4-DAG: Decl[Struct]/OtherModule[Swift]/TypeRelation[Identical]: String[#String#];
+// METHOD_4: End completions
+  }
+
+  value.method1 {
+    #^METHOD_5^#
+// Same as METHOD_1
+    fn2: { "" }
+  }
+}

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -71,3 +71,18 @@ multiple_trailing_with_defaults(duration: 42) {
   completion: {}
 }
 
+foo {
+  a: { 42 }
+  b: { 42 }
+
+  _ = 1 + 2
+  // expected-error@-1 {{expected an argument label followed by a closure literal}}
+}
+
+foo { // expected-note {{to match this opening '{'}}
+  a: { 42 }
+  b: { "" }
+
+  func foo() {} // expected-error {{expected an argument label followed by a closure literal}}
+  // expected-error@-1 {{expected '}' at the end of a trailing closures block}}
+} // expected-error {{extraneous '}' at top level}}

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -71,6 +71,60 @@ multiple_trailing_with_defaults(duration: 42) {
   completion: {}
 }
 
+func test_multiple_trailing_syntax_without_labels() {
+  func fn(f: () -> Void) {}
+
+  fn {
+    _: {} // Ok
+  }
+
+  fn {
+    f: {} // Ok
+  }
+
+  func multiple(_: () -> Void, _: () -> Void) {}
+
+  multiple {
+    _: { }
+    _: { }
+  }
+
+  func mixed_args_1(a: () -> Void, _: () -> Void) {}
+  func mixed_args_2(_: () -> Void, a: () -> Void, _: () -> Void) {} // expected-note 2 {{'mixed_args_2(_:a:_:)' declared here}}
+
+  mixed_args_1 {
+    a: {}
+    _: {}
+  }
+
+  mixed_args_1 {
+    _: {}
+    a: {} // expected-error {{argument 'a' must precede unnamed argument #1}}
+  }
+
+  mixed_args_2 {
+    _: {}
+    a: {}
+    _: {}
+  }
+
+  mixed_args_2 {
+    _: {} // expected-error {{missing argument for parameter 'a' in call}}
+    _: {}
+  }
+
+  mixed_args_2 {
+    a: {}
+    _: {}
+    _: {} // expected-error {{unnamed argument #3 must precede argument 'a'}}
+  }
+
+  mixed_args_2 {
+    a: {} // expected-error {{missing argument for parameter #1 in call}}
+    _: {}
+  }
+}
+
 foo {
   a: { 42 }
   b: { 42 }

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -79,6 +79,19 @@ foo {
   // expected-error@-1 {{expected an argument label followed by a closure literal}}
 }
 
+foo {
+  a: { 42 }
+  b: { 45 }
+  c:
+} // expected-error {{expected a closure literal}}
+
+foo {
+  a: { 42 }
+  b: { 45 }
+  c: 67 // expected-error {{expected a closure literal}}
+  // expected-error@-1 {{extra argument 'c' in call}}
+}
+
 foo { // expected-note {{to match this opening '{'}}
   a: { 42 }
   b: { "" }

--- a/test/Parse/multiple_trailing_closures.swift
+++ b/test/Parse/multiple_trailing_closures.swift
@@ -1,0 +1,73 @@
+// RUN: %target-typecheck-verify-swift
+
+func foo<T, U>(a: () -> T, b: () -> U) {}
+
+foo {
+  a: { 42 }
+  b: { "" }
+}
+
+foo { a: { 42 } b: { "" } }
+
+foo {
+  a: { 42 }, // expected-error {{unexpected ',' separator}} {{12-13=}}
+  b: { "" }
+}
+
+func when<T>(_ condition: @autoclosure () -> Bool,
+             `then` trueBranch: () -> T,
+             `else` falseBranch: () -> T) -> T {
+  return condition() ? trueBranch() : falseBranch()
+}
+
+let _ = when (2 < 3) {
+  then: { 3 }
+  else: { 4 }
+}
+
+struct S {
+  static func foo(a: Int = 42, b: (inout Int) -> Void) -> S {
+    return S()
+  }
+
+  subscript(v v: () -> Int) -> Int {
+    get { return v() }
+  }
+
+  subscript(cond: Bool, v v: () -> Int) -> Int {
+    get { return cond ? 0 : v() }
+  }
+}
+
+let _: S = .foo {
+  b: { $0 = $0 + 1 }
+}
+
+func bar(_ s: S) {
+  _ = s[] {
+    v: { 42 }
+  }
+
+  _ = s[true] {
+    v: { 42 }
+  }
+}
+
+func multiple_trailing_with_defaults(
+  duration: Int,
+  animations: (() -> Void)? = nil,
+  completion: (() -> Void)? = nil) {}
+
+multiple_trailing_with_defaults(duration: 42) {
+  animations: {}
+}
+
+multiple_trailing_with_defaults(duration: 42) {
+  completion: {}
+}
+
+multiple_trailing_with_defaults(duration: 42) {
+  animations: {}
+  completion: {}
+}
+

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -94,6 +94,9 @@ class C <MemberDeclBlock>{<MemberDeclListItem><FunctionDecl>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><MemberAccessExpr>.foo</MemberAccessExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><FunctionCallExpr><MemberAccessExpr>.foo</MemberAccessExpr>(<TupleExprElement>x: <IntegerLiteralExpr>12</IntegerLiteralExpr></TupleExprElement>)</FunctionCallExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><FunctionCallExpr><MemberAccessExpr>.foo </MemberAccessExpr><ClosureExpr>{ <IntegerLiteralExpr>12 </IntegerLiteralExpr>}</ClosureExpr></FunctionCallExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
+    _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><FunctionCallExpr><MemberAccessExpr>.foo </MemberAccessExpr><MultipleTrailingClosureClause>{<MultipleTrailingClosureElement>
+        arg1: <ClosureExpr>{ <IntegerLiteralExpr>12 </IntegerLiteralExpr>}</ClosureExpr></MultipleTrailingClosureElement>
+      }</MultipleTrailingClosureClause></FunctionCallExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><SubscriptExpr><MemberAccessExpr>.foo</MemberAccessExpr>[<TupleExprElement><IntegerLiteralExpr>12</IntegerLiteralExpr></TupleExprElement>]</SubscriptExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
     _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><MemberAccessExpr><MemberAccessExpr>.foo</MemberAccessExpr>.bar</MemberAccessExpr></SequenceExpr>
   }</CodeBlock></FunctionDecl></MemberDeclListItem><MemberDeclListItem><InitializerDecl>
@@ -257,14 +260,29 @@ func closure<FunctionSignature><ParameterClause>() </ParameterClause></FunctionS
 func postfix<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<FunctionCallExpr><IdentifierExpr>
   foo</IdentifierExpr>()</FunctionCallExpr><FunctionCallExpr><IdentifierExpr>
   foo</IdentifierExpr>() <ClosureExpr>{}</ClosureExpr></FunctionCallExpr><FunctionCallExpr><IdentifierExpr>
+  foo </IdentifierExpr><ClosureExpr>{}</ClosureExpr></FunctionCallExpr><FunctionCallExpr><IdentifierExpr>
+  foo </IdentifierExpr><MultipleTrailingClosureClause>{<MultipleTrailingClosureElement>
+    arg1: <ClosureExpr>{}</ClosureExpr></MultipleTrailingClosureElement>
+  }</MultipleTrailingClosureClause></FunctionCallExpr><FunctionCallExpr><IdentifierExpr>
+  foo</IdentifierExpr>() <MultipleTrailingClosureClause>{<MultipleTrailingClosureElement>
+    arg1: <ClosureExpr>{}</ClosureExpr></MultipleTrailingClosureElement><MultipleTrailingClosureElement>
+    arg2: <ClosureExpr>{}</ClosureExpr></MultipleTrailingClosureElement>
+  }</MultipleTrailingClosureClause></FunctionCallExpr><FunctionCallExpr><IdentifierExpr>
   foo </IdentifierExpr><ClosureExpr>{}</ClosureExpr></FunctionCallExpr><FunctionCallExpr><MemberAccessExpr><IdentifierExpr>
   foo</IdentifierExpr>.bar</MemberAccessExpr>()</FunctionCallExpr><FunctionCallExpr><MemberAccessExpr><IdentifierExpr>
   foo</IdentifierExpr>.bar</MemberAccessExpr>() <ClosureExpr>{}</ClosureExpr></FunctionCallExpr><FunctionCallExpr><MemberAccessExpr><IdentifierExpr>
+  foo</IdentifierExpr>.bar</MemberAccessExpr>() <MultipleTrailingClosureClause>{<MultipleTrailingClosureElement>
+    arg1: <ClosureExpr>{}</ClosureExpr></MultipleTrailingClosureElement>
+  }</MultipleTrailingClosureClause></FunctionCallExpr><FunctionCallExpr><MemberAccessExpr><IdentifierExpr>
   foo</IdentifierExpr>.bar </MemberAccessExpr><ClosureExpr>{}</ClosureExpr></FunctionCallExpr><SubscriptExpr><IdentifierExpr>
   foo</IdentifierExpr>[]</SubscriptExpr><SubscriptExpr><IdentifierExpr>
   foo</IdentifierExpr>[<TupleExprElement><IntegerLiteralExpr>1</IntegerLiteralExpr></TupleExprElement>]</SubscriptExpr><SubscriptExpr><IdentifierExpr>
   foo</IdentifierExpr>[] <ClosureExpr>{}</ClosureExpr></SubscriptExpr><SubscriptExpr><IdentifierExpr>
-  foo</IdentifierExpr>[<TupleExprElement><IntegerLiteralExpr>1</IntegerLiteralExpr></TupleExprElement>] <ClosureExpr>{}</ClosureExpr></SubscriptExpr><SubscriptExpr><SubscriptExpr><IdentifierExpr>
+  foo</IdentifierExpr>[<TupleExprElement><IntegerLiteralExpr>1</IntegerLiteralExpr></TupleExprElement>] <ClosureExpr>{}</ClosureExpr></SubscriptExpr><SubscriptExpr><IdentifierExpr>
+  foo</IdentifierExpr>[<TupleExprElement><IntegerLiteralExpr>1</IntegerLiteralExpr></TupleExprElement>] <MultipleTrailingClosureClause>{<MultipleTrailingClosureElement>
+    arg1: <ClosureExpr>{}</ClosureExpr></MultipleTrailingClosureElement><MultipleTrailingClosureElement>
+    arg2: <ClosureExpr>{}</ClosureExpr></MultipleTrailingClosureElement>
+  }</MultipleTrailingClosureClause></SubscriptExpr><SubscriptExpr><SubscriptExpr><IdentifierExpr>
   foo</IdentifierExpr>[<TupleExprElement><IntegerLiteralExpr>1</IntegerLiteralExpr></TupleExprElement>]</SubscriptExpr>[<TupleExprElement><IntegerLiteralExpr>2</IntegerLiteralExpr>,</TupleExprElement><TupleExprElement>x:<IntegerLiteralExpr>3</IntegerLiteralExpr></TupleExprElement>]</SubscriptExpr><MemberAccessExpr><FunctionCallExpr><ForcedValueExpr><MemberAccessExpr><PostfixUnaryExpr><OptionalChainingExpr><IdentifierExpr>
   foo</IdentifierExpr>?</OptionalChainingExpr>++</PostfixUnaryExpr>.bar</MemberAccessExpr>!</ForcedValueExpr>(<TupleExprElement><IdentifierExpr>baz</IdentifierExpr></TupleExprElement>)</FunctionCallExpr>.self</MemberAccessExpr><MemberAccessExpr><FunctionCallExpr><IdentifierExpr>
   foo</IdentifierExpr>()</FunctionCallExpr>.0</MemberAccessExpr><MemberAccessExpr><SpecializeExpr><IdentifierExpr>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -94,6 +94,9 @@ class C {
     _ = .foo
     _ = .foo(x: 12)
     _ = .foo { 12 }
+    _ = .foo {
+        arg1: { 12 }
+      }
     _ = .foo[12]
     _ = .foo.bar
   }
@@ -258,13 +261,28 @@ func postfix() {
   foo()
   foo() {}
   foo {}
+  foo {
+    arg1: {}
+  }
+  foo() {
+    arg1: {}
+    arg2: {}
+  }
+  foo {}
   foo.bar()
   foo.bar() {}
+  foo.bar() {
+    arg1: {}
+  }
   foo.bar {}
   foo[]
   foo[1]
   foo[] {}
   foo[1] {}
+  foo[1] {
+    arg1: {}
+    arg2: {}
+  }
   foo[1][2,x:3]
   foo?++.bar!(baz).self
   foo().0

--- a/test/swift-indent/multiple-trailing-closures.swift
+++ b/test/swift-indent/multiple-trailing-closures.swift
@@ -1,0 +1,107 @@
+// RUN: %swift-indent %s >%t.response
+// RUN: diff -u %s %t.response
+
+foo(c: 12, d: 34) {
+    a: { print("foo") }
+}
+
+foo {
+    a: { print("foo") }
+}
+
+foo {
+    a: { print("foo") }
+    b
+}
+
+foo (c: 12, d: 34) {
+    a: { print("foo") }
+    b:
+}
+
+// Invalid, but we should still indent correctly.
+foo {
+    a: {
+        print("foo")
+    }
+    b: bar(a: 1,
+           b: 2) {
+        print("bar")
+    }
+}
+
+foo {
+    a: {
+        print("foo")
+    }
+    b: {
+        print("bar")
+    }
+}
+
+foo(c: 12, d: 34) {
+    a: {
+        print("foo")
+    }
+    b: {
+        print("bar")
+    }
+}
+
+foo(c: 12, d: 34) { a: {
+    print("foo")
+} b: {
+    print("bar")
+}}
+
+foo(c: 12, d: 34) { a: {print("foo")}
+    b: {print("bar")} }
+
+foo(c: 12, d: 34) { a: {print("foo")}
+    /*comment*/b: {
+        print("bar")
+    }}
+
+foobar(c: 12,
+       d: 34) {
+    a: {
+        print("foo")
+    }
+    b: {
+        print("bar")
+    }
+}
+
+foo(c: 12, d: 34)
+{
+    a: {
+        print("foo")
+    }
+    b: {
+        print("bar")
+    }
+}
+
+foobar[c: 12,
+       d: 34] {
+    a: {
+        print("foo")
+    }
+    b: {
+        print("bar")
+    }
+}
+
+foo(c: 12, d: 34)
+{
+    a: {
+        print("foo")
+    }
+    // comment
+    b: {
+        print("bar")
+    }
+
+func invalidCode() {
+    print("blah")
+}

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -394,6 +394,32 @@ EXPR_NODES = [
              Child('Pattern', kind='Pattern'),
          ]),
 
+    # trailing-closure-element -> identifier ':' closure-expression
+    Node('MultipleTrailingClosureElement', kind='Syntax',
+         children=[
+             Child('Label', kind='Token',
+                   token_choices=[
+                       'IdentifierToken',
+                       'WildcardToken'
+                   ]),
+             Child('Colon', kind='ColonToken'),
+             Child('Closure', kind='ClosureExpr'),
+         ]),
+
+    Node('MultipleTrailingClosureElementList', kind='SyntaxCollection',
+         element='MultipleTrailingClosureElement'),
+
+    # multiple-trailing-closure-clause ->
+    #   '{' multiple-trailing-closure-element-list '}'
+    Node('MultipleTrailingClosureClause', kind='Syntax',
+         traits=['Braced'],
+         children=[
+             Child('LeftBrace', kind='LeftBraceToken'),
+             Child('Elements', kind='MultipleTrailingClosureElementList',
+                   collection_element_name='Element'),
+             Child('RightBrace', kind='RightBraceToken'),
+         ]),
+
     # call-expr -> expr '(' call-argument-list ')' closure-expr?
     #            | expr closure-expr
     Node('FunctionCallExpr', kind='Expr',
@@ -405,8 +431,12 @@ EXPR_NODES = [
                    collection_element_name='Argument'),
              Child('RightParen', kind='RightParenToken',
                    is_optional=True),
-             Child('TrailingClosure', kind='ClosureExpr',
-                   is_optional=True),
+             Child('TrailingClosure', kind='Syntax', is_optional=True,
+                   node_choices=[
+                       Child('SingleClosure', kind='ClosureExpr'),
+                       Child('MultipleTrailingClosures',
+                             kind='MultipleTrailingClosureClause'),
+                   ]),
          ]),
 
     # subscript-expr -> expr '[' call-argument-list ']' closure-expr?
@@ -417,8 +447,12 @@ EXPR_NODES = [
              Child('ArgumentList', kind='TupleExprElementList',
                    collection_element_name='Argument'),
              Child('RightBracket', kind='RightSquareBracketToken'),
-             Child('TrailingClosure', kind='ClosureExpr',
-                   is_optional=True),
+             Child('TrailingClosure', kind='Syntax', is_optional=True,
+                   node_choices=[
+                       Child('SingleClosure', kind='ClosureExpr'),
+                       Child('MultipleTrailingClosures',
+                             kind='MultipleTrailingClosureClause'),
+                   ]),
          ]),
 
     # optional-chaining-expr -> expr '?'

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -246,6 +246,9 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'QualifiedDeclName': 242,
     'CatchItem': 243,
     'CatchItemList': 244,
+    'MultipleTrailingClosureClause': 245,
+    'MultipleTrailingClosureElementList': 246,
+    'MultipleTrailingClosureElement': 247,
 }
 
 


### PR DESCRIPTION
Accept trailing closures in following form:

```swift
foo {
  <label-1>: { ... }
  <label-2>: { ... }
  ...
  <label-N>: { ... }
}
```

Consider each labeled block to be a regular argument to a call or subscript,
so the result of parser looks like this:

```swift
foo(<label-1>: { ... }, ..., <label-N>: { ... })
```

Note that in this example parens surrounding parameter list are implicit
and for the cases when they are given by the user e.g.

```swift
foo(bar) {
  <label-1>: { ... }
  ...
}
```

location of `)` is changed to a location of `}` to make sure that call
"covers" all of the transformed arguments and parser result would look
like this:

```swift
foo(bar,
  <label-1>: { ... }
)
```

Resolves: rdar://problem/59203764

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
