### PR TITLE
Handling strict conversion criteria for StringRef to std::string from TOT llvm.

### DIFF
--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -346,7 +346,7 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     // Setup the callbacks for serialization, which can occur during the
     // optimization pipeline.
     SerializationOptions SerializationOpts;
-    std::string OutPathStr = OutPath;
+    std::string OutPathStr = OutPath.str();
     SerializationOpts.EnableNestedTypeLookupTable
         = FEOpts.EnableSerializationNestedTypeLookupTable;
     SerializationOpts.OutputPath = OutPathStr.c_str();

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -916,7 +916,7 @@ static bool passCursorInfoForDecl(SourceFile* SF,
     if (ClangMod)
       ModuleName = ClangMod->getFullModuleName();
   } else if (VD->getLoc().isInvalid() && VD->getModuleContext() != MainModule) {
-    ModuleName = VD->getModuleContext()->getName().str();
+    ModuleName = VD->getModuleContext()->getName().str().str();
   }
   StringRef ModuleInterfaceName;
   if (auto IFaceGenRef = Lang.getIFaceGenContexts().find(ModuleName, Invok))


### PR DESCRIPTION
When building against upstream llvm, you now need an explicit conversion from StringRef to std::string. 