### PR TITLE
[Diagnostics] Refactor diagnoseAmbiguityWithFixes.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -68,9 +68,6 @@ NOTE(candidate_partial_match,none,
      "candidate has partially matching parameter list %0",
      (StringRef))
 
-ERROR(ambiguous_subscript,none,
-      "ambiguous subscript with base type %0 and index type %1",
-      (Type, Type))
 ERROR(could_not_find_value_subscript,none,
       "value of type %0 has no subscripts",
       (Type))
@@ -272,16 +269,6 @@ ERROR(cannot_call_non_function_value,none,
 ERROR(no_candidates_match_result_type,none,
       "no '%0' candidates produce the expected contextual result type %1",
       (StringRef, Type))
-
-ERROR(candidates_no_match_result_type,none,
-      "'%0' produces %1, not the expected contextual result type %2",
-      (StringRef, Type, Type))
-
-
-
-ERROR(invalid_callee_result_type,none,
-      "cannot convert call result type %0 to expected type %1",
-      (Type, Type))
 
 
 ERROR(cannot_invoke_closure,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -61,14 +61,8 @@ ERROR(ambiguous_member_overload_set,none,
 ERROR(ambiguous_reference_to_decl,none,
       "ambiguous reference to %0 %1", (DescriptiveDeclKind, DeclName))
 ERROR(no_overloads_match_exactly_in_call,none,
-      "no exact matches in call to %0 %1",
-      (DescriptiveDeclKind, DeclName))
-ERROR(no_overloads_match_exactly_in_call_no_labels,none,
-      "no exact matches in call to %0 %1",
-      (DescriptiveDeclKind, DeclBaseName))
-ERROR(no_overloads_match_exactly_in_call_special,none,
-      "no exact matches in call to %0",
-      (DescriptiveDeclKind))
+      "no exact matches in call to %0 %select{%2|}1",
+      (DescriptiveDeclKind, bool, DeclBaseName))
 ERROR(no_overloads_match_exactly_in_assignment,none,
       "no exact matches in assignment to %0",
       (DeclBaseName))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -385,6 +385,10 @@ ERROR(cannot_convert_argument_value_generic,none,
       "cannot convert value of type %0 (%1) to expected argument type %2 (%3)",
       (Type, StringRef, Type, StringRef))
 
+ERROR(conflicting_arguments_for_generic_parameter,none,
+      "conflicting arguments to generic parameter %0 (%1)",
+      (Type, StringRef))
+
 // @_nonEphemeral conversion diagnostics
 ERROR(cannot_pass_type_to_non_ephemeral,none,
       "cannot pass %0 to parameter; argument %1 must be a pointer that "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -61,11 +61,8 @@ ERROR(ambiguous_member_overload_set,none,
 ERROR(ambiguous_reference_to_decl,none,
       "ambiguous reference to %0 %1", (DescriptiveDeclKind, DeclName))
 ERROR(no_overloads_match_exactly_in_call,none,
-      "no exact matches in call to %0 %select{%2|}1",
-      (DescriptiveDeclKind, bool, DeclBaseName))
-ERROR(no_overloads_match_exactly_in_assignment,none,
-      "no exact matches in assignment to %0",
-      (DeclBaseName))
+      "no exact matches in %select{reference|call}0 to %1 %select{%3|}2",
+      (bool, DescriptiveDeclKind, bool, DeclBaseName))
 
 NOTE(candidate_partial_match,none,
      "candidate has partially matching parameter list %0",

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1247,17 +1247,6 @@ void FailureDiagnosis::diagnoseAmbiguity(Expr *E) {
     return;
   }
 
-  // Diagnose ".foo" expressions that lack context specifically.
-  if (auto UME =
-        dyn_cast<UnresolvedMemberExpr>(E->getSemanticsProvidingExpr())) {
-    if (!CS.getContextualType(E)) {
-      diagnose(E->getLoc(), diag::unresolved_member_no_inference,UME->getName())
-        .highlight(SourceRange(UME->getDotLoc(),
-                               UME->getNameLoc().getSourceRange().End));
-      return;
-    }
-  }
-
   // Attempt to re-type-check the entire expression, allowing ambiguity, but
   // ignoring a contextual type.
   if (expr == E) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5585,40 +5585,6 @@ bool ArgumentMismatchFailure::diagnoseArchetypeMismatch() const {
   if (!(paramDecl && argDecl))
     return false;
 
-  auto describeGenericType = [&](ValueDecl *genericParam,
-                                 bool includeName = false) -> std::string {
-    if (!genericParam)
-      return "";
-
-    Decl *parent = nullptr;
-    if (auto *AT = dyn_cast<AssociatedTypeDecl>(genericParam)) {
-      parent = AT->getProtocol();
-    } else {
-      auto *dc = genericParam->getDeclContext();
-      parent = dc->getInnermostDeclarationDeclContext();
-    }
-
-    if (!parent)
-      return "";
-
-    llvm::SmallString<64> result;
-    llvm::raw_svector_ostream OS(result);
-
-    OS << Decl::getDescriptiveKindName(genericParam->getDescriptiveKind());
-
-    if (includeName && genericParam->hasName())
-      OS << " '" << genericParam->getBaseName() << "'";
-
-    OS << " of ";
-    OS << Decl::getDescriptiveKindName(parent->getDescriptiveKind());
-    if (auto *decl = dyn_cast<ValueDecl>(parent)) {
-      if (decl->hasName())
-        OS << " '" << decl->getFullName() << "'";
-    }
-
-    return OS.str();
-  };
-
   emitDiagnostic(
       getAnchor()->getLoc(), diag::cannot_convert_argument_value_generic, argTy,
       describeGenericType(argDecl), paramTy, describeGenericType(paramDecl));

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1106,6 +1106,12 @@ UseValueTypeOfRawRepresentative::attempt(ConstraintSystem &cs, Type argType,
   return nullptr;
 }
 
+unsigned AllowArgumentMismatch::getParamIdx() const {
+  const auto *locator = getLocator();
+  auto elt = locator->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
+  return elt.getParamIdx();
+}
+
 bool AllowArgumentMismatch::diagnose(bool asNote) const {
   auto &cs = getConstraintSystem();
   ArgumentMismatchFailure failure(cs, getFromType(), getToType(),

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1499,11 +1499,17 @@ public:
     return "allow argument to parameter type conversion mismatch";
   }
 
+  unsigned getParamIdx() const;
+
   bool diagnose(bool asNote = false) const override;
 
   static AllowArgumentMismatch *create(ConstraintSystem &cs, Type argType,
                                        Type paramType,
                                        ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowArgumentTypeMismatch;
+  }
 };
 
 class ExpandArrayIntoVarargs final : public AllowArgumentMismatch {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -289,6 +289,8 @@ public:
   /// Diagnose a failure associated with this fix.
   virtual bool diagnose(bool asNote = false) const = 0;
 
+  virtual bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const { return false; }
+
   void print(llvm::raw_ostream &Out) const;
 
   SWIFT_DEBUG_DUMP;
@@ -843,6 +845,8 @@ public:
 
   bool diagnose(bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override;
+
   static DefineMemberBasedOnUse *create(ConstraintSystem &cs, Type baseType,
                                         DeclNameRef member, bool alreadyDiagnosed,
                                         ConstraintLocator *locator);
@@ -1109,6 +1113,10 @@ public:
 
   bool diagnose(bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
+    return diagnose();
+  }
+
   static AddMissingArguments *create(ConstraintSystem &cs,
                                      llvm::ArrayRef<Param> synthesizedArgs,
                                      ConstraintLocator *locator);
@@ -1148,6 +1156,10 @@ public:
   }
 
   bool diagnose(bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
+    return diagnose();
+  }
 
   /// FIXME(diagnostics): Once `resolveDeclRefExpr` is gone this
   /// logic would be obsolete.
@@ -1349,6 +1361,10 @@ public:
 
   bool diagnose(bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
+    return diagnose();
+  }
+
   static DefaultGenericArgument *create(ConstraintSystem &cs,
                                         GenericTypeParamType *param,
                                         ConstraintLocator *locator);
@@ -1419,6 +1435,10 @@ public:
   }
 
   bool diagnose(bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(ArrayRef<Solution> solutions) const override {
+    return diagnose();
+  }
 
   static IgnoreContextualType *create(ConstraintSystem &cs, Type resultTy,
                                       Type specifiedTy,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2824,25 +2824,11 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
       auto baseName = name.getBaseName();
       DE.diagnose(commonAnchor->getLoc(), diag::no_candidates_match_result_type,
                   baseName.userFacingName(), getContextualType(anchor));
-    } else if (name.isSpecial()) {
-      // If this is a special name, avoid printing it because printing the
-      // decl kind is sufficient.
-      DE.diagnose(commonAnchor->getLoc(),
-                  diag::no_overloads_match_exactly_in_call_special,
-                  decl->getDescriptiveKind());
-    } else if (llvm::all_of(ambiguousOverload->choices,
-                            [&name](const OverloadChoice &choice) {
-                              return choice.getDecl()->getFullName() == name;
-                            })) {
-      // If the labels match in each overload, print a full name.
+    } else {
       DE.diagnose(commonAnchor->getLoc(),
                   diag::no_overloads_match_exactly_in_call,
-                  decl->getDescriptiveKind(), name);
-    } else {
-      // If the labels are different, we can only print a base name.
-      DE.diagnose(commonAnchor->getLoc(),
-                  diag::no_overloads_match_exactly_in_call_no_labels,
-                  decl->getDescriptiveKind(), name.getBaseName());
+                  decl->getDescriptiveKind(), name.isSpecial(),
+                  name.getBaseName());
     }
 
     // Produce candidate notes

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2805,6 +2805,9 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
           if (binding == solution.typeBindings.end())
             return false;
 
+          // Contextual opaque result type is uniquely identified by
+          // declaration it's associated with, so we have to compare
+          // declarations instead of using pointer equality on such types.
           if (auto *opaque =
                   binding->second->getAs<OpaqueTypeArchetypeType>()) {
             auto *decl = opaque->getDecl();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2973,9 +2973,10 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
                                 commonCalleeLocator);
       return true;
     } else {
-      bool isApplication = llvm::find_if(ArgumentInfos, [&](const auto argInfo) {
-        return argInfo.first->getAnchor() == commonAnchor;
-      }) != ArgumentInfos.end();
+      bool isApplication =
+          llvm::any_of(ArgumentInfos, [&](const auto &argInfo) {
+            return argInfo.first->getAnchor() == commonAnchor;
+          });
 
       DE.diagnose(commonAnchor->getLoc(),
                   diag::no_overloads_match_exactly_in_call,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2770,7 +2770,7 @@ std::string swift::describeGenericType(ValueDecl *GP, bool includeName) {
 /// }
 ///
 /// It's done by first retrieving all generic parameters from each solution,
-/// filtering boundings into distrinct set and diagnosing any differences.
+/// filtering bindings into a distinct set and diagnosing any differences.
 static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
                                                 const SolutionDiff &diff,
                                                 ArrayRef<Solution> solutions) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2771,9 +2771,9 @@ std::string swift::describeGenericType(ValueDecl *GP, bool includeName) {
 ///
 /// It's done by first retrieving all generic parameters from each solution,
 /// filtering boundings into distrinct set and diagnosing any differences.
-static bool diagnoseConflictingArguments(ConstraintSystem &cs,
-                                         const SolutionDiff &diff,
-                                         ArrayRef<Solution> solutions) {
+static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
+                                                const SolutionDiff &diff,
+                                                ArrayRef<Solution> solutions) {
   if (!diff.overloads.empty())
     return false;
 
@@ -2899,7 +2899,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
 
   SolutionDiff solutionDiff(solutions);
 
-  if (diagnoseConflictingArguments(*this, solutionDiff, solutions))
+  if (diagnoseConflictingGenericArguments(*this, solutionDiff, solutions))
     return true;
 
   // Collect aggregated fixes from all solutions

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -837,21 +837,9 @@ public:
   llvm::DenseMap<std::pair<CanType, CanType>, ConversionRestrictionKind>
     ConstraintRestrictions;
 
-  using ConstraintFixVector = llvm::SmallVector<ConstraintFix *, 4>;
   /// The list of fixes that need to be applied to the initial expression
   /// to make the solution work.
-  ConstraintFixVector Fixes;
-
-  using AggregatedFixesMap = llvm::SmallMapVector<ConstraintLocator *,
-      llvm::SmallMapVector<FixKind, ConstraintFixVector, 4>, 4>;
-
-  AggregatedFixesMap getAggregatedFixes() const {
-    AggregatedFixesMap aggregatedFixes;
-    for (auto *fix: Fixes) {
-      aggregatedFixes[fix->getLocator()][fix->getKind()].push_back(fix);
-    }
-    return aggregatedFixes;
-  }
+  llvm::SmallVector<ConstraintFix *, 4> Fixes;
 
   /// The set of disjunction choices used to arrive at this solution,
   /// which informs constraint application.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -837,9 +837,21 @@ public:
   llvm::DenseMap<std::pair<CanType, CanType>, ConversionRestrictionKind>
     ConstraintRestrictions;
 
+  using ConstraintFixVector = llvm::SmallVector<ConstraintFix *, 4>;
   /// The list of fixes that need to be applied to the initial expression
   /// to make the solution work.
-  llvm::SmallVector<ConstraintFix *, 4> Fixes;
+  ConstraintFixVector Fixes;
+
+  using AggregatedFixesMap = llvm::SmallMapVector<ConstraintLocator *,
+      llvm::SmallMapVector<FixKind, ConstraintFixVector, 4>, 4>;
+
+  AggregatedFixesMap getAggregatedFixes() const {
+    AggregatedFixesMap aggregatedFixes;
+    for (auto *fix: Fixes) {
+      aggregatedFixes[fix->getLocator()][fix->getKind()].push_back(fix);
+    }
+    return aggregatedFixes;
+  }
 
   /// The set of disjunction choices used to arrive at this solution,
   /// which informs constraint application.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -5115,6 +5115,8 @@ bool exprNeedsParensOutsideFollowingOperator(
 /// Determine whether this is a SIMD operator.
 bool isSIMDOperator(ValueDecl *value);
 
+std::string describeGenericType(ValueDecl *GP, bool includeName = false);
+
 /// Apply the given function builder transform within a specific solution
 /// to produce the rewritten body.
 ///

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -371,7 +371,7 @@ func someGeneric19997471<T>(_ x: T) {
 func rdar21078316() {
   var foo : [String : String]?
   var bar : [(String, String)]?
-  bar = foo.map { ($0, $1) }  // expected-error {{contextual closure type '(Dictionary<String, String>) throws -> (Dictionary<String, String>, _)' expects 1 argument, but 2 were used in closure body}}
+  bar = foo.map { ($0, $1) }  // expected-error {{contextual closure type '([String : String]) throws -> [(String, String)]' expects 1 argument, but 2 were used in closure body}}
 }
 
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -186,7 +186,7 @@ func testMap() {
 }
 
 // <rdar://problem/22414757> "UnresolvedDot" "in wrong phase" assertion from verifier
-[].reduce { $0 + $1 }  // expected-error {{cannot invoke 'reduce' with an argument list of type '(_)'}}
+[].reduce { $0 + $1 }  // expected-error {{missing argument for parameter #1 in call}}
 
 
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -935,7 +935,7 @@ class CacheValue {
 
 func valueForKey<K>(_ key: K) -> CacheValue? {
   let cache = NSCache<K, CacheValue>()
-  return cache.object(forKey: key)?.value // expected-error {{no exact matches in call to instance method 'value'}}
+  return cache.object(forKey: key)?.value // expected-error {{no exact matches in reference to instance method 'value'}}
 }
 
 // SR-2242: poor diagnostic when argument label is omitted

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1085,7 +1085,7 @@ func SR_6272_c() {
 struct SR_6272_D: ExpressibleByIntegerLiteral {
   typealias IntegerLiteralType = Int
   init(integerLiteral: Int) {}
-  static func +(lhs: SR_6272_D, rhs: Int) -> Float { return 42.0 } // expected-note 2 {{candidate expects value of type 'Int' for parameter #2}}
+  static func +(lhs: SR_6272_D, rhs: Int) -> Float { return 42.0 }
 }
 
 func SR_6272_d() {

--- a/test/Constraints/one_way_constraints.swift
+++ b/test/Constraints/one_way_constraints.swift
@@ -10,7 +10,7 @@ func testTernaryOneWay(b: Bool) {
   let _: Float = b ? 3.14159 : 17
 
   // Errors due to one-way inference.
-  let _: Float = b ? Builtin.one_way(3.14159) // expected-error{{result values in '? :' expression have mismatching types 'Double' and 'Int'}}
+  let _: Float = b ? Builtin.one_way(3.14159) // expected-error{{cannot convert value of type 'Double' to specified type 'Float'}}
                    : 17
   let _: Float = b ? 3.14159 // expected-error {{cannot convert value of type 'Int' to specified type 'Float'}}
                    : Builtin.one_way(17)

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -301,7 +301,7 @@ switch staticMembers {
   // TODO: repeated error message
   case .optProp: break // expected-error* {{not unwrapped}}
 
-  case .method: break // expected-error{{no exact matches in call to static method 'method'}}
+  case .method: break // expected-error{{no exact matches in reference to static method 'method'}}
   case .method(0): break
   case .method(_): break // expected-error{{'_' can only appear in a pattern}}
   case .method(let x): break // expected-error{{cannot appear in an expression}}

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -28,7 +28,6 @@ func useIdentity(_ x: Int, y: Float, i32: Int32) {
   xx = identity2(yy) // expected-error{{no exact matches in call to global function 'identity2'}}
 }
 
-// FIXME: Crummy diagnostic!
 func twoIdentical<T>(_ x: T, _ y: T) -> T {}
 
 func useTwoIdentical(_ xi: Int, yi: Float) {
@@ -40,7 +39,7 @@ func useTwoIdentical(_ xi: Int, yi: Float) {
   y = twoIdentical(1.0, y)
   y = twoIdentical(y, 1.0)
   
-  twoIdentical(x, y) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
+  twoIdentical(x, y) // expected-error{{conflicting arguments to generic parameter 'T' ('Int' vs. 'Float')}}
 }
 
 func mySwap<T>(_ x: inout T,
@@ -67,8 +66,9 @@ func takeTuples<T, U>(_: (T, U), _: (U, T)) {
 func useTuples(_ x: Int, y: Float, z: (Float, Int)) {
   takeTuples((x, y), (y, x))
 
-  takeTuples((x, y), (x, y)) // expected-error{{cannot convert value of type '(Int, Float)' to expected argument type '(Float, Int)'}}
-
+  takeTuples((x, y), (x, y))
+  // expected-error@-1 {{conflicting arguments to generic parameter 'U' ('Float' vs. 'Int')}}
+  // expected-error@-2 {{conflicting arguments to generic parameter 'T' ('Int' vs. 'Float')}}
   // FIXME: Use 'z', which requires us to fix our tuple-conversion
   // representation.
 }
@@ -315,7 +315,7 @@ struct A {}
 func foo() {
     for i in min(1,2) { // expected-error{{for-in loop requires 'Int' to conform to 'Sequence'}}
     }
-    let j = min(Int(3), Float(2.5)) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
+    let j = min(Int(3), Float(2.5)) // expected-error{{conflicting arguments to generic parameter 'T' ('Int' vs. 'Float')}}
     let k = min(A(), A()) // expected-error{{global function 'min' requires that 'A' conform to 'Comparable'}}
     let oi : Int? = 5
     let l = min(3, oi) // expected-error{{global function 'min' requires that 'Int?' conform to 'Comparable'}}

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -47,12 +47,12 @@ takesInt(noParams(1)) // expected-error{{argument passed to call that takes no a
 takesInt(takesAndReturnsInt("")) // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
 
 // Test error recovery for type expressions.
-struct MyArray<Element> {}
+struct MyArray<Element> {} // expected-note {{'Element' declared as parameter to type 'MyArray'}}
 class A {
     var a: MyArray<Int>
     init() {
-        a = MyArray<Int // expected-error{{binary operator '<' cannot be applied to operands of type 'MyArray<_>.Type' and 'Int.Type'}}
-	// expected-note @-1 {{overloads for '<' exist with these partially matching parameter lists:}}
+        a = MyArray<Int // expected-error {{generic parameter 'Element' could not be inferred}}
+        // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
     }
 }
 

--- a/test/NameBinding/import-resolution-overload.swift
+++ b/test/NameBinding/import-resolution-overload.swift
@@ -46,7 +46,7 @@ scopedFunction = 42
 // FIXME: Should be an error -- a type name and a function cannot overload.
 var _ : Int = TypeNameWins(42)
 
-TypeNameWins = 42 // expected-error {{no exact matches in assignment to 'TypeNameWins'}}
+TypeNameWins = 42 // expected-error {{no exact matches in reference to global function 'TypeNameWins'}}
 var _ : TypeNameWins // no-warning
 
 // rdar://problem/21739333

--- a/test/Parse/super.swift
+++ b/test/Parse/super.swift
@@ -39,7 +39,7 @@ class D : B {
     super.bar        // expected-error {{expression resolves to an unused function}}
     super.bar()
     // FIXME: should also say "'super.init' cannot be referenced outside of an initializer"
-    super.init // expected-error{{no exact matches in call to initializer}}
+    super.init // expected-error{{no exact matches in reference to initializer}}
     super.init() // expected-error{{'super.init' cannot be called outside of an initializer}}
     super.init(0) // expected-error{{'super.init' cannot be called outside of an initializer}} // expected-error {{missing argument label 'x:' in call}}
     super[0]        // expected-error {{expression resolves to an unused subscript}}

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -12,8 +12,8 @@ func fe(_: Int, _: Int) {}
 fe(E.baz) // expected-error {{type 'E' has no member 'baz'; did you mean 'bar'?}}
 fe(.baz) // expected-error {{reference to member 'baz' cannot be resolved without a contextual type}}
 
-// FIXME: maybe complain about .nope also?
-fe(.nope, .nyet) // expected-error {{reference to member 'nyet' cannot be resolved without a contextual type}}
+fe(.nope, .nyet) // expected-error {{type 'Int' has no member 'nope'}}
+// expected-error@-1 {{reference to member 'nyet' cannot be resolved without a contextual type}}
 
 func fg<T>(_ f: (T) -> T) -> Void {} // expected-note {{in call to function 'fg'}}
 fg({x in x}) // expected-error {{generic parameter 'T' could not be inferred}}

--- a/test/Sema/diag_non_ephemeral.swift
+++ b/test/Sema/diag_non_ephemeral.swift
@@ -489,7 +489,7 @@ func takesPointerOverload(x: Int = 0, @_nonEphemeral _ ptr: UnsafeMutablePointer
 
 func testAmbiguity() {
   var arr = [1, 2, 3]
-  takesPointerOverload(&arr) // expected-error {{no exact matches in call to global function 'takesPointerOverload(x:_:)'}}
+  takesPointerOverload(&arr) // expected-error {{no exact matches in call to global function 'takesPointerOverload'}}
 }
 
 func takesPointerOverload2(@_nonEphemeral _ ptr: UnsafePointer<Int>) {}

--- a/test/Sema/suppress-argument-labels-in-types.swift
+++ b/test/Sema/suppress-argument-labels-in-types.swift
@@ -203,7 +203,7 @@ class C0 {
 }
 
 // Check diagnostics changes.
-let _ = min(Int(3), Float(2.5)) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
+let _ = min(Int(3), Float(2.5)) // expected-error{{conflicting arguments to generic parameter 'T' ('Int' vs. 'Float')}}
 
 // SR-11429
 func testIntermediateCoercions() {

--- a/test/Sema/type_join.swift
+++ b/test/Sema/type_join.swift
@@ -98,9 +98,9 @@ func joinFunctions(
   //        Any to be inferred for the generic type. That's pretty
   //        arbitrary.
   _ = commonSupertype(escaping, x)
-  // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '() -> ()'}}
+  // expected-error@-1 {{conflicting arguments to generic parameter 'T' ('() -> ()' vs. 'Int')}}
   _ = commonSupertype(x, escaping)
-  // expected-error@-1 {{cannot convert value of type '() -> ()' to expected argument type 'Int'}}
+  // expected-error@-1 {{conflicting arguments to generic parameter 'T' ('Int' vs. '() -> ()')}}
 
   let a: Any = 1
   _ = commonSupertype(nonescaping, a)

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -236,9 +236,9 @@ extension P4 where Self.AssocP4 == Bool {
 }
 
 func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
-  s4a.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a()'}}
+  s4a.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a'}}
   s4b.extP4a() // ok
-  s4c.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a()'}}
+  s4c.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a'}}
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above

--- a/test/decl/func/default-values.swift
+++ b/test/decl/func/default-values.swift
@@ -92,7 +92,7 @@ defaultArgTuplesNotMaterializable(identity(5))
 
 // <rdar://problem/22333090> QoI: Propagate contextual information in a call to operands
 defaultArgTuplesNotMaterializable(identity((5, y: 10)))
-// expected-error@-1 {{cannot convert value of type '(Int, y: Int)' to expected argument type 'Int'}}
+// expected-error@-1 {{conflicting arguments to generic parameter 'T' ('(Int, y: Int)' vs. 'Int')}}
 
 
 // rdar://problem/21799331

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -385,9 +385,9 @@ func testSubscript1(_ s1 : SubscriptTest1) {
   _ = s1.subscript(SuperClass())
   // expected-error@-1 {{no exact matches in call to subscript}}
   _ = s1.subscript("hello")
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
+  // expected-error@-1 {{no exact matches in call to subscript}}
   _ = s1.subscript("hello"
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
+  // expected-error@-1 {{no exact matches in call to subscript}}
   // expected-note@-2 {{to match this opening '('}}
 
   let _ = s1["hello"]

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -270,10 +270,15 @@ func associatedTypeIdentity() {
 
   sameType(cr, c.r_out())
   sameType(dr, d.r_out())
-  sameType(cr, dr) // expected-error {{cannot convert value of type '(some opaque.R).S' (associated type of protocol 'R') to expected argument type '(some opaque.R).S' (associated type of protocol 'R')}}
+  sameType(cr, dr) // expected-error {{conflicting arguments to generic parameter 'T' ('(some R).S' (associated type of protocol 'R') vs. '(some R).S' (associated type of protocol 'R'))}}
   sameType(gary(candace()).r_out(), gary(candace()).r_out())
   sameType(gary(doug()).r_out(), gary(doug()).r_out())
-  sameType(gary(doug()).r_out(), gary(candace()).r_out()) // expected-error {{cannot convert value of type 'some R' (result of 'candace()') to expected argument type 'some R' (result of 'doug()')}}
+  // TODO(diagnostics): This is not great but we the problem comes from the way solver discovers and attempts bindings, if we could detect that
+  // `(some R).S` from first reference to `gary()` in incosistent with the second one based on the parent type of `S` it would be much easier to diagnose.
+  sameType(gary(doug()).r_out(), gary(candace()).r_out())
+  // expected-error@-1:3  {{conflicting arguments to generic parameter 'T' ('(some R).S' (associated type of protocol 'R') vs. '(some R).S' (associated type of protocol 'R'))}}
+  // expected-error@-2:12 {{conflicting arguments to generic parameter 'T' ('some R' (result type of 'doug') vs. 'some R' (result type of 'candace'))}}
+  // expected-error@-3:34 {{conflicting arguments to generic parameter 'T' ('some R' (result type of 'doug') vs. 'some R' (result type of 'candace'))}}
 }
 
 func redeclaration() -> some P { return 0 } // expected-note 2{{previously declared}}

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -273,7 +273,7 @@ func associatedTypeIdentity() {
   sameType(cr, dr) // expected-error {{conflicting arguments to generic parameter 'T' ('(some R).S' (associated type of protocol 'R') vs. '(some R).S' (associated type of protocol 'R'))}}
   sameType(gary(candace()).r_out(), gary(candace()).r_out())
   sameType(gary(doug()).r_out(), gary(doug()).r_out())
-  // TODO(diagnostics): This is not great but we the problem comes from the way solver discovers and attempts bindings, if we could detect that
+  // TODO(diagnostics): This is not great but the problem comes from the way solver discovers and attempts bindings, if we could detect that
   // `(some R).S` from first reference to `gary()` in incosistent with the second one based on the parent type of `S` it would be much easier to diagnose.
   sameType(gary(doug()).r_out(), gary(candace()).r_out())
   // expected-error@-1:3  {{conflicting arguments to generic parameter 'T' ('(some R).S' (associated type of protocol 'R') vs. '(some R).S' (associated type of protocol 'R'))}}

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -173,9 +173,7 @@ takesP1AndP2([Swift.AnyObject & P1 & P2]())
 takesP1AndP2([AnyObject & protocol_composition.P1 & P2]())
 takesP1AndP2([AnyObject & P1 & protocol_composition.P2]())
 takesP1AndP2([DoesNotExist & P1 & P2]()) // expected-error {{use of unresolved identifier 'DoesNotExist'}}
-// TODO(diagnostics): The problem here is that `&` is interpreted as a binary operator, we need to re-think
-// how "missing member" fix is implemented because currently it finds N solutions with multiple fixes.
-takesP1AndP2([Swift.DoesNotExist & P1 & P2]()) // expected-error {{cannot invoke '' with no arguments}}
+takesP1AndP2([Swift.DoesNotExist & P1 & P2]()) // expected-error {{module 'Swift' has no member named 'DoesNotExist'}}
 
 typealias T08 = P1 & inout P2 // expected-error {{'inout' may only be used on parameters}}
 typealias T09 = P1 & __shared P2 // expected-error {{'__shared' may only be used on parameters}}


### PR DESCRIPTION
This change refactors `diagnoseAmbiguityWithFixes` to have a generalized strategy based on the differences between solutions in order to find the ambiguous overload, or other source of ambiguity. The new strategy will:
* Aggregate fixes from all of the solutions, grouping "common" ones based on the `FixKind` and locator.
* Identify the ambiguous overload based on the callee anchor of the overload choice and the anchor of the aggregated fixes.
* If there is no ambiguous overload, it will diagnose common fixes that appear in all of the solutions.

This change also introduces a new method on `CSFix` called `diagnoseForAmbiguity`. This is called when there is no ambiguous overload, but the fix appears in each of the solutions.

Resolves: rdar://problem/55605863